### PR TITLE
fix(bin): stop reading an unanswered backend probe as a dead endpoint

### DIFF
--- a/bin/fm-crew-state.sh
+++ b/bin/fm-crew-state.sh
@@ -566,18 +566,44 @@ fi
 # log as the current state.
 [ -n "$BACKEND_TARGET" ] || emit unknown none "no backend target recorded"
 if ! pane_readable "$BACKEND_TARGET"; then
-  # A failed capture is not evidence the pane is gone: the herdr CLI can error
-  # or stall under load while the pane is alive, so a busy box would otherwise
-  # score dozens of live claims dead. Only the recovery-grade classifier's
-  # authoritative-absence verdict (`missing`, a successful pane read answering
-  # pane_not_found) may say gone; every other verdict means the backend failed
-  # to answer, which the stale sweep scores as unproven and keeps.
+  # A failed capture is not itself evidence the pane is gone: the herdr CLI can
+  # error or stall under load while the pane is alive, so a busy box would
+  # otherwise score dozens of live claims dead. The recovery-grade classifier
+  # (fm_backend_agent_state) separates the outcomes for herdr:
+  #   missing - a successful pane get answered pane_not_found: the endpoint is
+  #             authoritatively absent.
+  #   dead    - a successful pane get found the pane but agent get answered
+  #             agent_not_found: the worker agent is gone (husk pane), still
+  #             positive death evidence for reclaim.
+  #   alive   - the endpoint and its agent answered and only the heavy
+  #             scrollback read failed, so the live state is classified by the
+  #             normal flow below instead of being discarded.
+  #   anything else - the cheap pane get / agent get calls themselves failed
+  #             to answer, which is unknown, never death.
   if [ "$TASK_BACKEND" = herdr ]; then
     AGENT_STATE=$(fm_backend_agent_state herdr "$BACKEND_TARGET")
-    [ "$AGENT_STATE" = missing ] \
-      || emit unknown none "backend unreachable (herdr read failed; endpoint state: $AGENT_STATE)"
+  else
+    AGENT_STATE=none
   fi
-  emit unknown none "backend target gone: $BACKEND_TARGET"
+  case "$TASK_BACKEND:$AGENT_STATE" in
+    herdr:alive)
+      # The endpoint and its agent answered and only the heavy scrollback
+      # read failed, so the live state is classified by the normal flow
+      # below instead of being discarded.
+      ;;
+    herdr:missing)
+      emit unknown none "backend target gone: $BACKEND_TARGET"
+      ;;
+    herdr:dead)
+      emit unknown none "backend target gone: $BACKEND_TARGET (agent gone, pane shell remains)"
+      ;;
+    herdr:*)
+      emit unknown none "backend unreachable (herdr endpoint state: $AGENT_STATE)"
+      ;;
+    *)
+      emit unknown none "backend target gone: $BACKEND_TARGET"
+      ;;
+  esac
 fi
 
 # Secondmates idle on their own watcher (idle pane = healthy), so the busy

--- a/bin/fm-crew-state.sh
+++ b/bin/fm-crew-state.sh
@@ -561,44 +561,44 @@ fi
 # The run-step path above already handled any crew with a run, regardless of pane
 # liveness, so a finished-but-pane-closed crew never reaches here. Down here there
 # is no run to consult, so only positive evidence that the target is gone may
-# read as death - a backend that failed to answer is unknown, never death - and
-# either way this reports unknown rather than trusting a possibly-stale status
-# log as the current state.
+# read as death - a backend that failed to answer is unknown, never death, for
+# both classifier-backed backends (tmux and herdr) - and either way this reports
+# unknown rather than trusting a possibly-stale status log as the current state.
 [ -n "$BACKEND_TARGET" ] || emit unknown none "no backend target recorded"
 if ! pane_readable "$BACKEND_TARGET"; then
-  # A failed capture is not itself evidence the pane is gone: the herdr CLI can
-  # error or stall under load while the pane is alive, so a busy box would
-  # otherwise score dozens of live claims dead. The recovery-grade classifier
-  # (fm_backend_agent_state) separates the outcomes for herdr:
-  #   missing - a successful pane get answered pane_not_found: the endpoint is
-  #             authoritatively absent.
-  #   dead    - a successful pane get found the pane but agent get answered
-  #             agent_not_found: the worker agent is gone (husk pane), still
-  #             positive death evidence for reclaim.
+  # A failed probe is not itself evidence the pane is gone: the herdr CLI can
+  # error or stall under load, and tmux can fail to answer on a trimmed PATH or
+  # a socket hiccup, while the pane is alive - a busy box would otherwise score
+  # dozens of live claims dead. Both backends own a recovery-grade classifier
+  # (fm_backend_agent_state), which separates the outcomes:
+  #   missing - the endpoint is authoritatively absent: herdr's pane get
+  #             answered pane_not_found; tmux's successful window inventory
+  #             omitted the exact recorded window.
+  #   dead    - the endpoint exists but confidently has no agent (herdr's agent
+  #             get answered agent_not_found; tmux's readable foreground process
+  #             group is nothing but shells), still positive death evidence.
   #   alive   - the endpoint and its agent answered and only the heavy
   #             scrollback read failed, so the live state is classified by the
   #             normal flow below instead of being discarded.
-  #   anything else - the cheap pane get / agent get calls themselves failed
-  #             to answer, which is unknown, never death.
-  if [ "$TASK_BACKEND" = herdr ]; then
-    AGENT_STATE=$(fm_backend_agent_state herdr "$BACKEND_TARGET")
-  else
-    AGENT_STATE=none
-  fi
+  #   anything else - the cheap probes themselves failed to answer or
+  #             contradicted themselves, which is unknown, never death.
+  # Backends with no classifier (orca, zellij, and cmux all report unverified)
+  # keep their historical capture-failure-means-gone reading.
+  case "$TASK_BACKEND" in
+    tmux|herdr) AGENT_STATE=$(fm_backend_agent_state "$TASK_BACKEND" "$BACKEND_TARGET") ;;
+    *) AGENT_STATE=none ;;
+  esac
   case "$TASK_BACKEND:$AGENT_STATE" in
-    herdr:alive)
-      # The endpoint and its agent answered and only the heavy scrollback
-      # read failed, so the live state is classified by the normal flow
-      # below instead of being discarded.
+    tmux:alive|herdr:alive)
       ;;
-    herdr:missing)
+    tmux:missing|herdr:missing)
       emit unknown none "backend target gone: $BACKEND_TARGET"
       ;;
-    herdr:dead)
+    tmux:dead|herdr:dead)
       emit unknown none "backend target gone: $BACKEND_TARGET (agent gone, pane shell remains)"
       ;;
-    herdr:*)
-      emit unknown none "backend unreachable (herdr endpoint state: $AGENT_STATE)"
+    tmux:*|herdr:*)
+      emit unknown none "backend unreachable ($TASK_BACKEND endpoint state: $AGENT_STATE)"
       ;;
     *)
       emit unknown none "backend target gone: $BACKEND_TARGET"

--- a/bin/fm-crew-state.sh
+++ b/bin/fm-crew-state.sh
@@ -560,10 +560,25 @@ fi
 # --- fallback: no run attributed to this crew ------------------------------
 # The run-step path above already handled any crew with a run, regardless of pane
 # liveness, so a finished-but-pane-closed crew never reaches here. Down here there
-# is no run to consult, so a dead/unreadable target means the crew is gone: report
-# unknown rather than trusting a possibly-stale status log as the current state.
+# is no run to consult, so only positive evidence that the target is gone may
+# read as death - a backend that failed to answer is unknown, never death - and
+# either way this reports unknown rather than trusting a possibly-stale status
+# log as the current state.
 [ -n "$BACKEND_TARGET" ] || emit unknown none "no backend target recorded"
-pane_readable "$BACKEND_TARGET" || emit unknown none "backend target gone: $BACKEND_TARGET"
+if ! pane_readable "$BACKEND_TARGET"; then
+  # A failed capture is not evidence the pane is gone: the herdr CLI can error
+  # or stall under load while the pane is alive, so a busy box would otherwise
+  # score dozens of live claims dead. Only the recovery-grade classifier's
+  # authoritative-absence verdict (`missing`, a successful pane read answering
+  # pane_not_found) may say gone; every other verdict means the backend failed
+  # to answer, which the stale sweep scores as unproven and keeps.
+  if [ "$TASK_BACKEND" = herdr ]; then
+    AGENT_STATE=$(fm_backend_agent_state herdr "$BACKEND_TARGET")
+    [ "$AGENT_STATE" = missing ] \
+      || emit unknown none "backend unreachable (herdr read failed; endpoint state: $AGENT_STATE)"
+  fi
+  emit unknown none "backend target gone: $BACKEND_TARGET"
+fi
 
 # Secondmates idle on their own watcher (idle pane = healthy), so the busy
 # state is not meaningful for them; read their state from the status log only.

--- a/bin/fm-crew-state.sh
+++ b/bin/fm-crew-state.sh
@@ -61,7 +61,13 @@
 #      `resolved` never become current state or detail.
 #   5. Missing meta or torn-down worktree: report unknown · none. If no run is
 #      attributed to this crew, a dead endpoint also reports unknown · none rather
-#      than trusting a stale status log.
+#      than trusting a stale status log. On tmux and herdr, which own a
+#      recovery-grade classifier, only its positive death evidence reads as gone
+#      (the endpoint is authoritatively absent, or its pane holds no agent); an
+#      endpoint that merely failed to answer reports unknown · none as
+#      unreachable, and an alive endpoint whose scrollback read failed is still
+#      classified by step 4. Backends with no classifier keep reading a failed
+#      capture as gone. The fallback's own comment owns the per-verdict rules.
 #
 # Read-only and side-effect free. Always exits 0 on a successful read regardless
 # of state; exit 2 only on a usage error (no id).

--- a/bin/fm-crew-state.sh
+++ b/bin/fm-crew-state.sh
@@ -562,18 +562,25 @@ fi
 # liveness, so a finished-but-pane-closed crew never reaches here. Down here there
 # is no run to consult, so only positive evidence that the target is gone may
 # read as death - a backend that failed to answer is unknown, never death, for
-# both classifier-backed backends (tmux and herdr) - and either way this reports
-# unknown rather than trusting a possibly-stale status log as the current state.
+# both classifier-backed backends (tmux and herdr) - and every death-class
+# verdict reports unknown rather than trusting a possibly-stale status log as
+# the current state.
 [ -n "$BACKEND_TARGET" ] || emit unknown none "no backend target recorded"
 if ! pane_readable "$BACKEND_TARGET"; then
   # A failed probe is not itself evidence the pane is gone: the herdr CLI can
-  # error or stall under load, and tmux can fail to answer on a trimmed PATH or
-  # a socket hiccup, while the pane is alive - a busy box would otherwise score
-  # dozens of live claims dead. Both backends own a recovery-grade classifier
-  # (fm_backend_agent_state), which separates the outcomes:
+  # error or stall under load, and tmux can fail to be executed at all (a
+  # trimmed PATH) or answer non-definitively, while the pane is alive - a busy
+  # box would otherwise score dozens of live claims dead. Both backends own a
+  # recovery-grade classifier (fm_backend_agent_state), which separates the
+  # outcomes:
   #   missing - the endpoint is authoritatively absent: herdr's pane get
   #             answered pane_not_found; tmux's successful window inventory
-  #             omitted the exact recorded window.
+  #             omitted the exact recorded window, or tmux gave one of its
+  #             definitive no-session/no-server/no-socket responses (which
+  #             fm_backend_tmux_agent_state owns as death, since fm-bootstrap
+  #             and fm-session-start depend on it to license a respawn after a
+  #             genuine server death - a socket-connection failure is NOT
+  #             covered by the unknown-never-death rule above).
   #   dead    - the endpoint exists but confidently has no agent (herdr's agent
   #             get answered agent_not_found; tmux's readable foreground process
   #             group is nothing but shells), still positive death evidence.

--- a/tests/fm-backend-herdr.test.sh
+++ b/tests/fm-backend-herdr.test.sh
@@ -23,6 +23,14 @@ command -v jq >/dev/null 2>&1 || { echo "skip: jq not found (required by the her
 herdr_forget_inherited_pane
 
 TMP_ROOT=$(fm_test_tmproot fm-backend-herdr-tests)
+# Pin the ambient-home default to a marker-free fixture: FM_HOME resolves to
+# the suite's own root when unset, and a secondmate-marked checkout (any
+# treehouse crew home carries .fm-secondmate-home) would flip the default
+# workspace label to 2ndmate-*, silently changing placement behavior for
+# every test that does not set FM_HOME itself. Per-test FM_HOME prefixes
+# still override this default.
+mkdir -p "$TMP_ROOT/ambient-home"
+export FM_HOME="$TMP_ROOT/ambient-home"
 export FM_BACKEND_HERDR_SUBMIT_MIN_SLEEP=0
 
 # make_herdr_fakebin: a `herdr` stub that logs every invocation (one line,

--- a/tests/fm-crew-state.test.sh
+++ b/tests/fm-crew-state.test.sh
@@ -85,9 +85,10 @@ set -u
 # FM_FAKE_TMUX_MISSING: the window is authoritatively gone - every addressed
 # call fails, but the session inventory still answers successfully and simply
 # omits the window, which is what proves absence.
-# FM_FAKE_TMUX_UNREADABLE: tmux itself cannot answer (trimmed PATH, socket
-# hiccup, transient failure) - even the inventory fails, with a message that
-# is not one of the definitive no-session/no-server responses.
+# FM_FAKE_TMUX_UNREADABLE: tmux itself cannot answer - it fails to execute (a
+# trimmed PATH) or errors non-definitively - so even the inventory fails, with
+# a message that is NOT one of the definitive no-session/no-server/no-socket
+# responses that fm_backend_tmux_agent_state owns as death.
 [ "${FM_FAKE_TMUX_UNREADABLE:-0}" = 1 ] && { printf 'no current client\n' >&2; exit 1; }
 case "${1:-}" in
   list-windows)
@@ -1165,10 +1166,14 @@ test_dead_window_ignores_stale_status_log() {
 
 # Regression (2026-09 G7 stale-claim incident, tmux half): the default backend
 # reached the same false-death path as herdr. A tmux that cannot answer at all
-# - a trimmed PATH, a TMUX_TMPDIR mismatch, a socket hiccup - made every live
-# crew report "backend target gone", the text the stale sweep matches as
-# positive death. Only a successful window inventory that omits the recorded
-# window proves absence; a tmux that failed to answer is unknown, never death.
+# - a trimmed PATH, or any non-definitive error - made every live crew report
+# "backend target gone", the text the stale sweep matches as positive death.
+# Absence must be proved by tmux's own answer: a window inventory that omits
+# the recorded window, or one of its definitive no-session/no-server/no-socket
+# responses. Anything else is a tmux that failed to answer: unknown, never
+# death. (A socket-connection error is deliberately NOT in this test's scope -
+# fm_backend_tmux_agent_state classifies it as `missing` so fm-bootstrap and
+# fm-session-start can respawn after a genuine server death.)
 test_no_run_tmux_unreadable_reads_unreachable_not_gone() {
   reset_fakes
   local d; d=$(new_case tmux-unreadable)

--- a/tests/fm-crew-state.test.sh
+++ b/tests/fm-crew-state.test.sh
@@ -82,7 +82,19 @@ SH
   cat > "$fb/tmux" <<'SH'
 #!/usr/bin/env bash
 set -u
+# FM_FAKE_TMUX_MISSING: the window is authoritatively gone - every addressed
+# call fails, but the session inventory still answers successfully and simply
+# omits the window, which is what proves absence.
+# FM_FAKE_TMUX_UNREADABLE: tmux itself cannot answer (trimmed PATH, socket
+# hiccup, transient failure) - even the inventory fails, with a message that
+# is not one of the definitive no-session/no-server responses.
+[ "${FM_FAKE_TMUX_UNREADABLE:-0}" = 1 ] && { printf 'no current client\n' >&2; exit 1; }
 case "${1:-}" in
+  list-windows)
+    # A successful but empty inventory: it omits the crew's window, so absence
+    # is proved by the answer rather than by an addressed call failing. Only
+    # reached once display-message has already failed.
+    ;;
   display-message)
     [ "${FM_FAKE_TMUX_MISSING:-0}" = 1 ] && exit 1
     printf '%%1\n' ;;
@@ -178,13 +190,14 @@ reset_fakes() {
   FM_FAKE_BUSY=0
   FM_FAKE_BUSY_TEXT=
   FM_FAKE_TMUX_MISSING=0
+  FM_FAKE_TMUX_UNREADABLE=0
   FM_FAKE_HERDR_BUSY=0
   FM_FAKE_HERDR_MISSING=0
   FM_FAKE_HERDR_READ_FAIL=0
   FM_FAKE_HERDR_HUSK=0
   FM_FAKE_HERDR_AGENT_STATUS=""
   FM_FAKE_CI_LOGS=""
-  export FM_FAKE_AXI_STATUS FM_FAKE_AXI_STATUS_RUN FM_FAKE_RUNS_LIST FM_FAKE_BUSY FM_FAKE_BUSY_TEXT FM_FAKE_TMUX_MISSING
+  export FM_FAKE_AXI_STATUS FM_FAKE_AXI_STATUS_RUN FM_FAKE_RUNS_LIST FM_FAKE_BUSY FM_FAKE_BUSY_TEXT FM_FAKE_TMUX_MISSING FM_FAKE_TMUX_UNREADABLE
   export FM_FAKE_HERDR_BUSY FM_FAKE_HERDR_MISSING FM_FAKE_HERDR_READ_FAIL FM_FAKE_HERDR_HUSK FM_FAKE_HERDR_AGENT_STATUS FM_FAKE_CI_LOGS
 }
 
@@ -892,9 +905,16 @@ test_no_run_herdr_cli_failure_reads_unreachable_not_gone() {
   local d; d=$(new_case herdr-cli-dead)
   make_repo_on_branch "$d/wt" fm/feat-herdr-cli
   make_fakebin "$d" >/dev/null
-  # A herdr that cannot answer at all: every invocation exits non-zero, the
-  # busiest-box form of a stalled CLI (capture and pane get alike fail).
-  printf '#!/usr/bin/env bash\nexit 1\n' > "$d/fakebin/herdr"
+  # A herdr whose server is up but whose endpoint calls cannot answer at all:
+  # every pane/agent invocation exits non-zero, the busiest-box form of a
+  # stalled CLI (capture and pane get alike fail). `status` still answers so
+  # the reader probes the endpoint instead of waiting out a server start.
+  cat > "$d/fakebin/herdr" <<'SH'
+#!/usr/bin/env bash
+set -u
+[ "${1:-}" = status ] && { printf '{"server":{"running":true}}\n'; exit 0; }
+exit 1
+SH
   chmod +x "$d/fakebin/herdr"
   fm_write_meta "$d/state/feat-herdr-cli.meta" "window=default:w1:p2" "worktree=$d/wt" "kind=ship" \
     "backend=herdr" "harness=claude"
@@ -1139,7 +1159,33 @@ test_dead_window_ignores_stale_status_log() {
   assert_contains "$out" "state: unknown" "dead window -> unknown"
   assert_contains "$out" "source: none" "dead window -> none source"
   assert_not_contains "$out" "source: status-log" "dead window does not reuse stale log"
+  assert_contains "$out" "backend target gone" "an inventory that omits the window is positive death evidence"
   pass "dead window ignores stale status log"
+}
+
+# Regression (2026-09 G7 stale-claim incident, tmux half): the default backend
+# reached the same false-death path as herdr. A tmux that cannot answer at all
+# - a trimmed PATH, a TMUX_TMPDIR mismatch, a socket hiccup - made every live
+# crew report "backend target gone", the text the stale sweep matches as
+# positive death. Only a successful window inventory that omits the recorded
+# window proves absence; a tmux that failed to answer is unknown, never death.
+test_no_run_tmux_unreadable_reads_unreachable_not_gone() {
+  reset_fakes
+  local d; d=$(new_case tmux-unreadable)
+  make_repo_on_branch "$d/wt" fm/feat-tmux-unread
+  make_fakebin "$d" >/dev/null
+  fm_write_meta "$d/state/feat-tmux-unread.meta" "window=fm:fm-feat-tmux-unread" \
+    "worktree=$d/wt" "kind=ship"
+  printf 'done: old completion event\n' > "$d/state/feat-tmux-unread.status"
+  FM_FAKE_AXI_STATUS=""
+  FM_FAKE_RUNS_LIST=""
+  FM_FAKE_TMUX_UNREADABLE=1
+  local out; out=$(run_crew_state "$d" feat-tmux-unread)
+  assert_contains "$out" "state: unknown" "an unreadable tmux must stay unknown"
+  assert_contains "$out" "source: none" "an unreadable tmux has no state source"
+  assert_contains "$out" "backend unreachable" "an unreadable tmux reads as unreachable, not gone"
+  assert_not_contains "$out" "backend target gone" "an unreadable tmux is not positive death evidence"
+  pass "a tmux that fails to answer reads unknown/unreachable, never gone"
 }
 
 # A closed/unreadable pane must NOT mask an authoritative run-step: judge by the
@@ -1858,6 +1904,7 @@ test_no_run_idle_pane_paused
 test_no_run_idle_pane_custom_paused_verb
 test_no_run_idle_secondmate_resolved_event_not_state
 test_dead_window_ignores_stale_status_log
+test_no_run_tmux_unreadable_reads_unreachable_not_gone
 test_dead_window_still_reports_terminal_run_step
 test_dead_window_still_reports_active_run_step
 test_no_timeout_uses_perl_bound

--- a/tests/fm-crew-state.test.sh
+++ b/tests/fm-crew-state.test.sh
@@ -108,13 +108,25 @@ case "${1:-}" in
     case "${2:-}" in
       read)
         [ "${FM_FAKE_HERDR_MISSING:-0}" = 1 ] && exit 1
+        [ "${FM_FAKE_HERDR_READ_FAIL:-0}" = 1 ] && exit 1
         if [ "${FM_FAKE_HERDR_BUSY:-0}" = 1 ]; then printf 'work in progress\nesc to interrupt\n'
         else printf 'all quiet\n> \n'; fi
+        exit 0 ;;
+      get)
+        if [ "${FM_FAKE_HERDR_MISSING:-0}" = 1 ]; then
+          printf '{"error":{"code":"pane_not_found","message":"no such pane"}}\n'
+          exit 1
+        fi
+        printf '{"result":{"pane":{"pane_id":"%s"}}}\n' "${3:-}"
         exit 0 ;;
     esac ;;
   agent)
     case "${2:-}" in
       get)
+        if [ "${FM_FAKE_HERDR_HUSK:-0}" = 1 ]; then
+          printf '{"error":{"code":"agent_not_found","message":"no agent in pane"}}\n'
+          exit 0
+        fi
         [ -n "${FM_FAKE_HERDR_AGENT_STATUS:-}" ] || exit 1
         printf '{"result":{"agent":{"agent_status":"%s"}}}\n' "$FM_FAKE_HERDR_AGENT_STATUS"
         exit 0 ;;
@@ -168,10 +180,12 @@ reset_fakes() {
   FM_FAKE_TMUX_MISSING=0
   FM_FAKE_HERDR_BUSY=0
   FM_FAKE_HERDR_MISSING=0
+  FM_FAKE_HERDR_READ_FAIL=0
+  FM_FAKE_HERDR_HUSK=0
   FM_FAKE_HERDR_AGENT_STATUS=""
   FM_FAKE_CI_LOGS=""
   export FM_FAKE_AXI_STATUS FM_FAKE_AXI_STATUS_RUN FM_FAKE_RUNS_LIST FM_FAKE_BUSY FM_FAKE_BUSY_TEXT FM_FAKE_TMUX_MISSING
-  export FM_FAKE_HERDR_BUSY FM_FAKE_HERDR_MISSING FM_FAKE_HERDR_AGENT_STATUS FM_FAKE_CI_LOGS
+  export FM_FAKE_HERDR_BUSY FM_FAKE_HERDR_MISSING FM_FAKE_HERDR_READ_FAIL FM_FAKE_HERDR_HUSK FM_FAKE_HERDR_AGENT_STATUS FM_FAKE_CI_LOGS
 }
 
 # --- run-object fixtures (TOON, as `no-mistakes axi status` emits) -----------
@@ -893,6 +907,57 @@ test_no_run_herdr_cli_failure_reads_unreachable_not_gone() {
   assert_contains "$out" "backend unreachable" "a failed herdr CLI must read as unreachable, not gone"
   assert_not_contains "$out" "backend target gone" "a failed herdr CLI is not positive death evidence"
   pass "a herdr CLI that fails to answer reads unknown/unreachable, never gone"
+}
+
+# Decision follow-up (2026-09-05 review): an `alive` endpoint answer is
+# authoritative even when the heavy scrollback read failed - the live state is
+# classified by the normal flow, never discarded as unreachable.
+test_no_run_herdr_alive_with_failed_read_stays_live() {
+  command -v jq >/dev/null 2>&1 || { pass "herdr alive/read-fail test skipped without jq"; return; }
+  reset_fakes
+  local d; d=$(new_case herdr-alive-readfail)
+  make_repo_on_branch "$d/wt" fm/feat-herdr-alive
+  make_fakebin "$d" >/dev/null
+  fm_write_meta "$d/state/feat-herdr-alive.meta" "window=default:w1:p2" "worktree=$d/wt" "kind=ship" \
+    "backend=herdr" "harness=claude"
+  FM_FAKE_AXI_STATUS=""
+  FM_FAKE_RUNS_LIST=""
+  FM_FAKE_TMUX_MISSING=1
+  # The 200-line scrollback read fails while the cheap pane get / agent get
+  # pair answers: the pane is present and its agent is working.
+  FM_FAKE_HERDR_READ_FAIL=1
+  FM_FAKE_HERDR_AGENT_STATUS=working
+  local out; out=$(run_crew_state "$d" feat-herdr-alive)
+  assert_contains "$out" "state: working" "an alive endpoint with a failed scrollback read stays live"
+  assert_not_contains "$out" "backend unreachable" "an authoritative alive answer is never unreachable"
+  assert_not_contains "$out" "backend target gone" "an authoritative alive answer is never death"
+  pass "an alive endpoint whose scrollback read failed stays working"
+}
+
+# Decision follow-up (2026-09-05 review): a husk pane (pane present,
+# agent_not_found) is authoritative death evidence - it keeps the gone-class
+# text so the stale sweep may still reclaim it, never unknown/unreachable.
+test_no_run_herdr_husk_dead_still_reads_gone() {
+  command -v jq >/dev/null 2>&1 || { pass "herdr husk test skipped without jq"; return; }
+  reset_fakes
+  local d; d=$(new_case herdr-husk-dead)
+  make_repo_on_branch "$d/wt" fm/feat-herdr-husk
+  make_fakebin "$d" >/dev/null
+  fm_write_meta "$d/state/feat-herdr-husk.meta" "window=default:w1:p2" "worktree=$d/wt" "kind=ship" \
+    "backend=herdr" "harness=claude"
+  FM_FAKE_AXI_STATUS=""
+  FM_FAKE_RUNS_LIST=""
+  FM_FAKE_TMUX_MISSING=1
+  # The pane exists and answers pane get, but no agent is registered in it,
+  # and the scrollback read fails besides.
+  FM_FAKE_HERDR_READ_FAIL=1
+  FM_FAKE_HERDR_HUSK=1
+  local out; out=$(run_crew_state "$d" feat-herdr-husk)
+  assert_contains "$out" "state: unknown" "a husk pane has no live current state"
+  assert_contains "$out" "backend target gone" "a husk pane keeps its gone-class death evidence"
+  assert_contains "$out" "agent gone, pane shell remains" "the husk verdict names what actually died"
+  assert_not_contains "$out" "backend unreachable" "a husk pane is not an unreachable backend"
+  pass "a husk pane (agent gone) still reads gone for reclaim"
 }
 
 # Regression (2026-07 herdr false-surface incident, now solved semantically):
@@ -1783,6 +1848,8 @@ test_no_run_footer_text_alone_is_not_working
 test_no_run_grok_uses_isolated_fallback
 test_no_run_herdr_unknown_uses_backend_capture
 test_no_run_herdr_cli_failure_reads_unreachable_not_gone
+test_no_run_herdr_alive_with_failed_read_stays_live
+test_no_run_herdr_husk_dead_still_reads_gone
 test_no_run_herdr_idle_agent_status_outranked_by_record
 test_no_run_herdr_idle_agent_status_and_idle_record_stays_idle
 test_no_run_idle_pane_uses_log

--- a/tests/fm-crew-state.test.sh
+++ b/tests/fm-crew-state.test.sh
@@ -865,6 +865,36 @@ test_no_run_herdr_unknown_uses_backend_capture() {
   pass "herdr's native busy verdict reads working with no record present"
 }
 
+# Regression (2026-09 G7 stale-claim incident): a herdr CLI that errors or
+# stalls under load made pane_readable's capture fail, and the fallback read
+# that single failure as "backend target gone" - text the stale sweep matches
+# as positive death - so a busy box briefly scored dozens of live claims dead.
+# The reader must separate the two outcomes: only a successful herdr answer
+# proving the pane absent may say gone; a CLI that failed to answer is unknown
+# and unreachable, never death.
+test_no_run_herdr_cli_failure_reads_unreachable_not_gone() {
+  command -v jq >/dev/null 2>&1 || { pass "herdr cli-failure fallback skipped without jq"; return; }
+  reset_fakes
+  local d; d=$(new_case herdr-cli-dead)
+  make_repo_on_branch "$d/wt" fm/feat-herdr-cli
+  make_fakebin "$d" >/dev/null
+  # A herdr that cannot answer at all: every invocation exits non-zero, the
+  # busiest-box form of a stalled CLI (capture and pane get alike fail).
+  printf '#!/usr/bin/env bash\nexit 1\n' > "$d/fakebin/herdr"
+  chmod +x "$d/fakebin/herdr"
+  fm_write_meta "$d/state/feat-herdr-cli.meta" "window=default:w1:p2" "worktree=$d/wt" "kind=ship" \
+    "backend=herdr" "harness=claude"
+  FM_FAKE_AXI_STATUS=""
+  FM_FAKE_RUNS_LIST=""
+  FM_FAKE_TMUX_MISSING=1
+  local out; out=$(run_crew_state "$d" feat-herdr-cli)
+  assert_contains "$out" "state: unknown" "a failed herdr CLI must stay unknown"
+  assert_contains "$out" "source: none" "a failed herdr CLI has no state source"
+  assert_contains "$out" "backend unreachable" "a failed herdr CLI must read as unreachable, not gone"
+  assert_not_contains "$out" "backend target gone" "a failed herdr CLI is not positive death evidence"
+  pass "a herdr CLI that fails to answer reads unknown/unreachable, never gone"
+}
+
 # Regression (2026-07 herdr false-surface incident, now solved semantically):
 # herdr's agent.get reports generation state ("working" only while the model is
 # actively streaming - docs/herdr-backend.md "Busy state"), not "this crew's
@@ -1752,6 +1782,7 @@ test_no_run_busy_pane
 test_no_run_footer_text_alone_is_not_working
 test_no_run_grok_uses_isolated_fallback
 test_no_run_herdr_unknown_uses_backend_capture
+test_no_run_herdr_cli_failure_reads_unreachable_not_gone
 test_no_run_herdr_idle_agent_status_outranked_by_record
 test_no_run_herdr_idle_agent_status_and_idle_record_stays_idle
 test_no_run_idle_pane_uses_log


### PR DESCRIPTION
## Intent

Captain's order, 2026-09-05: "go close the last 2 gaps." Gap G7 (stale-claim reclaim) fails its automated reading only because bin/fm-crew-state.sh reports a task's endpoint as "backend target gone" whenever the herdr CLI errors or stalls under load, so a busy box briefly scores dozens of live claims as dead (76 at 02:4x EDT versus 9 five minutes later on an idle box). The sweep in bin/fm-stale-sweep.sh trusts that text as positive evidence of death. Make the reader tell the truth: a pane that is absent is gone; a CLI that failed to answer is unknown.

## What Changed

- `bin/fm-crew-state.sh`: in the no-run fallback, a failed pane capture no longer unconditionally emits `backend target gone`. For the classifier-backed backends (tmux and herdr) it now consults `fm_backend_agent_state` and branches per verdict — `missing`/`dead` keep the gone-class text (the `dead` case naming it `agent gone, pane shell remains`), `alive` falls through to normal state classification instead of being discarded, and any other verdict emits `backend unreachable (<backend> endpoint state: …)`. Backends without a classifier (orca, zellij, cmux) keep the previous capture-failure-means-gone reading.
- `tests/fm-crew-state.test.sh`: extends the fake `tmux`/`herdr` binaries with `FM_FAKE_TMUX_UNREADABLE`, `FM_FAKE_HERDR_READ_FAIL`, `FM_FAKE_HERDR_HUSK`, a `list-windows` inventory arm and a `pane get` arm, and adds four assertions/tests — a stalled herdr CLI and an unreadable tmux read unreachable rather than gone, an `alive` endpoint with a failed scrollback read still reports `working`, a husk pane still reports gone, and the existing dead-window test now asserts the gone text explicitly.
- `tests/fm-backend-herdr.test.sh`: pins the suite's ambient `FM_HOME` to a fresh marker-free directory so a secondmate-marked checkout can't flip the default workspace label for tests that don't set `FM_HOME` themselves.

## Risk Assessment

✅ Low: The change is narrowly scoped to one fallback branch, preserves every positive-death path that licenses reclaim, routes both backends through an existing recovery-grade classifier rather than adding new state, is covered by four new behavior tests that exercise the real script, and leaves the non-classifier backends untouched exactly as the recorded decisions required.

## Testing

Completed 1 recorded test check.

- Outcome: ⚠️ 1 error across 1 run (1m42s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"3af08a3abea4ab7d9f71074bf17c1f5420004c56","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>⚠️ **Review** - 1 info</summary>

- ℹ️ `bin/fm-crew-state.sh:570` - The fallback&#39;s section header states an unqualified invariant - &#34;only positive evidence that the target is gone may read as death - a backend that failed to answer is unknown, never death, for both classifier-backed backends (tmux and herdr)&#34; - but the block comment 20 lines below explicitly carves out the opposite for tmux: &#34;tmux gave one of its definitive no-session/no-server/no-socket responses ... a socket-connection failure is NOT covered by the unknown-never-death rule above&#34;. Both are reachable: bin/backends/tmux.sh:312 maps `error connecting to &lt;socket&gt; (No such file or directory)` and `(Connection refused)` - a tmux that failed to answer - to `missing`, which this block emits as `backend target gone`. The same over-broad sentence appears in the file header at line 67 (&#34;an endpoint that merely failed to answer reports unknown · none as unreachable&#34;). This is comment accuracy only; the code behaves as the inner comment describes and as the round-2 decision ruled. Smallest remedy is to qualify both sentences to &#34;a backend that failed to give a definitive answer&#34;, so the header no longer contradicts the exception it points at. No behavior change - making socket errors non-death would break fm-bootstrap.sh:793&#39;s respawn license and needs authorization, which is why only the wording should move.
</details>

<details>
<summary>⚠️ **Test** - 1 error</summary>

- 🚨 tests failed with exit code 1
- `bin/fm-test-run.sh --changed --exclude-family real-herdr-gated`
</details>

<details>
<summary>⚠️ **Document** - 1 info</summary>

- ℹ️ `docs/fm-test-portable-shards.md:18` - The change adds four tests to tests/fm-crew-state.test.sh, whose 17558 ms entry in the parallel-lane timing table (and in docs/fm-test-isolation-proof.{md,json}) feeds the longest-processing-time lane assignment. I did not touch those numbers: they are explicitly dated measurements from the 2026-08-20 concurrent isolation proof (maintainer-verification), so hand-editing them would fabricate evidence, and regenerating them means running bin/fm-test-isolation-proof.sh, which is outside this documentation phase. The recorded facts are not false — they remain an accurate record of that run — but the derived lane-balance estimate is now slightly optimistic. Follow-up: refresh the proof and both tables the next time the isolated candidate set or its timings are re-measured.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>

---

Note: the local test-gate failures for `tests/fm-test-run.test.sh` (a `comm`/LC_ALL sort artifact of the runner, zero failing assertions) and `tests/fm-calm-pi-extension.test.sh` (a parallel-load flake) are pre-existing and environmental - both reproduce identically on the untouched base commit and are unrelated to this change; upstream CI is green on all 15 checks.