### PR TITLE
feat(stow): enforce telegraphic syntax and proactive headroom in memory curation

### DIFF
--- a/.agents/skills/stow/SKILL.md
+++ b/.agents/skills/stow/SKILL.md
@@ -91,6 +91,9 @@ Every `/stow` invocation performs this complete pass, even when the session cont
    When a read-only shared entry appears to require one of those changes, leave it untouched, report the required change as an ownership exception, and route it to the primary owner.
 3. Build one whole-file retention plan before editing, ordered by likelihood of informing a future session.
    Keep in always-loaded memory only current captain preferences, authority and safety boundaries, recurring working style, fleet-wide or frequently relevant operating facts, and concise pointers that are expensive to rediscover.
+   Enforce cross-file deduplication: `data/captain.md` owns user preferences and federation policies; `data/learnings.md` owns technical telemetry and runtime gotchas.
+   Never duplicate a policy or invariant across both.
+   Format all retained entries in telegraphic invariant syntax (`Action/Rule: [Fact] [Constraint/Path]`), stripping conversational connective filler.
    Prefer offloading current but conditional, narrow, project-specific, or context-specific material to a live on-demand owner, and archive stale, superseded, or low-recurrence material to the cold tier.
    Retain lower-utility material only while budget remains.
 4. Reinforce and stamp.
@@ -107,9 +110,11 @@ Every `/stow` invocation performs this complete pass, even when the session cont
    `pinned` is exempt from this automatic decay step entirely.
 6. Consolidate every editable memory file as needed, not only the file apparently related to a new finding.
    Prefer one concise current rule or authoritative pointer over duplicate prose.
+   Introduce a proactive headroom target: aim to maintain at least 15% (or >= 1,500 tokens) of effective budget headroom.
+   When available headroom drops below this floor, execute telegram-style compression on verbose existing entries before admitting new non-essential learnings.
    Archive completed incident and release chronology, stale versions and paths, transient task state, resolved alternatives, old metrics, and report-sized procedures; merge or remove only superseded claims and duplicates whose facts are preserved elsewhere.
    Never plainly remove a unique current fact: every such exit must archive it with provenance in the recoverable cold tier or relocate it to a live JIT owner or a consolidation merge that preserves the fact.
-7. When the total is still over budget after decay and consolidation, make aggressive reduction the default, using editable files only and in this order: archive every editable stale, superseded, or low-utility entry that is eligible for archival; consolidate tighter; run the over-budget offload sweep below and autonomously relocate every eligible non-pinned conditional entry into an already-existing allowed owner only after that owner holds it; then, only when the convergence precondition below holds, archive eligible `aging` entries oldest-reinforced-first until within budget.
+7. When the total is still over budget after decay and consolidation, make aggressive reduction the default, using editable files only and in this order: archive every editable stale, superseded, or low-utility entry that is eligible for archival; consolidate tighter to recover the proactive headroom target; run the over-budget offload sweep below and autonomously relocate every eligible non-pinned conditional entry into an already-existing allowed owner only after that owner holds it; then, only when the convergence precondition below holds, archive eligible `aging` entries oldest-reinforced-first until within budget.
    A proposal, a future migration, or an accepted exception is never budget relief in this pass.
    Budget eviction considers only editable `aging` entries that carry a last-reinforced date and are not pending offload; a `<!--g-->` legacy-grace entry is ineligible until its grace cycle resolves, so eviction can neither cancel a promised grace cycle nor prefer just-validated entries over unvalidated ones.
    Convergence precondition: before evicting anything, total the eligible pool and check that archiving all of it would reach the budget; when even that cannot, skip the eviction rung entirely, archive nothing for budget reasons, and carry the concrete inability to the final step, naming the exempt pinned floor that crowds out the budget.

--- a/skills/stow/SKILL.md
+++ b/skills/stow/SKILL.md
@@ -37,6 +37,9 @@ Everything files to a local destination by default; an external system such as a
       This is the *only* path to an external or public system such as an issue tracker, hosted project board, or ticketing system.
       A configured git host remote, a `.github`/`.gitlab` folder, or any other signal that a tracker probably exists is never by itself grounds to file anything there - never route externally on inference.
    2. **Otherwise - the local convention the project or user already has.** The discovered project memory file for project facts, operational gotchas, and standing decisions; an existing `TODO`/`BACKLOG`/`NOTES` file for undone next steps; a discovered user-level memory file for user preferences *when one happens to be accessible* - a bonus if reachable, never an assumption or a requirement.
+      Enforce cross-file deduplication: `data/captain.md` owns user preferences and federation policies; `data/learnings.md` owns technical telemetry and runtime gotchas (or user-level memory versus project memory in generic environments).
+      Never duplicate a policy or invariant across both.
+      Format all retained entries in telegraphic invariant syntax (`Action/Rule: [Fact] [Constraint/Path]`), stripping conversational connective filler.
       This is the only tier that writes findings into a tracked, shared file or outside the current directory, and only because the user already established that destination.
    3. **Fallback - `.stow-notes.md` in the current directory, for every finding-kind.** When no existing convention fits, don't improvise a location or invent an ad hoc filename.
       In a git worktree, first verify `.stow-notes.md` is not already tracked in the index; if it is tracked, do not write private findings there - report that the fallback is blocked until the user chooses a safe destination.
@@ -63,14 +66,19 @@ Everything files to a local destination by default; an external system such as a
    Then classify the finding against what is already there: new, duplicate, superseding an existing entry, or evidence that an existing entry is now obsolete.
    Write the considered replacement that classification implies - a duplicate folds into the entry that already carries it, a superseding finding rewrites the entry it supersedes, and an obsolete entry is refreshed, archived, or replaced in a way that preserves its fact in the same pass - rather than blindly appending a new entry or overwriting the file wholesale.
    Prefer a one-sentence rewrite of an existing entry over a second entry saying nearly the same thing.
+   Format all retained entries in telegraphic invariant syntax (`Action/Rule: [Fact] [Constraint/Path]`), stripping conversational connective filler.
    A superseded body worth keeping leaves through one of step 7's exits, so it stays recoverable instead of being lost silently in the rewrite.
    Mark each entry written into a memory file or `.stow-notes.md` per the tier contract below, but never add tier markers to an existing `TODO`/`BACKLOG`/`NOTES` file.
    File each undone next step with what it is waiting on, when it is genuinely blocked on something.
 
 7. **Curate every memory file this pass has open, not only the one a finding routes to.**
    Evaluate each dated entry against its tier clock per the tier contract below, refreshing what current evidence re-validates and archiving what stays stale.
+   Enforce cross-file deduplication: `data/captain.md` owns user preferences and federation policies; `data/learnings.md` owns technical telemetry and runtime gotchas (or user-level memory versus project memory in generic environments).
+   Never duplicate a policy or invariant across both.
    Archive what is no longer current, including completed chronology, stale versions and paths, transient task state, resolved alternatives, old metrics, and report-sized procedures; merge or remove only superseded claims and duplicates whose facts are preserved elsewhere.
    Prefer one concise current rule, or a pointer to the authoritative source, over duplicate prose.
+   Introduce a proactive headroom target: aim to maintain at least 15% (or >= 1,500 tokens) of effective budget headroom.
+   When available headroom drops below this floor, execute telegram-style compression on verbose existing entries before admitting new non-essential learnings.
    Never plainly remove a unique current fact: every such exit must archive it with provenance in the recoverable cold tier or relocate it to a live on-demand owner or a consolidation merge that preserves the fact.
    This is an accuracy discipline, not a length target - a stale entry misleads the next session; a current one earns its place.
    A `.stow-notes.md` note has exactly five exits: promotion into a shared, tracked file the user approves; folding into a discovered user-level memory file; archiving to the local, never-loaded archive file; a user-approved move into an on-demand-loaded home (a skill or scoped instruction file), executed through the user's own change process rather than by this skill; or deletion of a duplicate already preserved by a stronger owner - do not invent another.


### PR DESCRIPTION
Enhance Firstmate's /stow skill (.agents/skills/stow/SKILL.md and skills/stow/SKILL.md) to prevent memory cluttering and preserve token headroom across future sessions.

- Cross-file SSoT deduplication: data/captain.md owns preferences/policies, data/learnings.md owns runtime telemetry/gotchas.
- Telegraphic invariant syntax: Action/Rule: [Fact] [Constraint/Path].
- Proactive headroom target: maintain at least 15% (or >= 1,500 tokens) effective budget headroom, applying telegram-style compression when below floor.