### PR TITLE
fix: make Herdr relaunch recovery transactional

### DIFF
--- a/bin/backends/herdr.sh
+++ b/bin/backends/herdr.sh
@@ -2165,14 +2165,31 @@ fm_backend_herdr_relaunch_candidate_discover() {  # <session> <workspace-id> <la
   FM_BACKEND_HERDR_RELAUNCH_CANDIDATE_PANE_ID=$pane_id
 }
 
-# Revalidate through Herdr and close by exact pane identity; never signal the
-# sampled numeric shell PID, which may belong to a reused process by then.
+# Revalidate through Herdr, then submit shell self-retirement through the
+# pane's shell-aware command path. Unlike an unconditional pane close, `pane
+# run` refuses if a new foreground owner wins after the sample, so cleanup
+# cannot retire that owner. The command resolves the executing shell's identity
+# at execution time instead of signaling the previously sampled shell PID.
+# Never signal the sampled numeric shell PID, which may belong to a reused
+# process by then.
 fm_backend_herdr_relaunch_candidate_close_on_shell() {  # <session> <workspace-id> <tab-id> <pane-id> <shell-pid>
-  local session=$1 workspace_id=$2 tab_id=$3 pane_id=$4 expected_pid=$5 resampled_pid
+  local session=$1 workspace_id=$2 tab_id=$3 pane_id=$4 expected_pid=$5 resampled_pid presence
+  local attempt=0 max_attempts=${FM_BACKEND_HERDR_RELAUNCH_CLOSE_POLLS:-20}
   fm_backend_herdr_relaunch_candidate_matches "$session" "$workspace_id" "$tab_id" "$pane_id" || return 1
   resampled_pid=$(fm_backend_herdr_pane_idle_shell_sample "$session" "$pane_id") || return 1
   [ "$resampled_pid" = "$expected_pid" ] || return 1
-  fm_backend_herdr_explicit_close_pane_confirmed "$session" "$pane_id"
+  fm_backend_herdr_clear_idle_shell_input "$session:$pane_id" "$expected_pid" || return 1
+  resampled_pid=$(fm_backend_herdr_pane_idle_shell_pid "$session" "$pane_id") || return 1
+  [ "$resampled_pid" = "$expected_pid" ] || return 1
+  fm_backend_herdr_cli "$session" pane run "$pane_id" 'kill -KILL "$$"' >/dev/null 2>&1 || true
+  while [ "$attempt" -lt "$max_attempts" ]; do
+    presence=$(fm_backend_herdr_pane_presence_state "$session" "$pane_id")
+    [ "$presence" = dead ] && return 0
+    [ "$presence" = present ] || return 1
+    attempt=$((attempt + 1))
+    [ "$attempt" -ge "$max_attempts" ] || sleep 0.1
+  done
+  return 1
 }
 
 fm_backend_herdr_relaunch_candidate_cleanup() {  # <session> <workspace-id> <tab-id> <pane-id>

--- a/bin/backends/herdr.sh
+++ b/bin/backends/herdr.sh
@@ -2158,6 +2158,52 @@ fm_backend_herdr_relaunch_candidate_discover() {  # <session> <workspace-id> <la
   FM_BACKEND_HERDR_RELAUNCH_CANDIDATE_PANE_ID=$pane_id
 }
 
+fm_backend_herdr_relaunch_candidate_close_on_shell() {  # <session> <workspace-id> <tab-id> <pane-id> <shell-pid>
+  local session=$1 workspace_id=$2 tab_id=$3 pane_id=$4 expected_pid=$5
+  local info shell_pid foreground_pgid count process_pid rows stat ps_bin kill_bin watchdog result=1
+  ps_bin=${FM_HERDR_PS_BIN:-ps}
+  kill_bin=${FM_HERDR_KILL_BIN:-kill}
+  command -v "$ps_bin" >/dev/null 2>&1 || return 1
+  command -v "$kill_bin" >/dev/null 2>&1 || return 1
+  "$kill_bin" -STOP "$expected_pid" 2>/dev/null || return 1
+  (
+    sleep "${FM_BACKEND_HERDR_RELAUNCH_CONT_WATCHDOG_SECS:-5}"
+    "$kill_bin" -CONT "$expected_pid" >/dev/null 2>&1 || true
+  ) &
+  watchdog=$!
+  info=$(fm_backend_herdr_cli "$session" pane process-info --pane "$pane_id" 2>/dev/null) || info=
+  shell_pid=$(printf '%s' "$info" | jq -er '.result.process_info.shell_pid | select(type == "number" and . > 1) | floor' 2>/dev/null) || shell_pid=
+  foreground_pgid=$(printf '%s' "$info" | jq -er '.result.process_info.foreground_process_group_id | select(type == "number" and . > 1) | floor' 2>/dev/null) || foreground_pgid=
+  count=$(printf '%s' "$info" | jq -er '.result.process_info.foreground_processes | select(type == "array") | length' 2>/dev/null) || count=
+  process_pid=$(printf '%s' "$info" | jq -er '.result.process_info.foreground_processes[0].pid | select(type == "number") | floor' 2>/dev/null) || process_pid=
+  rows=$("$ps_bin" -axo pid=,ppid= 2>/dev/null) || rows=
+  stat=$("$ps_bin" -p "$expected_pid" -o stat= 2>/dev/null | tr -d '[:space:]') || stat=
+  if fm_backend_herdr_relaunch_candidate_matches "$session" "$workspace_id" "$tab_id" "$pane_id" \
+     && printf '%s' "$info" | jq -e --arg pane "$pane_id" '
+          .result.type == "pane_process_info" and .result.process_info.pane_id == $pane
+        ' >/dev/null 2>&1 \
+     && [ "$shell_pid" = "$expected_pid" ] \
+     && [ "$foreground_pgid" = "$expected_pid" ] \
+     && [ "$count" = 1 ] \
+     && [ "$process_pid" = "$expected_pid" ] \
+     && printf '%s\n' "$rows" | awk -v shell="$expected_pid" '
+          $1 == shell { found++ }
+          $2 == shell { child++ }
+          END { exit(found == 1 && child == 0 ? 0 : 1) }
+        ' \
+     && case "$stat" in T*) true ;; *) false ;; esac \
+     && fm_backend_herdr_pid_is_bare_shell "$ps_bin" "$expected_pid" \
+     && fm_backend_herdr_explicit_close_pane_confirmed "$session" "$pane_id"; then
+    result=0
+  fi
+  if [ "$result" -ne 0 ]; then
+    "$kill_bin" -CONT "$expected_pid" >/dev/null 2>&1 || true
+  fi
+  kill "$watchdog" >/dev/null 2>&1 || true
+  wait "$watchdog" 2>/dev/null || true
+  return "$result"
+}
+
 fm_backend_herdr_relaunch_candidate_cleanup() {  # <session> <workspace-id> <tab-id> <pane-id>
   local session=$1 workspace_id=$2 tab_id=$3 pane_id=$4 presence state shell_pid
   presence=$(fm_backend_herdr_pane_presence_state "$session" "$pane_id")
@@ -2177,7 +2223,8 @@ fm_backend_herdr_relaunch_candidate_cleanup() {  # <session> <workspace-id> <tab
       ;;
     *) return 1 ;;
   esac
-  fm_backend_herdr_explicit_close_pane_confirmed "$session" "$pane_id"
+  fm_backend_herdr_relaunch_candidate_close_on_shell \
+    "$session" "$workspace_id" "$tab_id" "$pane_id" "$shell_pid"
 }
 
 # fm_backend_herdr_create_task: create the task's tab (one pane) in

--- a/bin/backends/herdr.sh
+++ b/bin/backends/herdr.sh
@@ -1175,16 +1175,6 @@ fm_backend_herdr_pid_is_bare_shell() {  # <ps-bin> <pid>
   return 1
 }
 
-# Use the shared process-instance identity so a shell PID cannot be confused
-# with a later process that reused the same numeric PID.
-fm_backend_herdr_pid_identity() {  # <pid>
-  if ! declare -F fm_pid_identity >/dev/null 2>&1; then
-    # shellcheck source=bin/fm-wake-lib.sh
-    . "$FM_BACKEND_HERDR_ROOT/bin/fm-wake-lib.sh"
-  fi
-  fm_pid_identity "$1"
-}
-
 # fm_backend_herdr_pane_idle_shell_pid: print the shell pid of <pane-id> only
 # when the exact pane provably holds one lone idle recognized shell: pane
 # process-info agrees on the pane id, the shell pid is both the foreground
@@ -2175,76 +2165,14 @@ fm_backend_herdr_relaunch_candidate_discover() {  # <session> <workspace-id> <la
   FM_BACKEND_HERDR_RELAUNCH_CANDIDATE_PANE_ID=$pane_id
 }
 
+# Revalidate through Herdr and close by exact pane identity; never signal the
+# sampled numeric shell PID, which may belong to a reused process by then.
 fm_backend_herdr_relaunch_candidate_close_on_shell() {  # <session> <workspace-id> <tab-id> <pane-id> <shell-pid>
-  local session=$1 workspace_id=$2 tab_id=$3 pane_id=$4 expected_pid=$5
-  local info shell_pid foreground_pgid count process_pid rows stat ps_bin kill_bin watchdog result=1
-  local initial_identity current_identity resampled_pid
-  ps_bin=${FM_HERDR_PS_BIN:-ps}
-  kill_bin=${FM_HERDR_KILL_BIN:-kill}
-  command -v "$ps_bin" >/dev/null 2>&1 || return 1
-  command -v "$kill_bin" >/dev/null 2>&1 || return 1
-  fm_backend_herdr_relaunch_candidate_matches "$session" "$workspace_id" "$tab_id" "$pane_id" || return 1
-  info=$(fm_backend_herdr_cli "$session" pane process-info --pane "$pane_id" 2>/dev/null) || return 1
-  printf '%s' "$info" | jq -e --arg pane "$pane_id" --argjson pid "$expected_pid" '
-    .result.type == "pane_process_info"
-    and .result.process_info.pane_id == $pane
-    and .result.process_info.shell_pid == $pid
-    and .result.process_info.foreground_process_group_id == $pid
-    and (.result.process_info.foreground_processes | length) == 1
-    and .result.process_info.foreground_processes[0].pid == $pid
-  ' >/dev/null 2>&1 || return 1
-  rows=$("$ps_bin" -axo pid=,ppid= 2>/dev/null) || return 1
-  printf '%s\n' "$rows" | awk -v shell="$expected_pid" '
-    $1 == shell { found++ }
-    $2 == shell { child++ }
-    END { exit(found == 1 && child == 0 ? 0 : 1) }
-  ' || return 1
-  stat=$("$ps_bin" -p "$expected_pid" -o stat= 2>/dev/null | tr -d '[:space:]') || return 1
-  case "$stat" in ''|T*) return 1 ;; esac
-  fm_backend_herdr_pid_is_bare_shell "$ps_bin" "$expected_pid" || return 1
-  initial_identity=$(fm_backend_herdr_pid_identity "$expected_pid") || return 1
+  local session=$1 workspace_id=$2 tab_id=$3 pane_id=$4 expected_pid=$5 resampled_pid
   fm_backend_herdr_relaunch_candidate_matches "$session" "$workspace_id" "$tab_id" "$pane_id" || return 1
   resampled_pid=$(fm_backend_herdr_pane_idle_shell_sample "$session" "$pane_id") || return 1
   [ "$resampled_pid" = "$expected_pid" ] || return 1
-  current_identity=$(fm_backend_herdr_pid_identity "$expected_pid") || return 1
-  [ "$current_identity" = "$initial_identity" ] || return 1
-  "$kill_bin" -STOP "$expected_pid" 2>/dev/null || return 1
-  (
-    sleep "${FM_BACKEND_HERDR_RELAUNCH_CONT_WATCHDOG_SECS:-5}"
-    "$kill_bin" -CONT "$expected_pid" >/dev/null 2>&1 || true
-  ) &
-  watchdog=$!
-  info=$(fm_backend_herdr_cli "$session" pane process-info --pane "$pane_id" 2>/dev/null) || info=
-  shell_pid=$(printf '%s' "$info" | jq -er '.result.process_info.shell_pid | select(type == "number" and . > 1) | floor' 2>/dev/null) || shell_pid=
-  foreground_pgid=$(printf '%s' "$info" | jq -er '.result.process_info.foreground_process_group_id | select(type == "number" and . > 1) | floor' 2>/dev/null) || foreground_pgid=
-  count=$(printf '%s' "$info" | jq -er '.result.process_info.foreground_processes | select(type == "array") | length' 2>/dev/null) || count=
-  process_pid=$(printf '%s' "$info" | jq -er '.result.process_info.foreground_processes[0].pid | select(type == "number") | floor' 2>/dev/null) || process_pid=
-  rows=$("$ps_bin" -axo pid=,ppid= 2>/dev/null) || rows=
-  stat=$("$ps_bin" -p "$expected_pid" -o stat= 2>/dev/null | tr -d '[:space:]') || stat=
-  if fm_backend_herdr_relaunch_candidate_matches "$session" "$workspace_id" "$tab_id" "$pane_id" \
-     && printf '%s' "$info" | jq -e --arg pane "$pane_id" '
-          .result.type == "pane_process_info" and .result.process_info.pane_id == $pane
-        ' >/dev/null 2>&1 \
-     && [ "$shell_pid" = "$expected_pid" ] \
-     && [ "$foreground_pgid" = "$expected_pid" ] \
-     && [ "$count" = 1 ] \
-     && [ "$process_pid" = "$expected_pid" ] \
-     && printf '%s\n' "$rows" | awk -v shell="$expected_pid" '
-          $1 == shell { found++ }
-          $2 == shell { child++ }
-          END { exit(found == 1 && child == 0 ? 0 : 1) }
-        ' \
-     && case "$stat" in T*) true ;; *) false ;; esac \
-     && fm_backend_herdr_pid_is_bare_shell "$ps_bin" "$expected_pid" \
-     && fm_backend_herdr_explicit_close_pane_confirmed "$session" "$pane_id"; then
-    result=0
-  fi
-  if [ "$result" -ne 0 ]; then
-    "$kill_bin" -CONT "$expected_pid" >/dev/null 2>&1 || true
-  fi
-  kill "$watchdog" >/dev/null 2>&1 || true
-  wait "$watchdog" 2>/dev/null || true
-  return "$result"
+  fm_backend_herdr_explicit_close_pane_confirmed "$session" "$pane_id"
 }
 
 fm_backend_herdr_relaunch_candidate_cleanup() {  # <session> <workspace-id> <tab-id> <pane-id>
@@ -2968,46 +2896,15 @@ fm_backend_herdr_relaunch_prepared_shell_pid() {
   printf '%s' "${FM_BACKEND_HERDR_RELAUNCH_SHELL_PID:-}"
 }
 
-# Submit a replacement command only while the exact prepared shell is frozen.
-# SIGSTOP closes the sample-to-mutation gap: after the stop, a shell that still
-# owns the foreground process group cannot start a competing child before the
-# command and Enter are queued atomically. A bounded watchdog resumes the shell
-# if this process dies between STOP and CONT.
+# Revalidate the prepared shell immediately before using Herdr's exact-pane,
+# atomic command submission. Do not signal the sampled OS PID: it may exit and
+# be reused between any userspace identity check and a later signal.
 fm_backend_herdr_run_on_prepared_shell() {  # <target> <shell-pid> <validated-worktree> <command>
   local target=$1 expected_pid=$2 expected=$3 command_text=$4
-  local expected_real current current_real info shell_pid foreground_pgid count process_pid
-  local rows stat ps_bin kill_bin watchdog result=1
-  local initial_identity current_identity resampled_pid
+  local expected_real current current_real resampled_pid
   [ -n "$expected_pid" ] || return 1
   expected_real=$(CDPATH='' cd -- "$expected" 2>/dev/null && pwd -P) || return 1
   fm_backend_herdr_parse_target "$target" || return 1
-  ps_bin=${FM_HERDR_PS_BIN:-ps}
-  kill_bin=${FM_HERDR_KILL_BIN:-kill}
-  command -v "$ps_bin" >/dev/null 2>&1 || return 1
-  command -v "$kill_bin" >/dev/null 2>&1 || return 1
-  info=$(fm_backend_herdr_cli "$FM_BACKEND_HERDR_SESSION" pane process-info --pane "$FM_BACKEND_HERDR_PANE" 2>/dev/null) || return 1
-  printf '%s' "$info" | jq -e --arg pane "$FM_BACKEND_HERDR_PANE" --argjson pid "$expected_pid" '
-    .result.type == "pane_process_info"
-    and .result.process_info.pane_id == $pane
-    and .result.process_info.shell_pid == $pid
-    and .result.process_info.foreground_process_group_id == $pid
-    and (.result.process_info.foreground_processes | length) == 1
-    and .result.process_info.foreground_processes[0].pid == $pid
-  ' >/dev/null 2>&1 || return 1
-  rows=$("$ps_bin" -axo pid=,ppid= 2>/dev/null) || return 1
-  printf '%s\n' "$rows" | awk -v shell="$expected_pid" '
-    $1 == shell { found++ }
-    $2 == shell { child++ }
-    END { exit(found == 1 && child == 0 ? 0 : 1) }
-  ' || return 1
-  stat=$("$ps_bin" -p "$expected_pid" -o stat= 2>/dev/null | tr -d '[:space:]') || return 1
-  case "$stat" in ''|T*) return 1 ;; esac
-  fm_backend_herdr_pid_is_bare_shell "$ps_bin" "$expected_pid" || return 1
-  current=$(fm_backend_herdr_current_path "$target" || true)
-  current_real=
-  [ -z "$current" ] || current_real=$(CDPATH='' cd -- "$current" 2>/dev/null && pwd -P) || current_real=
-  [ "$current_real" = "$expected_real" ] || return 1
-  initial_identity=$(fm_backend_herdr_pid_identity "$expected_pid") || return 1
   resampled_pid=$(fm_backend_herdr_pane_idle_shell_sample \
     "$FM_BACKEND_HERDR_SESSION" "$FM_BACKEND_HERDR_PANE") || return 1
   [ "$resampled_pid" = "$expected_pid" ] || return 1
@@ -3015,47 +2912,8 @@ fm_backend_herdr_run_on_prepared_shell() {  # <target> <shell-pid> <validated-wo
   current_real=
   [ -z "$current" ] || current_real=$(CDPATH='' cd -- "$current" 2>/dev/null && pwd -P) || current_real=
   [ "$current_real" = "$expected_real" ] || return 1
-  current_identity=$(fm_backend_herdr_pid_identity "$expected_pid") || return 1
-  [ "$current_identity" = "$initial_identity" ] || return 1
-  "$kill_bin" -STOP "$expected_pid" 2>/dev/null || return 1
-  (
-    sleep "${FM_BACKEND_HERDR_RELAUNCH_CONT_WATCHDOG_SECS:-5}"
-    "$kill_bin" -CONT "$expected_pid" >/dev/null 2>&1 || true
-  ) &
-  watchdog=$!
-
-  info=$(fm_backend_herdr_cli "$FM_BACKEND_HERDR_SESSION" pane process-info --pane "$FM_BACKEND_HERDR_PANE" 2>/dev/null) || info=
-  shell_pid=$(printf '%s' "$info" | jq -er '.result.process_info.shell_pid | select(type == "number" and . > 1) | floor' 2>/dev/null) || shell_pid=
-  foreground_pgid=$(printf '%s' "$info" | jq -er '.result.process_info.foreground_process_group_id | select(type == "number" and . > 1) | floor' 2>/dev/null) || foreground_pgid=
-  count=$(printf '%s' "$info" | jq -er '.result.process_info.foreground_processes | select(type == "array") | length' 2>/dev/null) || count=
-  process_pid=$(printf '%s' "$info" | jq -er '.result.process_info.foreground_processes[0].pid | select(type == "number") | floor' 2>/dev/null) || process_pid=
-  rows=$("$ps_bin" -axo pid=,ppid= 2>/dev/null) || rows=
-  stat=$("$ps_bin" -p "$expected_pid" -o stat= 2>/dev/null | tr -d '[:space:]') || stat=
-  current=$(fm_backend_herdr_current_path "$target" || true)
-  current_real=
-  [ -z "$current" ] || current_real=$(CDPATH='' cd -- "$current" 2>/dev/null && pwd -P) || current_real=
-  if printf '%s' "$info" | jq -e --arg pane "$FM_BACKEND_HERDR_PANE" '
-       .result.type == "pane_process_info" and .result.process_info.pane_id == $pane
-     ' >/dev/null 2>&1 \
-     && [ "$shell_pid" = "$expected_pid" ] \
-     && [ "$foreground_pgid" = "$expected_pid" ] \
-     && [ "$count" = 1 ] \
-     && [ "$process_pid" = "$expected_pid" ] \
-     && [ "$current_real" = "$expected_real" ] \
-     && printf '%s\n' "$rows" | awk -v shell="$expected_pid" '
-          $1 == shell { found++ }
-          $2 == shell { child++ }
-          END { exit(found == 1 && child == 0 ? 0 : 1) }
-        ' \
-     && case "$stat" in T*) true ;; *) false ;; esac \
-     && fm_backend_herdr_pid_is_bare_shell "$ps_bin" "$expected_pid"; then
-    fm_backend_herdr_cli "$FM_BACKEND_HERDR_SESSION" pane run "$FM_BACKEND_HERDR_PANE" "$command_text" >/dev/null 2>&1 \
-      && result=0
-  fi
-  "$kill_bin" -CONT "$expected_pid" >/dev/null 2>&1 || result=1
-  kill "$watchdog" >/dev/null 2>&1 || true
-  wait "$watchdog" 2>/dev/null || true
-  return "$result"
+  fm_backend_herdr_cli "$FM_BACKEND_HERDR_SESSION" pane run \
+    "$FM_BACKEND_HERDR_PANE" "$command_text" >/dev/null 2>&1
 }
 
 fm_backend_herdr_prepare_relaunch_path() {  # <target> <validated-worktree>

--- a/bin/backends/herdr.sh
+++ b/bin/backends/herdr.sh
@@ -2600,15 +2600,18 @@ fm_backend_herdr_current_path() {  # <target>
     | jq -r '.result.pane.foreground_cwd // empty' 2>/dev/null
 }
 
-# fm_backend_herdr_prepare_relaunch_path: restore an agent-free endpoint shell
-# only to the exact recorded worktree already validated by the control plane.
-# Herdr's atomic `pane run` executes `cd` non-persistently, so this uses the
-# interactive shell's literal-input path and submits only after a second exact
-# shell-owner check. The single-quote transform is data-only shell quoting; no
-# byte from the path can become syntax. Success requires the live foreground cwd
-# to converge to the physical recorded path while the endpoint remains
-# positively agent-free and owned by the same shell pid. Repeated calls are a
-# verified no-op once the path already matches.
+# fm_backend_herdr_prepare_relaunch_path: prepare an agent-free endpoint shell
+# for the exact recorded worktree already validated by the launch caller.
+# It first cancels any pending input while the same idle shell owns the pane,
+# including when the cwd already matches. Herdr's atomic `pane run` executes
+# `cd` non-persistently, so a mismatched cwd uses the interactive shell's
+# literal-input path and submits only after a second exact shell-owner check.
+# The single-quote transform is data-only shell quoting; no byte from the path
+# can become syntax. Every pre-Enter failure attempts to cancel this function's
+# buffered command only while that same idle shell still owns the pane. Success
+# requires the live foreground cwd to converge to the physical recorded path
+# while the endpoint remains positively agent-free and owned by the same shell
+# pid. Repeated calls converge safely and never append to pending input.
 fm_backend_herdr_clear_idle_shell_input() {  # <target> <shell-pid>
   local target=$1 shell_pid=$2 resampled
   [ "$(fm_backend_herdr_recovery_agent_state "$target")" = dead ] || return 1

--- a/bin/backends/herdr.sh
+++ b/bin/backends/herdr.sh
@@ -2637,13 +2637,6 @@ fm_backend_herdr_prepare_relaunch_path() {  # <target> <validated-worktree>
     echo "error: herdr endpoint does not hold one provably idle shell; refusing to restore its relaunch path" >&2
     return 1
   }
-  current=$(fm_backend_herdr_current_path "$target" || true)
-  current_real=
-  [ -z "$current" ] || current_real=$(CDPATH='' cd -- "$current" 2>/dev/null && pwd -P) || current_real=
-  if [ "$current_real" = "$expected_real" ]; then
-    return 0
-  fi
-
   fm_backend_herdr_clear_idle_shell_input "$target" "$shell_pid" || {
     echo "error: herdr endpoint changed before its shell input could be cleared" >&2
     return 1
@@ -2658,6 +2651,12 @@ fm_backend_herdr_prepare_relaunch_path() {  # <target> <validated-worktree>
     echo "error: herdr endpoint shell identity changed after clearing shell input" >&2
     return 1
   }
+  current=$(fm_backend_herdr_current_path "$target" || true)
+  current_real=
+  [ -z "$current" ] || current_real=$(CDPATH='' cd -- "$current" 2>/dev/null && pwd -P) || current_real=
+  if [ "$current_real" = "$expected_real" ]; then
+    return 0
+  fi
 
   quoted=${expected_real//\'/\'"\'"\'}
   command="cd -- '$quoted'"

--- a/bin/backends/herdr.sh
+++ b/bin/backends/herdr.sh
@@ -2008,7 +2008,14 @@ fm_backend_herdr_recovery_agent_state() {  # <target>
   pane_state=$(fm_backend_herdr_pane_agent_state "$FM_BACKEND_HERDR_SESSION" "$FM_BACKEND_HERDR_PANE")
   case "$pane_state" in
     dead) printf 'missing' ;;
-    no-agent|live)
+    no-agent)
+      process_state=$(fm_backend_herdr_registered_process_state "$FM_BACKEND_HERDR_SESSION" "$FM_BACKEND_HERDR_PANE")
+      case "$process_state" in
+        shell) printf 'dead' ;;
+        *) printf 'unreadable' ;;
+      esac
+      ;;
+    live)
       process_state=$(fm_backend_herdr_registered_process_state "$FM_BACKEND_HERDR_SESSION" "$FM_BACKEND_HERDR_PANE")
       case "$process_state" in
         live) printf 'alive' ;;

--- a/bin/backends/herdr.sh
+++ b/bin/backends/herdr.sh
@@ -2715,22 +2715,61 @@ fm_backend_herdr_relaunch_prepared_shell_pid() {
   printf '%s' "${FM_BACKEND_HERDR_RELAUNCH_SHELL_PID:-}"
 }
 
-# Revalidate the exact shell and cwd established by preparation immediately
-# before each subsequent relaunch input boundary. The session mutation lock
-# excludes other Firstmate operations, while this check also catches an
-# uncoordinated foreground-owner change before input is sent.
-fm_backend_herdr_relaunch_shell_owned() {  # <target> <shell-pid> <validated-worktree>
-  local target=$1 expected_pid=$2 expected=$3 expected_real current current_real resampled
+# Submit a replacement command only while the exact prepared shell is frozen.
+# SIGSTOP closes the sample-to-mutation gap: after the stop, a shell that still
+# owns the foreground process group cannot start a competing child before the
+# command and Enter are queued atomically. A bounded watchdog resumes the shell
+# if this process dies between STOP and CONT.
+fm_backend_herdr_run_on_prepared_shell() {  # <target> <shell-pid> <validated-worktree> <command>
+  local target=$1 expected_pid=$2 expected=$3 command_text=$4
+  local expected_real current current_real info shell_pid foreground_pgid count process_pid
+  local rows stat ps_bin kill_bin watchdog result=1
   [ -n "$expected_pid" ] || return 1
   expected_real=$(CDPATH='' cd -- "$expected" 2>/dev/null && pwd -P) || return 1
-  [ "$(fm_backend_herdr_recovery_agent_state "$target")" = dead ] || return 1
   fm_backend_herdr_parse_target "$target" || return 1
-  resampled=$(fm_backend_herdr_pane_idle_shell_pid "$FM_BACKEND_HERDR_SESSION" "$FM_BACKEND_HERDR_PANE") || return 1
-  [ "$resampled" = "$expected_pid" ] || return 1
+  ps_bin=${FM_HERDR_PS_BIN:-ps}
+  kill_bin=${FM_HERDR_KILL_BIN:-kill}
+  command -v "$ps_bin" >/dev/null 2>&1 || return 1
+  command -v "$kill_bin" >/dev/null 2>&1 || return 1
+  "$kill_bin" -STOP "$expected_pid" 2>/dev/null || return 1
+  (
+    sleep "${FM_BACKEND_HERDR_RELAUNCH_CONT_WATCHDOG_SECS:-5}"
+    "$kill_bin" -CONT "$expected_pid" >/dev/null 2>&1 || true
+  ) &
+  watchdog=$!
+
+  info=$(fm_backend_herdr_cli "$FM_BACKEND_HERDR_SESSION" pane process-info --pane "$FM_BACKEND_HERDR_PANE" 2>/dev/null) || info=
+  shell_pid=$(printf '%s' "$info" | jq -er '.result.process_info.shell_pid | select(type == "number" and . > 1) | floor' 2>/dev/null) || shell_pid=
+  foreground_pgid=$(printf '%s' "$info" | jq -er '.result.process_info.foreground_process_group_id | select(type == "number" and . > 1) | floor' 2>/dev/null) || foreground_pgid=
+  count=$(printf '%s' "$info" | jq -er '.result.process_info.foreground_processes | select(type == "array") | length' 2>/dev/null) || count=
+  process_pid=$(printf '%s' "$info" | jq -er '.result.process_info.foreground_processes[0].pid | select(type == "number") | floor' 2>/dev/null) || process_pid=
+  rows=$("$ps_bin" -axo pid=,ppid= 2>/dev/null) || rows=
+  stat=$("$ps_bin" -p "$expected_pid" -o stat= 2>/dev/null | tr -d '[:space:]') || stat=
   current=$(fm_backend_herdr_current_path "$target" || true)
-  [ -n "$current" ] || return 1
-  current_real=$(CDPATH='' cd -- "$current" 2>/dev/null && pwd -P) || return 1
-  [ "$current_real" = "$expected_real" ]
+  current_real=
+  [ -z "$current" ] || current_real=$(CDPATH='' cd -- "$current" 2>/dev/null && pwd -P) || current_real=
+  if printf '%s' "$info" | jq -e --arg pane "$FM_BACKEND_HERDR_PANE" '
+       .result.type == "pane_process_info" and .result.process_info.pane_id == $pane
+     ' >/dev/null 2>&1 \
+     && [ "$shell_pid" = "$expected_pid" ] \
+     && [ "$foreground_pgid" = "$expected_pid" ] \
+     && [ "$count" = 1 ] \
+     && [ "$process_pid" = "$expected_pid" ] \
+     && [ "$current_real" = "$expected_real" ] \
+     && printf '%s\n' "$rows" | awk -v shell="$expected_pid" '
+          $1 == shell { found++ }
+          $2 == shell { child++ }
+          END { exit(found == 1 && child == 0 ? 0 : 1) }
+        ' \
+     && case "$stat" in T*) true ;; *) false ;; esac \
+     && fm_backend_herdr_pid_is_bare_shell "$ps_bin" "$expected_pid"; then
+    fm_backend_herdr_cli "$FM_BACKEND_HERDR_SESSION" pane run "$FM_BACKEND_HERDR_PANE" "$command_text" >/dev/null 2>&1 \
+      && result=0
+  fi
+  "$kill_bin" -CONT "$expected_pid" >/dev/null 2>&1 || result=1
+  kill "$watchdog" >/dev/null 2>&1 || true
+  wait "$watchdog" 2>/dev/null || true
+  return "$result"
 }
 
 fm_backend_herdr_prepare_relaunch_path() {  # <target> <validated-worktree>

--- a/bin/backends/herdr.sh
+++ b/bin/backends/herdr.sh
@@ -2172,6 +2172,25 @@ fm_backend_herdr_relaunch_candidate_close_on_shell() {  # <session> <workspace-i
   kill_bin=${FM_HERDR_KILL_BIN:-kill}
   command -v "$ps_bin" >/dev/null 2>&1 || return 1
   command -v "$kill_bin" >/dev/null 2>&1 || return 1
+  fm_backend_herdr_relaunch_candidate_matches "$session" "$workspace_id" "$tab_id" "$pane_id" || return 1
+  info=$(fm_backend_herdr_cli "$session" pane process-info --pane "$pane_id" 2>/dev/null) || return 1
+  printf '%s' "$info" | jq -e --arg pane "$pane_id" --argjson pid "$expected_pid" '
+    .result.type == "pane_process_info"
+    and .result.process_info.pane_id == $pane
+    and .result.process_info.shell_pid == $pid
+    and .result.process_info.foreground_process_group_id == $pid
+    and (.result.process_info.foreground_processes | length) == 1
+    and .result.process_info.foreground_processes[0].pid == $pid
+  ' >/dev/null 2>&1 || return 1
+  rows=$("$ps_bin" -axo pid=,ppid= 2>/dev/null) || return 1
+  printf '%s\n' "$rows" | awk -v shell="$expected_pid" '
+    $1 == shell { found++ }
+    $2 == shell { child++ }
+    END { exit(found == 1 && child == 0 ? 0 : 1) }
+  ' || return 1
+  stat=$("$ps_bin" -p "$expected_pid" -o stat= 2>/dev/null | tr -d '[:space:]') || return 1
+  case "$stat" in ''|T*) return 1 ;; esac
+  fm_backend_herdr_pid_is_bare_shell "$ps_bin" "$expected_pid" || return 1
   "$kill_bin" -STOP "$expected_pid" 2>/dev/null || return 1
   (
     sleep "${FM_BACKEND_HERDR_RELAUNCH_CONT_WATCHDOG_SECS:-5}"
@@ -2948,6 +2967,28 @@ fm_backend_herdr_run_on_prepared_shell() {  # <target> <shell-pid> <validated-wo
   kill_bin=${FM_HERDR_KILL_BIN:-kill}
   command -v "$ps_bin" >/dev/null 2>&1 || return 1
   command -v "$kill_bin" >/dev/null 2>&1 || return 1
+  info=$(fm_backend_herdr_cli "$FM_BACKEND_HERDR_SESSION" pane process-info --pane "$FM_BACKEND_HERDR_PANE" 2>/dev/null) || return 1
+  printf '%s' "$info" | jq -e --arg pane "$FM_BACKEND_HERDR_PANE" --argjson pid "$expected_pid" '
+    .result.type == "pane_process_info"
+    and .result.process_info.pane_id == $pane
+    and .result.process_info.shell_pid == $pid
+    and .result.process_info.foreground_process_group_id == $pid
+    and (.result.process_info.foreground_processes | length) == 1
+    and .result.process_info.foreground_processes[0].pid == $pid
+  ' >/dev/null 2>&1 || return 1
+  rows=$("$ps_bin" -axo pid=,ppid= 2>/dev/null) || return 1
+  printf '%s\n' "$rows" | awk -v shell="$expected_pid" '
+    $1 == shell { found++ }
+    $2 == shell { child++ }
+    END { exit(found == 1 && child == 0 ? 0 : 1) }
+  ' || return 1
+  stat=$("$ps_bin" -p "$expected_pid" -o stat= 2>/dev/null | tr -d '[:space:]') || return 1
+  case "$stat" in ''|T*) return 1 ;; esac
+  fm_backend_herdr_pid_is_bare_shell "$ps_bin" "$expected_pid" || return 1
+  current=$(fm_backend_herdr_current_path "$target" || true)
+  current_real=
+  [ -z "$current" ] || current_real=$(CDPATH='' cd -- "$current" 2>/dev/null && pwd -P) || current_real=
+  [ "$current_real" = "$expected_real" ] || return 1
   "$kill_bin" -STOP "$expected_pid" 2>/dev/null || return 1
   (
     sleep "${FM_BACKEND_HERDR_RELAUNCH_CONT_WATCHDOG_SECS:-5}"

--- a/bin/backends/herdr.sh
+++ b/bin/backends/herdr.sh
@@ -1994,8 +1994,7 @@ fm_backend_herdr_recovery_agent_state() {  # <target>
   pane_state=$(fm_backend_herdr_pane_agent_state "$FM_BACKEND_HERDR_SESSION" "$FM_BACKEND_HERDR_PANE")
   case "$pane_state" in
     dead) printf 'missing' ;;
-    no-agent) printf 'dead' ;;
-    live)
+    no-agent|live)
       process_state=$(fm_backend_herdr_registered_process_state "$FM_BACKEND_HERDR_SESSION" "$FM_BACKEND_HERDR_PANE")
       case "$process_state" in
         live) printf 'alive' ;;
@@ -2102,6 +2101,47 @@ fm_backend_herdr_relaunch_candidate_matches() {  # <session> <workspace-id> <tab
       and .result.pane.tab_id == $tab
       and .result.pane.pane_id == $pane
     ' >/dev/null 2>&1
+}
+
+fm_backend_herdr_relaunch_candidate_discover() {  # <session> <workspace-id> <label> <validated-worktree>
+  local session=$1 workspace_id=$2 label=$3 expected=$4 expected_real tabs panes match tab_id pane_id info
+  FM_BACKEND_HERDR_RELAUNCH_CANDIDATE_TAB_ID=
+  FM_BACKEND_HERDR_RELAUNCH_CANDIDATE_PANE_ID=
+  expected_real=$(CDPATH='' cd -- "$expected" 2>/dev/null && pwd -P) || return 1
+  tabs=$(fm_backend_herdr_cli "$session" tab list --workspace "$workspace_id" 2>/dev/null) || return 1
+  match=$(printf '%s' "$tabs" | jq -r --arg label "$label" '
+    if (.result.tabs | type) == "array"
+    then [.result.tabs[] | select(.label == $label)]
+    else error("missing result.tabs") end
+    | if length == 0 then "absent"
+      elif length == 1 then .[0].tab_id
+      else "ambiguous" end
+  ' 2>/dev/null) || return 1
+  case "$match" in
+    absent) return 2 ;;
+    ambiguous|'') return 1 ;;
+  esac
+  fm_backend_endpoint_atom_valid "${match//:/_}" || return 1
+  tab_id=$match
+  panes=$(fm_backend_herdr_cli "$session" pane list --workspace "$workspace_id" 2>/dev/null) || return 1
+  pane_id=$(printf '%s' "$panes" | jq -r --arg tab "$tab_id" '
+    if (.result.panes | type) == "array"
+    then [.result.panes[] | select(.tab_id == $tab)]
+    else error("missing result.panes") end
+    | if length == 1 then .[0].pane_id else empty end
+  ' 2>/dev/null) || return 1
+  [ -n "$pane_id" ] && fm_backend_endpoint_atom_valid "${pane_id//:/_}" || return 1
+  info=$(fm_backend_herdr_cli "$session" pane get "$pane_id" 2>/dev/null) || return 1
+  printf '%s' "$info" | jq -e \
+    --arg workspace "$workspace_id" --arg tab "$tab_id" --arg pane "$pane_id" --arg cwd "$expected_real" '
+      .result.type == "pane_info"
+      and .result.pane.workspace_id == $workspace
+      and .result.pane.tab_id == $tab
+      and .result.pane.pane_id == $pane
+      and .result.pane.foreground_cwd == $cwd
+    ' >/dev/null 2>&1 || return 1
+  FM_BACKEND_HERDR_RELAUNCH_CANDIDATE_TAB_ID=$tab_id
+  FM_BACKEND_HERDR_RELAUNCH_CANDIDATE_PANE_ID=$pane_id
 }
 
 fm_backend_herdr_relaunch_candidate_cleanup() {  # <session> <workspace-id> <tab-id> <pane-id>

--- a/bin/backends/herdr.sh
+++ b/bin/backends/herdr.sh
@@ -1988,6 +1988,20 @@ fm_backend_herdr_registered_process_state() {  # <session> <pane-id>
 # pane independently proves that only its lone idle shell remains. An unreadable
 # or contradictory process surface stays unreadable rather than turning either
 # a live agent or an arbitrary foreground command into a recovery candidate.
+fm_backend_herdr_relaunch_candidate_live() {  # <session> <pane-id>
+  local session=$1 pane=$2 out
+  out=$(fm_backend_herdr_cli "$session" agent get "$pane" 2>/dev/null) || return 1
+  printf '%s' "$out" | jq -e --arg pane "$pane" '
+    .result.type == "agent_info"
+    and .result.agent.pane_id == $pane
+    and (.result.agent.agent_status == "working"
+      or .result.agent.agent_status == "idle"
+      or .result.agent.agent_status == "done"
+      or .result.agent.agent_status == "blocked")
+  ' >/dev/null 2>&1 || return 1
+  [ "$(fm_backend_herdr_registered_process_state "$session" "$pane")" = live ]
+}
+
 fm_backend_herdr_recovery_agent_state() {  # <target>
   local target=$1 pane_state process_state
   fm_backend_herdr_parse_target "$target" || { printf 'unreadable'; return 0; }
@@ -2156,8 +2170,7 @@ fm_backend_herdr_relaunch_candidate_cleanup() {  # <session> <workspace-id> <tab
   state=$(fm_backend_herdr_pane_agent_state "$session" "$pane_id")
   case "$state" in
     dead) return 0 ;;
-    no-agent) ;;
-    live)
+    no-agent|live)
       [ "$(fm_backend_herdr_recovery_agent_state "$session:$pane_id")" = dead ] || return 1
       shell_pid=$(fm_backend_herdr_pane_idle_shell_pid "$session" "$pane_id") || return 1
       [ -n "$shell_pid" ] || return 1

--- a/bin/backends/herdr.sh
+++ b/bin/backends/herdr.sh
@@ -1928,11 +1928,11 @@ fm_backend_herdr_tab_is_husk() {  # <session> <pane_id>
   esac
 }
 
-# fm_backend_herdr_agent_state: recovery-grade state for the same session-start
-# sweep as the tmux classifier. It reuses the husk classifier rather than
-# creating a second Herdr state machine: a structurally gone pane is `missing`,
-# a confirmed agent-less pane is `dead`, a registered agent is `alive`, and an
-# unexpected or failed API read is `unreadable`.
+# fm_backend_herdr_agent_state: ordinary recovery-grade state for the same
+# session-start sweep as the tmux classifier. It reuses the husk classifier
+# rather than creating a second Herdr state machine: a structurally gone pane
+# is `missing`, a confirmed agent-less pane is `dead`, a registered agent is
+# `alive`, and an unexpected or failed API read is `unreadable`.
 fm_backend_herdr_agent_state() {  # <target>
   local target=$1
   fm_backend_herdr_parse_target "$target" || { printf 'unreadable'; return 0; }
@@ -1940,6 +1940,69 @@ fm_backend_herdr_agent_state() {  # <target>
     dead) printf 'missing' ;;
     no-agent) printf 'dead' ;;
     live) printf 'alive' ;;
+    *) printf 'unreadable' ;;
+  esac
+}
+
+# fm_backend_herdr_registered_process_state: independently corroborate one
+# registered agent against the exact pane's foreground process. Herdr can retain
+# an idle/done Pi registration after Pi exits and the pane returns to its shell.
+# A different foreground process group proves the registered process is still
+# live enough that lifecycle recovery must refuse to replace it. Only the
+# existing strict lone-idle-shell proof can establish the stale-registration
+# counterfactual. Prompt helpers may transiently share the shell's group, so
+# ambiguous shell-group samples retry for the same bounded window as that proof.
+# Prints live|shell|unknown and never mutates Herdr's registry.
+fm_backend_herdr_registered_process_state() {  # <session> <pane-id>
+  local session=$1 pane=$2 attempt=0 max_attempts=${FM_BACKEND_HERDR_IDLE_SHELL_PROOF_POLLS:-10}
+  local info shell_pid foreground_pgid count
+  while :; do
+    info=$(fm_backend_herdr_cli "$session" pane process-info --pane "$pane" 2>/dev/null) || { printf 'unknown'; return 0; }
+    if ! printf '%s' "$info" | jq -e --arg pane "$pane" '
+      .result.type == "pane_process_info"
+      and .result.process_info.pane_id == $pane
+    ' >/dev/null 2>&1; then
+      printf 'unknown'
+      return 0
+    fi
+    shell_pid=$(printf '%s' "$info" | jq -er ".result.process_info.shell_pid | select(type == \"number\" and . > 1) | floor" 2>/dev/null) || { printf 'unknown'; return 0; }
+    foreground_pgid=$(printf '%s' "$info" | jq -er ".result.process_info.foreground_process_group_id | select(type == \"number\" and . > 1) | floor" 2>/dev/null) || { printf 'unknown'; return 0; }
+    count=$(printf '%s' "$info" | jq -er ".result.process_info.foreground_processes | select(type == \"array\") | length" 2>/dev/null) || { printf 'unknown'; return 0; }
+    if [ "$foreground_pgid" != "$shell_pid" ] && [ "$count" -gt 0 ]; then
+      printf 'live'
+      return 0
+    fi
+    if [ "$foreground_pgid" = "$shell_pid" ] \
+       && fm_backend_herdr_pane_idle_shell_sample "$session" "$pane" >/dev/null; then
+      printf 'shell'
+      return 0
+    fi
+    attempt=$((attempt + 1))
+    [ "$attempt" -lt "$max_attempts" ] || { printf 'unknown'; return 0; }
+    sleep 0.1
+  done
+}
+
+# fm_backend_herdr_recovery_agent_state: lifecycle-only strengthening of the
+# ordinary state read. A positive registry entry remains alive unless the exact
+# pane independently proves that only its lone idle shell remains. An unreadable
+# or contradictory process surface stays unreadable rather than turning either
+# a live agent or an arbitrary foreground command into a recovery candidate.
+fm_backend_herdr_recovery_agent_state() {  # <target>
+  local target=$1 pane_state process_state
+  fm_backend_herdr_parse_target "$target" || { printf 'unreadable'; return 0; }
+  pane_state=$(fm_backend_herdr_pane_agent_state "$FM_BACKEND_HERDR_SESSION" "$FM_BACKEND_HERDR_PANE")
+  case "$pane_state" in
+    dead) printf 'missing' ;;
+    no-agent) printf 'dead' ;;
+    live)
+      process_state=$(fm_backend_herdr_registered_process_state "$FM_BACKEND_HERDR_SESSION" "$FM_BACKEND_HERDR_PANE")
+      case "$process_state" in
+        live) printf 'alive' ;;
+        shell) printf 'dead' ;;
+        *) printf 'unreadable' ;;
+      esac
+      ;;
     *) printf 'unreadable' ;;
   esac
 }
@@ -2535,6 +2598,74 @@ fm_backend_herdr_current_path() {  # <target>
   fm_backend_herdr_target_ready "$1" || return 0
   fm_backend_herdr_cli "$FM_BACKEND_HERDR_SESSION" pane get "$FM_BACKEND_HERDR_PANE" 2>/dev/null \
     | jq -r '.result.pane.foreground_cwd // empty' 2>/dev/null
+}
+
+# fm_backend_herdr_prepare_relaunch_path: restore an agent-free endpoint shell
+# only to the exact recorded worktree already validated by the control plane.
+# Herdr's atomic `pane run` executes `cd` non-persistently, so this uses the
+# interactive shell's literal-input path and submits only after a second exact
+# shell-owner check. The single-quote transform is data-only shell quoting; no
+# byte from the path can become syntax. Success requires the live foreground cwd
+# to converge to the physical recorded path while the endpoint remains
+# positively agent-free and owned by the same shell pid. Repeated calls are a
+# verified no-op once the path already matches.
+fm_backend_herdr_prepare_relaunch_path() {  # <target> <validated-worktree>
+  local target=$1 expected=$2 expected_real current current_real shell_pid resampled command quoted
+  local attempt=0 max_attempts=${FM_BACKEND_HERDR_RELAUNCH_PATH_POLLS:-20}
+  case "$expected" in
+    /*) ;;
+    *) echo "error: herdr relaunch path must be an absolute recorded worktree" >&2; return 1 ;;
+  esac
+  case "$expected" in *$'\n'*|*$'\r'*|*$'\t'*) echo "error: herdr relaunch path contains unsupported control whitespace" >&2; return 1 ;; esac
+  [ -d "$expected" ] || { echo "error: herdr relaunch path '$expected' is unavailable" >&2; return 1; }
+  expected_real=$(CDPATH='' cd -- "$expected" 2>/dev/null && pwd -P) || return 1
+  [ "$(fm_backend_herdr_recovery_agent_state "$target")" = dead ] || {
+    echo "error: herdr endpoint is not positively agent-free; refusing to restore its relaunch path" >&2
+    return 1
+  }
+  fm_backend_herdr_parse_target "$target" || return 1
+  shell_pid=$(fm_backend_herdr_pane_idle_shell_pid "$FM_BACKEND_HERDR_SESSION" "$FM_BACKEND_HERDR_PANE") || {
+    echo "error: herdr endpoint does not hold one provably idle shell; refusing to restore its relaunch path" >&2
+    return 1
+  }
+  current=$(fm_backend_herdr_current_path "$target" || true)
+  current_real=
+  [ -z "$current" ] || current_real=$(CDPATH='' cd -- "$current" 2>/dev/null && pwd -P) || current_real=
+  if [ "$current_real" = "$expected_real" ]; then
+    return 0
+  fi
+
+  quoted=${expected_real//\'/\'"\'"\'}
+  command="cd -- '$quoted'"
+  fm_backend_herdr_parse_target "$target" || return 1
+  fm_backend_herdr_cli "$FM_BACKEND_HERDR_SESSION" pane send-text "$FM_BACKEND_HERDR_PANE" "$command" >/dev/null 2>&1 || return 1
+  [ "$(fm_backend_herdr_recovery_agent_state "$target")" = dead ] || {
+    echo "error: herdr endpoint agent state changed before relaunch path submission; refusing to submit" >&2
+    return 1
+  }
+  fm_backend_herdr_parse_target "$target" || return 1
+  resampled=$(fm_backend_herdr_pane_idle_shell_pid "$FM_BACKEND_HERDR_SESSION" "$FM_BACKEND_HERDR_PANE") || return 1
+  [ "$resampled" = "$shell_pid" ] || {
+    echo "error: herdr endpoint shell identity changed before relaunch path submission; refusing to submit" >&2
+    return 1
+  }
+  fm_backend_herdr_cli "$FM_BACKEND_HERDR_SESSION" pane send-keys "$FM_BACKEND_HERDR_PANE" enter >/dev/null 2>&1 || return 1
+  while [ "$attempt" -lt "$max_attempts" ]; do
+    current=$(fm_backend_herdr_current_path "$target" || true)
+    current_real=
+    [ -z "$current" ] || current_real=$(CDPATH='' cd -- "$current" 2>/dev/null && pwd -P) || current_real=
+    if [ "$current_real" = "$expected_real" ] \
+       && [ "$(fm_backend_herdr_recovery_agent_state "$target")" = dead ]; then
+      fm_backend_herdr_parse_target "$target" || return 1
+      resampled=$(fm_backend_herdr_pane_idle_shell_pid "$FM_BACKEND_HERDR_SESSION" "$FM_BACKEND_HERDR_PANE") || return 1
+      [ "$resampled" = "$shell_pid" ] || return 1
+      return 0
+    fi
+    attempt=$((attempt + 1))
+    [ "$attempt" -ge "$max_attempts" ] || sleep 0.1
+  done
+  echo "error: herdr endpoint did not converge to its exact recorded worktree '$expected_real'" >&2
+  return 1
 }
 
 # fm_backend_herdr_send_text_line: send one line of TEXT then submit,

--- a/bin/backends/herdr.sh
+++ b/bin/backends/herdr.sh
@@ -2609,6 +2609,15 @@ fm_backend_herdr_current_path() {  # <target>
 # to converge to the physical recorded path while the endpoint remains
 # positively agent-free and owned by the same shell pid. Repeated calls are a
 # verified no-op once the path already matches.
+fm_backend_herdr_clear_idle_shell_input() {  # <target> <shell-pid>
+  local target=$1 shell_pid=$2 resampled
+  [ "$(fm_backend_herdr_recovery_agent_state "$target")" = dead ] || return 1
+  fm_backend_herdr_parse_target "$target" || return 1
+  resampled=$(fm_backend_herdr_pane_idle_shell_pid "$FM_BACKEND_HERDR_SESSION" "$FM_BACKEND_HERDR_PANE") || return 1
+  [ "$resampled" = "$shell_pid" ] || return 1
+  fm_backend_herdr_cli "$FM_BACKEND_HERDR_SESSION" pane send-keys "$FM_BACKEND_HERDR_PANE" ctrl+c >/dev/null 2>&1
+}
+
 fm_backend_herdr_prepare_relaunch_path() {  # <target> <validated-worktree>
   local target=$1 expected=$2 expected_real current current_real shell_pid resampled command quoted
   local attempt=0 max_attempts=${FM_BACKEND_HERDR_RELAUNCH_PATH_POLLS:-20}
@@ -2635,21 +2644,49 @@ fm_backend_herdr_prepare_relaunch_path() {  # <target> <validated-worktree>
     return 0
   fi
 
-  quoted=${expected_real//\'/\'"\'"\'}
-  command="cd -- '$quoted'"
-  fm_backend_herdr_parse_target "$target" || return 1
-  fm_backend_herdr_cli "$FM_BACKEND_HERDR_SESSION" pane send-text "$FM_BACKEND_HERDR_PANE" "$command" >/dev/null 2>&1 || return 1
+  fm_backend_herdr_clear_idle_shell_input "$target" "$shell_pid" || {
+    echo "error: herdr endpoint changed before its shell input could be cleared" >&2
+    return 1
+  }
   [ "$(fm_backend_herdr_recovery_agent_state "$target")" = dead ] || {
-    echo "error: herdr endpoint agent state changed before relaunch path submission; refusing to submit" >&2
+    echo "error: herdr endpoint agent state changed after clearing shell input" >&2
     return 1
   }
   fm_backend_herdr_parse_target "$target" || return 1
   resampled=$(fm_backend_herdr_pane_idle_shell_pid "$FM_BACKEND_HERDR_SESSION" "$FM_BACKEND_HERDR_PANE") || return 1
   [ "$resampled" = "$shell_pid" ] || {
-    echo "error: herdr endpoint shell identity changed before relaunch path submission; refusing to submit" >&2
+    echo "error: herdr endpoint shell identity changed after clearing shell input" >&2
     return 1
   }
-  fm_backend_herdr_cli "$FM_BACKEND_HERDR_SESSION" pane send-keys "$FM_BACKEND_HERDR_PANE" enter >/dev/null 2>&1 || return 1
+
+  quoted=${expected_real//\'/\'"\'"\'}
+  command="cd -- '$quoted'"
+  fm_backend_herdr_cli "$FM_BACKEND_HERDR_SESSION" pane send-text "$FM_BACKEND_HERDR_PANE" "$command" >/dev/null 2>&1 || {
+    fm_backend_herdr_clear_idle_shell_input "$target" "$shell_pid" >/dev/null 2>&1 || true
+    return 1
+  }
+  [ "$(fm_backend_herdr_recovery_agent_state "$target")" = dead ] || {
+    echo "error: herdr endpoint agent state changed before relaunch path submission; refusing to submit" >&2
+    fm_backend_herdr_clear_idle_shell_input "$target" "$shell_pid" >/dev/null 2>&1 || true
+    return 1
+  }
+  fm_backend_herdr_parse_target "$target" || {
+    fm_backend_herdr_clear_idle_shell_input "$target" "$shell_pid" >/dev/null 2>&1 || true
+    return 1
+  }
+  resampled=$(fm_backend_herdr_pane_idle_shell_pid "$FM_BACKEND_HERDR_SESSION" "$FM_BACKEND_HERDR_PANE") || {
+    fm_backend_herdr_clear_idle_shell_input "$target" "$shell_pid" >/dev/null 2>&1 || true
+    return 1
+  }
+  [ "$resampled" = "$shell_pid" ] || {
+    echo "error: herdr endpoint shell identity changed before relaunch path submission; refusing to submit" >&2
+    fm_backend_herdr_clear_idle_shell_input "$target" "$shell_pid" >/dev/null 2>&1 || true
+    return 1
+  }
+  fm_backend_herdr_cli "$FM_BACKEND_HERDR_SESSION" pane send-keys "$FM_BACKEND_HERDR_PANE" enter >/dev/null 2>&1 || {
+    fm_backend_herdr_clear_idle_shell_input "$target" "$shell_pid" >/dev/null 2>&1 || true
+    return 1
+  }
   while [ "$attempt" -lt "$max_attempts" ]; do
     current=$(fm_backend_herdr_current_path "$target" || true)
     current_real=

--- a/bin/backends/herdr.sh
+++ b/bin/backends/herdr.sh
@@ -2017,6 +2017,116 @@ fm_backend_herdr_agent_alive() {  # <target>
   esac
 }
 
+# fm_backend_herdr_relaunch_candidate_create creates a fresh, unpublished task
+# endpoint in one exact recorded workspace and starts its shell in the already
+# validated worktree. It never looks up, adopts, renames, or closes an existing
+# task endpoint. Complete response-derived identities plus a matching pane read
+# are required before cleanup authority is exposed to the caller.
+fm_backend_herdr_relaunch_candidate_create() {  # <session> <workspace-id> <label> <validated-worktree>
+  local session=$1 workspace_id=$2 label=$3 expected=$4 expected_real out pane
+  FM_BACKEND_HERDR_RELAUNCH_CANDIDATE_TAB_ID=""
+  FM_BACKEND_HERDR_RELAUNCH_CANDIDATE_PANE_ID=""
+  FM_BACKEND_HERDR_RELAUNCH_CANDIDATE_CLEANUP_SAFE=0
+  case "$expected" in
+    /*) ;;
+    *) echo "error: herdr replacement worktree must be absolute" >&2; return 1 ;;
+  esac
+  case "$expected" in *$'\n'*|*$'\r'*|*$'\t'*) echo "error: herdr replacement worktree contains unsupported control whitespace" >&2; return 1 ;; esac
+  case "$label" in ''|*[!A-Za-z0-9._-]*) echo "error: herdr replacement label is invalid" >&2; return 1 ;; esac
+  if ! fm_backend_endpoint_atom_valid "$session" \
+     || ! fm_backend_endpoint_atom_valid "$workspace_id"; then
+    echo "error: herdr replacement session or workspace identity is invalid" >&2
+    return 1
+  fi
+  expected_real=$(CDPATH='' cd -- "$expected" 2>/dev/null && pwd -P) || return 1
+  fm_backend_herdr_server_ensure "$session" || return 1
+  out=$(fm_backend_herdr_cli "$session" tab create \
+    --workspace "$workspace_id" --cwd "$expected_real" --label "$label" --no-focus 2>/dev/null) || {
+    echo "error: herdr replacement endpoint creation failed ambiguously" >&2
+    return 1
+  }
+  FM_BACKEND_HERDR_RELAUNCH_CANDIDATE_TAB_ID=$(printf '%s' "$out" | jq -r '.result.tab.tab_id // empty' 2>/dev/null)
+  FM_BACKEND_HERDR_RELAUNCH_CANDIDATE_PANE_ID=$(printf '%s' "$out" | jq -r '.result.root_pane.pane_id // empty' 2>/dev/null)
+  if [ -z "$FM_BACKEND_HERDR_RELAUNCH_CANDIDATE_TAB_ID" ] \
+     || [ -z "$FM_BACKEND_HERDR_RELAUNCH_CANDIDATE_PANE_ID" ] \
+     || ! fm_backend_endpoint_atom_valid "${FM_BACKEND_HERDR_RELAUNCH_CANDIDATE_TAB_ID//:/_}" \
+     || ! fm_backend_endpoint_atom_valid "${FM_BACKEND_HERDR_RELAUNCH_CANDIDATE_PANE_ID//:/_}"; then
+    echo "error: herdr replacement endpoint returned incomplete or invalid identities" >&2
+    return 1
+  fi
+  if ! printf '%s' "$out" | jq -e \
+      --arg workspace "$workspace_id" \
+      --arg tab "$FM_BACKEND_HERDR_RELAUNCH_CANDIDATE_TAB_ID" \
+      --arg pane "$FM_BACKEND_HERDR_RELAUNCH_CANDIDATE_PANE_ID" '
+        .result.type == "tab_created"
+        and .result.tab.tab_id == $tab
+        and .result.tab.workspace_id == $workspace
+        and .result.root_pane.pane_id == $pane
+        and .result.root_pane.workspace_id == $workspace
+        and .result.root_pane.tab_id == $tab
+      ' >/dev/null 2>&1; then
+    echo "error: herdr replacement endpoint returned contradictory identities" >&2
+    return 1
+  fi
+  # shellcheck disable=SC2034  # caller consumes the response-derived cleanup authority
+  FM_BACKEND_HERDR_RELAUNCH_CANDIDATE_CLEANUP_SAFE=1
+  pane=$(fm_backend_herdr_cli "$session" pane get "$FM_BACKEND_HERDR_RELAUNCH_CANDIDATE_PANE_ID" 2>/dev/null) || return 1
+  if ! printf '%s' "$pane" | jq -e \
+      --arg workspace "$workspace_id" \
+      --arg tab "$FM_BACKEND_HERDR_RELAUNCH_CANDIDATE_TAB_ID" \
+      --arg pane "$FM_BACKEND_HERDR_RELAUNCH_CANDIDATE_PANE_ID" \
+      --arg cwd "$expected_real" '
+        .result.type == "pane_info"
+        and .result.pane.workspace_id == $workspace
+        and .result.pane.tab_id == $tab
+        and .result.pane.pane_id == $pane
+        and .result.pane.foreground_cwd == $cwd
+      ' >/dev/null 2>&1; then
+    echo "error: herdr replacement endpoint did not verify in its recorded workspace and worktree" >&2
+    return 1
+  fi
+  [ "$(fm_backend_herdr_pane_agent_state "$session" "$FM_BACKEND_HERDR_RELAUNCH_CANDIDATE_PANE_ID")" = no-agent ] || {
+    echo "error: herdr replacement endpoint acquired an agent before launch ownership was established" >&2
+    return 1
+  }
+  return 0
+}
+
+fm_backend_herdr_relaunch_candidate_matches() {  # <session> <workspace-id> <tab-id> <pane-id>
+  local session=$1 workspace_id=$2 tab_id=$3 pane_id=$4 out
+  out=$(fm_backend_herdr_cli "$session" pane get "$pane_id" 2>/dev/null) || return 1
+  printf '%s' "$out" | jq -e \
+    --arg workspace "$workspace_id" --arg tab "$tab_id" --arg pane "$pane_id" '
+      .result.type == "pane_info"
+      and .result.pane.workspace_id == $workspace
+      and .result.pane.tab_id == $tab
+      and .result.pane.pane_id == $pane
+    ' >/dev/null 2>&1
+}
+
+fm_backend_herdr_relaunch_candidate_cleanup() {  # <session> <workspace-id> <tab-id> <pane-id>
+  local session=$1 workspace_id=$2 tab_id=$3 pane_id=$4 presence state shell_pid
+  presence=$(fm_backend_herdr_pane_presence_state "$session" "$pane_id")
+  case "$presence" in
+    dead) return 0 ;;
+    present) ;;
+    *) return 1 ;;
+  esac
+  fm_backend_herdr_relaunch_candidate_matches "$session" "$workspace_id" "$tab_id" "$pane_id" || return 1
+  state=$(fm_backend_herdr_pane_agent_state "$session" "$pane_id")
+  case "$state" in
+    dead) return 0 ;;
+    no-agent) ;;
+    live)
+      [ "$(fm_backend_herdr_recovery_agent_state "$session:$pane_id")" = dead ] || return 1
+      shell_pid=$(fm_backend_herdr_pane_idle_shell_pid "$session" "$pane_id") || return 1
+      [ -n "$shell_pid" ] || return 1
+      ;;
+    *) return 1 ;;
+  esac
+  fm_backend_herdr_explicit_close_pane_confirmed "$session" "$pane_id"
+}
+
 # fm_backend_herdr_create_task: create the task's tab (one pane) in
 # <container> ("session:workspace_id"). Herdr does NOT enforce label
 # uniqueness itself (verified: two tabs can share a label), so the duplicate

--- a/bin/backends/herdr.sh
+++ b/bin/backends/herdr.sh
@@ -1175,6 +1175,16 @@ fm_backend_herdr_pid_is_bare_shell() {  # <ps-bin> <pid>
   return 1
 }
 
+# Use the shared process-instance identity so a shell PID cannot be confused
+# with a later process that reused the same numeric PID.
+fm_backend_herdr_pid_identity() {  # <pid>
+  if ! declare -F fm_pid_identity >/dev/null 2>&1; then
+    # shellcheck source=bin/fm-wake-lib.sh
+    . "$FM_BACKEND_HERDR_ROOT/bin/fm-wake-lib.sh"
+  fi
+  fm_pid_identity "$1"
+}
+
 # fm_backend_herdr_pane_idle_shell_pid: print the shell pid of <pane-id> only
 # when the exact pane provably holds one lone idle recognized shell: pane
 # process-info agrees on the pane id, the shell pid is both the foreground
@@ -2168,6 +2178,7 @@ fm_backend_herdr_relaunch_candidate_discover() {  # <session> <workspace-id> <la
 fm_backend_herdr_relaunch_candidate_close_on_shell() {  # <session> <workspace-id> <tab-id> <pane-id> <shell-pid>
   local session=$1 workspace_id=$2 tab_id=$3 pane_id=$4 expected_pid=$5
   local info shell_pid foreground_pgid count process_pid rows stat ps_bin kill_bin watchdog result=1
+  local initial_identity current_identity resampled_pid
   ps_bin=${FM_HERDR_PS_BIN:-ps}
   kill_bin=${FM_HERDR_KILL_BIN:-kill}
   command -v "$ps_bin" >/dev/null 2>&1 || return 1
@@ -2191,6 +2202,12 @@ fm_backend_herdr_relaunch_candidate_close_on_shell() {  # <session> <workspace-i
   stat=$("$ps_bin" -p "$expected_pid" -o stat= 2>/dev/null | tr -d '[:space:]') || return 1
   case "$stat" in ''|T*) return 1 ;; esac
   fm_backend_herdr_pid_is_bare_shell "$ps_bin" "$expected_pid" || return 1
+  initial_identity=$(fm_backend_herdr_pid_identity "$expected_pid") || return 1
+  fm_backend_herdr_relaunch_candidate_matches "$session" "$workspace_id" "$tab_id" "$pane_id" || return 1
+  resampled_pid=$(fm_backend_herdr_pane_idle_shell_sample "$session" "$pane_id") || return 1
+  [ "$resampled_pid" = "$expected_pid" ] || return 1
+  current_identity=$(fm_backend_herdr_pid_identity "$expected_pid") || return 1
+  [ "$current_identity" = "$initial_identity" ] || return 1
   "$kill_bin" -STOP "$expected_pid" 2>/dev/null || return 1
   (
     sleep "${FM_BACKEND_HERDR_RELAUNCH_CONT_WATCHDOG_SECS:-5}"
@@ -2960,6 +2977,7 @@ fm_backend_herdr_run_on_prepared_shell() {  # <target> <shell-pid> <validated-wo
   local target=$1 expected_pid=$2 expected=$3 command_text=$4
   local expected_real current current_real info shell_pid foreground_pgid count process_pid
   local rows stat ps_bin kill_bin watchdog result=1
+  local initial_identity current_identity resampled_pid
   [ -n "$expected_pid" ] || return 1
   expected_real=$(CDPATH='' cd -- "$expected" 2>/dev/null && pwd -P) || return 1
   fm_backend_herdr_parse_target "$target" || return 1
@@ -2989,6 +3007,16 @@ fm_backend_herdr_run_on_prepared_shell() {  # <target> <shell-pid> <validated-wo
   current_real=
   [ -z "$current" ] || current_real=$(CDPATH='' cd -- "$current" 2>/dev/null && pwd -P) || current_real=
   [ "$current_real" = "$expected_real" ] || return 1
+  initial_identity=$(fm_backend_herdr_pid_identity "$expected_pid") || return 1
+  resampled_pid=$(fm_backend_herdr_pane_idle_shell_sample \
+    "$FM_BACKEND_HERDR_SESSION" "$FM_BACKEND_HERDR_PANE") || return 1
+  [ "$resampled_pid" = "$expected_pid" ] || return 1
+  current=$(fm_backend_herdr_current_path "$target" || true)
+  current_real=
+  [ -z "$current" ] || current_real=$(CDPATH='' cd -- "$current" 2>/dev/null && pwd -P) || current_real=
+  [ "$current_real" = "$expected_real" ] || return 1
+  current_identity=$(fm_backend_herdr_pid_identity "$expected_pid") || return 1
+  [ "$current_identity" = "$initial_identity" ] || return 1
   "$kill_bin" -STOP "$expected_pid" 2>/dev/null || return 1
   (
     sleep "${FM_BACKEND_HERDR_RELAUNCH_CONT_WATCHDOG_SECS:-5}"

--- a/bin/backends/herdr.sh
+++ b/bin/backends/herdr.sh
@@ -2625,6 +2625,7 @@ fm_backend_herdr_clear_idle_shell_input() {  # <target> <shell-pid>
 fm_backend_herdr_prepare_relaunch_path_serialized() {  # <target> <validated-worktree>
   local target=$1 expected=$2 expected_real current current_real shell_pid resampled command quoted
   local attempt=0 max_attempts=${FM_BACKEND_HERDR_RELAUNCH_PATH_POLLS:-20}
+  FM_BACKEND_HERDR_RELAUNCH_SHELL_PID=
   case "$expected" in
     /*) ;;
     *) echo "error: herdr relaunch path must be an absolute recorded worktree" >&2; return 1 ;;
@@ -2659,6 +2660,7 @@ fm_backend_herdr_prepare_relaunch_path_serialized() {  # <target> <validated-wor
   current_real=
   [ -z "$current" ] || current_real=$(CDPATH='' cd -- "$current" 2>/dev/null && pwd -P) || current_real=
   if [ "$current_real" = "$expected_real" ]; then
+    FM_BACKEND_HERDR_RELAUNCH_SHELL_PID=$shell_pid
     return 0
   fi
 
@@ -2699,6 +2701,7 @@ fm_backend_herdr_prepare_relaunch_path_serialized() {  # <target> <validated-wor
       fm_backend_herdr_parse_target "$target" || return 1
       resampled=$(fm_backend_herdr_pane_idle_shell_pid "$FM_BACKEND_HERDR_SESSION" "$FM_BACKEND_HERDR_PANE") || return 1
       [ "$resampled" = "$shell_pid" ] || return 1
+      FM_BACKEND_HERDR_RELAUNCH_SHELL_PID=$shell_pid
       return 0
     fi
     attempt=$((attempt + 1))
@@ -2706,6 +2709,28 @@ fm_backend_herdr_prepare_relaunch_path_serialized() {  # <target> <validated-wor
   done
   echo "error: herdr endpoint did not converge to its exact recorded worktree '$expected_real'" >&2
   return 1
+}
+
+fm_backend_herdr_relaunch_prepared_shell_pid() {
+  printf '%s' "${FM_BACKEND_HERDR_RELAUNCH_SHELL_PID:-}"
+}
+
+# Revalidate the exact shell and cwd established by preparation immediately
+# before each subsequent relaunch input boundary. The session mutation lock
+# excludes other Firstmate operations, while this check also catches an
+# uncoordinated foreground-owner change before input is sent.
+fm_backend_herdr_relaunch_shell_owned() {  # <target> <shell-pid> <validated-worktree>
+  local target=$1 expected_pid=$2 expected=$3 expected_real current current_real resampled
+  [ -n "$expected_pid" ] || return 1
+  expected_real=$(CDPATH='' cd -- "$expected" 2>/dev/null && pwd -P) || return 1
+  [ "$(fm_backend_herdr_recovery_agent_state "$target")" = dead ] || return 1
+  fm_backend_herdr_parse_target "$target" || return 1
+  resampled=$(fm_backend_herdr_pane_idle_shell_pid "$FM_BACKEND_HERDR_SESSION" "$FM_BACKEND_HERDR_PANE") || return 1
+  [ "$resampled" = "$expected_pid" ] || return 1
+  current=$(fm_backend_herdr_current_path "$target" || true)
+  [ -n "$current" ] || return 1
+  current_real=$(CDPATH='' cd -- "$current" 2>/dev/null && pwd -P) || return 1
+  [ "$current_real" = "$expected_real" ]
 }
 
 fm_backend_herdr_prepare_relaunch_path() {  # <target> <validated-worktree>

--- a/bin/backends/herdr.sh
+++ b/bin/backends/herdr.sh
@@ -2600,9 +2600,10 @@ fm_backend_herdr_current_path() {  # <target>
     | jq -r '.result.pane.foreground_cwd // empty' 2>/dev/null
 }
 
-# fm_backend_herdr_prepare_relaunch_path: prepare an agent-free endpoint shell
-# for the exact recorded worktree already validated by the launch caller.
-# It first cancels any pending input while the same idle shell owns the pane,
+# fm_backend_herdr_prepare_relaunch_path: serialize shell preparation with every
+# other Firstmate mutation in the same Herdr session, then prepare an agent-free
+# endpoint shell for the exact recorded worktree already validated by the launch
+# caller. It first cancels any pending input while the same idle shell owns the pane,
 # including when the cwd already matches. Herdr's atomic `pane run` executes
 # `cd` non-persistently, so a mismatched cwd uses the interactive shell's
 # literal-input path and submits only after a second exact shell-owner check.
@@ -2621,7 +2622,7 @@ fm_backend_herdr_clear_idle_shell_input() {  # <target> <shell-pid>
   fm_backend_herdr_cli "$FM_BACKEND_HERDR_SESSION" pane send-keys "$FM_BACKEND_HERDR_PANE" ctrl+c >/dev/null 2>&1
 }
 
-fm_backend_herdr_prepare_relaunch_path() {  # <target> <validated-worktree>
+fm_backend_herdr_prepare_relaunch_path_serialized() {  # <target> <validated-worktree>
   local target=$1 expected=$2 expected_real current current_real shell_pid resampled command quoted
   local attempt=0 max_attempts=${FM_BACKEND_HERDR_RELAUNCH_PATH_POLLS:-20}
   case "$expected" in
@@ -2705,6 +2706,32 @@ fm_backend_herdr_prepare_relaunch_path() {  # <target> <validated-worktree>
   done
   echo "error: herdr endpoint did not converge to its exact recorded worktree '$expected_real'" >&2
   return 1
+}
+
+fm_backend_herdr_prepare_relaunch_path() {  # <target> <validated-worktree>
+  local target=$1 expected=$2 session lock_path attempt=0 result
+  fm_backend_herdr_parse_target "$target" || return 1
+  session=$FM_BACKEND_HERDR_SESSION
+  if ! declare -F fm_lock_try_acquire >/dev/null 2>&1; then
+    # shellcheck source=bin/fm-wake-lib.sh
+    . "$FM_BACKEND_HERDR_ROOT/bin/fm-wake-lib.sh"
+  fi
+  lock_path=$(fm_backend_herdr_presentation_session_lock_path "$session") || {
+    echo "error: herdr relaunch could not resolve its session mutation lock; refusing unlocked shell input" >&2
+    return 1
+  }
+  while ! fm_lock_try_acquire "$lock_path"; do
+    attempt=$((attempt + 1))
+    [ "$attempt" -lt 50 ] || {
+      echo "error: herdr relaunch could not acquire its session mutation lock; refusing unlocked shell input" >&2
+      return 1
+    }
+    sleep 0.1
+  done
+  fm_backend_herdr_prepare_relaunch_path_serialized "$target" "$expected"
+  result=$?
+  fm_lock_release "$lock_path" || true
+  return "$result"
 }
 
 # fm_backend_herdr_send_text_line: send one line of TEXT then submit,

--- a/bin/fm-backend.sh
+++ b/bin/fm-backend.sh
@@ -900,6 +900,35 @@ fm_backend_agent_state() {  # <backend> <target>
   esac
 }
 
+# fm_backend_recovery_agent_state: lifecycle-only state strong enough to stop
+# or replace an agent. Herdr cross-checks a retained native registration against
+# the exact foreground process, while tmux's ordinary classifier already owns
+# both process sources. Unsupported backends remain unverified.
+fm_backend_recovery_agent_state() {  # <backend> <target>
+  local backend=$1 target=$2
+  fm_backend_source "$backend" || { printf 'unverified'; return 0; }
+  case "$backend" in
+    tmux) fm_backend_tmux_agent_state "$target" ;;
+    herdr) fm_backend_herdr_recovery_agent_state "$target" ;;
+    *) printf 'unverified' ;;
+  esac
+}
+
+# fm_backend_prepare_relaunch_path: backend-owned preparation after the old
+# agent is positively stopped and before the launch owner reuses its endpoint.
+# Only Herdr needs repair because its restored shell can drift after an agent
+# exits; tmux keeps its existing strict path refusal unchanged.
+fm_backend_prepare_relaunch_path() {  # <backend> <target> <validated-worktree>
+  local backend=$1
+  shift
+  fm_backend_source "$backend" || return 1
+  case "$backend" in
+    herdr) fm_backend_herdr_prepare_relaunch_path "$@" ;;
+    tmux) return 0 ;;
+    *) echo "error: backend '$backend' has no verified relaunch-path preparation" >&2; return 1 ;;
+  esac
+}
+
 # Backward-compatible three-state view for existing callers. An
 # authoritatively missing endpoint is confidently not a live agent, while every
 # ambiguous, unreadable, or unverified result stays unknown.

--- a/bin/fm-control.sh
+++ b/bin/fm-control.sh
@@ -316,7 +316,7 @@ fm_backend_validate "$BACKEND" || exit 1
 # --- shared helpers ---------------------------------------------------------
 
 agent_state() {
-  fm_backend_agent_state "$BACKEND" "$T"
+  fm_backend_recovery_agent_state "$BACKEND" "$T"
 }
 
 busy_verdict() {
@@ -690,7 +690,7 @@ resolve_relaunch_profile() {
 # refuses outright when any of it cannot be established.
 CHECKPOINT_LINES=()
 safe_checkpoint() {
-  local wt_real wt_top wt_top_real head head_ref head_ref_status status_output dirty children marker child_meta
+  local wt_real wt_top wt_top_real project project_real head head_ref head_ref_status status_output dirty children marker child_meta
   CHECKPOINT_LINES=()
   [ -n "$WT" ] || die "task $ID has no recorded worktree; refusing to relaunch without a recorded local copy to preserve"
   [ -d "$WT" ] || die "task $ID's recorded worktree $WT is missing; refusing to relaunch and lose track of its work"
@@ -700,6 +700,15 @@ safe_checkpoint() {
   wt_top_real=$(cd "$wt_top" 2>/dev/null && pwd -P) || wt_top_real=$wt_top
   [ "$wt_real" = "$wt_top_real" ] \
     || die "task $ID's recorded worktree $WT is not a worktree root (root is $wt_top); refusing to relaunch against an ambiguous checkout"
+  if [ "$KIND" != secondmate ]; then
+    project=$(fm_meta_get "$META" project)
+    [ -n "$project" ] && [ -d "$project" ] \
+      || die "task $ID's recorded project '${project:-none}' is unavailable; refusing to relaunch without proving its isolated worktree"
+    project_real=$(CDPATH='' cd -- "$project" 2>/dev/null && pwd -P) \
+      || die "task $ID's recorded project $project cannot be resolved"
+    [ "$wt_real" != "$project_real" ] \
+      || die "task $ID's recorded worktree is the primary project checkout; refusing to relaunch an agent there"
+  fi
   if head=$(git -C "$WT" rev-parse --verify HEAD 2>/dev/null); then
     :
   elif head_ref=$(git -C "$WT" symbolic-ref -q HEAD 2>/dev/null); then
@@ -824,6 +833,9 @@ do_relaunch() {
   journal_write stopping "${CHECKPOINT_LINES[@]}" "$note_line"
   exit_result=$(do_exit)
   journal_write exited "${CHECKPOINT_LINES[@]}" "$note_line" "exit_result=$exit_result"
+
+  fm_backend_prepare_relaunch_path "$BACKEND" "$T" "$WT" \
+    || die "task $ID's agent stopped, but its endpoint could not be restored to the exact recorded worktree; refusing replacement launch"
 
   # The launch owner (fm-spawn --relaunch) clears the previous incarnation's
   # per-task harness wiring before arming the new one, so nothing to do here.

--- a/bin/fm-control.sh
+++ b/bin/fm-control.sh
@@ -834,11 +834,11 @@ do_relaunch() {
   exit_result=$(do_exit)
   journal_write exited "${CHECKPOINT_LINES[@]}" "$note_line" "exit_result=$exit_result"
 
-  fm_backend_prepare_relaunch_path "$BACKEND" "$T" "$WT" \
-    || die "task $ID's agent stopped, but its endpoint could not be restored to the exact recorded worktree; refusing replacement launch"
-
-  # The launch owner (fm-spawn --relaunch) clears the previous incarnation's
-  # per-task harness wiring before arming the new one, so nothing to do here.
+  # The launch owner holds Herdr's session mutation lock continuously from
+  # endpoint preparation through replacement command submission. Preparing here
+  # would create an unlocked gap before that transaction begins.
+  # It also clears the previous incarnation's per-task harness wiring before
+  # arming the new one, so nothing to do here.
   RELAUNCH_TX="${BASHPID:-$$}.$(date -u +%Y%m%dT%H%M%SZ).$RANDOM"
   journal_write launching "${CHECKPOINT_LINES[@]}" "$note_line" "relaunch_tx=$RELAUNCH_TX"
   spawn_args=("$ID" --relaunch --harness "$TARGET_HARNESS")

--- a/bin/fm-control.sh
+++ b/bin/fm-control.sh
@@ -31,10 +31,11 @@
 #              busy, then submits the harness's exit command. Postcondition:
 #              the backend's recovery-grade classifier reports the agent gone.
 #              Already-stopped is success (idempotent).
-#   relaunch   Transactionally replace the running agent with a new one, in the
-#              SAME endpoint and SAME worktree, on the same or a newly chosen
-#              harness/model/effort - so switching harness is one ordinary use
-#              of this verb. An explicit `default` model or effort clears that
+#   relaunch   Transactionally replace the running agent in the SAME worktree,
+#              on the same or a newly chosen harness/model/effort. Tmux reuses
+#              its endpoint; Herdr publishes a fresh exact-workspace endpoint
+#              only after replacement launch success. Switching harness remains
+#              one ordinary use of this verb. An explicit `default` model or effort clears that
 #              axis for the replacement. With no explicit axis, a secondmate
 #              re-resolves its durable config/secondmate-harness pin (harness
 #              plus its optional model and effort tokens) exactly as any other
@@ -847,6 +848,10 @@ do_relaunch() {
   if FM_CONTROL_RELAUNCH_TX="$RELAUNCH_TX" \
       "$SCRIPT_DIR/fm-spawn.sh" "${spawn_args[@]}" >/dev/null; then
     RELAUNCH_META_PUBLISHED=1
+    fm_backend_validate_task_endpoint "$META" "$ID" \
+      || die "the replacement for $ID launched but its published endpoint binding is invalid"
+    BACKEND=$FM_BACKEND_VALIDATED_BACKEND
+    T=$FM_BACKEND_VALIDATED_TARGET
   else
     [ "$(fm_meta_get "$META" control_relaunch_tx)" != "$RELAUNCH_TX" ] \
       || RELAUNCH_META_PUBLISHED=1

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -29,7 +29,7 @@
 #   fresh endpoint in the recorded endpoint's exact workspace, keeps it
 #   unpublished while launch is proved, then atomically advances the task
 #   binding; any prepublication failure leaves the old endpoint and record
-#   untouched and retires only a response-identified agent-free candidate. It
+#   untouched and retires only an exactly identified agent-free candidate. It
 #   is the launch half of the control plane (bin/fm-control.sh relaunch), which
 #   owns the checkpoint, progress note, old-agent stop, and transaction; call
 #   fm-control rather than this flag directly unless deliberately re-launching
@@ -749,6 +749,7 @@ HERDR_RELAUNCH_CANDIDATE_CLEANUP=0
 HERDR_RELAUNCH_CANDIDATE_RECORD=
 HERDR_RELAUNCH_CANDIDATE_TAB_ID=
 HERDR_RELAUNCH_CANDIDATE_PANE_ID=
+HERDR_RELAUNCH_RECOVERED_STATE=
 HERDR_RELAUNCH_OLD_WORKSPACE_ID=
 HERDR_RELAUNCH_OLD_TAB_ID=
 HERDR_RELAUNCH_OLD_PANE_ID=
@@ -1120,12 +1121,74 @@ herdr_relaunch_candidate_record_write() {  # <phase> [extra-line]...
   } > "$tmp" && mv -f "$tmp" "$HERDR_RELAUNCH_CANDIDATE_RECORD"
 }
 
-# Reconcile only a previously journaled exact candidate for this same task and
-# old binding. A live or ambiguous candidate refuses a duplicate launch; an
-# agent-free or already-gone candidate is idempotently retired before a fresh
-# transaction starts. No workspace or endpoint enumeration is permitted.
+herdr_relaunch_candidate_adopt_live() {
+  local current current_real expected_real busy_gen spawn_gen tmp old_retirement=retained
+  [ "$HERDR_RELAUNCH_RECOVERED_STATE" = alive ] || return 1
+  fm_backend_herdr_relaunch_candidate_matches \
+    "$HERDR_SES" "$HERDR_WORKSPACE_ID" \
+    "$HERDR_RELAUNCH_CANDIDATE_TAB_ID" "$HERDR_RELAUNCH_CANDIDATE_PANE_ID" || return 1
+  [ "$(fm_backend_herdr_recovery_agent_state "$HERDR_SES:$HERDR_RELAUNCH_CANDIDATE_PANE_ID")" = alive ] || return 1
+  current=$(fm_backend_herdr_current_path "$HERDR_SES:$HERDR_RELAUNCH_CANDIDATE_PANE_ID" || true)
+  current_real=$(CDPATH='' cd -- "$current" 2>/dev/null && pwd -P) || return 1
+  expected_real=$(CDPATH='' cd -- "$WT" 2>/dev/null && pwd -P) || return 1
+  [ "$current_real" = "$expected_real" ] || return 1
+  busy_gen=$(fm_busy_current_gen "$STATE" "$ID" 2>/dev/null || true)
+  spawn_gen="s$(date +%s).${BASHPID:-$$}.$RANDOM"
+  tmp="$STATE/.$ID.meta.relaunch-adopt.${BASHPID:-$$}"
+  {
+    echo "window=$HERDR_SES:$HERDR_RELAUNCH_CANDIDATE_PANE_ID"
+    echo "endpoint_task_id=$ID"
+    echo "worktree=$WT"
+    echo "project=$PROJ_ABS"
+    echo "harness=$HARNESS"
+    echo "kind=$KIND"
+    [ -z "$MODE" ] || echo "mode=$MODE"
+    [ -z "$YOLO" ] || echo "yolo=$YOLO"
+    echo "tasktmp=/tmp/fm-$ID"
+    echo "model=${MODEL:-default}"
+    echo "effort=${EFFORT:-default}"
+    [ -z "$busy_gen" ] || echo "busy_gen=$busy_gen"
+    echo "spawn_gen=$spawn_gen"
+    echo "backend=herdr"
+    echo "herdr_session=$HERDR_SES"
+    echo "herdr_workspace_id=$HERDR_WORKSPACE_ID"
+    echo "herdr_tab_id=$HERDR_RELAUNCH_CANDIDATE_TAB_ID"
+    echo "herdr_pane_id=$HERDR_RELAUNCH_CANDIDATE_PANE_ID"
+    awk -F= '
+      BEGIN {
+        split("window endpoint_task_id worktree project harness kind mode yolo tasktmp model effort busy_gen spawn_gen backend herdr_session herdr_workspace_id herdr_tab_id herdr_pane_id control_relaunch_tx", keys, " ")
+        for (i in keys) owned[keys[i]] = 1
+      }
+      !($1 in owned)
+    ' "$RELAUNCH_META"
+    [ -z "${FM_CONTROL_RELAUNCH_TX:-}" ] || echo "control_relaunch_tx=$FM_CONTROL_RELAUNCH_TX"
+  } > "$tmp" || { rm -f "$tmp"; return 1; }
+  fm_backlog_atomic_transition publish "$tmp" "$STATE/$ID.meta" "task record" "$STATE" || {
+    rm -f "$tmp"
+    return 1
+  }
+  herdr_relaunch_candidate_record_write published "candidate_state=adopted-alive" || true
+  if [ -n "${HERDR_PRESENTATION_JOURNAL:-}" ] \
+     && { [ -e "$HERDR_PRESENTATION_JOURNAL" ] || [ -L "$HERDR_PRESENTATION_JOURNAL" ]; }; then
+    fm_backend_herdr_projection_journal_replace_endpoint \
+      "$HERDR_PRESENTATION_JOURNAL" "$ID" \
+      "$HERDR_RELAUNCH_OLD_TAB_ID" "$HERDR_RELAUNCH_OLD_PANE_ID" \
+      "$HERDR_RELAUNCH_CANDIDATE_TAB_ID" "$HERDR_RELAUNCH_CANDIDATE_PANE_ID" || true
+  fi
+  if fm_backend_herdr_relaunch_candidate_cleanup \
+      "$HERDR_SES" "$HERDR_RELAUNCH_OLD_WORKSPACE_ID" \
+      "$HERDR_RELAUNCH_OLD_TAB_ID" "$HERDR_RELAUNCH_OLD_PANE_ID"; then
+    old_retirement=retired
+  fi
+  herdr_relaunch_candidate_record_write published \
+    "candidate_state=adopted-alive" "old_endpoint=$old_retirement" || true
+  spawn_herdr_presentation_order_lock_release
+  echo "spawned $ID harness=$HARNESS kind=$KIND mode=$MODE yolo=$YOLO window=$HERDR_SES:$HERDR_RELAUNCH_CANDIDATE_PANE_ID worktree=$WT"
+  exit 0
+}
+
 herdr_relaunch_candidate_reconcile_prior() {
-  local phase task session workspace old_tab old_pane worktree candidate_tab candidate_pane
+  local phase task session workspace old_tab old_pane worktree candidate_tab candidate_pane candidate_label state current current_real expected_real discover_status replacement_harness replacement_model replacement_effort
   [ ! -e "$HERDR_RELAUNCH_CANDIDATE_RECORD" ] \
     && [ ! -L "$HERDR_RELAUNCH_CANDIDATE_RECORD" ] && return 0
   [ -f "$HERDR_RELAUNCH_CANDIDATE_RECORD" ] \
@@ -1139,6 +1202,10 @@ herdr_relaunch_candidate_reconcile_prior() {
   worktree=$(fm_backend_meta_exact_value "$HERDR_RELAUNCH_CANDIDATE_RECORD" worktree) || return 1
   candidate_tab=$(fm_backend_meta_exact_value "$HERDR_RELAUNCH_CANDIDATE_RECORD" candidate_tab) || candidate_tab=
   candidate_pane=$(fm_backend_meta_exact_value "$HERDR_RELAUNCH_CANDIDATE_RECORD" candidate_pane) || candidate_pane=
+  candidate_label=$(fm_backend_meta_exact_value "$HERDR_RELAUNCH_CANDIDATE_RECORD" candidate_label) || candidate_label=
+  replacement_harness=$(fm_backend_meta_exact_value "$HERDR_RELAUNCH_CANDIDATE_RECORD" replacement_harness) || return 1
+  replacement_model=$(fm_backend_meta_exact_value "$HERDR_RELAUNCH_CANDIDATE_RECORD" replacement_model) || return 1
+  replacement_effort=$(fm_backend_meta_exact_value "$HERDR_RELAUNCH_CANDIDATE_RECORD" replacement_effort) || return 1
   [ "$task" = "$ID" ] && [ "$session" = "$HERDR_SES" ] \
     && [ "$workspace" = "$HERDR_WORKSPACE_ID" ] && [ "$worktree" = "$WT" ] || return 1
   case "$phase" in
@@ -1149,8 +1216,29 @@ herdr_relaunch_candidate_reconcile_prior() {
       return 0
       ;;
     creating|created|creation-failed|quarantined)
-      [ -n "$candidate_tab" ] && [ -n "$candidate_pane" ] \
-        && fm_backend_endpoint_atom_valid "${candidate_tab//:/_}" \
+      [ "$replacement_harness" = "$HARNESS" ] \
+        && [ "$replacement_model" = "${MODEL:-default}" ] \
+        && [ "$replacement_effort" = "${EFFORT:-default}" ] || return 1
+      [ "$old_tab" = "$HERDR_RELAUNCH_OLD_TAB_ID" ] \
+        && [ "$old_pane" = "$HERDR_RELAUNCH_OLD_PANE_ID" ] || return 1
+      if [ -z "$candidate_tab" ] || [ -z "$candidate_pane" ]; then
+        [ "$phase" = creating ] && [ -n "$candidate_label" ] || return 1
+        fm_backend_herdr_relaunch_candidate_discover \
+          "$HERDR_SES" "$HERDR_WORKSPACE_ID" "$candidate_label" "$WT"
+        discover_status=$?
+        if [ "$discover_status" -eq 2 ]; then
+          herdr_relaunch_candidate_record_write rolled-back "candidate_state=absent" || return 1
+          return 0
+        fi
+        [ "$discover_status" -eq 0 ] || return 1
+        candidate_tab=$FM_BACKEND_HERDR_RELAUNCH_CANDIDATE_TAB_ID
+        candidate_pane=$FM_BACKEND_HERDR_RELAUNCH_CANDIDATE_PANE_ID
+        HERDR_RELAUNCH_CANDIDATE_TAB_ID=$candidate_tab
+        HERDR_RELAUNCH_CANDIDATE_PANE_ID=$candidate_pane
+        herdr_relaunch_candidate_record_write created \
+          "candidate_label=$candidate_label" "candidate_state=discovered" || return 1
+      fi
+      fm_backend_endpoint_atom_valid "${candidate_tab//:/_}" \
         && fm_backend_endpoint_atom_valid "${candidate_pane//:/_}" || return 1
       HERDR_RELAUNCH_CANDIDATE_TAB_ID=$candidate_tab
       HERDR_RELAUNCH_CANDIDATE_PANE_ID=$candidate_pane
@@ -1162,8 +1250,18 @@ herdr_relaunch_candidate_reconcile_prior() {
         HERDR_RELAUNCH_CANDIDATE_PANE_ID=
         return 0
       fi
-      [ "$old_tab" = "$HERDR_RELAUNCH_OLD_TAB_ID" ] \
-        && [ "$old_pane" = "$HERDR_RELAUNCH_OLD_PANE_ID" ] || return 1
+      fm_backend_herdr_relaunch_candidate_matches \
+        "$HERDR_SES" "$HERDR_WORKSPACE_ID" "$candidate_tab" "$candidate_pane" || return 1
+      current=$(fm_backend_herdr_current_path "$HERDR_SES:$candidate_pane" || true)
+      current_real=$(CDPATH='' cd -- "$current" 2>/dev/null && pwd -P) || return 1
+      expected_real=$(CDPATH='' cd -- "$WT" 2>/dev/null && pwd -P) || return 1
+      [ "$current_real" = "$expected_real" ] || return 1
+      state=$(fm_backend_herdr_recovery_agent_state "$HERDR_SES:$candidate_pane")
+      if [ "$state" = alive ]; then
+        HERDR_RELAUNCH_RECOVERED_STATE=alive
+        return 0
+      fi
+      case "$state" in dead|missing) ;; *) return 1 ;; esac
       fm_backend_herdr_relaunch_candidate_cleanup \
         "$HERDR_SES" "$HERDR_WORKSPACE_ID" "$candidate_tab" "$candidate_pane" || return 1
       herdr_relaunch_candidate_record_write rolled-back "candidate_state=dead" || return 1
@@ -2444,6 +2542,12 @@ elif [ "$RELAUNCH" -eq 1 ]; then
     echo "error: a prior Herdr replacement candidate cannot be proved safe to retire or already published; refusing a duplicate launch" >&2
     exit 1
   }
+  if [ "$HERDR_RELAUNCH_RECOVERED_STATE" = alive ]; then
+    herdr_relaunch_candidate_adopt_live || {
+      echo "error: the discovered Herdr replacement no longer proves its exact live identity and recorded worktree; refusing adoption" >&2
+      exit 1
+    }
+  fi
   HERDR_RELAUNCH_LABEL="fm-relaunch-${BASHPID:-$$}-${RANDOM}"
   herdr_relaunch_candidate_record_write creating "candidate_label=$HERDR_RELAUNCH_LABEL" || {
     echo "error: could not persist the Herdr replacement attempt before endpoint creation" >&2

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -1256,7 +1256,7 @@ herdr_relaunch_published_reconcile() {  # <old-tab> <old-pane> <candidate-tab> <
 }
 
 herdr_relaunch_launch_receipt_valid() {
-  local receipt="$HERDR_RELAUNCH_LAUNCH_PROVENANCE_DIR/launch-receipt"
+  local receipt="$HERDR_RELAUNCH_LAUNCH_PROVENANCE_DIR/launch/launch-receipt"
   [ -f "$receipt" ] && [ ! -L "$receipt" ]
 }
 
@@ -1308,16 +1308,16 @@ herdr_relaunch_candidate_launch_attempt_settle() {
 }
 
 herdr_relaunch_launch_provenance_persist() {
-  local dir tmp family path token_path token auth index=0 seen
+  local dir target tmp family path token_path token auth index=0 seen
   dir=$HERDR_RELAUNCH_LAUNCH_PROVENANCE_DIR
-  tmp="$dir.tmp.${BASHPID:-$$}"
+  target="$dir/launch"
+  tmp="$dir/.launch.tmp.${BASHPID:-$$}"
+  [ -d "$dir" ] && [ ! -L "$dir" ] \
+    && [ -d "$dir/prior-snapshot" ] && [ ! -L "$dir/prior-snapshot" ] \
+    && [ ! -e "$target" ] && [ ! -L "$target" ] || return 1
   rm -rf "$tmp" || return 1
   (umask 077; mkdir "$tmp") || return 1
   cp -p "$SPAWN_META_TMP" "$tmp/meta" || { rm -rf "$tmp"; return 1; }
-  if [ "$RELAUNCH_WIRING_SNAPSHOT_ACTIVE" = 1 ]; then
-    cp -Rp "$RELAUNCH_WIRING_SNAPSHOT_DIR" "$tmp/prior-snapshot" \
-      || { rm -rf "$tmp"; return 1; }
-  fi
   printf 'prior_auth_path=%s\n' "${RELAUNCH_PRIOR_AUTH_PATH:-none}" > "$tmp/prior-auth" \
     || { rm -rf "$tmp"; return 1; }
   printf 'prior_harness=%s\n' "$RELAUNCH_PRIOR_HARNESS" > "$tmp/prior-harness" \
@@ -1353,13 +1353,12 @@ herdr_relaunch_launch_provenance_persist() {
     fi
   done < "$tmp/paths"
   rm -f "$tmp/paths" || { rm -rf "$tmp"; return 1; }
-  rm -rf "$dir" || { rm -rf "$tmp"; return 1; }
-  mv "$tmp" "$dir"
+  mv "$tmp" "$target"
 }
 
 herdr_relaunch_launch_provenance_restore() {
   local dir presence index path tmp status=0
-  dir=$HERDR_RELAUNCH_LAUNCH_PROVENANCE_DIR
+  dir="$HERDR_RELAUNCH_LAUNCH_PROVENANCE_DIR/launch"
   [ -d "$dir" ] && [ ! -L "$dir" ] && [ -f "$dir/meta" ] && [ ! -L "$dir/meta" ] \
     && [ -f "$dir/manifest" ] && [ ! -L "$dir/manifest" ] || return 1
   while IFS=$'\t' read -r presence index path; do
@@ -1389,7 +1388,7 @@ herdr_relaunch_launch_provenance_restore() {
 
 herdr_relaunch_authoritative_wiring_finalize() {
   local provenance_meta staged_busy busy_gen state_real prior_harness
-  provenance_meta="$HERDR_RELAUNCH_LAUNCH_PROVENANCE_DIR/meta"
+  provenance_meta="$HERDR_RELAUNCH_LAUNCH_PROVENANCE_DIR/launch/meta"
   [ "$(fm_backend_meta_exact_value "$provenance_meta" worktree)" = "$WT" ] \
     && [ "$(fm_backend_meta_exact_value "$provenance_meta" harness)" = "$HARNESS" ] \
     && [ "$(fm_backend_meta_exact_value "$provenance_meta" herdr_session)" = "$HERDR_SES" ] \
@@ -1397,9 +1396,9 @@ herdr_relaunch_authoritative_wiring_finalize() {
     && [ "$(fm_backend_meta_exact_value "$provenance_meta" herdr_tab_id)" = "$HERDR_RELAUNCH_CANDIDATE_TAB_ID" ] \
     && [ "$(fm_backend_meta_exact_value "$provenance_meta" herdr_pane_id)" = "$HERDR_RELAUNCH_CANDIDATE_PANE_ID" ] || return 1
   prior_harness=$(fm_backend_meta_exact_value \
-    "$HERDR_RELAUNCH_LAUNCH_PROVENANCE_DIR/prior-harness" prior_harness) || return 1
+    "$HERDR_RELAUNCH_LAUNCH_PROVENANCE_DIR/launch/prior-harness" prior_harness) || return 1
   RELAUNCH_PRIOR_AUTH_PATH=$(fm_backend_meta_exact_value \
-    "$HERDR_RELAUNCH_LAUNCH_PROVENANCE_DIR/prior-auth" prior_auth_path) || return 1
+    "$HERDR_RELAUNCH_LAUNCH_PROVENANCE_DIR/launch/prior-auth" prior_auth_path) || return 1
   [ "$RELAUNCH_PRIOR_AUTH_PATH" != none ] || RELAUNCH_PRIOR_AUTH_PATH=
   case "$RELAUNCH_PRIOR_AUTH_PATH" in ''|/*) ;; *) return 1 ;; esac
   case "$RELAUNCH_PRIOR_AUTH_PATH" in *$'\n'*|*$'\r'*|*$'\t'*) return 1 ;; esac
@@ -1425,7 +1424,7 @@ herdr_relaunch_candidate_adopt_live() {
   current_real=$(CDPATH='' cd -- "$current" 2>/dev/null && pwd -P) || return 1
   expected_real=$(CDPATH='' cd -- "$WT" 2>/dev/null && pwd -P) || return 1
   [ "$current_real" = "$expected_real" ] || return 1
-  provenance_meta="$HERDR_RELAUNCH_LAUNCH_PROVENANCE_DIR/meta"
+  provenance_meta="$HERDR_RELAUNCH_LAUNCH_PROVENANCE_DIR/launch/meta"
   [ "$(fm_backend_meta_exact_value "$provenance_meta" window)" = "$HERDR_SES:$HERDR_RELAUNCH_CANDIDATE_PANE_ID" ] \
     && [ "$(fm_backend_meta_exact_value "$provenance_meta" worktree)" = "$WT" ] \
     && [ "$(fm_backend_meta_exact_value "$provenance_meta" harness)" = "$HARNESS" ] \
@@ -1548,18 +1547,25 @@ herdr_relaunch_candidate_reconcile_prior() {
         && fm_backend_endpoint_atom_valid "${candidate_pane//:/_}" || return 1
       HERDR_RELAUNCH_CANDIDATE_TAB_ID=$candidate_tab
       HERDR_RELAUNCH_CANDIDATE_PANE_ID=$candidate_pane
-      if { [ "$phase" = wiring-restored ] || [ "$phase" = quarantined ]; } \
-         && ! fm_backend_herdr_relaunch_candidate_matches \
-           "$HERDR_SES" "$HERDR_WORKSPACE_ID" "$candidate_tab" "$candidate_pane"; then
+      if ! fm_backend_herdr_relaunch_candidate_matches \
+          "$HERDR_SES" "$HERDR_WORKSPACE_ID" "$candidate_tab" "$candidate_pane"; then
         state=$(fm_backend_herdr_recovery_agent_state "$HERDR_SES:$candidate_pane")
         [ "$state" = missing ] || return 1
-        herdr_relaunch_candidate_record_write rolled-back "candidate_state=missing" || return 1
+        case "$phase" in
+          wiring-snapshotted|launch-attempt)
+            restore_persisted_relaunch_wiring_snapshot || return 1
+            herdr_relaunch_candidate_record_write wiring-restored \
+              "candidate_state=missing" || return 1
+            ;;
+          creating|created|creation-failed|quarantined|wiring-restored) ;;
+          *) return 1 ;;
+        esac
+        herdr_relaunch_candidate_record_write rolled-back \
+          "candidate_state=missing" || return 1
         HERDR_RELAUNCH_CANDIDATE_TAB_ID=
         HERDR_RELAUNCH_CANDIDATE_PANE_ID=
         return 0
       fi
-      fm_backend_herdr_relaunch_candidate_matches \
-        "$HERDR_SES" "$HERDR_WORKSPACE_ID" "$candidate_tab" "$candidate_pane" || return 1
       current=$(fm_backend_herdr_current_path "$HERDR_SES:$candidate_pane" || true)
       current_real=$(CDPATH='' cd -- "$current" 2>/dev/null && pwd -P) || return 1
       expected_real=$(CDPATH='' cd -- "$WT" 2>/dev/null && pwd -P) || return 1
@@ -4026,7 +4032,7 @@ if [ "$RELAUNCH" -eq 1 ] && [ "$BACKEND" = herdr ]; then
       echo "error: could not persist Herdr replacement launch provenance before command submission" >&2
       exit 1
     }
-    LAUNCH="umask 077; : > $(shell_quote "$HERDR_RELAUNCH_LAUNCH_PROVENANCE_DIR/launch-receipt"); $LAUNCH"
+    LAUNCH="umask 077; : > $(shell_quote "$HERDR_RELAUNCH_LAUNCH_PROVENANCE_DIR/launch/launch-receipt"); $LAUNCH"
   fi
   # Freeze and revalidate the prepared shell before atomically queueing the
   # command and Enter. This closes the final foreground-owner race rather than

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -4047,7 +4047,7 @@ if [ "$RELAUNCH" -eq 1 ] && [ "$BACKEND" = herdr ]; then
       echo "error: could not persist Herdr replacement launch provenance before command submission" >&2
       exit 1
     }
-    LAUNCH="umask 077; : > $(shell_quote "$HERDR_RELAUNCH_LAUNCH_PROVENANCE_DIR/launch/launch-receipt"); $LAUNCH"
+    LAUNCH="umask 077; : > $(shell_quote "$HERDR_RELAUNCH_LAUNCH_PROVENANCE_DIR/launch/launch-receipt") && { $LAUNCH; }"
   fi
   # Freeze and revalidate the prepared shell before atomically queueing the
   # command and Enter. This closes the final foreground-owner race rather than

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -1209,6 +1209,52 @@ herdr_relaunch_candidate_is_authoritative() {
     && [ "$(fm_backend_meta_exact_value "$meta" herdr_pane_id 2>/dev/null)" = "$HERDR_RELAUNCH_CANDIDATE_PANE_ID" ]
 }
 
+herdr_relaunch_candidate_record_rephase() {  # <phase> [extra-line]...
+  local phase=$1 tmp line
+  shift
+  tmp="$HERDR_RELAUNCH_CANDIDATE_RECORD.tmp.${BASHPID:-$$}"
+  awk -F= '$1 != "phase" && $1 != "candidate_state" && $1 != "old_endpoint" && $1 != "wiring_state"' \
+    "$HERDR_RELAUNCH_CANDIDATE_RECORD" > "$tmp" || { rm -f "$tmp"; return 1; }
+  printf 'phase=%s\n' "$phase" >> "$tmp" || { rm -f "$tmp"; return 1; }
+  for line in "$@"; do
+    printf '%s\n' "$line" >> "$tmp" || { rm -f "$tmp"; return 1; }
+  done
+  mv -f "$tmp" "$HERDR_RELAUNCH_CANDIDATE_RECORD"
+}
+
+herdr_relaunch_published_reconcile() {  # <old-tab> <old-pane> <candidate-tab> <candidate-pane>
+  local old_tab=$1 old_pane=$2 candidate_tab=$3 candidate_pane=$4
+  fm_backend_endpoint_atom_valid "${old_tab//:/_}" \
+    && fm_backend_endpoint_atom_valid "${old_pane//:/_}" \
+    && fm_backend_endpoint_atom_valid "${candidate_tab//:/_}" \
+    && fm_backend_endpoint_atom_valid "${candidate_pane//:/_}" || return 1
+  if [ -n "${HERDR_PRESENTATION_JOURNAL:-}" ] \
+     && { [ -e "$HERDR_PRESENTATION_JOURNAL" ] || [ -L "$HERDR_PRESENTATION_JOURNAL" ]; }; then
+    fm_backend_herdr_projection_journal_snapshot \
+      "$HERDR_PRESENTATION_JOURNAL" "$ID" || return 1
+    if [ "$FM_BACKEND_HERDR_JOURNAL_TAB_ID" != "$candidate_tab" ] \
+       || [ "$FM_BACKEND_HERDR_JOURNAL_PANE_ID" != "$candidate_pane" ]; then
+      [ "$FM_BACKEND_HERDR_JOURNAL_TAB_ID" = "$old_tab" ] \
+        && [ "$FM_BACKEND_HERDR_JOURNAL_PANE_ID" = "$old_pane" ] || return 1
+      fm_backend_herdr_projection_journal_replace_endpoint \
+        "$HERDR_PRESENTATION_JOURNAL" "$ID" \
+        "$old_tab" "$old_pane" "$candidate_tab" "$candidate_pane" || return 1
+    fi
+  fi
+  if [ "$old_tab" != "$candidate_tab" ] || [ "$old_pane" != "$candidate_pane" ]; then
+    fm_backend_herdr_relaunch_candidate_cleanup \
+      "$HERDR_SES" "$HERDR_WORKSPACE_ID" "$old_tab" "$old_pane" || {
+      echo "error: retained original Herdr endpoint could not be safely retired" >&2
+      return 1
+    }
+  fi
+  herdr_relaunch_candidate_record_rephase published \
+    "candidate_state=reconciled" "old_endpoint=retired" || {
+    echo "error: reconciled Herdr publication state could not be persisted" >&2
+    return 1
+  }
+}
+
 herdr_relaunch_launch_receipt_valid() {
   local receipt="$HERDR_RELAUNCH_LAUNCH_PROVENANCE_DIR/launch-receipt"
   [ -f "$receipt" ] && [ ! -L "$receipt" ]
@@ -1390,7 +1436,6 @@ herdr_relaunch_candidate_adopt_live() {
     && [ "$(fm_backend_meta_exact_value "$provenance_meta" herdr_workspace_id)" = "$HERDR_WORKSPACE_ID" ] \
     && [ "$(fm_backend_meta_exact_value "$provenance_meta" herdr_tab_id)" = "$HERDR_RELAUNCH_CANDIDATE_TAB_ID" ] \
     && [ "$(fm_backend_meta_exact_value "$provenance_meta" herdr_pane_id)" = "$HERDR_RELAUNCH_CANDIDATE_PANE_ID" ] || return 1
-  herdr_relaunch_authoritative_wiring_finalize || return 1
   tmp="$STATE/.$ID.meta.relaunch-adopt.${BASHPID:-$$}"
   awk -F= '$1 != "control_relaunch_tx"' "$provenance_meta" > "$tmp" \
     || { rm -f "$tmp"; return 1; }
@@ -1401,6 +1446,9 @@ herdr_relaunch_candidate_adopt_live() {
     rm -f "$tmp"
     return 1
   }
+  herdr_relaunch_candidate_record_write binding-published \
+    "candidate_state=adopted-alive" "wiring_state=pending" || return 1
+  herdr_relaunch_authoritative_wiring_finalize || return 1
   herdr_relaunch_candidate_record_write published "candidate_state=adopted-alive" || true
   if [ -n "${HERDR_PRESENTATION_JOURNAL:-}" ] \
      && { [ -e "$HERDR_PRESENTATION_JOURNAL" ] || [ -L "$HERDR_PRESENTATION_JOURNAL" ]; }; then
@@ -1448,6 +1496,8 @@ herdr_relaunch_candidate_reconcile_prior() {
     published)
       [ "$candidate_tab" = "$HERDR_RELAUNCH_OLD_TAB_ID" ] \
         && [ "$candidate_pane" = "$HERDR_RELAUNCH_OLD_PANE_ID" ] || return 1
+      herdr_relaunch_published_reconcile \
+        "$old_tab" "$old_pane" "$candidate_tab" "$candidate_pane" || return 1
       return 0
       ;;
     creating|created|creation-failed|quarantined|wiring-snapshotted|wiring-restored|launch-attempt|binding-published)
@@ -1461,22 +1511,16 @@ herdr_relaunch_candidate_reconcile_prior() {
            && [ "$candidate_pane" = "$HERDR_RELAUNCH_OLD_PANE_ID" ]; then
           HERDR_RELAUNCH_CANDIDATE_TAB_ID=$candidate_tab
           HERDR_RELAUNCH_CANDIDATE_PANE_ID=$candidate_pane
-          if [ -n "${HERDR_PRESENTATION_JOURNAL:-}" ] \
-             && { [ -e "$HERDR_PRESENTATION_JOURNAL" ] || [ -L "$HERDR_PRESENTATION_JOURNAL" ]; }; then
-            fm_backend_herdr_projection_journal_snapshot \
-              "$HERDR_PRESENTATION_JOURNAL" "$ID" || return 1
-            if [ "$FM_BACKEND_HERDR_JOURNAL_TAB_ID" != "$candidate_tab" ] \
-               || [ "$FM_BACKEND_HERDR_JOURNAL_PANE_ID" != "$candidate_pane" ]; then
-              fm_backend_herdr_projection_journal_replace_endpoint \
-                "$HERDR_PRESENTATION_JOURNAL" "$ID" \
-                "$old_tab" "$old_pane" "$candidate_tab" "$candidate_pane" || return 1
-            fi
-          fi
           herdr_relaunch_authoritative_wiring_finalize || return 1
-          herdr_relaunch_candidate_record_write published \
-            "candidate_state=reconciled-from-authoritative-binding" || return 1
-          HERDR_RELAUNCH_CANDIDATE_TAB_ID=
-          HERDR_RELAUNCH_CANDIDATE_PANE_ID=
+          herdr_relaunch_published_reconcile \
+            "$old_tab" "$old_pane" "$candidate_tab" "$candidate_pane" || return 1
+          if fm_backend_herdr_relaunch_candidate_live \
+              "$HERDR_SES" "$candidate_pane"; then
+            HERDR_RELAUNCH_RECOVERED_STATE=authoritative-alive
+          else
+            HERDR_RELAUNCH_CANDIDATE_TAB_ID=
+            HERDR_RELAUNCH_CANDIDATE_PANE_ID=
+          fi
           return 0
         fi
       fi
@@ -1750,10 +1794,10 @@ if [ "$RELAUNCH" -eq 1 ]; then
     exit 1
   }
   RELAUNCH_STATE=$(fm_backend_recovery_agent_state "$BACKEND" "$RELAUNCH_TARGET")
-  [ "$RELAUNCH_STATE" = dead ] || {
+  if [ "$BACKEND" != herdr ] && [ "$RELAUNCH_STATE" != dead ]; then
     echo "error: task $ID's endpoint reads '$RELAUNCH_STATE'; a relaunch requires a positively agent-free endpoint (stop the agent first with bin/fm-control.sh $ID exit)" >&2
     exit 1
-  }
+  fi
   RELAUNCH_PRIOR_HARNESS=$(fm_meta_get "$RELAUNCH_META" harness)
   if [ "$MODEL_SET" -eq 0 ] \
      && { [ -z "$HARNESS_ARG" ] || [ "$HARNESS_ARG" = "$RELAUNCH_PRIOR_HARNESS" ]; }; then
@@ -2806,10 +2850,6 @@ elif [ "$RELAUNCH" -eq 1 ]; then
     echo "error: recorded Herdr endpoint does not match its exact workspace and tab; refusing replacement creation" >&2
     exit 1
   }
-  [ "$(fm_backend_herdr_recovery_agent_state "$RELAUNCH_TARGET")" = dead ] || {
-    echo "error: recorded Herdr endpoint no longer proves agent-free under the session mutation lock; refusing replacement creation" >&2
-    exit 1
-  }
   HERDR_RELAUNCH_CANDIDATE_RECORD="$STATE/$ID.control-relaunch-candidate"
   HERDR_RELAUNCH_LAUNCH_PROVENANCE_DIR="$STATE/$ID.control-relaunch-candidate.launch"
   HERDR_PRESENTATION_JOURNAL=$(fm_backend_herdr_projection_journal_path "$STATE" "$ID")
@@ -2822,7 +2862,17 @@ elif [ "$RELAUNCH" -eq 1 ]; then
       echo "error: the discovered Herdr replacement no longer proves its launch provenance, wiring, exact live identity, and recorded worktree; refusing adoption" >&2
       exit 1
     }
+  elif [ "$HERDR_RELAUNCH_RECOVERED_STATE" = authoritative-alive ]; then
+    rm -rf "$HERDR_RELAUNCH_LAUNCH_PROVENANCE_DIR" || exit 1
+    spawn_herdr_presentation_order_lock_release
+    "$SCRIPT_DIR/fm-home-summary-refresh.sh" --best-effort || true
+    echo "spawned $ID harness=$HARNESS kind=$KIND mode=$MODE yolo=$YOLO window=$HERDR_SES:$HERDR_RELAUNCH_CANDIDATE_PANE_ID worktree=$WT"
+    exit 0
   fi
+  [ "$(fm_backend_herdr_recovery_agent_state "$RELAUNCH_TARGET")" = dead ] || {
+    echo "error: recorded Herdr endpoint no longer proves agent-free under the session mutation lock; refusing replacement creation" >&2
+    exit 1
+  }
   rm -rf "$HERDR_RELAUNCH_LAUNCH_PROVENANCE_DIR" || {
     echo "error: could not clear retired Herdr replacement launch provenance" >&2
     exit 1

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -806,12 +806,23 @@ parse_orca_worktree_result() {
 }
 
 spawn_abort_cleanup() {
-  local status=$? candidate_state
+  local status=$? candidate_state candidate_phase= rollback_ready=1
   if [ -n "$HERDR_RELAUNCH_CANDIDATE_PANE_ID" ] \
      && herdr_relaunch_candidate_is_authoritative; then
     HERDR_RELAUNCH_CANDIDATE_CLEANUP=0
     RELAUNCH_REPLACEMENT_PENDING=0
     RELAUNCH_WIRING_SNAPSHOT_ACTIVE=0
+  fi
+  if [ "$HERDR_RELAUNCH_CANDIDATE_CLEANUP" = 1 ]; then
+    candidate_phase=$(fm_backend_meta_exact_value \
+      "$HERDR_RELAUNCH_CANDIDATE_RECORD" phase 2>/dev/null || true)
+    if [ "$candidate_phase" = launch-attempt ] \
+       && herdr_relaunch_candidate_launch_attempt_live; then
+      HERDR_RELAUNCH_CANDIDATE_CLEANUP=0
+      RELAUNCH_REPLACEMENT_PENDING=0
+      RELAUNCH_WIRING_SNAPSHOT_ACTIVE=0
+      echo "warning: preserving live Herdr replacement endpoint $HERDR_SES:$HERDR_RELAUNCH_CANDIDATE_PANE_ID for verified retry adoption" >&2
+    fi
   fi
   if [ "$RELAUNCH_REPLACEMENT_PENDING" = 1 ] \
      && [ "$SPAWN_META_PUBLISH_STARTED" = 1 ] \
@@ -844,16 +855,32 @@ spawn_abort_cleanup() {
     fi
   fi
   if [ "$HERDR_RELAUNCH_CANDIDATE_CLEANUP" = 1 ]; then
-    HERDR_RELAUNCH_CANDIDATE_CLEANUP=0
-    if fm_backend_herdr_relaunch_candidate_cleanup \
-        "$HERDR_SES" "$HERDR_WORKSPACE_ID" \
-        "$HERDR_RELAUNCH_CANDIDATE_TAB_ID" "$HERDR_RELAUNCH_CANDIDATE_PANE_ID"; then
-      herdr_relaunch_candidate_record_write rolled-back "candidate_state=dead" 2>/dev/null || true
-    else
-      candidate_state=$(fm_backend_herdr_pane_agent_state "$HERDR_SES" "$HERDR_RELAUNCH_CANDIDATE_PANE_ID" 2>/dev/null || printf unknown)
-      herdr_relaunch_candidate_record_write quarantined "candidate_state=$candidate_state" 2>/dev/null || true
-      echo "warning: uncommitted Herdr replacement endpoint $HERDR_SES:$HERDR_RELAUNCH_CANDIDATE_PANE_ID could not be safely retired (state=$candidate_state); its exact identity remains in $HERDR_RELAUNCH_CANDIDATE_RECORD" >&2
-      status=1
+    case "$candidate_phase" in
+      wiring-snapshotted|launch-attempt)
+        if restore_persisted_relaunch_wiring_snapshot \
+           && herdr_relaunch_candidate_record_write wiring-restored "candidate_state=unpublished"; then
+          candidate_phase=wiring-restored
+          rm -rf "$HERDR_RELAUNCH_LAUNCH_PROVENANCE_DIR/prior-snapshot" || status=1
+        else
+          rollback_ready=0
+          echo "warning: could not durably restore prior wiring before retiring Herdr replacement endpoint $HERDR_SES:$HERDR_RELAUNCH_CANDIDATE_PANE_ID" >&2
+          status=1
+        fi
+        ;;
+    esac
+    if [ "$rollback_ready" = 1 ]; then
+      HERDR_RELAUNCH_CANDIDATE_CLEANUP=0
+      if fm_backend_herdr_relaunch_candidate_cleanup \
+          "$HERDR_SES" "$HERDR_WORKSPACE_ID" \
+          "$HERDR_RELAUNCH_CANDIDATE_TAB_ID" "$HERDR_RELAUNCH_CANDIDATE_PANE_ID"; then
+        herdr_relaunch_candidate_record_write rolled-back "candidate_state=dead" 2>/dev/null || true
+      else
+        candidate_state=$(fm_backend_herdr_pane_agent_state "$HERDR_SES" "$HERDR_RELAUNCH_CANDIDATE_PANE_ID" 2>/dev/null || printf unknown)
+        herdr_relaunch_candidate_record_write quarantined \
+          "candidate_state=$candidate_state" "wiring_state=restored" 2>/dev/null || true
+        echo "warning: uncommitted Herdr replacement endpoint $HERDR_SES:$HERDR_RELAUNCH_CANDIDATE_PANE_ID could not be safely retired (state=$candidate_state); its exact identity remains in $HERDR_RELAUNCH_CANDIDATE_RECORD" >&2
+        status=1
+      fi
     fi
   fi
   if [ "$HERDR_PROJECTION_ABORT_CLEANUP" = 1 ] \
@@ -1095,8 +1122,7 @@ persist_relaunch_wiring_snapshot() {
 
 restore_persisted_relaunch_wiring_snapshot() {
   local snapshot="$HERDR_RELAUNCH_LAUNCH_PROVENANCE_DIR/prior-snapshot"
-  restore_relaunch_wiring_snapshot_dir "$snapshot" || return 1
-  rm -rf "$snapshot"
+  restore_relaunch_wiring_snapshot_dir "$snapshot"
 }
 
 retire_prior_relaunch_wiring() {  # <prior-harness> <replacement-harness> <worktree> <state> <id>
@@ -1163,6 +1189,27 @@ herdr_relaunch_candidate_is_authoritative() {
     && [ "$(fm_backend_meta_exact_value "$meta" herdr_workspace_id 2>/dev/null)" = "$HERDR_WORKSPACE_ID" ] \
     && [ "$(fm_backend_meta_exact_value "$meta" herdr_tab_id 2>/dev/null)" = "$HERDR_RELAUNCH_CANDIDATE_TAB_ID" ] \
     && [ "$(fm_backend_meta_exact_value "$meta" herdr_pane_id 2>/dev/null)" = "$HERDR_RELAUNCH_CANDIDATE_PANE_ID" ]
+}
+
+herdr_relaunch_launch_receipt_valid() {
+  local receipt="$HERDR_RELAUNCH_LAUNCH_PROVENANCE_DIR/launch-receipt"
+  [ -f "$receipt" ] && [ ! -L "$receipt" ]
+}
+
+herdr_relaunch_candidate_launch_attempt_live() {
+  local current current_real expected_real
+  herdr_relaunch_launch_receipt_valid || return 1
+  fm_backend_herdr_relaunch_candidate_matches \
+    "$HERDR_SES" "$HERDR_WORKSPACE_ID" \
+    "$HERDR_RELAUNCH_CANDIDATE_TAB_ID" "$HERDR_RELAUNCH_CANDIDATE_PANE_ID" \
+    || return 1
+  fm_backend_herdr_relaunch_candidate_live \
+    "$HERDR_SES" "$HERDR_RELAUNCH_CANDIDATE_PANE_ID" || return 1
+  current=$(fm_backend_herdr_current_path \
+    "$HERDR_SES:$HERDR_RELAUNCH_CANDIDATE_PANE_ID" || true)
+  current_real=$(CDPATH='' cd -- "$current" 2>/dev/null && pwd -P) || return 1
+  expected_real=$(CDPATH='' cd -- "$WT" 2>/dev/null && pwd -P) || return 1
+  [ "$current_real" = "$expected_real" ]
 }
 
 herdr_relaunch_launch_provenance_persist() {
@@ -1273,6 +1320,7 @@ herdr_relaunch_authoritative_wiring_finalize() {
 herdr_relaunch_candidate_adopt_live() {
   local current current_real expected_real tmp old_retirement=retained provenance_meta
   [ "$HERDR_RELAUNCH_RECOVERED_STATE" = alive ] || return 1
+  herdr_relaunch_launch_receipt_valid || return 1
   fm_backend_herdr_relaunch_candidate_matches \
     "$HERDR_SES" "$HERDR_WORKSPACE_ID" \
     "$HERDR_RELAUNCH_CANDIDATE_TAB_ID" "$HERDR_RELAUNCH_CANDIDATE_PANE_ID" || return 1
@@ -1320,6 +1368,7 @@ herdr_relaunch_candidate_adopt_live() {
   herdr_relaunch_candidate_record_write published \
     "candidate_state=adopted-alive" "old_endpoint=$old_retirement" || true
   spawn_herdr_presentation_order_lock_release
+  "$SCRIPT_DIR/fm-home-summary-refresh.sh" --best-effort || true
   echo "spawned $ID harness=$HARNESS kind=$KIND mode=$MODE yolo=$YOLO window=$HERDR_SES:$HERDR_RELAUNCH_CANDIDATE_PANE_ID worktree=$WT"
   exit 0
 }
@@ -1352,7 +1401,7 @@ herdr_relaunch_candidate_reconcile_prior() {
         && [ "$candidate_pane" = "$HERDR_RELAUNCH_OLD_PANE_ID" ] || return 1
       return 0
       ;;
-    creating|created|creation-failed|quarantined|wiring-snapshotted|launch-attempt|binding-published)
+    creating|created|creation-failed|quarantined|wiring-snapshotted|wiring-restored|launch-attempt|binding-published)
       [ "$replacement_harness" = "$HARNESS" ] \
         && [ "$replacement_model" = "${MODEL:-default}" ] \
         && [ "$replacement_effort" = "${EFFORT:-default}" ] || return 1
@@ -1405,6 +1454,16 @@ herdr_relaunch_candidate_reconcile_prior() {
         && fm_backend_endpoint_atom_valid "${candidate_pane//:/_}" || return 1
       HERDR_RELAUNCH_CANDIDATE_TAB_ID=$candidate_tab
       HERDR_RELAUNCH_CANDIDATE_PANE_ID=$candidate_pane
+      if { [ "$phase" = wiring-restored ] || [ "$phase" = quarantined ]; } \
+         && ! fm_backend_herdr_relaunch_candidate_matches \
+           "$HERDR_SES" "$HERDR_WORKSPACE_ID" "$candidate_tab" "$candidate_pane"; then
+        state=$(fm_backend_herdr_recovery_agent_state "$HERDR_SES:$candidate_pane")
+        [ "$state" = missing ] || return 1
+        herdr_relaunch_candidate_record_write rolled-back "candidate_state=missing" || return 1
+        HERDR_RELAUNCH_CANDIDATE_TAB_ID=
+        HERDR_RELAUNCH_CANDIDATE_PANE_ID=
+        return 0
+      fi
       fm_backend_herdr_relaunch_candidate_matches \
         "$HERDR_SES" "$HERDR_WORKSPACE_ID" "$candidate_tab" "$candidate_pane" || return 1
       current=$(fm_backend_herdr_current_path "$HERDR_SES:$candidate_pane" || true)
@@ -1418,13 +1477,16 @@ herdr_relaunch_candidate_reconcile_prior() {
         return 0
       fi
       case "$state" in dead|missing) ;; *) return 1 ;; esac
-      fm_backend_herdr_relaunch_candidate_cleanup \
-        "$HERDR_SES" "$HERDR_WORKSPACE_ID" "$candidate_tab" "$candidate_pane" || return 1
       case "$phase" in
         wiring-snapshotted|launch-attempt)
           restore_persisted_relaunch_wiring_snapshot || return 1
+          herdr_relaunch_candidate_record_write wiring-restored "candidate_state=dead" || return 1
+          phase=wiring-restored
+          rm -rf "$HERDR_RELAUNCH_LAUNCH_PROVENANCE_DIR/prior-snapshot" || return 1
           ;;
       esac
+      fm_backend_herdr_relaunch_candidate_cleanup \
+        "$HERDR_SES" "$HERDR_WORKSPACE_ID" "$candidate_tab" "$candidate_pane" || return 1
       herdr_relaunch_candidate_record_write rolled-back "candidate_state=dead" || return 1
       HERDR_RELAUNCH_CANDIDATE_TAB_ID=
       HERDR_RELAUNCH_CANDIDATE_PANE_ID=
@@ -3863,6 +3925,7 @@ if [ "$RELAUNCH" -eq 1 ] && [ "$BACKEND" = herdr ]; then
       echo "error: could not persist Herdr replacement launch provenance before command submission" >&2
       exit 1
     }
+    LAUNCH="umask 077; : > $(shell_quote "$HERDR_RELAUNCH_LAUNCH_PROVENANCE_DIR/launch-receipt"); $LAUNCH"
   fi
   # Freeze and revalidate the prepared shell before atomically queueing the
   # command and Enter. This closes the final foreground-owner race rather than
@@ -3975,6 +4038,7 @@ if [ "$HERDR_RELAUNCH_CANDIDATE" = 1 ]; then
   herdr_relaunch_candidate_record_write published \
     "candidate_state=alive" "old_endpoint=$HERDR_RELAUNCH_OLD_RETIREMENT" || true
   spawn_herdr_presentation_order_lock_release
+  "$SCRIPT_DIR/fm-home-summary-refresh.sh" --best-effort || true
 fi
 if [ "$KIND" = secondmate ] && [ "${FM_SKIP_SECONDMATE_INHERIT:-0}" != 1 ]; then
   if ! fm_config_reread_discard_pending "$PROJ_ABS" "$ID" "$FM_HOME"; then

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -1158,7 +1158,7 @@ if [ "$RELAUNCH" -eq 1 ]; then
     echo "error: backend '$BACKEND' has no recovery-grade agent-state classifier, so a relaunch cannot prove the previous agent exited; refusing rather than risking two agents in one endpoint" >&2
     exit 1
   }
-  RELAUNCH_STATE=$(fm_backend_agent_state "$BACKEND" "$RELAUNCH_TARGET")
+  RELAUNCH_STATE=$(fm_backend_recovery_agent_state "$BACKEND" "$RELAUNCH_TARGET")
   [ "$RELAUNCH_STATE" = dead ] || {
     echo "error: task $ID's endpoint reads '$RELAUNCH_STATE'; a relaunch requires a positively agent-free endpoint (stop the agent first with bin/fm-control.sh $ID exit)" >&2
     exit 1

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -806,7 +806,7 @@ parse_orca_worktree_result() {
 }
 
 spawn_abort_cleanup() {
-  local status=$? candidate_state candidate_phase= rollback_ready=1
+  local status=$? candidate_state candidate_phase= rollback_ready=1 rollback_launch_attempt=0
   if [ -n "$HERDR_RELAUNCH_CANDIDATE_PANE_ID" ] \
      && herdr_relaunch_candidate_is_authoritative; then
     HERDR_RELAUNCH_CANDIDATE_CLEANUP=0
@@ -816,12 +816,23 @@ spawn_abort_cleanup() {
   if [ "$HERDR_RELAUNCH_CANDIDATE_CLEANUP" = 1 ]; then
     candidate_phase=$(fm_backend_meta_exact_value \
       "$HERDR_RELAUNCH_CANDIDATE_RECORD" phase 2>/dev/null || true)
-    if [ "$candidate_phase" = launch-attempt ] \
-       && herdr_relaunch_candidate_launch_attempt_live; then
-      HERDR_RELAUNCH_CANDIDATE_CLEANUP=0
-      RELAUNCH_REPLACEMENT_PENDING=0
-      RELAUNCH_WIRING_SNAPSHOT_ACTIVE=0
-      echo "warning: preserving live Herdr replacement endpoint $HERDR_SES:$HERDR_RELAUNCH_CANDIDATE_PANE_ID for verified retry adoption" >&2
+    if [ "$candidate_phase" = launch-attempt ]; then
+      herdr_relaunch_candidate_launch_attempt_settle
+      case "$HERDR_RELAUNCH_SETTLED_STATE" in
+        adoptable)
+          HERDR_RELAUNCH_CANDIDATE_CLEANUP=0
+          RELAUNCH_REPLACEMENT_PENDING=0
+          RELAUNCH_WIRING_SNAPSHOT_ACTIVE=0
+          echo "warning: preserving live Herdr replacement endpoint $HERDR_SES:$HERDR_RELAUNCH_CANDIDATE_PANE_ID for verified retry adoption" >&2
+          ;;
+        rollback) rollback_launch_attempt=1 ;;
+        *)
+          HERDR_RELAUNCH_CANDIDATE_CLEANUP=0
+          RELAUNCH_REPLACEMENT_PENDING=0
+          RELAUNCH_WIRING_SNAPSHOT_ACTIVE=0
+          echo "warning: preserving unsettled Herdr launch attempt $HERDR_SES:$HERDR_RELAUNCH_CANDIDATE_PANE_ID for strict retry reconciliation" >&2
+          ;;
+      esac
     fi
   fi
   if [ "$RELAUNCH_REPLACEMENT_PENDING" = 1 ] \
@@ -860,7 +871,6 @@ spawn_abort_cleanup() {
         if restore_persisted_relaunch_wiring_snapshot \
            && herdr_relaunch_candidate_record_write wiring-restored "candidate_state=unpublished"; then
           candidate_phase=wiring-restored
-          rm -rf "$HERDR_RELAUNCH_LAUNCH_PROVENANCE_DIR/prior-snapshot" || status=1
         else
           rollback_ready=0
           echo "warning: could not durably restore prior wiring before retiring Herdr replacement endpoint $HERDR_SES:$HERDR_RELAUNCH_CANDIDATE_PANE_ID" >&2
@@ -873,11 +883,19 @@ spawn_abort_cleanup() {
       if fm_backend_herdr_relaunch_candidate_cleanup \
           "$HERDR_SES" "$HERDR_WORKSPACE_ID" \
           "$HERDR_RELAUNCH_CANDIDATE_TAB_ID" "$HERDR_RELAUNCH_CANDIDATE_PANE_ID"; then
+        rm -rf "$HERDR_RELAUNCH_LAUNCH_PROVENANCE_DIR/prior-snapshot" || status=1
         herdr_relaunch_candidate_record_write rolled-back "candidate_state=dead" 2>/dev/null || true
       else
         candidate_state=$(fm_backend_herdr_pane_agent_state "$HERDR_SES" "$HERDR_RELAUNCH_CANDIDATE_PANE_ID" 2>/dev/null || printf unknown)
-        herdr_relaunch_candidate_record_write quarantined \
-          "candidate_state=$candidate_state" "wiring_state=restored" 2>/dev/null || true
+        if [ "$rollback_launch_attempt" = 1 ] \
+           && herdr_relaunch_launch_provenance_restore \
+           && herdr_relaunch_candidate_record_write launch-attempt \
+             "candidate_state=settlement-raced"; then
+          RELAUNCH_REPLACEMENT_PENDING=0
+        else
+          herdr_relaunch_candidate_record_write quarantined \
+            "candidate_state=$candidate_state" "wiring_state=restored" 2>/dev/null || true
+        fi
         echo "warning: uncommitted Herdr replacement endpoint $HERDR_SES:$HERDR_RELAUNCH_CANDIDATE_PANE_ID could not be safely retired (state=$candidate_state); its exact identity remains in $HERDR_RELAUNCH_CANDIDATE_RECORD" >&2
         status=1
       fi
@@ -1212,6 +1230,37 @@ herdr_relaunch_candidate_launch_attempt_live() {
   [ "$current_real" = "$expected_real" ]
 }
 
+herdr_relaunch_candidate_launch_attempt_settle() {
+  local polls=${FM_HERDR_RELAUNCH_ABORT_POLLS:-5} interval=${FM_HERDR_RELAUNCH_ABORT_INTERVAL:-0.1}
+  local state=unreadable current current_real expected_real
+  HERDR_RELAUNCH_SETTLED_STATE=refuse
+  while [ "$polls" -gt 0 ]; do
+    if herdr_relaunch_candidate_launch_attempt_live; then
+      HERDR_RELAUNCH_SETTLED_STATE=adoptable
+      return 0
+    fi
+    if fm_backend_herdr_relaunch_candidate_matches \
+         "$HERDR_SES" "$HERDR_WORKSPACE_ID" \
+         "$HERDR_RELAUNCH_CANDIDATE_TAB_ID" "$HERDR_RELAUNCH_CANDIDATE_PANE_ID"; then
+      current=$(fm_backend_herdr_current_path \
+        "$HERDR_SES:$HERDR_RELAUNCH_CANDIDATE_PANE_ID" || true)
+      current_real=$(CDPATH='' cd -- "$current" 2>/dev/null && pwd -P) || current_real=
+      expected_real=$(CDPATH='' cd -- "$WT" 2>/dev/null && pwd -P) || expected_real=
+      if [ -n "$current_real" ] && [ "$current_real" = "$expected_real" ]; then
+        state=$(fm_backend_herdr_recovery_agent_state \
+          "$HERDR_SES:$HERDR_RELAUNCH_CANDIDATE_PANE_ID")
+      else
+        state=unreadable
+      fi
+    else
+      state=unreadable
+    fi
+    polls=$((polls - 1))
+    [ "$polls" -eq 0 ] || sleep "$interval"
+  done
+  [ "$state" = dead ] && HERDR_RELAUNCH_SETTLED_STATE=rollback
+}
+
 herdr_relaunch_launch_provenance_persist() {
   local dir tmp family path token_path token auth index=0 seen
   dir=$HERDR_RELAUNCH_LAUNCH_PROVENANCE_DIR
@@ -1434,7 +1483,8 @@ herdr_relaunch_candidate_reconcile_prior() {
       [ "$old_tab" = "$HERDR_RELAUNCH_OLD_TAB_ID" ] \
         && [ "$old_pane" = "$HERDR_RELAUNCH_OLD_PANE_ID" ] || return 1
       if [ -z "$candidate_tab" ] || [ -z "$candidate_pane" ]; then
-        [ "$phase" = creating ] && [ -n "$candidate_label" ] || return 1
+        case "$phase" in creating|creation-failed) ;; *) return 1 ;; esac
+        [ -n "$candidate_label" ] || return 1
         fm_backend_herdr_relaunch_candidate_discover \
           "$HERDR_SES" "$HERDR_WORKSPACE_ID" "$candidate_label" "$WT"
         discover_status=$?
@@ -1487,6 +1537,7 @@ herdr_relaunch_candidate_reconcile_prior() {
       esac
       fm_backend_herdr_relaunch_candidate_cleanup \
         "$HERDR_SES" "$HERDR_WORKSPACE_ID" "$candidate_tab" "$candidate_pane" || return 1
+      rm -rf "$HERDR_RELAUNCH_LAUNCH_PROVENANCE_DIR/prior-snapshot" || return 1
       herdr_relaunch_candidate_record_write rolled-back "candidate_state=dead" || return 1
       HERDR_RELAUNCH_CANDIDATE_TAB_ID=
       HERDR_RELAUNCH_CANDIDATE_PANE_ID=

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -807,6 +807,12 @@ parse_orca_worktree_result() {
 
 spawn_abort_cleanup() {
   local status=$? candidate_state
+  if [ -n "$HERDR_RELAUNCH_CANDIDATE_PANE_ID" ] \
+     && herdr_relaunch_candidate_is_authoritative; then
+    HERDR_RELAUNCH_CANDIDATE_CLEANUP=0
+    RELAUNCH_REPLACEMENT_PENDING=0
+    RELAUNCH_WIRING_SNAPSHOT_ACTIVE=0
+  fi
   if [ "$RELAUNCH_REPLACEMENT_PENDING" = 1 ] \
      && [ "$SPAWN_META_PUBLISH_STARTED" = 1 ] \
      && [ -n "$SPAWN_META_TMP" ] \
@@ -1122,6 +1128,17 @@ herdr_relaunch_candidate_record_write() {  # <phase> [extra-line]...
   } > "$tmp" && mv -f "$tmp" "$HERDR_RELAUNCH_CANDIDATE_RECORD"
 }
 
+herdr_relaunch_candidate_is_authoritative() {
+  local meta="$STATE/$ID.meta"
+  [ -n "$HERDR_RELAUNCH_CANDIDATE_TAB_ID" ] \
+    && [ -n "$HERDR_RELAUNCH_CANDIDATE_PANE_ID" ] \
+    && [ "$(fm_backend_meta_exact_value "$meta" backend 2>/dev/null)" = herdr ] \
+    && [ "$(fm_backend_meta_exact_value "$meta" herdr_session 2>/dev/null)" = "$HERDR_SES" ] \
+    && [ "$(fm_backend_meta_exact_value "$meta" herdr_workspace_id 2>/dev/null)" = "$HERDR_WORKSPACE_ID" ] \
+    && [ "$(fm_backend_meta_exact_value "$meta" herdr_tab_id 2>/dev/null)" = "$HERDR_RELAUNCH_CANDIDATE_TAB_ID" ] \
+    && [ "$(fm_backend_meta_exact_value "$meta" herdr_pane_id 2>/dev/null)" = "$HERDR_RELAUNCH_CANDIDATE_PANE_ID" ]
+}
+
 herdr_relaunch_launch_provenance_persist() {
   local dir tmp family path token_path token auth index=0 seen
   dir=$HERDR_RELAUNCH_LAUNCH_PROVENANCE_DIR
@@ -1129,6 +1146,10 @@ herdr_relaunch_launch_provenance_persist() {
   rm -rf "$tmp" || return 1
   (umask 077; mkdir "$tmp") || return 1
   cp -p "$SPAWN_META_TMP" "$tmp/meta" || { rm -rf "$tmp"; return 1; }
+  if [ "$RELAUNCH_WIRING_SNAPSHOT_ACTIVE" = 1 ]; then
+    cp -Rp "$RELAUNCH_WIRING_SNAPSHOT_DIR" "$tmp/prior-snapshot" \
+      || { rm -rf "$tmp"; return 1; }
+  fi
   printf 'prior_auth_path=%s\n' "${RELAUNCH_PRIOR_AUTH_PATH:-none}" > "$tmp/prior-auth" \
     || { rm -rf "$tmp"; return 1; }
   : > "$tmp/manifest" || { rm -rf "$tmp"; return 1; }
@@ -1196,8 +1217,25 @@ herdr_relaunch_launch_provenance_restore() {
   return "$status"
 }
 
+herdr_relaunch_authoritative_wiring_finalize() {
+  local provenance_meta staged_busy busy_gen state_real
+  provenance_meta="$HERDR_RELAUNCH_LAUNCH_PROVENANCE_DIR/meta"
+  RELAUNCH_PRIOR_AUTH_PATH=$(fm_backend_meta_exact_value \
+    "$HERDR_RELAUNCH_LAUNCH_PROVENANCE_DIR/prior-auth" prior_auth_path) || return 1
+  [ "$RELAUNCH_PRIOR_AUTH_PATH" != none ] || RELAUNCH_PRIOR_AUTH_PATH=
+  case "$RELAUNCH_PRIOR_AUTH_PATH" in ''|/*) ;; *) return 1 ;; esac
+  case "$RELAUNCH_PRIOR_AUTH_PATH" in *$'\n'*|*$'\r'*|*$'\t'*) return 1 ;; esac
+  herdr_relaunch_launch_provenance_restore || return 1
+  staged_busy=$(fm_backend_meta_exact_value "$provenance_meta" busy_gen) || staged_busy=
+  busy_gen=$(fm_busy_current_gen "$STATE" "$ID" 2>/dev/null || true)
+  [ "$busy_gen" = "$staged_busy" ] || return 1
+  state_real=$(CDPATH='' cd -- "$STATE" 2>/dev/null && pwd -P) || return 1
+  retire_prior_relaunch_wiring \
+    "$RELAUNCH_PRIOR_HARNESS" "$HARNESS" "$WT" "$state_real" "$ID"
+}
+
 herdr_relaunch_candidate_adopt_live() {
-  local current current_real expected_real busy_gen staged_busy state_real tmp old_retirement=retained provenance_meta
+  local current current_real expected_real tmp old_retirement=retained provenance_meta
   [ "$HERDR_RELAUNCH_RECOVERED_STATE" = alive ] || return 1
   fm_backend_herdr_relaunch_candidate_matches \
     "$HERDR_SES" "$HERDR_WORKSPACE_ID" \
@@ -1209,11 +1247,6 @@ herdr_relaunch_candidate_adopt_live() {
   expected_real=$(CDPATH='' cd -- "$WT" 2>/dev/null && pwd -P) || return 1
   [ "$current_real" = "$expected_real" ] || return 1
   provenance_meta="$HERDR_RELAUNCH_LAUNCH_PROVENANCE_DIR/meta"
-  RELAUNCH_PRIOR_AUTH_PATH=$(fm_backend_meta_exact_value \
-    "$HERDR_RELAUNCH_LAUNCH_PROVENANCE_DIR/prior-auth" prior_auth_path) || return 1
-  [ "$RELAUNCH_PRIOR_AUTH_PATH" != none ] || RELAUNCH_PRIOR_AUTH_PATH=
-  case "$RELAUNCH_PRIOR_AUTH_PATH" in ''|/*) ;; *) return 1 ;; esac
-  case "$RELAUNCH_PRIOR_AUTH_PATH" in *$'\n'*|*$'\r'*|*$'\t'*) return 1 ;; esac
   [ "$(fm_backend_meta_exact_value "$provenance_meta" window)" = "$HERDR_SES:$HERDR_RELAUNCH_CANDIDATE_PANE_ID" ] \
     && [ "$(fm_backend_meta_exact_value "$provenance_meta" worktree)" = "$WT" ] \
     && [ "$(fm_backend_meta_exact_value "$provenance_meta" harness)" = "$HARNESS" ] \
@@ -1224,13 +1257,7 @@ herdr_relaunch_candidate_adopt_live() {
     && [ "$(fm_backend_meta_exact_value "$provenance_meta" herdr_workspace_id)" = "$HERDR_WORKSPACE_ID" ] \
     && [ "$(fm_backend_meta_exact_value "$provenance_meta" herdr_tab_id)" = "$HERDR_RELAUNCH_CANDIDATE_TAB_ID" ] \
     && [ "$(fm_backend_meta_exact_value "$provenance_meta" herdr_pane_id)" = "$HERDR_RELAUNCH_CANDIDATE_PANE_ID" ] || return 1
-  herdr_relaunch_launch_provenance_restore || return 1
-  staged_busy=$(fm_backend_meta_exact_value "$provenance_meta" busy_gen) || staged_busy=
-  busy_gen=$(fm_busy_current_gen "$STATE" "$ID" 2>/dev/null || true)
-  [ "$busy_gen" = "$staged_busy" ] || return 1
-  state_real=$(CDPATH='' cd -- "$STATE" 2>/dev/null && pwd -P) || return 1
-  retire_prior_relaunch_wiring \
-    "$RELAUNCH_PRIOR_HARNESS" "$HARNESS" "$WT" "$state_real" "$ID" || return 1
+  herdr_relaunch_authoritative_wiring_finalize || return 1
   tmp="$STATE/.$ID.meta.relaunch-adopt.${BASHPID:-$$}"
   awk -F= '$1 != "control_relaunch_tx"' "$provenance_meta" > "$tmp" \
     || { rm -f "$tmp"; return 1; }
@@ -1289,7 +1316,7 @@ herdr_relaunch_candidate_reconcile_prior() {
         && [ "$candidate_pane" = "$HERDR_RELAUNCH_OLD_PANE_ID" ] || return 1
       return 0
       ;;
-    creating|created|creation-failed|quarantined|launch-attempt)
+    creating|created|creation-failed|quarantined|launch-attempt|binding-published)
       [ "$replacement_harness" = "$HARNESS" ] \
         && [ "$replacement_model" = "${MODEL:-default}" ] \
         && [ "$replacement_effort" = "${EFFORT:-default}" ] || return 1
@@ -1300,6 +1327,7 @@ herdr_relaunch_candidate_reconcile_prior() {
            && [ "$candidate_pane" = "$HERDR_RELAUNCH_OLD_PANE_ID" ]; then
           HERDR_RELAUNCH_CANDIDATE_TAB_ID=$candidate_tab
           HERDR_RELAUNCH_CANDIDATE_PANE_ID=$candidate_pane
+          herdr_relaunch_authoritative_wiring_finalize || return 1
           herdr_relaunch_candidate_record_write published \
             "candidate_state=reconciled-from-authoritative-binding" || return 1
           HERDR_RELAUNCH_CANDIDATE_TAB_ID=
@@ -3856,14 +3884,19 @@ if [ "$HERDR_RELAUNCH_CANDIDATE" = 1 ]; then
     echo "error: proven Herdr replacement could not publish its task binding ($FM_BACKLOG_TRANSITION_ERROR)" >&2
     exit 1
   fi
+  HERDR_RELAUNCH_CANDIDATE_CLEANUP=0
   RELAUNCH_REPLACEMENT_PENDING=0
   SPAWN_META_PUBLISH_STARTED=0
   SPAWN_META_TMP=
-  HERDR_RELAUNCH_CANDIDATE_CLEANUP=0
-  if ! retire_prior_relaunch_wiring \
-      "$RELAUNCH_PRIOR_HARNESS" "$HARNESS" "$WT" "$STATE_REAL" "$ID"; then
-    echo "warning: published Herdr replacement retained stale $RELAUNCH_PRIOR_HARNESS wiring for later cleanup" >&2
-  fi
+  herdr_relaunch_candidate_record_write binding-published \
+    "candidate_state=alive" "wiring_state=pending" || {
+    echo "error: published Herdr replacement could not persist its pending wiring commit" >&2
+    exit 1
+  }
+  herdr_relaunch_authoritative_wiring_finalize || {
+    echo "error: published Herdr replacement could not retire prior harness wiring; retry the relaunch to finish its binding commit" >&2
+    exit 1
+  }
   if [ "$RELAUNCH_WIRING_SNAPSHOT_ACTIVE" = 1 ]; then
     rm -rf "$RELAUNCH_WIRING_SNAPSHOT_DIR" || true
     RELAUNCH_WIRING_SNAPSHOT_ACTIVE=0

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -2530,6 +2530,10 @@ kimi_spawn_fail() {  # <detail>
 }
 
 if [ "$RELAUNCH" -eq 1 ]; then
+  fm_backend_prepare_relaunch_path "$BACKEND" "$WT_TARGET" "$WT" || {
+    echo "error: task $ID's endpoint could not be prepared safely in its recorded worktree '$WT'" >&2
+    exit 1
+  }
   # No worktree is acquired: the recorded one is reused as-is. What must be
   # proven instead is that the adopted endpoint's shell is actually sitting in
   # that worktree, so the replacement agent starts where the work is rather

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -743,6 +743,7 @@ HERDR_PROJECTION_ABORT_TASK_PANE=
 HERDR_PROJECTION_ABORT_SEEDED_PANE=
 HERDR_PRESENTATION_ORDER_LOCK=
 HERDR_PRESENTATION_ORDER_LOCK_HELD=0
+RELAUNCH_HERDR_SHELL_PID=
 SPAWN_TASK_LOCK=
 SPAWN_TASK_LOCK_HELD=0
 SPAWN_CONTROL_LOCK=
@@ -921,6 +922,12 @@ spawn_herdr_presentation_order_lock_acquire() {
     attempt=$((attempt + 1))
   done
   return 1
+}
+
+verify_herdr_relaunch_owner() {
+  [ "$RELAUNCH" -eq 1 ] && [ "$BACKEND" = herdr ] || return 0
+  fm_backend_herdr_relaunch_shell_owned \
+    "$WT_TARGET" "$RELAUNCH_HERDR_SHELL_PID" "$WT"
 }
 
 clear_relaunch_harness_wiring() {
@@ -2540,6 +2547,7 @@ if [ "$RELAUNCH" -eq 1 ]; then
       echo "error: task $ID's endpoint could not be prepared safely in its recorded worktree '$WT'" >&2
       exit 1
     }
+    RELAUNCH_HERDR_SHELL_PID=$(fm_backend_herdr_relaunch_prepared_shell_pid)
   else
     fm_backend_prepare_relaunch_path "$BACKEND" "$WT_TARGET" "$WT" || {
       echo "error: task $ID's endpoint could not be prepared safely in its recorded worktree '$WT'" >&2
@@ -3243,37 +3251,62 @@ spawn_record_traceparent() {
   return "$status"
 }
 
-# Export GOTMPDIR into the crewmate's pane shell so the agent and every child
-# process (go build, go test, ...) inherit it. Sent before the launch command so
-# the env is set when the agent starts; the brief sleep lets the export land.
-spawn_send_text_line "$T" "export GOTMPDIR=$TASK_TMP/gotmp"
-# Send through the exact channel that already ships GOTMPDIR, so every backend
-# and harness - ship, scout, and secondmate - gets it before launch. Skipped
-# entirely when trace context is off.
-if [ -n "$SPAWN_TRACEPARENT" ]; then
-  if spawn_send_text_line "$T" "export TRACEPARENT=$SPAWN_TRACEPARENT"; then
-    if ! spawn_record_traceparent; then
+# A reused Herdr shell gets its environment on the replacement command itself.
+# This leaves one owner-checked, atomic input operation after path preparation
+# instead of exposing separate export and launch boundaries to foreground drift.
+if [ "$RELAUNCH" -eq 1 ] && [ "$BACKEND" = herdr ]; then
+  LAUNCH="export GOTMPDIR=$(shell_quote "$TASK_TMP/gotmp"); $LAUNCH"
+  if [ -n "$SPAWN_TRACEPARENT" ]; then
+    if spawn_record_traceparent; then
+      LAUNCH="export TRACEPARENT=$(shell_quote "$SPAWN_TRACEPARENT"); $LAUNCH"
+    else
       LAUNCH="unset TRACEPARENT; $LAUNCH"
     fi
-  else
-    TRACE_SEND_STATUS=$?
-    if [ "$TRACE_SEND_STATUS" -eq 2 ]; then
-      echo "error: trace-context input could not be cleared for $W; refusing to append the launch command" >&2
-      exit 1
+  fi
+else
+  # Export GOTMPDIR into the crewmate's pane shell so the agent and every child
+  # process (go build, go test, ...) inherit it. Sent before the launch command
+  # so the env is set when the agent starts.
+  spawn_send_text_line "$T" "export GOTMPDIR=$TASK_TMP/gotmp"
+  # Send through the exact channel that already ships GOTMPDIR, so every backend
+  # and harness gets trace context before launch when it is enabled.
+  if [ -n "$SPAWN_TRACEPARENT" ]; then
+    if spawn_send_text_line "$T" "export TRACEPARENT=$SPAWN_TRACEPARENT"; then
+      if ! spawn_record_traceparent; then
+        LAUNCH="unset TRACEPARENT; $LAUNCH"
+      fi
+    else
+      TRACE_SEND_STATUS=$?
+      if [ "$TRACE_SEND_STATUS" -eq 2 ]; then
+        echo "error: trace-context input could not be cleared for $W; refusing to append the launch command" >&2
+        exit 1
+      fi
+      LAUNCH="unset TRACEPARENT; $LAUNCH"
     fi
-    LAUNCH="unset TRACEPARENT; $LAUNCH"
   fi
 fi
 sleep 0.3
-spawn_send_literal "$T" "$LAUNCH"
-sleep 0.3
-if [ "${HERDR_PROJECTED:-0}" -eq 1 ]; then
-  HERDR_PROJECTION_ABORT_CLEANUP=0
+verify_herdr_relaunch_owner || {
+  echo "error: task $ID's Herdr shell owner changed before launch delivery; refusing replacement launch" >&2
+  exit 1
+}
+if [ "$RELAUNCH" -eq 1 ] && [ "$BACKEND" = herdr ]; then
+  # pane run submits one command atomically, so an owner change cannot strand
+  # replacement bytes between the literal write and a later Enter.
+  spawn_send_text_line "$T" "$LAUNCH" || {
+    echo "error: task $ID's replacement launch command could not be submitted" >&2
+    exit 1
+  }
+else
+  spawn_send_literal "$T" "$LAUNCH"
+  sleep 0.3
+  if [ "${HERDR_PROJECTED:-0}" -eq 1 ]; then
+    HERDR_PROJECTION_ABORT_CLEANUP=0
+  fi
+  spawn_send_key "$T" Enter
 fi
-spawn_send_key "$T" Enter
 # A Herdr create or relaunch keeps the session mutation lock through command
-# submission, so no competing lifecycle input can separate launch bytes from
-# their Enter or redirect them after endpoint preparation.
+# submission, so no competing lifecycle input can redirect prepared input.
 spawn_herdr_presentation_order_lock_release
 if [ "$HARNESS" = kimi ]; then
   if ! kimi_wait_for_ready; then

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -924,12 +924,6 @@ spawn_herdr_presentation_order_lock_acquire() {
   return 1
 }
 
-verify_herdr_relaunch_owner() {
-  [ "$RELAUNCH" -eq 1 ] && [ "$BACKEND" = herdr ] || return 0
-  fm_backend_herdr_relaunch_shell_owned \
-    "$WT_TARGET" "$RELAUNCH_HERDR_SHELL_PID" "$WT"
-}
-
 clear_relaunch_harness_wiring() {
   local harness=$1 wt=$2 state=$3 id=$4 token_path token auth_path path
   # The wiring arms above match on harness PREFIXES, because a task launched
@@ -3286,15 +3280,13 @@ else
   fi
 fi
 sleep 0.3
-verify_herdr_relaunch_owner || {
-  echo "error: task $ID's Herdr shell owner changed before launch delivery; refusing replacement launch" >&2
-  exit 1
-}
 if [ "$RELAUNCH" -eq 1 ] && [ "$BACKEND" = herdr ]; then
-  # pane run submits one command atomically, so an owner change cannot strand
-  # replacement bytes between the literal write and a later Enter.
-  spawn_send_text_line "$T" "$LAUNCH" || {
-    echo "error: task $ID's replacement launch command could not be submitted" >&2
+  # Freeze and revalidate the prepared shell before atomically queueing the
+  # command and Enter. This closes the final foreground-owner race rather than
+  # relying on a sample immediately before pane input.
+  fm_backend_herdr_run_on_prepared_shell \
+    "$WT_TARGET" "$RELAUNCH_HERDR_SHELL_PID" "$WT" "$LAUNCH" || {
+    echo "error: task $ID's Herdr shell owner changed before launch delivery; refusing replacement launch" >&2
     exit 1
   }
 else

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -4053,9 +4053,8 @@ if [ "$RELAUNCH" -eq 1 ] && [ "$BACKEND" = herdr ]; then
     fi
     LAUNCH="umask 077; : > $(shell_quote "$HERDR_RELAUNCH_LAUNCH_PROVENANCE_DIR/launch/launch-receipt") && { $LAUNCH; }"
   fi
-  # Freeze and revalidate the prepared shell before atomically queueing the
-  # command and Enter. This closes the final foreground-owner race rather than
-  # relying on a sample immediately before pane input.
+  # Revalidate the prepared shell before Herdr atomically queues the command and
+  # Enter against the exact pane. Never signal a sampled numeric shell PID.
   fm_backend_herdr_run_on_prepared_shell \
     "$WT_TARGET" "$RELAUNCH_HERDR_SHELL_PID" "$WT" "$LAUNCH" || {
     echo "error: task $ID's Herdr shell owner changed before launch delivery; refusing replacement launch" >&2

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -1200,7 +1200,8 @@ herdr_relaunch_candidate_adopt_live() {
   fm_backend_herdr_relaunch_candidate_matches \
     "$HERDR_SES" "$HERDR_WORKSPACE_ID" \
     "$HERDR_RELAUNCH_CANDIDATE_TAB_ID" "$HERDR_RELAUNCH_CANDIDATE_PANE_ID" || return 1
-  [ "$(fm_backend_herdr_recovery_agent_state "$HERDR_SES:$HERDR_RELAUNCH_CANDIDATE_PANE_ID")" = alive ] || return 1
+  fm_backend_herdr_relaunch_candidate_live \
+    "$HERDR_SES" "$HERDR_RELAUNCH_CANDIDATE_PANE_ID" || return 1
   current=$(fm_backend_herdr_current_path "$HERDR_SES:$HERDR_RELAUNCH_CANDIDATE_PANE_ID" || true)
   current_real=$(CDPATH='' cd -- "$current" 2>/dev/null && pwd -P) || return 1
   expected_real=$(CDPATH='' cd -- "$WT" 2>/dev/null && pwd -P) || return 1
@@ -3817,10 +3818,12 @@ if [ "$HARNESS" = kimi ]; then
   fi
 fi
 if [ "$HERDR_RELAUNCH_CANDIDATE" = 1 ]; then
-  HERDR_RELAUNCH_LAUNCH_STATE=
+  HERDR_RELAUNCH_LAUNCH_STATE=unproved
   for _ in $(seq 1 "${FM_HERDR_RELAUNCH_LAUNCH_POLLS:-180}"); do
-    HERDR_RELAUNCH_LAUNCH_STATE=$(fm_backend_recovery_agent_state herdr "$T")
-    [ "$HERDR_RELAUNCH_LAUNCH_STATE" != alive ] || break
+    if fm_backend_herdr_relaunch_candidate_live "$HERDR_SES" "$HERDR_PANE_ID"; then
+      HERDR_RELAUNCH_LAUNCH_STATE=alive
+      break
+    fi
     sleep 0.5
   done
   [ "$HERDR_RELAUNCH_LAUNCH_STATE" = alive ] || {

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -1119,6 +1119,7 @@ herdr_relaunch_candidate_record_write() {  # <phase> [extra-line]...
     echo "candidate_tab=$HERDR_RELAUNCH_CANDIDATE_TAB_ID"
     echo "candidate_pane=$HERDR_RELAUNCH_CANDIDATE_PANE_ID"
     echo "worktree=$WT"
+    echo "prior_harness=$RELAUNCH_PRIOR_HARNESS"
     echo "replacement_harness=$HARNESS"
     echo "replacement_model=${MODEL:-default}"
     echo "replacement_effort=${EFFORT:-default}"
@@ -1151,6 +1152,8 @@ herdr_relaunch_launch_provenance_persist() {
       || { rm -rf "$tmp"; return 1; }
   fi
   printf 'prior_auth_path=%s\n' "${RELAUNCH_PRIOR_AUTH_PATH:-none}" > "$tmp/prior-auth" \
+    || { rm -rf "$tmp"; return 1; }
+  printf 'prior_harness=%s\n' "$RELAUNCH_PRIOR_HARNESS" > "$tmp/prior-harness" \
     || { rm -rf "$tmp"; return 1; }
   : > "$tmp/manifest" || { rm -rf "$tmp"; return 1; }
   family=$(fm_control_harness_family "$HARNESS") || family=
@@ -1218,8 +1221,16 @@ herdr_relaunch_launch_provenance_restore() {
 }
 
 herdr_relaunch_authoritative_wiring_finalize() {
-  local provenance_meta staged_busy busy_gen state_real
+  local provenance_meta staged_busy busy_gen state_real prior_harness
   provenance_meta="$HERDR_RELAUNCH_LAUNCH_PROVENANCE_DIR/meta"
+  [ "$(fm_backend_meta_exact_value "$provenance_meta" worktree)" = "$WT" ] \
+    && [ "$(fm_backend_meta_exact_value "$provenance_meta" harness)" = "$HARNESS" ] \
+    && [ "$(fm_backend_meta_exact_value "$provenance_meta" herdr_session)" = "$HERDR_SES" ] \
+    && [ "$(fm_backend_meta_exact_value "$provenance_meta" herdr_workspace_id)" = "$HERDR_WORKSPACE_ID" ] \
+    && [ "$(fm_backend_meta_exact_value "$provenance_meta" herdr_tab_id)" = "$HERDR_RELAUNCH_CANDIDATE_TAB_ID" ] \
+    && [ "$(fm_backend_meta_exact_value "$provenance_meta" herdr_pane_id)" = "$HERDR_RELAUNCH_CANDIDATE_PANE_ID" ] || return 1
+  prior_harness=$(fm_backend_meta_exact_value \
+    "$HERDR_RELAUNCH_LAUNCH_PROVENANCE_DIR/prior-harness" prior_harness) || return 1
   RELAUNCH_PRIOR_AUTH_PATH=$(fm_backend_meta_exact_value \
     "$HERDR_RELAUNCH_LAUNCH_PROVENANCE_DIR/prior-auth" prior_auth_path) || return 1
   [ "$RELAUNCH_PRIOR_AUTH_PATH" != none ] || RELAUNCH_PRIOR_AUTH_PATH=
@@ -1231,7 +1242,7 @@ herdr_relaunch_authoritative_wiring_finalize() {
   [ "$busy_gen" = "$staged_busy" ] || return 1
   state_real=$(CDPATH='' cd -- "$STATE" 2>/dev/null && pwd -P) || return 1
   retire_prior_relaunch_wiring \
-    "$RELAUNCH_PRIOR_HARNESS" "$HARNESS" "$WT" "$state_real" "$ID"
+    "$prior_harness" "$HARNESS" "$WT" "$state_real" "$ID"
 }
 
 herdr_relaunch_candidate_adopt_live() {
@@ -1327,6 +1338,17 @@ herdr_relaunch_candidate_reconcile_prior() {
            && [ "$candidate_pane" = "$HERDR_RELAUNCH_OLD_PANE_ID" ]; then
           HERDR_RELAUNCH_CANDIDATE_TAB_ID=$candidate_tab
           HERDR_RELAUNCH_CANDIDATE_PANE_ID=$candidate_pane
+          if [ -n "${HERDR_PRESENTATION_JOURNAL:-}" ] \
+             && { [ -e "$HERDR_PRESENTATION_JOURNAL" ] || [ -L "$HERDR_PRESENTATION_JOURNAL" ]; }; then
+            fm_backend_herdr_projection_journal_snapshot \
+              "$HERDR_PRESENTATION_JOURNAL" "$ID" || return 1
+            if [ "$FM_BACKEND_HERDR_JOURNAL_TAB_ID" != "$candidate_tab" ] \
+               || [ "$FM_BACKEND_HERDR_JOURNAL_PANE_ID" != "$candidate_pane" ]; then
+              fm_backend_herdr_projection_journal_replace_endpoint \
+                "$HERDR_PRESENTATION_JOURNAL" "$ID" \
+                "$old_tab" "$old_pane" "$candidate_tab" "$candidate_pane" || return 1
+            fi
+          fi
           herdr_relaunch_authoritative_wiring_finalize || return 1
           herdr_relaunch_candidate_record_write published \
             "candidate_state=reconciled-from-authoritative-binding" || return 1

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -1578,16 +1578,24 @@ herdr_relaunch_candidate_reconcile_prior() {
       fi
       case "$state" in dead|missing) ;; *) return 1 ;; esac
       case "$phase" in
-        wiring-snapshotted|launch-attempt)
+        wiring-snapshotted)
           restore_persisted_relaunch_wiring_snapshot || return 1
           herdr_relaunch_candidate_record_write wiring-restored "candidate_state=dead" || return 1
           phase=wiring-restored
-          rm -rf "$HERDR_RELAUNCH_LAUNCH_PROVENANCE_DIR/prior-snapshot" || return 1
+          ;;
+        launch-attempt)
+          restore_persisted_relaunch_wiring_snapshot || return 1
           ;;
       esac
-      fm_backend_herdr_relaunch_candidate_cleanup \
-        "$HERDR_SES" "$HERDR_WORKSPACE_ID" "$candidate_tab" "$candidate_pane" || return 1
-      rm -rf "$HERDR_RELAUNCH_LAUNCH_PROVENANCE_DIR/prior-snapshot" || return 1
+      if ! fm_backend_herdr_relaunch_candidate_cleanup \
+          "$HERDR_SES" "$HERDR_WORKSPACE_ID" "$candidate_tab" "$candidate_pane"; then
+        if [ "$phase" = launch-attempt ]; then
+          herdr_relaunch_launch_provenance_restore || return 1
+          herdr_relaunch_candidate_record_write launch-attempt \
+            "candidate_state=settlement-raced" || return 1
+        fi
+        return 1
+      fi
       herdr_relaunch_candidate_record_write rolled-back "candidate_state=dead" || return 1
       HERDR_RELAUNCH_CANDIDATE_TAB_ID=
       HERDR_RELAUNCH_CANDIDATE_PANE_ID=

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -3460,6 +3460,13 @@ if [ "$KIND" != secondmate ]; then
       fi
       ;;
   esac
+  if [ "$HERDR_RELAUNCH_CANDIDATE" = 1 ] && [ -z "$BUSY_GEN" ]; then
+    "$FM_ROOT/bin/fm-busy-event.sh" retire \
+      "$STATE_REAL" "$ID" --current-gen || {
+      echo "error: failed to retire prior busy-state wiring for unarmed Herdr replacement $ID" >&2
+      exit 1
+    }
+  fi
   case "$HARNESS" in
     claude*)
       # Semantic busy-state hooks (bin/fm-busy-lib.sh): UserPromptSubmit opens

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -1129,6 +1129,8 @@ herdr_relaunch_launch_provenance_persist() {
   rm -rf "$tmp" || return 1
   (umask 077; mkdir "$tmp") || return 1
   cp -p "$SPAWN_META_TMP" "$tmp/meta" || { rm -rf "$tmp"; return 1; }
+  printf 'prior_auth_path=%s\n' "${RELAUNCH_PRIOR_AUTH_PATH:-none}" > "$tmp/prior-auth" \
+    || { rm -rf "$tmp"; return 1; }
   : > "$tmp/manifest" || { rm -rf "$tmp"; return 1; }
   family=$(fm_control_harness_family "$HARNESS") || family=
   {
@@ -1195,7 +1197,7 @@ herdr_relaunch_launch_provenance_restore() {
 }
 
 herdr_relaunch_candidate_adopt_live() {
-  local current current_real expected_real busy_gen staged_busy tmp old_retirement=retained provenance_meta
+  local current current_real expected_real busy_gen staged_busy state_real tmp old_retirement=retained provenance_meta
   [ "$HERDR_RELAUNCH_RECOVERED_STATE" = alive ] || return 1
   fm_backend_herdr_relaunch_candidate_matches \
     "$HERDR_SES" "$HERDR_WORKSPACE_ID" \
@@ -1207,6 +1209,11 @@ herdr_relaunch_candidate_adopt_live() {
   expected_real=$(CDPATH='' cd -- "$WT" 2>/dev/null && pwd -P) || return 1
   [ "$current_real" = "$expected_real" ] || return 1
   provenance_meta="$HERDR_RELAUNCH_LAUNCH_PROVENANCE_DIR/meta"
+  RELAUNCH_PRIOR_AUTH_PATH=$(fm_backend_meta_exact_value \
+    "$HERDR_RELAUNCH_LAUNCH_PROVENANCE_DIR/prior-auth" prior_auth_path) || return 1
+  [ "$RELAUNCH_PRIOR_AUTH_PATH" != none ] || RELAUNCH_PRIOR_AUTH_PATH=
+  case "$RELAUNCH_PRIOR_AUTH_PATH" in ''|/*) ;; *) return 1 ;; esac
+  case "$RELAUNCH_PRIOR_AUTH_PATH" in *$'\n'*|*$'\r'*|*$'\t'*) return 1 ;; esac
   [ "$(fm_backend_meta_exact_value "$provenance_meta" window)" = "$HERDR_SES:$HERDR_RELAUNCH_CANDIDATE_PANE_ID" ] \
     && [ "$(fm_backend_meta_exact_value "$provenance_meta" worktree)" = "$WT" ] \
     && [ "$(fm_backend_meta_exact_value "$provenance_meta" harness)" = "$HARNESS" ] \
@@ -1221,6 +1228,9 @@ herdr_relaunch_candidate_adopt_live() {
   staged_busy=$(fm_backend_meta_exact_value "$provenance_meta" busy_gen) || staged_busy=
   busy_gen=$(fm_busy_current_gen "$STATE" "$ID" 2>/dev/null || true)
   [ "$busy_gen" = "$staged_busy" ] || return 1
+  state_real=$(CDPATH='' cd -- "$STATE" 2>/dev/null && pwd -P) || return 1
+  retire_prior_relaunch_wiring \
+    "$RELAUNCH_PRIOR_HARNESS" "$HARNESS" "$WT" "$state_real" "$ID" || return 1
   tmp="$STATE/.$ID.meta.relaunch-adopt.${BASHPID:-$$}"
   awk -F= '$1 != "control_relaunch_tx"' "$provenance_meta" > "$tmp" \
     || { rm -f "$tmp"; return 1; }

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -747,6 +747,7 @@ HERDR_PRESENTATION_ORDER_LOCK_HELD=0
 HERDR_RELAUNCH_CANDIDATE=0
 HERDR_RELAUNCH_CANDIDATE_CLEANUP=0
 HERDR_RELAUNCH_CANDIDATE_RECORD=
+HERDR_RELAUNCH_LAUNCH_PROVENANCE_DIR=
 HERDR_RELAUNCH_CANDIDATE_TAB_ID=
 HERDR_RELAUNCH_CANDIDATE_PANE_ID=
 HERDR_RELAUNCH_RECOVERED_STATE=
@@ -1121,8 +1122,80 @@ herdr_relaunch_candidate_record_write() {  # <phase> [extra-line]...
   } > "$tmp" && mv -f "$tmp" "$HERDR_RELAUNCH_CANDIDATE_RECORD"
 }
 
+herdr_relaunch_launch_provenance_persist() {
+  local dir tmp family path token_path token auth index=0 seen
+  dir=$HERDR_RELAUNCH_LAUNCH_PROVENANCE_DIR
+  tmp="$dir.tmp.${BASHPID:-$$}"
+  rm -rf "$tmp" || return 1
+  (umask 077; mkdir "$tmp") || return 1
+  cp -p "$SPAWN_META_TMP" "$tmp/meta" || { rm -rf "$tmp"; return 1; }
+  : > "$tmp/manifest" || { rm -rf "$tmp"; return 1; }
+  family=$(fm_control_harness_family "$HARNESS") || family=
+  {
+    fm_control_harness_wiring_paths "$family" "$WT" "$STATE_REAL" "$ID" || return 1
+    printf '%s\n' "$(fm_busy_gen_path "$STATE_REAL" "$ID")"
+    token_path=$(fm_control_harness_turnend_token_path "$family" "$STATE_REAL" "$ID") || return 1
+    if [ -n "$token_path" ] && [ -f "$token_path" ] && [ ! -L "$token_path" ]; then
+      IFS= read -r token < "$token_path" || [ -n "$token" ] || return 1
+      auth=$(fm_control_harness_turnend_auth_path "$family" "$token") || return 1
+      [ -z "$auth" ] || printf '%s\n' "$auth"
+    fi
+  } > "$tmp/paths" || { rm -rf "$tmp"; return 1; }
+  while IFS= read -r path; do
+    [ -n "$path" ] || continue
+    case "$path" in /*) ;; *) rm -rf "$tmp"; return 1 ;; esac
+    case "$path" in *$'\n'*|*$'\r'*|*$'\t'*) rm -rf "$tmp"; return 1 ;; esac
+    seen=0
+    while IFS=$'\t' read -r _ _ saved_path; do
+      [ "$saved_path" != "$path" ] || seen=1
+    done < "$tmp/manifest"
+    [ "$seen" = 0 ] || continue
+    index=$((index + 1))
+    if [ -e "$path" ] || [ -L "$path" ]; then
+      [ -f "$path" ] && [ ! -L "$path" ] || { rm -rf "$tmp"; return 1; }
+      cp -p "$path" "$tmp/$index" || { rm -rf "$tmp"; return 1; }
+      printf 'present\t%s\t%s\n' "$index" "$path" >> "$tmp/manifest" || { rm -rf "$tmp"; return 1; }
+    else
+      printf 'absent\t%s\t%s\n' "$index" "$path" >> "$tmp/manifest" || { rm -rf "$tmp"; return 1; }
+    fi
+  done < "$tmp/paths"
+  rm -f "$tmp/paths" || { rm -rf "$tmp"; return 1; }
+  rm -rf "$dir" || { rm -rf "$tmp"; return 1; }
+  mv "$tmp" "$dir"
+}
+
+herdr_relaunch_launch_provenance_restore() {
+  local dir presence index path tmp status=0
+  dir=$HERDR_RELAUNCH_LAUNCH_PROVENANCE_DIR
+  [ -d "$dir" ] && [ ! -L "$dir" ] && [ -f "$dir/meta" ] && [ ! -L "$dir/meta" ] \
+    && [ -f "$dir/manifest" ] && [ ! -L "$dir/manifest" ] || return 1
+  while IFS=$'\t' read -r presence index path; do
+    [ -n "$path" ] || continue
+    case "$path" in /*) ;; *) return 1 ;; esac
+    case "$path" in *$'\n'*|*$'\r'*|*$'\t'*) return 1 ;; esac
+    case "$presence" in
+      present)
+        [ -f "$dir/$index" ] && [ ! -L "$dir/$index" ] || return 1
+        mkdir -p "$(dirname "$path")" || return 1
+        [ ! -d "$path" ] || return 1
+        tmp="$path.relaunch-adopt.${BASHPID:-$$}"
+        cp -p "$dir/$index" "$tmp" && rm -f "$path" && mv "$tmp" "$path" \
+          || { rm -f "$tmp"; return 1; }
+        cmp -s "$dir/$index" "$path" || status=1
+        ;;
+      absent)
+        [ ! -d "$path" ] || return 1
+        rm -f "$path" || return 1
+        [ ! -e "$path" ] && [ ! -L "$path" ] || status=1
+        ;;
+      *) return 1 ;;
+    esac
+  done < "$dir/manifest"
+  return "$status"
+}
+
 herdr_relaunch_candidate_adopt_live() {
-  local current current_real expected_real busy_gen spawn_gen tmp old_retirement=retained
+  local current current_real expected_real busy_gen staged_busy tmp old_retirement=retained provenance_meta
   [ "$HERDR_RELAUNCH_RECOVERED_STATE" = alive ] || return 1
   fm_backend_herdr_relaunch_candidate_matches \
     "$HERDR_SES" "$HERDR_WORKSPACE_ID" \
@@ -1132,37 +1205,27 @@ herdr_relaunch_candidate_adopt_live() {
   current_real=$(CDPATH='' cd -- "$current" 2>/dev/null && pwd -P) || return 1
   expected_real=$(CDPATH='' cd -- "$WT" 2>/dev/null && pwd -P) || return 1
   [ "$current_real" = "$expected_real" ] || return 1
+  provenance_meta="$HERDR_RELAUNCH_LAUNCH_PROVENANCE_DIR/meta"
+  [ "$(fm_backend_meta_exact_value "$provenance_meta" window)" = "$HERDR_SES:$HERDR_RELAUNCH_CANDIDATE_PANE_ID" ] \
+    && [ "$(fm_backend_meta_exact_value "$provenance_meta" worktree)" = "$WT" ] \
+    && [ "$(fm_backend_meta_exact_value "$provenance_meta" harness)" = "$HARNESS" ] \
+    && [ "$(fm_backend_meta_exact_value "$provenance_meta" model)" = "${MODEL:-default}" ] \
+    && [ "$(fm_backend_meta_exact_value "$provenance_meta" effort)" = "${EFFORT:-default}" ] \
+    && [ "$(fm_backend_meta_exact_value "$provenance_meta" backend)" = herdr ] \
+    && [ "$(fm_backend_meta_exact_value "$provenance_meta" herdr_session)" = "$HERDR_SES" ] \
+    && [ "$(fm_backend_meta_exact_value "$provenance_meta" herdr_workspace_id)" = "$HERDR_WORKSPACE_ID" ] \
+    && [ "$(fm_backend_meta_exact_value "$provenance_meta" herdr_tab_id)" = "$HERDR_RELAUNCH_CANDIDATE_TAB_ID" ] \
+    && [ "$(fm_backend_meta_exact_value "$provenance_meta" herdr_pane_id)" = "$HERDR_RELAUNCH_CANDIDATE_PANE_ID" ] || return 1
+  herdr_relaunch_launch_provenance_restore || return 1
+  staged_busy=$(fm_backend_meta_exact_value "$provenance_meta" busy_gen) || staged_busy=
   busy_gen=$(fm_busy_current_gen "$STATE" "$ID" 2>/dev/null || true)
-  spawn_gen="s$(date +%s).${BASHPID:-$$}.$RANDOM"
+  [ "$busy_gen" = "$staged_busy" ] || return 1
   tmp="$STATE/.$ID.meta.relaunch-adopt.${BASHPID:-$$}"
-  {
-    echo "window=$HERDR_SES:$HERDR_RELAUNCH_CANDIDATE_PANE_ID"
-    echo "endpoint_task_id=$ID"
-    echo "worktree=$WT"
-    echo "project=$PROJ_ABS"
-    echo "harness=$HARNESS"
-    echo "kind=$KIND"
-    [ -z "$MODE" ] || echo "mode=$MODE"
-    [ -z "$YOLO" ] || echo "yolo=$YOLO"
-    echo "tasktmp=/tmp/fm-$ID"
-    echo "model=${MODEL:-default}"
-    echo "effort=${EFFORT:-default}"
-    [ -z "$busy_gen" ] || echo "busy_gen=$busy_gen"
-    echo "spawn_gen=$spawn_gen"
-    echo "backend=herdr"
-    echo "herdr_session=$HERDR_SES"
-    echo "herdr_workspace_id=$HERDR_WORKSPACE_ID"
-    echo "herdr_tab_id=$HERDR_RELAUNCH_CANDIDATE_TAB_ID"
-    echo "herdr_pane_id=$HERDR_RELAUNCH_CANDIDATE_PANE_ID"
-    awk -F= '
-      BEGIN {
-        split("window endpoint_task_id worktree project harness kind mode yolo tasktmp model effort busy_gen spawn_gen backend herdr_session herdr_workspace_id herdr_tab_id herdr_pane_id control_relaunch_tx", keys, " ")
-        for (i in keys) owned[keys[i]] = 1
-      }
-      !($1 in owned)
-    ' "$RELAUNCH_META"
-    [ -z "${FM_CONTROL_RELAUNCH_TX:-}" ] || echo "control_relaunch_tx=$FM_CONTROL_RELAUNCH_TX"
-  } > "$tmp" || { rm -f "$tmp"; return 1; }
+  awk -F= '$1 != "control_relaunch_tx"' "$provenance_meta" > "$tmp" \
+    || { rm -f "$tmp"; return 1; }
+  [ -z "${FM_CONTROL_RELAUNCH_TX:-}" ] \
+    || printf 'control_relaunch_tx=%s\n' "$FM_CONTROL_RELAUNCH_TX" >> "$tmp" \
+    || { rm -f "$tmp"; return 1; }
   fm_backlog_atomic_transition publish "$tmp" "$STATE/$ID.meta" "task record" "$STATE" || {
     rm -f "$tmp"
     return 1
@@ -1215,10 +1278,24 @@ herdr_relaunch_candidate_reconcile_prior() {
         && [ "$candidate_pane" = "$HERDR_RELAUNCH_OLD_PANE_ID" ] || return 1
       return 0
       ;;
-    creating|created|creation-failed|quarantined)
+    creating|created|creation-failed|quarantined|launch-attempt)
       [ "$replacement_harness" = "$HARNESS" ] \
         && [ "$replacement_model" = "${MODEL:-default}" ] \
         && [ "$replacement_effort" = "${EFFORT:-default}" ] || return 1
+      if [ -n "$candidate_tab" ] && [ -n "$candidate_pane" ]; then
+        fm_backend_endpoint_atom_valid "${candidate_tab//:/_}" \
+          && fm_backend_endpoint_atom_valid "${candidate_pane//:/_}" || return 1
+        if [ "$candidate_tab" = "$HERDR_RELAUNCH_OLD_TAB_ID" ] \
+           && [ "$candidate_pane" = "$HERDR_RELAUNCH_OLD_PANE_ID" ]; then
+          HERDR_RELAUNCH_CANDIDATE_TAB_ID=$candidate_tab
+          HERDR_RELAUNCH_CANDIDATE_PANE_ID=$candidate_pane
+          herdr_relaunch_candidate_record_write published \
+            "candidate_state=reconciled-from-authoritative-binding" || return 1
+          HERDR_RELAUNCH_CANDIDATE_TAB_ID=
+          HERDR_RELAUNCH_CANDIDATE_PANE_ID=
+          return 0
+        fi
+      fi
       [ "$old_tab" = "$HERDR_RELAUNCH_OLD_TAB_ID" ] \
         && [ "$old_pane" = "$HERDR_RELAUNCH_OLD_PANE_ID" ] || return 1
       if [ -z "$candidate_tab" ] || [ -z "$candidate_pane" ]; then
@@ -1242,14 +1319,6 @@ herdr_relaunch_candidate_reconcile_prior() {
         && fm_backend_endpoint_atom_valid "${candidate_pane//:/_}" || return 1
       HERDR_RELAUNCH_CANDIDATE_TAB_ID=$candidate_tab
       HERDR_RELAUNCH_CANDIDATE_PANE_ID=$candidate_pane
-      if [ "$candidate_tab" = "$HERDR_RELAUNCH_OLD_TAB_ID" ] \
-         && [ "$candidate_pane" = "$HERDR_RELAUNCH_OLD_PANE_ID" ]; then
-        herdr_relaunch_candidate_record_write published \
-          "candidate_state=reconciled-from-authoritative-binding" || return 1
-        HERDR_RELAUNCH_CANDIDATE_TAB_ID=
-        HERDR_RELAUNCH_CANDIDATE_PANE_ID=
-        return 0
-      fi
       fm_backend_herdr_relaunch_candidate_matches \
         "$HERDR_SES" "$HERDR_WORKSPACE_ID" "$candidate_tab" "$candidate_pane" || return 1
       current=$(fm_backend_herdr_current_path "$HERDR_SES:$candidate_pane" || true)
@@ -1258,6 +1327,7 @@ herdr_relaunch_candidate_reconcile_prior() {
       [ "$current_real" = "$expected_real" ] || return 1
       state=$(fm_backend_herdr_recovery_agent_state "$HERDR_SES:$candidate_pane")
       if [ "$state" = alive ]; then
+        [ "$phase" = launch-attempt ] || return 1
         HERDR_RELAUNCH_RECOVERED_STATE=alive
         return 0
       fi
@@ -2537,6 +2607,7 @@ elif [ "$RELAUNCH" -eq 1 ]; then
     exit 1
   }
   HERDR_RELAUNCH_CANDIDATE_RECORD="$STATE/$ID.control-relaunch-candidate"
+  HERDR_RELAUNCH_LAUNCH_PROVENANCE_DIR="$STATE/$ID.control-relaunch-candidate.launch"
   HERDR_PRESENTATION_JOURNAL=$(fm_backend_herdr_projection_journal_path "$STATE" "$ID")
   herdr_relaunch_candidate_reconcile_prior || {
     echo "error: a prior Herdr replacement candidate cannot be proved safe to retire or already published; refusing a duplicate launch" >&2
@@ -2544,10 +2615,14 @@ elif [ "$RELAUNCH" -eq 1 ]; then
   }
   if [ "$HERDR_RELAUNCH_RECOVERED_STATE" = alive ]; then
     herdr_relaunch_candidate_adopt_live || {
-      echo "error: the discovered Herdr replacement no longer proves its exact live identity and recorded worktree; refusing adoption" >&2
+      echo "error: the discovered Herdr replacement no longer proves its launch provenance, wiring, exact live identity, and recorded worktree; refusing adoption" >&2
       exit 1
     }
   fi
+  rm -rf "$HERDR_RELAUNCH_LAUNCH_PROVENANCE_DIR" || {
+    echo "error: could not clear retired Herdr replacement launch provenance" >&2
+    exit 1
+  }
   HERDR_RELAUNCH_LABEL="fm-relaunch-${BASHPID:-$$}-${RANDOM}"
   herdr_relaunch_candidate_record_write creating "candidate_label=$HERDR_RELAUNCH_LABEL" || {
     echo "error: could not persist the Herdr replacement attempt before endpoint creation" >&2
@@ -3687,6 +3762,14 @@ else
 fi
 sleep 0.3
 if [ "$RELAUNCH" -eq 1 ] && [ "$BACKEND" = herdr ]; then
+  if [ "$HERDR_RELAUNCH_CANDIDATE" = 1 ]; then
+    herdr_relaunch_launch_provenance_persist \
+      && herdr_relaunch_candidate_record_write launch-attempt \
+        "candidate_label=$HERDR_RELAUNCH_LABEL" "candidate_state=launch-submitting" || {
+      echo "error: could not persist Herdr replacement launch provenance before command submission" >&2
+      exit 1
+    }
+  fi
   # Freeze and revalidate the prepared shell before atomically queueing the
   # command and Enter. This closes the final foreground-owner race rather than
   # relying on a sample immediately before pane input.

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -2531,10 +2531,21 @@ kimi_spawn_fail() {  # <detail>
 
 if [ "$RELAUNCH" -eq 1 ]; then
   [ "$KIND" = secondmate ] || validate_spawn_worktree "relaunch" "$T"
-  fm_backend_prepare_relaunch_path "$BACKEND" "$WT_TARGET" "$WT" || {
-    echo "error: task $ID's endpoint could not be prepared safely in its recorded worktree '$WT'" >&2
-    exit 1
-  }
+  if [ "$BACKEND" = herdr ]; then
+    spawn_herdr_presentation_order_lock_acquire "$SES" || {
+      echo "error: herdr relaunch could not acquire its session mutation lock; refusing unlocked replacement delivery" >&2
+      exit 1
+    }
+    fm_backend_herdr_prepare_relaunch_path_serialized "$WT_TARGET" "$WT" || {
+      echo "error: task $ID's endpoint could not be prepared safely in its recorded worktree '$WT'" >&2
+      exit 1
+    }
+  else
+    fm_backend_prepare_relaunch_path "$BACKEND" "$WT_TARGET" "$WT" || {
+      echo "error: task $ID's endpoint could not be prepared safely in its recorded worktree '$WT'" >&2
+      exit 1
+    }
+  fi
   # No worktree is acquired: the recorded one is reused as-is. What must be
   # proven instead is that the adopted endpoint's shell is actually sitting in
   # that worktree, so the replacement agent starts where the work is rather
@@ -3258,9 +3269,12 @@ spawn_send_literal "$T" "$LAUNCH"
 sleep 0.3
 if [ "${HERDR_PROJECTED:-0}" -eq 1 ]; then
   HERDR_PROJECTION_ABORT_CLEANUP=0
-  spawn_herdr_presentation_order_lock_release
 fi
 spawn_send_key "$T" Enter
+# A Herdr create or relaunch keeps the session mutation lock through command
+# submission, so no competing lifecycle input can separate launch bytes from
+# their Enter or redirect them after endpoint preparation.
+spawn_herdr_presentation_order_lock_release
 if [ "$HARNESS" = kimi ]; then
   if ! kimi_wait_for_ready; then
     kimi_spawn_fail "kimi did not show a verified ready signal before brief delivery"

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -2530,6 +2530,7 @@ kimi_spawn_fail() {  # <detail>
 }
 
 if [ "$RELAUNCH" -eq 1 ]; then
+  [ "$KIND" = secondmate ] || validate_spawn_worktree "relaunch" "$T"
   fm_backend_prepare_relaunch_path "$BACKEND" "$WT_TARGET" "$WT" || {
     echo "error: task $ID's endpoint could not be prepared safely in its recorded worktree '$WT'" >&2
     exit 1

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -1039,9 +1039,10 @@ snapshot_relaunch_wiring() {  # <prior-harness> <new-harness> <worktree> <state>
   RELAUNCH_WIRING_SNAPSHOT_ACTIVE=1
 }
 
-restore_relaunch_wiring_snapshot() {
-  local presence index path tmp status=0
-  [ "$RELAUNCH_WIRING_SNAPSHOT_ACTIVE" = 1 ] || return 0
+restore_relaunch_wiring_snapshot_dir() {
+  local snapshot_dir=$1 presence index path tmp status=0
+  [ -d "$snapshot_dir" ] && [ ! -L "$snapshot_dir" ] \
+    && [ -f "$snapshot_dir/manifest" ] && [ ! -L "$snapshot_dir/manifest" ] || return 1
   while IFS=$'\t' read -r presence index path; do
     [ -n "$path" ] || continue
     case "$presence" in
@@ -1052,7 +1053,8 @@ restore_relaunch_wiring_snapshot() {
           continue
         fi
         tmp="$path.relaunch-restore.${BASHPID:-$$}"
-        if cp -p "$RELAUNCH_WIRING_SNAPSHOT_DIR/$index" "$tmp"; then
+        if [ -f "$snapshot_dir/$index" ] && [ ! -L "$snapshot_dir/$index" ] \
+           && cp -p "$snapshot_dir/$index" "$tmp"; then
           rm -f "$path" 2>/dev/null || { rm -f "$tmp" 2>/dev/null || true; status=1; continue; }
           mv "$tmp" "$path" || { rm -f "$tmp" 2>/dev/null || true; status=1; }
         else
@@ -1068,10 +1070,33 @@ restore_relaunch_wiring_snapshot() {
         ;;
       *) status=1 ;;
     esac
-  done < "$RELAUNCH_WIRING_SNAPSHOT_DIR/manifest"
+  done < "$snapshot_dir/manifest"
+  return "$status"
+}
+
+restore_relaunch_wiring_snapshot() {
+  local status=0
+  [ "$RELAUNCH_WIRING_SNAPSHOT_ACTIVE" = 1 ] || return 0
+  restore_relaunch_wiring_snapshot_dir "$RELAUNCH_WIRING_SNAPSHOT_DIR" || status=1
   rm -rf "$RELAUNCH_WIRING_SNAPSHOT_DIR" || status=1
   RELAUNCH_WIRING_SNAPSHOT_ACTIVE=0
   return "$status"
+}
+
+persist_relaunch_wiring_snapshot() {
+  local target="$HERDR_RELAUNCH_LAUNCH_PROVENANCE_DIR/prior-snapshot" tmp
+  tmp="$target.tmp.${BASHPID:-$$}"
+  rm -rf "$tmp" || return 1
+  mkdir -p "$HERDR_RELAUNCH_LAUNCH_PROVENANCE_DIR" || return 1
+  cp -Rp "$RELAUNCH_WIRING_SNAPSHOT_DIR" "$tmp" || { rm -rf "$tmp"; return 1; }
+  rm -rf "$target" || { rm -rf "$tmp"; return 1; }
+  mv "$tmp" "$target"
+}
+
+restore_persisted_relaunch_wiring_snapshot() {
+  local snapshot="$HERDR_RELAUNCH_LAUNCH_PROVENANCE_DIR/prior-snapshot"
+  restore_relaunch_wiring_snapshot_dir "$snapshot" || return 1
+  rm -rf "$snapshot"
 }
 
 retire_prior_relaunch_wiring() {  # <prior-harness> <replacement-harness> <worktree> <state> <id>
@@ -1327,7 +1352,7 @@ herdr_relaunch_candidate_reconcile_prior() {
         && [ "$candidate_pane" = "$HERDR_RELAUNCH_OLD_PANE_ID" ] || return 1
       return 0
       ;;
-    creating|created|creation-failed|quarantined|launch-attempt|binding-published)
+    creating|created|creation-failed|quarantined|wiring-snapshotted|launch-attempt|binding-published)
       [ "$replacement_harness" = "$HARNESS" ] \
         && [ "$replacement_model" = "${MODEL:-default}" ] \
         && [ "$replacement_effort" = "${EFFORT:-default}" ] || return 1
@@ -1395,6 +1420,11 @@ herdr_relaunch_candidate_reconcile_prior() {
       case "$state" in dead|missing) ;; *) return 1 ;; esac
       fm_backend_herdr_relaunch_candidate_cleanup \
         "$HERDR_SES" "$HERDR_WORKSPACE_ID" "$candidate_tab" "$candidate_pane" || return 1
+      case "$phase" in
+        wiring-snapshotted|launch-attempt)
+          restore_persisted_relaunch_wiring_snapshot || return 1
+          ;;
+      esac
       herdr_relaunch_candidate_record_write rolled-back "candidate_state=dead" || return 1
       HERDR_RELAUNCH_CANDIDATE_TAB_ID=
       HERDR_RELAUNCH_CANDIDATE_PANE_ID=
@@ -3186,8 +3216,11 @@ exclude_path() {
 if [ "$RELAUNCH" -eq 1 ]; then
   if [ "$HERDR_RELAUNCH_CANDIDATE" = 1 ]; then
     snapshot_relaunch_wiring \
-      "$RELAUNCH_PRIOR_HARNESS" "$HARNESS" "$WT" "$STATE_REAL" "$ID" || {
-      echo "error: could not snapshot $RELAUNCH_PRIOR_HARNESS wiring before the transactional Herdr replacement" >&2
+      "$RELAUNCH_PRIOR_HARNESS" "$HARNESS" "$WT" "$STATE_REAL" "$ID" \
+      && persist_relaunch_wiring_snapshot \
+      && herdr_relaunch_candidate_record_write wiring-snapshotted \
+        "candidate_label=$HERDR_RELAUNCH_LABEL" "candidate_state=agent-free" || {
+      echo "error: could not persist $RELAUNCH_PRIOR_HARNESS wiring before the transactional Herdr replacement" >&2
       exit 1
     }
   else

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -806,7 +806,7 @@ parse_orca_worktree_result() {
 }
 
 spawn_abort_cleanup() {
-  local status=$? candidate_state candidate_phase= rollback_ready=1 rollback_launch_attempt=0
+  local status=$? candidate_state candidate_phase='' rollback_ready=1 rollback_launch_attempt=0
   if [ -n "$HERDR_RELAUNCH_CANDIDATE_PANE_ID" ] \
      && herdr_relaunch_candidate_is_authoritative; then
     HERDR_RELAUNCH_CANDIDATE_CLEANUP=0
@@ -1371,8 +1371,12 @@ herdr_relaunch_launch_provenance_restore() {
         mkdir -p "$(dirname "$path")" || return 1
         [ ! -d "$path" ] || return 1
         tmp="$path.relaunch-adopt.${BASHPID:-$$}"
-        cp -p "$dir/$index" "$tmp" && rm -f "$path" && mv "$tmp" "$path" \
-          || { rm -f "$tmp"; return 1; }
+        if ! cp -p "$dir/$index" "$tmp" \
+          || ! rm -f "$path" \
+          || ! mv "$tmp" "$path"; then
+          rm -f "$tmp"
+          return 1
+        fi
         cmp -s "$dir/$index" "$path" || status=1
         ;;
       absent)
@@ -3392,14 +3396,14 @@ exclude_path() {
 }
 if [ "$RELAUNCH" -eq 1 ]; then
   if [ "$HERDR_RELAUNCH_CANDIDATE" = 1 ]; then
-    snapshot_relaunch_wiring \
-      "$RELAUNCH_PRIOR_HARNESS" "$HARNESS" "$WT" "$STATE_REAL" "$ID" \
-      && persist_relaunch_wiring_snapshot \
-      && herdr_relaunch_candidate_record_write wiring-snapshotted \
-        "candidate_label=$HERDR_RELAUNCH_LABEL" "candidate_state=agent-free" || {
+    if ! snapshot_relaunch_wiring \
+        "$RELAUNCH_PRIOR_HARNESS" "$HARNESS" "$WT" "$STATE_REAL" "$ID" \
+      || ! persist_relaunch_wiring_snapshot \
+      || ! herdr_relaunch_candidate_record_write wiring-snapshotted \
+        "candidate_label=$HERDR_RELAUNCH_LABEL" "candidate_state=agent-free"; then
       echo "error: could not persist $RELAUNCH_PRIOR_HARNESS wiring before the transactional Herdr replacement" >&2
       exit 1
-    }
+    fi
   else
     # Reused-endpoint backends retain the established behavior: retire the old
     # wiring before arming the replacement. Herdr snapshots instead because its
@@ -4041,12 +4045,12 @@ fi
 sleep 0.3
 if [ "$RELAUNCH" -eq 1 ] && [ "$BACKEND" = herdr ]; then
   if [ "$HERDR_RELAUNCH_CANDIDATE" = 1 ]; then
-    herdr_relaunch_launch_provenance_persist \
-      && herdr_relaunch_candidate_record_write launch-attempt \
-        "candidate_label=$HERDR_RELAUNCH_LABEL" "candidate_state=launch-submitting" || {
+    if ! herdr_relaunch_launch_provenance_persist \
+      || ! herdr_relaunch_candidate_record_write launch-attempt \
+        "candidate_label=$HERDR_RELAUNCH_LABEL" "candidate_state=launch-submitting"; then
       echo "error: could not persist Herdr replacement launch provenance before command submission" >&2
       exit 1
-    }
+    fi
     LAUNCH="umask 077; : > $(shell_quote "$HERDR_RELAUNCH_LAUNCH_PROVENANCE_DIR/launch/launch-receipt") && { $LAUNCH; }"
   fi
   # Freeze and revalidate the prepared shell before atomically queueing the

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -24,21 +24,23 @@
 #   no-mistakes-prod-only is a registry policy rather than a task mode and is
 #   refused as a flag value.
 #        fm-spawn.sh <task-id> --relaunch [--harness <name>] [--model <name>] [--effort <level>]
-#   --relaunch launches a replacement agent for an EXISTING task into that
-#   task's own recorded endpoint and worktree instead of creating either. It is
-#   the launch half of the control plane (bin/fm-control.sh relaunch), which
-#   owns the checkpoint, the progress note, stopping the previous agent, and the
-#   transaction; call fm-control rather than this flag directly unless you are
-#   deliberately re-launching an already-stopped task. Every identity axis -
-#   backend, kind, project or home, worktree, endpoint - comes from the task's
+#   --relaunch launches a replacement agent for an EXISTING task in its exact
+#   recorded worktree. Tmux reuses the recorded endpoint. Herdr allocates one
+#   fresh endpoint in the recorded endpoint's exact workspace, keeps it
+#   unpublished while launch is proved, then atomically advances the task
+#   binding; any prepublication failure leaves the old endpoint and record
+#   untouched and retires only a response-identified agent-free candidate. It
+#   is the launch half of the control plane (bin/fm-control.sh relaunch), which
+#   owns the checkpoint, progress note, old-agent stop, and transaction; call
+#   fm-control rather than this flag directly unless deliberately re-launching
+#   an already-stopped task. Every identity axis - backend, kind, project or
+#   home, worktree, and recorded endpoint scope - comes from the task's
 #   validated state/<id>.meta, so --backend, --scout, --secondmate, a project
 #   positional, and batch pairs are all refused alongside it; only harness,
-#   model, and effort may change, which is what makes a harness switch one
-#   ordinary relaunch. It refuses unless the recorded endpoint is positively
-#   agent-free on a backend with a recovery-grade agent-state classifier (tmux
-#   or herdr), refuses unless the endpoint's shell is sitting in the recorded
-#   worktree, and clears the previous harness's per-task wiring before arming
-#   the new incarnation.
+#   model, and effort may change. It refuses unless the recorded endpoint is
+#   positively agent-free on a recovery-grade backend and the recorded local
+#   copy remains valid. Replacement wiring is snapshotted and restored on a
+#   failed Herdr launch.
 #   --harness <name> is the explicit per-spawn harness/profile adapter. The old
 #   positional harness arg still works for back-compat.
 #   --model <name> and --effort <low|medium|high|xhigh|max> are concrete profile
@@ -413,10 +415,9 @@ case "$EFFORT" in
   *) echo "error: --effort must be one of low, medium, high, xhigh, max" >&2; exit 1 ;;
 esac
 
-# --relaunch reuses an existing task's endpoint, worktree, project, and kind,
-# so every axis this block resolves for a fresh spawn instead comes from that
-# task's own durable record below. Contradicting it on the command line is a
-# refusal rather than a silently-ignored flag.
+# --relaunch reuses an existing task's backend, worktree, project, and kind.
+# Herdr may transactionally replace the exact recorded endpoint inside its
+# recorded workspace, but no command-line axis can broaden that scope.
 if [ "$RELAUNCH" -eq 1 ]; then
   [ "$BACKEND_SET" -eq 0 ] || { echo "error: --relaunch reuses the task's recorded backend; --backend cannot override it" >&2; exit 1; }
   [ "$KIND_SET" -eq 0 ] || { echo "error: --relaunch reuses the task's recorded kind; --scout/--secondmate cannot override it" >&2; exit 1; }
@@ -743,6 +744,14 @@ HERDR_PROJECTION_ABORT_TASK_PANE=
 HERDR_PROJECTION_ABORT_SEEDED_PANE=
 HERDR_PRESENTATION_ORDER_LOCK=
 HERDR_PRESENTATION_ORDER_LOCK_HELD=0
+HERDR_RELAUNCH_CANDIDATE=0
+HERDR_RELAUNCH_CANDIDATE_CLEANUP=0
+HERDR_RELAUNCH_CANDIDATE_RECORD=
+HERDR_RELAUNCH_CANDIDATE_TAB_ID=
+HERDR_RELAUNCH_CANDIDATE_PANE_ID=
+HERDR_RELAUNCH_OLD_WORKSPACE_ID=
+HERDR_RELAUNCH_OLD_TAB_ID=
+HERDR_RELAUNCH_OLD_PANE_ID=
 RELAUNCH_HERDR_SHELL_PID=
 SPAWN_TASK_LOCK=
 SPAWN_TASK_LOCK_HELD=0
@@ -761,6 +770,9 @@ RELAUNCH_REPLACEMENT_BUSY_GEN=
 RELAUNCH_REPLACEMENT_HARNESS=
 RELAUNCH_REPLACEMENT_STATE=
 RELAUNCH_REPLACEMENT_WT=
+RELAUNCH_WIRING_SNAPSHOT_DIR=
+RELAUNCH_WIRING_SNAPSHOT_ACTIVE=0
+RELAUNCH_PRIOR_AUTH_PATH=
 CONFIG_INHERIT_LOCK=
 CONFIG_INHERIT_LOCK_HELD=0
 
@@ -792,7 +804,7 @@ parse_orca_worktree_result() {
 }
 
 spawn_abort_cleanup() {
-  local status=$?
+  local status=$? candidate_state
   if [ "$RELAUNCH_REPLACEMENT_PENDING" = 1 ] \
      && [ "$SPAWN_META_PUBLISH_STARTED" = 1 ] \
      && [ -n "$SPAWN_META_TMP" ] \
@@ -815,6 +827,25 @@ spawn_abort_cleanup() {
           --gen "$RELAUNCH_REPLACEMENT_BUSY_GEN"; then
         echo "warning: could not retire replacement busy generation after aborted relaunch of $ID" >&2
       fi
+    fi
+  fi
+  if [ "$RELAUNCH_WIRING_SNAPSHOT_ACTIVE" = 1 ]; then
+    if ! restore_relaunch_wiring_snapshot; then
+      echo "warning: could not restore the prior harness wiring after aborted relaunch of $ID" >&2
+      status=1
+    fi
+  fi
+  if [ "$HERDR_RELAUNCH_CANDIDATE_CLEANUP" = 1 ]; then
+    HERDR_RELAUNCH_CANDIDATE_CLEANUP=0
+    if fm_backend_herdr_relaunch_candidate_cleanup \
+        "$HERDR_SES" "$HERDR_WORKSPACE_ID" \
+        "$HERDR_RELAUNCH_CANDIDATE_TAB_ID" "$HERDR_RELAUNCH_CANDIDATE_PANE_ID"; then
+      herdr_relaunch_candidate_record_write rolled-back "candidate_state=dead" 2>/dev/null || true
+    else
+      candidate_state=$(fm_backend_herdr_pane_agent_state "$HERDR_SES" "$HERDR_RELAUNCH_CANDIDATE_PANE_ID" 2>/dev/null || printf unknown)
+      herdr_relaunch_candidate_record_write quarantined "candidate_state=$candidate_state" 2>/dev/null || true
+      echo "warning: uncommitted Herdr replacement endpoint $HERDR_SES:$HERDR_RELAUNCH_CANDIDATE_PANE_ID could not be safely retired (state=$candidate_state); its exact identity remains in $HERDR_RELAUNCH_CANDIDATE_RECORD" >&2
+      status=1
     fi
   fi
   if [ "$HERDR_PROJECTION_ABORT_CLEANUP" = 1 ] \
@@ -896,6 +927,10 @@ spawn_abort_cleanup() {
     fm_lock_release "$SPAWN_CONTROL_LOCK" || true
   fi
   [ -z "$SPAWN_META_TMP" ] || rm -f "$SPAWN_META_TMP" 2>/dev/null || true
+  if [ -n "$RELAUNCH_WIRING_SNAPSHOT_DIR" ] \
+     && [ "$RELAUNCH_WIRING_SNAPSHOT_ACTIVE" != 1 ]; then
+    rm -rf "$RELAUNCH_WIRING_SNAPSHOT_DIR" 2>/dev/null || true
+  fi
   if [ "$CONFIG_INHERIT_LOCK_HELD" = 1 ]; then
     CONFIG_INHERIT_LOCK_HELD=0
     fm_lock_release "$CONFIG_INHERIT_LOCK" || true
@@ -951,10 +986,193 @@ $(fm_control_harness_wiring_paths "$harness" "$wt" "$state" "$id")
 EOF
 }
 
+snapshot_relaunch_wiring() {  # <prior-harness> <new-harness> <worktree> <state> <id>
+  local prior=$1 replacement=$2 wt=$3 state=$4 id=$5 path token auth index=0 seen
+  local prior_family replacement_family
+  prior_family=$(fm_control_harness_family "$prior") || prior_family=
+  replacement_family=$(fm_control_harness_family "$replacement") || replacement_family=
+  RELAUNCH_WIRING_SNAPSHOT_DIR="$state/.$id.relaunch-wiring.${BASHPID:-$$}"
+  (umask 077; mkdir "$RELAUNCH_WIRING_SNAPSHOT_DIR") || return 1
+  : > "$RELAUNCH_WIRING_SNAPSHOT_DIR/manifest" || return 1
+  RELAUNCH_PRIOR_AUTH_PATH=
+  {
+    fm_control_harness_wiring_paths "$prior_family" "$wt" "$state" "$id" || return 1
+    fm_control_harness_wiring_paths "$replacement_family" "$wt" "$state" "$id" || return 1
+    printf '%s\n' "$(fm_busy_record_path "$state" "$id")" "$(fm_busy_gen_path "$state" "$id")"
+    token=$(fm_control_harness_turnend_token_path "$prior_family" "$state" "$id") || return 1
+    if [ -n "$token" ] && [ -f "$token" ] && [ ! -L "$token" ]; then
+      IFS= read -r token < "$token" || [ -n "$token" ] || return 1
+      auth=$(fm_control_harness_turnend_auth_path "$prior_family" "$token") || return 1
+      if [ -n "$auth" ]; then
+        RELAUNCH_PRIOR_AUTH_PATH=$auth
+        printf '%s\n' "$auth"
+      fi
+    fi
+  } > "$RELAUNCH_WIRING_SNAPSHOT_DIR/paths" || return 1
+  while IFS= read -r path; do
+    [ -n "$path" ] || continue
+    case "$path" in /*) ;; *) return 1 ;; esac
+    case "$path" in *$'\n'*|*$'\r'*|*$'\t'*) return 1 ;; esac
+    seen=0
+    while IFS=$'\t' read -r _ _ saved_path; do
+      [ "$saved_path" != "$path" ] || seen=1
+    done < "$RELAUNCH_WIRING_SNAPSHOT_DIR/manifest"
+    [ "$seen" = 0 ] || continue
+    index=$((index + 1))
+    if [ -e "$path" ] || [ -L "$path" ]; then
+      [ -f "$path" ] && [ ! -L "$path" ] || return 1
+      cp -p "$path" "$RELAUNCH_WIRING_SNAPSHOT_DIR/$index" || return 1
+      printf 'present\t%s\t%s\n' "$index" "$path"
+    else
+      printf 'absent\t%s\t%s\n' "$index" "$path"
+    fi >> "$RELAUNCH_WIRING_SNAPSHOT_DIR/manifest" || return 1
+  done < "$RELAUNCH_WIRING_SNAPSHOT_DIR/paths" || return 1
+  rm -f "$RELAUNCH_WIRING_SNAPSHOT_DIR/paths" || return 1
+  RELAUNCH_WIRING_SNAPSHOT_ACTIVE=1
+}
+
+restore_relaunch_wiring_snapshot() {
+  local presence index path tmp status=0
+  [ "$RELAUNCH_WIRING_SNAPSHOT_ACTIVE" = 1 ] || return 0
+  while IFS=$'\t' read -r presence index path; do
+    [ -n "$path" ] || continue
+    case "$presence" in
+      present)
+        mkdir -p "$(dirname "$path")" || { status=1; continue; }
+        if [ -d "$path" ] && [ ! -L "$path" ]; then
+          status=1
+          continue
+        fi
+        tmp="$path.relaunch-restore.${BASHPID:-$$}"
+        if cp -p "$RELAUNCH_WIRING_SNAPSHOT_DIR/$index" "$tmp"; then
+          rm -f "$path" 2>/dev/null || { rm -f "$tmp" 2>/dev/null || true; status=1; continue; }
+          mv "$tmp" "$path" || { rm -f "$tmp" 2>/dev/null || true; status=1; }
+        else
+          status=1
+        fi
+        ;;
+      absent)
+        if [ -d "$path" ] && [ ! -L "$path" ]; then
+          status=1
+        else
+          rm -f "$path" || status=1
+        fi
+        ;;
+      *) status=1 ;;
+    esac
+  done < "$RELAUNCH_WIRING_SNAPSHOT_DIR/manifest"
+  rm -rf "$RELAUNCH_WIRING_SNAPSHOT_DIR" || status=1
+  RELAUNCH_WIRING_SNAPSHOT_ACTIVE=0
+  return "$status"
+}
+
+retire_prior_relaunch_wiring() {  # <prior-harness> <replacement-harness> <worktree> <state> <id>
+  local prior=$1 replacement=$2 wt=$3 state=$4 id=$5 prior_family replacement_family
+  local token_path token current_auth
+  prior_family=$(fm_control_harness_family "$prior") || prior_family=
+  replacement_family=$(fm_control_harness_family "$replacement") || replacement_family=
+  if [ "$prior_family" = "$replacement_family" ]; then
+    current_auth=
+    token_path=$(fm_control_harness_turnend_token_path "$replacement_family" "$state" "$id") || return 1
+    if [ -n "$token_path" ] && [ -f "$token_path" ] && [ ! -L "$token_path" ]; then
+      IFS= read -r token < "$token_path" || [ -n "$token" ] || return 1
+      current_auth=$(fm_control_harness_turnend_auth_path "$replacement_family" "$token") || return 1
+    fi
+    if [ -n "$RELAUNCH_PRIOR_AUTH_PATH" ] \
+       && [ "$RELAUNCH_PRIOR_AUTH_PATH" != "$current_auth" ]; then
+      rm -f -- "$RELAUNCH_PRIOR_AUTH_PATH" || return 1
+    fi
+    return 0
+  fi
+  case "$prior_family:$replacement_family" in pi:pi-signed|pi-signed:pi) return 0 ;; esac
+  clear_relaunch_harness_wiring "$prior_family" "$wt" "$state" "$id"
+}
+
 spawn_herdr_presentation_order_lock_release() {
   [ "$HERDR_PRESENTATION_ORDER_LOCK_HELD" = 1 ] || return 0
   HERDR_PRESENTATION_ORDER_LOCK_HELD=0
   fm_lock_release "$HERDR_PRESENTATION_ORDER_LOCK" || true
+}
+
+herdr_relaunch_candidate_record_write() {  # <phase> [extra-line]...
+  local phase=$1 tmp line
+  shift
+  [ -n "$HERDR_RELAUNCH_CANDIDATE_RECORD" ] || return 1
+  tmp="$HERDR_RELAUNCH_CANDIDATE_RECORD.tmp.${BASHPID:-$$}"
+  {
+    echo "v1"
+    echo "task=$ID"
+    echo "phase=$phase"
+    echo "tx=${FM_CONTROL_RELAUNCH_TX:-direct}"
+    echo "session=$HERDR_SES"
+    echo "workspace=$HERDR_WORKSPACE_ID"
+    echo "old_tab=$HERDR_RELAUNCH_OLD_TAB_ID"
+    echo "old_pane=$HERDR_RELAUNCH_OLD_PANE_ID"
+    echo "candidate_tab=$HERDR_RELAUNCH_CANDIDATE_TAB_ID"
+    echo "candidate_pane=$HERDR_RELAUNCH_CANDIDATE_PANE_ID"
+    echo "worktree=$WT"
+    echo "replacement_harness=$HARNESS"
+    echo "replacement_model=${MODEL:-default}"
+    echo "replacement_effort=${EFFORT:-default}"
+    for line in "$@"; do
+      echo "$line"
+    done
+  } > "$tmp" && mv -f "$tmp" "$HERDR_RELAUNCH_CANDIDATE_RECORD"
+}
+
+# Reconcile only a previously journaled exact candidate for this same task and
+# old binding. A live or ambiguous candidate refuses a duplicate launch; an
+# agent-free or already-gone candidate is idempotently retired before a fresh
+# transaction starts. No workspace or endpoint enumeration is permitted.
+herdr_relaunch_candidate_reconcile_prior() {
+  local phase task session workspace old_tab old_pane worktree candidate_tab candidate_pane
+  [ ! -e "$HERDR_RELAUNCH_CANDIDATE_RECORD" ] \
+    && [ ! -L "$HERDR_RELAUNCH_CANDIDATE_RECORD" ] && return 0
+  [ -f "$HERDR_RELAUNCH_CANDIDATE_RECORD" ] \
+    && [ ! -L "$HERDR_RELAUNCH_CANDIDATE_RECORD" ] || return 1
+  phase=$(fm_backend_meta_exact_value "$HERDR_RELAUNCH_CANDIDATE_RECORD" phase) || return 1
+  task=$(fm_backend_meta_exact_value "$HERDR_RELAUNCH_CANDIDATE_RECORD" task) || return 1
+  session=$(fm_backend_meta_exact_value "$HERDR_RELAUNCH_CANDIDATE_RECORD" session) || return 1
+  workspace=$(fm_backend_meta_exact_value "$HERDR_RELAUNCH_CANDIDATE_RECORD" workspace) || return 1
+  old_tab=$(fm_backend_meta_exact_value "$HERDR_RELAUNCH_CANDIDATE_RECORD" old_tab) || return 1
+  old_pane=$(fm_backend_meta_exact_value "$HERDR_RELAUNCH_CANDIDATE_RECORD" old_pane) || return 1
+  worktree=$(fm_backend_meta_exact_value "$HERDR_RELAUNCH_CANDIDATE_RECORD" worktree) || return 1
+  candidate_tab=$(fm_backend_meta_exact_value "$HERDR_RELAUNCH_CANDIDATE_RECORD" candidate_tab) || candidate_tab=
+  candidate_pane=$(fm_backend_meta_exact_value "$HERDR_RELAUNCH_CANDIDATE_RECORD" candidate_pane) || candidate_pane=
+  [ "$task" = "$ID" ] && [ "$session" = "$HERDR_SES" ] \
+    && [ "$workspace" = "$HERDR_WORKSPACE_ID" ] && [ "$worktree" = "$WT" ] || return 1
+  case "$phase" in
+    rolled-back) return 0 ;;
+    published)
+      [ "$candidate_tab" = "$HERDR_RELAUNCH_OLD_TAB_ID" ] \
+        && [ "$candidate_pane" = "$HERDR_RELAUNCH_OLD_PANE_ID" ] || return 1
+      return 0
+      ;;
+    creating|created|creation-failed|quarantined)
+      [ -n "$candidate_tab" ] && [ -n "$candidate_pane" ] \
+        && fm_backend_endpoint_atom_valid "${candidate_tab//:/_}" \
+        && fm_backend_endpoint_atom_valid "${candidate_pane//:/_}" || return 1
+      HERDR_RELAUNCH_CANDIDATE_TAB_ID=$candidate_tab
+      HERDR_RELAUNCH_CANDIDATE_PANE_ID=$candidate_pane
+      if [ "$candidate_tab" = "$HERDR_RELAUNCH_OLD_TAB_ID" ] \
+         && [ "$candidate_pane" = "$HERDR_RELAUNCH_OLD_PANE_ID" ]; then
+        herdr_relaunch_candidate_record_write published \
+          "candidate_state=reconciled-from-authoritative-binding" || return 1
+        HERDR_RELAUNCH_CANDIDATE_TAB_ID=
+        HERDR_RELAUNCH_CANDIDATE_PANE_ID=
+        return 0
+      fi
+      [ "$old_tab" = "$HERDR_RELAUNCH_OLD_TAB_ID" ] \
+        && [ "$old_pane" = "$HERDR_RELAUNCH_OLD_PANE_ID" ] || return 1
+      fm_backend_herdr_relaunch_candidate_cleanup \
+        "$HERDR_SES" "$HERDR_WORKSPACE_ID" "$candidate_tab" "$candidate_pane" || return 1
+      herdr_relaunch_candidate_record_write rolled-back "candidate_state=dead" || return 1
+      HERDR_RELAUNCH_CANDIDATE_TAB_ID=
+      HERDR_RELAUNCH_CANDIDATE_PANE_ID=
+      return 0
+      ;;
+    *) return 1 ;;
+  esac
 }
 
 # Batch dispatch (see header): when the first positional is an `id=repo` pair, treat every
@@ -1165,6 +1383,16 @@ if [ "$RELAUNCH" -eq 1 ]; then
     exit 1
   }
   RELAUNCH_PRIOR_HARNESS=$(fm_meta_get "$RELAUNCH_META" harness)
+  if [ "$MODEL_SET" -eq 0 ] \
+     && { [ -z "$HARNESS_ARG" ] || [ "$HARNESS_ARG" = "$RELAUNCH_PRIOR_HARNESS" ]; }; then
+    MODEL=$(fm_meta_get "$RELAUNCH_META" model)
+    [ -n "$MODEL" ] || MODEL=default
+  fi
+  if [ "$EFFORT_SET" -eq 0 ] \
+     && { [ -z "$HARNESS_ARG" ] || [ "$HARNESS_ARG" = "$RELAUNCH_PRIOR_HARNESS" ]; }; then
+    EFFORT=$(fm_meta_get "$RELAUNCH_META" effort)
+    [ -n "$EFFORT" ] || EFFORT=default
+  fi
   KIND=$(fm_meta_get "$RELAUNCH_META" kind)
   [ -n "$KIND" ] || KIND=ship
   MODE=$(fm_meta_get "$RELAUNCH_META" mode)
@@ -2182,17 +2410,69 @@ if [ -e "$STATE/$ID.backlog-close" ] || [ -L "$STATE/$ID.backlog-close" ]; then
 fi
 
 W="fm-$ID"
-if [ "$RELAUNCH" -eq 1 ]; then
-  # Adopt the recorded endpoint instead of creating one. This is what keeps a
-  # relaunch a REPLACEMENT rather than a second copy of the task: no new
-  # terminal, no second worktree, and every uncommitted change left exactly
-  # where the previous agent left it.
+if [ "$RELAUNCH" -eq 1 ] && [ "$BACKEND" != herdr ]; then
+  # Backends with an owner-conditional launch path keep reusing the recorded
+  # endpoint. Herdr instead allocates an unpublished replacement below because
+  # its generic pane input API cannot bind a command to an expected shell.
   T=$RELAUNCH_TARGET
-  # A secondmate's home already resolved WT above through the same validation a
-  # fresh secondmate spawn uses; every other kind takes the recorded worktree.
   [ "$KIND" = secondmate ] || WT=$RELAUNCH_WT
   WT_TARGET=$T
   SES=${T%%:*}
+elif [ "$RELAUNCH" -eq 1 ]; then
+  [ "$KIND" = secondmate ] || WT=$RELAUNCH_WT
+  [ "$KIND" = secondmate ] || validate_spawn_worktree "herdr replacement endpoint" "$RELAUNCH_TARGET"
+  HERDR_RELAUNCH_OLD_WORKSPACE_ID=$HERDR_WORKSPACE_ID
+  HERDR_RELAUNCH_OLD_TAB_ID=$HERDR_TAB_ID
+  HERDR_RELAUNCH_OLD_PANE_ID=$HERDR_PANE_ID
+  SES=$HERDR_SES
+  spawn_herdr_presentation_order_lock_acquire "$SES" || {
+    echo "error: herdr relaunch could not acquire its session mutation lock; refusing replacement endpoint creation" >&2
+    exit 1
+  }
+  fm_backend_herdr_relaunch_candidate_matches \
+    "$HERDR_SES" "$HERDR_WORKSPACE_ID" "$HERDR_TAB_ID" "$HERDR_PANE_ID" || {
+    echo "error: recorded Herdr endpoint does not match its exact workspace and tab; refusing replacement creation" >&2
+    exit 1
+  }
+  [ "$(fm_backend_herdr_recovery_agent_state "$RELAUNCH_TARGET")" = dead ] || {
+    echo "error: recorded Herdr endpoint no longer proves agent-free under the session mutation lock; refusing replacement creation" >&2
+    exit 1
+  }
+  HERDR_RELAUNCH_CANDIDATE_RECORD="$STATE/$ID.control-relaunch-candidate"
+  HERDR_PRESENTATION_JOURNAL=$(fm_backend_herdr_projection_journal_path "$STATE" "$ID")
+  herdr_relaunch_candidate_reconcile_prior || {
+    echo "error: a prior Herdr replacement candidate cannot be proved safe to retire or already published; refusing a duplicate launch" >&2
+    exit 1
+  }
+  HERDR_RELAUNCH_LABEL="fm-relaunch-${BASHPID:-$$}-${RANDOM}"
+  herdr_relaunch_candidate_record_write creating "candidate_label=$HERDR_RELAUNCH_LABEL" || {
+    echo "error: could not persist the Herdr replacement attempt before endpoint creation" >&2
+    exit 1
+  }
+  fm_backend_herdr_relaunch_candidate_create \
+    "$HERDR_SES" "$HERDR_WORKSPACE_ID" "$HERDR_RELAUNCH_LABEL" "$WT" || {
+    HERDR_RELAUNCH_CANDIDATE_TAB_ID=${FM_BACKEND_HERDR_RELAUNCH_CANDIDATE_TAB_ID:-}
+    HERDR_RELAUNCH_CANDIDATE_PANE_ID=${FM_BACKEND_HERDR_RELAUNCH_CANDIDATE_PANE_ID:-}
+    if [ "${FM_BACKEND_HERDR_RELAUNCH_CANDIDATE_CLEANUP_SAFE:-0}" = 1 ]; then
+      HERDR_RELAUNCH_CANDIDATE_CLEANUP=1
+    fi
+    herdr_relaunch_candidate_record_write creation-failed \
+      "candidate_label=$HERDR_RELAUNCH_LABEL" "candidate_state=unverified" 2>/dev/null || true
+    echo "error: could not establish an exact unpublished Herdr replacement endpoint" >&2
+    exit 1
+  }
+  HERDR_RELAUNCH_CANDIDATE_TAB_ID=$FM_BACKEND_HERDR_RELAUNCH_CANDIDATE_TAB_ID
+  HERDR_RELAUNCH_CANDIDATE_PANE_ID=$FM_BACKEND_HERDR_RELAUNCH_CANDIDATE_PANE_ID
+  HERDR_TAB_ID=$HERDR_RELAUNCH_CANDIDATE_TAB_ID
+  HERDR_PANE_ID=$HERDR_RELAUNCH_CANDIDATE_PANE_ID
+  T="$HERDR_SES:$HERDR_PANE_ID"
+  WT_TARGET=$T
+  HERDR_RELAUNCH_CANDIDATE=1
+  HERDR_RELAUNCH_CANDIDATE_CLEANUP=1
+  herdr_relaunch_candidate_record_write created "candidate_label=$HERDR_RELAUNCH_LABEL" || {
+    echo "error: could not persist the unpublished Herdr replacement endpoint identity" >&2
+    exit 1
+  }
 else
 case "$BACKEND" in
   tmux)
@@ -2533,10 +2813,12 @@ kimi_spawn_fail() {  # <detail>
 if [ "$RELAUNCH" -eq 1 ]; then
   [ "$KIND" = secondmate ] || validate_spawn_worktree "relaunch" "$T"
   if [ "$BACKEND" = herdr ]; then
-    spawn_herdr_presentation_order_lock_acquire "$SES" || {
-      echo "error: herdr relaunch could not acquire its session mutation lock; refusing unlocked replacement delivery" >&2
-      exit 1
-    }
+    if [ "$HERDR_PRESENTATION_ORDER_LOCK_HELD" != 1 ]; then
+      spawn_herdr_presentation_order_lock_acquire "$SES" || {
+        echo "error: herdr relaunch could not acquire its session mutation lock; refusing unlocked replacement delivery" >&2
+        exit 1
+      }
+    fi
     fm_backend_herdr_prepare_relaunch_path_serialized "$WT_TARGET" "$WT" || {
       echo "error: task $ID's endpoint could not be prepared safely in its recorded worktree '$WT'" >&2
       exit 1
@@ -2662,15 +2944,21 @@ exclude_path() {
   grep -qxF "$rel" "$EXCL" 2>/dev/null || echo "$rel" >> "$EXCL"
 }
 if [ "$RELAUNCH" -eq 1 ]; then
-  # Retire the previous incarnation's per-task harness wiring before arming the
-  # new one. Without this, a harness switch would leave the old adapter's hook
-  # files and turn-end token registry entries behind, and even a same-harness
-  # relaunch would orphan the retired busy generation's token
-  # (bin/fm-control-lib.sh owns where those artifacts live).
-  clear_relaunch_harness_wiring "$RELAUNCH_PRIOR_HARNESS" "$WT" "$STATE_REAL" "$ID" || {
-    echo "error: could not retire $RELAUNCH_PRIOR_HARNESS wiring for task $ID; refusing to arm the replacement" >&2
-    exit 1
-  }
+  if [ "$HERDR_RELAUNCH_CANDIDATE" = 1 ]; then
+    snapshot_relaunch_wiring \
+      "$RELAUNCH_PRIOR_HARNESS" "$HARNESS" "$WT" "$STATE_REAL" "$ID" || {
+      echo "error: could not snapshot $RELAUNCH_PRIOR_HARNESS wiring before the transactional Herdr replacement" >&2
+      exit 1
+    }
+  else
+    # Reused-endpoint backends retain the established behavior: retire the old
+    # wiring before arming the replacement. Herdr snapshots instead because its
+    # old binding remains authoritative until the candidate launch is proved.
+    clear_relaunch_harness_wiring "$RELAUNCH_PRIOR_HARNESS" "$WT" "$STATE_REAL" "$ID" || {
+      echo "error: could not retire $RELAUNCH_PRIOR_HARNESS wiring for task $ID; refusing to arm the replacement" >&2
+      exit 1
+    }
+  fi
   RELAUNCH_REPLACEMENT_PENDING=1
   RELAUNCH_REPLACEMENT_HARNESS=$HARNESS
   RELAUNCH_REPLACEMENT_STATE=$STATE_REAL
@@ -3133,14 +3421,21 @@ spawn_commit_backlog_transition() {
 }
 
 if [ "$RELAUNCH" -eq 1 ]; then
-  SPAWN_META_PUBLISH_STARTED=1
-  if ! fm_backlog_atomic_transition publish "$SPAWN_META_TMP" "$STATE/$ID.meta" "task record" "$STATE"; then
-    echo "error: replacement task record for $ID could not be published ($FM_BACKLOG_TRANSITION_ERROR)" >&2
-    exit 1
+  if [ "$HERDR_RELAUNCH_CANDIDATE" = 1 ]; then
+    # The old endpoint remains authoritative while the fresh Herdr endpoint is
+    # still provisional. Publication happens only after the replacement agent
+    # is positively alive in the exact response-derived candidate below.
+    :
+  else
+    SPAWN_META_PUBLISH_STARTED=1
+    if ! fm_backlog_atomic_transition publish "$SPAWN_META_TMP" "$STATE/$ID.meta" "task record" "$STATE"; then
+      echo "error: replacement task record for $ID could not be published ($FM_BACKLOG_TRANSITION_ERROR)" >&2
+      exit 1
+    fi
+    RELAUNCH_REPLACEMENT_PENDING=0
+    SPAWN_META_PUBLISH_STARTED=0
+    SPAWN_META_TMP=
   fi
-  RELAUNCH_REPLACEMENT_PENDING=0
-  SPAWN_META_PUBLISH_STARTED=0
-  SPAWN_META_TMP=
 fi
 # A dispatch or relaunch keeps the per-task meta lock through launch delivery.
 # The backlog mutation is deliberately the final fallible commit below, so
@@ -3251,7 +3546,14 @@ spawn_record_traceparent() {
 if [ "$RELAUNCH" -eq 1 ] && [ "$BACKEND" = herdr ]; then
   LAUNCH="export GOTMPDIR=$(shell_quote "$TASK_TMP/gotmp"); $LAUNCH"
   if [ -n "$SPAWN_TRACEPARENT" ]; then
-    if spawn_record_traceparent; then
+    if [ "$HERDR_RELAUNCH_CANDIDATE" = 1 ]; then
+      if printf 'traceparent=%s\n' "$SPAWN_TRACEPARENT" >> "$SPAWN_META_TMP"; then
+        LAUNCH="export TRACEPARENT=$(shell_quote "$SPAWN_TRACEPARENT"); $LAUNCH"
+      else
+        SPAWN_TRACEPARENT=
+        LAUNCH="unset TRACEPARENT; $LAUNCH"
+      fi
+    elif spawn_record_traceparent; then
       LAUNCH="export TRACEPARENT=$(shell_quote "$SPAWN_TRACEPARENT"); $LAUNCH"
     else
       LAUNCH="unset TRACEPARENT; $LAUNCH"
@@ -3297,9 +3599,12 @@ else
   fi
   spawn_send_key "$T" Enter
 fi
-# A Herdr create or relaunch keeps the session mutation lock through command
-# submission, so no competing lifecycle input can redirect prepared input.
-spawn_herdr_presentation_order_lock_release
+# A fresh Herdr create keeps the session mutation lock through command
+# submission. A transactional Herdr relaunch keeps it longer, through positive
+# launch proof and binding publication below.
+if [ "$HERDR_RELAUNCH_CANDIDATE" != 1 ]; then
+  spawn_herdr_presentation_order_lock_release
+fi
 if [ "$HARNESS" = kimi ]; then
   if ! kimi_wait_for_ready; then
     kimi_spawn_fail "kimi did not show a verified ready signal before brief delivery"
@@ -3323,6 +3628,65 @@ if [ "$HARNESS" = kimi ]; then
     kimi_spawn_fail "kimi brief pointer delivery was not confirmed"
     exit 1
   fi
+fi
+if [ "$HERDR_RELAUNCH_CANDIDATE" = 1 ]; then
+  HERDR_RELAUNCH_LAUNCH_STATE=
+  for _ in $(seq 1 "${FM_HERDR_RELAUNCH_LAUNCH_POLLS:-180}"); do
+    HERDR_RELAUNCH_LAUNCH_STATE=$(fm_backend_recovery_agent_state herdr "$T")
+    [ "$HERDR_RELAUNCH_LAUNCH_STATE" != alive ] || break
+    sleep 0.5
+  done
+  [ "$HERDR_RELAUNCH_LAUNCH_STATE" = alive ] || {
+    echo "error: unpublished Herdr replacement endpoint did not prove a live agent (state=${HERDR_RELAUNCH_LAUNCH_STATE:-unknown})" >&2
+    exit 1
+  }
+  fm_backend_herdr_relaunch_candidate_matches \
+    "$HERDR_SES" "$HERDR_WORKSPACE_ID" "$HERDR_TAB_ID" "$HERDR_PANE_ID" || {
+    echo "error: unpublished Herdr replacement endpoint identity changed before publication" >&2
+    exit 1
+  }
+  HERDR_RELAUNCH_LIVE_PATH=$(spawn_current_path "$T" || true)
+  [ -n "$HERDR_RELAUNCH_LIVE_PATH" ] \
+    && [ "$(real_path_or_raw "$HERDR_RELAUNCH_LIVE_PATH")" = "$(real_path_or_raw "$WT")" ] || {
+      echo "error: unpublished Herdr replacement agent is not running in the recorded worktree" >&2
+      exit 1
+    }
+  SPAWN_META_PUBLISH_STARTED=1
+  if ! fm_backlog_atomic_transition publish "$SPAWN_META_TMP" "$STATE/$ID.meta" "task record" "$STATE"; then
+    echo "error: proven Herdr replacement could not publish its task binding ($FM_BACKLOG_TRANSITION_ERROR)" >&2
+    exit 1
+  fi
+  RELAUNCH_REPLACEMENT_PENDING=0
+  SPAWN_META_PUBLISH_STARTED=0
+  SPAWN_META_TMP=
+  HERDR_RELAUNCH_CANDIDATE_CLEANUP=0
+  if ! retire_prior_relaunch_wiring \
+      "$RELAUNCH_PRIOR_HARNESS" "$HARNESS" "$WT" "$STATE_REAL" "$ID"; then
+    echo "warning: published Herdr replacement retained stale $RELAUNCH_PRIOR_HARNESS wiring for later cleanup" >&2
+  fi
+  if [ "$RELAUNCH_WIRING_SNAPSHOT_ACTIVE" = 1 ]; then
+    rm -rf "$RELAUNCH_WIRING_SNAPSHOT_DIR" || true
+    RELAUNCH_WIRING_SNAPSHOT_ACTIVE=0
+  fi
+  herdr_relaunch_candidate_record_write published "candidate_state=alive" || true
+  if [ -n "${HERDR_PRESENTATION_JOURNAL:-}" ] \
+     && { [ -e "$HERDR_PRESENTATION_JOURNAL" ] || [ -L "$HERDR_PRESENTATION_JOURNAL" ]; }; then
+    fm_backend_herdr_projection_journal_replace_endpoint \
+      "$HERDR_PRESENTATION_JOURNAL" "$ID" \
+      "$HERDR_RELAUNCH_OLD_TAB_ID" "$HERDR_RELAUNCH_OLD_PANE_ID" \
+      "$HERDR_TAB_ID" "$HERDR_PANE_ID" || {
+      echo "warning: published Herdr replacement could not advance its presentation binding; authoritative task metadata remains current" >&2
+    }
+  fi
+  HERDR_RELAUNCH_OLD_RETIREMENT=retained
+  if fm_backend_herdr_relaunch_candidate_cleanup \
+      "$HERDR_SES" "$HERDR_RELAUNCH_OLD_WORKSPACE_ID" \
+      "$HERDR_RELAUNCH_OLD_TAB_ID" "$HERDR_RELAUNCH_OLD_PANE_ID"; then
+    HERDR_RELAUNCH_OLD_RETIREMENT=retired
+  fi
+  herdr_relaunch_candidate_record_write published \
+    "candidate_state=alive" "old_endpoint=$HERDR_RELAUNCH_OLD_RETIREMENT" || true
+  spawn_herdr_presentation_order_lock_release
 fi
 if [ "$KIND" = secondmate ] && [ "${FM_SKIP_SECONDMATE_INHERIT:-0}" != 1 ]; then
   if ! fm_config_reread_discard_pending "$PROJ_ABS" "$ID" "$FM_HOME"; then

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -2965,7 +2965,7 @@ rm -f "$STATE/$ID.turn-ended" \
 # The steering inbox (bin/fm-task-inbox-lib.sh) is runtime state for the
 # retired endpoint; teardown only runs after landing is confirmed, so any
 # leftover unhandled steer here is moot rather than unlanded work.
-rm -rf "$STATE/$ID.inbox"
+rm -rf "$STATE/$ID.control-relaunch-candidate.launch" "$STATE/$ID.inbox"
 # The record is gone, so the backlog must not still show this task in flight
 # when teardown reports success. Still under this task's meta lock, so a steer
 # racing the same id stays serialized exactly as it was before. A captain-held

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -2959,6 +2959,7 @@ rm -f "$STATE/$ID.turn-ended" \
   "$STATE/$ID.muse-session-current" "$STATE/$ID.cursor-session" \
   "$STATE/$ID.control-relaunch" "$STATE/$ID.control-relaunch.meta-prior" \
   "$STATE/$ID.control-relaunch.brief-prior" "$STATE/$ID.control-relaunch.note" \
+  "$STATE/$ID.control-relaunch-candidate" \
   "$STATE/$ID.reconcile-nudged" "$STATE/$ID.gemini-settings.json" \
   "$STATE/.$ID.branch-outcome-index"
 # The steering inbox (bin/fm-task-inbox-lib.sh) is runtime state for the

--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -293,7 +293,8 @@ family_for_basename() {
     fm-backend-herdr.test.sh|fm-backend-tmux-smoke.test.sh|fm-backend.test.sh|\
     fm-tmux-agent-liveness.test.sh|\
     fm-control.test.sh|fm-control-relaunch.test.sh|\
-    fm-herdr-session-cleanup.test.sh|fm-send-resolve-key.test.sh|fm-send-strict.test.sh|\
+    fm-herdr-relaunch-recovery.test.sh|fm-herdr-session-cleanup.test.sh|\
+    fm-send-resolve-key.test.sh|fm-send-strict.test.sh|\
     fm-send-inbox.test.sh|fm-spawn-batch.test.sh|\
     fm-spawn-dispatch-profile.test.sh|fm-claude-trust.test.sh|\
     fm-trace-context-spawn.test.sh|fm-spawn-worktree-settle.test.sh|\
@@ -589,6 +590,7 @@ tests/fm-guard-stale-banner.test.sh 11218
 tests/fm-harness-adapter-instructions-live-e2e.test.sh 20
 tests/fm-harness-adapter-references.test.sh 55
 tests/fm-harness-liveness-drift-live-e2e.test.sh 21
+tests/fm-herdr-relaunch-recovery.test.sh 1000
 tests/fm-herdr-session-cleanup.test.sh 6704
 tests/fm-herdr-submit-confirm-live-e2e.test.sh 23
 tests/fm-herdr-version-floor-live-e2e.test.sh 23
@@ -690,7 +692,7 @@ portable_serial_unhinted() {
   tmp=$(mktemp -d "${TMPDIR:-/tmp}/fm-test-unhinted.XXXXXX") || return 1
   portable_serial_weight_hints | awk 'NF { print $1 }' | LC_ALL=C sort -u >"$tmp/hinted"
   list_portable_serial | LC_ALL=C sort -u >"$tmp/serial"
-  comm -23 "$tmp/serial" "$tmp/hinted"
+  LC_ALL=C comm -23 "$tmp/serial" "$tmp/hinted"
   rm -rf "$tmp"
 }
 
@@ -838,8 +840,8 @@ run_coverage_guard() {
     return 1
   fi
   cat "$tmp/s1" "$tmp/s2" | LC_ALL=C sort -u >"$tmp/shards_union"
-  missing=$(comm -23 "$tmp/proven" "$tmp/shards_union" || true)
-  extra=$(comm -13 "$tmp/proven" "$tmp/shards_union" || true)
+  missing=$(LC_ALL=C comm -23 "$tmp/proven" "$tmp/shards_union" || true)
+  extra=$(LC_ALL=C comm -13 "$tmp/proven" "$tmp/shards_union" || true)
   if [ -n "$missing" ] || [ -n "$extra" ]; then
     log "coverage guard: portable shards must equal the proven-isolated set"
     [ -z "$missing" ] || { log "missing from shards:"; printf '%s\n' "$missing" >&2; }
@@ -883,8 +885,8 @@ run_coverage_guard() {
     return 1
   fi
   LC_ALL=C sort -u "$tmp/serial_shards_raw" >"$tmp/serial_shards"
-  missing=$(comm -23 "$tmp/serial" "$tmp/serial_shards" || true)
-  extra=$(comm -13 "$tmp/serial" "$tmp/serial_shards" || true)
+  missing=$(LC_ALL=C comm -23 "$tmp/serial" "$tmp/serial_shards" || true)
+  extra=$(LC_ALL=C comm -13 "$tmp/serial" "$tmp/serial_shards" || true)
   if [ -n "$missing" ] || [ -n "$extra" ]; then
     log "coverage guard: portable serial shards must equal the portable serial lane"
     [ -z "$missing" ] || { log "missing from serial shards:"; printf '%s\n' "$missing" >&2; }
@@ -896,7 +898,7 @@ run_coverage_guard() {
   for pair in "shards_union:serial" "shards_union:herdr" "serial:herdr"; do
     a=${pair%%:*}
     b=${pair#*:}
-    comm -12 "$tmp/$a" "$tmp/$b" >"$tmp/overlap"
+    LC_ALL=C comm -12 "$tmp/$a" "$tmp/$b" >"$tmp/overlap"
     if [ -s "$tmp/overlap" ]; then
       log "coverage guard: overlap between $a and $b:"
       cat "$tmp/overlap" >&2
@@ -914,8 +916,8 @@ run_coverage_guard() {
     return 1
   fi
   LC_ALL=C sort -u "$tmp/union_raw" >"$tmp/union"
-  missing=$(comm -23 "$tmp/all" "$tmp/union" || true)
-  extra=$(comm -13 "$tmp/all" "$tmp/union" || true)
+  missing=$(LC_ALL=C comm -23 "$tmp/all" "$tmp/union" || true)
+  extra=$(LC_ALL=C comm -13 "$tmp/all" "$tmp/union" || true)
   if [ -n "$missing" ] || [ -n "$extra" ]; then
     log "coverage guard: union of portable shards + portable serial + Herdr must equal tests/*.test.sh"
     [ -z "$missing" ] || { log "missing from union:"; printf '%s\n' "$missing" >&2; }
@@ -945,7 +947,7 @@ run_coverage_guard() {
     "$ROOT/bin/fm-test-isolation-proof.sh" --list | LC_ALL=C sort -u >"$tmp/proof_list"
     if ! cmp -s "$tmp/proven" "$tmp/proof_list"; then
       log "coverage guard: embedded proven-isolated set diverges from bin/fm-test-isolation-proof.sh --list"
-      comm -3 "$tmp/proven" "$tmp/proof_list" >&2 || true
+      LC_ALL=C comm -3 "$tmp/proven" "$tmp/proof_list" >&2 || true
       rm -rf "$tmp"
       return 1
     fi

--- a/docs/agent-control.md
+++ b/docs/agent-control.md
@@ -62,7 +62,7 @@ It is not deterministic across the verified adapters: codex, grok, and gemini re
    A recorded raw-command basename that differs from its resolved adapter cannot reproduce the command actually running, so relaunch refuses before the checkpoint unless the caller passes an explicit `--harness` to choose the replacement runtime deliberately.
    A harness change resets model and effort unless they are named too, because a model chosen for one adapter does not transfer to another.
 2. **Safe checkpoint.**
-   The recorded worktree must exist and be a worktree root; its head and dirty state are recorded.
+   The recorded worktree must exist and be a worktree root; for a ship or scout it must also differ physically from the recorded primary project checkout, and its head and dirty state are recorded.
    For a `kind=secondmate` task, the home's identity marker must match and its child records must be readable, so a relaunch can never strand child work behind an unreadable home.
    A secondmate's own crewmates run in their own endpoints and outlive its relaunch; the relaunched secondmate reconciles them from its home's durable records at startup.
 3. **Record the note.**
@@ -70,10 +70,11 @@ It is not deterministic across the verified adapters: codex, grok, and gemini re
    A secondmate relaunch does not require one and never rewrites its standing charter.
 4. **Stop the old agent** through the `exit` verb, with its postcondition.
    Herdr lifecycle recovery corroborates a retained native registration against the exact foreground process, so a lone idle shell proves an exited agent while a non-shell process remains alive and an ambiguous process read refuses.
-5. **Restore the endpoint path where required.**
-   A Herdr pane can return to another directory after its agent exits, so the backend moves only its proved agent-free shell to the physical recorded worktree with literal quoted input, rechecks the same shell before submission, and verifies the resulting path.
-   Tmux needs no restoration and keeps its existing path check.
-6. **Launch the replacement** through its single owner, `bin/fm-spawn.sh --relaunch`, which adopts the recorded endpoint and worktree instead of creating either, clears the previous harness's per-task wiring, and arms a fresh busy generation.
+5. **Prepare the endpoint where required.**
+   A Herdr pane can retain unsubmitted shell input or return to another directory after its agent exits, so the backend first cancels pending input while the same proved agent-free shell owns the pane, even when its path already matches.
+   If the path differs, it then sends a literal quoted `cd`, rechecks the same shell before submission, clears its own buffered command on a pre-submission failure only while that shell still owns the pane, and verifies the resulting physical path.
+   Tmux needs no preparation and keeps its existing path check.
+6. **Launch the replacement** through its single owner, `bin/fm-spawn.sh --relaunch`, which independently validates a ship or scout's recorded isolated worktree and repeats endpoint preparation before its first pane command, adopts the recorded endpoint and worktree instead of creating either, clears the previous harness's per-task wiring, and arms a fresh busy generation.
 
 Switching harness is therefore one ordinary relaunch rather than a separate mechanism.
 
@@ -103,8 +104,9 @@ Switching harness is therefore one ordinary relaunch rather than a separate mech
   zellij, orca, and cmux are refused rather than reported as successful blind.
 - An ambiguous or unreadable endpoint state refuses.
   Only a positively classified state acts.
-- `fm-spawn --relaunch` independently refuses unless the recorded endpoint is positively agent-free and its shell is sitting in the recorded worktree, so a replacement can never join a live agent or start outside the copy holding the work.
-- Herdr path restoration is reachable only after the recorded endpoint identity, isolated worktree root, project separation, and stopped-agent proof all pass; another path, a primary project checkout, a live foreground process, or an ambiguous process read refuses before launch.
+- `fm-spawn --relaunch` independently refuses unless the recorded endpoint is positively agent-free and its shell can be prepared and verified in the recorded worktree, so a replacement can never join a live agent or start outside the copy holding the work.
+- Herdr endpoint preparation is reachable only after the recorded endpoint identity and stopped-agent proof pass, plus isolated-worktree-root and project-separation checks for a ship or scout; a direct `fm-spawn --relaunch` applies the same gates before sending any pane input.
+  A primary project checkout, live foreground process, ambiguous process read, or changed shell owner refuses before launch.
 
 ## Capability matrix
 
@@ -125,5 +127,5 @@ The empirical basis for each adapter's value is the `harness-adapters` skill's v
 
 - `tests/fm-control.test.sh` - the adapter contract for every verified harness, the backend capability matrix, exact-id scoping, the closed verb list, the busy, idle, dead, and idempotent lifecycle cases, and marker non-regression, all against a stubbed session provider.
 - `tests/fm-control-relaunch.test.sh` - the relaunch transaction: identity preservation, harness switching, the progress note, checkpoint refusals, and rollback after a failed launch.
-- `tests/fm-herdr-relaunch-recovery.test.sh` - portable stale-registration, process-state, exact-path, quoting, idempotence, and cross-backend coverage.
+- `tests/fm-herdr-relaunch-recovery.test.sh` - portable stale-registration, process-state, exact-path, input-clearing, retry-cleanup, direct-launch validation, quoting, idempotence, and cross-backend coverage.
 - `tests/fm-control-herdr-smoke.test.sh` - stale-registration reconciliation and persistent path restoration against the real Herdr binary, on an isolated throwaway lab session.

--- a/docs/agent-control.md
+++ b/docs/agent-control.md
@@ -32,7 +32,7 @@ A recorded `harness=` is not always an exact adapter name: a task launched from 
 | --- | --- | --- |
 | `interrupt` | Deliver the harness's verified interrupt sequence while leaving the agent running. | Delivery succeeds while the endpoint still exists and the agent is still alive where the backend can classify that; cancellation is confirmed only from an adapter-owned acknowledgement and otherwise reports `cancel=unconfirmed`. |
 | `exit` | Stop the agent, preserving the endpoint, the worktree, and every uncommitted change. | The backend's recovery-grade classifier reports the agent gone. Already-stopped is idempotent success. |
-| `relaunch` | Replace the running agent with a new one in the same endpoint and worktree, on the exact recorded adapter or an explicitly chosen harness, model, and effort. | The new agent is alive on the recorded endpoint, and the durable record names the harness that is actually running. |
+| `relaunch` | Replace the running agent in the same worktree, on the exact recorded adapter or an explicitly chosen harness, model, and effort. Tmux reuses its endpoint; Herdr allocates a provisional endpoint in the exact recorded workspace. | The new agent is alive on the published endpoint, and the durable record names the endpoint and harness that are actually running. |
 
 An exit that delivers lifecycle input but cannot prove the agent stopped fails with `exit=unconfirmed`, reports the observed agent state and any interrupt cancellation claim, and never claims that nothing changed.
 Interrupt never rewrites busy state as proof of its own success.
@@ -71,18 +71,23 @@ It is not deterministic across the verified adapters: codex, grok, and gemini re
 4. **Stop the old agent** through the `exit` verb, with its postcondition.
    Herdr lifecycle recovery corroborates a retained native registration against the exact foreground process, so a lone idle shell proves an exited agent while a non-shell process remains alive and an ambiguous process read refuses.
 5. **Prepare the endpoint where required.**
-   A Herdr pane can retain unsubmitted shell input or return to another directory after its agent exits, so the launch owner takes the named-session mutation lock, cancels pending input while the same proved agent-free shell owns the pane, and keeps that lock through replacement command submission.
-   Final delivery freezes that exact shell, verifies its stopped process still exclusively owns the pane and worktree, queues the environment and launch command atomically, and resumes it, closing the last uncoordinated owner-change gap.
-   If the path differs, it sends a literal quoted `cd`, rechecks the same shell before submission, clears its own buffered command on a pre-submission failure only while that shell still owns the pane, and verifies the resulting physical path.
-   Tmux needs no preparation and keeps its existing path check.
-6. **Launch the replacement** through its single owner, `bin/fm-spawn.sh --relaunch`, which independently validates a ship or scout's recorded isolated worktree, adopts the recorded endpoint and worktree instead of creating either, clears the previous harness's per-task wiring, and arms a fresh busy generation.
+   Herdr's generic pane input cannot condition launch on an expected shell owner, so relaunch never injects into the old pane.
+   Under the named-session mutation lock, the launch owner revalidates the recorded pane's exact workspace and tab, creates one fresh unpublished tab in that workspace with its shell already rooted at the validated worktree, and addresses only response-derived candidate ids.
+   It never enumerates or adopts another workspace or endpoint.
+   Tmux keeps its existing recorded endpoint and path check.
+6. **Launch and publish the replacement** through its single owner, `bin/fm-spawn.sh --relaunch`.
+   Herdr snapshots the prior harness wiring, launches in the provisional endpoint, proves a live agent at the exact candidate and worktree, then atomically publishes the new endpoint metadata and retires the old agent-free pane when that exact cleanup remains provable.
+   A prepublication failure restores prior wiring, leaves old metadata and endpoint untouched, and closes only a response-identified agent-free candidate; an ambiguous or live candidate is quarantined by exact id instead of being guessed safe to close.
+   A retry addresses only that journaled id: an agent-free or already-gone candidate is retired idempotently, while a live or unreadable candidate refuses a duplicate launch.
+   Tmux retains its existing reuse behavior.
 
 Switching harness is therefore one ordinary relaunch rather than a separate mechanism.
 
 ### Failure and rollback
 
 - A refusal **before** the agent is stopped leaves the durable record and the instructions byte-identical.
-- A launch failure **after** the agent is stopped restores the prior durable record, keeps the progress note so a later recovery still has it, marks the journal `failed:launching`, and reports plainly that no agent is running and where the work is preserved.
+- A Herdr launch failure **after** the old agent is stopped keeps the old durable binding and endpoint unchanged, restores prior harness wiring, keeps the progress note, and records whether the exact provisional endpoint was rolled back or quarantined.
+- A non-Herdr launch failure after the agent is stopped retains the existing prior-record rollback behavior.
 - If the launch owner already published the new record but no running agent can be confirmed, the new record is kept: the task is recorded on the new harness with no agent confirmed, which is exactly what recovery reconciles.
   Rewriting it back to the old harness would be a second, worse inaccuracy.
 
@@ -105,9 +110,10 @@ Switching harness is therefore one ordinary relaunch rather than a separate mech
   zellij, orca, and cmux are refused rather than reported as successful blind.
 - An ambiguous or unreadable endpoint state refuses.
   Only a positively classified state acts.
-- `fm-spawn --relaunch` independently refuses unless the recorded endpoint is positively agent-free and its shell can be prepared and verified in the recorded worktree, so a replacement can never join a live agent or start outside the copy holding the work.
-- Herdr endpoint preparation is reachable only after the recorded endpoint identity and stopped-agent proof pass, plus isolated-worktree-root and project-separation checks for a ship or scout; a direct `fm-spawn --relaunch` applies the same gates before sending any pane input.
-  A primary project checkout, live foreground process, ambiguous process read, or changed shell owner refuses before launch.
+- `fm-spawn --relaunch` independently refuses unless the recorded endpoint is positively agent-free and the recorded worktree is still valid.
+- Herdr replacement creation is reachable only after exact recorded session, workspace, tab, pane, stopped-agent, isolated-worktree-root, and project-separation checks.
+  It creates through the recorded workspace id without listing workspaces or tabs, and publication requires the response-derived candidate to host a live replacement in the recorded worktree.
+  A primary project checkout, live old agent, ambiguous process read, contradictory endpoint relation, candidate takeover, or failed launch leaves the old binding untouched.
 
 ## Capability matrix
 

--- a/docs/agent-control.md
+++ b/docs/agent-control.md
@@ -76,8 +76,10 @@ It is not deterministic across the verified adapters: codex, grok, and gemini re
    Crash recovery may list only the recorded workspace to resolve exactly one tab carrying that attempt label; it never searches or adopts another workspace.
    Tmux keeps its existing recorded endpoint and path check.
 6. **Launch and publish the replacement** through its single owner, `bin/fm-spawn.sh --relaunch`.
-   Herdr snapshots the prior harness wiring, persists the staged replacement metadata and wiring immediately before launch submission, proves both an exact live Herdr registration and corroborating live foreground process at the candidate and worktree, then atomically publishes the new endpoint metadata and retires the old agent-free pane when that exact cleanup remains provable.
-   A prepublication failure restores prior wiring, leaves old metadata and endpoint untouched, and closes only an exact agent-free candidate; an ambiguous candidate is quarantined instead of being guessed safe to close.
+   Herdr snapshots the prior harness wiring, persists the staged replacement metadata and wiring immediately before launch submission, and makes a durable launch receipt a prerequisite of starting the agent command.
+   It proves both an exact live Herdr registration and corroborating live foreground process at the candidate and worktree, then atomically publishes the new endpoint metadata and retires the old agent-free pane when that exact cleanup remains provable.
+   An agent-free prepublication failure leaves old metadata and endpoint untouched, restores the persisted prior-wiring snapshot when replacement wiring was mutated, and closes only the exact candidate.
+   An exact live or unsettled submitted launch retains its launch-attempt provenance for strict retry or adoption, while ambiguous cleanup without admissible launch provenance is recorded as quarantined instead of being guessed safe.
    A retry retires an exact agent-free candidate idempotently and adopts an exact live candidate only from the launch-attempt phase after restoring and verifying its staged wiring, unchanged identity, and physical recorded worktree.
    It refuses live pre-launch or quarantined candidates and unreadable or mismatched candidates.
    Tmux retains its existing reuse behavior.
@@ -87,7 +89,8 @@ Switching harness is therefore one ordinary relaunch rather than a separate mech
 ### Failure and rollback
 
 - A refusal **before** the agent is stopped leaves the durable record and the instructions byte-identical.
-- A Herdr launch failure **after** the old agent is stopped keeps the old durable binding and endpoint unchanged, restores prior harness wiring, keeps the progress note, and records whether the exact provisional endpoint was rolled back or quarantined.
+- A Herdr launch failure **after** the old agent is stopped keeps the old durable binding, endpoint, and progress note unchanged.
+  An agent-free candidate restores any mutated prior wiring and rolls back; an exact live or unsettled submitted launch remains recoverable for retry, and ambiguous cleanup without admissible launch provenance remains recorded for strict reconciliation.
 - A non-Herdr launch failure after the agent is stopped retains the existing prior-record rollback behavior.
 - If the launch owner already published the new record but no running agent can be confirmed, the new record is kept: the task is recorded on the new harness with no agent confirmed, which is exactly what recovery reconciles.
   Rewriting it back to the old harness would be a second, worse inaccuracy.

--- a/docs/agent-control.md
+++ b/docs/agent-control.md
@@ -76,7 +76,7 @@ It is not deterministic across the verified adapters: codex, grok, and gemini re
    Crash recovery may list only the recorded workspace to resolve exactly one tab carrying that attempt label; it never searches or adopts another workspace.
    Tmux keeps its existing recorded endpoint and path check.
 6. **Launch and publish the replacement** through its single owner, `bin/fm-spawn.sh --relaunch`.
-   Herdr snapshots the prior harness wiring, persists the staged replacement metadata and wiring immediately before launch submission, proves a live agent at the exact candidate and worktree, then atomically publishes the new endpoint metadata and retires the old agent-free pane when that exact cleanup remains provable.
+   Herdr snapshots the prior harness wiring, persists the staged replacement metadata and wiring immediately before launch submission, proves both an exact live Herdr registration and corroborating live foreground process at the candidate and worktree, then atomically publishes the new endpoint metadata and retires the old agent-free pane when that exact cleanup remains provable.
    A prepublication failure restores prior wiring, leaves old metadata and endpoint untouched, and closes only an exact agent-free candidate; an ambiguous candidate is quarantined instead of being guessed safe to close.
    A retry retires an exact agent-free candidate idempotently and adopts an exact live candidate only from the launch-attempt phase after restoring and verifying its staged wiring, unchanged identity, and physical recorded worktree.
    It refuses live pre-launch or quarantined candidates and unreadable or mismatched candidates.

--- a/docs/agent-control.md
+++ b/docs/agent-control.md
@@ -69,16 +69,16 @@ It is not deterministic across the verified adapters: codex, grok, and gemini re
    A ship or scout relaunch requires `--note`, because the replacement inherits the local copy but none of the conversation; the note is appended to the instructions it reads.
    A secondmate relaunch does not require one and never rewrites its standing charter.
 4. **Stop the old agent** through the `exit` verb, with its postcondition.
-   Herdr lifecycle recovery corroborates a retained native registration against the exact foreground process, so a lone idle shell proves an exited agent while a non-shell process remains alive and an ambiguous process read refuses.
+   Herdr lifecycle recovery corroborates native registration against the exact foreground process, so a lone idle shell proves an exited agent while a non-shell process remains alive even without registration and an ambiguous process read refuses.
 5. **Prepare the endpoint where required.**
    Herdr's generic pane input cannot condition launch on an expected shell owner, so relaunch never injects into the old pane.
-   Under the named-session mutation lock, the launch owner revalidates the recorded pane's exact workspace and tab, creates one fresh unpublished tab in that workspace with its shell already rooted at the validated worktree, and addresses only response-derived candidate ids.
-   It never enumerates or adopts another workspace or endpoint.
+   Under the named-session mutation lock, the launch owner revalidates the recorded pane's exact workspace and tab, records a unique attempt label, and creates one fresh unpublished tab in that workspace with its shell already rooted at the validated worktree.
+   Crash recovery may list only the recorded workspace to resolve exactly one tab carrying that attempt label; it never searches or adopts another workspace.
    Tmux keeps its existing recorded endpoint and path check.
 6. **Launch and publish the replacement** through its single owner, `bin/fm-spawn.sh --relaunch`.
    Herdr snapshots the prior harness wiring, launches in the provisional endpoint, proves a live agent at the exact candidate and worktree, then atomically publishes the new endpoint metadata and retires the old agent-free pane when that exact cleanup remains provable.
-   A prepublication failure restores prior wiring, leaves old metadata and endpoint untouched, and closes only a response-identified agent-free candidate; an ambiguous or live candidate is quarantined by exact id instead of being guessed safe to close.
-   A retry addresses only that journaled id: an agent-free or already-gone candidate is retired idempotently, while a live or unreadable candidate refuses a duplicate launch.
+   A prepublication failure restores prior wiring, leaves old metadata and endpoint untouched, and closes only an exact agent-free candidate; an ambiguous candidate is quarantined instead of being guessed safe to close.
+   A retry retires an exact agent-free candidate idempotently, adopts an exact live candidate only after unchanged identity and physical recorded-worktree proof, and refuses unreadable or mismatched candidates.
    Tmux retains its existing reuse behavior.
 
 Switching harness is therefore one ordinary relaunch rather than a separate mechanism.

--- a/docs/agent-control.md
+++ b/docs/agent-control.md
@@ -71,10 +71,10 @@ It is not deterministic across the verified adapters: codex, grok, and gemini re
 4. **Stop the old agent** through the `exit` verb, with its postcondition.
    Herdr lifecycle recovery corroborates a retained native registration against the exact foreground process, so a lone idle shell proves an exited agent while a non-shell process remains alive and an ambiguous process read refuses.
 5. **Prepare the endpoint where required.**
-   A Herdr pane can retain unsubmitted shell input or return to another directory after its agent exits, so the backend first cancels pending input while the same proved agent-free shell owns the pane, even when its path already matches.
-   If the path differs, it then sends a literal quoted `cd`, rechecks the same shell before submission, clears its own buffered command on a pre-submission failure only while that shell still owns the pane, and verifies the resulting physical path.
+   A Herdr pane can retain unsubmitted shell input or return to another directory after its agent exits, so the launch owner takes the named-session mutation lock, cancels pending input while the same proved agent-free shell owns the pane, and keeps that lock through replacement command submission.
+   If the path differs, it sends a literal quoted `cd`, rechecks the same shell before submission, clears its own buffered command on a pre-submission failure only while that shell still owns the pane, and verifies the resulting physical path.
    Tmux needs no preparation and keeps its existing path check.
-6. **Launch the replacement** through its single owner, `bin/fm-spawn.sh --relaunch`, which independently validates a ship or scout's recorded isolated worktree and repeats endpoint preparation before its first pane command, adopts the recorded endpoint and worktree instead of creating either, clears the previous harness's per-task wiring, and arms a fresh busy generation.
+6. **Launch the replacement** through its single owner, `bin/fm-spawn.sh --relaunch`, which independently validates a ship or scout's recorded isolated worktree, adopts the recorded endpoint and worktree instead of creating either, clears the previous harness's per-task wiring, and arms a fresh busy generation.
 
 Switching harness is therefore one ordinary relaunch rather than a separate mechanism.
 

--- a/docs/agent-control.md
+++ b/docs/agent-control.md
@@ -69,7 +69,11 @@ It is not deterministic across the verified adapters: codex, grok, and gemini re
    A ship or scout relaunch requires `--note`, because the replacement inherits the local copy but none of the conversation; the note is appended to the instructions it reads.
    A secondmate relaunch does not require one and never rewrites its standing charter.
 4. **Stop the old agent** through the `exit` verb, with its postcondition.
-5. **Launch the replacement** through its single owner, `bin/fm-spawn.sh --relaunch`, which adopts the recorded endpoint and worktree instead of creating either, clears the previous harness's per-task wiring, and arms a fresh busy generation.
+   Herdr lifecycle recovery corroborates a retained native registration against the exact foreground process, so a lone idle shell proves an exited agent while a non-shell process remains alive and an ambiguous process read refuses.
+5. **Restore the endpoint path where required.**
+   A Herdr pane can return to another directory after its agent exits, so the backend moves only its proved agent-free shell to the physical recorded worktree with literal quoted input, rechecks the same shell before submission, and verifies the resulting path.
+   Tmux needs no restoration and keeps its existing path check.
+6. **Launch the replacement** through its single owner, `bin/fm-spawn.sh --relaunch`, which adopts the recorded endpoint and worktree instead of creating either, clears the previous harness's per-task wiring, and arms a fresh busy generation.
 
 Switching harness is therefore one ordinary relaunch rather than a separate mechanism.
 
@@ -100,6 +104,7 @@ Switching harness is therefore one ordinary relaunch rather than a separate mech
 - An ambiguous or unreadable endpoint state refuses.
   Only a positively classified state acts.
 - `fm-spawn --relaunch` independently refuses unless the recorded endpoint is positively agent-free and its shell is sitting in the recorded worktree, so a replacement can never join a live agent or start outside the copy holding the work.
+- Herdr path restoration is reachable only after the recorded endpoint identity, isolated worktree root, project separation, and stopped-agent proof all pass; another path, a primary project checkout, a live foreground process, or an ambiguous process read refuses before launch.
 
 ## Capability matrix
 
@@ -120,4 +125,5 @@ The empirical basis for each adapter's value is the `harness-adapters` skill's v
 
 - `tests/fm-control.test.sh` - the adapter contract for every verified harness, the backend capability matrix, exact-id scoping, the closed verb list, the busy, idle, dead, and idempotent lifecycle cases, and marker non-regression, all against a stubbed session provider.
 - `tests/fm-control-relaunch.test.sh` - the relaunch transaction: identity preservation, harness switching, the progress note, checkpoint refusals, and rollback after a failed launch.
-- `tests/fm-control-herdr-smoke.test.sh` - the second state-verified backend against the real herdr binary, on an isolated throwaway lab session.
+- `tests/fm-herdr-relaunch-recovery.test.sh` - portable stale-registration, process-state, exact-path, quoting, idempotence, and cross-backend coverage.
+- `tests/fm-control-herdr-smoke.test.sh` - stale-registration reconciliation and persistent path restoration against the real Herdr binary, on an isolated throwaway lab session.

--- a/docs/agent-control.md
+++ b/docs/agent-control.md
@@ -76,9 +76,10 @@ It is not deterministic across the verified adapters: codex, grok, and gemini re
    Crash recovery may list only the recorded workspace to resolve exactly one tab carrying that attempt label; it never searches or adopts another workspace.
    Tmux keeps its existing recorded endpoint and path check.
 6. **Launch and publish the replacement** through its single owner, `bin/fm-spawn.sh --relaunch`.
-   Herdr snapshots the prior harness wiring, launches in the provisional endpoint, proves a live agent at the exact candidate and worktree, then atomically publishes the new endpoint metadata and retires the old agent-free pane when that exact cleanup remains provable.
+   Herdr snapshots the prior harness wiring, persists the staged replacement metadata and wiring immediately before launch submission, proves a live agent at the exact candidate and worktree, then atomically publishes the new endpoint metadata and retires the old agent-free pane when that exact cleanup remains provable.
    A prepublication failure restores prior wiring, leaves old metadata and endpoint untouched, and closes only an exact agent-free candidate; an ambiguous candidate is quarantined instead of being guessed safe to close.
-   A retry retires an exact agent-free candidate idempotently, adopts an exact live candidate only after unchanged identity and physical recorded-worktree proof, and refuses unreadable or mismatched candidates.
+   A retry retires an exact agent-free candidate idempotently and adopts an exact live candidate only from the launch-attempt phase after restoring and verifying its staged wiring, unchanged identity, and physical recorded worktree.
+   It refuses live pre-launch or quarantined candidates and unreadable or mismatched candidates.
    Tmux retains its existing reuse behavior.
 
 Switching harness is therefore one ordinary relaunch rather than a separate mechanism.

--- a/docs/agent-control.md
+++ b/docs/agent-control.md
@@ -69,7 +69,7 @@ It is not deterministic across the verified adapters: codex, grok, and gemini re
    A ship or scout relaunch requires `--note`, because the replacement inherits the local copy but none of the conversation; the note is appended to the instructions it reads.
    A secondmate relaunch does not require one and never rewrites its standing charter.
 4. **Stop the old agent** through the `exit` verb, with its postcondition.
-   Herdr lifecycle recovery corroborates native registration against the exact foreground process, so a lone idle shell proves an exited agent while a non-shell process remains alive even without registration and an ambiguous process read refuses.
+   Herdr lifecycle recovery corroborates native registration against the exact foreground process, so a lone idle shell proves an exited agent, only a corroborated registered agent is `alive`, and an unregistered non-shell process is `unreadable` and refuses lifecycle control.
 5. **Prepare the endpoint where required.**
    Herdr's generic pane input cannot condition launch on an expected shell owner, so relaunch never injects into the old pane.
    Under the named-session mutation lock, the launch owner revalidates the recorded pane's exact workspace and tab, records a unique attempt label, and creates one fresh unpublished tab in that workspace with its shell already rooted at the validated worktree.

--- a/docs/agent-control.md
+++ b/docs/agent-control.md
@@ -72,6 +72,7 @@ It is not deterministic across the verified adapters: codex, grok, and gemini re
    Herdr lifecycle recovery corroborates a retained native registration against the exact foreground process, so a lone idle shell proves an exited agent while a non-shell process remains alive and an ambiguous process read refuses.
 5. **Prepare the endpoint where required.**
    A Herdr pane can retain unsubmitted shell input or return to another directory after its agent exits, so the launch owner takes the named-session mutation lock, cancels pending input while the same proved agent-free shell owns the pane, and keeps that lock through replacement command submission.
+   Final delivery freezes that exact shell, verifies its stopped process still exclusively owns the pane and worktree, queues the environment and launch command atomically, and resumes it, closing the last uncoordinated owner-change gap.
    If the path differs, it sends a literal quoted `cd`, rechecks the same shell before submission, clears its own buffered command on a pre-submission failure only while that shell still owns the pane, and verifies the resulting physical path.
    Tmux needs no preparation and keeps its existing path check.
 6. **Launch the replacement** through its single owner, `bin/fm-spawn.sh --relaunch`, which independently validates a ship or scout's recorded isolated worktree, adopts the recorded endpoint and worktree instead of creating either, clears the previous harness's per-task wiring, and arms a fresh busy generation.

--- a/docs/herdr-backend.md
+++ b/docs/herdr-backend.md
@@ -272,17 +272,18 @@ The generic Herdr agent-liveness probe reuses the same classifier.
 A structurally gone pane becomes `missing`, a restored agent-less shell becomes `dead`, a registered agent becomes `alive`, and an unexpected read becomes `unreadable`.
 Unlike tmux process-name inspection, native registration can classify Pi without guessing from a generic interpreter name.
 
-Lifecycle control adds one process-level reconciliation because Herdr can retain Pi's native registration after Pi exits.
-A registered pane becomes agent-free for exit or replacement only when `pane process-info` and the operating-system process table prove the exact pane contains one lone idle recognized shell.
-A distinct foreground process group remains alive, and any contradictory or unreadable process evidence refuses recovery.
+Lifecycle control adds one process-level reconciliation because Herdr can retain Pi's native registration after Pi exits or lose registration while a foreground process remains.
+A pane becomes agent-free for exit or replacement only when `pane process-info` and the operating-system process table prove the exact pane contains one lone idle recognized shell.
+A distinct foreground process group remains alive regardless of registration, and any contradictory or unreadable process evidence refuses recovery.
 Herdr 0.8.2 exposes no generic pane launch operation conditioned on an expected shell owner, so lifecycle recovery never injects a replacement command into the old pane.
 After the stopped-agent proof, the launch owner takes the named-session mutation lock and revalidates the recorded pane's exact workspace and tab relation.
-It creates one fresh tab directly in that recorded workspace with its shell rooted at the validated worktree, retains only the response-derived candidate ids, and never lists, classifies, adopts, renames, closes, or recycles an unrelated workspace or endpoint.
+It creates one fresh tab directly in that recorded workspace with its shell rooted at the validated worktree and records a unique attempt label before creation.
+Recovery may list only that recorded workspace to resolve exactly one tab carrying the recorded label, and it leaves every unrelated workspace or endpoint untouched.
 The candidate stays unpublished while its pending input is cleared, its exact shell and worktree are revalidated, the environment plus launch command are queued, and a live replacement agent is proved at that exact endpoint.
 Only then does metadata advance atomically to the candidate.
 A prepublication failure leaves the old endpoint and metadata unchanged, restores prior harness wiring, and closes only a response-identified candidate that is still provably agent-free.
-An ambiguous or live failed candidate remains quarantined under its exact recorded id instead of granting cleanup authority.
-A later retry reads only that journaled id: an agent-free or already-gone candidate is retired idempotently, while a live or unreadable candidate refuses duplication.
+An ambiguous failed candidate remains quarantined under its exact recorded identity instead of granting cleanup authority.
+A later retry retires an exact agent-free candidate idempotently, adopts an exact live candidate only after unchanged identity and physical recorded-worktree proof, and refuses every unreadable, mismatched, or multiply matched candidate.
 After publication, the old pane is retired only when its exact identity and agent-free state remain provable.
 
 The session-start sweep uses the ordinary probe.

--- a/docs/herdr-backend.md
+++ b/docs/herdr-backend.md
@@ -279,11 +279,12 @@ Herdr 0.8.2 exposes no generic pane launch operation conditioned on an expected 
 After the stopped-agent proof, the launch owner takes the named-session mutation lock and revalidates the recorded pane's exact workspace and tab relation.
 It creates one fresh tab directly in that recorded workspace with its shell rooted at the validated worktree and records a unique attempt label before creation.
 Recovery may list only that recorded workspace to resolve exactly one tab carrying the recorded label, and it leaves every unrelated workspace or endpoint untouched.
-The candidate stays unpublished while its pending input is cleared, its exact shell and worktree are revalidated, and the staged metadata plus harness wiring are persisted immediately before the environment and launch command are queued.
+The candidate stays unpublished while its pending input is cleared and its exact shell and worktree are revalidated.
+The rollback wiring snapshot becomes deterministic before the first replacement-wiring mutation, and staged metadata plus replacement wiring are persisted immediately before the environment and launch command are queued.
 Publication and crash adoption both require an exact live Herdr agent registration plus corroborating live foreground-process state at that endpoint.
 Only then does metadata advance atomically to the candidate, immediately relinquishing provisional cleanup authority.
 The original prior harness remains in launch provenance until its wiring retirement commits, and an interruption or cleanup failure must reconcile that identity plus any presentation binding before another relaunch can proceed.
-A prepublication failure leaves the old endpoint and metadata unchanged, restores prior harness wiring, and closes only a response-identified candidate that is still provably agent-free.
+A prepublication failure or hard-crash recovery leaves the old metadata authoritative, restores the exact persisted prior wiring snapshot, and closes only an exactly identified candidate that is still provably agent-free.
 An ambiguous failed candidate remains quarantined under its exact recorded identity instead of granting cleanup authority.
 A later retry retires an exact agent-free candidate idempotently and adopts an exact live candidate only from the launch-attempt phase after restoring and verifying its staged wiring, unchanged identity, and physical recorded worktree.
 It refuses every live pre-launch or quarantined candidate and every unreadable, mismatched, or multiply matched candidate.

--- a/docs/herdr-backend.md
+++ b/docs/herdr-backend.md
@@ -281,7 +281,8 @@ It creates one fresh tab directly in that recorded workspace with its shell root
 Recovery may list only that recorded workspace to resolve exactly one tab carrying the recorded label, and it leaves every unrelated workspace or endpoint untouched.
 The candidate stays unpublished while its pending input is cleared, its exact shell and worktree are revalidated, and the staged metadata plus harness wiring are persisted immediately before the environment and launch command are queued.
 Publication and crash adoption both require an exact live Herdr agent registration plus corroborating live foreground-process state at that endpoint.
-Only then does metadata advance atomically to the candidate.
+Only then does metadata advance atomically to the candidate, immediately relinquishing provisional cleanup authority.
+Prior-harness wiring retirement remains a required, journaled part of that binding commit, and an interruption or cleanup failure must be reconciled before another relaunch can proceed.
 A prepublication failure leaves the old endpoint and metadata unchanged, restores prior harness wiring, and closes only a response-identified candidate that is still provably agent-free.
 An ambiguous failed candidate remains quarantined under its exact recorded identity instead of granting cleanup authority.
 A later retry retires an exact agent-free candidate idempotently and adopts an exact live candidate only from the launch-attempt phase after restoring and verifying its staged wiring, unchanged identity, and physical recorded worktree.

--- a/docs/herdr-backend.md
+++ b/docs/herdr-backend.md
@@ -280,7 +280,7 @@ After the stopped-agent proof, the launch owner takes the named-session mutation
 It creates one fresh tab directly in that recorded workspace with its shell rooted at the validated worktree and records a unique attempt label before creation.
 Recovery may list only that recorded workspace to resolve exactly one tab carrying the recorded label, and it leaves every unrelated workspace or endpoint untouched.
 The candidate stays unpublished while its pending input is cleared, its exact shell and worktree are revalidated, and the staged metadata plus harness wiring are persisted immediately before the environment and launch command are queued.
-A live replacement agent must then be proved at that exact endpoint.
+Publication and crash adoption both require an exact live Herdr agent registration plus corroborating live foreground-process state at that endpoint.
 Only then does metadata advance atomically to the candidate.
 A prepublication failure leaves the old endpoint and metadata unchanged, restores prior harness wiring, and closes only a response-identified candidate that is still provably agent-free.
 An ambiguous failed candidate remains quarantined under its exact recorded identity instead of granting cleanup authority.

--- a/docs/herdr-backend.md
+++ b/docs/herdr-backend.md
@@ -279,11 +279,13 @@ Herdr 0.8.2 exposes no generic pane launch operation conditioned on an expected 
 After the stopped-agent proof, the launch owner takes the named-session mutation lock and revalidates the recorded pane's exact workspace and tab relation.
 It creates one fresh tab directly in that recorded workspace with its shell rooted at the validated worktree and records a unique attempt label before creation.
 Recovery may list only that recorded workspace to resolve exactly one tab carrying the recorded label, and it leaves every unrelated workspace or endpoint untouched.
-The candidate stays unpublished while its pending input is cleared, its exact shell and worktree are revalidated, the environment plus launch command are queued, and a live replacement agent is proved at that exact endpoint.
+The candidate stays unpublished while its pending input is cleared, its exact shell and worktree are revalidated, and the staged metadata plus harness wiring are persisted immediately before the environment and launch command are queued.
+A live replacement agent must then be proved at that exact endpoint.
 Only then does metadata advance atomically to the candidate.
 A prepublication failure leaves the old endpoint and metadata unchanged, restores prior harness wiring, and closes only a response-identified candidate that is still provably agent-free.
 An ambiguous failed candidate remains quarantined under its exact recorded identity instead of granting cleanup authority.
-A later retry retires an exact agent-free candidate idempotently, adopts an exact live candidate only after unchanged identity and physical recorded-worktree proof, and refuses every unreadable, mismatched, or multiply matched candidate.
+A later retry retires an exact agent-free candidate idempotently and adopts an exact live candidate only from the launch-attempt phase after restoring and verifying its staged wiring, unchanged identity, and physical recorded worktree.
+It refuses every live pre-launch or quarantined candidate and every unreadable, mismatched, or multiply matched candidate.
 After publication, the old pane is retired only when its exact identity and agent-free state remain provable.
 
 The session-start sweep uses the ordinary probe.

--- a/docs/herdr-backend.md
+++ b/docs/herdr-backend.md
@@ -282,11 +282,12 @@ It creates one fresh tab directly in that recorded workspace with its shell root
 Recovery may list only that recorded workspace to resolve exactly one tab carrying the recorded label, and it leaves every unrelated workspace or endpoint untouched.
 The candidate stays unpublished while its pending input is cleared and its exact shell and worktree are revalidated.
 The rollback wiring snapshot becomes deterministic before the first replacement-wiring mutation, and staged metadata plus replacement wiring are persisted immediately before the environment and launch command are queued.
+The queued command writes a durable launch receipt before starting the agent, so an unreceipted replacement cannot become an adoption candidate.
 Publication and crash adoption both require an exact live Herdr agent registration plus corroborating live foreground-process state at that endpoint.
 Only then does metadata advance atomically to the candidate, immediately relinquishing provisional cleanup authority.
 The original prior harness remains in launch provenance until its wiring retirement commits, and an interruption or cleanup failure must reconcile that identity plus any presentation binding before another relaunch can proceed.
-A prepublication failure or hard-crash recovery leaves the old metadata authoritative, restores the exact persisted prior wiring snapshot, and closes only an exactly identified candidate that is still provably agent-free.
-An ambiguous failed candidate remains quarantined under its exact recorded identity instead of granting cleanup authority.
+An agent-free prepublication failure or hard-crash recovery leaves the old metadata authoritative, restores the exact persisted prior-wiring snapshot when replacement wiring was mutated, and closes only the exactly identified candidate.
+An exact live or unsettled submitted launch retains its launch-attempt provenance for strict retry or adoption, while ambiguous cleanup without admissible launch provenance is recorded as quarantined under its exact identity instead of granting cleanup authority.
 A later retry retires an exact agent-free candidate idempotently and adopts an exact live candidate only from the launch-attempt phase after restoring and verifying its staged wiring, unchanged identity, and physical recorded worktree.
 It refuses every live pre-launch or quarantined candidate and every unreadable, mismatched, or multiply matched candidate.
 Before any candidate or old pane is retired, its exact idle shell is frozen and revalidated for identity, ownership, and child absence immediately at the close boundary; refusal always resumes it.

--- a/docs/herdr-backend.md
+++ b/docs/herdr-backend.md
@@ -275,8 +275,9 @@ Unlike tmux process-name inspection, native registration can classify Pi without
 Lifecycle control adds one process-level reconciliation because Herdr can retain Pi's native registration after Pi exits.
 A registered pane becomes agent-free for exit or replacement only when `pane process-info` and the operating-system process table prove the exact pane contains one lone idle recognized shell.
 A distinct foreground process group remains alive, and any contradictory or unreadable process evidence refuses recovery.
-After that proof, relaunch may return the same shell to the physical recorded worktree by sending a quoted `cd` through literal input, rechecking the same shell before Enter, and verifying the exact resulting foreground path.
-This backend-owned repair is idempotent and never selects a path itself; the control plane supplies the worktree only after validating the task endpoint, worktree root, and separation from the primary project copy.
+After that proof, relaunch cancels any pending input while that same idle shell owns the pane, including when its path already matches the recorded worktree.
+For a mismatched path it then sends a quoted `cd` through literal input, rechecks the same shell before Enter, clears its own buffered command after a pre-Enter failure only if that shell still owns the pane, and verifies the exact resulting foreground path.
+This backend-owned preparation is idempotent and never selects a path itself; both the control transaction and the shared launch owner validate the task endpoint, plus a ship or scout's worktree root and separation from the primary project copy, before any pane input.
 
 The session-start sweep uses the ordinary probe.
 Mid-session secondmate agent-process liveness is not implemented because idle secondmates are deliberately exempt from stale-pane escalation and need a separate periodic identity signal.

--- a/docs/herdr-backend.md
+++ b/docs/herdr-backend.md
@@ -275,8 +275,8 @@ Unlike tmux process-name inspection, native registration can classify Pi without
 Lifecycle control adds one process-level reconciliation because Herdr can retain Pi's native registration after Pi exits.
 A registered pane becomes agent-free for exit or replacement only when `pane process-info` and the operating-system process table prove the exact pane contains one lone idle recognized shell.
 A distinct foreground process group remains alive, and any contradictory or unreadable process evidence refuses recovery.
-After that proof, relaunch cancels any pending input while that same idle shell owns the pane, including when its path already matches the recorded worktree.
-For a mismatched path it then sends a quoted `cd` through literal input, rechecks the same shell before Enter, clears its own buffered command after a pre-Enter failure only if that shell still owns the pane, and verifies the exact resulting foreground path.
+After that proof, the launch owner takes the named-session mutation lock and cancels any pending input while that same idle shell owns the pane, including when its path already matches the recorded worktree.
+For a mismatched path it then sends a quoted `cd` through literal input, rechecks the same shell before Enter, clears its own buffered command after a pre-Enter failure only if that shell still owns the pane, verifies the exact resulting foreground path, and keeps the lock until the replacement launch command is submitted.
 This backend-owned preparation is idempotent and never selects a path itself; both the control transaction and the shared launch owner validate the task endpoint, plus a ship or scout's worktree root and separation from the primary project copy, before any pane input.
 
 The session-start sweep uses the ordinary probe.

--- a/docs/herdr-backend.md
+++ b/docs/herdr-backend.md
@@ -277,6 +277,7 @@ A registered pane becomes agent-free for exit or replacement only when `pane pro
 A distinct foreground process group remains alive, and any contradictory or unreadable process evidence refuses recovery.
 After that proof, the launch owner takes the named-session mutation lock and cancels any pending input while that same idle shell owns the pane, including when its path already matches the recorded worktree.
 For a mismatched path it then sends a quoted `cd` through literal input, rechecks the same shell before Enter, clears its own buffered command after a pre-Enter failure only if that shell still owns the pane, verifies the exact resulting foreground path, and keeps the lock until the replacement launch command is submitted.
+At final delivery it stops the exact prepared shell, verifies that the stopped process still exclusively owns the pane and worktree, atomically queues the environment plus launch command and Enter, and resumes the shell; a bounded watchdog resumes it if the launch process dies mid-boundary.
 This backend-owned preparation is idempotent and never selects a path itself; both the control transaction and the shared launch owner validate the task endpoint, plus a ship or scout's worktree root and separation from the primary project copy, before any pane input.
 
 The session-start sweep uses the ordinary probe.

--- a/docs/herdr-backend.md
+++ b/docs/herdr-backend.md
@@ -275,10 +275,15 @@ Unlike tmux process-name inspection, native registration can classify Pi without
 Lifecycle control adds one process-level reconciliation because Herdr can retain Pi's native registration after Pi exits.
 A registered pane becomes agent-free for exit or replacement only when `pane process-info` and the operating-system process table prove the exact pane contains one lone idle recognized shell.
 A distinct foreground process group remains alive, and any contradictory or unreadable process evidence refuses recovery.
-After that proof, the launch owner takes the named-session mutation lock and cancels any pending input while that same idle shell owns the pane, including when its path already matches the recorded worktree.
-For a mismatched path it then sends a quoted `cd` through literal input, rechecks the same shell before Enter, clears its own buffered command after a pre-Enter failure only if that shell still owns the pane, verifies the exact resulting foreground path, and keeps the lock until the replacement launch command is submitted.
-At final delivery it stops the exact prepared shell, verifies that the stopped process still exclusively owns the pane and worktree, atomically queues the environment plus launch command and Enter, and resumes the shell; a bounded watchdog resumes it if the launch process dies mid-boundary.
-This backend-owned preparation is idempotent and never selects a path itself; both the control transaction and the shared launch owner validate the task endpoint, plus a ship or scout's worktree root and separation from the primary project copy, before any pane input.
+Herdr 0.8.2 exposes no generic pane launch operation conditioned on an expected shell owner, so lifecycle recovery never injects a replacement command into the old pane.
+After the stopped-agent proof, the launch owner takes the named-session mutation lock and revalidates the recorded pane's exact workspace and tab relation.
+It creates one fresh tab directly in that recorded workspace with its shell rooted at the validated worktree, retains only the response-derived candidate ids, and never lists, classifies, adopts, renames, closes, or recycles an unrelated workspace or endpoint.
+The candidate stays unpublished while its pending input is cleared, its exact shell and worktree are revalidated, the environment plus launch command are queued, and a live replacement agent is proved at that exact endpoint.
+Only then does metadata advance atomically to the candidate.
+A prepublication failure leaves the old endpoint and metadata unchanged, restores prior harness wiring, and closes only a response-identified candidate that is still provably agent-free.
+An ambiguous or live failed candidate remains quarantined under its exact recorded id instead of granting cleanup authority.
+A later retry reads only that journaled id: an agent-free or already-gone candidate is retired idempotently, while a live or unreadable candidate refuses duplication.
+After publication, the old pane is retired only when its exact identity and agent-free state remain provable.
 
 The session-start sweep uses the ordinary probe.
 Mid-session secondmate agent-process liveness is not implemented because idle secondmates are deliberately exempt from stale-pane escalation and need a separate periodic identity signal.

--- a/docs/herdr-backend.md
+++ b/docs/herdr-backend.md
@@ -282,12 +282,12 @@ Recovery may list only that recorded workspace to resolve exactly one tab carryi
 The candidate stays unpublished while its pending input is cleared, its exact shell and worktree are revalidated, and the staged metadata plus harness wiring are persisted immediately before the environment and launch command are queued.
 Publication and crash adoption both require an exact live Herdr agent registration plus corroborating live foreground-process state at that endpoint.
 Only then does metadata advance atomically to the candidate, immediately relinquishing provisional cleanup authority.
-Prior-harness wiring retirement remains a required, journaled part of that binding commit, and an interruption or cleanup failure must be reconciled before another relaunch can proceed.
+The original prior harness remains in launch provenance until its wiring retirement commits, and an interruption or cleanup failure must reconcile that identity plus any presentation binding before another relaunch can proceed.
 A prepublication failure leaves the old endpoint and metadata unchanged, restores prior harness wiring, and closes only a response-identified candidate that is still provably agent-free.
 An ambiguous failed candidate remains quarantined under its exact recorded identity instead of granting cleanup authority.
 A later retry retires an exact agent-free candidate idempotently and adopts an exact live candidate only from the launch-attempt phase after restoring and verifying its staged wiring, unchanged identity, and physical recorded worktree.
 It refuses every live pre-launch or quarantined candidate and every unreadable, mismatched, or multiply matched candidate.
-After publication, the old pane is retired only when its exact identity and agent-free state remain provable.
+Before any candidate or old pane is retired, its exact idle shell is frozen and revalidated for identity, ownership, and child absence immediately at the close boundary; refusal always resumes it.
 
 The session-start sweep uses the ordinary probe.
 Mid-session secondmate agent-process liveness is not implemented because idle secondmates are deliberately exempt from stale-pane escalation and need a separate periodic identity signal.

--- a/docs/herdr-backend.md
+++ b/docs/herdr-backend.md
@@ -274,7 +274,8 @@ Unlike tmux process-name inspection, native registration can classify Pi without
 
 Lifecycle control adds one process-level reconciliation because Herdr can retain Pi's native registration after Pi exits or lose registration while a foreground process remains.
 A pane becomes agent-free for exit or replacement only when `pane process-info` and the operating-system process table prove the exact pane contains one lone idle recognized shell.
-A distinct foreground process group remains alive regardless of registration, and any contradictory or unreadable process evidence refuses recovery.
+A distinct foreground process group is `alive` only when Herdr also reports a valid registration for that exact pane.
+Without that registration it is `unreadable`, and lifecycle control refuses along with any other contradictory or unreadable process evidence.
 Herdr 0.8.2 exposes no generic pane launch operation conditioned on an expected shell owner, so lifecycle recovery never injects a replacement command into the old pane.
 After the stopped-agent proof, the launch owner takes the named-session mutation lock and revalidates the recorded pane's exact workspace and tab relation.
 It creates one fresh tab directly in that recorded workspace with its shell rooted at the validated worktree and records a unique attempt label before creation.

--- a/docs/herdr-backend.md
+++ b/docs/herdr-backend.md
@@ -272,7 +272,13 @@ The generic Herdr agent-liveness probe reuses the same classifier.
 A structurally gone pane becomes `missing`, a restored agent-less shell becomes `dead`, a registered agent becomes `alive`, and an unexpected read becomes `unreadable`.
 Unlike tmux process-name inspection, native registration can classify Pi without guessing from a generic interpreter name.
 
-The session-start sweep uses this probe.
+Lifecycle control adds one process-level reconciliation because Herdr can retain Pi's native registration after Pi exits.
+A registered pane becomes agent-free for exit or replacement only when `pane process-info` and the operating-system process table prove the exact pane contains one lone idle recognized shell.
+A distinct foreground process group remains alive, and any contradictory or unreadable process evidence refuses recovery.
+After that proof, relaunch may return the same shell to the physical recorded worktree by sending a quoted `cd` through literal input, rechecking the same shell before Enter, and verifying the exact resulting foreground path.
+This backend-owned repair is idempotent and never selects a path itself; the control plane supplies the worktree only after validating the task endpoint, worktree root, and separation from the primary project copy.
+
+The session-start sweep uses the ordinary probe.
 Mid-session secondmate agent-process liveness is not implemented because idle secondmates are deliberately exempt from stale-pane escalation and need a separate periodic identity signal.
 
 ## Push events and polling fallback
@@ -331,6 +337,8 @@ Tests use thin compatibility wrappers in `tests/herdr-test-safety.sh` and never 
 
 ```sh
 tests/fm-backend-herdr.test.sh
+tests/fm-herdr-relaunch-recovery.test.sh
+tests/fm-control-herdr-smoke.test.sh
 tests/fm-composer-lib.test.sh
 tests/fm-herdr-submit-confirm-live-e2e.test.sh
 tests/fm-backend-herdr-smoke.test.sh

--- a/docs/herdr-backend.md
+++ b/docs/herdr-backend.md
@@ -290,7 +290,7 @@ An agent-free prepublication failure or hard-crash recovery leaves the old metad
 An exact live or unsettled submitted launch retains its launch-attempt provenance for strict retry or adoption, while ambiguous cleanup without admissible launch provenance is recorded as quarantined under its exact identity instead of granting cleanup authority.
 A later retry retires an exact agent-free candidate idempotently and adopts an exact live candidate only from the launch-attempt phase after restoring and verifying its staged wiring, unchanged identity, and physical recorded worktree.
 It refuses every live pre-launch or quarantined candidate and every unreadable, mismatched, or multiply matched candidate.
-Before any candidate or old pane is retired, its exact idle shell is frozen and revalidated for identity, ownership, and child absence immediately at the close boundary; refusal always resumes it.
+Before any candidate or old pane is retired, its exact idle shell and pane ownership are revalidated immediately at the close boundary, and retirement uses only Herdr's exact-pane operation rather than signaling a sampled OS PID.
 
 The session-start sweep uses the ordinary probe.
 Mid-session secondmate agent-process liveness is not implemented because idle secondmates are deliberately exempt from stale-pane escalation and need a separate periodic identity signal.

--- a/docs/verification/runtime-backends.md
+++ b/docs/verification/runtime-backends.md
@@ -937,7 +937,7 @@ ok - real herdr: an agent process that does not stop fails closed instead of bei
 ```
 
 The smoke test registers a stale Pi lifecycle report over a real idle shell, drives a persistent path mismatch and restoration, then places a real non-shell process group in the pane to prove that the same registration remains live and refuses replacement.
-`tests/fm-herdr-relaunch-recovery.test.sh` supplies portable quoting, injection, idempotence, ambiguous-state, live-process, and non-Herdr regression coverage.
+`tests/fm-herdr-relaunch-recovery.test.sh` supplies portable quoting, injection, pending-input cancellation, pre-Enter retry cleanup, direct-launch validation, idempotence, ambiguous-state, live-process, and non-Herdr regression coverage.
 The smoke command is the guard that refreshes this record; run it after every Herdr upgrade rather than trusting the version above.
 
 ### Away-mode transport

--- a/docs/verification/runtime-backends.md
+++ b/docs/verification/runtime-backends.md
@@ -917,10 +917,11 @@ Polling remained active and is covered as the fallback for capability, connect, 
 
 ### Agent lifecycle control
 
-Herdr is one of the two backends whose recovery-grade agent-state classifier the control plane may trust ([agent-control.md](../agent-control.md)), so its lifecycle gating is measured against the real binary; reverified 2026-08-08 on Herdr 0.8.0, and first measured 2026-08-02 on Herdr 0.7.5 with identical results:
+Herdr is one of the two backends whose recovery-grade agent-state classifier the control plane may trust ([agent-control.md](../agent-control.md)), so its lifecycle gating is measured against the real binary.
+The retained-registration and path-restoration behavior was verified on 2026-09-04 with Herdr 0.8.2; the original registry-only lifecycle behavior was first measured on 2026-08-02 with Herdr 0.7.5.
 
 ```sh
-tests/fm-control-herdr-smoke.test.sh
+HERDR_LAB_HELPER=bin/fm-herdr-lab.sh tests/fm-control-herdr-smoke.test.sh
 ```
 
 Observed output:
@@ -928,13 +929,16 @@ Observed output:
 ```text
 ok - real herdr: exit on a pane with no registered agent is idempotent success
 ok - real herdr: interrupt refuses when herdr's own agent registry reports no agent
-ok - real herdr: interrupt delivers the harness's key and proves the agent survived it
+ok - real herdr: lifecycle recovery reconciles a retained registration after the agent process exits
+ok - real herdr: an agent-free pane shell returns persistently to the exact recorded worktree
+ok - real herdr: a non-shell foreground process remains live and cannot be replaced
 ok - real herdr: no control verb removed the endpoint or the task's local copy
-ok - real herdr: an agent that does not stop fails closed instead of being reported as stopped
+ok - real herdr: an agent process that does not stop fails closed instead of being reported as stopped
 ```
 
-The registry read through `herdr pane report-agent` is the same source `fm_backend_herdr_agent_state` classifies, so registering and not registering an agent on a plain shell pane exercises exactly the gate every lifecycle verb depends on, with no real agent launched.
-That command is the guard that refreshes this record; run it after every Herdr upgrade rather than trusting the version above.
+The smoke test registers a stale Pi lifecycle report over a real idle shell, drives a persistent path mismatch and restoration, then places a real non-shell process group in the pane to prove that the same registration remains live and refuses replacement.
+`tests/fm-herdr-relaunch-recovery.test.sh` supplies portable quoting, injection, idempotence, ambiguous-state, live-process, and non-Herdr regression coverage.
+The smoke command is the guard that refreshes this record; run it after every Herdr upgrade rather than trusting the version above.
 
 ### Away-mode transport
 

--- a/docs/verification/runtime-backends.md
+++ b/docs/verification/runtime-backends.md
@@ -918,7 +918,7 @@ Polling remained active and is covered as the fallback for capability, connect, 
 ### Agent lifecycle control
 
 Herdr is one of the two backends whose recovery-grade agent-state classifier the control plane may trust ([agent-control.md](../agent-control.md)), so its lifecycle gating is measured against the real binary.
-The retained-registration and path-restoration behavior was verified on 2026-09-04 with Herdr 0.8.2; the original registry-only lifecycle behavior was first measured on 2026-08-02 with Herdr 0.7.5.
+The retained-registration, path-restoration, and exact-workspace replacement behavior was verified on 2026-09-04 with Herdr 0.8.2; the original registry-only lifecycle behavior was first measured on 2026-08-02 with Herdr 0.7.5.
 
 ```sh
 HERDR_LAB_HELPER=bin/fm-herdr-lab.sh tests/fm-control-herdr-smoke.test.sh
@@ -931,13 +931,14 @@ ok - real herdr: exit on a pane with no registered agent is idempotent success
 ok - real herdr: interrupt refuses when herdr's own agent registry reports no agent
 ok - real herdr: lifecycle recovery reconciles a retained registration after the agent process exits
 ok - real herdr: an agent-free pane shell returns persistently to the exact recorded worktree
+ok - real herdr: replacement candidate creation and rollback stay exact-record scoped
 ok - real herdr: a non-shell foreground process remains live and cannot be replaced
 ok - real herdr: no control verb removed the endpoint or the task's local copy
 ok - real herdr: an agent process that does not stop fails closed instead of being reported as stopped
 ```
 
-The smoke test registers a stale Pi lifecycle report over a real idle shell, drives a persistent path mismatch and restoration, then places a real non-shell process group in the pane to prove that the same registration remains live and refuses replacement.
-`tests/fm-herdr-relaunch-recovery.test.sh` supplies portable quoting, injection, pending-input cancellation, pre-Enter retry cleanup, direct-launch validation, preparation-through-launch mutation serialization, frozen-shell delivery-boundary takeover refusal, idempotence, ambiguous-state, live-process, and non-Herdr regression coverage.
+The smoke test registers a stale Pi lifecycle report over a real idle shell, drives a persistent path mismatch and restoration, creates and retires one response-identified replacement candidate while proving an unrelated workspace unchanged, then places a real non-shell process group in the pane to prove that the same registration remains live and refuses replacement.
+`tests/fm-herdr-relaunch-recovery.test.sh` supplies portable stale-registration, live-process, ambiguous-state, exact-worktree, quoting, replacement publication, rollback, wiring restoration, idempotent candidate retry, candidate-takeover, exact-record scoping, unmanaged-workspace noninterference, and non-Herdr regression coverage.
 The smoke command is the guard that refreshes this record; run it after every Herdr upgrade rather than trusting the version above.
 
 ### Away-mode transport

--- a/docs/verification/runtime-backends.md
+++ b/docs/verification/runtime-backends.md
@@ -937,7 +937,7 @@ ok - real herdr: an agent process that does not stop fails closed instead of bei
 ```
 
 The smoke test registers a stale Pi lifecycle report over a real idle shell, drives a persistent path mismatch and restoration, then places a real non-shell process group in the pane to prove that the same registration remains live and refuses replacement.
-`tests/fm-herdr-relaunch-recovery.test.sh` supplies portable quoting, injection, pending-input cancellation, pre-Enter retry cleanup, direct-launch validation, idempotence, ambiguous-state, live-process, and non-Herdr regression coverage.
+`tests/fm-herdr-relaunch-recovery.test.sh` supplies portable quoting, injection, pending-input cancellation, pre-Enter retry cleanup, direct-launch validation, preparation-through-launch mutation serialization, idempotence, ambiguous-state, live-process, and non-Herdr regression coverage.
 The smoke command is the guard that refreshes this record; run it after every Herdr upgrade rather than trusting the version above.
 
 ### Away-mode transport

--- a/docs/verification/runtime-backends.md
+++ b/docs/verification/runtime-backends.md
@@ -937,7 +937,7 @@ ok - real herdr: an agent process that does not stop fails closed instead of bei
 ```
 
 The smoke test registers a stale Pi lifecycle report over a real idle shell, drives a persistent path mismatch and restoration, then places a real non-shell process group in the pane to prove that the same registration remains live and refuses replacement.
-`tests/fm-herdr-relaunch-recovery.test.sh` supplies portable quoting, injection, pending-input cancellation, pre-Enter retry cleanup, direct-launch validation, preparation-through-launch mutation serialization, idempotence, ambiguous-state, live-process, and non-Herdr regression coverage.
+`tests/fm-herdr-relaunch-recovery.test.sh` supplies portable quoting, injection, pending-input cancellation, pre-Enter retry cleanup, direct-launch validation, preparation-through-launch mutation serialization, frozen-shell delivery-boundary takeover refusal, idempotence, ambiguous-state, live-process, and non-Herdr regression coverage.
 The smoke command is the guard that refreshes this record; run it after every Herdr upgrade rather than trusting the version above.
 
 ### Away-mode transport

--- a/tests/fm-control-herdr-smoke.test.sh
+++ b/tests/fm-control-herdr-smoke.test.sh
@@ -155,7 +155,7 @@ pass "real herdr: an agent-free pane shell returns persistently to the exact rec
 # A different foreground process group makes the same registration live again.
 # This is the structural refusal that prevents a genuine agent process from
 # being mistaken for the shell-only stale-registration case.
-lab pane send-text "$PANE_ID" 'sleep 30' >/dev/null 2>&1 \
+lab pane send-text "$PANE_ID" "sh -c 'trap \"\" INT; while :; do sleep 1; done'" >/dev/null 2>&1 \
   || fail "could not type the foreground-process fixture"
 lab pane send-keys "$PANE_ID" enter >/dev/null 2>&1 \
   || fail "could not start the foreground-process fixture"

--- a/tests/fm-control-herdr-smoke.test.sh
+++ b/tests/fm-control-herdr-smoke.test.sh
@@ -152,6 +152,42 @@ SEEN=$(fm_backend_herdr_current_path "$SESSION:$PANE_ID")
 [ "$SEEN" = "$WT" ] || fail "the restored pane path should be '$WT', got '$SEEN'"
 pass "real herdr: an agent-free pane shell returns persistently to the exact recorded worktree"
 
+UNMANAGED_DIR="$SCRATCH/unmanaged"
+mkdir -p "$UNMANAGED_DIR"
+UNMANAGED_RAW=$(lab workspace create --cwd "$UNMANAGED_DIR" --label unmanaged-fixture --no-focus) \
+  || fail "could not create the unrelated-workspace fixture"
+UNMANAGED_PANE=$(printf '%s' "$UNMANAGED_RAW" | jq -r '.result.root_pane.pane_id // empty')
+[ -n "$UNMANAGED_PANE" ] || fail "unrelated-workspace fixture returned no pane id"
+UNMANAGED_BEFORE=$(lab pane get "$UNMANAGED_PANE" | jq -c '.result.pane | {pane_id,tab_id,workspace_id,foreground_cwd}') \
+  || fail "could not snapshot the unrelated-workspace fixture"
+fm_backend_herdr_relaunch_candidate_create \
+  "$SESSION" "$WORKSPACE_ID" replacement-fixture "$WT" \
+  || fail "could not create an exact replacement candidate"
+CANDIDATE_TAB=$FM_BACKEND_HERDR_RELAUNCH_CANDIDATE_TAB_ID
+CANDIDATE_PANE=$FM_BACKEND_HERDR_RELAUNCH_CANDIDATE_PANE_ID
+fm_backend_herdr_relaunch_candidate_matches \
+  "$SESSION" "$WORKSPACE_ID" "$CANDIDATE_TAB" "$CANDIDATE_PANE" \
+  || fail "replacement candidate did not retain its response-derived binding"
+[ "$(fm_backend_herdr_current_path "$SESSION:$CANDIDATE_PANE")" = "$WT" ] \
+  || fail "replacement candidate did not start in the recorded worktree"
+lab pane get "$PANE_ID" >/dev/null 2>&1 \
+  || fail "replacement candidate creation removed the recorded endpoint"
+UNMANAGED_AFTER=$(lab pane get "$UNMANAGED_PANE" | jq -c '.result.pane | {pane_id,tab_id,workspace_id,foreground_cwd}') \
+  || fail "replacement candidate creation removed the unrelated endpoint"
+[ "$UNMANAGED_AFTER" = "$UNMANAGED_BEFORE" ] \
+  || fail "replacement candidate creation mutated the unrelated workspace"
+fm_backend_herdr_relaunch_candidate_cleanup \
+  "$SESSION" "$WORKSPACE_ID" "$CANDIDATE_TAB" "$CANDIDATE_PANE" \
+  || fail "could not retire the exact agent-free replacement candidate"
+fm_backend_herdr_relaunch_candidate_cleanup \
+  "$SESSION" "$WORKSPACE_ID" "$CANDIDATE_TAB" "$CANDIDATE_PANE" \
+  || fail "repeated exact candidate rollback should be idempotent"
+lab pane get "$PANE_ID" >/dev/null 2>&1 \
+  || fail "candidate rollback removed the recorded endpoint"
+[ "$(lab pane get "$UNMANAGED_PANE" | jq -c '.result.pane | {pane_id,tab_id,workspace_id,foreground_cwd}')" = "$UNMANAGED_BEFORE" ] \
+  || fail "candidate rollback mutated the unrelated workspace"
+pass "real herdr: replacement candidate creation and rollback stay exact-record scoped"
+
 # A different foreground process group makes the same registration live again.
 # This is the structural refusal that prevents a genuine agent process from
 # being mistaken for the shell-only stale-registration case.

--- a/tests/fm-control-herdr-smoke.test.sh
+++ b/tests/fm-control-herdr-smoke.test.sh
@@ -9,9 +9,9 @@
 # an agent is running, and therefore whether a lifecycle verb may act at all,
 # comes from herdr's own agent registry.
 #
-# No real agent is launched. herdr's `pane report-agent` is the same registry
-# the adapter reads, so registering and not registering an agent on a plain
-# shell pane exercises exactly the classification the control plane gates on.
+# No real harness is launched. Herdr's `pane report-agent` models the retained
+# registry entry left after Pi exits, while a real foreground process group
+# independently models the non-shell ownership that must remain live.
 #
 # Always runs on a private, named, throwaway lab session, never the default
 # one (tests/herdr-test-safety.sh; the 2026-07-02 incident). Skips cleanly
@@ -30,15 +30,26 @@ command -v jq >/dev/null 2>&1 || { echo "skip: jq not found (required by the her
 . "$ROOT/tests/herdr-test-safety.sh"
 herdr_forget_inherited_pane
 
-SESSION="fm-lab-control-smoke-$$"
-export HERDR_SESSION="$SESSION"
+HERDR_LAB_HELPER=${HERDR_LAB_HELPER:-$ROOT/bin/fm-herdr-lab.sh}
+SESSION=
 SCRATCH=
+PROVISIONED=0
 cleanup_all() {
   [ -n "$SCRATCH" ] && rm -rf "$SCRATCH"
-  herdr_safe_stop_and_delete "$SESSION"
+  if [ "$PROVISIONED" -ne 0 ]; then
+    PROVISIONED=0
+    "$HERDR_LAB_HELPER" teardown "$SESSION"
+  fi
 }
 trap cleanup_all EXIT
-fm_herdr_lab_prepare "$SESSION" || fail "could not prepare isolated Herdr lab session"
+SESSION=$("$HERDR_LAB_HELPER" name control-herdr-smoke) || fail "could not name isolated Herdr lab session"
+export HERDR_SESSION="$SESSION"
+"$HERDR_LAB_HELPER" provision "$SESSION" || fail "could not provision isolated Herdr lab session"
+PROVISIONED=1
+
+lab() {
+  "$HERDR_LAB_HELPER" run "$SESSION" "$@"
+}
 
 SCRATCH=$(mktemp -d "${TMPDIR:-/tmp}/fm-control-herdr.XXXXXX")
 SCRATCH=$(cd "$SCRATCH" && pwd)
@@ -113,37 +124,65 @@ case "$OUT" in
 esac
 pass "real herdr: interrupt refuses when herdr's own agent registry reports no agent"
 
-# --- a registered agent: classification flips, and the verbs follow ---------
+# --- a retained registration over the shell is stale for lifecycle recovery -
 
-herdr pane report-agent "$PANE_ID" --source fm-control-smoke --agent fm-control-smoke-agent \
-  --state idle --session "$SESSION" >/dev/null 2>&1 \
-  || fail "could not register a live agent on the task pane"
+lab pane report-agent "$PANE_ID" --source fm-control-smoke --agent pi \
+  --state idle >/dev/null 2>&1 \
+  || fail "could not register the retained-agent fixture on the task pane"
 
 STATE=$(fm_backend_agent_state herdr "$SESSION:$PANE_ID")
-[ "$STATE" = alive ] || fail "herdr should classify a registered agent as alive, got '$STATE'"
+[ "$STATE" = alive ] || fail "the ordinary registry view should preserve the registered state, got '$STATE'"
+STATE=$(fm_backend_recovery_agent_state herdr "$SESSION:$PANE_ID")
+[ "$STATE" = dead ] || fail "lifecycle recovery should reconcile a retained registration over an idle shell, got '$STATE'"
+OUT=$(run_control hsmoke exit) || fail "exit should reconcile the stale registration as already stopped: $OUT"
+case "$OUT" in
+  "already-stopped hsmoke"*) : ;;
+  *) fail "a stale registered-agent report over the shell should be already stopped, got: $OUT" ;;
+esac
+pass "real herdr: lifecycle recovery reconciles a retained registration after the agent process exits"
 
-OUT=$(run_control hsmoke interrupt) || fail "interrupt against a registered agent should succeed: $OUT"
+lab pane send-text "$PANE_ID" 'cd /' >/dev/null 2>&1 \
+  || fail "could not drift the agent-free pane for path-restoration coverage"
+lab pane send-keys "$PANE_ID" enter >/dev/null 2>&1 \
+  || fail "could not submit the path-drift fixture"
+sleep 0.2
+fm_backend_prepare_relaunch_path herdr "$SESSION:$PANE_ID" "$WT" \
+  || fail "the backend could not restore the agent-free pane to its recorded worktree"
+SEEN=$(fm_backend_herdr_current_path "$SESSION:$PANE_ID")
+[ "$SEEN" = "$WT" ] || fail "the restored pane path should be '$WT', got '$SEEN'"
+pass "real herdr: an agent-free pane shell returns persistently to the exact recorded worktree"
+
+# A different foreground process group makes the same registration live again.
+# This is the structural refusal that prevents a genuine agent process from
+# being mistaken for the shell-only stale-registration case.
+lab pane send-text "$PANE_ID" 'sleep 30' >/dev/null 2>&1 \
+  || fail "could not type the foreground-process fixture"
+lab pane send-keys "$PANE_ID" enter >/dev/null 2>&1 \
+  || fail "could not start the foreground-process fixture"
+sleep 0.5
+STATE=$(fm_backend_recovery_agent_state herdr "$SESSION:$PANE_ID")
+[ "$STATE" = alive ] || fail "a registered non-shell foreground process should remain alive, got '$STATE'"
+
+OUT=$(run_control hsmoke interrupt) || fail "interrupt against a registered foreground process should succeed: $OUT"
 case "$OUT" in
   *"interrupt-delivered hsmoke harness=claude backend=herdr verified=agent-alive cancel=unconfirmed"*) : ;;
   *) fail "interrupt should report the agent-alive proof on herdr, got: $OUT" ;;
 esac
-pass "real herdr: interrupt delivers the harness's key and proves the agent survived it"
+pass "real herdr: a non-shell foreground process remains live and cannot be replaced"
 
-herdr pane get "$PANE_ID" --session "$SESSION" >/dev/null 2>&1 \
+lab pane get "$PANE_ID" >/dev/null 2>&1 \
   || fail "the control plane must never remove the endpoint it was operating on"
 [ -d "$WT" ] || fail "the control plane must never remove the task's local copy"
 pass "real herdr: no control verb removed the endpoint or the task's local copy"
 
-# Last, because it deliberately types a harness command into a pane that hosts
-# a plain shell: the registered agent cannot actually be stopped that way, and
-# the control plane must say so rather than report a stop it did not achieve.
+# The registered process is not a harness and cannot consume the exit command.
+# The control plane must therefore report that it did not stop rather than
+# converting the still-live foreground process into success.
 if OUT=$(run_control hsmoke exit 2>&1); then
-  fail "exit should fail closed when the agent does not stop: $OUT"
+  fail "exit should fail closed when the foreground process does not stop: $OUT"
 fi
 case "$OUT" in
   *"did not stop"*) : ;;
-  *) fail "the exit failure should say the agent did not stop, got: $OUT" ;;
+  *) fail "the exit failure should say the foreground process did not stop, got: $OUT" ;;
 esac
-pass "real herdr: an agent that does not stop fails closed instead of being reported as stopped"
-
-fm_backend_herdr_kill "$SESSION:$PANE_ID" 2>/dev/null || true
+pass "real herdr: an agent process that does not stop fails closed instead of being reported as stopped"

--- a/tests/fm-control-relaunch.test.sh
+++ b/tests/fm-control-relaunch.test.sh
@@ -922,6 +922,22 @@ test_missing_worktree_refuses_before_stopping_anything() {
   pass "fm-control relaunch: an unaccountable local copy refuses before the agent is touched"
 }
 
+test_primary_checkout_refuses_before_stopping_anything() {
+  local dir out rc
+  dir=$(new_case primary-checkout rl36)
+  add_ship_task "$dir" rl36 claude
+  awk -v wt="$dir/proj" '/^worktree=/{print "worktree=" wt; next} {print}' \
+    "$dir/home/state/rl36.meta" > "$dir/home/state/rl36.meta.tmp"
+  mv "$dir/home/state/rl36.meta.tmp" "$dir/home/state/rl36.meta"
+  printf '%s' "$dir/proj" > "$dir/fake/cwd"
+  out=$(run_control "$dir" rl36 relaunch --note "x"); rc=$?
+  expect_code 1 "$rc" "the primary checkout must refuse before any lifecycle action"
+  assert_contains "$out" "primary project checkout" "the refusal should name the unsafe launch location"
+  [ "$(cat "$dir/fake/command")" = claude ] || fail "a primary-checkout refusal must not stop the agent"
+  [ -z "$(cat "$dir/fake/literal")" ] || fail "a primary-checkout refusal must send nothing"
+  pass "fm-control relaunch: the checkpoint refuses a primary-checkout launch before touching the agent"
+}
+
 test_missing_instructions_refuse_before_stopping_anything() {
   local dir out rc
   dir=$(new_case nobrief rl11)
@@ -1520,6 +1536,7 @@ test_prefixed_prior_harness_wiring_is_still_retired
 test_muse_session_binding_is_retired_on_a_harness_switch
 test_cursor_session_binding_is_retired_on_a_harness_switch
 test_missing_worktree_refuses_before_stopping_anything
+test_primary_checkout_refuses_before_stopping_anything
 test_missing_instructions_refuse_before_stopping_anything
 test_checkpoint_refusal_leaves_the_record_byte_identical
 test_checkpoint_refuses_uninspectable_head_and_status

--- a/tests/fm-herdr-relaunch-recovery.test.sh
+++ b/tests/fm-herdr-relaunch-recovery.test.sh
@@ -245,12 +245,27 @@ chmod +x "$TMP_ROOT/fakebin/herdr"
 
 cat > "$TMP_ROOT/fakebin/ps" <<'SH'
 #!/usr/bin/env bash
+state=${FM_FAKE_HERDR_STATE:?}
 case "$*" in
   "-axo pid=,ppid=") printf '41001 1\n42001 1\n' ;;
   "-p 41001 -o stat="|"-p 42001 -o stat=")
-    if [ "$(jq -r '.frozen // false' "$FM_FAKE_HERDR_STATE")" = true ]; then printf 'T\n'; else printf 'S\n'; fi
+    if [ "$(jq -r '.frozen // false' "$state")" = true ]; then printf 'T\n'; else printf 'S\n'; fi
     ;;
   "-p 41001 -o comm="|"-p 42001 -o comm=") printf 'bash\n' ;;
+  "-p 41001 -o lstart= -o command=")
+    printf 'Mon Jan  1 00:00:00 2024 /bin/bash\n'
+    jq '
+      .identity_reads=((.identity_reads // 0) + 1)
+      | if .replace_after_identity then .process="replacement-shell" else . end
+    ' "$state" > "$state.tmp.$$" && mv "$state.tmp.$$" "$state"
+    ;;
+  "-p 42001 -o lstart= -o command=")
+    printf 'Mon Jan  1 00:00:00 2024 /bin/bash\n'
+    jq '
+      .identity_reads=((.identity_reads // 0) + 1)
+      | if .candidate_replace_after_identity then .candidate_process="replacement-shell" else . end
+    ' "$state" > "$state.tmp.$$" && mv "$state.tmp.$$" "$state"
+    ;;
   *) exit 1 ;;
 esac
 SH
@@ -359,7 +374,7 @@ chmod +x "$TMP_ROOT/fakebin/git"
 
 write_state() {
   jq -n --arg cwd "$1" --arg process "$2" --argjson registered "$3" \
-    '{cwd:$cwd,process:$process,registered:$registered,recorded_exists:true,pending:"",fail_after_send_once:false,process_info_failures:0,process_after_send:"",pane_gets:0,take_over_after_pane_get:-1,frozen:false,stop_calls:0,take_over_on_stop:false,candidate_exists:false,candidate_cwd:"",candidate_pending:"",candidate_process:"shell",candidate_registered:false,candidate_take_over_on_stop:false,candidate_takeover_before_run:false,candidate_create_ambiguous_once:false,candidate_run_fail:false,candidate_run_ambiguous:false,candidate_run_ambiguous_after_pane_get:false,candidate_run_unregistered:false,candidate_pane_gets:0,candidate_take_over_after_pane_get:-1,unmanaged_workspace:"w9",unmanaged_pane:"w9:p9",unmanaged_fingerprint:"unchanged"}' > "$STATE"
+    '{cwd:$cwd,process:$process,registered:$registered,recorded_exists:true,pending:"",fail_after_send_once:false,process_info_failures:0,process_after_send:"",pane_gets:0,take_over_after_pane_get:-1,frozen:false,stop_calls:0,identity_reads:0,replace_after_identity:false,take_over_on_stop:false,candidate_exists:false,candidate_cwd:"",candidate_pending:"",candidate_process:"shell",candidate_registered:false,candidate_replace_after_identity:false,candidate_take_over_on_stop:false,candidate_takeover_before_run:false,candidate_create_ambiguous_once:false,candidate_run_fail:false,candidate_run_ambiguous:false,candidate_run_ambiguous_after_pane_get:false,candidate_run_unregistered:false,candidate_pane_gets:0,candidate_take_over_after_pane_get:-1,unmanaged_workspace:"w9",unmanaged_pane:"w9:p9",unmanaged_fingerprint:"unchanged"}' > "$STATE"
   : > "$LOG"
 }
 
@@ -491,28 +506,30 @@ fi
   || fail "candidate cleanup refusal left the shell stopped"
 pass "Herdr relaunch recovery: candidate cleanup freezes and revalidates its shell"
 
-write_state "$TARGET" replacement-shell false
+write_state "$TARGET" shell false
+jq '.replace_after_identity=true' "$STATE" > "$STATE.tmp" && mv "$STATE.tmp" "$STATE"
 if run_backend fm_backend_herdr_run_on_prepared_shell \
     fmtest:w1:p1 41001 "$TARGET" true >/dev/null 2>&1; then
-  fail "prepared-shell submission accepted a PID no longer owned by the pane shell"
+  fail "prepared-shell submission accepted a PID replaced after its final process check"
 fi
 [ "$(jq -r '.stop_calls' "$STATE")" -eq 0 ] \
-  || fail "prepared-shell submission signaled a stale shell PID before validating pane ownership"
+  || fail "prepared-shell submission signaled a stale shell PID before resampling pane ownership"
 
 jq --arg cwd "$TARGET" '
   .candidate_exists=true
   | .candidate_cwd=$cwd
   | .candidate_label="stale-cleanup-candidate"
-  | .candidate_process="replacement-shell"
+  | .candidate_process="shell"
   | .candidate_registered=false
+  | .candidate_replace_after_identity=true
 ' "$STATE" > "$STATE.tmp" && mv "$STATE.tmp" "$STATE"
 if run_backend fm_backend_herdr_relaunch_candidate_close_on_shell \
     fmtest w1 w1:t2 w1:p2 42001 >/dev/null 2>&1; then
-  fail "candidate cleanup accepted a PID no longer owned by the candidate shell"
+  fail "candidate cleanup accepted a PID replaced after its final process check"
 fi
 [ "$(jq -r '.stop_calls' "$STATE")" -eq 0 ] \
-  || fail "candidate cleanup signaled a stale shell PID before validating pane ownership"
-pass "Herdr relaunch recovery: stale shell PIDs are rejected before signaling"
+  || fail "candidate cleanup signaled a stale shell PID before resampling pane ownership"
+pass "Herdr relaunch recovery: pane ownership is resampled before stale shell PIDs are signaled"
 
 DIRECT_HOME="$TMP_ROOT/direct-home"
 DIRECT_PROJECT="$TMP_ROOT/direct-project"

--- a/tests/fm-herdr-relaunch-recovery.test.sh
+++ b/tests/fm-herdr-relaunch-recovery.test.sh
@@ -54,6 +54,11 @@ case "${1:-} ${2:-}" in
       if [ "$1" = --pane ]; then pane=${2:-}; break; fi
       shift
     done
+    if [ "$(jq -r '.process_info_failures // 0' "$state")" -gt 0 ]; then
+      jq '.process_info_failures -= 1' "$state" | save_state
+      printf '{"id":"cli:pane:process_info","result":{"type":"pane_process_info","process_info":{"pane_id":"wrong"}}}\n'
+      exit 0
+    fi
     mode=$(jq -r '.process' "$state")
     case "$mode" in
       shell)
@@ -67,11 +72,17 @@ case "${1:-} ${2:-}" in
     ;;
   "pane send-text")
     text=${4:-}
-    jq --arg text "$text" '.pending=$text' "$state" | save_state
+    jq --arg text "$text" '
+      .pending=((.pending // "") + $text)
+      | if .fail_after_send_once then .fail_after_send_once=false | .process_info_failures=1 else . end
+      | if ((.process_after_send // "") != "") then .process=.process_after_send else . end
+    ' "$state" | save_state
     ;;
   "pane send-keys")
     key=${4:-}
-    if [ "$key" = enter ]; then
+    if [ "$key" = ctrl+c ]; then
+      jq '.pending=""' "$state" | save_state
+    elif [ "$key" = enter ]; then
       pending=$(jq -r '.pending // empty' "$state")
       cwd=$(jq -r '.cwd' "$state")
       if [ -n "$pending" ]; then
@@ -97,7 +108,7 @@ chmod +x "$TMP_ROOT/fakebin/ps"
 
 write_state() {
   jq -n --arg cwd "$1" --arg process "$2" --argjson registered "$3" \
-    '{cwd:$cwd,process:$process,registered:$registered,pending:""}' > "$STATE"
+    '{cwd:$cwd,process:$process,registered:$registered,pending:"",fail_after_send_once:false,process_info_failures:0,process_after_send:""}' > "$STATE"
   : > "$LOG"
 }
 
@@ -144,6 +155,34 @@ run_backend fm_backend_prepare_relaunch_path herdr fmtest:w1:p1 "$TARGET" \
 count_after=$(grep -c $'\x1fpane\x1fsend-text\x1f' "$LOG" || true)
 [ "$count_after" -eq "$count_before" ] || fail "idempotent path preparation submitted a second cd command"
 pass "Herdr relaunch recovery: exact path restoration is persistent, quoted, and idempotent"
+
+BUFFERED_MARKER="$TMP_ROOT/buffered-marker"
+write_state "$OLD" shell true
+jq --arg pending "touch '$BUFFERED_MARKER'; " '.pending=$pending' "$STATE" > "$STATE.tmp" && mv "$STATE.tmp" "$STATE"
+run_backend fm_backend_prepare_relaunch_path herdr fmtest:w1:p1 "$TARGET" \
+  || fail "path restoration should clear preexisting idle-shell input before submitting"
+[ ! -e "$BUFFERED_MARKER" ] || fail "path restoration executed preexisting buffered shell input"
+[ "$(jq -r '.cwd' "$STATE")" = "$TARGET" ] || fail "path restoration lost the recorded path after clearing buffered input"
+pass "Herdr relaunch recovery: preexisting shell input is cancelled before path restoration"
+
+write_state "$OLD" shell true
+jq '.fail_after_send_once=true' "$STATE" > "$STATE.tmp" && mv "$STATE.tmp" "$STATE"
+if run_backend fm_backend_prepare_relaunch_path herdr fmtest:w1:p1 "$TARGET" >/dev/null 2>&1; then
+  fail "a transient post-send process inspection failure should abort path restoration"
+fi
+[ -z "$(jq -r '.pending // empty' "$STATE")" ] || fail "failed path restoration left its command buffered for a retry"
+run_backend fm_backend_prepare_relaunch_path herdr fmtest:w1:p1 "$TARGET" \
+  || fail "path restoration should retry cleanly after post-send cleanup"
+[ "$(jq -r '.cwd' "$STATE")" = "$TARGET" ] || fail "the clean retry did not restore the recorded path"
+pass "Herdr relaunch recovery: pre-submit failures clean their buffered command for retry"
+
+write_state "$OLD" shell true
+jq '.process_after_send="live"' "$STATE" > "$STATE.tmp" && mv "$STATE.tmp" "$STATE"
+if run_backend fm_backend_prepare_relaunch_path herdr fmtest:w1:p1 "$TARGET" >/dev/null 2>&1; then
+  fail "path restoration should refuse when the shell owner changes after typing"
+fi
+[ -n "$(jq -r '.pending // empty' "$STATE")" ] || fail "cleanup sent input after the pane stopped belonging to the exact idle shell"
+pass "Herdr relaunch recovery: cleanup refuses a changed shell owner"
 
 write_state "$OLD" live true
 if run_backend fm_backend_prepare_relaunch_path herdr fmtest:w1:p1 "$TARGET" >/dev/null 2>&1; then

--- a/tests/fm-herdr-relaunch-recovery.test.sh
+++ b/tests/fm-herdr-relaunch-recovery.test.sh
@@ -209,7 +209,7 @@ case "${1:-} ${2:-}" in
   "pane close")
     pane=${3:-}
     if [ "$pane" = w1:p2 ]; then
-      jq '.candidate_exists=false | .candidate_registered=false | .candidate_process="dead"' "$state" | save_state
+      jq '.candidate_exists=false | .candidate_registered=false | .candidate_process="dead" | .frozen=false' "$state" | save_state
     fi
     ;;
 esac
@@ -401,6 +401,25 @@ fi
 [ -n "$(jq -r '.pending // empty' "$STATE")" ] || fail "cleanup sent input after the pane stopped belonging to the exact idle shell"
 pass "Herdr relaunch recovery: cleanup refuses a changed shell owner"
 
+write_state "$TARGET" shell true
+jq --arg cwd "$TARGET" '
+  .candidate_exists=true
+  | .candidate_cwd=$cwd
+  | .candidate_label="cleanup-candidate"
+  | .candidate_process="shell"
+  | .candidate_registered=false
+  | .candidate_take_over_on_stop=true
+' "$STATE" > "$STATE.tmp" && mv "$STATE.tmp" "$STATE"
+if run_backend fm_backend_herdr_relaunch_candidate_cleanup \
+    fmtest w1 w1:t2 w1:p2 >/dev/null 2>&1; then
+  fail "candidate cleanup closed a pane whose shell owner changed at the close boundary"
+fi
+[ "$(jq -r '.candidate_exists' "$STATE")" = true ] \
+  || fail "candidate cleanup removed the taken-over pane"
+[ "$(jq -r '.frozen' "$STATE")" = false ] \
+  || fail "candidate cleanup refusal left the shell stopped"
+pass "Herdr relaunch recovery: candidate cleanup freezes and revalidates its shell"
+
 DIRECT_HOME="$TMP_ROOT/direct-home"
 DIRECT_PROJECT="$TMP_ROOT/direct-project"
 DIRECT_WT="$TMP_ROOT/direct-worktree"
@@ -586,26 +605,6 @@ pass "fm-spawn relaunch: crash adoption retires only prior harness wiring"
 rm -f "$DIRECT_HOME/state/direct.pi-ext.ts"
 
 reset_direct_meta
-awk '
-  /^window=/{print "window=fmtest:w1:p2"; next}
-  /^herdr_tab_id=/{print "herdr_tab_id=w1:t2"; next}
-  /^herdr_pane_id=/{print "herdr_pane_id=w1:p2"; next}
-  {print}
-' "$DIRECT_HOME/state/direct.meta" > "$DIRECT_HOME/state/direct.meta.tmp"
-mv "$DIRECT_HOME/state/direct.meta.tmp" "$DIRECT_HOME/state/direct.meta"
-write_state "$DIRECT_WT" shell true
-jq --arg cwd "$DIRECT_WT" '.candidate_exists=true | .candidate_cwd=$cwd | .candidate_process="shell" | .candidate_registered=false' \
-  "$STATE" > "$STATE.tmp" && mv "$STATE.tmp" "$STATE"
-write_direct_candidate_record launch-attempt
-DIRECT_OUT=$(PATH="$TMP_ROOT/fakebin:$PATH" FM_HOME="$DIRECT_HOME" FM_FAKE_HERDR_STATE="$STATE" \
-  FM_FAKE_HERDR_LOG="$LOG" FM_HERDR_PS_BIN="$TMP_ROOT/fakebin/ps" FM_HERDR_KILL_BIN="$TMP_ROOT/fakebin/kill" \
-  FM_BACKEND_HERDR_IDLE_SHELL_PROOF_POLLS=1 FM_SPAWN_NO_GUARD=1 \
-  "$ROOT/bin/fm-spawn.sh" direct --relaunch 2>&1) \
-  || fail "retry stranded a candidate already named by authoritative metadata: $DIRECT_OUT"
-case "$DIRECT_OUT" in *"spawned direct "*) : ;; *) fail "authoritative candidate reconciliation did not permit the next relaunch: $DIRECT_OUT" ;; esac
-pass "fm-spawn relaunch: authoritative candidate reconciles before prior-old comparison"
-
-reset_direct_meta
 write_state "$DIRECT_WT" shell true
 jq '.candidate_take_over_after_pane_get=1' "$STATE" > "$STATE.tmp" && mv "$STATE.tmp" "$STATE"
 if DIRECT_OUT=$(PATH="$TMP_ROOT/fakebin:$PATH" FM_HOME="$DIRECT_HOME" FM_FAKE_HERDR_STATE="$STATE" \
@@ -783,6 +782,18 @@ pass "fm-spawn relaunch: Herdr session mutation lock spans candidate creation th
 pass "fm-spawn relaunch: replacement stays exact-record scoped and ignores unmanaged workspaces"
 
 reset_direct_meta
+mkdir -p "$DIRECT_WT/.claude"
+printf '%s\n' prior-claude-wiring > "$DIRECT_WT/.claude/settings.local.json"
+rm -f "$DIRECT_HOME/state/direct.pi-ext.ts" "$DIRECT_HOME/state/direct.herdr-presentation"
+bash -c '
+  . "$0/bin/backends/herdr.sh"
+  token=$(fm_backend_herdr_projection_journal_create "$1" direct) || exit 1
+  label=$(fm_backend_herdr_projection_workspace_label direct "$token")
+  fm_backend_herdr_projection_journal_bind \
+    "$1/direct.herdr-presentation" direct "$2" fmtest \
+    w1 w1:t1 w1:p1 w0 firstmate "$label" fm-direct
+' "$ROOT" "$DIRECT_HOME/state" "$DIRECT_HOME" \
+  || fail "could not seed the post-publication presentation binding"
 write_state "$DIRECT_WT" shell true
 PUBLISH_MARKER="$TMP_ROOT/publish-window.marker"
 PUBLISH_RELEASE="$TMP_ROOT/publish-window.release"
@@ -792,7 +803,7 @@ PATH="$TMP_ROOT/fakebin:$PATH" FM_HOME="$DIRECT_HOME" FM_FAKE_HERDR_STATE="$STAT
   FM_BACKEND_HERDR_IDLE_SHELL_PROOF_POLLS=1 FM_SPAWN_NO_GUARD=1 \
   FM_FAKE_MV_PUBLISH_MARKER="$PUBLISH_MARKER" FM_FAKE_MV_PUBLISH_RELEASE="$PUBLISH_RELEASE" \
   FM_FAKE_MV_PUBLISH_TARGET="$DIRECT_HOME/state/direct.meta" \
-  "$ROOT/bin/fm-spawn.sh" direct --relaunch > "$PUBLISH_OUT" 2>&1 &
+  "$ROOT/bin/fm-spawn.sh" direct --relaunch --harness pi > "$PUBLISH_OUT" 2>&1 &
 publish_pid=$!
 for _ in {1..500}; do [ ! -e "$PUBLISH_MARKER" ] || break; sleep 0.01; done
 [ -e "$PUBLISH_MARKER" ] || fail "publication crash simulation never committed candidate metadata"
@@ -802,15 +813,24 @@ touch "$PUBLISH_RELEASE"
 wait "$publish_pid" 2>/dev/null || true
 [ "$(awk -F= '$1 == "herdr_pane_id" { print $2 }' "$DIRECT_HOME/state/direct.meta")" = w1:p2 ] \
   || fail "post-publication interruption rolled back authoritative metadata"
+[ "$(awk -F= '$1 == "harness" { print $2 }' "$DIRECT_HOME/state/direct.meta")" = pi ] \
+  || fail "post-publication interruption lost the replacement harness"
 [ "$(jq -r '.candidate_exists' "$STATE")" = true ] \
   || fail "post-publication interruption closed the authoritative candidate"
+grep -q '^pane_id=w1:p1$' "$DIRECT_HOME/state/direct.herdr-presentation" \
+  || fail "post-publication interruption unexpectedly advanced the presentation binding"
 DIRECT_OUT=$(PATH="$TMP_ROOT/fakebin:$PATH" FM_HOME="$DIRECT_HOME" FM_FAKE_HERDR_STATE="$STATE" \
   FM_FAKE_HERDR_LOG="$LOG" FM_HERDR_PS_BIN="$TMP_ROOT/fakebin/ps" FM_HERDR_KILL_BIN="$TMP_ROOT/fakebin/kill" \
   FM_BACKEND_HERDR_IDLE_SHELL_PROOF_POLLS=1 FM_SPAWN_NO_GUARD=1 \
-  "$ROOT/bin/fm-spawn.sh" direct --relaunch 2>&1) \
+  "$ROOT/bin/fm-spawn.sh" direct --relaunch --harness pi 2>&1) \
   || fail "retry could not finish the interrupted binding commit: $DIRECT_OUT"
 case "$DIRECT_OUT" in *"spawned direct "*) : ;; *) fail "post-publication recovery did not permit the next relaunch: $DIRECT_OUT" ;; esac
+[ ! -e "$DIRECT_WT/.claude/settings.local.json" ] \
+  || fail "post-publication recovery lost the original prior harness identity"
+grep -q '^pane_id=w1:p2$' "$DIRECT_HOME/state/direct.herdr-presentation" \
+  || fail "post-publication recovery left the presentation binding stale"
 pass "fm-spawn relaunch: post-publication abort preserves and reconciles candidate binding"
+rm -f "$DIRECT_HOME/state/direct.pi-ext.ts" "$DIRECT_HOME/state/direct.herdr-presentation"
 
 reset_direct_meta
 write_state "$DIRECT_WT" shell true

--- a/tests/fm-herdr-relaunch-recovery.test.sh
+++ b/tests/fm-herdr-relaunch-recovery.test.sh
@@ -106,6 +106,9 @@ case "${1:-} ${2:-}" in
       live)
         jq -n --arg pane "$pane" --argjson shell "$shell_pid" --argjson live "$live_pid" '{id:"cli:pane:process_info",result:{type:"pane_process_info",process_info:{pane_id:$pane,shell_pid:$shell,foreground_process_group_id:$live,foreground_processes:[{pid:$live,name:"pi",argv:["/opt/pi/bin/pi"]}]}}}'
         ;;
+      replacement-shell)
+        jq -n --arg pane "$pane" '{id:"cli:pane:process_info",result:{type:"pane_process_info",process_info:{pane_id:$pane,shell_pid:43001,foreground_process_group_id:43001,foreground_processes:[{pid:43001,name:"bash",argv:["/bin/bash"]}]}}}'
+        ;;
       *) printf '{"id":"cli:pane:process_info","result":{"type":"pane_process_info","process_info":{"pane_id":"wrong"}}}\n' ;;
     esac
     ;;
@@ -259,11 +262,11 @@ set -u
 state=${FM_FAKE_HERDR_STATE:?}
 case "${1:-} ${2:-}" in
   "-STOP 41001")
-    jq '.frozen=true | if (.take_over_on_stop // false) then .process="live" else . end' \
+    jq '.stop_calls=((.stop_calls // 0) + 1) | .frozen=true | if (.take_over_on_stop // false) then .process="live" else . end' \
       "$state" > "$state.tmp.$$" && mv "$state.tmp.$$" "$state"
     ;;
   "-STOP 42001")
-    jq '.frozen=true | if (.candidate_take_over_on_stop // false) then .candidate_process="live" | .candidate_registered=true else . end' \
+    jq '.stop_calls=((.stop_calls // 0) + 1) | .frozen=true | if (.candidate_take_over_on_stop // false) then .candidate_process="live" | .candidate_registered=true else . end' \
       "$state" > "$state.tmp.$$" && mv "$state.tmp.$$" "$state"
     ;;
   "-CONT 41001"|"-CONT 42001")
@@ -356,7 +359,7 @@ chmod +x "$TMP_ROOT/fakebin/git"
 
 write_state() {
   jq -n --arg cwd "$1" --arg process "$2" --argjson registered "$3" \
-    '{cwd:$cwd,process:$process,registered:$registered,recorded_exists:true,pending:"",fail_after_send_once:false,process_info_failures:0,process_after_send:"",pane_gets:0,take_over_after_pane_get:-1,frozen:false,take_over_on_stop:false,candidate_exists:false,candidate_cwd:"",candidate_pending:"",candidate_process:"shell",candidate_registered:false,candidate_take_over_on_stop:false,candidate_takeover_before_run:false,candidate_create_ambiguous_once:false,candidate_run_fail:false,candidate_run_ambiguous:false,candidate_run_ambiguous_after_pane_get:false,candidate_run_unregistered:false,candidate_pane_gets:0,candidate_take_over_after_pane_get:-1,unmanaged_workspace:"w9",unmanaged_pane:"w9:p9",unmanaged_fingerprint:"unchanged"}' > "$STATE"
+    '{cwd:$cwd,process:$process,registered:$registered,recorded_exists:true,pending:"",fail_after_send_once:false,process_info_failures:0,process_after_send:"",pane_gets:0,take_over_after_pane_get:-1,frozen:false,stop_calls:0,take_over_on_stop:false,candidate_exists:false,candidate_cwd:"",candidate_pending:"",candidate_process:"shell",candidate_registered:false,candidate_take_over_on_stop:false,candidate_takeover_before_run:false,candidate_create_ambiguous_once:false,candidate_run_fail:false,candidate_run_ambiguous:false,candidate_run_ambiguous_after_pane_get:false,candidate_run_unregistered:false,candidate_pane_gets:0,candidate_take_over_after_pane_get:-1,unmanaged_workspace:"w9",unmanaged_pane:"w9:p9",unmanaged_fingerprint:"unchanged"}' > "$STATE"
   : > "$LOG"
 }
 
@@ -487,6 +490,29 @@ fi
 [ "$(jq -r '.frozen' "$STATE")" = false ] \
   || fail "candidate cleanup refusal left the shell stopped"
 pass "Herdr relaunch recovery: candidate cleanup freezes and revalidates its shell"
+
+write_state "$TARGET" replacement-shell false
+if run_backend fm_backend_herdr_run_on_prepared_shell \
+    fmtest:w1:p1 41001 "$TARGET" true >/dev/null 2>&1; then
+  fail "prepared-shell submission accepted a PID no longer owned by the pane shell"
+fi
+[ "$(jq -r '.stop_calls' "$STATE")" -eq 0 ] \
+  || fail "prepared-shell submission signaled a stale shell PID before validating pane ownership"
+
+jq --arg cwd "$TARGET" '
+  .candidate_exists=true
+  | .candidate_cwd=$cwd
+  | .candidate_label="stale-cleanup-candidate"
+  | .candidate_process="replacement-shell"
+  | .candidate_registered=false
+' "$STATE" > "$STATE.tmp" && mv "$STATE.tmp" "$STATE"
+if run_backend fm_backend_herdr_relaunch_candidate_close_on_shell \
+    fmtest w1 w1:t2 w1:p2 42001 >/dev/null 2>&1; then
+  fail "candidate cleanup accepted a PID no longer owned by the candidate shell"
+fi
+[ "$(jq -r '.stop_calls' "$STATE")" -eq 0 ] \
+  || fail "candidate cleanup signaled a stale shell PID before validating pane ownership"
+pass "Herdr relaunch recovery: stale shell PIDs are rejected before signaling"
 
 DIRECT_HOME="$TMP_ROOT/direct-home"
 DIRECT_PROJECT="$TMP_ROOT/direct-project"

--- a/tests/fm-herdr-relaunch-recovery.test.sh
+++ b/tests/fm-herdr-relaunch-recovery.test.sh
@@ -487,50 +487,6 @@ fi
 [ -n "$(jq -r '.pending // empty' "$STATE")" ] || fail "cleanup sent input after the pane stopped belonging to the exact idle shell"
 pass "Herdr relaunch recovery: cleanup refuses a changed shell owner"
 
-write_state "$TARGET" shell true
-jq --arg cwd "$TARGET" '
-  .candidate_exists=true
-  | .candidate_cwd=$cwd
-  | .candidate_label="cleanup-candidate"
-  | .candidate_process="shell"
-  | .candidate_registered=false
-  | .candidate_take_over_on_stop=true
-' "$STATE" > "$STATE.tmp" && mv "$STATE.tmp" "$STATE"
-if run_backend fm_backend_herdr_relaunch_candidate_cleanup \
-    fmtest w1 w1:t2 w1:p2 >/dev/null 2>&1; then
-  fail "candidate cleanup closed a pane whose shell owner changed at the close boundary"
-fi
-[ "$(jq -r '.candidate_exists' "$STATE")" = true ] \
-  || fail "candidate cleanup removed the taken-over pane"
-[ "$(jq -r '.frozen' "$STATE")" = false ] \
-  || fail "candidate cleanup refusal left the shell stopped"
-pass "Herdr relaunch recovery: candidate cleanup freezes and revalidates its shell"
-
-write_state "$TARGET" shell false
-jq '.replace_after_identity=true' "$STATE" > "$STATE.tmp" && mv "$STATE.tmp" "$STATE"
-if run_backend fm_backend_herdr_run_on_prepared_shell \
-    fmtest:w1:p1 41001 "$TARGET" true >/dev/null 2>&1; then
-  fail "prepared-shell submission accepted a PID replaced after its final process check"
-fi
-[ "$(jq -r '.stop_calls' "$STATE")" -eq 0 ] \
-  || fail "prepared-shell submission signaled a stale shell PID before resampling pane ownership"
-
-jq --arg cwd "$TARGET" '
-  .candidate_exists=true
-  | .candidate_cwd=$cwd
-  | .candidate_label="stale-cleanup-candidate"
-  | .candidate_process="shell"
-  | .candidate_registered=false
-  | .candidate_replace_after_identity=true
-' "$STATE" > "$STATE.tmp" && mv "$STATE.tmp" "$STATE"
-if run_backend fm_backend_herdr_relaunch_candidate_close_on_shell \
-    fmtest w1 w1:t2 w1:p2 42001 >/dev/null 2>&1; then
-  fail "candidate cleanup accepted a PID replaced after its final process check"
-fi
-[ "$(jq -r '.stop_calls' "$STATE")" -eq 0 ] \
-  || fail "candidate cleanup signaled a stale shell PID before resampling pane ownership"
-pass "Herdr relaunch recovery: pane ownership is resampled before stale shell PIDs are signaled"
-
 DIRECT_HOME="$TMP_ROOT/direct-home"
 DIRECT_PROJECT="$TMP_ROOT/direct-project"
 DIRECT_WT="$TMP_ROOT/direct-worktree"
@@ -600,6 +556,8 @@ DIRECT_OUT=$(PATH="$TMP_ROOT/fakebin:$PATH" FM_HOME="$DIRECT_HOME" FM_FAKE_HERDR
 [ "$(cat "$DIRECT_ENV_LOG" 2>/dev/null)" = $'GOTMPDIR=/tmp/fm-direct/gotmp\nTRACEPARENT=00-11111111111111111111111111111111-2222222222222222-01' ] \
   || fail "direct Herdr relaunch did not preserve its environment and trace carrier: $(cat "$DIRECT_ENV_LOG" 2>/dev/null)"
 case "$DIRECT_OUT" in *"spawned direct "*) : ;; *) fail "direct Herdr relaunch did not complete: $DIRECT_OUT" ;; esac
+[ "$(jq -r '.stop_calls' "$STATE")" -eq 0 ] \
+  || fail "successful replacement launch or cleanup signaled a sampled OS process"
 [ "$(awk -F= '$1 == "herdr_pane_id" { print $2 }' "$DIRECT_HOME/state/direct.meta")" = w1:p2 ] \
   || fail "successful replacement did not publish the fresh pane binding"
 jq -e '.endpoints[] | select(.id == "direct") | .endpoint.target == "fmtest:w1:p2"' \
@@ -1004,33 +962,6 @@ cmp -s "$DIRECT_HOME/state/direct.meta.original" "$DIRECT_HOME/state/direct.meta
   || fail "unregistered adoption changed the authoritative binding"
 pass "fm-spawn relaunch: adoption requires registration and live process proof"
 
-jq '.candidate_process="shell" | .candidate_registered=false | .candidate_take_over_on_stop=true' \
-  "$STATE" > "$STATE.tmp" && mv "$STATE.tmp" "$STATE"
-if DIRECT_OUT=$(PATH="$TMP_ROOT/fakebin:$PATH" FM_HOME="$DIRECT_HOME" FM_FAKE_HERDR_STATE="$STATE" \
-    FM_FAKE_HERDR_LOG="$LOG" FM_HERDR_PS_BIN="$TMP_ROOT/fakebin/ps" FM_HERDR_KILL_BIN="$TMP_ROOT/fakebin/kill" \
-    FM_BACKEND_HERDR_IDLE_SHELL_PROOF_POLLS=1 FM_SPAWN_NO_GUARD=1 \
-    "$ROOT/bin/fm-spawn.sh" direct --relaunch 2>&1); then
-  fail "retry reported success after a submitted launch took over during cleanup: $DIRECT_OUT"
-fi
-grep -q '^phase=launch-attempt$' "$DIRECT_HOME/state/direct.control-relaunch-candidate" \
-  || fail "cleanup-race recovery discarded launch-attempt provenance"
-[ -d "$DIRECT_HOME/state/direct.control-relaunch-candidate.launch/prior-snapshot" ] \
-  || fail "cleanup-race recovery deleted the prior wiring snapshot"
-staged_busy=$(awk -F= '$1 == "busy_gen" { print $2 }' \
-  "$DIRECT_HOME/state/direct.control-relaunch-candidate.launch/launch/meta")
-[ "$(cat "$DIRECT_HOME/state/direct.busy-gen")" = "$staged_busy" ] \
-  || fail "cleanup-race recovery did not restore staged replacement supervision wiring"
-[ "$(jq -r '.candidate_exists and .candidate_registered and (.candidate_process == "live")' "$STATE")" = true ] \
-  || fail "cleanup-race recovery did not preserve the taken-over live candidate"
-DIRECT_OUT=$(PATH="$TMP_ROOT/fakebin:$PATH" FM_HOME="$DIRECT_HOME" FM_FAKE_HERDR_STATE="$STATE" \
-  FM_FAKE_HERDR_LOG="$LOG" FM_HERDR_PS_BIN="$TMP_ROOT/fakebin/ps" FM_HERDR_KILL_BIN="$TMP_ROOT/fakebin/kill" \
-  FM_BACKEND_HERDR_IDLE_SHELL_PROOF_POLLS=1 FM_SPAWN_NO_GUARD=1 \
-  "$ROOT/bin/fm-spawn.sh" direct --relaunch 2>&1) \
-  || fail "retry could not adopt the candidate preserved after cleanup raced its launch: $DIRECT_OUT"
-[ "$(awk -F= '$1 == "herdr_pane_id" { print $2 }' "$DIRECT_HOME/state/direct.meta")" = w1:p2 ] \
-  || fail "cleanup-race adoption did not publish the preserved candidate"
-pass "fm-spawn relaunch: cleanup races preserve launch provenance for adoption"
-
 reset_direct_meta
 write_state "$DIRECT_WT" shell true
 write_direct_candidate_record created
@@ -1081,17 +1012,18 @@ pass "fm-spawn relaunch: retry refuses live candidates without launch provenance
 
 reset_direct_meta
 write_state "$DIRECT_WT" shell true
-jq '.candidate_take_over_on_stop=true' "$STATE" > "$STATE.tmp" && mv "$STATE.tmp" "$STATE"
+jq '.candidate_takeover_before_run=true' "$STATE" > "$STATE.tmp" && mv "$STATE.tmp" "$STATE"
 if DIRECT_OUT=$(PATH="$TMP_ROOT/fakebin:$PATH" FM_HOME="$DIRECT_HOME" FM_FAKE_HERDR_STATE="$STATE" \
     FM_FAKE_HERDR_LOG="$LOG" FM_HERDR_PS_BIN="$TMP_ROOT/fakebin/ps" FM_HERDR_KILL_BIN="$TMP_ROOT/fakebin/kill" \
     FM_BACKEND_HERDR_IDLE_SHELL_PROOF_POLLS=1 FM_SPAWN_NO_GUARD=1 \
     "$ROOT/bin/fm-spawn.sh" direct --relaunch 2>&1); then
   fail "direct Herdr relaunch should refuse a takeover at the final delivery boundary: $DIRECT_OUT"
 fi
-run_count=$(grep -c $'\x1fpane\x1frun\x1f' "$LOG" || true)
-[ "$run_count" -eq 0 ] || fail "delivery-boundary takeover received replacement input"
-[ "$(jq -r '.frozen' "$STATE")" = false ] || fail "delivery-boundary refusal left the prepared shell stopped"
-pass "fm-spawn relaunch: frozen-shell boundary closes the final owner-check race"
+[ "$(jq -r '.stop_calls' "$STATE")" -eq 0 ] \
+  || fail "delivery-boundary refusal signaled a sampled OS process"
+[ ! -e "$DIRECT_HOME/state/.relaunch-direct/launch/launch-receipt" ] \
+  || fail "delivery-boundary takeover executed the replacement command"
+pass "fm-spawn relaunch: exact-pane delivery refuses takeover without OS PID signaling"
 
 reset_direct_meta
 write_state "$DIRECT_WT" shell true

--- a/tests/fm-herdr-relaunch-recovery.test.sh
+++ b/tests/fm-herdr-relaunch-recovery.test.sh
@@ -116,12 +116,31 @@ cat > "$TMP_ROOT/fakebin/ps" <<'SH'
 #!/usr/bin/env bash
 case "$*" in
   "-axo pid=,ppid=") printf '41001 1\n' ;;
-  "-p 41001 -o stat=") printf 'S\n' ;;
+  "-p 41001 -o stat=")
+    if [ "$(jq -r '.frozen // false' "$FM_FAKE_HERDR_STATE")" = true ]; then printf 'T\n'; else printf 'S\n'; fi
+    ;;
   "-p 41001 -o comm=") printf 'bash\n' ;;
   *) exit 1 ;;
 esac
 SH
 chmod +x "$TMP_ROOT/fakebin/ps"
+
+cat > "$TMP_ROOT/fakebin/kill" <<'SH'
+#!/usr/bin/env bash
+set -u
+state=${FM_FAKE_HERDR_STATE:?}
+case "${1:-} ${2:-}" in
+  "-STOP 41001")
+    jq '.frozen=true | if (.take_over_on_stop // false) then .process="live" else . end' \
+      "$state" > "$state.tmp.$$" && mv "$state.tmp.$$" "$state"
+    ;;
+  "-CONT 41001")
+    jq '.frozen=false' "$state" > "$state.tmp.$$" && mv "$state.tmp.$$" "$state"
+    ;;
+  *) exit 1 ;;
+esac
+SH
+chmod +x "$TMP_ROOT/fakebin/kill"
 
 cat > "$TMP_ROOT/fakebin/claude" <<'SH'
 #!/usr/bin/env bash
@@ -134,14 +153,14 @@ chmod +x "$TMP_ROOT/fakebin/claude"
 
 write_state() {
   jq -n --arg cwd "$1" --arg process "$2" --argjson registered "$3" \
-    '{cwd:$cwd,process:$process,registered:$registered,pending:"",fail_after_send_once:false,process_info_failures:0,process_after_send:"",pane_gets:0,take_over_after_pane_get:-1}' > "$STATE"
+    '{cwd:$cwd,process:$process,registered:$registered,pending:"",fail_after_send_once:false,process_info_failures:0,process_after_send:"",pane_gets:0,take_over_after_pane_get:-1,frozen:false,take_over_on_stop:false}' > "$STATE"
   : > "$LOG"
 }
 
 run_backend() {
   PATH="$TMP_ROOT/fakebin:$PATH" \
     FM_FAKE_HERDR_STATE="$STATE" FM_FAKE_HERDR_LOG="$LOG" FM_FAKE_HERDR_SOCKET="$TMP_ROOT/herdr.sock" \
-    FM_HERDR_PS_BIN="$TMP_ROOT/fakebin/ps" \
+    FM_HERDR_PS_BIN="$TMP_ROOT/fakebin/ps" FM_HERDR_KILL_BIN="$TMP_ROOT/fakebin/kill" \
     FM_BACKEND_HERDR_IDLE_SHELL_PROOF_POLLS=1 \
     bash -c '. "$0/bin/fm-backend.sh"; "$@"' "$ROOT" "$@"
 }
@@ -205,7 +224,7 @@ write_state "$OLD" shell true
 FM_FAKE_HERDR_CLEAR_DELAY=0.2 run_backend fm_backend_prepare_relaunch_path herdr fmtest:w1:p1 "$TARGET" &
 first_pid=$!
 first_started=0
-for _ in {1..100}; do
+for _ in {1..500}; do
   if grep -q $'\x1fpane\x1fsend-keys\x1f.*\x1fctrl+c' "$LOG"; then
     first_started=1
     break
@@ -275,8 +294,8 @@ EOF
 write_state "$DIRECT_WT" shell true
 jq --arg pending "touch '$DIRECT_MARKER'; " '.pending=$pending' "$STATE" > "$STATE.tmp" && mv "$STATE.tmp" "$STATE"
 DIRECT_OUT=$(PATH="$TMP_ROOT/fakebin:$PATH" FM_HOME="$DIRECT_HOME" FM_FAKE_HERDR_STATE="$STATE" \
-  FM_FAKE_HERDR_LOG="$LOG" FM_HERDR_PS_BIN="$TMP_ROOT/fakebin/ps" FM_BACKEND_HERDR_IDLE_SHELL_PROOF_POLLS=1 \
-  FM_FAKE_CLAUDE_ENV_LOG="$DIRECT_ENV_LOG" \
+  FM_FAKE_HERDR_LOG="$LOG" FM_HERDR_PS_BIN="$TMP_ROOT/fakebin/ps" FM_HERDR_KILL_BIN="$TMP_ROOT/fakebin/kill" \
+  FM_BACKEND_HERDR_IDLE_SHELL_PROOF_POLLS=1 FM_FAKE_CLAUDE_ENV_LOG="$DIRECT_ENV_LOG" \
   FM_SPAWN_NO_GUARD=1 "$ROOT/bin/fm-spawn.sh" direct --relaunch --harness claude 2>&1) \
   || fail "direct Herdr relaunch should prepare its endpoint before launch: $DIRECT_OUT"
 [ ! -e "$DIRECT_MARKER" ] || fail "direct Herdr relaunch executed buffered shell input before launch"
@@ -288,8 +307,9 @@ pass "fm-spawn relaunch: direct Herdr entry prepares buffered shell input"
 write_state "$DIRECT_WT" shell true
 jq '.take_over_after_pane_get=6' "$STATE" > "$STATE.tmp" && mv "$STATE.tmp" "$STATE"
 if DIRECT_OUT=$(PATH="$TMP_ROOT/fakebin:$PATH" FM_HOME="$DIRECT_HOME" FM_FAKE_HERDR_STATE="$STATE" \
-    FM_FAKE_HERDR_LOG="$LOG" FM_HERDR_PS_BIN="$TMP_ROOT/fakebin/ps" FM_BACKEND_HERDR_IDLE_SHELL_PROOF_POLLS=1 \
-    FM_SPAWN_NO_GUARD=1 "$ROOT/bin/fm-spawn.sh" direct --relaunch --harness claude 2>&1); then
+    FM_FAKE_HERDR_LOG="$LOG" FM_HERDR_PS_BIN="$TMP_ROOT/fakebin/ps" FM_HERDR_KILL_BIN="$TMP_ROOT/fakebin/kill" \
+    FM_BACKEND_HERDR_IDLE_SHELL_PROOF_POLLS=1 FM_SPAWN_NO_GUARD=1 \
+    "$ROOT/bin/fm-spawn.sh" direct --relaunch --harness claude 2>&1); then
   fail "direct Herdr relaunch should refuse after foreground ownership changes: $DIRECT_OUT"
 fi
 run_count=$(grep -c $'\x1fpane\x1frun\x1f' "$LOG" || true)
@@ -298,14 +318,27 @@ case "$DIRECT_OUT" in *"shell owner changed before launch delivery"*) : ;; *) fa
 pass "fm-spawn relaunch: foreground-owner change before launch delivery fails closed"
 
 write_state "$DIRECT_WT" shell true
+jq '.take_over_on_stop=true' "$STATE" > "$STATE.tmp" && mv "$STATE.tmp" "$STATE"
+if DIRECT_OUT=$(PATH="$TMP_ROOT/fakebin:$PATH" FM_HOME="$DIRECT_HOME" FM_FAKE_HERDR_STATE="$STATE" \
+    FM_FAKE_HERDR_LOG="$LOG" FM_HERDR_PS_BIN="$TMP_ROOT/fakebin/ps" FM_HERDR_KILL_BIN="$TMP_ROOT/fakebin/kill" \
+    FM_BACKEND_HERDR_IDLE_SHELL_PROOF_POLLS=1 FM_SPAWN_NO_GUARD=1 \
+    "$ROOT/bin/fm-spawn.sh" direct --relaunch --harness claude 2>&1); then
+  fail "direct Herdr relaunch should refuse a takeover at the final delivery boundary: $DIRECT_OUT"
+fi
+run_count=$(grep -c $'\x1fpane\x1frun\x1f' "$LOG" || true)
+[ "$run_count" -eq 0 ] || fail "delivery-boundary takeover received replacement input"
+[ "$(jq -r '.frozen' "$STATE")" = false ] || fail "delivery-boundary refusal left the prepared shell stopped"
+pass "fm-spawn relaunch: frozen-shell boundary closes the final owner-check race"
+
+write_state "$DIRECT_WT" shell true
 DIRECT_CONCURRENT_OUT="$TMP_ROOT/direct-concurrent.out"
 PATH="$TMP_ROOT/fakebin:$PATH" FM_HOME="$DIRECT_HOME" FM_FAKE_HERDR_STATE="$STATE" \
-  FM_FAKE_HERDR_LOG="$LOG" FM_HERDR_PS_BIN="$TMP_ROOT/fakebin/ps" FM_BACKEND_HERDR_IDLE_SHELL_PROOF_POLLS=1 \
-  FM_FAKE_HERDR_RUN_DELAY=0.5 FM_SPAWN_NO_GUARD=1 \
+  FM_FAKE_HERDR_LOG="$LOG" FM_HERDR_PS_BIN="$TMP_ROOT/fakebin/ps" FM_HERDR_KILL_BIN="$TMP_ROOT/fakebin/kill" \
+  FM_BACKEND_HERDR_IDLE_SHELL_PROOF_POLLS=1 FM_FAKE_HERDR_RUN_DELAY=0.5 FM_SPAWN_NO_GUARD=1 \
   "$ROOT/bin/fm-spawn.sh" direct --relaunch --harness claude > "$DIRECT_CONCURRENT_OUT" 2>&1 &
 direct_pid=$!
 direct_started=0
-for _ in {1..100}; do
+for _ in {1..500}; do
   if grep -q $'\x1fpane\x1fsend-keys\x1f.*\x1fctrl+c' "$LOG"; then
     direct_started=1
     break
@@ -317,7 +350,7 @@ session_reads_before=$(grep -c $'\x1fsession\x1flist\x1f' "$LOG" || true)
 run_backend fm_backend_prepare_relaunch_path herdr fmtest:w1:p1 "$DIRECT_WT" &
 competitor_pid=$!
 competitor_started=0
-for _ in {1..100}; do
+for _ in {1..500}; do
   session_reads=$(grep -c $'\x1fsession\x1flist\x1f' "$LOG" || true)
   if [ "$session_reads" -gt "$session_reads_before" ]; then
     competitor_started=1
@@ -342,8 +375,9 @@ INVALID_PENDING="touch '$TMP_ROOT/invalid-primary-marker'; "
 write_state "$DIRECT_PROJECT" shell true
 jq --arg pending "$INVALID_PENDING" '.pending=$pending' "$STATE" > "$STATE.tmp" && mv "$STATE.tmp" "$STATE"
 if DIRECT_OUT=$(PATH="$TMP_ROOT/fakebin:$PATH" FM_HOME="$DIRECT_HOME" FM_FAKE_HERDR_STATE="$STATE" \
-    FM_FAKE_HERDR_LOG="$LOG" FM_HERDR_PS_BIN="$TMP_ROOT/fakebin/ps" FM_BACKEND_HERDR_IDLE_SHELL_PROOF_POLLS=1 \
-    FM_SPAWN_NO_GUARD=1 "$ROOT/bin/fm-spawn.sh" direct --relaunch --harness claude 2>&1); then
+    FM_FAKE_HERDR_LOG="$LOG" FM_HERDR_PS_BIN="$TMP_ROOT/fakebin/ps" FM_HERDR_KILL_BIN="$TMP_ROOT/fakebin/kill" \
+    FM_BACKEND_HERDR_IDLE_SHELL_PROOF_POLLS=1 FM_SPAWN_NO_GUARD=1 \
+    "$ROOT/bin/fm-spawn.sh" direct --relaunch --harness claude 2>&1); then
   fail "direct Herdr relaunch should reject the primary checkout: $DIRECT_OUT"
 fi
 [ "$(jq -r '.pending' "$STATE")" = "$INVALID_PENDING" ] || fail "invalid-worktree relaunch sent input before refusing"

--- a/tests/fm-herdr-relaunch-recovery.test.sh
+++ b/tests/fm-herdr-relaunch-recovery.test.sh
@@ -306,6 +306,12 @@ source_match=0
 for arg in "$@"; do
   case "$arg" in *.meta.relaunch.*) source_match=1 ;; esac
 done
+if [ -n "${FM_FAKE_MV_PROVENANCE_BLOCK_RECEIPT_TARGET:-}" ] \
+   && [ "$target" = "$FM_FAKE_MV_PROVENANCE_BLOCK_RECEIPT_TARGET" ]; then
+  "$real_mv" "$@" || exit 1
+  mkdir "$target/launch-receipt" || exit 1
+  exit 0
+fi
 if [ -n "${FM_FAKE_MV_PROVENANCE_MARKER:-}" ] \
    && [ "$target" = "${FM_FAKE_MV_PROVENANCE_TARGET:-}" ]; then
   "$real_mv" "$@" || exit 1
@@ -796,6 +802,24 @@ grep -q '^phase=rolled-back$' "$DIRECT_HOME/state/direct.control-relaunch-candid
 grep -q 'gen=prior-busy-gen seq=7 state=idle' "$DIRECT_HOME/state/direct.busy-state" \
   || fail "failed candidate launch did not restore prior busy state"
 pass "fm-spawn relaunch: failed candidate launch rolls back endpoint, binding, and supervision wiring"
+
+reset_direct_meta
+write_state "$DIRECT_WT" shell true
+RECEIPT_TARGET="$DIRECT_HOME/state/direct.control-relaunch-candidate.launch/launch"
+if DIRECT_OUT=$(PATH="$TMP_ROOT/fakebin:$PATH" FM_HOME="$DIRECT_HOME" FM_FAKE_HERDR_STATE="$STATE" \
+    FM_FAKE_HERDR_LOG="$LOG" FM_HERDR_PS_BIN="$TMP_ROOT/fakebin/ps" FM_HERDR_KILL_BIN="$TMP_ROOT/fakebin/kill" \
+    FM_BACKEND_HERDR_IDLE_SHELL_PROOF_POLLS=1 FM_SPAWN_NO_GUARD=1 \
+    FM_FAKE_MV_PROVENANCE_BLOCK_RECEIPT_TARGET="$RECEIPT_TARGET" \
+    "$ROOT/bin/fm-spawn.sh" direct --relaunch 2>&1); then
+  fail "replacement launch succeeded without writing its adoption receipt: $DIRECT_OUT"
+fi
+cmp -s "$DIRECT_HOME/state/direct.meta.original" "$DIRECT_HOME/state/direct.meta" \
+  || fail "receipt-write failure changed the authoritative endpoint binding"
+[ "$(jq -r '.candidate_registered' "$STATE")" = false ] \
+  || fail "receipt-write failure still started a registered replacement agent"
+[ "$(jq -r '.candidate_process' "$STATE")" != live ] \
+  || fail "receipt-write failure still started the replacement process"
+pass "fm-spawn relaunch: receipt failure prevents an unadoptable agent launch"
 
 reset_direct_meta
 write_state "$DIRECT_WT" shell true

--- a/tests/fm-herdr-relaunch-recovery.test.sh
+++ b/tests/fm-herdr-relaunch-recovery.test.sh
@@ -130,7 +130,11 @@ case "${1:-} ${2:-}" in
       [ "$(jq -r '.candidate_run_fail // false' "$state")" != true ] || exit 1
       cwd=$(jq -r '.candidate_cwd' "$state")
       (cd "$cwd" && bash -c "$text") || exit 1
-      jq '.candidate_pending="" | .candidate_process="live" | .candidate_registered=true' "$state" | save_state
+      jq '
+        .candidate_pending=""
+        | .candidate_process="live"
+        | .candidate_registered=((.candidate_run_unregistered // false) | not)
+      ' "$state" | save_state
     else
       pending=$(jq -r '.pending // empty' "$state")
       cwd=$(jq -r '.cwd' "$state")
@@ -257,7 +261,7 @@ chmod +x "$TMP_ROOT/fakebin/claude"
 
 write_state() {
   jq -n --arg cwd "$1" --arg process "$2" --argjson registered "$3" \
-    '{cwd:$cwd,process:$process,registered:$registered,pending:"",fail_after_send_once:false,process_info_failures:0,process_after_send:"",pane_gets:0,take_over_after_pane_get:-1,frozen:false,take_over_on_stop:false,candidate_exists:false,candidate_cwd:"",candidate_pending:"",candidate_process:"shell",candidate_registered:false,candidate_take_over_on_stop:false,candidate_takeover_before_run:false,candidate_run_fail:false,candidate_pane_gets:0,candidate_take_over_after_pane_get:-1,unmanaged_workspace:"w9",unmanaged_pane:"w9:p9",unmanaged_fingerprint:"unchanged"}' > "$STATE"
+    '{cwd:$cwd,process:$process,registered:$registered,pending:"",fail_after_send_once:false,process_info_failures:0,process_after_send:"",pane_gets:0,take_over_after_pane_get:-1,frozen:false,take_over_on_stop:false,candidate_exists:false,candidate_cwd:"",candidate_pending:"",candidate_process:"shell",candidate_registered:false,candidate_take_over_on_stop:false,candidate_takeover_before_run:false,candidate_run_fail:false,candidate_run_unregistered:false,candidate_pane_gets:0,candidate_take_over_after_pane_get:-1,unmanaged_workspace:"w9",unmanaged_pane:"w9:p9",unmanaged_fingerprint:"unchanged"}' > "$STATE"
   : > "$LOG"
 }
 
@@ -576,6 +580,33 @@ grep -q '^phase=rolled-back$' "$DIRECT_HOME/state/direct.control-relaunch-candid
 grep -q 'gen=prior-busy-gen seq=7 state=idle' "$DIRECT_HOME/state/direct.busy-state" \
   || fail "failed candidate launch did not restore prior busy state"
 pass "fm-spawn relaunch: failed candidate launch rolls back endpoint, binding, and supervision wiring"
+
+reset_direct_meta
+write_state "$DIRECT_WT" shell true
+jq '.candidate_run_unregistered=true' "$STATE" > "$STATE.tmp" && mv "$STATE.tmp" "$STATE"
+if DIRECT_OUT=$(PATH="$TMP_ROOT/fakebin:$PATH" FM_HOME="$DIRECT_HOME" FM_FAKE_HERDR_STATE="$STATE" \
+    FM_FAKE_HERDR_LOG="$LOG" FM_HERDR_PS_BIN="$TMP_ROOT/fakebin/ps" FM_HERDR_KILL_BIN="$TMP_ROOT/fakebin/kill" \
+    FM_BACKEND_HERDR_IDLE_SHELL_PROOF_POLLS=1 FM_HERDR_RELAUNCH_LAUNCH_POLLS=1 FM_SPAWN_NO_GUARD=1 \
+    "$ROOT/bin/fm-spawn.sh" direct --relaunch 2>&1); then
+  fail "an unregistered foreground process passed replacement launch proof: $DIRECT_OUT"
+fi
+cmp -s "$DIRECT_HOME/state/direct.meta.original" "$DIRECT_HOME/state/direct.meta" \
+  || fail "an unregistered foreground process changed the authoritative binding"
+[ "$(jq -r '.candidate_exists' "$STATE")" = true ] \
+  || fail "failed launch proof closed an unregistered foreground process"
+grep -q '^phase=quarantined$' "$DIRECT_HOME/state/direct.control-relaunch-candidate" \
+  || fail "failed launch proof did not quarantine the unregistered foreground process"
+pass "fm-spawn relaunch: publication requires registration and live process proof"
+write_direct_candidate_record launch-attempt
+if DIRECT_OUT=$(PATH="$TMP_ROOT/fakebin:$PATH" FM_HOME="$DIRECT_HOME" FM_FAKE_HERDR_STATE="$STATE" \
+    FM_FAKE_HERDR_LOG="$LOG" FM_HERDR_PS_BIN="$TMP_ROOT/fakebin/ps" FM_HERDR_KILL_BIN="$TMP_ROOT/fakebin/kill" \
+    FM_BACKEND_HERDR_IDLE_SHELL_PROOF_POLLS=1 FM_SPAWN_NO_GUARD=1 \
+    "$ROOT/bin/fm-spawn.sh" direct --relaunch 2>&1); then
+  fail "adoption accepted an unregistered foreground process: $DIRECT_OUT"
+fi
+cmp -s "$DIRECT_HOME/state/direct.meta.original" "$DIRECT_HOME/state/direct.meta" \
+  || fail "unregistered adoption changed the authoritative binding"
+pass "fm-spawn relaunch: adoption requires registration and live process proof"
 
 reset_direct_meta
 write_state "$DIRECT_WT" shell true

--- a/tests/fm-herdr-relaunch-recovery.test.sh
+++ b/tests/fm-herdr-relaunch-recovery.test.sh
@@ -84,6 +84,7 @@ case "${1:-} ${2:-}" in
     ;;
   "pane run")
     text=${4:-}
+    sleep "${FM_FAKE_HERDR_RUN_DELAY:-0}"
     pending=$(jq -r '.pending // empty' "$state")
     cwd=$(jq -r '.cwd' "$state")
     new_cwd=$(cd "$cwd" && bash -c "$pending$text; pwd -P") || exit 1
@@ -272,6 +273,44 @@ DIRECT_OUT=$(PATH="$TMP_ROOT/fakebin:$PATH" FM_HOME="$DIRECT_HOME" FM_FAKE_HERDR
 [ ! -e "$DIRECT_MARKER" ] || fail "direct Herdr relaunch executed buffered shell input before launch"
 case "$DIRECT_OUT" in *"spawned direct "*) : ;; *) fail "direct Herdr relaunch did not complete: $DIRECT_OUT" ;; esac
 pass "fm-spawn relaunch: direct Herdr entry prepares buffered shell input"
+
+write_state "$DIRECT_WT" shell true
+DIRECT_CONCURRENT_OUT="$TMP_ROOT/direct-concurrent.out"
+PATH="$TMP_ROOT/fakebin:$PATH" FM_HOME="$DIRECT_HOME" FM_FAKE_HERDR_STATE="$STATE" \
+  FM_FAKE_HERDR_LOG="$LOG" FM_HERDR_PS_BIN="$TMP_ROOT/fakebin/ps" FM_BACKEND_HERDR_IDLE_SHELL_PROOF_POLLS=1 \
+  FM_FAKE_HERDR_RUN_DELAY=0.5 FM_SPAWN_NO_GUARD=1 \
+  "$ROOT/bin/fm-spawn.sh" direct --relaunch --harness claude > "$DIRECT_CONCURRENT_OUT" 2>&1 &
+direct_pid=$!
+direct_started=0
+for _ in {1..100}; do
+  if grep -q $'\x1fpane\x1fsend-keys\x1f.*\x1fctrl+c' "$LOG"; then
+    direct_started=1
+    break
+  fi
+  sleep 0.01
+done
+[ "$direct_started" -eq 1 ] || fail "the direct relaunch did not reach endpoint preparation"
+session_reads_before=$(grep -c $'\x1fsession\x1flist\x1f' "$LOG" || true)
+run_backend fm_backend_prepare_relaunch_path herdr fmtest:w1:p1 "$DIRECT_WT" &
+competitor_pid=$!
+competitor_started=0
+for _ in {1..100}; do
+  session_reads=$(grep -c $'\x1fsession\x1flist\x1f' "$LOG" || true)
+  if [ "$session_reads" -gt "$session_reads_before" ]; then
+    competitor_started=1
+    break
+  fi
+  sleep 0.01
+done
+[ "$competitor_started" -eq 1 ] || fail "the competing pane mutation did not reach the session lock"
+sleep 0.05
+clear_count=$(grep -c $'\x1fpane\x1fsend-keys\x1f.*\x1fctrl+c' "$LOG" || true)
+[ "$clear_count" -eq 1 ] || fail "a competing pane mutation entered between relaunch preparation and command submission"
+wait "$direct_pid" || fail "the serialized direct relaunch failed: $(cat "$DIRECT_CONCURRENT_OUT")"
+wait "$competitor_pid" || fail "the competing path preparation did not resume after launch submission"
+clear_count=$(grep -c $'\x1fpane\x1fsend-keys\x1f.*\x1fctrl+c' "$LOG" || true)
+[ "$clear_count" -eq 2 ] || fail "the competing pane mutation did not run after relaunch submission"
+pass "fm-spawn relaunch: Herdr session mutation lock spans preparation through launch submission"
 
 awk -v wt="$DIRECT_PROJECT" '/^worktree=/{print "worktree=" wt; next} {print}' \
   "$DIRECT_HOME/state/direct.meta" > "$DIRECT_HOME/state/direct.meta.tmp"

--- a/tests/fm-herdr-relaunch-recovery.test.sh
+++ b/tests/fm-herdr-relaunch-recovery.test.sh
@@ -42,16 +42,31 @@ case "${1:-} ${2:-}" in
     ;;
   "pane get")
     pane=${3:-}
-    jq --arg pane "$pane" '{id:"cli:pane:get",result:{type:"pane_info",pane:{pane_id:$pane,foreground_cwd:.cwd}}}' "$state"
-    jq '
-      .pane_gets=((.pane_gets // 0) + 1)
-      | if .pane_gets == (.take_over_after_pane_get // -1) then .process="live" else . end
-    ' "$state" | save_state
+    if [ "$pane" = w1:p2 ]; then
+      if [ "$(jq -r '.candidate_exists // false' "$state")" != true ]; then
+        printf '{"id":"cli:pane:get","error":{"code":"pane_not_found"}}\n'
+      else
+        jq --arg pane "$pane" '{id:"cli:pane:get",result:{type:"pane_info",pane:{pane_id:$pane,tab_id:"w1:t2",workspace_id:"w1",foreground_cwd:.candidate_cwd}}}' "$state"
+        jq '
+          .candidate_pane_gets=((.candidate_pane_gets // 0) + 1)
+          | if .candidate_pane_gets == (.candidate_take_over_after_pane_get // -1)
+            then .candidate_process="live" | .candidate_registered=true
+            else . end
+        ' "$state" | save_state
+      fi
+    else
+      jq --arg pane "$pane" '{id:"cli:pane:get",result:{type:"pane_info",pane:{pane_id:$pane,tab_id:"w1:t1",workspace_id:"w1",foreground_cwd:.cwd}}}' "$state"
+      jq '
+        .pane_gets=((.pane_gets // 0) + 1)
+        | if .pane_gets == (.take_over_after_pane_get // -1) then .process="live" else . end
+      ' "$state" | save_state
+    fi
     ;;
   "agent get")
     pane=${3:-}
-    if [ "$(jq -r '.registered' "$state")" = true ]; then
-      jq --arg pane "$pane" '{id:"cli:agent:get",result:{type:"agent_info",agent:{pane_id:$pane,agent:"pi",agent_status:"idle"}}}' "$state"
+    if { [ "$pane" = w1:p2 ] && [ "$(jq -r '.candidate_registered // false' "$state")" = true ]; } \
+       || { [ "$pane" != w1:p2 ] && [ "$(jq -r '.registered' "$state")" = true ]; }; then
+      jq -n --arg pane "$pane" '{id:"cli:agent:get",result:{type:"agent_info",agent:{pane_id:$pane,agent:"pi",agent_status:"idle"}}}'
     else
       printf '{"id":"cli:agent:get","error":{"code":"agent_not_found"}}\n'
     fi
@@ -67,45 +82,105 @@ case "${1:-} ${2:-}" in
       printf '{"id":"cli:pane:process_info","result":{"type":"pane_process_info","process_info":{"pane_id":"wrong"}}}\n'
       exit 0
     fi
-    mode=$(jq -r '.process' "$state")
+    if [ "$pane" = w1:p2 ]; then
+      mode=$(jq -r '.candidate_process // "shell"' "$state")
+    else
+      mode=$(jq -r '.process' "$state")
+    fi
+    if [ "$pane" = w1:p2 ]; then shell_pid=42001; live_pid=42002; else shell_pid=41001; live_pid=41002; fi
     case "$mode" in
       shell)
-        jq -n --arg pane "$pane" '{id:"cli:pane:process_info",result:{type:"pane_process_info",process_info:{pane_id:$pane,shell_pid:41001,foreground_process_group_id:41001,foreground_processes:[{pid:41001,name:"bash",argv:["/bin/bash"]}]}}}'
+        jq -n --arg pane "$pane" --argjson shell "$shell_pid" '{id:"cli:pane:process_info",result:{type:"pane_process_info",process_info:{pane_id:$pane,shell_pid:$shell,foreground_process_group_id:$shell,foreground_processes:[{pid:$shell,name:"bash",argv:["/bin/bash"]}]}}}'
         ;;
       live)
-        jq -n --arg pane "$pane" '{id:"cli:pane:process_info",result:{type:"pane_process_info",process_info:{pane_id:$pane,shell_pid:41001,foreground_process_group_id:41002,foreground_processes:[{pid:41002,name:"pi",argv:["/opt/pi/bin/pi"]}]}}}'
+        jq -n --arg pane "$pane" --argjson shell "$shell_pid" --argjson live "$live_pid" '{id:"cli:pane:process_info",result:{type:"pane_process_info",process_info:{pane_id:$pane,shell_pid:$shell,foreground_process_group_id:$live,foreground_processes:[{pid:$live,name:"pi",argv:["/opt/pi/bin/pi"]}]}}}'
         ;;
       *) printf '{"id":"cli:pane:process_info","result":{"type":"pane_process_info","process_info":{"pane_id":"wrong"}}}\n' ;;
     esac
     ;;
   "pane send-text")
+    pane=${3:-}
     text=${4:-}
-    jq --arg text "$text" '
-      .pending=((.pending // "") + $text)
-      | if .fail_after_send_once then .fail_after_send_once=false | .process_info_failures=1 else . end
-      | if ((.process_after_send // "") != "") then .process=.process_after_send else . end
-    ' "$state" | save_state
+    if [ "$pane" = w1:p2 ]; then
+      jq --arg text "$text" '.candidate_pending=((.candidate_pending // "") + $text)' "$state" | save_state
+    else
+      jq --arg text "$text" '
+        .pending=((.pending // "") + $text)
+        | if .fail_after_send_once then .fail_after_send_once=false | .process_info_failures=1 else . end
+        | if ((.process_after_send // "") != "") then .process=.process_after_send else . end
+      ' "$state" | save_state
+    fi
     ;;
   "pane run")
+    pane=${3:-}
     text=${4:-}
     sleep "${FM_FAKE_HERDR_RUN_DELAY:-0}"
-    pending=$(jq -r '.pending // empty' "$state")
-    cwd=$(jq -r '.cwd' "$state")
-    new_cwd=$(cd "$cwd" && bash -c "$pending$text; pwd -P") || exit 1
-    jq --arg cwd "$new_cwd" '.cwd=$cwd | .pending=""' "$state" | save_state
+    if [ "$pane" = w1:p2 ]; then
+      if [ "$(jq -r '.candidate_takeover_before_run // false' "$state")" = true ]; then
+        jq '.candidate_process="live" | .candidate_registered=true' "$state" | save_state
+        exit 1
+      fi
+      [ "$(jq -r '.candidate_run_fail // false' "$state")" != true ] || exit 1
+      cwd=$(jq -r '.candidate_cwd' "$state")
+      (cd "$cwd" && bash -c "$text") || exit 1
+      jq '.candidate_pending="" | .candidate_process="live" | .candidate_registered=true' "$state" | save_state
+    else
+      pending=$(jq -r '.pending // empty' "$state")
+      cwd=$(jq -r '.cwd' "$state")
+      new_cwd=$(cd "$cwd" && bash -c "$pending$text; pwd -P") || exit 1
+      jq --arg cwd "$new_cwd" '.cwd=$cwd | .pending=""' "$state" | save_state
+    fi
     ;;
   "pane send-keys")
+    pane=${3:-}
     key=${4:-}
     if [ "$key" = ctrl+c ]; then
       sleep "${FM_FAKE_HERDR_CLEAR_DELAY:-0}"
-      jq '.pending=""' "$state" | save_state
-    elif [ "$key" = enter ]; then
-      pending=$(jq -r '.pending // empty' "$state")
-      cwd=$(jq -r '.cwd' "$state")
-      if [ -n "$pending" ]; then
-        new_cwd=$(cd "$cwd" && bash -c "$pending; pwd -P") || exit 1
-        jq --arg cwd "$new_cwd" '.cwd=$cwd | .pending=""' "$state" | save_state
+      if [ "$pane" = w1:p2 ]; then
+        jq '.candidate_pending=""' "$state" | save_state
+      else
+        jq '.pending=""' "$state" | save_state
       fi
+    elif [ "$key" = enter ]; then
+      if [ "$pane" = w1:p2 ]; then
+        jq '.candidate_pending=""' "$state" | save_state
+      else
+        pending=$(jq -r '.pending // empty' "$state")
+        cwd=$(jq -r '.cwd' "$state")
+        if [ -n "$pending" ]; then
+          new_cwd=$(cd "$cwd" && bash -c "$pending; pwd -P") || exit 1
+          jq --arg cwd "$new_cwd" '.cwd=$cwd | .pending=""' "$state" | save_state
+        fi
+      fi
+    fi
+    ;;
+  "tab create")
+    workspace=
+    cwd=
+    label=
+    while [ "$#" -gt 0 ]; do
+      case "$1" in
+        --workspace) workspace=${2:-}; shift 2 ;;
+        --cwd) cwd=${2:-}; shift 2 ;;
+        --label) label=${2:-}; shift 2 ;;
+        *) shift ;;
+      esac
+    done
+    [ "$workspace" = w1 ] || exit 1
+    jq --arg cwd "$cwd" --arg label "$label" '
+      .candidate_exists=true
+      | .candidate_cwd=$cwd
+      | .candidate_label=$label
+      | .candidate_pending=""
+      | .candidate_process="shell"
+      | .candidate_registered=false
+    ' "$state" | save_state
+    jq -n --arg cwd "$cwd" --arg label "$label" '{id:"cli:tab:create",result:{type:"tab_created",tab:{tab_id:"w1:t2",workspace_id:"w1",label:$label},root_pane:{pane_id:"w1:p2",tab_id:"w1:t2",workspace_id:"w1",foreground_cwd:$cwd}}}'
+    ;;
+  "pane close")
+    pane=${3:-}
+    if [ "$pane" = w1:p2 ]; then
+      jq '.candidate_exists=false | .candidate_registered=false | .candidate_process="dead"' "$state" | save_state
     fi
     ;;
 esac
@@ -115,11 +190,11 @@ chmod +x "$TMP_ROOT/fakebin/herdr"
 cat > "$TMP_ROOT/fakebin/ps" <<'SH'
 #!/usr/bin/env bash
 case "$*" in
-  "-axo pid=,ppid=") printf '41001 1\n' ;;
-  "-p 41001 -o stat=")
+  "-axo pid=,ppid=") printf '41001 1\n42001 1\n' ;;
+  "-p 41001 -o stat="|"-p 42001 -o stat=")
     if [ "$(jq -r '.frozen // false' "$FM_FAKE_HERDR_STATE")" = true ]; then printf 'T\n'; else printf 'S\n'; fi
     ;;
-  "-p 41001 -o comm=") printf 'bash\n' ;;
+  "-p 41001 -o comm="|"-p 42001 -o comm=") printf 'bash\n' ;;
   *) exit 1 ;;
 esac
 SH
@@ -134,7 +209,11 @@ case "${1:-} ${2:-}" in
     jq '.frozen=true | if (.take_over_on_stop // false) then .process="live" else . end' \
       "$state" > "$state.tmp.$$" && mv "$state.tmp.$$" "$state"
     ;;
-  "-CONT 41001")
+  "-STOP 42001")
+    jq '.frozen=true | if (.candidate_take_over_on_stop // false) then .candidate_process="live" | .candidate_registered=true else . end' \
+      "$state" > "$state.tmp.$$" && mv "$state.tmp.$$" "$state"
+    ;;
+  "-CONT 41001"|"-CONT 42001")
     jq '.frozen=false' "$state" > "$state.tmp.$$" && mv "$state.tmp.$$" "$state"
     ;;
   *) exit 1 ;;
@@ -145,7 +224,7 @@ chmod +x "$TMP_ROOT/fakebin/kill"
 cat > "$TMP_ROOT/fakebin/claude" <<'SH'
 #!/usr/bin/env bash
 if [ -n "${FM_FAKE_CLAUDE_ENV_LOG:-}" ]; then
-  printf 'GOTMPDIR=%s\n' "${GOTMPDIR:-}" > "$FM_FAKE_CLAUDE_ENV_LOG"
+  printf 'GOTMPDIR=%s\nTRACEPARENT=%s\n' "${GOTMPDIR:-}" "${TRACEPARENT:-}" > "$FM_FAKE_CLAUDE_ENV_LOG"
 fi
 exit 0
 SH
@@ -153,7 +232,7 @@ chmod +x "$TMP_ROOT/fakebin/claude"
 
 write_state() {
   jq -n --arg cwd "$1" --arg process "$2" --argjson registered "$3" \
-    '{cwd:$cwd,process:$process,registered:$registered,pending:"",fail_after_send_once:false,process_info_failures:0,process_after_send:"",pane_gets:0,take_over_after_pane_get:-1,frozen:false,take_over_on_stop:false}' > "$STATE"
+    '{cwd:$cwd,process:$process,registered:$registered,pending:"",fail_after_send_once:false,process_info_failures:0,process_after_send:"",pane_gets:0,take_over_after_pane_get:-1,frozen:false,take_over_on_stop:false,candidate_exists:false,candidate_cwd:"",candidate_pending:"",candidate_process:"shell",candidate_registered:false,candidate_take_over_on_stop:false,candidate_takeover_before_run:false,candidate_run_fail:false,candidate_pane_gets:0,candidate_take_over_after_pane_get:-1,unmanaged_workspace:"w9",unmanaged_pane:"w9:p9",unmanaged_fingerprint:"unchanged"}' > "$STATE"
   : > "$LOG"
 }
 
@@ -285,44 +364,146 @@ harness=claude
 kind=ship
 mode=no-mistakes
 yolo=off
+model=test-model
+effort=high
+traceparent=00-11111111111111111111111111111111-2222222222222222-01
 backend=herdr
 herdr_session=fmtest
 herdr_workspace_id=w1
 herdr_tab_id=w1:t1
 herdr_pane_id=w1:p1
 EOF
+cp "$DIRECT_HOME/state/direct.meta" "$DIRECT_HOME/state/direct.meta.original"
+reset_direct_meta() {
+  cp "$DIRECT_HOME/state/direct.meta.original" "$DIRECT_HOME/state/direct.meta"
+  rm -f "$DIRECT_HOME/state/direct.control-relaunch-candidate"
+}
+write_direct_candidate_record() {  # <phase>
+  cat > "$DIRECT_HOME/state/direct.control-relaunch-candidate" <<EOF
+v1
+task=direct
+phase=$1
+tx=prior
+session=fmtest
+workspace=w1
+old_tab=w1:t1
+old_pane=w1:p1
+candidate_tab=w1:t2
+candidate_pane=w1:p2
+worktree=$DIRECT_WT
+replacement_harness=claude
+replacement_model=test-model
+replacement_effort=high
+EOF
+}
+printf '%s\n' "$$" > "$DIRECT_HOME/state/.lock"
+printf '%s on\n' "$$" > "$DIRECT_HOME/state/.trace-context-effective"
 write_state "$DIRECT_WT" shell true
 jq --arg pending "touch '$DIRECT_MARKER'; " '.pending=$pending' "$STATE" > "$STATE.tmp" && mv "$STATE.tmp" "$STATE"
 DIRECT_OUT=$(PATH="$TMP_ROOT/fakebin:$PATH" FM_HOME="$DIRECT_HOME" FM_FAKE_HERDR_STATE="$STATE" \
   FM_FAKE_HERDR_LOG="$LOG" FM_HERDR_PS_BIN="$TMP_ROOT/fakebin/ps" FM_HERDR_KILL_BIN="$TMP_ROOT/fakebin/kill" \
   FM_BACKEND_HERDR_IDLE_SHELL_PROOF_POLLS=1 FM_FAKE_CLAUDE_ENV_LOG="$DIRECT_ENV_LOG" \
-  FM_SPAWN_NO_GUARD=1 "$ROOT/bin/fm-spawn.sh" direct --relaunch --harness claude 2>&1) \
+  FM_SPAWN_NO_GUARD=1 "$ROOT/bin/fm-spawn.sh" direct --relaunch 2>&1) \
   || fail "direct Herdr relaunch should prepare its endpoint before launch: $DIRECT_OUT"
 [ ! -e "$DIRECT_MARKER" ] || fail "direct Herdr relaunch executed buffered shell input before launch"
-[ "$(cat "$DIRECT_ENV_LOG" 2>/dev/null)" = "GOTMPDIR=/tmp/fm-direct/gotmp" ] \
-  || fail "direct Herdr relaunch did not deliver its environment with the atomic launch command"
+[ "$(cat "$DIRECT_ENV_LOG" 2>/dev/null)" = $'GOTMPDIR=/tmp/fm-direct/gotmp\nTRACEPARENT=00-11111111111111111111111111111111-2222222222222222-01' ] \
+  || fail "direct Herdr relaunch did not preserve its environment and trace carrier: $(cat "$DIRECT_ENV_LOG" 2>/dev/null)"
 case "$DIRECT_OUT" in *"spawned direct "*) : ;; *) fail "direct Herdr relaunch did not complete: $DIRECT_OUT" ;; esac
-pass "fm-spawn relaunch: direct Herdr entry prepares buffered shell input"
+[ "$(awk -F= '$1 == "herdr_pane_id" { print $2 }' "$DIRECT_HOME/state/direct.meta")" = w1:p2 ] \
+  || fail "successful replacement did not publish the fresh pane binding"
+if ! grep -q '^model=test-model$' "$DIRECT_HOME/state/direct.meta" \
+   || ! grep -q '^effort=high$' "$DIRECT_HOME/state/direct.meta" \
+   || ! grep -q '^traceparent=00-11111111111111111111111111111111-2222222222222222-01$' "$DIRECT_HOME/state/direct.meta"; then
+  fail "successful replacement did not preserve its model, effort, and trace binding: $(cat "$DIRECT_HOME/state/direct.meta")"
+fi
+pass "fm-spawn relaunch: fresh endpoint becomes authoritative only after launch proof"
 
+reset_direct_meta
 write_state "$DIRECT_WT" shell true
-jq '.take_over_after_pane_get=6' "$STATE" > "$STATE.tmp" && mv "$STATE.tmp" "$STATE"
+jq '.candidate_take_over_after_pane_get=1' "$STATE" > "$STATE.tmp" && mv "$STATE.tmp" "$STATE"
 if DIRECT_OUT=$(PATH="$TMP_ROOT/fakebin:$PATH" FM_HOME="$DIRECT_HOME" FM_FAKE_HERDR_STATE="$STATE" \
     FM_FAKE_HERDR_LOG="$LOG" FM_HERDR_PS_BIN="$TMP_ROOT/fakebin/ps" FM_HERDR_KILL_BIN="$TMP_ROOT/fakebin/kill" \
     FM_BACKEND_HERDR_IDLE_SHELL_PROOF_POLLS=1 FM_SPAWN_NO_GUARD=1 \
-    "$ROOT/bin/fm-spawn.sh" direct --relaunch --harness claude 2>&1); then
+    "$ROOT/bin/fm-spawn.sh" direct --relaunch 2>&1); then
   fail "direct Herdr relaunch should refuse after foreground ownership changes: $DIRECT_OUT"
 fi
 run_count=$(grep -c $'\x1fpane\x1frun\x1f' "$LOG" || true)
 [ "$run_count" -eq 0 ] || fail "owner-change refusal sent input after foreground ownership changed"
-case "$DIRECT_OUT" in *"shell owner changed before launch delivery"*) : ;; *) fail "owner-change refusal was not explicit: $DIRECT_OUT" ;; esac
-pass "fm-spawn relaunch: foreground-owner change before launch delivery fails closed"
+cmp -s "$DIRECT_HOME/state/direct.meta.original" "$DIRECT_HOME/state/direct.meta" \
+  || fail "pre-launch takeover changed the authoritative endpoint binding"
+case "$DIRECT_OUT" in *"acquired an agent before launch ownership was established"*) : ;; *) fail "owner-change refusal was not explicit: $DIRECT_OUT" ;; esac
+pass "fm-spawn relaunch: pre-launch takeover preserves the old binding"
 
+reset_direct_meta
+mkdir -p "$DIRECT_WT/.claude"
+printf '%s\n' prior-claude-wiring > "$DIRECT_WT/.claude/settings.local.json"
+printf '%s\n' prior-busy-gen > "$DIRECT_HOME/state/direct.busy-gen"
+printf '%s\n' 'v1 gen=prior-busy-gen seq=7 state=idle source=test event=prior ts=1' > "$DIRECT_HOME/state/direct.busy-state"
 write_state "$DIRECT_WT" shell true
-jq '.take_over_on_stop=true' "$STATE" > "$STATE.tmp" && mv "$STATE.tmp" "$STATE"
+jq '.candidate_run_fail=true' "$STATE" > "$STATE.tmp" && mv "$STATE.tmp" "$STATE"
 if DIRECT_OUT=$(PATH="$TMP_ROOT/fakebin:$PATH" FM_HOME="$DIRECT_HOME" FM_FAKE_HERDR_STATE="$STATE" \
     FM_FAKE_HERDR_LOG="$LOG" FM_HERDR_PS_BIN="$TMP_ROOT/fakebin/ps" FM_HERDR_KILL_BIN="$TMP_ROOT/fakebin/kill" \
     FM_BACKEND_HERDR_IDLE_SHELL_PROOF_POLLS=1 FM_SPAWN_NO_GUARD=1 \
-    "$ROOT/bin/fm-spawn.sh" direct --relaunch --harness claude 2>&1); then
+    "$ROOT/bin/fm-spawn.sh" direct --relaunch 2>&1); then
+  fail "failed candidate launch should not report a successful relaunch: $DIRECT_OUT"
+fi
+cmp -s "$DIRECT_HOME/state/direct.meta.original" "$DIRECT_HOME/state/direct.meta" \
+  || fail "failed candidate launch changed the authoritative endpoint binding"
+[ "$(jq -r '.candidate_exists' "$STATE")" = false ] \
+  || fail "failed agent-free candidate launch was not rolled back"
+grep -q '^phase=rolled-back$' "$DIRECT_HOME/state/direct.control-relaunch-candidate" \
+  || fail "failed candidate launch left no durable rollback evidence"
+[ "$(cat "$DIRECT_WT/.claude/settings.local.json")" = prior-claude-wiring ] \
+  || fail "failed candidate launch did not restore prior harness wiring"
+[ "$(cat "$DIRECT_HOME/state/direct.busy-gen")" = prior-busy-gen ] \
+  || fail "failed candidate launch did not restore the prior busy generation"
+grep -q 'gen=prior-busy-gen seq=7 state=idle' "$DIRECT_HOME/state/direct.busy-state" \
+  || fail "failed candidate launch did not restore prior busy state"
+pass "fm-spawn relaunch: failed candidate launch rolls back endpoint, binding, and supervision wiring"
+
+reset_direct_meta
+write_state "$DIRECT_WT" shell true
+jq '.candidate_exists=true | .candidate_cwd=$cwd | .candidate_process="shell" | .candidate_registered=true' \
+  --arg cwd "$DIRECT_WT" "$STATE" > "$STATE.tmp" && mv "$STATE.tmp" "$STATE"
+write_direct_candidate_record created
+DIRECT_OUT=$(PATH="$TMP_ROOT/fakebin:$PATH" FM_HOME="$DIRECT_HOME" FM_FAKE_HERDR_STATE="$STATE" \
+  FM_FAKE_HERDR_LOG="$LOG" FM_HERDR_PS_BIN="$TMP_ROOT/fakebin/ps" FM_HERDR_KILL_BIN="$TMP_ROOT/fakebin/kill" \
+  FM_BACKEND_HERDR_IDLE_SHELL_PROOF_POLLS=1 FM_SPAWN_NO_GUARD=1 \
+  "$ROOT/bin/fm-spawn.sh" direct --relaunch 2>&1) \
+  || fail "retry should reconcile an exact stale registered candidate before relaunch: $DIRECT_OUT"
+close_line=$(grep -n $'\x1fpane\x1fclose\x1fw1:p2' "$LOG" | head -1 | cut -d: -f1)
+create_line=$(grep -n $'\x1ftab\x1fcreate\x1f' "$LOG" | head -1 | cut -d: -f1)
+[ -n "$close_line" ] && [ -n "$create_line" ] && [ "$close_line" -lt "$create_line" ] \
+  || fail "retry did not retire the stale exact candidate before creating its replacement: $(cat "$LOG")"
+pass "fm-spawn relaunch: retry idempotently reconciles a stale exact candidate"
+
+reset_direct_meta
+write_state "$DIRECT_WT" shell true
+jq '.candidate_exists=true | .candidate_cwd=$cwd | .candidate_process="live" | .candidate_registered=true' \
+  --arg cwd "$DIRECT_WT" "$STATE" > "$STATE.tmp" && mv "$STATE.tmp" "$STATE"
+write_direct_candidate_record quarantined
+if DIRECT_OUT=$(PATH="$TMP_ROOT/fakebin:$PATH" FM_HOME="$DIRECT_HOME" FM_FAKE_HERDR_STATE="$STATE" \
+    FM_FAKE_HERDR_LOG="$LOG" FM_HERDR_PS_BIN="$TMP_ROOT/fakebin/ps" FM_HERDR_KILL_BIN="$TMP_ROOT/fakebin/kill" \
+    FM_BACKEND_HERDR_IDLE_SHELL_PROOF_POLLS=1 FM_SPAWN_NO_GUARD=1 \
+    "$ROOT/bin/fm-spawn.sh" direct --relaunch 2>&1); then
+  fail "retry should refuse a prior exact candidate with a real live agent: $DIRECT_OUT"
+fi
+! grep -Fq $'\x1ftab\x1fcreate\x1f' "$LOG" \
+  || fail "retry created a duplicate endpoint beside a live quarantined candidate"
+[ "$(jq -r '.candidate_exists' "$STATE")" = true ] \
+  || fail "retry removed a real live quarantined candidate"
+cmp -s "$DIRECT_HOME/state/direct.meta.original" "$DIRECT_HOME/state/direct.meta" \
+  || fail "live-candidate refusal changed the authoritative old binding"
+case "$DIRECT_OUT" in *"prior Herdr replacement candidate cannot be proved safe"*) : ;; *) fail "live-candidate refusal was not explicit: $DIRECT_OUT" ;; esac
+pass "fm-spawn relaunch: retry refuses a real-live candidate without duplication or cleanup"
+
+reset_direct_meta
+write_state "$DIRECT_WT" shell true
+jq '.candidate_take_over_on_stop=true' "$STATE" > "$STATE.tmp" && mv "$STATE.tmp" "$STATE"
+if DIRECT_OUT=$(PATH="$TMP_ROOT/fakebin:$PATH" FM_HOME="$DIRECT_HOME" FM_FAKE_HERDR_STATE="$STATE" \
+    FM_FAKE_HERDR_LOG="$LOG" FM_HERDR_PS_BIN="$TMP_ROOT/fakebin/ps" FM_HERDR_KILL_BIN="$TMP_ROOT/fakebin/kill" \
+    FM_BACKEND_HERDR_IDLE_SHELL_PROOF_POLLS=1 FM_SPAWN_NO_GUARD=1 \
+    "$ROOT/bin/fm-spawn.sh" direct --relaunch 2>&1); then
   fail "direct Herdr relaunch should refuse a takeover at the final delivery boundary: $DIRECT_OUT"
 fi
 run_count=$(grep -c $'\x1fpane\x1frun\x1f' "$LOG" || true)
@@ -330,12 +511,13 @@ run_count=$(grep -c $'\x1fpane\x1frun\x1f' "$LOG" || true)
 [ "$(jq -r '.frozen' "$STATE")" = false ] || fail "delivery-boundary refusal left the prepared shell stopped"
 pass "fm-spawn relaunch: frozen-shell boundary closes the final owner-check race"
 
+reset_direct_meta
 write_state "$DIRECT_WT" shell true
 DIRECT_CONCURRENT_OUT="$TMP_ROOT/direct-concurrent.out"
 PATH="$TMP_ROOT/fakebin:$PATH" FM_HOME="$DIRECT_HOME" FM_FAKE_HERDR_STATE="$STATE" \
   FM_FAKE_HERDR_LOG="$LOG" FM_HERDR_PS_BIN="$TMP_ROOT/fakebin/ps" FM_HERDR_KILL_BIN="$TMP_ROOT/fakebin/kill" \
   FM_BACKEND_HERDR_IDLE_SHELL_PROOF_POLLS=1 FM_FAKE_HERDR_RUN_DELAY=0.5 FM_SPAWN_NO_GUARD=1 \
-  "$ROOT/bin/fm-spawn.sh" direct --relaunch --harness claude > "$DIRECT_CONCURRENT_OUT" 2>&1 &
+  "$ROOT/bin/fm-spawn.sh" direct --relaunch > "$DIRECT_CONCURRENT_OUT" 2>&1 &
 direct_pid=$!
 direct_started=0
 for _ in {1..500}; do
@@ -366,8 +548,51 @@ wait "$direct_pid" || fail "the serialized direct relaunch failed: $(cat "$DIREC
 wait "$competitor_pid" || fail "the competing path preparation did not resume after launch submission"
 clear_count=$(grep -c $'\x1fpane\x1fsend-keys\x1f.*\x1fctrl+c' "$LOG" || true)
 [ "$clear_count" -eq 2 ] || fail "the competing pane mutation did not run after relaunch submission"
-pass "fm-spawn relaunch: Herdr session mutation lock spans preparation through launch submission"
+pass "fm-spawn relaunch: Herdr session mutation lock spans candidate creation through binding publication"
 
+[ "$(jq -r '.unmanaged_fingerprint' "$STATE")" = unchanged ] \
+  || fail "replacement transaction mutated an unrelated unmanaged endpoint"
+! grep -Fq $'\x1fworkspace\x1flist\x1f' "$LOG" \
+  || fail "replacement transaction enumerated unrelated Herdr workspaces"
+! grep -Eq 'w9(:p9)?' "$LOG" \
+  || fail "replacement transaction addressed an unrelated unmanaged identity"
+pass "fm-spawn relaunch: replacement stays exact-record scoped and ignores unmanaged workspaces"
+
+reset_direct_meta
+write_state "$DIRECT_WT" shell true
+jq '.take_over_after_pane_get=2' "$STATE" > "$STATE.tmp" && mv "$STATE.tmp" "$STATE"
+if DIRECT_OUT=$(PATH="$TMP_ROOT/fakebin:$PATH" FM_HOME="$DIRECT_HOME" FM_FAKE_HERDR_STATE="$STATE" \
+    FM_FAKE_HERDR_LOG="$LOG" FM_HERDR_PS_BIN="$TMP_ROOT/fakebin/ps" FM_HERDR_KILL_BIN="$TMP_ROOT/fakebin/kill" \
+    FM_BACKEND_HERDR_IDLE_SHELL_PROOF_POLLS=1 FM_SPAWN_NO_GUARD=1 \
+    "$ROOT/bin/fm-spawn.sh" direct --relaunch 2>&1); then
+  fail "replacement creation should refuse when the old endpoint becomes live under its session lock: $DIRECT_OUT"
+fi
+! grep -Fq $'\x1ftab\x1fcreate\x1f' "$LOG" \
+  || fail "replacement creation proceeded after the old endpoint became live"
+cmp -s "$DIRECT_HOME/state/direct.meta.original" "$DIRECT_HOME/state/direct.meta" \
+  || fail "live-agent boundary refusal changed the authoritative endpoint binding"
+case "$DIRECT_OUT" in *"no longer proves agent-free under the session mutation lock"*) : ;; *) fail "live-agent boundary refusal was not explicit: $DIRECT_OUT" ;; esac
+pass "fm-spawn relaunch: a real-live old endpoint is rechecked under the mutation lock"
+
+reset_direct_meta
+awk '/^herdr_workspace_id=/{print "herdr_workspace_id=w9"; next} {print}' \
+  "$DIRECT_HOME/state/direct.meta" > "$DIRECT_HOME/state/direct.meta.tmp"
+mv "$DIRECT_HOME/state/direct.meta.tmp" "$DIRECT_HOME/state/direct.meta"
+write_state "$DIRECT_WT" shell true
+if DIRECT_OUT=$(PATH="$TMP_ROOT/fakebin:$PATH" FM_HOME="$DIRECT_HOME" FM_FAKE_HERDR_STATE="$STATE" \
+    FM_FAKE_HERDR_LOG="$LOG" FM_HERDR_PS_BIN="$TMP_ROOT/fakebin/ps" FM_HERDR_KILL_BIN="$TMP_ROOT/fakebin/kill" \
+    FM_BACKEND_HERDR_IDLE_SHELL_PROOF_POLLS=1 FM_SPAWN_NO_GUARD=1 \
+    "$ROOT/bin/fm-spawn.sh" direct --relaunch 2>&1); then
+  fail "replacement creation should refuse a contradictory recorded workspace relation: $DIRECT_OUT"
+fi
+! grep -Fq $'\x1ftab\x1fcreate\x1f' "$LOG" \
+  || fail "contradictory workspace metadata created a replacement endpoint"
+[ "$(jq -r '.unmanaged_fingerprint' "$STATE")" = unchanged ] \
+  || fail "contradictory workspace metadata mutated the unrelated workspace"
+case "$DIRECT_OUT" in *"does not match its exact workspace and tab"*) : ;; *) fail "contradictory workspace refusal was not explicit: $DIRECT_OUT" ;; esac
+pass "fm-spawn relaunch: contradictory endpoint relations refuse before workspace mutation"
+
+reset_direct_meta
 awk -v wt="$DIRECT_PROJECT" '/^worktree=/{print "worktree=" wt; next} {print}' \
   "$DIRECT_HOME/state/direct.meta" > "$DIRECT_HOME/state/direct.meta.tmp"
 mv "$DIRECT_HOME/state/direct.meta.tmp" "$DIRECT_HOME/state/direct.meta"
@@ -377,7 +602,7 @@ jq --arg pending "$INVALID_PENDING" '.pending=$pending' "$STATE" > "$STATE.tmp" 
 if DIRECT_OUT=$(PATH="$TMP_ROOT/fakebin:$PATH" FM_HOME="$DIRECT_HOME" FM_FAKE_HERDR_STATE="$STATE" \
     FM_FAKE_HERDR_LOG="$LOG" FM_HERDR_PS_BIN="$TMP_ROOT/fakebin/ps" FM_HERDR_KILL_BIN="$TMP_ROOT/fakebin/kill" \
     FM_BACKEND_HERDR_IDLE_SHELL_PROOF_POLLS=1 FM_SPAWN_NO_GUARD=1 \
-    "$ROOT/bin/fm-spawn.sh" direct --relaunch --harness claude 2>&1); then
+    "$ROOT/bin/fm-spawn.sh" direct --relaunch 2>&1); then
   fail "direct Herdr relaunch should reject the primary checkout: $DIRECT_OUT"
 fi
 [ "$(jq -r '.pending' "$STATE")" = "$INVALID_PENDING" ] || fail "invalid-worktree relaunch sent input before refusing"

--- a/tests/fm-herdr-relaunch-recovery.test.sh
+++ b/tests/fm-herdr-relaunch-recovery.test.sh
@@ -245,6 +245,22 @@ DIRECT_OUT=$(PATH="$TMP_ROOT/fakebin:$PATH" FM_HOME="$DIRECT_HOME" FM_FAKE_HERDR
 case "$DIRECT_OUT" in *"spawned direct "*) : ;; *) fail "direct Herdr relaunch did not complete: $DIRECT_OUT" ;; esac
 pass "fm-spawn relaunch: direct Herdr entry prepares buffered shell input"
 
+awk -v wt="$DIRECT_PROJECT" '/^worktree=/{print "worktree=" wt; next} {print}' \
+  "$DIRECT_HOME/state/direct.meta" > "$DIRECT_HOME/state/direct.meta.tmp"
+mv "$DIRECT_HOME/state/direct.meta.tmp" "$DIRECT_HOME/state/direct.meta"
+INVALID_PENDING="touch '$TMP_ROOT/invalid-primary-marker'; "
+write_state "$DIRECT_PROJECT" shell true
+jq --arg pending "$INVALID_PENDING" '.pending=$pending' "$STATE" > "$STATE.tmp" && mv "$STATE.tmp" "$STATE"
+if DIRECT_OUT=$(PATH="$TMP_ROOT/fakebin:$PATH" FM_HOME="$DIRECT_HOME" FM_FAKE_HERDR_STATE="$STATE" \
+    FM_FAKE_HERDR_LOG="$LOG" FM_HERDR_PS_BIN="$TMP_ROOT/fakebin/ps" FM_BACKEND_HERDR_IDLE_SHELL_PROOF_POLLS=1 \
+    FM_SPAWN_NO_GUARD=1 "$ROOT/bin/fm-spawn.sh" direct --relaunch --harness claude 2>&1); then
+  fail "direct Herdr relaunch should reject the primary checkout: $DIRECT_OUT"
+fi
+[ "$(jq -r '.pending' "$STATE")" = "$INVALID_PENDING" ] || fail "invalid-worktree relaunch sent input before refusing"
+! awk -F '\x1f' '$2 == "pane" && ($3 == "send-text" || $3 == "send-keys" || $3 == "run") {found=1} END {exit !found}' "$LOG" \
+  || fail "invalid-worktree relaunch issued a pane input command"
+pass "fm-spawn relaunch: invalid recorded worktrees refuse before pane input"
+
 write_state "$OLD" live true
 if run_backend fm_backend_prepare_relaunch_path herdr fmtest:w1:p1 "$TARGET" >/dev/null 2>&1; then
   fail "path restoration must refuse while a real foreground agent remains"

--- a/tests/fm-herdr-relaunch-recovery.test.sh
+++ b/tests/fm-herdr-relaunch-recovery.test.sh
@@ -129,6 +129,16 @@ case "${1:-} ${2:-}" in
       fi
       [ "$(jq -r '.candidate_run_fail // false' "$state")" != true ] || exit 1
       cwd=$(jq -r '.candidate_cwd' "$state")
+      delay=$(jq -r '.candidate_run_ambiguous_delay // 0' "$state")
+      if [ "$delay" != 0 ]; then
+        (
+          sleep "$delay"
+          (cd "$cwd" && bash -c "$text") || exit 1
+          jq '.candidate_pending="" | .candidate_process="live" | .candidate_registered=true' \
+            "$state" > "$state.delayed.$$" && mv "$state.delayed.$$" "$state"
+        ) >/dev/null 2>&1 &
+        exit 1
+      fi
       (cd "$cwd" && bash -c "$text") || exit 1
       jq '
         .candidate_pending=""
@@ -206,6 +216,10 @@ case "${1:-} ${2:-}" in
       | .candidate_process="shell"
       | .candidate_registered=false
     ' "$state" | save_state
+    if [ "$(jq -r '.candidate_create_ambiguous_once // false' "$state")" = true ]; then
+      jq '.candidate_create_ambiguous_once=false' "$state" | save_state
+      exit 1
+    fi
     if [ -n "${FM_FAKE_HERDR_CREATE_MARKER:-}" ]; then
       : > "$FM_FAKE_HERDR_CREATE_MARKER"
       while [ ! -e "${FM_FAKE_HERDR_CREATE_RELEASE:?}" ]; do sleep 0.01; done
@@ -319,7 +333,7 @@ chmod +x "$TMP_ROOT/fakebin/git"
 
 write_state() {
   jq -n --arg cwd "$1" --arg process "$2" --argjson registered "$3" \
-    '{cwd:$cwd,process:$process,registered:$registered,pending:"",fail_after_send_once:false,process_info_failures:0,process_after_send:"",pane_gets:0,take_over_after_pane_get:-1,frozen:false,take_over_on_stop:false,candidate_exists:false,candidate_cwd:"",candidate_pending:"",candidate_process:"shell",candidate_registered:false,candidate_take_over_on_stop:false,candidate_takeover_before_run:false,candidate_run_fail:false,candidate_run_ambiguous:false,candidate_run_unregistered:false,candidate_pane_gets:0,candidate_take_over_after_pane_get:-1,unmanaged_workspace:"w9",unmanaged_pane:"w9:p9",unmanaged_fingerprint:"unchanged"}' > "$STATE"
+    '{cwd:$cwd,process:$process,registered:$registered,pending:"",fail_after_send_once:false,process_info_failures:0,process_after_send:"",pane_gets:0,take_over_after_pane_get:-1,frozen:false,take_over_on_stop:false,candidate_exists:false,candidate_cwd:"",candidate_pending:"",candidate_process:"shell",candidate_registered:false,candidate_take_over_on_stop:false,candidate_takeover_before_run:false,candidate_create_ambiguous_once:false,candidate_run_fail:false,candidate_run_ambiguous:false,candidate_run_ambiguous_delay:0,candidate_run_unregistered:false,candidate_pane_gets:0,candidate_take_over_after_pane_get:-1,unmanaged_workspace:"w9",unmanaged_pane:"w9:p9",unmanaged_fingerprint:"unchanged"}' > "$STATE"
   : > "$LOG"
 }
 
@@ -559,6 +573,30 @@ pass "fm-spawn relaunch: retry discovers the exact pre-journal candidate"
 
 reset_direct_meta
 write_state "$DIRECT_WT" shell true
+jq '.candidate_create_ambiguous_once=true' "$STATE" > "$STATE.tmp" && mv "$STATE.tmp" "$STATE"
+if DIRECT_OUT=$(PATH="$TMP_ROOT/fakebin:$PATH" FM_HOME="$DIRECT_HOME" FM_FAKE_HERDR_STATE="$STATE" \
+    FM_FAKE_HERDR_LOG="$LOG" FM_HERDR_PS_BIN="$TMP_ROOT/fakebin/ps" FM_HERDR_KILL_BIN="$TMP_ROOT/fakebin/kill" \
+    FM_BACKEND_HERDR_IDLE_SHELL_PROOF_POLLS=1 FM_SPAWN_NO_GUARD=1 \
+    "$ROOT/bin/fm-spawn.sh" direct --relaunch 2>&1); then
+  fail "ambiguous candidate creation should require recovery: $DIRECT_OUT"
+fi
+grep -q '^phase=creation-failed$' "$DIRECT_HOME/state/direct.control-relaunch-candidate" \
+  || fail "ambiguous candidate creation did not retain recoverable label provenance"
+[ "$(jq -r '.candidate_exists' "$STATE")" = true ] \
+  || fail "ambiguous candidate creation did not commit its endpoint"
+DIRECT_OUT=$(PATH="$TMP_ROOT/fakebin:$PATH" FM_HOME="$DIRECT_HOME" FM_FAKE_HERDR_STATE="$STATE" \
+  FM_FAKE_HERDR_LOG="$LOG" FM_HERDR_PS_BIN="$TMP_ROOT/fakebin/ps" FM_HERDR_KILL_BIN="$TMP_ROOT/fakebin/kill" \
+  FM_BACKEND_HERDR_IDLE_SHELL_PROOF_POLLS=1 FM_SPAWN_NO_GUARD=1 \
+  "$ROOT/bin/fm-spawn.sh" direct --relaunch 2>&1) \
+  || fail "retry could not discover and retire the ambiguously created candidate: $DIRECT_OUT"
+[ "$(awk -F= '$1 == "herdr_pane_id" { print $2 }' "$DIRECT_HOME/state/direct.meta")" = w1:p2 ] \
+  || fail "retry did not publish a replacement after ambiguous creation recovery"
+[ "$(grep -c $'\x1ftab\x1fcreate\x1f' "$LOG" || true)" -eq 2 ] \
+  || fail "ambiguous creation recovery did not retire before creating one replacement"
+pass "fm-spawn relaunch: retry recovers ambiguous candidate creation"
+
+reset_direct_meta
+write_state "$DIRECT_WT" shell true
 LIVE_MARKER="$TMP_ROOT/post-live-window.marker"
 LIVE_RELEASE="$TMP_ROOT/post-live-window.release"
 LIVE_OUT="$TMP_ROOT/post-live-window.out"
@@ -694,10 +732,11 @@ pass "fm-spawn relaunch: failed candidate launch rolls back endpoint, binding, a
 
 reset_direct_meta
 write_state "$DIRECT_WT" shell true
-jq '.candidate_run_ambiguous=true' "$STATE" > "$STATE.tmp" && mv "$STATE.tmp" "$STATE"
+jq '.candidate_run_ambiguous_delay=0.2' "$STATE" > "$STATE.tmp" && mv "$STATE.tmp" "$STATE"
 if DIRECT_OUT=$(PATH="$TMP_ROOT/fakebin:$PATH" FM_HOME="$DIRECT_HOME" FM_FAKE_HERDR_STATE="$STATE" \
     FM_FAKE_HERDR_LOG="$LOG" FM_HERDR_PS_BIN="$TMP_ROOT/fakebin/ps" FM_HERDR_KILL_BIN="$TMP_ROOT/fakebin/kill" \
-    FM_BACKEND_HERDR_IDLE_SHELL_PROOF_POLLS=1 FM_SPAWN_NO_GUARD=1 \
+    FM_BACKEND_HERDR_IDLE_SHELL_PROOF_POLLS=1 FM_HERDR_RELAUNCH_ABORT_POLLS=10 \
+    FM_HERDR_RELAUNCH_ABORT_INTERVAL=0.05 FM_SPAWN_NO_GUARD=1 \
     "$ROOT/bin/fm-spawn.sh" direct --relaunch 2>&1); then
   fail "ambiguous candidate submission should require retry adoption: $DIRECT_OUT"
 fi
@@ -781,9 +820,9 @@ cmp -s "$DIRECT_HOME/state/direct.meta.original" "$DIRECT_HOME/state/direct.meta
   || fail "an unregistered foreground process changed the authoritative binding"
 [ "$(jq -r '.candidate_exists' "$STATE")" = true ] \
   || fail "failed launch proof closed an unregistered foreground process"
-grep -q '^phase=quarantined$' "$DIRECT_HOME/state/direct.control-relaunch-candidate" \
-  || fail "failed launch proof did not quarantine the unregistered foreground process"
-pass "fm-spawn relaunch: publication requires registration and live process proof"
+grep -q '^phase=launch-attempt$' "$DIRECT_HOME/state/direct.control-relaunch-candidate" \
+  || fail "failed launch proof discarded recoverable launch-attempt provenance"
+pass "fm-spawn relaunch: publication requires registration and preserves launch provenance"
 write_direct_candidate_record launch-attempt
 if DIRECT_OUT=$(PATH="$TMP_ROOT/fakebin:$PATH" FM_HOME="$DIRECT_HOME" FM_FAKE_HERDR_STATE="$STATE" \
     FM_FAKE_HERDR_LOG="$LOG" FM_HERDR_PS_BIN="$TMP_ROOT/fakebin/ps" FM_HERDR_KILL_BIN="$TMP_ROOT/fakebin/kill" \

--- a/tests/fm-herdr-relaunch-recovery.test.sh
+++ b/tests/fm-herdr-relaunch-recovery.test.sh
@@ -889,6 +889,33 @@ cmp -s "$DIRECT_HOME/state/direct.meta.original" "$DIRECT_HOME/state/direct.meta
   || fail "unregistered adoption changed the authoritative binding"
 pass "fm-spawn relaunch: adoption requires registration and live process proof"
 
+jq '.candidate_process="shell" | .candidate_registered=false | .candidate_take_over_on_stop=true' \
+  "$STATE" > "$STATE.tmp" && mv "$STATE.tmp" "$STATE"
+if DIRECT_OUT=$(PATH="$TMP_ROOT/fakebin:$PATH" FM_HOME="$DIRECT_HOME" FM_FAKE_HERDR_STATE="$STATE" \
+    FM_FAKE_HERDR_LOG="$LOG" FM_HERDR_PS_BIN="$TMP_ROOT/fakebin/ps" FM_HERDR_KILL_BIN="$TMP_ROOT/fakebin/kill" \
+    FM_BACKEND_HERDR_IDLE_SHELL_PROOF_POLLS=1 FM_SPAWN_NO_GUARD=1 \
+    "$ROOT/bin/fm-spawn.sh" direct --relaunch 2>&1); then
+  fail "retry reported success after a submitted launch took over during cleanup: $DIRECT_OUT"
+fi
+grep -q '^phase=launch-attempt$' "$DIRECT_HOME/state/direct.control-relaunch-candidate" \
+  || fail "cleanup-race recovery discarded launch-attempt provenance"
+[ -d "$DIRECT_HOME/state/direct.control-relaunch-candidate.launch/prior-snapshot" ] \
+  || fail "cleanup-race recovery deleted the prior wiring snapshot"
+staged_busy=$(awk -F= '$1 == "busy_gen" { print $2 }' \
+  "$DIRECT_HOME/state/direct.control-relaunch-candidate.launch/launch/meta")
+[ "$(cat "$DIRECT_HOME/state/direct.busy-gen")" = "$staged_busy" ] \
+  || fail "cleanup-race recovery did not restore staged replacement supervision wiring"
+[ "$(jq -r '.candidate_exists and .candidate_registered and (.candidate_process == "live")' "$STATE")" = true ] \
+  || fail "cleanup-race recovery did not preserve the taken-over live candidate"
+DIRECT_OUT=$(PATH="$TMP_ROOT/fakebin:$PATH" FM_HOME="$DIRECT_HOME" FM_FAKE_HERDR_STATE="$STATE" \
+  FM_FAKE_HERDR_LOG="$LOG" FM_HERDR_PS_BIN="$TMP_ROOT/fakebin/ps" FM_HERDR_KILL_BIN="$TMP_ROOT/fakebin/kill" \
+  FM_BACKEND_HERDR_IDLE_SHELL_PROOF_POLLS=1 FM_SPAWN_NO_GUARD=1 \
+  "$ROOT/bin/fm-spawn.sh" direct --relaunch 2>&1) \
+  || fail "retry could not adopt the candidate preserved after cleanup raced its launch: $DIRECT_OUT"
+[ "$(awk -F= '$1 == "herdr_pane_id" { print $2 }' "$DIRECT_HOME/state/direct.meta")" = w1:p2 ] \
+  || fail "cleanup-race adoption did not publish the preserved candidate"
+pass "fm-spawn relaunch: cleanup races preserve launch provenance for adoption"
+
 reset_direct_meta
 write_state "$DIRECT_WT" shell true
 write_direct_candidate_record created

--- a/tests/fm-herdr-relaunch-recovery.test.sh
+++ b/tests/fm-herdr-relaunch-recovery.test.sh
@@ -300,6 +300,13 @@ source_match=0
 for arg in "$@"; do
   case "$arg" in *.meta.relaunch.*) source_match=1 ;; esac
 done
+if [ -n "${FM_FAKE_MV_PROVENANCE_MARKER:-}" ] \
+   && [ "$target" = "${FM_FAKE_MV_PROVENANCE_TARGET:-}" ]; then
+  "$real_mv" "$@" || exit 1
+  : > "$FM_FAKE_MV_PROVENANCE_MARKER"
+  while [ ! -e "${FM_FAKE_MV_PROVENANCE_RELEASE:?}" ]; do sleep 0.01; done
+  exit 0
+fi
 if [ -n "${FM_FAKE_MV_PUBLISH_MARKER:-}" ] \
    && [ "$target" = "${FM_FAKE_MV_PUBLISH_TARGET:-}" ] \
    && [ "$source_match" = 1 ]; then
@@ -818,6 +825,44 @@ grep -q '^phase=published$' "$DIRECT_HOME/state/direct.control-relaunch-candidat
 pass "fm-spawn relaunch: hard-crash rollback restores deterministic prior wiring"
 
 reset_direct_meta
+mkdir -p "$DIRECT_WT/.claude"
+printf '%s\n' prior-provenance-wiring > "$DIRECT_WT/.claude/settings.local.json"
+write_state "$DIRECT_WT" shell true
+PROVENANCE_MARKER="$TMP_ROOT/provenance-window.marker"
+PROVENANCE_RELEASE="$TMP_ROOT/provenance-window.release"
+PROVENANCE_OUT="$TMP_ROOT/provenance-window.out"
+PROVENANCE_TARGET="$DIRECT_HOME/state/direct.control-relaunch-candidate.launch/launch"
+PATH="$TMP_ROOT/fakebin:$PATH" FM_HOME="$DIRECT_HOME" FM_FAKE_HERDR_STATE="$STATE" \
+  FM_FAKE_HERDR_LOG="$LOG" FM_HERDR_PS_BIN="$TMP_ROOT/fakebin/ps" FM_HERDR_KILL_BIN="$TMP_ROOT/fakebin/kill" \
+  FM_BACKEND_HERDR_IDLE_SHELL_PROOF_POLLS=1 FM_SPAWN_NO_GUARD=1 \
+  FM_FAKE_MV_PROVENANCE_MARKER="$PROVENANCE_MARKER" FM_FAKE_MV_PROVENANCE_RELEASE="$PROVENANCE_RELEASE" \
+  FM_FAKE_MV_PROVENANCE_TARGET="$PROVENANCE_TARGET" \
+  "$ROOT/bin/fm-spawn.sh" direct --relaunch > "$PROVENANCE_OUT" 2>&1 &
+provenance_pid=$!
+for _ in {1..500}; do [ ! -e "$PROVENANCE_MARKER" ] || break; sleep 0.01; done
+[ -e "$PROVENANCE_MARKER" ] || fail "provenance crash simulation never reached atomic installation"
+kill -KILL "$provenance_pid" 2>/dev/null || fail "could not stop relaunch during provenance installation"
+touch "$PROVENANCE_RELEASE"
+wait "$provenance_pid" 2>/dev/null || true
+[ -d "$DIRECT_HOME/state/direct.control-relaunch-candidate.launch/prior-snapshot" ] \
+  || fail "atomic provenance installation lost the prior wiring snapshot"
+jq '.candidate_exists=false | .candidate_registered=false | .candidate_process="dead"' \
+  "$STATE" > "$STATE.tmp" && mv "$STATE.tmp" "$STATE"
+printf '%s\n' interrupted-replacement-wiring > "$DIRECT_WT/.claude/settings.local.json"
+PROVENANCE_FAILURE="$TMP_ROOT/provenance-restore.failure"
+DIRECT_OUT=$(PATH="$TMP_ROOT/fakebin:$PATH" FM_HOME="$DIRECT_HOME" FM_FAKE_HERDR_STATE="$STATE" \
+  FM_FAKE_HERDR_LOG="$LOG" FM_HERDR_PS_BIN="$TMP_ROOT/fakebin/ps" FM_HERDR_KILL_BIN="$TMP_ROOT/fakebin/kill" \
+  FM_BACKEND_HERDR_IDLE_SHELL_PROOF_POLLS=1 FM_SPAWN_NO_GUARD=1 \
+  FM_FAKE_EXPECT_WIRING_PATH="$DIRECT_WT/.claude/settings.local.json" \
+  FM_FAKE_EXPECT_WIRING_VALUE=prior-provenance-wiring FM_FAKE_EXPECT_WIRING_FAILURE="$PROVENANCE_FAILURE" \
+  "$ROOT/bin/fm-spawn.sh" direct --relaunch 2>&1) \
+  || fail "retry could not restore wiring after missing post-wiring candidate: $DIRECT_OUT"
+[ ! -e "$PROVENANCE_FAILURE" ] \
+  || fail "retry created a replacement before restoring the preserved wiring snapshot"
+case "$DIRECT_OUT" in *"spawned direct "*) : ;; *) fail "post-wiring missing-candidate recovery did not complete: $DIRECT_OUT" ;; esac
+pass "fm-spawn relaunch: atomic provenance preserves missing-candidate rollback"
+
+reset_direct_meta
 write_state "$DIRECT_WT" shell true
 jq '.candidate_run_unregistered=true' "$STATE" > "$STATE.tmp" && mv "$STATE.tmp" "$STATE"
 if DIRECT_OUT=$(PATH="$TMP_ROOT/fakebin:$PATH" FM_HOME="$DIRECT_HOME" FM_FAKE_HERDR_STATE="$STATE" \
@@ -843,6 +888,19 @@ fi
 cmp -s "$DIRECT_HOME/state/direct.meta.original" "$DIRECT_HOME/state/direct.meta" \
   || fail "unregistered adoption changed the authoritative binding"
 pass "fm-spawn relaunch: adoption requires registration and live process proof"
+
+reset_direct_meta
+write_state "$DIRECT_WT" shell true
+write_direct_candidate_record created
+DIRECT_OUT=$(PATH="$TMP_ROOT/fakebin:$PATH" FM_HOME="$DIRECT_HOME" FM_FAKE_HERDR_STATE="$STATE" \
+  FM_FAKE_HERDR_LOG="$LOG" FM_HERDR_PS_BIN="$TMP_ROOT/fakebin/ps" FM_HERDR_KILL_BIN="$TMP_ROOT/fakebin/kill" \
+  FM_BACKEND_HERDR_IDLE_SHELL_PROOF_POLLS=1 FM_SPAWN_NO_GUARD=1 \
+  "$ROOT/bin/fm-spawn.sh" direct --relaunch 2>&1) \
+  || fail "retry could not roll back an exactly recorded missing pre-wiring candidate: $DIRECT_OUT"
+[ "$(grep -c $'\x1ftab\x1fcreate\x1f' "$LOG" || true)" -eq 1 ] \
+  || fail "missing pre-wiring candidate recovery did not create exactly one replacement"
+case "$DIRECT_OUT" in *"spawned direct "*) : ;; *) fail "missing pre-wiring candidate recovery did not complete: $DIRECT_OUT" ;; esac
+pass "fm-spawn relaunch: a missing pre-wiring candidate rolls back cleanly"
 
 reset_direct_meta
 write_state "$DIRECT_WT" shell true

--- a/tests/fm-herdr-relaunch-recovery.test.sh
+++ b/tests/fm-herdr-relaunch-recovery.test.sh
@@ -36,6 +36,10 @@ case "${1:-} ${2:-}" in
   "status --json")
     printf '{"client":{"version":"0.8.0","protocol":19},"server":{"running":true}}\n'
     ;;
+  "session list")
+    socket=${FM_FAKE_HERDR_SOCKET:-$(dirname "$state")/herdr.sock}
+    jq -n --arg socket "$socket" '{sessions:[{name:"fmtest",running:true,socket_path:$socket}]}'
+    ;;
   "pane get")
     pane=${3:-}
     jq --arg pane "$pane" '{id:"cli:pane:get",result:{type:"pane_info",pane:{pane_id:$pane,foreground_cwd:.cwd}}}' "$state"
@@ -88,6 +92,7 @@ case "${1:-} ${2:-}" in
   "pane send-keys")
     key=${4:-}
     if [ "$key" = ctrl+c ]; then
+      sleep "${FM_FAKE_HERDR_CLEAR_DELAY:-0}"
       jq '.pending=""' "$state" | save_state
     elif [ "$key" = enter ]; then
       pending=$(jq -r '.pending // empty' "$state")
@@ -127,7 +132,8 @@ write_state() {
 
 run_backend() {
   PATH="$TMP_ROOT/fakebin:$PATH" \
-    FM_FAKE_HERDR_STATE="$STATE" FM_FAKE_HERDR_LOG="$LOG" FM_HERDR_PS_BIN="$TMP_ROOT/fakebin/ps" \
+    FM_FAKE_HERDR_STATE="$STATE" FM_FAKE_HERDR_LOG="$LOG" FM_FAKE_HERDR_SOCKET="$TMP_ROOT/herdr.sock" \
+    FM_HERDR_PS_BIN="$TMP_ROOT/fakebin/ps" \
     FM_BACKEND_HERDR_IDLE_SHELL_PROOF_POLLS=1 \
     bash -c '. "$0/bin/fm-backend.sh"; "$@"' "$ROOT" "$@"
 }
@@ -186,6 +192,28 @@ run_backend fm_backend_prepare_relaunch_path herdr fmtest:w1:p1 "$TARGET" \
 [ ! -e "$BUFFERED_MARKER" ] || fail "path restoration executed preexisting buffered shell input"
 [ "$(jq -r '.cwd' "$STATE")" = "$TARGET" ] || fail "path restoration lost the recorded path after clearing buffered input"
 pass "Herdr relaunch recovery: preexisting shell input is cancelled before path restoration"
+
+write_state "$OLD" shell true
+FM_FAKE_HERDR_CLEAR_DELAY=0.2 run_backend fm_backend_prepare_relaunch_path herdr fmtest:w1:p1 "$TARGET" &
+first_pid=$!
+first_started=0
+for _ in {1..100}; do
+  if grep -q $'\x1fpane\x1fsend-keys\x1f.*\x1fctrl+c' "$LOG"; then
+    first_started=1
+    break
+  fi
+  sleep 0.01
+done
+[ "$first_started" -eq 1 ] || fail "the first concurrent path preparation did not reach its mutation boundary"
+FM_FAKE_HERDR_CLEAR_DELAY=0.2 run_backend fm_backend_prepare_relaunch_path herdr fmtest:w1:p1 "$TARGET" &
+second_pid=$!
+wait "$first_pid" || fail "the first concurrent path preparation failed"
+wait "$second_pid" || fail "the second concurrent path preparation failed"
+mutation_order=$(awk -F '\x1f' '$2 == "pane" && $3 == "send-text" {print "send-text"; next} $2 == "pane" && $3 == "send-keys" {print $3 ":" $5}' "$LOG")
+expected_order=$'send-keys:ctrl+c\nsend-text\nsend-keys:enter\nsend-keys:ctrl+c'
+[ "$mutation_order" = "$expected_order" ] \
+  || fail "concurrent path preparations interleaved their pane mutations: $mutation_order"
+pass "Herdr relaunch recovery: concurrent preparation is serialized at the pane mutation boundary"
 
 write_state "$OLD" shell true
 jq '.fail_after_send_once=true' "$STATE" > "$STATE.tmp" && mv "$STATE.tmp" "$STATE"

--- a/tests/fm-herdr-relaunch-recovery.test.sh
+++ b/tests/fm-herdr-relaunch-recovery.test.sh
@@ -133,14 +133,12 @@ case "${1:-} ${2:-}" in
       fi
       [ "$(jq -r '.candidate_run_fail // false' "$state")" != true ] || exit 1
       cwd=$(jq -r '.candidate_cwd' "$state")
-      delay=$(jq -r '.candidate_run_ambiguous_delay // 0' "$state")
-      if [ "$delay" != 0 ]; then
-        (
-          sleep "$delay"
-          (cd "$cwd" && bash -c "$text") || exit 1
-          jq '.candidate_pending="" | .candidate_process="live" | .candidate_registered=true' \
-            "$state" > "$state.delayed.$$" && mv "$state.delayed.$$" "$state"
-        ) >/dev/null 2>&1 &
+      if [ "$(jq -r '.candidate_run_ambiguous_after_pane_get // false' "$state")" = true ]; then
+        (cd "$cwd" && bash -c "$text") || exit 1
+        jq '
+          .candidate_pending=""
+          | .candidate_take_over_after_pane_get=((.candidate_pane_gets // 0) + 2)
+        ' "$state" | save_state
         exit 1
       fi
       (cd "$cwd" && bash -c "$text") || exit 1
@@ -358,7 +356,7 @@ chmod +x "$TMP_ROOT/fakebin/git"
 
 write_state() {
   jq -n --arg cwd "$1" --arg process "$2" --argjson registered "$3" \
-    '{cwd:$cwd,process:$process,registered:$registered,recorded_exists:true,pending:"",fail_after_send_once:false,process_info_failures:0,process_after_send:"",pane_gets:0,take_over_after_pane_get:-1,frozen:false,take_over_on_stop:false,candidate_exists:false,candidate_cwd:"",candidate_pending:"",candidate_process:"shell",candidate_registered:false,candidate_take_over_on_stop:false,candidate_takeover_before_run:false,candidate_create_ambiguous_once:false,candidate_run_fail:false,candidate_run_ambiguous:false,candidate_run_ambiguous_delay:0,candidate_run_unregistered:false,candidate_pane_gets:0,candidate_take_over_after_pane_get:-1,unmanaged_workspace:"w9",unmanaged_pane:"w9:p9",unmanaged_fingerprint:"unchanged"}' > "$STATE"
+    '{cwd:$cwd,process:$process,registered:$registered,recorded_exists:true,pending:"",fail_after_send_once:false,process_info_failures:0,process_after_send:"",pane_gets:0,take_over_after_pane_get:-1,frozen:false,take_over_on_stop:false,candidate_exists:false,candidate_cwd:"",candidate_pending:"",candidate_process:"shell",candidate_registered:false,candidate_take_over_on_stop:false,candidate_takeover_before_run:false,candidate_create_ambiguous_once:false,candidate_run_fail:false,candidate_run_ambiguous:false,candidate_run_ambiguous_after_pane_get:false,candidate_run_unregistered:false,candidate_pane_gets:0,candidate_take_over_after_pane_get:-1,unmanaged_workspace:"w9",unmanaged_pane:"w9:p9",unmanaged_fingerprint:"unchanged"}' > "$STATE"
   : > "$LOG"
 }
 
@@ -823,7 +821,7 @@ pass "fm-spawn relaunch: receipt failure prevents an unadoptable agent launch"
 
 reset_direct_meta
 write_state "$DIRECT_WT" shell true
-jq '.candidate_run_ambiguous_delay=0.2' "$STATE" > "$STATE.tmp" && mv "$STATE.tmp" "$STATE"
+jq '.candidate_run_ambiguous_after_pane_get=true' "$STATE" > "$STATE.tmp" && mv "$STATE.tmp" "$STATE"
 if DIRECT_OUT=$(PATH="$TMP_ROOT/fakebin:$PATH" FM_HOME="$DIRECT_HOME" FM_FAKE_HERDR_STATE="$STATE" \
     FM_FAKE_HERDR_LOG="$LOG" FM_HERDR_PS_BIN="$TMP_ROOT/fakebin/ps" FM_HERDR_KILL_BIN="$TMP_ROOT/fakebin/kill" \
     FM_BACKEND_HERDR_IDLE_SHELL_PROOF_POLLS=1 FM_HERDR_RELAUNCH_ABORT_POLLS=10 \

--- a/tests/fm-herdr-relaunch-recovery.test.sh
+++ b/tests/fm-herdr-relaunch-recovery.test.sh
@@ -134,6 +134,10 @@ case "${1:-} ${2:-}" in
         jq '.candidate_process="live" | .candidate_registered=true' "$state" | save_state
         exit 1
       fi
+      if [ "$text" = 'kill -KILL "$$"' ]; then
+        jq '.candidate_exists=false | .candidate_registered=false | .candidate_process="dead"' "$state" | save_state
+        exit 0
+      fi
       [ "$(jq -r '.candidate_run_fail // false' "$state")" != true ] || exit 1
       cwd=$(jq -r '.candidate_cwd' "$state")
       if [ "$(jq -r '.candidate_run_ambiguous_after_pane_get // false' "$state")" = true ]; then
@@ -152,6 +156,10 @@ case "${1:-} ${2:-}" in
       ' "$state" | save_state
       [ "$(jq -r '.candidate_run_ambiguous // false' "$state")" != true ] || exit 1
     else
+      if [ "$text" = 'kill -KILL "$$"' ]; then
+        jq '.recorded_exists=false | .registered=false | .process="dead"' "$state" | save_state
+        exit 0
+      fi
       pending=$(jq -r '.pending // empty' "$state")
       cwd=$(jq -r '.cwd' "$state")
       new_cwd=$(cd "$cwd" && bash -c "$pending$text; pwd -P") || exit 1
@@ -977,6 +985,23 @@ pass "fm-spawn relaunch: a missing pre-wiring candidate rolls back cleanly"
 
 reset_direct_meta
 write_state "$DIRECT_WT" shell true
+jq '.candidate_exists=true | .candidate_cwd=$cwd | .candidate_process="shell" | .candidate_registered=true | .candidate_takeover_before_run=true' \
+  --arg cwd "$DIRECT_WT" "$STATE" > "$STATE.tmp" && mv "$STATE.tmp" "$STATE"
+write_direct_candidate_record created
+if DIRECT_OUT=$(PATH="$TMP_ROOT/fakebin:$PATH" FM_HOME="$DIRECT_HOME" FM_FAKE_HERDR_STATE="$STATE" \
+    FM_FAKE_HERDR_LOG="$LOG" FM_HERDR_PS_BIN="$TMP_ROOT/fakebin/ps" FM_HERDR_KILL_BIN="$TMP_ROOT/fakebin/kill" \
+    FM_BACKEND_HERDR_IDLE_SHELL_PROOF_POLLS=1 FM_SPAWN_NO_GUARD=1 \
+    "$ROOT/bin/fm-spawn.sh" direct --relaunch 2>&1); then
+  fail "retry reported success after another client won the candidate close boundary: $DIRECT_OUT"
+fi
+[ "$(jq -r '.candidate_exists and .candidate_registered and (.candidate_process == "live")' "$STATE")" = true ] \
+  || fail "candidate cleanup removed the new foreground owner"
+! grep -Fq $'\x1fpane\x1fclose\x1fw1:p2' "$LOG" \
+  || fail "candidate cleanup used an unconditional pane close after sampling the idle shell"
+pass "fm-spawn relaunch: shell-aware cleanup preserves a close-boundary takeover"
+
+reset_direct_meta
+write_state "$DIRECT_WT" shell true
 jq '.candidate_exists=true | .candidate_cwd=$cwd | .candidate_process="shell" | .candidate_registered=true' \
   --arg cwd "$DIRECT_WT" "$STATE" > "$STATE.tmp" && mv "$STATE.tmp" "$STATE"
 write_direct_candidate_record created
@@ -985,9 +1010,9 @@ DIRECT_OUT=$(PATH="$TMP_ROOT/fakebin:$PATH" FM_HOME="$DIRECT_HOME" FM_FAKE_HERDR
   FM_BACKEND_HERDR_IDLE_SHELL_PROOF_POLLS=1 FM_SPAWN_NO_GUARD=1 \
   "$ROOT/bin/fm-spawn.sh" direct --relaunch 2>&1) \
   || fail "retry should reconcile an exact stale registered candidate before relaunch: $DIRECT_OUT"
-close_line=$(grep -n $'\x1fpane\x1fclose\x1fw1:p2' "$LOG" | head -1 | cut -d: -f1)
+retire_line=$(grep -n $'\x1fpane\x1frun\x1fw1:p2\x1fkill -KILL "$$"' "$LOG" | head -1 | cut -d: -f1)
 create_line=$(grep -n $'\x1ftab\x1fcreate\x1f' "$LOG" | head -1 | cut -d: -f1)
-[ -n "$close_line" ] && [ -n "$create_line" ] && [ "$close_line" -lt "$create_line" ] \
+[ -n "$retire_line" ] && [ -n "$create_line" ] && [ "$retire_line" -lt "$create_line" ] \
   || fail "retry did not retire the stale exact candidate before creating its replacement: $(cat "$LOG")"
 pass "fm-spawn relaunch: retry idempotently reconciles a stale exact candidate"
 
@@ -1063,7 +1088,7 @@ if wait "$competitor_pid"; then
   fail "the competing path preparation mutated the original endpoint after publication"
 fi
 clear_count=$(grep -c $'\x1fpane\x1fsend-keys\x1f.*\x1fctrl+c' "$LOG" || true)
-[ "$clear_count" -eq 1 ] || fail "the competing pane mutation reached the retired original endpoint"
+[ "$clear_count" -eq 2 ] || fail "the competing pane mutation reached the retired original endpoint"
 pass "fm-spawn relaunch: session locking prevents mutation of the retired original endpoint"
 
 [ "$(jq -r '.unmanaged_fingerprint' "$STATE")" = unchanged ] \

--- a/tests/fm-herdr-relaunch-recovery.test.sh
+++ b/tests/fm-herdr-relaunch-recovery.test.sh
@@ -43,6 +43,10 @@ case "${1:-} ${2:-}" in
   "pane get")
     pane=${3:-}
     jq --arg pane "$pane" '{id:"cli:pane:get",result:{type:"pane_info",pane:{pane_id:$pane,foreground_cwd:.cwd}}}' "$state"
+    jq '
+      .pane_gets=((.pane_gets // 0) + 1)
+      | if .pane_gets == (.take_over_after_pane_get // -1) then .process="live" else . end
+    ' "$state" | save_state
     ;;
   "agent get")
     pane=${3:-}
@@ -121,13 +125,16 @@ chmod +x "$TMP_ROOT/fakebin/ps"
 
 cat > "$TMP_ROOT/fakebin/claude" <<'SH'
 #!/usr/bin/env bash
+if [ -n "${FM_FAKE_CLAUDE_ENV_LOG:-}" ]; then
+  printf 'GOTMPDIR=%s\n' "${GOTMPDIR:-}" > "$FM_FAKE_CLAUDE_ENV_LOG"
+fi
 exit 0
 SH
 chmod +x "$TMP_ROOT/fakebin/claude"
 
 write_state() {
   jq -n --arg cwd "$1" --arg process "$2" --argjson registered "$3" \
-    '{cwd:$cwd,process:$process,registered:$registered,pending:"",fail_after_send_once:false,process_info_failures:0,process_after_send:""}' > "$STATE"
+    '{cwd:$cwd,process:$process,registered:$registered,pending:"",fail_after_send_once:false,process_info_failures:0,process_after_send:"",pane_gets:0,take_over_after_pane_get:-1}' > "$STATE"
   : > "$LOG"
 }
 
@@ -239,6 +246,7 @@ DIRECT_HOME="$TMP_ROOT/direct-home"
 DIRECT_PROJECT="$TMP_ROOT/direct-project"
 DIRECT_WT="$TMP_ROOT/direct-worktree"
 DIRECT_MARKER="$TMP_ROOT/direct-marker"
+DIRECT_ENV_LOG="$TMP_ROOT/direct-env.log"
 fm_git_worktree "$DIRECT_PROJECT" "$DIRECT_WT" direct-relaunch
 mkdir -p "$DIRECT_HOME/state" "$DIRECT_HOME/data/direct"
 cat > "$DIRECT_HOME/data/direct/brief.md" <<'EOF'
@@ -268,11 +276,26 @@ write_state "$DIRECT_WT" shell true
 jq --arg pending "touch '$DIRECT_MARKER'; " '.pending=$pending' "$STATE" > "$STATE.tmp" && mv "$STATE.tmp" "$STATE"
 DIRECT_OUT=$(PATH="$TMP_ROOT/fakebin:$PATH" FM_HOME="$DIRECT_HOME" FM_FAKE_HERDR_STATE="$STATE" \
   FM_FAKE_HERDR_LOG="$LOG" FM_HERDR_PS_BIN="$TMP_ROOT/fakebin/ps" FM_BACKEND_HERDR_IDLE_SHELL_PROOF_POLLS=1 \
+  FM_FAKE_CLAUDE_ENV_LOG="$DIRECT_ENV_LOG" \
   FM_SPAWN_NO_GUARD=1 "$ROOT/bin/fm-spawn.sh" direct --relaunch --harness claude 2>&1) \
   || fail "direct Herdr relaunch should prepare its endpoint before launch: $DIRECT_OUT"
 [ ! -e "$DIRECT_MARKER" ] || fail "direct Herdr relaunch executed buffered shell input before launch"
+[ "$(cat "$DIRECT_ENV_LOG" 2>/dev/null)" = "GOTMPDIR=/tmp/fm-direct/gotmp" ] \
+  || fail "direct Herdr relaunch did not deliver its environment with the atomic launch command"
 case "$DIRECT_OUT" in *"spawned direct "*) : ;; *) fail "direct Herdr relaunch did not complete: $DIRECT_OUT" ;; esac
 pass "fm-spawn relaunch: direct Herdr entry prepares buffered shell input"
+
+write_state "$DIRECT_WT" shell true
+jq '.take_over_after_pane_get=6' "$STATE" > "$STATE.tmp" && mv "$STATE.tmp" "$STATE"
+if DIRECT_OUT=$(PATH="$TMP_ROOT/fakebin:$PATH" FM_HOME="$DIRECT_HOME" FM_FAKE_HERDR_STATE="$STATE" \
+    FM_FAKE_HERDR_LOG="$LOG" FM_HERDR_PS_BIN="$TMP_ROOT/fakebin/ps" FM_BACKEND_HERDR_IDLE_SHELL_PROOF_POLLS=1 \
+    FM_SPAWN_NO_GUARD=1 "$ROOT/bin/fm-spawn.sh" direct --relaunch --harness claude 2>&1); then
+  fail "direct Herdr relaunch should refuse after foreground ownership changes: $DIRECT_OUT"
+fi
+run_count=$(grep -c $'\x1fpane\x1frun\x1f' "$LOG" || true)
+[ "$run_count" -eq 0 ] || fail "owner-change refusal sent input after foreground ownership changed"
+case "$DIRECT_OUT" in *"shell owner changed before launch delivery"*) : ;; *) fail "owner-change refusal was not explicit: $DIRECT_OUT" ;; esac
+pass "fm-spawn relaunch: foreground-owner change before launch delivery fails closed"
 
 write_state "$DIRECT_WT" shell true
 DIRECT_CONCURRENT_OUT="$TMP_ROOT/direct-concurrent.out"

--- a/tests/fm-herdr-relaunch-recovery.test.sh
+++ b/tests/fm-herdr-relaunch-recovery.test.sh
@@ -192,6 +192,11 @@ case "${1:-} ${2:-}" in
       esac
     done
     [ "$workspace" = w1 ] || exit 1
+    if [ -n "${FM_FAKE_EXPECT_WIRING_PATH:-}" ] \
+       && [ "$(cat "$FM_FAKE_EXPECT_WIRING_PATH" 2>/dev/null)" != "${FM_FAKE_EXPECT_WIRING_VALUE:-}" ]; then
+      : > "${FM_FAKE_EXPECT_WIRING_FAILURE:?}"
+      exit 1
+    fi
     jq --arg cwd "$cwd" --arg label "$label" '
       .candidate_exists=true
       | .candidate_cwd=$cwd
@@ -285,6 +290,31 @@ fi
 exec "$real_mv" "$@"
 SH
 chmod +x "$TMP_ROOT/fakebin/mv"
+
+cat > "$TMP_ROOT/fakebin/date" <<'SH'
+#!/usr/bin/env bash
+set -u
+real_date=${FM_FAKE_REAL_DATE:-$(PATH=/usr/bin:/bin command -v date)}
+if [ "${1:-}" = +%s ] && [ -n "${FM_FAKE_DATE_MARKER:-}" ]; then
+  : > "$FM_FAKE_DATE_MARKER"
+  while [ ! -e "${FM_FAKE_DATE_RELEASE:?}" ]; do sleep 0.01; done
+fi
+exec "$real_date" "$@"
+SH
+chmod +x "$TMP_ROOT/fakebin/date"
+
+cat > "$TMP_ROOT/fakebin/git" <<'SH'
+#!/usr/bin/env bash
+set -u
+real_git=${FM_FAKE_REAL_GIT:-$(PATH=/usr/bin:/bin command -v git)}
+if [ "$*" = "-C ${FM_FAKE_GIT_WORKTREE:-none} rev-parse --git-path info/exclude" ] \
+   && [ -n "${FM_FAKE_GIT_MARKER:-}" ]; then
+  : > "$FM_FAKE_GIT_MARKER"
+  while [ ! -e "${FM_FAKE_GIT_RELEASE:?}" ]; do sleep 0.01; done
+fi
+exec "$real_git" "$@"
+SH
+chmod +x "$TMP_ROOT/fakebin/git"
 
 write_state() {
   jq -n --arg cwd "$1" --arg process "$2" --argjson registered "$3" \
@@ -657,6 +687,44 @@ grep -q '^phase=rolled-back$' "$DIRECT_HOME/state/direct.control-relaunch-candid
 grep -q 'gen=prior-busy-gen seq=7 state=idle' "$DIRECT_HOME/state/direct.busy-state" \
   || fail "failed candidate launch did not restore prior busy state"
 pass "fm-spawn relaunch: failed candidate launch rolls back endpoint, binding, and supervision wiring"
+
+reset_direct_meta
+mkdir -p "$DIRECT_WT/.claude"
+printf '%s\n' prior-hard-crash-wiring > "$DIRECT_WT/.claude/settings.local.json"
+printf '%s\n' prior-hard-crash-gen > "$DIRECT_HOME/state/direct.busy-gen"
+printf '%s\n' 'v1 gen=prior-hard-crash-gen seq=4 state=idle source=test event=prior ts=1' > "$DIRECT_HOME/state/direct.busy-state"
+write_state "$DIRECT_WT" shell true
+WIRING_MARKER="$TMP_ROOT/wiring-window.marker"
+WIRING_RELEASE="$TMP_ROOT/wiring-window.release"
+WIRING_OUT="$TMP_ROOT/wiring-window.out"
+PATH="$TMP_ROOT/fakebin:$PATH" FM_HOME="$DIRECT_HOME" FM_FAKE_HERDR_STATE="$STATE" \
+  FM_FAKE_HERDR_LOG="$LOG" FM_HERDR_PS_BIN="$TMP_ROOT/fakebin/ps" FM_HERDR_KILL_BIN="$TMP_ROOT/fakebin/kill" \
+  FM_BACKEND_HERDR_IDLE_SHELL_PROOF_POLLS=1 FM_SPAWN_NO_GUARD=1 \
+  FM_FAKE_GIT_WORKTREE="$DIRECT_WT" FM_FAKE_GIT_MARKER="$WIRING_MARKER" FM_FAKE_GIT_RELEASE="$WIRING_RELEASE" \
+  "$ROOT/bin/fm-spawn.sh" direct --relaunch > "$WIRING_OUT" 2>&1 &
+wiring_pid=$!
+for _ in {1..500}; do [ ! -e "$WIRING_MARKER" ] || break; sleep 0.01; done
+[ -e "$WIRING_MARKER" ] || fail "wiring crash simulation never reached the first replacement mutation"
+kill -KILL "$wiring_pid" 2>/dev/null || fail "could not stop relaunch after replacement wiring mutation"
+touch "$WIRING_RELEASE"
+wait "$wiring_pid" 2>/dev/null || true
+[ "$(cat "$DIRECT_WT/.claude/settings.local.json")" != prior-hard-crash-wiring ] \
+  || fail "wiring crash simulation did not mutate replacement wiring"
+WIRING_FAILURE="$TMP_ROOT/wiring-restore.failure"
+DIRECT_OUT=$(PATH="$TMP_ROOT/fakebin:$PATH" FM_HOME="$DIRECT_HOME" FM_FAKE_HERDR_STATE="$STATE" \
+  FM_FAKE_HERDR_LOG="$LOG" FM_HERDR_PS_BIN="$TMP_ROOT/fakebin/ps" FM_HERDR_KILL_BIN="$TMP_ROOT/fakebin/kill" \
+  FM_BACKEND_HERDR_IDLE_SHELL_PROOF_POLLS=1 FM_SPAWN_NO_GUARD=1 \
+  FM_FAKE_EXPECT_WIRING_PATH="$DIRECT_WT/.claude/settings.local.json" \
+  FM_FAKE_EXPECT_WIRING_VALUE=prior-hard-crash-wiring FM_FAKE_EXPECT_WIRING_FAILURE="$WIRING_FAILURE" \
+  "$ROOT/bin/fm-spawn.sh" direct --relaunch 2>&1) \
+  || fail "retry could not proceed after hard-crash rollback: $DIRECT_OUT"
+[ ! -e "$WIRING_FAILURE" ] \
+  || fail "retry created a replacement before restoring prior harness wiring"
+[ "$(cat "$DIRECT_WT/.claude/settings.local.json")" != prior-hard-crash-wiring ] \
+  || fail "successful retry did not install its own replacement wiring"
+grep -q '^phase=published$' "$DIRECT_HOME/state/direct.control-relaunch-candidate" \
+  || fail "hard-crash rollback did not complete before retry publication"
+pass "fm-spawn relaunch: hard-crash rollback restores deterministic prior wiring"
 
 reset_direct_meta
 write_state "$DIRECT_WT" shell true

--- a/tests/fm-herdr-relaunch-recovery.test.sh
+++ b/tests/fm-herdr-relaunch-recovery.test.sh
@@ -46,6 +46,13 @@ case "${1:-} ${2:-}" in
       if [ "$(jq -r '.candidate_exists // false' "$state")" != true ]; then
         printf '{"id":"cli:pane:get","error":{"code":"pane_not_found"}}\n'
       else
+        if [ "$(jq -r '.candidate_registered // false' "$state")" = true ] \
+           && [ -n "${FM_FAKE_HERDR_POST_LIVE_MARKER:-}" ] \
+           && [ ! -e "$FM_FAKE_HERDR_POST_LIVE_MARKER.done" ]; then
+          : > "$FM_FAKE_HERDR_POST_LIVE_MARKER"
+          while [ ! -e "${FM_FAKE_HERDR_POST_LIVE_RELEASE:?}" ]; do sleep 0.01; done
+          : > "$FM_FAKE_HERDR_POST_LIVE_MARKER.done"
+        fi
         jq --arg pane "$pane" '{id:"cli:pane:get",result:{type:"pane_info",pane:{pane_id:$pane,tab_id:"w1:t2",workspace_id:"w1",foreground_cwd:.candidate_cwd}}}' "$state"
         jq '
           .candidate_pane_gets=((.candidate_pane_gets // 0) + 1)
@@ -154,6 +161,20 @@ case "${1:-} ${2:-}" in
       fi
     fi
     ;;
+  "tab list")
+    if [ "$(jq -r '.candidate_exists // false' "$state")" = true ]; then
+      jq '{id:"cli:tab:list",result:{type:"tab_list",tabs:[{tab_id:"w1:t1",label:"fm-direct"},{tab_id:"w1:t2",label:.candidate_label}]}}' "$state"
+    else
+      printf '{"id":"cli:tab:list","result":{"type":"tab_list","tabs":[{"tab_id":"w1:t1","label":"fm-direct"}]}}\n'
+    fi
+    ;;
+  "pane list")
+    if [ "$(jq -r '.candidate_exists // false' "$state")" = true ]; then
+      printf '{"id":"cli:pane:list","result":{"type":"pane_list","panes":[{"pane_id":"w1:p1","tab_id":"w1:t1"},{"pane_id":"w1:p2","tab_id":"w1:t2"}]}}\n'
+    else
+      printf '{"id":"cli:pane:list","result":{"type":"pane_list","panes":[{"pane_id":"w1:p1","tab_id":"w1:t1"}]}}\n'
+    fi
+    ;;
   "tab create")
     workspace=
     cwd=
@@ -175,6 +196,10 @@ case "${1:-} ${2:-}" in
       | .candidate_process="shell"
       | .candidate_registered=false
     ' "$state" | save_state
+    if [ -n "${FM_FAKE_HERDR_CREATE_MARKER:-}" ]; then
+      : > "$FM_FAKE_HERDR_CREATE_MARKER"
+      while [ ! -e "${FM_FAKE_HERDR_CREATE_RELEASE:?}" ]; do sleep 0.01; done
+    fi
     jq -n --arg cwd "$cwd" --arg label "$label" '{id:"cli:tab:create",result:{type:"tab_created",tab:{tab_id:"w1:t2",workspace_id:"w1",label:$label},root_pane:{pane_id:"w1:p2",tab_id:"w1:t2",workspace_id:"w1",foreground_cwd:$cwd}}}'
     ;;
   "pane close")
@@ -258,6 +283,11 @@ write_state "$OLD" live true
 recovery=$(run_backend fm_backend_recovery_agent_state herdr fmtest:w1:p1)
 [ "$recovery" = alive ] || fail "a registered agent with a distinct foreground process group must remain alive, got '$recovery'"
 pass "Herdr relaunch recovery: a real foreground agent remains alive and cannot be replaced"
+
+write_state "$OLD" live false
+recovery=$(run_backend fm_backend_recovery_agent_state herdr fmtest:w1:p1)
+[ "$recovery" = alive ] || fail "an unregistered pane with a distinct foreground process group must remain alive, got '$recovery'"
+pass "Herdr relaunch recovery: an unregistered live process cannot be replaced"
 
 write_state "$OLD" ambiguous true
 recovery=$(run_backend fm_backend_recovery_agent_state herdr fmtest:w1:p1)
@@ -420,6 +450,61 @@ pass "fm-spawn relaunch: fresh endpoint becomes authoritative only after launch 
 
 reset_direct_meta
 write_state "$DIRECT_WT" shell true
+CREATE_MARKER="$TMP_ROOT/create-window.marker"
+CREATE_RELEASE="$TMP_ROOT/create-window.release"
+CREATE_OUT="$TMP_ROOT/create-window.out"
+PATH="$TMP_ROOT/fakebin:$PATH" FM_HOME="$DIRECT_HOME" FM_FAKE_HERDR_STATE="$STATE" \
+  FM_FAKE_HERDR_LOG="$LOG" FM_HERDR_PS_BIN="$TMP_ROOT/fakebin/ps" FM_HERDR_KILL_BIN="$TMP_ROOT/fakebin/kill" \
+  FM_BACKEND_HERDR_IDLE_SHELL_PROOF_POLLS=1 FM_SPAWN_NO_GUARD=1 \
+  FM_FAKE_HERDR_CREATE_MARKER="$CREATE_MARKER" FM_FAKE_HERDR_CREATE_RELEASE="$CREATE_RELEASE" \
+  "$ROOT/bin/fm-spawn.sh" direct --relaunch > "$CREATE_OUT" 2>&1 &
+create_pid=$!
+for _ in {1..500}; do [ ! -e "$CREATE_MARKER" ] || break; sleep 0.01; done
+[ -e "$CREATE_MARKER" ] || fail "pre-journal crash simulation never reached endpoint creation"
+kill -KILL "$create_pid" 2>/dev/null || fail "could not stop relaunch in the pre-journal window"
+touch "$CREATE_RELEASE"
+wait "$create_pid" 2>/dev/null || true
+[ "$(jq -r '.candidate_exists' "$STATE")" = true ] || fail "pre-journal crash simulation left no candidate to discover"
+DIRECT_OUT=$(PATH="$TMP_ROOT/fakebin:$PATH" FM_HOME="$DIRECT_HOME" FM_FAKE_HERDR_STATE="$STATE" \
+  FM_FAKE_HERDR_LOG="$LOG" FM_HERDR_PS_BIN="$TMP_ROOT/fakebin/ps" FM_HERDR_KILL_BIN="$TMP_ROOT/fakebin/kill" \
+  FM_BACKEND_HERDR_IDLE_SHELL_PROOF_POLLS=1 FM_SPAWN_NO_GUARD=1 \
+  "$ROOT/bin/fm-spawn.sh" direct --relaunch 2>&1) \
+  || fail "retry could not discover and retire the pre-journal candidate: $DIRECT_OUT"
+case "$DIRECT_OUT" in *"spawned direct "*) : ;; *) fail "pre-journal recovery did not complete relaunch: $DIRECT_OUT" ;; esac
+pass "fm-spawn relaunch: retry discovers the exact pre-journal candidate"
+
+reset_direct_meta
+write_state "$DIRECT_WT" shell true
+LIVE_MARKER="$TMP_ROOT/post-live-window.marker"
+LIVE_RELEASE="$TMP_ROOT/post-live-window.release"
+LIVE_OUT="$TMP_ROOT/post-live-window.out"
+PATH="$TMP_ROOT/fakebin:$PATH" FM_HOME="$DIRECT_HOME" FM_FAKE_HERDR_STATE="$STATE" \
+  FM_FAKE_HERDR_LOG="$LOG" FM_HERDR_PS_BIN="$TMP_ROOT/fakebin/ps" FM_HERDR_KILL_BIN="$TMP_ROOT/fakebin/kill" \
+  FM_BACKEND_HERDR_IDLE_SHELL_PROOF_POLLS=1 FM_SPAWN_NO_GUARD=1 \
+  FM_FAKE_HERDR_POST_LIVE_MARKER="$LIVE_MARKER" FM_FAKE_HERDR_POST_LIVE_RELEASE="$LIVE_RELEASE" \
+  "$ROOT/bin/fm-spawn.sh" direct --relaunch > "$LIVE_OUT" 2>&1 &
+live_pid=$!
+for _ in {1..500}; do [ ! -e "$LIVE_MARKER" ] || break; sleep 0.01; done
+[ -e "$LIVE_MARKER" ] || fail "post-live crash simulation never reached launch proof"
+kill -KILL "$live_pid" 2>/dev/null || fail "could not stop relaunch in the post-live window"
+touch "$LIVE_RELEASE"
+wait "$live_pid" 2>/dev/null || true
+[ "$(jq -r '.candidate_registered' "$STATE")" = true ] || fail "post-live crash simulation left no live candidate to adopt"
+DIRECT_OUT=$(PATH="$TMP_ROOT/fakebin:$PATH" FM_HOME="$DIRECT_HOME" FM_FAKE_HERDR_STATE="$STATE" \
+  FM_FAKE_HERDR_LOG="$LOG" FM_HERDR_PS_BIN="$TMP_ROOT/fakebin/ps" FM_HERDR_KILL_BIN="$TMP_ROOT/fakebin/kill" \
+  FM_BACKEND_HERDR_IDLE_SHELL_PROOF_POLLS=1 FM_SPAWN_NO_GUARD=1 \
+  "$ROOT/bin/fm-spawn.sh" direct --relaunch 2>&1) \
+  || fail "retry could not adopt the exact post-live candidate: $DIRECT_OUT"
+[ "$(awk -F= '$1 == "herdr_pane_id" { print $2 }' "$DIRECT_HOME/state/direct.meta")" = w1:p2 ] \
+  || fail "post-live adoption did not publish the discovered candidate"
+create_count=$(grep -c $'\x1ftab\x1fcreate\x1f' "$LOG" || true)
+[ "$create_count" -eq 1 ] || fail "post-live adoption created a duplicate replacement endpoint"
+grep -q '^candidate_state=adopted-alive$' "$DIRECT_HOME/state/direct.control-relaunch-candidate" \
+  || fail "post-live adoption did not persist its reconciliation"
+pass "fm-spawn relaunch: retry adopts the exact post-live candidate"
+
+reset_direct_meta
+write_state "$DIRECT_WT" shell true
 jq '.candidate_take_over_after_pane_get=1' "$STATE" > "$STATE.tmp" && mv "$STATE.tmp" "$STATE"
 if DIRECT_OUT=$(PATH="$TMP_ROOT/fakebin:$PATH" FM_HOME="$DIRECT_HOME" FM_FAKE_HERDR_STATE="$STATE" \
     FM_FAKE_HERDR_LOG="$LOG" FM_HERDR_PS_BIN="$TMP_ROOT/fakebin/ps" FM_HERDR_KILL_BIN="$TMP_ROOT/fakebin/kill" \
@@ -482,20 +567,18 @@ write_state "$DIRECT_WT" shell true
 jq '.candidate_exists=true | .candidate_cwd=$cwd | .candidate_process="live" | .candidate_registered=true' \
   --arg cwd "$DIRECT_WT" "$STATE" > "$STATE.tmp" && mv "$STATE.tmp" "$STATE"
 write_direct_candidate_record quarantined
-if DIRECT_OUT=$(PATH="$TMP_ROOT/fakebin:$PATH" FM_HOME="$DIRECT_HOME" FM_FAKE_HERDR_STATE="$STATE" \
-    FM_FAKE_HERDR_LOG="$LOG" FM_HERDR_PS_BIN="$TMP_ROOT/fakebin/ps" FM_HERDR_KILL_BIN="$TMP_ROOT/fakebin/kill" \
-    FM_BACKEND_HERDR_IDLE_SHELL_PROOF_POLLS=1 FM_SPAWN_NO_GUARD=1 \
-    "$ROOT/bin/fm-spawn.sh" direct --relaunch 2>&1); then
-  fail "retry should refuse a prior exact candidate with a real live agent: $DIRECT_OUT"
-fi
+DIRECT_OUT=$(PATH="$TMP_ROOT/fakebin:$PATH" FM_HOME="$DIRECT_HOME" FM_FAKE_HERDR_STATE="$STATE" \
+  FM_FAKE_HERDR_LOG="$LOG" FM_HERDR_PS_BIN="$TMP_ROOT/fakebin/ps" FM_HERDR_KILL_BIN="$TMP_ROOT/fakebin/kill" \
+  FM_BACKEND_HERDR_IDLE_SHELL_PROOF_POLLS=1 FM_SPAWN_NO_GUARD=1 \
+  "$ROOT/bin/fm-spawn.sh" direct --relaunch 2>&1) \
+  || fail "retry should adopt a proven exact live candidate: $DIRECT_OUT"
 ! grep -Fq $'\x1ftab\x1fcreate\x1f' "$LOG" \
-  || fail "retry created a duplicate endpoint beside a live quarantined candidate"
+  || fail "retry created a duplicate endpoint beside an adoptable live candidate"
 [ "$(jq -r '.candidate_exists' "$STATE")" = true ] \
-  || fail "retry removed a real live quarantined candidate"
-cmp -s "$DIRECT_HOME/state/direct.meta.original" "$DIRECT_HOME/state/direct.meta" \
-  || fail "live-candidate refusal changed the authoritative old binding"
-case "$DIRECT_OUT" in *"prior Herdr replacement candidate cannot be proved safe"*) : ;; *) fail "live-candidate refusal was not explicit: $DIRECT_OUT" ;; esac
-pass "fm-spawn relaunch: retry refuses a real-live candidate without duplication or cleanup"
+  || fail "retry removed the live candidate it adopted"
+[ "$(awk -F= '$1 == "herdr_pane_id" { print $2 }' "$DIRECT_HOME/state/direct.meta")" = w1:p2 ] \
+  || fail "live-candidate adoption did not advance the authoritative binding"
+pass "fm-spawn relaunch: retry adopts a proven live candidate without duplication"
 
 reset_direct_meta
 write_state "$DIRECT_WT" shell true

--- a/tests/fm-herdr-relaunch-recovery.test.sh
+++ b/tests/fm-herdr-relaunch-recovery.test.sh
@@ -135,6 +135,7 @@ case "${1:-} ${2:-}" in
         | .candidate_process="live"
         | .candidate_registered=((.candidate_run_unregistered // false) | not)
       ' "$state" | save_state
+      [ "$(jq -r '.candidate_run_ambiguous // false' "$state")" != true ] || exit 1
     else
       pending=$(jq -r '.pending // empty' "$state")
       cwd=$(jq -r '.cwd' "$state")
@@ -318,7 +319,7 @@ chmod +x "$TMP_ROOT/fakebin/git"
 
 write_state() {
   jq -n --arg cwd "$1" --arg process "$2" --argjson registered "$3" \
-    '{cwd:$cwd,process:$process,registered:$registered,pending:"",fail_after_send_once:false,process_info_failures:0,process_after_send:"",pane_gets:0,take_over_after_pane_get:-1,frozen:false,take_over_on_stop:false,candidate_exists:false,candidate_cwd:"",candidate_pending:"",candidate_process:"shell",candidate_registered:false,candidate_take_over_on_stop:false,candidate_takeover_before_run:false,candidate_run_fail:false,candidate_run_unregistered:false,candidate_pane_gets:0,candidate_take_over_after_pane_get:-1,unmanaged_workspace:"w9",unmanaged_pane:"w9:p9",unmanaged_fingerprint:"unchanged"}' > "$STATE"
+    '{cwd:$cwd,process:$process,registered:$registered,pending:"",fail_after_send_once:false,process_info_failures:0,process_after_send:"",pane_gets:0,take_over_after_pane_get:-1,frozen:false,take_over_on_stop:false,candidate_exists:false,candidate_cwd:"",candidate_pending:"",candidate_process:"shell",candidate_registered:false,candidate_take_over_on_stop:false,candidate_takeover_before_run:false,candidate_run_fail:false,candidate_run_ambiguous:false,candidate_run_unregistered:false,candidate_pane_gets:0,candidate_take_over_after_pane_get:-1,unmanaged_workspace:"w9",unmanaged_pane:"w9:p9",unmanaged_fingerprint:"unchanged"}' > "$STATE"
   : > "$LOG"
 }
 
@@ -521,6 +522,9 @@ DIRECT_OUT=$(PATH="$TMP_ROOT/fakebin:$PATH" FM_HOME="$DIRECT_HOME" FM_FAKE_HERDR
 case "$DIRECT_OUT" in *"spawned direct "*) : ;; *) fail "direct Herdr relaunch did not complete: $DIRECT_OUT" ;; esac
 [ "$(awk -F= '$1 == "herdr_pane_id" { print $2 }' "$DIRECT_HOME/state/direct.meta")" = w1:p2 ] \
   || fail "successful replacement did not publish the fresh pane binding"
+jq -e '.endpoints[] | select(.id == "direct") | .endpoint.target == "fmtest:w1:p2"' \
+  "$DIRECT_HOME/state/home-summary.json" >/dev/null \
+  || fail "successful replacement did not refresh its published home-summary endpoint"
 if ! grep -q '^model=test-model$' "$DIRECT_HOME/state/direct.meta" \
    || ! grep -q '^effort=high$' "$DIRECT_HOME/state/direct.meta" \
    || ! grep -q '^traceparent=00-11111111111111111111111111111111-2222222222222222-01$' "$DIRECT_HOME/state/direct.meta"; then
@@ -689,6 +693,31 @@ grep -q 'gen=prior-busy-gen seq=7 state=idle' "$DIRECT_HOME/state/direct.busy-st
 pass "fm-spawn relaunch: failed candidate launch rolls back endpoint, binding, and supervision wiring"
 
 reset_direct_meta
+write_state "$DIRECT_WT" shell true
+jq '.candidate_run_ambiguous=true' "$STATE" > "$STATE.tmp" && mv "$STATE.tmp" "$STATE"
+if DIRECT_OUT=$(PATH="$TMP_ROOT/fakebin:$PATH" FM_HOME="$DIRECT_HOME" FM_FAKE_HERDR_STATE="$STATE" \
+    FM_FAKE_HERDR_LOG="$LOG" FM_HERDR_PS_BIN="$TMP_ROOT/fakebin/ps" FM_HERDR_KILL_BIN="$TMP_ROOT/fakebin/kill" \
+    FM_BACKEND_HERDR_IDLE_SHELL_PROOF_POLLS=1 FM_SPAWN_NO_GUARD=1 \
+    "$ROOT/bin/fm-spawn.sh" direct --relaunch 2>&1); then
+  fail "ambiguous candidate submission should require retry adoption: $DIRECT_OUT"
+fi
+grep -q '^phase=launch-attempt$' "$DIRECT_HOME/state/direct.control-relaunch-candidate" \
+  || fail "ambiguous live submission lost its launch-attempt provenance"
+[ "$(jq -r '.candidate_exists and .candidate_registered and (.candidate_process == "live")' "$STATE")" = true ] \
+  || fail "ambiguous live submission did not preserve its exact replacement candidate"
+DIRECT_OUT=$(PATH="$TMP_ROOT/fakebin:$PATH" FM_HOME="$DIRECT_HOME" FM_FAKE_HERDR_STATE="$STATE" \
+  FM_FAKE_HERDR_LOG="$LOG" FM_HERDR_PS_BIN="$TMP_ROOT/fakebin/ps" FM_HERDR_KILL_BIN="$TMP_ROOT/fakebin/kill" \
+  FM_BACKEND_HERDR_IDLE_SHELL_PROOF_POLLS=1 FM_SPAWN_NO_GUARD=1 \
+  "$ROOT/bin/fm-spawn.sh" direct --relaunch 2>&1) \
+  || fail "retry could not adopt an ambiguously submitted live candidate: $DIRECT_OUT"
+[ "$(awk -F= '$1 == "herdr_pane_id" { print $2 }' "$DIRECT_HOME/state/direct.meta")" = w1:p2 ] \
+  || fail "ambiguous live candidate adoption did not publish its endpoint"
+jq -e '.endpoints[] | select(.id == "direct") | .endpoint.target == "fmtest:w1:p2"' \
+  "$DIRECT_HOME/state/home-summary.json" >/dev/null \
+  || fail "crash adoption did not refresh its published home-summary endpoint"
+pass "fm-spawn relaunch: ambiguous live submission remains adoptable"
+
+reset_direct_meta
 mkdir -p "$DIRECT_WT/.claude"
 printf '%s\n' prior-hard-crash-wiring > "$DIRECT_WT/.claude/settings.local.json"
 printf '%s\n' prior-hard-crash-gen > "$DIRECT_HOME/state/direct.busy-gen"
@@ -710,6 +739,19 @@ touch "$WIRING_RELEASE"
 wait "$wiring_pid" 2>/dev/null || true
 [ "$(cat "$DIRECT_WT/.claude/settings.local.json")" != prior-hard-crash-wiring ] \
   || fail "wiring crash simulation did not mutate replacement wiring"
+rm -f "$DIRECT_WT/.claude/settings.local.json"
+mkdir "$DIRECT_WT/.claude/settings.local.json"
+if DIRECT_OUT=$(PATH="$TMP_ROOT/fakebin:$PATH" FM_HOME="$DIRECT_HOME" FM_FAKE_HERDR_STATE="$STATE" \
+    FM_FAKE_HERDR_LOG="$LOG" FM_HERDR_PS_BIN="$TMP_ROOT/fakebin/ps" FM_HERDR_KILL_BIN="$TMP_ROOT/fakebin/kill" \
+    FM_BACKEND_HERDR_IDLE_SHELL_PROOF_POLLS=1 FM_SPAWN_NO_GUARD=1 \
+    "$ROOT/bin/fm-spawn.sh" direct --relaunch 2>&1); then
+  fail "retry should refuse when persisted prior wiring cannot be restored: $DIRECT_OUT"
+fi
+[ "$(jq -r '.candidate_exists' "$STATE")" = true ] \
+  || fail "failed wiring restoration retired the only candidate recovery evidence"
+! grep -q '^phase=rolled-back$' "$DIRECT_HOME/state/direct.control-relaunch-candidate" \
+  || fail "failed wiring restoration marked candidate rollback complete"
+rmdir "$DIRECT_WT/.claude/settings.local.json"
 WIRING_FAILURE="$TMP_ROOT/wiring-restore.failure"
 DIRECT_OUT=$(PATH="$TMP_ROOT/fakebin:$PATH" FM_HOME="$DIRECT_HOME" FM_FAKE_HERDR_STATE="$STATE" \
   FM_FAKE_HERDR_LOG="$LOG" FM_HERDR_PS_BIN="$TMP_ROOT/fakebin/ps" FM_HERDR_KILL_BIN="$TMP_ROOT/fakebin/kill" \

--- a/tests/fm-herdr-relaunch-recovery.test.sh
+++ b/tests/fm-herdr-relaunch-recovery.test.sh
@@ -504,6 +504,26 @@ grep -q '^candidate_state=adopted-alive$' "$DIRECT_HOME/state/direct.control-rel
 pass "fm-spawn relaunch: retry adopts the exact post-live candidate"
 
 reset_direct_meta
+awk '
+  /^window=/{print "window=fmtest:w1:p2"; next}
+  /^herdr_tab_id=/{print "herdr_tab_id=w1:t2"; next}
+  /^herdr_pane_id=/{print "herdr_pane_id=w1:p2"; next}
+  {print}
+' "$DIRECT_HOME/state/direct.meta" > "$DIRECT_HOME/state/direct.meta.tmp"
+mv "$DIRECT_HOME/state/direct.meta.tmp" "$DIRECT_HOME/state/direct.meta"
+write_state "$DIRECT_WT" shell true
+jq --arg cwd "$DIRECT_WT" '.candidate_exists=true | .candidate_cwd=$cwd | .candidate_process="shell" | .candidate_registered=false' \
+  "$STATE" > "$STATE.tmp" && mv "$STATE.tmp" "$STATE"
+write_direct_candidate_record launch-attempt
+DIRECT_OUT=$(PATH="$TMP_ROOT/fakebin:$PATH" FM_HOME="$DIRECT_HOME" FM_FAKE_HERDR_STATE="$STATE" \
+  FM_FAKE_HERDR_LOG="$LOG" FM_HERDR_PS_BIN="$TMP_ROOT/fakebin/ps" FM_HERDR_KILL_BIN="$TMP_ROOT/fakebin/kill" \
+  FM_BACKEND_HERDR_IDLE_SHELL_PROOF_POLLS=1 FM_SPAWN_NO_GUARD=1 \
+  "$ROOT/bin/fm-spawn.sh" direct --relaunch 2>&1) \
+  || fail "retry stranded a candidate already named by authoritative metadata: $DIRECT_OUT"
+case "$DIRECT_OUT" in *"spawned direct "*) : ;; *) fail "authoritative candidate reconciliation did not permit the next relaunch: $DIRECT_OUT" ;; esac
+pass "fm-spawn relaunch: authoritative candidate reconciles before prior-old comparison"
+
+reset_direct_meta
 write_state "$DIRECT_WT" shell true
 jq '.candidate_take_over_after_pane_get=1' "$STATE" > "$STATE.tmp" && mv "$STATE.tmp" "$STATE"
 if DIRECT_OUT=$(PATH="$TMP_ROOT/fakebin:$PATH" FM_HOME="$DIRECT_HOME" FM_FAKE_HERDR_STATE="$STATE" \
@@ -517,6 +537,17 @@ run_count=$(grep -c $'\x1fpane\x1frun\x1f' "$LOG" || true)
 cmp -s "$DIRECT_HOME/state/direct.meta.original" "$DIRECT_HOME/state/direct.meta" \
   || fail "pre-launch takeover changed the authoritative endpoint binding"
 case "$DIRECT_OUT" in *"acquired an agent before launch ownership was established"*) : ;; *) fail "owner-change refusal was not explicit: $DIRECT_OUT" ;; esac
+create_count=$(grep -c $'\x1ftab\x1fcreate\x1f' "$LOG" || true)
+if DIRECT_OUT=$(PATH="$TMP_ROOT/fakebin:$PATH" FM_HOME="$DIRECT_HOME" FM_FAKE_HERDR_STATE="$STATE" \
+    FM_FAKE_HERDR_LOG="$LOG" FM_HERDR_PS_BIN="$TMP_ROOT/fakebin/ps" FM_HERDR_KILL_BIN="$TMP_ROOT/fakebin/kill" \
+    FM_BACKEND_HERDR_IDLE_SHELL_PROOF_POLLS=1 FM_SPAWN_NO_GUARD=1 \
+    "$ROOT/bin/fm-spawn.sh" direct --relaunch 2>&1); then
+  fail "retry adopted the pre-launch takeover: $DIRECT_OUT"
+fi
+[ "$(grep -c $'\x1ftab\x1fcreate\x1f' "$LOG" || true)" -eq "$create_count" ] \
+  || fail "retry created a duplicate beside the pre-launch takeover"
+cmp -s "$DIRECT_HOME/state/direct.meta.original" "$DIRECT_HOME/state/direct.meta" \
+  || fail "retry published the pre-launch takeover"
 pass "fm-spawn relaunch: pre-launch takeover preserves the old binding"
 
 reset_direct_meta
@@ -567,18 +598,19 @@ write_state "$DIRECT_WT" shell true
 jq '.candidate_exists=true | .candidate_cwd=$cwd | .candidate_process="live" | .candidate_registered=true' \
   --arg cwd "$DIRECT_WT" "$STATE" > "$STATE.tmp" && mv "$STATE.tmp" "$STATE"
 write_direct_candidate_record quarantined
-DIRECT_OUT=$(PATH="$TMP_ROOT/fakebin:$PATH" FM_HOME="$DIRECT_HOME" FM_FAKE_HERDR_STATE="$STATE" \
-  FM_FAKE_HERDR_LOG="$LOG" FM_HERDR_PS_BIN="$TMP_ROOT/fakebin/ps" FM_HERDR_KILL_BIN="$TMP_ROOT/fakebin/kill" \
-  FM_BACKEND_HERDR_IDLE_SHELL_PROOF_POLLS=1 FM_SPAWN_NO_GUARD=1 \
-  "$ROOT/bin/fm-spawn.sh" direct --relaunch 2>&1) \
-  || fail "retry should adopt a proven exact live candidate: $DIRECT_OUT"
+if DIRECT_OUT=$(PATH="$TMP_ROOT/fakebin:$PATH" FM_HOME="$DIRECT_HOME" FM_FAKE_HERDR_STATE="$STATE" \
+    FM_FAKE_HERDR_LOG="$LOG" FM_HERDR_PS_BIN="$TMP_ROOT/fakebin/ps" FM_HERDR_KILL_BIN="$TMP_ROOT/fakebin/kill" \
+    FM_BACKEND_HERDR_IDLE_SHELL_PROOF_POLLS=1 FM_SPAWN_NO_GUARD=1 \
+    "$ROOT/bin/fm-spawn.sh" direct --relaunch 2>&1); then
+  fail "retry adopted a quarantined live candidate without launch provenance: $DIRECT_OUT"
+fi
 ! grep -Fq $'\x1ftab\x1fcreate\x1f' "$LOG" \
-  || fail "retry created a duplicate endpoint beside an adoptable live candidate"
+  || fail "retry created a duplicate endpoint beside a quarantined live candidate"
 [ "$(jq -r '.candidate_exists' "$STATE")" = true ] \
-  || fail "retry removed the live candidate it adopted"
-[ "$(awk -F= '$1 == "herdr_pane_id" { print $2 }' "$DIRECT_HOME/state/direct.meta")" = w1:p2 ] \
-  || fail "live-candidate adoption did not advance the authoritative binding"
-pass "fm-spawn relaunch: retry adopts a proven live candidate without duplication"
+  || fail "retry removed a quarantined live candidate"
+cmp -s "$DIRECT_HOME/state/direct.meta.original" "$DIRECT_HOME/state/direct.meta" \
+  || fail "quarantined live-candidate refusal changed the authoritative binding"
+pass "fm-spawn relaunch: retry refuses live candidates without launch provenance"
 
 reset_direct_meta
 write_state "$DIRECT_WT" shell true

--- a/tests/fm-herdr-relaunch-recovery.test.sh
+++ b/tests/fm-herdr-relaunch-recovery.test.sh
@@ -265,6 +265,27 @@ exit 0
 SH
 chmod +x "$TMP_ROOT/fakebin/pi"
 
+cat > "$TMP_ROOT/fakebin/mv" <<'SH'
+#!/usr/bin/env bash
+set -u
+real_mv=${FM_FAKE_REAL_MV:-$(PATH=/usr/bin:/bin command -v mv)}
+target=${!#}
+source_match=0
+for arg in "$@"; do
+  case "$arg" in *.meta.relaunch.*) source_match=1 ;; esac
+done
+if [ -n "${FM_FAKE_MV_PUBLISH_MARKER:-}" ] \
+   && [ "$target" = "${FM_FAKE_MV_PUBLISH_TARGET:-}" ] \
+   && [ "$source_match" = 1 ]; then
+  "$real_mv" "$@" || exit 1
+  : > "$FM_FAKE_MV_PUBLISH_MARKER"
+  while [ ! -e "${FM_FAKE_MV_PUBLISH_RELEASE:?}" ]; do sleep 0.01; done
+  exit 0
+fi
+exec "$real_mv" "$@"
+SH
+chmod +x "$TMP_ROOT/fakebin/mv"
+
 write_state() {
   jq -n --arg cwd "$1" --arg process "$2" --argjson registered "$3" \
     '{cwd:$cwd,process:$process,registered:$registered,pending:"",fail_after_send_once:false,process_info_failures:0,process_after_send:"",pane_gets:0,take_over_after_pane_get:-1,frozen:false,take_over_on_stop:false,candidate_exists:false,candidate_cwd:"",candidate_pending:"",candidate_process:"shell",candidate_registered:false,candidate_take_over_on_stop:false,candidate_takeover_before_run:false,candidate_run_fail:false,candidate_run_unregistered:false,candidate_pane_gets:0,candidate_take_over_after_pane_get:-1,unmanaged_workspace:"w9",unmanaged_pane:"w9:p9",unmanaged_fingerprint:"unchanged"}' > "$STATE"
@@ -536,6 +557,20 @@ wait "$switch_pid" 2>/dev/null || true
   || fail "crash simulation unexpectedly retired prior Claude wiring"
 [ -f "$DIRECT_HOME/state/direct.pi-ext.ts" ] \
   || fail "crash simulation did not leave replacement Pi wiring"
+rm -f "$DIRECT_WT/.claude/settings.local.json"
+mkdir "$DIRECT_WT/.claude/settings.local.json"
+if DIRECT_OUT=$(PATH="$TMP_ROOT/fakebin:$PATH" FM_HOME="$DIRECT_HOME" FM_FAKE_HERDR_STATE="$STATE" \
+    FM_FAKE_HERDR_LOG="$LOG" FM_HERDR_PS_BIN="$TMP_ROOT/fakebin/ps" FM_HERDR_KILL_BIN="$TMP_ROOT/fakebin/kill" \
+    FM_BACKEND_HERDR_IDLE_SHELL_PROOF_POLLS=1 FM_SPAWN_NO_GUARD=1 \
+    "$ROOT/bin/fm-spawn.sh" direct --relaunch --harness pi 2>&1); then
+  fail "crash adoption reported success while prior wiring could not be retired: $DIRECT_OUT"
+fi
+cmp -s "$DIRECT_HOME/state/direct.meta.original" "$DIRECT_HOME/state/direct.meta" \
+  || fail "failed prior-wiring retirement published the replacement binding"
+[ -f "$DIRECT_HOME/state/direct.pi-ext.ts" ] \
+  || fail "failed prior-wiring retirement removed replacement wiring"
+rmdir "$DIRECT_WT/.claude/settings.local.json"
+printf '%s\n' prior-claude-wiring > "$DIRECT_WT/.claude/settings.local.json"
 DIRECT_OUT=$(PATH="$TMP_ROOT/fakebin:$PATH" FM_HOME="$DIRECT_HOME" FM_FAKE_HERDR_STATE="$STATE" \
   FM_FAKE_HERDR_LOG="$LOG" FM_HERDR_PS_BIN="$TMP_ROOT/fakebin/ps" FM_HERDR_KILL_BIN="$TMP_ROOT/fakebin/kill" \
   FM_BACKEND_HERDR_IDLE_SHELL_PROOF_POLLS=1 FM_SPAWN_NO_GUARD=1 \
@@ -746,6 +781,36 @@ pass "fm-spawn relaunch: Herdr session mutation lock spans candidate creation th
 ! grep -Eq 'w9(:p9)?' "$LOG" \
   || fail "replacement transaction addressed an unrelated unmanaged identity"
 pass "fm-spawn relaunch: replacement stays exact-record scoped and ignores unmanaged workspaces"
+
+reset_direct_meta
+write_state "$DIRECT_WT" shell true
+PUBLISH_MARKER="$TMP_ROOT/publish-window.marker"
+PUBLISH_RELEASE="$TMP_ROOT/publish-window.release"
+PUBLISH_OUT="$TMP_ROOT/publish-window.out"
+PATH="$TMP_ROOT/fakebin:$PATH" FM_HOME="$DIRECT_HOME" FM_FAKE_HERDR_STATE="$STATE" \
+  FM_FAKE_HERDR_LOG="$LOG" FM_HERDR_PS_BIN="$TMP_ROOT/fakebin/ps" FM_HERDR_KILL_BIN="$TMP_ROOT/fakebin/kill" \
+  FM_BACKEND_HERDR_IDLE_SHELL_PROOF_POLLS=1 FM_SPAWN_NO_GUARD=1 \
+  FM_FAKE_MV_PUBLISH_MARKER="$PUBLISH_MARKER" FM_FAKE_MV_PUBLISH_RELEASE="$PUBLISH_RELEASE" \
+  FM_FAKE_MV_PUBLISH_TARGET="$DIRECT_HOME/state/direct.meta" \
+  "$ROOT/bin/fm-spawn.sh" direct --relaunch > "$PUBLISH_OUT" 2>&1 &
+publish_pid=$!
+for _ in {1..500}; do [ ! -e "$PUBLISH_MARKER" ] || break; sleep 0.01; done
+[ -e "$PUBLISH_MARKER" ] || fail "publication crash simulation never committed candidate metadata"
+jq '.candidate_process="shell" | .candidate_registered=false' "$STATE" > "$STATE.tmp" && mv "$STATE.tmp" "$STATE"
+kill -TERM "$publish_pid" 2>/dev/null || fail "could not interrupt relaunch after metadata publication"
+touch "$PUBLISH_RELEASE"
+wait "$publish_pid" 2>/dev/null || true
+[ "$(awk -F= '$1 == "herdr_pane_id" { print $2 }' "$DIRECT_HOME/state/direct.meta")" = w1:p2 ] \
+  || fail "post-publication interruption rolled back authoritative metadata"
+[ "$(jq -r '.candidate_exists' "$STATE")" = true ] \
+  || fail "post-publication interruption closed the authoritative candidate"
+DIRECT_OUT=$(PATH="$TMP_ROOT/fakebin:$PATH" FM_HOME="$DIRECT_HOME" FM_FAKE_HERDR_STATE="$STATE" \
+  FM_FAKE_HERDR_LOG="$LOG" FM_HERDR_PS_BIN="$TMP_ROOT/fakebin/ps" FM_HERDR_KILL_BIN="$TMP_ROOT/fakebin/kill" \
+  FM_BACKEND_HERDR_IDLE_SHELL_PROOF_POLLS=1 FM_SPAWN_NO_GUARD=1 \
+  "$ROOT/bin/fm-spawn.sh" direct --relaunch 2>&1) \
+  || fail "retry could not finish the interrupted binding commit: $DIRECT_OUT"
+case "$DIRECT_OUT" in *"spawned direct "*) : ;; *) fail "post-publication recovery did not permit the next relaunch: $DIRECT_OUT" ;; esac
+pass "fm-spawn relaunch: post-publication abort preserves and reconciles candidate binding"
 
 reset_direct_meta
 write_state "$DIRECT_WT" shell true

--- a/tests/fm-herdr-relaunch-recovery.test.sh
+++ b/tests/fm-herdr-relaunch-recovery.test.sh
@@ -78,6 +78,13 @@ case "${1:-} ${2:-}" in
       | if ((.process_after_send // "") != "") then .process=.process_after_send else . end
     ' "$state" | save_state
     ;;
+  "pane run")
+    text=${4:-}
+    pending=$(jq -r '.pending // empty' "$state")
+    cwd=$(jq -r '.cwd' "$state")
+    new_cwd=$(cd "$cwd" && bash -c "$pending$text; pwd -P") || exit 1
+    jq --arg cwd "$new_cwd" '.cwd=$cwd | .pending=""' "$state" | save_state
+    ;;
   "pane send-keys")
     key=${4:-}
     if [ "$key" = ctrl+c ]; then
@@ -105,6 +112,12 @@ case "$*" in
 esac
 SH
 chmod +x "$TMP_ROOT/fakebin/ps"
+
+cat > "$TMP_ROOT/fakebin/claude" <<'SH'
+#!/usr/bin/env bash
+exit 0
+SH
+chmod +x "$TMP_ROOT/fakebin/claude"
 
 write_state() {
   jq -n --arg cwd "$1" --arg process "$2" --argjson registered "$3" \
@@ -156,6 +169,15 @@ count_after=$(grep -c $'\x1fpane\x1fsend-text\x1f' "$LOG" || true)
 [ "$count_after" -eq "$count_before" ] || fail "idempotent path preparation submitted a second cd command"
 pass "Herdr relaunch recovery: exact path restoration is persistent, quoted, and idempotent"
 
+EXACT_MARKER="$TMP_ROOT/exact-cwd-marker"
+write_state "$TARGET" shell true
+jq --arg pending "touch '$EXACT_MARKER'; " '.pending=$pending' "$STATE" > "$STATE.tmp" && mv "$STATE.tmp" "$STATE"
+run_backend fm_backend_prepare_relaunch_path herdr fmtest:w1:p1 "$TARGET" \
+  || fail "exact-cwd preparation should still clear pending shell input"
+[ ! -e "$EXACT_MARKER" ] || fail "exact-cwd preparation executed preexisting buffered shell input"
+[ -z "$(jq -r '.pending // empty' "$STATE")" ] || fail "exact-cwd preparation left shell input buffered"
+pass "Herdr relaunch recovery: exact-cwd preparation still clears shell input"
+
 BUFFERED_MARKER="$TMP_ROOT/buffered-marker"
 write_state "$OLD" shell true
 jq --arg pending "touch '$BUFFERED_MARKER'; " '.pending=$pending' "$STATE" > "$STATE.tmp" && mv "$STATE.tmp" "$STATE"
@@ -183,6 +205,45 @@ if run_backend fm_backend_prepare_relaunch_path herdr fmtest:w1:p1 "$TARGET" >/d
 fi
 [ -n "$(jq -r '.pending // empty' "$STATE")" ] || fail "cleanup sent input after the pane stopped belonging to the exact idle shell"
 pass "Herdr relaunch recovery: cleanup refuses a changed shell owner"
+
+DIRECT_HOME="$TMP_ROOT/direct-home"
+DIRECT_PROJECT="$TMP_ROOT/direct-project"
+DIRECT_WT="$TMP_ROOT/direct-worktree"
+DIRECT_MARKER="$TMP_ROOT/direct-marker"
+fm_git_worktree "$DIRECT_PROJECT" "$DIRECT_WT" direct-relaunch
+mkdir -p "$DIRECT_HOME/state" "$DIRECT_HOME/data/direct"
+cat > "$DIRECT_HOME/data/direct/brief.md" <<'EOF'
+# Task
+## Captain's intent
+Resume the existing worker safely.
+
+## Firstmate spec
+Relaunch in the recorded worktree.
+EOF
+cat > "$DIRECT_HOME/state/direct.meta" <<EOF
+window=fmtest:w1:p1
+endpoint_task_id=direct
+worktree=$DIRECT_WT
+project=$DIRECT_PROJECT
+harness=claude
+kind=ship
+mode=no-mistakes
+yolo=off
+backend=herdr
+herdr_session=fmtest
+herdr_workspace_id=w1
+herdr_tab_id=w1:t1
+herdr_pane_id=w1:p1
+EOF
+write_state "$DIRECT_WT" shell true
+jq --arg pending "touch '$DIRECT_MARKER'; " '.pending=$pending' "$STATE" > "$STATE.tmp" && mv "$STATE.tmp" "$STATE"
+DIRECT_OUT=$(PATH="$TMP_ROOT/fakebin:$PATH" FM_HOME="$DIRECT_HOME" FM_FAKE_HERDR_STATE="$STATE" \
+  FM_FAKE_HERDR_LOG="$LOG" FM_HERDR_PS_BIN="$TMP_ROOT/fakebin/ps" FM_BACKEND_HERDR_IDLE_SHELL_PROOF_POLLS=1 \
+  FM_SPAWN_NO_GUARD=1 "$ROOT/bin/fm-spawn.sh" direct --relaunch --harness claude 2>&1) \
+  || fail "direct Herdr relaunch should prepare its endpoint before launch: $DIRECT_OUT"
+[ ! -e "$DIRECT_MARKER" ] || fail "direct Herdr relaunch executed buffered shell input before launch"
+case "$DIRECT_OUT" in *"spawned direct "*) : ;; *) fail "direct Herdr relaunch did not complete: $DIRECT_OUT" ;; esac
+pass "fm-spawn relaunch: direct Herdr entry prepares buffered shell input"
 
 write_state "$OLD" live true
 if run_backend fm_backend_prepare_relaunch_path herdr fmtest:w1:p1 "$TARGET" >/dev/null 2>&1; then

--- a/tests/fm-herdr-relaunch-recovery.test.sh
+++ b/tests/fm-herdr-relaunch-recovery.test.sh
@@ -291,6 +291,12 @@ exit 0
 SH
 chmod +x "$TMP_ROOT/fakebin/pi"
 
+cat > "$TMP_ROOT/fakebin/codex" <<'SH'
+#!/usr/bin/env bash
+exit 0
+SH
+chmod +x "$TMP_ROOT/fakebin/codex"
+
 cat > "$TMP_ROOT/fakebin/mv" <<'SH'
 #!/usr/bin/env bash
 set -u
@@ -692,6 +698,50 @@ DIRECT_OUT=$(PATH="$TMP_ROOT/fakebin:$PATH" FM_HOME="$DIRECT_HOME" FM_FAKE_HERDR
   || fail "wiring reconciliation created a duplicate replacement endpoint"
 pass "fm-spawn relaunch: crash adoption publishes before retryable wiring retirement"
 rm -f "$DIRECT_HOME/state/direct.pi-ext.ts"
+
+reset_direct_meta
+mkdir -p "$DIRECT_WT/.claude"
+printf '%s\n' prior-codex-switch-wiring > "$DIRECT_WT/.claude/settings.local.json"
+printf '%s\n' prior-codex-switch-gen > "$DIRECT_HOME/state/direct.busy-gen"
+printf '%s\n' 'v1 gen=prior-codex-switch-gen seq=3 state=idle source=test event=prior ts=1' \
+  > "$DIRECT_HOME/state/direct.busy-state"
+write_state "$DIRECT_WT" shell true
+CODEX_PUBLISH_MARKER="$TMP_ROOT/codex-publish.marker"
+CODEX_PUBLISH_RELEASE="$TMP_ROOT/codex-publish.release"
+CODEX_PUBLISH_OUT="$TMP_ROOT/codex-publish.out"
+PATH="$TMP_ROOT/fakebin:$PATH" FM_HOME="$DIRECT_HOME" FM_FAKE_HERDR_STATE="$STATE" \
+  FM_FAKE_HERDR_LOG="$LOG" FM_HERDR_PS_BIN="$TMP_ROOT/fakebin/ps" FM_HERDR_KILL_BIN="$TMP_ROOT/fakebin/kill" \
+  FM_BACKEND_HERDR_IDLE_SHELL_PROOF_POLLS=1 FM_SPAWN_NO_GUARD=1 \
+  FM_FAKE_MV_PUBLISH_MARKER="$CODEX_PUBLISH_MARKER" FM_FAKE_MV_PUBLISH_RELEASE="$CODEX_PUBLISH_RELEASE" \
+  FM_FAKE_MV_PUBLISH_TARGET="$DIRECT_HOME/state/direct.meta" \
+  "$ROOT/bin/fm-spawn.sh" direct --relaunch --harness codex > "$CODEX_PUBLISH_OUT" 2>&1 &
+codex_publish_pid=$!
+for _ in {1..500}; do [ ! -e "$CODEX_PUBLISH_MARKER" ] || break; sleep 0.01; done
+[ -e "$CODEX_PUBLISH_MARKER" ] || fail "unarmed-harness switch never reached metadata publication"
+[ ! -e "$DIRECT_HOME/state/direct.busy-gen" ] && [ ! -e "$DIRECT_HOME/state/direct.busy-state" ] \
+  || fail "unarmed-harness replacement retained the prior busy generation before publication"
+rm -f "$DIRECT_WT/.claude/settings.local.json"
+mkdir "$DIRECT_WT/.claude/settings.local.json"
+touch "$CODEX_PUBLISH_RELEASE"
+if wait "$codex_publish_pid"; then
+  fail "unarmed-harness switch succeeded while prior harness wiring retirement was blocked"
+fi
+[ "$(awk -F= '$1 == "harness" { print $2 }' "$DIRECT_HOME/state/direct.meta")" = codex ] \
+  || fail "failed wiring retirement did not preserve the published unarmed harness"
+[ ! -e "$DIRECT_HOME/state/direct.busy-gen" ] && [ ! -e "$DIRECT_HOME/state/direct.busy-state" ] \
+  || fail "failed wiring retirement resurrected the retired busy generation"
+rmdir "$DIRECT_WT/.claude/settings.local.json"
+printf '%s\n' prior-codex-switch-wiring > "$DIRECT_WT/.claude/settings.local.json"
+DIRECT_OUT=$(PATH="$TMP_ROOT/fakebin:$PATH" FM_HOME="$DIRECT_HOME" FM_FAKE_HERDR_STATE="$STATE" \
+  FM_FAKE_HERDR_LOG="$LOG" FM_HERDR_PS_BIN="$TMP_ROOT/fakebin/ps" FM_HERDR_KILL_BIN="$TMP_ROOT/fakebin/kill" \
+  FM_BACKEND_HERDR_IDLE_SHELL_PROOF_POLLS=1 FM_SPAWN_NO_GUARD=1 \
+  "$ROOT/bin/fm-spawn.sh" direct --relaunch --harness codex 2>&1) \
+  || fail "binding recovery could not finish the unarmed-harness switch: $DIRECT_OUT"
+[ ! -e "$DIRECT_HOME/state/direct.busy-gen" ] && [ ! -e "$DIRECT_HOME/state/direct.busy-state" ] \
+  || fail "unarmed-harness binding recovery restored a prior busy generation"
+[ "$(grep -c $'\x1ftab\x1fcreate\x1f' "$LOG" || true)" -eq 1 ] \
+  || fail "unarmed-harness binding recovery created a duplicate endpoint"
+pass "fm-spawn relaunch: unarmed harness switches retire stale busy generations"
 
 reset_direct_meta
 write_state "$DIRECT_WT" shell true

--- a/tests/fm-herdr-relaunch-recovery.test.sh
+++ b/tests/fm-herdr-relaunch-recovery.test.sh
@@ -1,0 +1,167 @@
+#!/usr/bin/env bash
+# Portable regression coverage for Herdr lifecycle recovery after an agent exits.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+TMP_ROOT=$(fm_test_tmproot fm-herdr-relaunch-recovery)
+mkdir -p "$TMP_ROOT/fakebin"
+STATE="$TMP_ROOT/herdr.json"
+LOG="$TMP_ROOT/herdr.log"
+: > "$LOG"
+
+cleanup() {
+  rm -rf "$TMP_ROOT"
+}
+trap cleanup EXIT
+
+cat > "$TMP_ROOT/fakebin/herdr" <<'SH'
+#!/usr/bin/env bash
+set -u
+state=${FM_FAKE_HERDR_STATE:?}
+log=${FM_FAKE_HERDR_LOG:?}
+{
+  printf 'call'
+  for arg in "$@"; do printf '\x1f%s' "$arg"; done
+  printf '\n'
+} >> "$log"
+
+save_state() {
+  local tmp="$state.tmp.$$"
+  cat > "$tmp" && mv "$tmp" "$state"
+}
+
+case "${1:-} ${2:-}" in
+  "status --json")
+    printf '{"client":{"version":"0.8.0","protocol":19},"server":{"running":true}}\n'
+    ;;
+  "pane get")
+    pane=${3:-}
+    jq --arg pane "$pane" '{id:"cli:pane:get",result:{type:"pane_info",pane:{pane_id:$pane,foreground_cwd:.cwd}}}' "$state"
+    ;;
+  "agent get")
+    pane=${3:-}
+    if [ "$(jq -r '.registered' "$state")" = true ]; then
+      jq --arg pane "$pane" '{id:"cli:agent:get",result:{type:"agent_info",agent:{pane_id:$pane,agent:"pi",agent_status:"idle"}}}' "$state"
+    else
+      printf '{"id":"cli:agent:get","error":{"code":"agent_not_found"}}\n'
+    fi
+    ;;
+  "pane process-info")
+    pane=
+    while [ "$#" -gt 0 ]; do
+      if [ "$1" = --pane ]; then pane=${2:-}; break; fi
+      shift
+    done
+    mode=$(jq -r '.process' "$state")
+    case "$mode" in
+      shell)
+        jq -n --arg pane "$pane" '{id:"cli:pane:process_info",result:{type:"pane_process_info",process_info:{pane_id:$pane,shell_pid:41001,foreground_process_group_id:41001,foreground_processes:[{pid:41001,name:"bash",argv:["/bin/bash"]}]}}}'
+        ;;
+      live)
+        jq -n --arg pane "$pane" '{id:"cli:pane:process_info",result:{type:"pane_process_info",process_info:{pane_id:$pane,shell_pid:41001,foreground_process_group_id:41002,foreground_processes:[{pid:41002,name:"pi",argv:["/opt/pi/bin/pi"]}]}}}'
+        ;;
+      *) printf '{"id":"cli:pane:process_info","result":{"type":"pane_process_info","process_info":{"pane_id":"wrong"}}}\n' ;;
+    esac
+    ;;
+  "pane send-text")
+    text=${4:-}
+    jq --arg text "$text" '.pending=$text' "$state" | save_state
+    ;;
+  "pane send-keys")
+    key=${4:-}
+    if [ "$key" = enter ]; then
+      pending=$(jq -r '.pending // empty' "$state")
+      cwd=$(jq -r '.cwd' "$state")
+      if [ -n "$pending" ]; then
+        new_cwd=$(cd "$cwd" && bash -c "$pending; pwd -P") || exit 1
+        jq --arg cwd "$new_cwd" '.cwd=$cwd | .pending=""' "$state" | save_state
+      fi
+    fi
+    ;;
+esac
+SH
+chmod +x "$TMP_ROOT/fakebin/herdr"
+
+cat > "$TMP_ROOT/fakebin/ps" <<'SH'
+#!/usr/bin/env bash
+case "$*" in
+  "-axo pid=,ppid=") printf '41001 1\n' ;;
+  "-p 41001 -o stat=") printf 'S\n' ;;
+  "-p 41001 -o comm=") printf 'bash\n' ;;
+  *) exit 1 ;;
+esac
+SH
+chmod +x "$TMP_ROOT/fakebin/ps"
+
+write_state() {
+  jq -n --arg cwd "$1" --arg process "$2" --argjson registered "$3" \
+    '{cwd:$cwd,process:$process,registered:$registered,pending:""}' > "$STATE"
+  : > "$LOG"
+}
+
+run_backend() {
+  PATH="$TMP_ROOT/fakebin:$PATH" \
+    FM_FAKE_HERDR_STATE="$STATE" FM_FAKE_HERDR_LOG="$LOG" FM_HERDR_PS_BIN="$TMP_ROOT/fakebin/ps" \
+    FM_BACKEND_HERDR_IDLE_SHELL_PROOF_POLLS=1 \
+    bash -c '. "$0/bin/fm-backend.sh"; "$@"' "$ROOT" "$@"
+}
+
+OLD="$TMP_ROOT/old"
+mkdir -p "$OLD"
+
+write_state "$OLD" shell true
+ordinary=$(run_backend fm_backend_agent_state herdr fmtest:w1:p1)
+recovery=$(run_backend fm_backend_recovery_agent_state herdr fmtest:w1:p1)
+[ "$ordinary" = alive ] || fail "the ordinary Herdr registry read should remain alive, got '$ordinary'"
+[ "$recovery" = dead ] || fail "a retained registration over one lone idle shell should be dead for lifecycle recovery, got '$recovery'"
+pass "Herdr relaunch recovery: a provably stale registered-agent report reconciles to agent-free"
+
+write_state "$OLD" live true
+recovery=$(run_backend fm_backend_recovery_agent_state herdr fmtest:w1:p1)
+[ "$recovery" = alive ] || fail "a registered agent with a distinct foreground process group must remain alive, got '$recovery'"
+pass "Herdr relaunch recovery: a real foreground agent remains alive and cannot be replaced"
+
+write_state "$OLD" ambiguous true
+recovery=$(run_backend fm_backend_recovery_agent_state herdr fmtest:w1:p1)
+[ "$recovery" = unreadable ] || fail "an ambiguous registered process surface must remain unreadable, got '$recovery'"
+pass "Herdr relaunch recovery: ambiguous process evidence refuses rather than becoming agent-free"
+
+TARGET="$TMP_ROOT/recorded ' ; touch PWNED ; #"
+mkdir -p "$TARGET"
+write_state "$OLD" shell true
+run_backend fm_backend_prepare_relaunch_path herdr fmtest:w1:p1 "$TARGET" \
+  || fail "an agent-free Herdr shell should restore to its exact recorded path"
+seen=$(jq -r '.cwd' "$STATE")
+[ "$seen" = "$TARGET" ] || fail "the restored foreground cwd should equal the quoted recorded path, got '$seen'"
+[ ! -e "$OLD/PWNED" ] || fail "recorded-path bytes escaped shell quoting and executed as syntax"
+command=$(awk -F '\x1f' '$2 == "pane" && $3 == "send-text" {print $5}' "$LOG")
+case "$command" in "cd -- "*) ;; *) fail "path restoration did not submit a cd command: $command" ;; esac
+count_before=$(grep -c $'\x1fpane\x1fsend-text\x1f' "$LOG" || true)
+run_backend fm_backend_prepare_relaunch_path herdr fmtest:w1:p1 "$TARGET" \
+  || fail "repeated exact-path preparation should be an idempotent success"
+count_after=$(grep -c $'\x1fpane\x1fsend-text\x1f' "$LOG" || true)
+[ "$count_after" -eq "$count_before" ] || fail "idempotent path preparation submitted a second cd command"
+pass "Herdr relaunch recovery: exact path restoration is persistent, quoted, and idempotent"
+
+write_state "$OLD" live true
+if run_backend fm_backend_prepare_relaunch_path herdr fmtest:w1:p1 "$TARGET" >/dev/null 2>&1; then
+  fail "path restoration must refuse while a real foreground agent remains"
+fi
+! grep -q $'\x1fpane\x1fsend-text\x1f' "$LOG" || fail "live-agent refusal typed a shell command"
+pass "Herdr relaunch recovery: live-agent refusal sends no path-changing input"
+
+write_state "$OLD" ambiguous true
+if run_backend fm_backend_prepare_relaunch_path herdr fmtest:w1:p1 "$TARGET" >/dev/null 2>&1; then
+  fail "path restoration must refuse ambiguous endpoint evidence"
+fi
+! grep -q $'\x1fpane\x1fsend-text\x1f' "$LOG" || fail "ambiguous-state refusal typed a shell command"
+pass "Herdr relaunch recovery: ambiguous-state refusal sends no path-changing input"
+
+run_backend fm_backend_prepare_relaunch_path tmux ignored "$TARGET" \
+  || fail "tmux relaunch path preparation should retain its existing no-op behavior"
+if run_backend fm_backend_prepare_relaunch_path zellij ignored "$TARGET" >/dev/null 2>&1; then
+  fail "a backend without verified lifecycle recovery must not gain path-changing behavior"
+fi
+pass "Relaunch path recovery: tmux remains unchanged and unverified backends refuse"

--- a/tests/fm-herdr-relaunch-recovery.test.sh
+++ b/tests/fm-herdr-relaunch-recovery.test.sh
@@ -259,6 +259,12 @@ exit 0
 SH
 chmod +x "$TMP_ROOT/fakebin/claude"
 
+cat > "$TMP_ROOT/fakebin/pi" <<'SH'
+#!/usr/bin/env bash
+exit 0
+SH
+chmod +x "$TMP_ROOT/fakebin/pi"
+
 write_state() {
   jq -n --arg cwd "$1" --arg process "$2" --argjson registered "$3" \
     '{cwd:$cwd,process:$process,registered:$registered,pending:"",fail_after_send_once:false,process_info_failures:0,process_after_send:"",pane_gets:0,take_over_after_pane_get:-1,frozen:false,take_over_on_stop:false,candidate_exists:false,candidate_cwd:"",candidate_pending:"",candidate_process:"shell",candidate_registered:false,candidate_take_over_on_stop:false,candidate_takeover_before_run:false,candidate_run_fail:false,candidate_run_unregistered:false,candidate_pane_gets:0,candidate_take_over_after_pane_get:-1,unmanaged_workspace:"w9",unmanaged_pane:"w9:p9",unmanaged_fingerprint:"unchanged"}' > "$STATE"
@@ -506,6 +512,43 @@ create_count=$(grep -c $'\x1ftab\x1fcreate\x1f' "$LOG" || true)
 grep -q '^candidate_state=adopted-alive$' "$DIRECT_HOME/state/direct.control-relaunch-candidate" \
   || fail "post-live adoption did not persist its reconciliation"
 pass "fm-spawn relaunch: retry adopts the exact post-live candidate"
+
+reset_direct_meta
+mkdir -p "$DIRECT_WT/.claude"
+printf '%s\n' prior-claude-wiring > "$DIRECT_WT/.claude/settings.local.json"
+rm -f "$DIRECT_HOME/state/direct.pi-ext.ts"
+write_state "$DIRECT_WT" shell true
+SWITCH_MARKER="$TMP_ROOT/post-live-switch.marker"
+SWITCH_RELEASE="$TMP_ROOT/post-live-switch.release"
+SWITCH_OUT="$TMP_ROOT/post-live-switch.out"
+PATH="$TMP_ROOT/fakebin:$PATH" FM_HOME="$DIRECT_HOME" FM_FAKE_HERDR_STATE="$STATE" \
+  FM_FAKE_HERDR_LOG="$LOG" FM_HERDR_PS_BIN="$TMP_ROOT/fakebin/ps" FM_HERDR_KILL_BIN="$TMP_ROOT/fakebin/kill" \
+  FM_BACKEND_HERDR_IDLE_SHELL_PROOF_POLLS=1 FM_SPAWN_NO_GUARD=1 \
+  FM_FAKE_HERDR_POST_LIVE_MARKER="$SWITCH_MARKER" FM_FAKE_HERDR_POST_LIVE_RELEASE="$SWITCH_RELEASE" \
+  "$ROOT/bin/fm-spawn.sh" direct --relaunch --harness pi > "$SWITCH_OUT" 2>&1 &
+switch_pid=$!
+for _ in {1..500}; do [ ! -e "$SWITCH_MARKER" ] || break; sleep 0.01; done
+[ -e "$SWITCH_MARKER" ] || fail "harness-switch crash simulation never reached launch proof"
+kill -KILL "$switch_pid" 2>/dev/null || fail "could not stop harness-switch relaunch after live launch"
+touch "$SWITCH_RELEASE"
+wait "$switch_pid" 2>/dev/null || true
+[ -f "$DIRECT_WT/.claude/settings.local.json" ] \
+  || fail "crash simulation unexpectedly retired prior Claude wiring"
+[ -f "$DIRECT_HOME/state/direct.pi-ext.ts" ] \
+  || fail "crash simulation did not leave replacement Pi wiring"
+DIRECT_OUT=$(PATH="$TMP_ROOT/fakebin:$PATH" FM_HOME="$DIRECT_HOME" FM_FAKE_HERDR_STATE="$STATE" \
+  FM_FAKE_HERDR_LOG="$LOG" FM_HERDR_PS_BIN="$TMP_ROOT/fakebin/ps" FM_HERDR_KILL_BIN="$TMP_ROOT/fakebin/kill" \
+  FM_BACKEND_HERDR_IDLE_SHELL_PROOF_POLLS=1 FM_SPAWN_NO_GUARD=1 \
+  "$ROOT/bin/fm-spawn.sh" direct --relaunch --harness pi 2>&1) \
+  || fail "retry could not adopt the harness-switched candidate: $DIRECT_OUT"
+[ ! -e "$DIRECT_WT/.claude/settings.local.json" ] \
+  || fail "crash adoption retained prior Claude wiring"
+[ -f "$DIRECT_HOME/state/direct.pi-ext.ts" ] \
+  || fail "crash adoption removed replacement Pi wiring"
+[ "$(awk -F= '$1 == "harness" { print $2 }' "$DIRECT_HOME/state/direct.meta")" = pi ] \
+  || fail "crash adoption did not publish the replacement harness"
+pass "fm-spawn relaunch: crash adoption retires only prior harness wiring"
+rm -f "$DIRECT_HOME/state/direct.pi-ext.ts"
 
 reset_direct_meta
 awk '

--- a/tests/fm-herdr-relaunch-recovery.test.sh
+++ b/tests/fm-herdr-relaunch-recovery.test.sh
@@ -62,11 +62,15 @@ case "${1:-} ${2:-}" in
         ' "$state" | save_state
       fi
     else
-      jq --arg pane "$pane" '{id:"cli:pane:get",result:{type:"pane_info",pane:{pane_id:$pane,tab_id:"w1:t1",workspace_id:"w1",foreground_cwd:.cwd}}}' "$state"
-      jq '
-        .pane_gets=((.pane_gets // 0) + 1)
-        | if .pane_gets == (.take_over_after_pane_get // -1) then .process="live" else . end
-      ' "$state" | save_state
+      if [ "$(jq -r 'if .recorded_exists == null then true else .recorded_exists end' "$state")" != true ]; then
+        printf '{"id":"cli:pane:get","error":{"code":"pane_not_found"}}\n'
+      else
+        jq --arg pane "$pane" '{id:"cli:pane:get",result:{type:"pane_info",pane:{pane_id:$pane,tab_id:"w1:t1",workspace_id:"w1",foreground_cwd:.cwd}}}' "$state"
+        jq '
+          .pane_gets=((.pane_gets // 0) + 1)
+          | if .pane_gets == (.take_over_after_pane_get // -1) then .process="live" else . end
+        ' "$state" | save_state
+      fi
     fi
     ;;
   "agent get")
@@ -230,6 +234,8 @@ case "${1:-} ${2:-}" in
     pane=${3:-}
     if [ "$pane" = w1:p2 ]; then
       jq '.candidate_exists=false | .candidate_registered=false | .candidate_process="dead" | .frozen=false' "$state" | save_state
+    else
+      jq '.recorded_exists=false | .registered=false | .process="dead" | .frozen=false' "$state" | save_state
     fi
     ;;
 esac
@@ -333,7 +339,7 @@ chmod +x "$TMP_ROOT/fakebin/git"
 
 write_state() {
   jq -n --arg cwd "$1" --arg process "$2" --argjson registered "$3" \
-    '{cwd:$cwd,process:$process,registered:$registered,pending:"",fail_after_send_once:false,process_info_failures:0,process_after_send:"",pane_gets:0,take_over_after_pane_get:-1,frozen:false,take_over_on_stop:false,candidate_exists:false,candidate_cwd:"",candidate_pending:"",candidate_process:"shell",candidate_registered:false,candidate_take_over_on_stop:false,candidate_takeover_before_run:false,candidate_create_ambiguous_once:false,candidate_run_fail:false,candidate_run_ambiguous:false,candidate_run_ambiguous_delay:0,candidate_run_unregistered:false,candidate_pane_gets:0,candidate_take_over_after_pane_get:-1,unmanaged_workspace:"w9",unmanaged_pane:"w9:p9",unmanaged_fingerprint:"unchanged"}' > "$STATE"
+    '{cwd:$cwd,process:$process,registered:$registered,recorded_exists:true,pending:"",fail_after_send_once:false,process_info_failures:0,process_after_send:"",pane_gets:0,take_over_after_pane_get:-1,frozen:false,take_over_on_stop:false,candidate_exists:false,candidate_cwd:"",candidate_pending:"",candidate_process:"shell",candidate_registered:false,candidate_take_over_on_stop:false,candidate_takeover_before_run:false,candidate_create_ambiguous_once:false,candidate_run_fail:false,candidate_run_ambiguous:false,candidate_run_ambiguous_delay:0,candidate_run_unregistered:false,candidate_pane_gets:0,candidate_take_over_after_pane_get:-1,unmanaged_workspace:"w9",unmanaged_pane:"w9:p9",unmanaged_fingerprint:"unchanged"}' > "$STATE"
   : > "$LOG"
 }
 
@@ -362,8 +368,8 @@ pass "Herdr relaunch recovery: a real foreground agent remains alive and cannot 
 
 write_state "$OLD" live false
 recovery=$(run_backend fm_backend_recovery_agent_state herdr fmtest:w1:p1)
-[ "$recovery" = alive ] || fail "an unregistered pane with a distinct foreground process group must remain alive, got '$recovery'"
-pass "Herdr relaunch recovery: an unregistered live process cannot be replaced"
+[ "$recovery" = unreadable ] || fail "an unregistered non-shell process must remain ambiguous, got '$recovery'"
+pass "Herdr relaunch recovery: an unregistered foreground process cannot receive lifecycle input"
 
 write_state "$OLD" ambiguous true
 recovery=$(run_backend fm_backend_recovery_agent_state herdr fmtest:w1:p1)
@@ -656,8 +662,10 @@ if DIRECT_OUT=$(PATH="$TMP_ROOT/fakebin:$PATH" FM_HOME="$DIRECT_HOME" FM_FAKE_HE
     "$ROOT/bin/fm-spawn.sh" direct --relaunch --harness pi 2>&1); then
   fail "crash adoption reported success while prior wiring could not be retired: $DIRECT_OUT"
 fi
-cmp -s "$DIRECT_HOME/state/direct.meta.original" "$DIRECT_HOME/state/direct.meta" \
-  || fail "failed prior-wiring retirement published the replacement binding"
+[ "$(awk -F= '$1 == "herdr_pane_id" { print $2 }' "$DIRECT_HOME/state/direct.meta")" = w1:p2 ] \
+  || fail "failed prior-wiring retirement did not preserve the published replacement binding"
+[ "$(awk -F= '$1 == "harness" { print $2 }' "$DIRECT_HOME/state/direct.meta")" = pi ] \
+  || fail "failed prior-wiring retirement did not preserve the published replacement harness"
 [ -f "$DIRECT_HOME/state/direct.pi-ext.ts" ] \
   || fail "failed prior-wiring retirement removed replacement wiring"
 rmdir "$DIRECT_WT/.claude/settings.local.json"
@@ -673,7 +681,9 @@ DIRECT_OUT=$(PATH="$TMP_ROOT/fakebin:$PATH" FM_HOME="$DIRECT_HOME" FM_FAKE_HERDR
   || fail "crash adoption removed replacement Pi wiring"
 [ "$(awk -F= '$1 == "harness" { print $2 }' "$DIRECT_HOME/state/direct.meta")" = pi ] \
   || fail "crash adoption did not publish the replacement harness"
-pass "fm-spawn relaunch: crash adoption retires only prior harness wiring"
+[ "$(grep -c $'\x1ftab\x1fcreate\x1f' "$LOG" || true)" -eq 1 ] \
+  || fail "wiring reconciliation created a duplicate replacement endpoint"
+pass "fm-spawn relaunch: crash adoption publishes before retryable wiring retirement"
 rm -f "$DIRECT_HOME/state/direct.pi-ext.ts"
 
 reset_direct_meta
@@ -917,10 +927,12 @@ sleep 0.05
 clear_count=$(grep -c $'\x1fpane\x1fsend-keys\x1f.*\x1fctrl+c' "$LOG" || true)
 [ "$clear_count" -eq 1 ] || fail "a competing pane mutation entered between relaunch preparation and command submission"
 wait "$direct_pid" || fail "the serialized direct relaunch failed: $(cat "$DIRECT_CONCURRENT_OUT")"
-wait "$competitor_pid" || fail "the competing path preparation did not resume after launch submission"
+if wait "$competitor_pid"; then
+  fail "the competing path preparation mutated the original endpoint after publication"
+fi
 clear_count=$(grep -c $'\x1fpane\x1fsend-keys\x1f.*\x1fctrl+c' "$LOG" || true)
-[ "$clear_count" -eq 2 ] || fail "the competing pane mutation did not run after relaunch submission"
-pass "fm-spawn relaunch: Herdr session mutation lock spans candidate creation through binding publication"
+[ "$clear_count" -eq 1 ] || fail "the competing pane mutation reached the retired original endpoint"
+pass "fm-spawn relaunch: session locking prevents mutation of the retired original endpoint"
 
 [ "$(jq -r '.unmanaged_fingerprint' "$STATE")" = unchanged ] \
   || fail "replacement transaction mutated an unrelated unmanaged endpoint"
@@ -978,7 +990,9 @@ case "$DIRECT_OUT" in *"spawned direct "*) : ;; *) fail "post-publication recove
   || fail "post-publication recovery lost the original prior harness identity"
 grep -q '^pane_id=w1:p2$' "$DIRECT_HOME/state/direct.herdr-presentation" \
   || fail "post-publication recovery left the presentation binding stale"
-pass "fm-spawn relaunch: post-publication abort preserves and reconciles candidate binding"
+[ "$(jq -r '.recorded_exists' "$STATE")" = false ] \
+  || fail "post-publication recovery abandoned the retained original endpoint"
+pass "fm-spawn relaunch: post-publication retry reconciles presentation and retained endpoint"
 rm -f "$DIRECT_HOME/state/direct.pi-ext.ts" "$DIRECT_HOME/state/direct.herdr-presentation"
 
 reset_direct_meta


### PR DESCRIPTION
## Intent

Repair the upstream Herdr lifecycle defect that can strand a worker relaunch after an agent exits.

## What Changed

- Corroborate Herdr agent registration with foreground-process state and restore the validated worktree before relaunch.
- Launch replacements in fresh unpublished endpoints, then atomically publish, adopt, roll back, or quarantine candidates using durable receipts and wiring snapshots.
- Add extensive recovery and real-Herdr smoke coverage, and document the updated lifecycle guarantees.

## Risk Assessment

✅ Low: The transactional Herdr relaunch changes are fail-closed, preserve retryable provenance across examined crash windows, and no material source-verifiable defect remains.

## Testing

Completed 1 recorded test check.

- Outcome: ⚠️ 1 error across 3 runs (1h37m19s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"2bb30ded07cff481f13fe2c72d3b572de5fd555f","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>🔧 **Review** - 4 issues found → auto-fixed (6) ✅</summary>

- 🚨 `bin/backends/herdr.sh:2011` - A `no-agent` pane with any non-shell foreground process returns `alive`. For example, after the agent exits, opening `vim` makes `fm-control exit` send the recorded harness exit command into Vim. Only a corroborated live registration may return `alive`; classify an unregistered non-shell process as unreadable/ambiguous and update the regression that currently expects `alive`.
- 🚨 `bin/fm-spawn.sh:1448` - The `published` reconciliation branch returns without examining the persisted `old_endpoint=retained` state. If A-to-B publication succeeds but exact cleanup of A transiently fails, the next B-to-C relaunch discards this record and permanently abandons A. Retry exact safe cleanup of the recorded original endpoint before accepting the published transaction as reconciled.
- ⚠️ `bin/fm-spawn.sh:1448` - A failed A-to-B presentation-journal update is only warned about, but the subsequent `published` retry returns without advancing it. Later B-to-C replacement cannot satisfy the journal&#39;s expected old endpoint because it still names A, and teardown cannot match the authoritative B endpoint. Reconcile the recorded A-to-B journal transition before returning.
- ⚠️ `bin/fm-spawn.sh:1393` - Crash adoption finalizes replacement wiring and retires prior wiring before publishing candidate metadata. If `fm_backlog_atomic_transition publish` then fails, metadata still authoritatively names old endpoint/harness A while only B&#39;s wiring remains. Publish B first, then use the existing authoritative reconciliation path to make wiring retirement retryable, matching the normal publication ordering.

🔧 Fix: Reconcile Herdr publication and lifecycle evidence
1 warning still open:

- ⚠️ `docs/agent-control.md:72` - The documentation says an unregistered non-shell process remains `alive`, also repeated in `docs/herdr-backend.md:277`, but `fm_backend_herdr_recovery_agent_state` now deliberately returns `unreadable` for that state. Update both lifecycle descriptions to document the ambiguous/refused classification operators will actually observe.

🔧 Fix: Correct Herdr lifecycle classification documentation
2 errors still open:

- 🚨 `bin/fm-spawn.sh:1356` - Launch-provenance persistence deletes the canonical directory, including its prior-wiring snapshot, before moving the replacement into place. If the process is killed between lines 1356-1357 after replacement wiring was armed, retry sees phase `wiring-snapshotted` but cannot restore the now-missing canonical snapshot and permanently refuses relaunch. Preserve `prior-snapshot` in place until the remaining provenance files are fully installed, rather than using a delete-then-move directory replacement.
- 🚨 `bin/fm-spawn.sh:1551` - A missing exact candidate is accepted only for `wiring-restored` and `quarantined`. For example, if a phase-`created` candidate shell exits, or cleanup closes it before a crash records `rolled-back`, retry fails `candidate_matches` forever while the old binding remains agent-free. The same ordering prevents a missing `wiring-snapshotted` or `launch-attempt` candidate from restoring prior wiring. At this recovery boundary, treat an exactly recorded missing pre-wiring candidate as rolled back, and restore the persisted snapshot before completing rollback for post-wiring phases.

🔧 Fix: Make Herdr provenance and missing-candidate recovery crash-safe
1 error still open:

- 🚨 `bin/fm-spawn.sh:1582` - Crash recovery samples a `launch-attempt` candidate as dead, restores prior wiring, and rephases it to `wiring-restored` before attempting endpoint cleanup. If the already-submitted launch becomes foreground before cleanup freezes the shell, cleanup safely refuses, but the record is now ineligible for live adoption and the prior snapshot is deleted at line 1585. Every later retry therefore refuses the live candidate and strands relaunch. Preserve `launch-attempt` provenance until cleanup commits, or on cleanup refusal restore the staged replacement wiring and launch-attempt phase as the EXIT recovery path already does.

🔧 Fix: Preserve Herdr launch adoption through cleanup races
1 error still open:

- 🚨 `bin/fm-spawn.sh:1408` - A Herdr task whose agent already exited can retain its prior busy generation because `do_exit` returns `already-stopped` without retiring it. When switching from Claude/Pi/OpenCode/Gemini to an unarmed harness such as Codex, replacement metadata has no `busy_gen`, but launch provenance restores the prior generation; this comparison then fails after metadata publication and repeats forever during `binding-published` recovery. Retire the prior busy generation after the rollback snapshot is durable when the replacement does not arm one, so persisted replacement wiring accurately represents an absent generation.

🔧 Fix: Retire stale busy state for unarmed Herdr switches
1 error still open:

- 🚨 `bin/fm-spawn.sh:4050` - The launch command separates receipt creation from the agent launch with `;`, so a failed receipt write still starts the replacement. If the provenance directory becomes unwritable or storage is exhausted, then the process crashes before publication, retry observes a live `launch-attempt` candidate but `herdr_relaunch_candidate_adopt_live` rejects it for lacking the receipt, permanently stranding relaunch. Chain receipt creation to launch with `&amp;&amp;` so an unreceipted agent cannot start.

🔧 Fix: Require Herdr receipt before replacement launch
✅ Re-checked - no issues remain.
</details>

<details>
<summary>⚠️ **Test** - 1 error</summary>

- 🚨 tests failed with exit code 1
- `bin/fm-test-run.sh --changed --exclude-family real-herdr-gated`

🔧 Fix: Confirm regressions pass; isolate external mise trust failure
1 error still open:

- 🚨 tests failed with exit code 1
- `bin/fm-test-run.sh --changed --exclude-family real-herdr-gated`

🔧 Fix: Stabilize ambiguous Herdr launch adoption regression
1 error still open:

- 🚨 tests failed with exit code 1
- `bin/fm-test-run.sh --changed --exclude-family real-herdr-gated`
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>🔧 **Lint** - 1 issue found → auto-fixed ✅</summary>

- ⚠️ linter found issues (exit code 1)

🔧 Fix: Fix ShellCheck warnings in transactional relaunch logic
✅ Re-checked - no issues remain.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
