### PR TITLE
fix: reduce local ShellCheck source-analysis cost

### DIFF
--- a/.no-mistakes.yaml
+++ b/.no-mistakes.yaml
@@ -22,12 +22,12 @@ document:
     evidence destination, and unique safety facts, then review the complete
     branch diff again after every documentation or lint fix.
 
-# Pin lint to the same owner CI runs instead of leaving it to no-mistakes'
+# Pin lint to the same owner CI invokes instead of leaving it to no-mistakes'
 # default handling, which does not invoke the repository's canonical lint gate.
-# `bin/fm-lint.sh` owns the complete lint definition, including GitHub workflow
-# lint via pinned actionlint in `bin/fm-lint-workflows.sh`, and
-# `.github/workflows/ci.yml` invokes it directly, with parity asserted by
-# `tests/fm-lint.test.sh` and `tests/fm-lint-workflows.test.sh`.
+# `bin/fm-lint.sh` owns the context-sensitive ShellCheck modes and GitHub
+# workflow lint via pinned actionlint in `bin/fm-lint-workflows.sh`.
+# Invocation wiring is asserted by `tests/fm-lint.test.sh` and
+# `tests/fm-lint-workflows.test.sh`.
 #
 # Pin the test baseline to the repository's own runner rather than leaving each
 # gate agent to chain `bash tests/a.test.sh && bash tests/b.test.sh` by hand.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,7 +69,7 @@ A crewmate picking up such a brief should load the skill even if the brief preda
 When supervising live crewmates, keep firstmate's own long validation or build commands in the background so watcher wakes can still be handled.
 Crewmate validation follows the installed no-mistakes version's SKILL.md and live `axi` help instead of duplicating gate mechanics in firstmate docs.
 Firstmate's wrapper still matters: crewmates route every `ask-user` finding to firstmate, which applies `ask-user-authority`, and crewmates never pass `--yes` or `-y` because either flag bypasses that check and any required captain escalation.
-`.no-mistakes.yaml` publishes test evidence to the orphan `no-mistakes/evidence` branch, which shares no history with code branches, pins the gate's lint command to `bin/fm-lint.sh`, matching the Linux CI lint job, and pins its test command to `bin/fm-test-run.sh --changed`.
+[`docs/configuration.md`](docs/configuration.md#gate-defaults-no-mistakesyaml) owns the tracked `.no-mistakes.yaml` gate defaults.
 Local no-mistakes Test is intent-targeted and must not re-run every `tests/*.test.sh`; `.github/workflows/ci.yml` owns the broad behavior suite plus platform-specific compatibility lanes.
 Verify the same way the gate does: reach for `bin/fm-test-run.sh` with the subjects you care about rather than chaining `bash tests/a.test.sh && bash tests/b.test.sh`, because a list of script paths gets the same bounded concurrency as `--changed`.
 The pipeline publishes that evidence itself, so never hand-commit `.no-mistakes/` paths onto a feature branch; CI rejects them as tracked personal fleet paths.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,8 +46,8 @@ See the [no-mistakes quick start](https://kunchenguid.github.io/no-mistakes/star
 - Helper scripts in `bin/` are plain bash.
   Each starts with a usage header comment; keep it accurate when you change behavior.
   Test scripts and helpers in `tests/` are plain bash too.
-  `bin/fm-lint.sh` must pass: it is the single owner of the lint definition (the shellcheck file set, config, pinned shellcheck version, and pinned actionlint workflow lint), and both CI and the no-mistakes pre-push gate run its no-argument full-analysis path.
-  Its header and `--help` output own the exact local lint modes and flags.
+  `bin/fm-lint.sh` must pass: it is the single owner of the lint definition (the shellcheck file set, config, pinned shellcheck version, and pinned actionlint workflow lint), and both CI and the no-mistakes pre-push gate invoke it with no arguments.
+  Its header and `--help` output own the exact local lint modes, file-set selection, and analysis flags.
   A malformed `.github/workflows/*.yml`, including a self-broken `ci.yml`, fails that local lint path before merge because a broken workflow cannot report its own breakage.
   It pins one exact shellcheck version and one exact actionlint version and refuses to run under any other.
   Print the shellcheck pin with `bin/fm-lint.sh --required-version` and the actionlint pin with `bin/fm-lint-workflows.sh --required-version`.

--- a/bin/fm-lint.sh
+++ b/bin/fm-lint.sh
@@ -6,24 +6,34 @@
 # no-mistakes both invoke this script with no arguments, so the rule set,
 # version, bounded execution, and diagnostics ordering cannot drift.
 # The explicit --fast mode is local-only and disables ShellCheck's extended
-# dataflow analysis while preserving ordinary shell lint checks. CI and
-# no-mistakes keep the full-analysis no-argument default.
+# dataflow analysis while preserving ordinary shell lint checks and source
+# following. CI, main, and merge-base-less runs keep --norc --external-sources
+# with full dataflow over the whole canonical set. An ordinary local branch
+# (changed-file mode, including the no-mistakes lint step) drops
+# --external-sources, keeps dataflow, and excludes SC1091, SC2034, SC2153,
+# and SC2329, the codes that need library context. Those codes still run in
+# CI over the whole set. Explicit paths keep --external-sources with the
+# selected dataflow mode.
 # Tests stop source analysis at imported production modules because every
 # production shell is already a canonical, source-aware root of this same run.
 # The default (no explicit-path) path also runs bin/fm-lint-workflows.sh so a
 # malformed GitHub workflow, including a self-broken ci.yml, fails locally
 # before merge instead of only failing to run as CI.
 #
-# With no explicit paths, the file set depends on context:
+# With no explicit paths, the file set and source-following posture depend
+# on context:
 #   - In CI (GITHUB_ACTIONS=true or CI=true), on the main branch, or when no
 #     merge-base against origin/main (or local main) can be found, it lints
-#     the full canonical set: bin/*.sh bin/backends/*.sh tests/*.sh. This is
-#     what CI always runs, so CI coverage never depends on a local diff.
+#     the full canonical set: bin/*.sh bin/backends/*.sh tests/*.sh, with
+#     --external-sources and full dataflow. This is what CI always runs, so
+#     CI coverage never depends on a local diff.
 #   - Otherwise (an ordinary local branch with a real merge-base) it lints
 #     only the canonical-set files changed since that merge-base, including
 #     uncommitted local edits, via plain local `git diff` (no network, no
-#     `gh`). A branch with zero matching changed files skips ShellCheck and
-#     prints a "no changed lint targets" note, then still validates workflows.
+#     `gh`). That local pass drops --external-sources and excludes SC1091,
+#     SC2034, SC2153, and SC2329. A branch with zero matching changed files
+#     skips ShellCheck and prints a "no changed lint targets" note, then
+#     still validates workflows.
 # Explicit paths always bypass this file-set selection and lint exactly the
 # given paths, matching the same config, without the workflow YAML check.
 #
@@ -47,6 +57,9 @@
 set -u
 
 REQUIRED_SHELLCHECK=0.11.0
+# Cross-file codes that need --external-sources. Local changed-file mode
+# cannot judge them, so they stay CI-only.
+LOCAL_NOX_EXCLUDE=SC1091,SC2034,SC2153,SC2329
 SELF_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SELF="$SELF_DIR/fm-lint.sh"
 ROOT="$(cd "$SELF_DIR/.." && pwd)"
@@ -75,7 +88,13 @@ fm_lint_worker() {  # <manifest> <output-dir> <shard-index>
     trap 'fm_lint_worker_stop; exit 129' HUP
     trap 'fm_lint_worker_stop; exit 130' INT
     trap 'fm_lint_worker_stop; exit 143' TERM
-    shellcheck_args=(--norc --external-sources)
+    shellcheck_args=(--norc)
+    if [ "${FM_LINT_INTERNAL_FOLLOW_SOURCES:-1}" -eq 1 ]; then
+      shellcheck_args+=(--external-sources)
+    fi
+    if [ -n "${FM_LINT_INTERNAL_EXCLUDE:-}" ]; then
+      shellcheck_args+=(--exclude="$FM_LINT_INTERNAL_EXCLUDE")
+    fi
     if [ "${FM_LINT_INTERNAL_FAST:-0}" -eq 1 ]; then
       shellcheck_args+=(--extended-analysis=false)
     fi
@@ -215,6 +234,8 @@ fm_lint_is_canonical_root() {
 
 CHANGED_MODE=0
 EXPLICIT_PATHS=0
+FOLLOW_SOURCES=1
+EXCLUDE_CODES=
 if [ "$#" -gt 0 ]; then
   EXPLICIT_PATHS=1
   ROOTS=("$@")
@@ -241,6 +262,11 @@ else
       ROOTS+=("$changed_path")
     done < <(git diff --name-only --diff-filter=ACMR -z "$merge_base" -- 2>/dev/null | LC_ALL=C sort -z)
   fi
+fi
+if [ "$CHANGED_MODE" -eq 1 ] && [ "$FAST" -eq 0 ]; then
+  FOLLOW_SOURCES=0
+  EXCLUDE_CODES=$LOCAL_NOX_EXCLUDE
+  ANALYSIS_MODE=local
 fi
 ROOT_COUNT=${#ROOTS[@]}
 
@@ -273,6 +299,8 @@ if [ "$resolved" != "$REQUIRED_SHELLCHECK" ]; then
 fi
 if [ "$FAST" -eq 1 ]; then
   printf 'fm-lint.sh: fast local mode; ShellCheck extended analysis disabled\n' >&2
+elif [ "$FOLLOW_SOURCES" -eq 0 ]; then
+  printf 'fm-lint.sh: local changed-file mode; ShellCheck source following disabled\n' >&2
 else
   printf 'fm-lint.sh: full ShellCheck extended analysis enabled\n' >&2
 fi
@@ -408,18 +436,24 @@ fm_lint_run_worker() {  # <worker-index>
     if [ "$(uname)" = Darwin ]; then
       exec "$PERL_BIN" -e 'setpgrp(0, 0) or die "setpgrp: $!"; exec @ARGV or die "exec: $!"' \
         /usr/bin/time -lp -o "$timing" \
-        env FM_LINT_INTERNAL=1 FM_LINT_INTERNAL_FAST="$FAST" FM_LINT_SHELLCHECK="$SHELLCHECK_BIN" \
+        env FM_LINT_INTERNAL=1 FM_LINT_INTERNAL_FAST="$FAST" \
+        FM_LINT_INTERNAL_FOLLOW_SOURCES="$FOLLOW_SOURCES" FM_LINT_INTERNAL_EXCLUDE="$EXCLUDE_CODES" \
+        FM_LINT_SHELLCHECK="$SHELLCHECK_BIN" \
         "${BASH:-bash}" "$SELF" --internal-worker "$manifest" "$OUTPUT_DIR" "$worker_index"
     else
       exec "$PERL_BIN" -e 'setpgrp(0, 0) or die "setpgrp: $!"; exec @ARGV or die "exec: $!"' \
         /usr/bin/time -f 'wall_seconds=%e\nuser_seconds=%U\nsystem_seconds=%S\nmax_rss_kib=%M' -o "$timing" \
-        env FM_LINT_INTERNAL=1 FM_LINT_INTERNAL_FAST="$FAST" FM_LINT_SHELLCHECK="$SHELLCHECK_BIN" \
+        env FM_LINT_INTERNAL=1 FM_LINT_INTERNAL_FAST="$FAST" \
+        FM_LINT_INTERNAL_FOLLOW_SOURCES="$FOLLOW_SOURCES" FM_LINT_INTERNAL_EXCLUDE="$EXCLUDE_CODES" \
+        FM_LINT_SHELLCHECK="$SHELLCHECK_BIN" \
         "${BASH:-bash}" "$SELF" --internal-worker "$manifest" "$OUTPUT_DIR" "$worker_index"
     fi
   else
     [ -z "$TELEMETRY" ] || printf 'timing_unavailable=1\n' > "$timing"
     exec "$PERL_BIN" -e 'setpgrp(0, 0) or die "setpgrp: $!"; exec @ARGV or die "exec: $!"' \
-      env FM_LINT_INTERNAL=1 FM_LINT_INTERNAL_FAST="$FAST" FM_LINT_SHELLCHECK="$SHELLCHECK_BIN" \
+      env FM_LINT_INTERNAL=1 FM_LINT_INTERNAL_FAST="$FAST" \
+      FM_LINT_INTERNAL_FOLLOW_SOURCES="$FOLLOW_SOURCES" FM_LINT_INTERNAL_EXCLUDE="$EXCLUDE_CODES" \
+      FM_LINT_SHELLCHECK="$SHELLCHECK_BIN" \
       "${BASH:-bash}" "$SELF" --internal-worker "$manifest" "$OUTPUT_DIR" "$worker_index"
   fi
 }

--- a/bin/fm-lint.sh
+++ b/bin/fm-lint.sh
@@ -3,8 +3,8 @@
 #
 # Runs its file set with ShellCheck's default severity, extended analysis,
 # ambient configuration disabled, and one exact ShellCheck version. CI and
-# no-mistakes both invoke this script with no arguments, so the rule set,
-# version, bounded execution, and diagnostics ordering cannot drift.
+# no-mistakes both invoke this script with no arguments, so this owner selects
+# the context-appropriate rule set without duplicating lint configuration.
 # The explicit --fast mode is local-only and disables ShellCheck's extended
 # dataflow analysis while preserving ordinary shell lint checks and source
 # following. CI, main, and merge-base-less runs keep --norc --external-sources
@@ -14,8 +14,8 @@
 # and SC2329, the codes that need library context. Those codes still run in
 # CI over the whole set. Explicit paths keep --external-sources with the
 # selected dataflow mode.
-# Tests stop source analysis at imported production modules because every
-# production shell is already a canonical, source-aware root of this same run.
+# Tests stop source analysis at imported production modules because CI analyzes
+# every production shell separately as a canonical, source-aware root.
 # The default (no explicit-path) path also runs bin/fm-lint-workflows.sh so a
 # malformed GitHub workflow, including a self-broken ci.yml, fails locally
 # before merge instead of only failing to run as CI.

--- a/bin/fm-lint.sh
+++ b/bin/fm-lint.sh
@@ -553,7 +553,11 @@ if [ -n "$TELEMETRY" ]; then
   source_directives=$(wc -l < "$TMP_ROOT/source-targets" | tr -d '[:space:]')
   source_boundaries=$(grep -c '^/dev/null$' "$TMP_ROOT/source-targets" 2>/dev/null || true)
   case "$source_boundaries" in ''|*[!0-9]*) source_boundaries=0 ;; esac
-  source_followed=$((source_directives - source_boundaries))
+  if [ "$FOLLOW_SOURCES" -eq 1 ]; then
+    source_followed=$((source_directives - source_boundaries))
+  else
+    source_followed=0
+  fi
   source_targets=$(LC_ALL=C sort -u "$TMP_ROOT/source-targets" | wc -l | tr -d '[:space:]')
   content_cksum=$(cksum "$TMP_ROOT/content-cksums" | awk '{print $1 "-" $2}')
   git_head=$(git rev-parse HEAD 2>/dev/null || printf 'unavailable')

--- a/bin/fm-lint.sh
+++ b/bin/fm-lint.sh
@@ -75,7 +75,7 @@ fm_lint_worker_stop() {
 }
 
 fm_lint_worker() {  # <manifest> <output-dir> <shard-index>
-  local manifest=$1 output_dir=$2 shard_index=$3 tab index path output rc=0
+  local manifest=$1 output_dir=$2 shard_index=$3 tab index path output invocation_rc rc=0
   local -a roots shellcheck_args
   roots=()
   tab=$(printf '\t')
@@ -98,10 +98,24 @@ fm_lint_worker() {  # <manifest> <output-dir> <shard-index>
     if [ "${FM_LINT_INTERNAL_FAST:-0}" -eq 1 ]; then
       shellcheck_args+=(--extended-analysis=false)
     fi
-    "$FM_LINT_SHELLCHECK" "${shellcheck_args[@]}" -- "${roots[@]}" > "$output.out" 2>&1 &
-    FM_LINT_WORKER_SHELLCHECK_PID=$!
-    wait "$FM_LINT_WORKER_SHELLCHECK_PID" || rc=$?
-    FM_LINT_WORKER_SHELLCHECK_PID=
+    : > "$output.out"
+    if [ "${FM_LINT_INTERNAL_FOLLOW_SOURCES:-1}" -eq 1 ]; then
+      "$FM_LINT_SHELLCHECK" "${shellcheck_args[@]}" -- "${roots[@]}" >> "$output.out" 2>&1 &
+      FM_LINT_WORKER_SHELLCHECK_PID=$!
+      wait "$FM_LINT_WORKER_SHELLCHECK_PID" || rc=$?
+      FM_LINT_WORKER_SHELLCHECK_PID=
+    else
+      for path in "${roots[@]}"; do
+        invocation_rc=0
+        "$FM_LINT_SHELLCHECK" "${shellcheck_args[@]}" -- "$path" >> "$output.out" 2>&1 &
+        FM_LINT_WORKER_SHELLCHECK_PID=$!
+        wait "$FM_LINT_WORKER_SHELLCHECK_PID" || invocation_rc=$?
+        FM_LINT_WORKER_SHELLCHECK_PID=
+        if [ "$rc" -eq 0 ] && [ "$invocation_rc" -ne 0 ]; then
+          rc=$invocation_rc
+        fi
+      done
+    fi
     trap - HUP INT TERM
   else
     : > "$output.out"

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -200,7 +200,7 @@ The flag is a home-local supervision-noise preference and is not inherited by se
 
 ## Gate defaults (.no-mistakes.yaml)
 
-The tracked `.no-mistakes.yaml` sets `test.evidence.store_in_repo: true`, pins `commands.lint` to `bin/fm-lint.sh` so local lint matches CI, and pins `commands.test` to `bin/fm-test-run.sh --changed --exclude-family real-herdr-gated` so the gate's test baseline runs through the repository's own runner instead of a hand-chained walk of `bash tests/*.test.sh`.
+The tracked `.no-mistakes.yaml` sets `test.evidence.store_in_repo: true`, pins `commands.lint` to `bin/fm-lint.sh`, the same owner CI invokes, and pins `commands.test` to `bin/fm-test-run.sh --changed --exclude-family real-herdr-gated` so the gate's test baseline runs through the repository's own runner instead of a hand-chained walk of `bash tests/*.test.sh`.
 Storing evidence in the repo publishes each run's test artifacts to the orphan `no-mistakes/evidence` branch and links them from the PR body, instead of keeping them on local disk under the no-mistakes home.
 That branch shares no history with code branches, so evidence never enters a pushed feature branch or the default branch; the worktree's `.no-mistakes/` stays local and CI rejects tracked entries under that path.
 `commands.test` stays changed-file-scoped and must never become a complete `tests/*.test.sh` walk: `--changed` selects only the families the branch's changed files map to, runs concurrency-admitted scripts with bounded concurrency, keeps every unproven stateful script serial, and applies its own generous per-script bound.

--- a/docs/documentation-audiences.json
+++ b/docs/documentation-audiences.json
@@ -425,6 +425,10 @@
       "audience": "maintainer-verification"
     },
     {
+      "path": "docs/verification/lint-option-a.md",
+      "audience": "maintainer-verification"
+    },
+    {
       "path": "docs/verification/muse.md",
       "audience": "maintainer-verification"
     },

--- a/docs/verification/lint-option-a.md
+++ b/docs/verification/lint-option-a.md
@@ -1,7 +1,6 @@
 # Local ShellCheck option A measurement
 
-The 2026-09-05 lint-cost audit measured the seven roots from the missed-reply
-incident at commit `f09de8a3d3a550b13b4d535346fbc7b9ac0d6c19`:
+The 2026-09-05 lint-cost audit measured the seven roots from the missed-reply incident at commit `f09de8a3d3a550b13b4d535346fbc7b9ac0d6c19`:
 
 ```text
 bin/fm-brief.sh
@@ -13,22 +12,20 @@ tests/fm-classify-corr-token.test.sh
 tests/fm-pending-reply.test.sh
 ```
 
-ShellCheck was the repository-pinned 0.11.0 Darwin arm64 build. The baseline was
-one source-aware invocation containing all seven roots. Option A used one
-process per root, omitted `--external-sources`, retained extended dataflow, and
-applied the local cross-file exclusion list. Both variants were measured in the
-same quiet-host window:
+ShellCheck was the repository-pinned 0.11.0 Darwin arm64 build.
+The baseline was one source-aware invocation containing all seven roots.
+Option A used one process per root, omitted `--external-sources`, retained extended dataflow, and applied the local cross-file exclusion list.
+Both variants were measured in the same quiet-host window:
 
 | Variant | User + system CPU | Reduction | Worst-process RSS | Reduction |
 | --- | ---: | ---: | ---: | ---: |
-| source-aware baseline | 140.1 s | — | 8.30 GB | — |
+| source-aware baseline | 140.1 s | n/a | 8.30 GB | n/a |
 | option A, per-root processes | 9.8 s | 93.0% | 0.56 GB | 93.3% |
 
 ## Reproduction
 
-Check out the recorded commit, install the pinned binary with
-`bin/fm-install-shellcheck.sh`, put it first on `PATH`, and run the following on
-macOS. No `--extended-analysis=false` flag is present, so dataflow remains on.
+Check out the recorded commit, install the pinned binary with `bin/fm-install-shellcheck.sh`, put it first on `PATH`, and run the following on macOS.
+No `--extended-analysis=false` flag is present, so dataflow remains on.
 Diagnostics are discarded because only process cost is under measurement.
 
 ```bash
@@ -70,7 +67,5 @@ awk '
 ' .lint-option-a-measurement/option-a.*.time
 ```
 
-CPU and RSS vary with host load, so percentage claims must compare runs from one
-measurement window. When results must be compared across windows, use the
-reported `bytes_allocated` totals as the stable work proxy rather than quoting a
-CPU or RSS ratio.
+CPU and RSS vary with host load, so percentage claims must compare runs from one measurement window.
+When results must be compared across windows, use the reported `bytes_allocated` totals as the stable work proxy rather than quoting a CPU or RSS ratio.

--- a/docs/verification/lint-option-a.md
+++ b/docs/verification/lint-option-a.md
@@ -1,0 +1,76 @@
+# Local ShellCheck option A measurement
+
+The 2026-09-05 lint-cost audit measured the seven roots from the missed-reply
+incident at commit `f09de8a3d3a550b13b4d535346fbc7b9ac0d6c19`:
+
+```text
+bin/fm-brief.sh
+bin/fm-parent-channel-lib.sh
+bin/fm-pending-reply-lib.sh
+bin/fm-secondmate-report.sh
+tests/fm-brief.test.sh
+tests/fm-classify-corr-token.test.sh
+tests/fm-pending-reply.test.sh
+```
+
+ShellCheck was the repository-pinned 0.11.0 Darwin arm64 build. The baseline was
+one source-aware invocation containing all seven roots. Option A used one
+process per root, omitted `--external-sources`, retained extended dataflow, and
+applied the local cross-file exclusion list. Both variants were measured in the
+same quiet-host window:
+
+| Variant | User + system CPU | Reduction | Worst-process RSS | Reduction |
+| --- | ---: | ---: | ---: | ---: |
+| source-aware baseline | 140.1 s | — | 8.30 GB | — |
+| option A, per-root processes | 9.8 s | 93.0% | 0.56 GB | 93.3% |
+
+## Reproduction
+
+Check out the recorded commit, install the pinned binary with
+`bin/fm-install-shellcheck.sh`, put it first on `PATH`, and run the following on
+macOS. No `--extended-analysis=false` flag is present, so dataflow remains on.
+Diagnostics are discarded because only process cost is under measurement.
+
+```bash
+set -eu
+[ "$(bin/fm-lint.sh --required-version)" = "$(shellcheck --version | awk '/^version:/ {print $2; exit}')" ]
+roots=(
+  bin/fm-brief.sh
+  bin/fm-parent-channel-lib.sh
+  bin/fm-pending-reply-lib.sh
+  bin/fm-secondmate-report.sh
+  tests/fm-brief.test.sh
+  tests/fm-classify-corr-token.test.sh
+  tests/fm-pending-reply.test.sh
+)
+rm -rf .lint-option-a-measurement
+mkdir .lint-option-a-measurement
+/usr/bin/time -lp -o .lint-option-a-measurement/baseline.time \
+  shellcheck --norc --external-sources -- "${roots[@]}" >/dev/null || true
+index=0
+for root in "${roots[@]}"; do
+  index=$((index + 1))
+  /usr/bin/time -lp -o ".lint-option-a-measurement/option-a.$index.time" \
+    shellcheck --norc --exclude=SC1091,SC2034,SC2153,SC2329 -- "$root" \
+    >/dev/null || true
+done
+awk '
+  /^user / {cpu += $2}
+  /^sys / {cpu += $2}
+  /maximum resident set size/ {if ($1 > rss) rss=$1}
+  /bytes allocated/ {allocated += $1}
+  END {printf "cpu_seconds=%.2f worst_rss_bytes=%.0f bytes_allocated=%.0f\n", cpu, rss, allocated}
+' .lint-option-a-measurement/baseline.time
+awk '
+  /^user / {cpu += $2}
+  /^sys / {cpu += $2}
+  /maximum resident set size/ {if ($1 > rss) rss=$1}
+  /bytes allocated/ {allocated += $1}
+  END {printf "cpu_seconds=%.2f worst_rss_bytes=%.0f bytes_allocated=%.0f\n", cpu, rss, allocated}
+' .lint-option-a-measurement/option-a.*.time
+```
+
+CPU and RSS vary with host load, so percentage claims must compare runs from one
+measurement window. When results must be compared across windows, use the
+reported `bytes_allocated` totals as the stable work proxy rather than quoting a
+CPU or RSS ratio.

--- a/tests/fm-lint.test.sh
+++ b/tests/fm-lint.test.sh
@@ -533,6 +533,32 @@ test_changed_mode_drops_external_sources_and_excludes_cross_file_codes() {
   pass "fm-lint.sh changed mode drops source following and excludes cross-file codes"
 }
 
+test_changed_mode_invokes_shellcheck_once_per_root() {
+  local tmp fakebin log flag_log diff_file out first second invocation_count
+  tmp=$(fm_test_tmproot fm-lint-local-per-root)
+  fakebin=$(fm_fakebin "$tmp")
+  fm_lint_stub_git "$fakebin"
+  log="$tmp/shellcheck.log"
+  flag_log="$tmp/flags.log"
+  fm_lint_stub_shellcheck "$fakebin" "$log"
+  diff_file="$tmp/diff.nul"
+  first="bin/fm-install-shellcheck.sh"
+  second="bin/fm-lint-workflows.sh"
+  fm_lint_write_diff_file "$diff_file" "$first" "$second"
+
+  out=$(PATH="$fakebin:$PATH" GITHUB_ACTIONS='' CI='' FM_LINT_JOBS=1 \
+    FM_TEST_GIT_BRANCH=feature FM_TEST_GIT_DIFF_FILE="$diff_file" \
+    FM_TEST_FLAG_LOG="$flag_log" "$LINT" 2>&1) \
+    || fail "changed-mode per-root lint failed"$'\n'"$out"
+  [ "$(LC_ALL=C sort "$log")" = "$first"$'\n'"$second" ] \
+    || fail "changed-mode lint did not analyze both changed roots"$'\n'"logged: $(cat "$log")"
+  invocation_count=$(grep -c '^external-sources=' "$flag_log" || true)
+  [ "$invocation_count" -eq 2 ] \
+    || fail "changed-mode lint used $invocation_count ShellCheck calls for two roots"
+  fm_lint_assert_flag_log "$flag_log" no "SC1091,SC2034,SC2153,SC2329"
+  pass "fm-lint.sh changed mode invokes ShellCheck once per root"
+}
+
 test_ci_keeps_external_sources_without_local_exclusions() {
   local tmp fakebin log flag_log mode_log fixture out
   tmp=$(fm_test_tmproot fm-lint-ci-follow)
@@ -1286,6 +1312,7 @@ test_explicit_path_bypasses_changed_logic
 test_zero_changed_files_exits_clean
 test_list_files_respects_changed_mode
 test_changed_mode_drops_external_sources_and_excludes_cross_file_codes
+test_changed_mode_invokes_shellcheck_once_per_root
 test_ci_keeps_external_sources_without_local_exclusions
 test_main_branch_keeps_external_sources
 test_merge_base_less_keeps_external_sources

--- a/tests/fm-lint.test.sh
+++ b/tests/fm-lint.test.sh
@@ -512,7 +512,7 @@ test_changed_mode_drops_external_sources_and_excludes_cross_file_codes() {
   telemetry="$tmp/telemetry.tsv"
   fm_lint_stub_shellcheck "$fakebin" "$log"
   diff_file="$tmp/diff.nul"
-  target="bin/fm-install-shellcheck.sh"
+  target="bin/fm-afk-launch.sh"
   fm_lint_write_diff_file "$diff_file" "$target"
 
   out=$(PATH="$fakebin:$PATH" GITHUB_ACTIONS='' CI='' FM_LINT_JOBS=1 \
@@ -530,6 +530,10 @@ test_changed_mode_drops_external_sources_and_excludes_cross_file_codes() {
     "changed-mode local lint did not disclose dropped source following"
   assert_grep $'analysis_mode\tlocal' "$telemetry" \
     "telemetry did not record local analysis mode"
+  assert_grep $'source_directives\t3' "$telemetry" \
+    "telemetry did not count the changed root's source directives"
+  assert_grep $'source_followed_directives\t0' "$telemetry" \
+    "telemetry reported followed sources in no-external-sources mode"
   pass "fm-lint.sh changed mode drops source following and excludes cross-file codes"
 }
 

--- a/tests/fm-lint.test.sh
+++ b/tests/fm-lint.test.sh
@@ -159,6 +159,10 @@ test_help_reports_the_complete_interface() {
   assert_contains "$help" "--list-files" "fm-lint.sh --help omitted --list-files"
   assert_contains "$help" "--help" "fm-lint.sh --help omitted --help"
   assert_contains "$help" "--fast" "fm-lint.sh --help omitted --fast"
+  assert_contains "$help" "SC1091" "fm-lint.sh --help omitted the local SC1091 exclusion"
+  assert_contains "$help" "SC2034" "fm-lint.sh --help omitted the local SC2034 exclusion"
+  assert_contains "$help" "SC2153" "fm-lint.sh --help omitted the local SC2153 exclusion"
+  assert_contains "$help" "SC2329" "fm-lint.sh --help omitted the local SC2329 exclusion"
   pass "fm-lint.sh --help reports the complete executable interface"
 }
 
@@ -240,7 +244,8 @@ fm_lint_write_diff_file() {
 # them, so changed-file mode tests can assert exactly which files fm-lint.sh
 # selected without depending on real ShellCheck findings. When
 # FM_TEST_MODE_LOG is set, it records the effective analysis mode, treating
-# ShellCheck's default as full analysis.
+# ShellCheck's default as full analysis. When FM_TEST_FLAG_LOG is set, it
+# records whether --external-sources was passed and the --exclude value.
 fm_lint_stub_shellcheck() {
   local fakebin=$1 log=$2
   : > "$log"
@@ -251,12 +256,25 @@ if [ "\${1:-}" = --version ]; then
   exit 0
 fi
 mode=on
+follow=no
+exclude=none
 while [ "\$#" -gt 0 ] && [ "\$1" != -- ]; do
-  [ "\$1" = --extended-analysis=false ] && mode=off
+  case "\$1" in
+    --extended-analysis=false) mode=off ;;
+    --external-sources) follow=yes ;;
+    --exclude=*) exclude=\${1#--exclude=} ;;
+    --exclude)
+      shift
+      exclude=\${1:-none}
+      ;;
+  esac
   shift
 done
 if [ -n "\${FM_TEST_MODE_LOG:-}" ]; then
   printf '%s\n' "\$mode" >> "\$FM_TEST_MODE_LOG"
+fi
+if [ -n "\${FM_TEST_FLAG_LOG:-}" ]; then
+  printf 'external-sources=%s\nexclude=%s\n' "\$follow" "\$exclude" >> "\$FM_TEST_FLAG_LOG"
 fi
 [ "\$#" -eq 0 ] || shift
 printf '%s\n' "\$@" >> "$log"
@@ -469,6 +487,252 @@ test_list_files_respects_changed_mode() {
   [ "$listed" = "tests/fm-lint.test.sh" ] \
     || fail "--list-files did not report the would-be changed set in changed mode"$'\n'"got: $listed"
   pass "fm-lint.sh --list-files reports the would-be changed set in changed mode"
+}
+
+fm_lint_assert_flag_log() {
+  local flag_log=$1 expected_follow=$2 expected_exclude=$3
+  [ -s "$flag_log" ] || fail "ShellCheck was not invoked; flag log is empty"
+  awk -v follow="$expected_follow" -v exclude="$expected_exclude" '
+    BEGIN { bad=0; saw=0 }
+    /^external-sources=/ { saw=1; if ($0 != "external-sources=" follow) bad=1 }
+    /^exclude=/ { if ($0 != "exclude=" exclude) bad=1 }
+    END { exit (saw && !bad) ? 0 : 1 }
+  ' "$flag_log" \
+    || fail "ShellCheck flags were not external-sources=$expected_follow exclude=$expected_exclude"$'\n'"$(cat "$flag_log")"
+}
+
+test_changed_mode_drops_external_sources_and_excludes_cross_file_codes() {
+  local tmp fakebin log flag_log mode_log diff_file telemetry out target
+  tmp=$(fm_test_tmproot fm-lint-local-nox)
+  fakebin=$(fm_fakebin "$tmp")
+  fm_lint_stub_git "$fakebin"
+  log="$tmp/shellcheck.log"
+  flag_log="$tmp/flags.log"
+  mode_log="$tmp/mode.log"
+  telemetry="$tmp/telemetry.tsv"
+  fm_lint_stub_shellcheck "$fakebin" "$log"
+  diff_file="$tmp/diff.nul"
+  target="bin/fm-install-shellcheck.sh"
+  fm_lint_write_diff_file "$diff_file" "$target"
+
+  out=$(PATH="$fakebin:$PATH" GITHUB_ACTIONS='' CI='' FM_LINT_JOBS=1 \
+    FM_TEST_GIT_BRANCH=feature \
+    FM_TEST_GIT_DIFF_FILE="$diff_file" \
+    FM_TEST_FLAG_LOG="$flag_log" FM_TEST_MODE_LOG="$mode_log" \
+    "$LINT" --telemetry "$telemetry" 2>&1) \
+    || fail "changed-mode local lint failed"$'\n'"$out"
+  [ "$(cat "$log")" = "$target" ] \
+    || fail "changed-mode lint did not run ShellCheck on exactly the changed file"$'\n'"logged: $(cat "$log")"
+  [ "$(cat "$mode_log")" = on ] \
+    || fail "changed-mode local lint disabled dataflow analysis"
+  fm_lint_assert_flag_log "$flag_log" no "SC1091,SC2034,SC2153,SC2329"
+  assert_contains "$out" "source following disabled" \
+    "changed-mode local lint did not disclose dropped source following"
+  assert_grep $'analysis_mode\tlocal' "$telemetry" \
+    "telemetry did not record local analysis mode"
+  pass "fm-lint.sh changed mode drops source following and excludes cross-file codes"
+}
+
+test_ci_keeps_external_sources_without_local_exclusions() {
+  local tmp fakebin log flag_log mode_log fixture out
+  tmp=$(fm_test_tmproot fm-lint-ci-follow)
+  fakebin=$(fm_fakebin "$tmp")
+  fixture="$tmp/fixture.sh"
+  log="$tmp/shellcheck.log"
+  flag_log="$tmp/flags.log"
+  mode_log="$tmp/mode.log"
+  cat > "$fixture" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n' "${1:-ok}"
+SH
+  fm_lint_stub_shellcheck "$fakebin" "$log"
+
+  out=$(PATH="$fakebin:$PATH" CI=true GITHUB_ACTIONS=true FM_LINT_JOBS=1 \
+    FM_TEST_FLAG_LOG="$flag_log" FM_TEST_MODE_LOG="$mode_log" \
+    "$LINT" "$fixture" 2>&1) \
+    || fail "CI lint with explicit path failed"$'\n'"$out"
+  [ "$(cat "$mode_log")" = on ] \
+    || fail "CI lint disabled dataflow analysis"
+  fm_lint_assert_flag_log "$flag_log" yes none
+  pass "fm-lint.sh CI keeps source following without the local exclusion list"
+}
+
+test_main_branch_keeps_external_sources() {
+  local tmp fakebin log flag_log out
+  tmp=$(fm_test_tmproot fm-lint-main-follow)
+  fakebin=$(fm_fakebin "$tmp")
+  fm_lint_stub_git "$fakebin"
+  log="$tmp/shellcheck.log"
+  flag_log="$tmp/flags.log"
+  fm_lint_stub_shellcheck "$fakebin" "$log"
+
+  out=$(PATH="$fakebin:$PATH" GITHUB_ACTIONS='' CI='' FM_LINT_JOBS=1 \
+    FM_TEST_GIT_BRANCH=main \
+    FM_TEST_FLAG_LOG="$flag_log" "$LINT" 2>&1) \
+    || fail "main-branch lint failed"$'\n'"$out"
+  fm_lint_assert_flag_log "$flag_log" yes none
+  pass "fm-lint.sh on main keeps source following without the local exclusion list"
+}
+
+test_merge_base_less_keeps_external_sources() {
+  local tmp fakebin log flag_log out
+  tmp=$(fm_test_tmproot fm-lint-nomergebase-follow)
+  fakebin=$(fm_fakebin "$tmp")
+  fm_lint_stub_git "$fakebin"
+  log="$tmp/shellcheck.log"
+  flag_log="$tmp/flags.log"
+  fm_lint_stub_shellcheck "$fakebin" "$log"
+
+  out=$(PATH="$fakebin:$PATH" GITHUB_ACTIONS='' CI='' FM_LINT_JOBS=1 \
+    FM_TEST_GIT_BRANCH=feature FM_TEST_GIT_MERGE_BASE_OK=0 \
+    FM_TEST_FLAG_LOG="$flag_log" "$LINT" 2>&1) \
+    || fail "merge-base-less lint failed"$'\n'"$out"
+  fm_lint_assert_flag_log "$flag_log" yes none
+  pass "fm-lint.sh without a merge-base keeps source following without the local exclusion list"
+}
+
+test_explicit_path_keeps_external_sources() {
+  local tmp fakebin log flag_log out target
+  tmp=$(fm_test_tmproot fm-lint-explicit-follow)
+  fakebin=$(fm_fakebin "$tmp")
+  fm_lint_stub_git "$fakebin"
+  log="$tmp/shellcheck.log"
+  flag_log="$tmp/flags.log"
+  fm_lint_stub_shellcheck "$fakebin" "$log"
+  target="bin/fm-install-shellcheck.sh"
+
+  out=$(PATH="$fakebin:$PATH" GITHUB_ACTIONS='' CI='' FM_LINT_JOBS=1 \
+    FM_TEST_GIT_BRANCH=feature \
+    FM_TEST_FLAG_LOG="$flag_log" "$LINT" "$target" 2>&1) \
+    || fail "explicit-path lint failed"$'\n'"$out"
+  fm_lint_assert_flag_log "$flag_log" yes none
+  pass "fm-lint.sh explicit paths keep source following"
+}
+
+test_fast_mode_on_a_local_branch_keeps_source_following() {
+  local tmp fakebin log flag_log mode_log diff_file out target
+  tmp=$(fm_test_tmproot fm-lint-fast-follow)
+  fakebin=$(fm_fakebin "$tmp")
+  fm_lint_stub_git "$fakebin"
+  log="$tmp/shellcheck.log"
+  flag_log="$tmp/flags.log"
+  mode_log="$tmp/mode.log"
+  fm_lint_stub_shellcheck "$fakebin" "$log"
+  diff_file="$tmp/diff.nul"
+  target="bin/fm-install-shellcheck.sh"
+  fm_lint_write_diff_file "$diff_file" "$target"
+
+  out=$(PATH="$fakebin:$PATH" GITHUB_ACTIONS='' CI='' FM_LINT_JOBS=1 \
+    FM_TEST_GIT_BRANCH=feature \
+    FM_TEST_GIT_DIFF_FILE="$diff_file" \
+    FM_TEST_FLAG_LOG="$flag_log" FM_TEST_MODE_LOG="$mode_log" \
+    "$LINT" --fast 2>&1) \
+    || fail "fast local-branch lint failed"$'\n'"$out"
+  [ "$(cat "$mode_log")" = off ] \
+    || fail "fast local-branch lint did not disable extended analysis"
+  fm_lint_assert_flag_log "$flag_log" yes none
+  pass "fm-lint.sh --fast on a local branch keeps source following"
+}
+
+test_changed_mode_hides_cross_file_codes_that_ci_still_sees() {
+  if ! pinned_ready; then
+    pass "SKIP (ShellCheck $REQUIRED not resolved): changed-mode exclusion behavior"
+    return
+  fi
+  local tmp fakebin diff_file fixture out rc
+  tmp=$(fm_test_tmproot fm-lint-local-exclude-behavior)
+  fixture="$ROOT/tests/fm-lint-local-exclude-fixture.test.sh"
+  printf '%s\n' "$fixture" >> "$FM_TEST_CLEANUP_REGISTRY"
+  cat > "$fixture" <<'SH'
+#!/usr/bin/env bash
+# Assigned here and only consumed by a library the local gate does not follow.
+cross_file_only=1
+outer() {
+  (
+    # Defined here and only invoked by a library the local gate does not follow.
+    cross_file_helper() {
+      printf 'ok\n'
+    }
+    printf 'hi\n'
+  )
+}
+outer
+SH
+  fakebin=$(fm_fakebin "$tmp")
+  fm_lint_stub_git "$fakebin"
+  diff_file="$tmp/diff.nul"
+  fm_lint_write_diff_file "$diff_file" "tests/fm-lint-local-exclude-fixture.test.sh"
+
+  rc=0
+  out=$(PATH="$fakebin:$PATH" GITHUB_ACTIONS='' CI='' FM_LINT_JOBS=1 \
+    FM_TEST_GIT_BRANCH=feature \
+    FM_TEST_GIT_DIFF_FILE="$diff_file" "$LINT" 2>&1) || rc=$?
+  [ "$rc" -eq 0 ] \
+    || fail "changed-mode local lint failed a cross-file-only fixture"$'\n'"$out"
+  assert_not_contains "$out" "SC2034" "changed-mode local lint still reported SC2034"
+  assert_not_contains "$out" "SC2329" "changed-mode local lint still reported SC2329"
+
+  rc=0
+  out=$("$LINT" "$fixture" 2>&1) || rc=$?
+  [ "$rc" -ne 0 ] || fail "explicit-path lint passed a cross-file-only fixture"$'\n'"$out"
+  assert_contains "$out" "SC2034" "explicit-path lint did not keep SC2034"
+  assert_contains "$out" "SC2329" "explicit-path lint did not keep SC2329"
+  rm -f "$fixture"
+  pass "fm-lint.sh changed mode excludes cross-file codes that explicit paths still report"
+}
+
+# One ShellCheck process per root. Passing the whole canonical set in a
+# single invocation still follows in-set sources and is not the no-x posture.
+fm_lint_nox_one_root() {
+  local index=$1 path=$2 outdir=$3
+  shellcheck --norc --format gcc -- "$path" > "$outdir/$index" || true
+}
+
+test_local_exclusion_list_covers_every_no_external_sources_code() {
+  if ! pinned_ready; then
+    pass "SKIP (ShellCheck $REQUIRED not resolved): local exclusion completeness"
+    return
+  fi
+  local tmp files_file out unexpected code path found i batch
+  local -a files
+  tmp=$(fm_test_tmproot fm-lint-nox-complete)
+  files_file="$tmp/files"
+  CI=true "$LINT" --list-files > "$files_file"
+  [ -s "$files_file" ] || fail "CI --list-files returned no canonical lint roots"
+  files=()
+  while IFS= read -r path; do
+    [ -n "$path" ] || continue
+    files+=("$path")
+  done < "$files_file"
+  [ "${#files[@]}" -gt 0 ] || fail "CI --list-files returned no readable lint roots"
+  mkdir -p "$tmp/gcc"
+  i=0
+  batch=0
+  for path in "${files[@]}"; do
+    i=$((i + 1))
+    fm_lint_nox_one_root "$i" "$path" "$tmp/gcc" &
+    batch=$((batch + 1))
+    if [ "$batch" -eq 4 ]; then
+      wait
+      batch=0
+    fi
+  done
+  wait
+  found=$(find "$tmp/gcc" -type f | wc -l | tr -d '[:space:]')
+  [ "$found" = "${#files[@]}" ] \
+    || fail "completeness sweep linted $found roots, expected ${#files[@]}"
+  out=$(cat "$tmp/gcc"/* 2>/dev/null || true)
+  unexpected=
+  while IFS= read -r code; do
+    [ -n "$code" ] || continue
+    case "$code" in
+      SC1091|SC2034|SC2153|SC2329) ;;
+      *) unexpected="${unexpected}${unexpected:+ }$code" ;;
+    esac
+  done < <(printf '%s\n' "$out" | sed -n 's/.*\[\(SC[0-9][0-9]*\)\].*/\1/p' | LC_ALL=C sort -u)
+  [ -z "$unexpected" ] \
+    || fail "no-external-sources pass emitted codes outside the local exclusion list: $unexpected"
+  pass "local exclusion list covers every no-external-sources ShellCheck code"
 }
 
 test_pins_an_explicit_version() {
@@ -1021,3 +1285,11 @@ test_main_branch_forces_full_lint
 test_explicit_path_bypasses_changed_logic
 test_zero_changed_files_exits_clean
 test_list_files_respects_changed_mode
+test_changed_mode_drops_external_sources_and_excludes_cross_file_codes
+test_ci_keeps_external_sources_without_local_exclusions
+test_main_branch_keeps_external_sources
+test_merge_base_less_keeps_external_sources
+test_explicit_path_keeps_external_sources
+test_fast_mode_on_a_local_branch_keeps_source_following
+test_changed_mode_hides_cross_file_codes_that_ci_still_sees
+test_local_exclusion_list_covers_every_no_external_sources_code


### PR DESCRIPTION
## Intent

Captain-approved 2026-09-05: take the 93 percent win from the lint-cost audit - implement option A. The LOCAL lint gate must stop following sourced libraries (drop ShellCheck's --external-sources) while retaining dataflow analysis, with measurements to prove the reduction (about 93 percent less CPU and worst-root memory 8.3 GB to ~0.56 GB on the incident's 7 roots). Because the local gate then can no longer see cross-file semantics, exclude locally exactly the four codes that need library context - SC1091, SC2034, SC2153, SC2329 - which continue to run in CI. Those four are the complete false-positive inventory of a no-external-sources pass over the canonical set; no other codes appear. CI, main, and merge-base-less runs keep the full --external-sources analysis with dataflow over the whole canonical set unchanged, so nothing is lost from the merge gate; what moves is only where a cross-file finding is first reported (local step to CI). Explicit-path and --fast invocations keep their current meaning. The 97 percent variant (also dropping dataflow locally), the fast-mode variant (option C), and the separate directive-only CI scoping/dedupe fix (follow each library once per file, source=/dev/null on nested or repeated inclusions) are NOT authorized - leave those parked. Ship it through the normal path.

## What Changed

- Run local changed-file lint once per root without `--external-sources`, while retaining dataflow analysis and excluding SC1091, SC2034, SC2153, and SC2329.
- Preserve full source-aware analysis for CI, main, merge-base-less, explicit-path, and `--fast` invocations.
- Add mode coverage, telemetry assertions, and reproducible measurements documenting roughly 93% lower CPU and peak memory usage.

## Risk Assessment

✅ Low: The change is bounded to local changed-file linting, preserves CI/main/merge-base-less and explicit/fast behavior, and the prior source-following and telemetry findings are correctly resolved.

## Testing

The successful baseline was supplemented with the focused lint behavior suite, a live changed-file lint showing source following disabled with zero followed directives, and a seven-root option-A measurement; all checks passed, with the measured option-A run using 1.81 CPU seconds and 191,971,328 bytes worst-process RSS.

<details>
<summary>Evidence: Live local changed-mode CLI transcript</summary>

Source: [Live local changed-mode CLI transcript](https://github.com/kunchenguid/firstmate/blob/7d4dd9a6234c6f8a4f6859847a90d029ad1eeb9b/.no-mistakes/evidence/fm/fm-lint-local-nox-optiona-r1/local-changed-mode-transcript.txt)

```text
fm-lint.sh: ShellCheck 0.11.0 (pinned 0.11.0)
fm-lint.sh: local changed-file mode; ShellCheck source following disabled
fm-lint-workflows.sh: actionlint 1.7.12 (pinned 1.7.12)
fm-lint-workflows.sh: 3 workflow files valid
```
</details>
<details>
<summary>Evidence: Live local changed-mode telemetry</summary>

Source: [Live local changed-mode telemetry](https://github.com/kunchenguid/firstmate/blob/7d4dd9a6234c6f8a4f6859847a90d029ad1eeb9b/.no-mistakes/evidence/fm/fm-lint-local-nox-optiona-r1/local-changed-mode-telemetry.tsv)

```text
format	fm-lint-telemetry-v1
git_head	3c0a789d09fdb80b9ee38722dc73144ef952e856
content_cksum	1600849615-71
shellcheck_version	0.11.0
analysis_mode	local
jobs	1
root_count	2
direct_lines	1969
direct_bytes	74734
source_directives	4
source_boundary_directives	2
source_followed_directives	0
source_target_count	3
shard_1_weight_bytes	51710
shard_2_weight_bytes	23024
wall_seconds	1
worker_wall_sum_seconds	0.81
max_worker_wall_seconds	0.54
user_seconds	0.69
system_seconds	0.02
max_worker_rss_kib	146544
worker_rss_sum_kib	282816
shellcheck_processes_start	0
shellcheck_processes_end	0
load_average_start	23.89/32.56/70.13
load_average_end	23.89/32.56/70.13
aggregate_cpu_percent_start	57.70
aggregate_cpu_percent_end	53.50
result_exit	0
```
</details>
<details>
<summary>Evidence: Seven-root option-A measurement summary</summary>

Source: [Seven-root option-A measurement summary](https://github.com/kunchenguid/firstmate/blob/7d4dd9a6234c6f8a4f6859847a90d029ad1eeb9b/.no-mistakes/evidence/fm/fm-lint-local-nox-optiona-r1/option-a-seven-root-summary.txt)

```text
ShellCheck version: 0.11.0
Mode: one no-external-sources, dataflow-enabled process per incident root
Roots: 7
cpu_seconds=1.81 worst_rss_bytes=191971328 bytes_allocated=0
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"54e9bdc45e71b6aad796c06fc1f31b219331ed4c","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>🔧 **Review** - 2 issues found → auto-fixed (2) ✅</summary>

- 🚨 `bin/fm-lint.sh:101` - The intent requires the local gate to “stop following sourced libraries,” but each worker still passes every root in its shard to one ShellCheck invocation. ShellCheck follows sourced files that are also invocation roots even without --external-sources; the new test helper explicitly acknowledges this at tests/fm-lint.test.sh:684-685. Thus a local change containing a caller and its sourced library in the same shard remains source-following and can reproduce the cost. Use one ShellCheck analysis per root within the bounded local workers.
- 🚨 `bin/fm-lint.sh:380` - The required “measurements to prove the reduction (about 93 percent less CPU and worst-root memory 8.3 GB to ~0.56 GB on the incident&#39;s 7 roots)” are absent. The diff adds telemetry labeling and functional tests, but no reproducible seven-root before/after measurement or recorded results demonstrating the required CPU and memory reduction.

🔧 Fix: Run local ShellCheck per root and document measurements
1 warning still open:

- ⚠️ `bin/fm-lint.sh:280` - Changed-file mode sets FOLLOW_SOURCES=0, but telemetry still computes source_followed_directives as every non-/dev/null directive at line 556. For example, locally linting changed bin/fm-afk-launch.sh reports its bin/fm-backend.sh directive as followed even though each per-root ShellCheck invocation omits --external-sources and cannot follow it. Set this metric to zero when source following is disabled so the measurement artifact accurately describes the new mode.

🔧 Fix: Correct local source-following telemetry
✅ Re-checked - no issues remain.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `bin/fm-test-run.sh --changed --exclude-family real-herdr-gated`
- <code>Baseline: `bin/fm-test-run.sh --changed --exclude-family real-herdr-gated`</code>
- `bin/fm-test-run.sh tests/fm-lint.test.sh`
- `bin/fm-lint.sh --jobs 1 --telemetry ~/.no-mistakes/evidence/01M1REA203A2YQDHWERY87ZAHX/local-changed-mode-telemetry.tsv`
- <code>Ran pinned ShellCheck 0.11.0 once per each of the seven incident roots with `--norc --exclude=SC1091,SC2034,SC2153,SC2329`, retaining dataflow and omitting `--external-sources`</code>
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
