### PR TITLE
feat(brief): ship briefs carry standing Ponytail minimal-dependency rule

### DIFF
--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -471,6 +471,10 @@ $ASK_USER_BLOCK
 7. Never stop, restart, or update the shared \`no-mistakes\` daemon - it is one instance serving
    every lane/home, so restarting it kills other lanes' in-flight pipeline runs. On ANY no-mistakes
    daemon error, append \`blocked: {the daemon error}\` and stop; only firstmate manages the daemon.
+8. Ponytail code style is a standing captain rule: keep the diff minimal and
+   dependency-free. Prefer the standard library and the existing project idioms;
+   no wrappers, no speculative generality, no new third-party dependency unless
+   the task explicitly requires it - then name the justification in your final report.
 
 $INBOX_SECTION
 

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -817,6 +817,23 @@ test_scout_and_secondmate_load_decision_hold_policy() {
   pass "fm-brief.sh: investigation and visual-review completions load the shared decision policy"
 }
 
+# Captain standing rule (data/captain.md, Ponytail philosophy): every ship
+# brief must carry the minimal, dependency-free code rule so every coding
+# crewmate receives it without firstmate hand-adding it per brief.
+test_ship_brief_carries_ponytail_rule() {
+  local home brief
+  home="$TMP_ROOT/ponytail-home"
+  mkdir -p "$home/data"
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" brief-ponytail-e1 some-proj --mode local-only >/dev/null 2>&1 \
+    || fail "fm-brief.sh ponytail fixture scaffold exited non-zero"
+  brief="$home/data/brief-ponytail-e1/brief.md"
+  assert_grep "Ponytail code style is a standing captain rule" "$brief" \
+    "ship brief missing the standing Ponytail rule"
+  assert_grep "no new third-party dependency unless" "$brief" \
+    "ship brief missing the Ponytail dependency bar"
+  pass "fm-brief.sh: ship briefs carry the standing Ponytail rule"
+}
+
 # Scout and secondmate paths still scaffold well-formed briefs.
 test_scout_and_secondmate_scaffold() {
   local brief
@@ -867,4 +884,5 @@ test_secondmate_marked_request_reporting_contract
 test_secondmate_directory_paths_are_absolute_and_output_is_stable
 test_pause_verb_override_renders_all_brief_scaffolds
 test_scout_and_secondmate_load_decision_hold_policy
+test_ship_brief_carries_ponytail_rule
 test_scout_and_secondmate_scaffold


### PR DESCRIPTION
## Summary

Every ship brief scaffold now instructs coding crewmates to keep the diff minimal and dependency-free, per the captain's standing Ponytail preference:

- Prefer the standard library and the existing project idioms.
- No wrappers, no speculative generality.
- No new third-party dependency unless the task explicitly requires it, with the justification named in the final report.

The rule lands as Rules item 8 in the ship scaffold only; scout and secondmate scaffolds are unchanged. This keeps the constraint deterministic (enforced by the scaffold) rather than relying on firstmate to hand-add it to every brief.

## Test evidence

- New regression test `test_ship_brief_carries_ponytail_rule` pins the rule's presence and its dependency bar in generated ship briefs.
- Full `tests/fm-brief.test.sh` suite passes: 23/23 on this branch (run against the current `origin/main` base, f09de8a).
- `bash -n` parse guard passes; the change is heredoc prose only.