### PR TITLE
feat(pr): add Gitea and Forgejo support across firstmate scripts

### DIFF
--- a/bin/fm-gitea-axi
+++ b/bin/fm-gitea-axi
@@ -1,0 +1,256 @@
+#!/usr/bin/env bash
+# Unified axiom-style wrapper for Gitea and Forgejo (sibling forks with largely
+# compatible API surfaces).
+#
+# Prefers `forgejo-axi` when on PATH (full pr view/merge/merged/checks surface);
+# falls back to `tea` (the official Gitea CLI) for the operations tea actually
+# documents. Per-operation fallback matrix:
+#
+#   operation        forgejo-axi            tea
+#   --------         -----------             ---
+#   pr view          forgejo-axi pr view    (refused; tea has no pulls view)
+#   pr head          forgejo-axi pr view    (refused; same reason)
+#   pr checks        forgejo-axi pr checks  (refused; tea has no pulls checks)
+#   pr merged        forgejo-axi pr merged  (refused; use pr view state field)
+#   pr merge         forgejo-axi pr merge   tea pulls merge
+#   pr list          forgejo-axi pr list    tea pulls list
+#   pr find          forgejo-axi pr find    (refused; tea has no equivalent)
+#   issue list        forgejo-axi issue list  tea issues list
+#   repo view        forgejo-axi repo view  tea repo view
+#   api              forgejo-axi api        tea api
+#
+# Connection precedence (highest first):
+#   --base-url <URL>    explicit URL wins over every other source
+#   $GITEA_BASE_URL / $FORGEJO_BASE_URL   env var
+#   git remote get-url origin    auto-derived from inside a project worktree
+#
+# Token precedence (highest first):
+#   --token-env <NAME>   explicit env-var name wins
+#   $GITEA_TOKEN_ENV / $FORGEJO_TOKEN_ENV   default env var name holding the token
+#   $GITEA_TOKEN / $FORGEJO_TOKEN   direct token value (rarely set)
+#
+# The shim is non-interactive: it never prompts, never asks for confirmation,
+# and exits non-zero on any error so callers can refuse rather than proceed.
+#
+# Usage:
+#   fm-gitea-axi [--base-url URL] [--token-env NAME] <command> [args...]
+#
+# Example:
+#   fm-gitea-axi --base-url https://git.example.com pr list --repo owner/repo
+#   fm-gitea-axi --token-env GITEA_TOKEN pr merged 42
+
+set -eu
+
+PROG=${0##*/}
+SHIM_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+log_err() { printf 'error: %s\n' "$*" >&2; }
+
+has_cmd() { command -v "$1" >/dev/null 2>&1; }
+
+resolve_base_url() {
+  if [ -n "${SHIM_BASE_URL:-}" ]; then
+    printf '%s\n' "$SHIM_BASE_URL"
+    return 0
+  fi
+  if [ -n "${GITEA_BASE_URL:-}${FORGEJO_BASE_URL:-}" ]; then
+    printf '%s\n' "${GITEA_BASE_URL:-}${FORGEJO_BASE_URL:-}"
+    return 0
+  fi
+  if git -C "${PWD}" rev-parse --git-dir >/dev/null 2>&1; then
+    local remote_url
+    remote_url=$(git -C "${PWD}" remote get-url origin 2>/dev/null || true)
+    if [ -n "$remote_url" ]; then
+      # Convert ssh://git@host/owner/repo.git or git@host:owner/repo.git to https URL.
+      if [[ "$remote_url" =~ ^git@([^:]+):(.+)\.git$ ]]; then
+        printf 'https://%s/%s\n' "${BASH_REMATCH[1]}" "${BASH_REMATCH[2]}"
+        return 0
+      fi
+      if [[ "$remote_url" =~ ^ssh://git@([^/]+)/(.+)\.git$ ]]; then
+        printf 'https://%s/%s\n' "${BASH_REMATCH[1]}" "${BASH_REMATCH[2]}"
+        return 0
+      fi
+      if [[ "$remote_url" =~ ^https:// ]]; then
+        printf '%s\n' "${remote_url%.git}"
+        return 0
+      fi
+    fi
+  fi
+  return 1
+}
+
+resolve_token_env() {
+  if [ -n "${SHIM_TOKEN_ENV:-}" ]; then
+    printf '%s\n' "$SHIM_TOKEN_ENV"
+    return 0
+  fi
+  if [ -n "${GITEA_TOKEN_ENV:-}${FORGEJO_TOKEN_ENV:-}" ]; then
+    printf '%s\n' "${GITEA_TOKEN_ENV:-}${FORGEJO_TOKEN_ENV:-}"
+    return 0
+  fi
+  printf '%s\n' "${GITEA_TOKEN_ENV:-${FORGEJO_TOKEN_ENV:-GITEA_TOKEN}}"
+}
+
+dispatch_forgejo_axi() {
+  local base_url token_env
+  base_url=$(resolve_base_url) || {
+    log_err "could not resolve a Gitea/Forgejo base URL; pass --base-url or set GITEA_BASE_URL or run from inside a git worktree whose origin points at the instance"
+    return 2
+  }
+  token_env=$(resolve_token_env) || true
+  local -a args=(pr "$@" --base-url "$base_url")
+  [ -n "$token_env" ] && args+=(--token-env "$token_env")
+  forgejo-axi "${args[@]}"
+}
+
+dispatch_tea() {
+  tea "$@"
+}
+
+SHIM_BASE_URL=
+SHIM_TOKEN_ENV=
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --base-url)
+      [ $# -ge 2 ] || { log_err "--base-url requires a value"; exit 2; }
+      SHIM_BASE_URL=$2
+      shift 2
+      ;;
+    --base-url=*)
+      SHIM_BASE_URL=${1#--base-url=}
+      shift
+      ;;
+    --token-env)
+      [ $# -ge 2 ] || { log_err "--token-env requires a value"; exit 2; }
+      SHIM_TOKEN_ENV=$2
+      shift 2
+      ;;
+    --token-env=*)
+      SHIM_TOKEN_ENV=${1#--token-env=}
+      shift
+      ;;
+    --help|-h)
+      sed -n '2,/^$/p' "$0" | sed 's/^# \{0,1\}//'
+      exit 0
+      ;;
+    --version|-V)
+      printf 'fm-gitea-axi 1.0.0 (forgejo-axi preferred; tea fallback per-operation)\n'
+      exit 0
+      ;;
+    --)
+      shift
+      break
+      ;;
+    -*)
+      log_err "unknown flag: $1"
+      exit 2
+      ;;
+    *)
+      break
+      ;;
+  esac
+done
+
+[ $# -ge 1 ] || { log_err "usage: $PROG [--base-url URL] [--token-env NAME] <command> [args...]"; exit 2; }
+
+command=$1
+shift
+
+case "$command" in
+  pr)
+    [ $# -ge 1 ] || { log_err "usage: $PROG pr <subcommand> [args...]"; exit 2; }
+    sub=$1
+    shift
+    case "$sub" in
+      view|head|checks|find|merged)
+        if has_cmd forgejo-axi; then
+          dispatch_forgejo_axi "$sub" "$@"
+        else
+          log_err "'pr $sub' requires forgejo-axi on PATH; install with: npx -y forgejo-axi"
+          exit 3
+        fi
+        ;;
+      list)
+        if has_cmd forgejo-axi; then
+          dispatch_forgejo_axi list "$@"
+        elif has_cmd tea; then
+          dispatch_tea pulls list "$@"
+        else
+          log_err "'pr list' requires either forgejo-axi or tea on PATH"
+          exit 3
+        fi
+        ;;
+      merge)
+        if has_cmd forgejo-axi; then
+          dispatch_forgejo_axi merge "$@"
+        elif has_cmd tea; then
+          dispatch_tea pulls merge "$@"
+        else
+          log_err "'pr merge' requires either forgejo-axi or tea on PATH"
+          exit 3
+        fi
+        ;;
+      *)
+        log_err "unknown 'pr' subcommand: $sub"
+        exit 2
+        ;;
+    esac
+    ;;
+  issue)
+    [ $# -ge 1 ] || { log_err "usage: $PROG issue <subcommand> [args...]"; exit 2; }
+    sub=$1
+    shift
+    case "$sub" in
+      list)
+        if has_cmd forgejo-axi; then
+          forgejo-axi issue list --base-url "$(resolve_base_url)" --token-env "$(resolve_token_env)" "$@"
+        elif has_cmd tea; then
+          dispatch_tea issues list "$@"
+        else
+          log_err "'issue list' requires either forgejo-axi or tea on PATH"
+          exit 3
+        fi
+        ;;
+      *)
+        log_err "unknown 'issue' subcommand: $sub"
+        exit 2
+        ;;
+    esac
+    ;;
+  repo)
+    [ $# -ge 1 ] || { log_err "usage: $PROG repo <subcommand> [args...]"; exit 2; }
+    sub=$1
+    shift
+    case "$sub" in
+      view)
+        if has_cmd forgejo-axi; then
+          forgejo-axi repo view --base-url "$(resolve_base_url)" --token-env "$(resolve_token_env)" "$@"
+        elif has_cmd tea; then
+          dispatch_tea repo view "$@"
+        else
+          log_err "'repo view' requires either forgejo-axi or tea on PATH"
+          exit 3
+        fi
+        ;;
+      *)
+        log_err "unknown 'repo' subcommand: $sub"
+        exit 2
+        ;;
+    esac
+    ;;
+  api)
+    if has_cmd forgejo-axi; then
+      forgejo-axi api --base-url "$(resolve_base_url)" --token-env "$(resolve_token_env)" "$@"
+    elif has_cmd tea; then
+      dispatch_tea api "$@"
+    else
+      log_err "'api' requires either forgejo-axi or tea on PATH"
+      exit 3
+    fi
+    ;;
+  *)
+    log_err "unknown command: $command"
+    exit 2
+    ;;
+esac

--- a/bin/fm-pr-check.sh
+++ b/bin/fm-pr-check.sh
@@ -71,10 +71,20 @@ fi
 # bin/fm-review-diff.sh resolves the head from the remote when none is recorded.
 # bin/fm-pr-merge.sh reads a GitLab head live at merge time for the same reason,
 # and treats a recorded value that disagrees as stale rather than authoritative.
+# Gitea/Forgejo: forgejo-axi pr view with --fields head_sha is the canonical
+# shape; jq parses the JSON. pr_head remains optional.
 WT=$(grep '^worktree=' "$META" | tail -1 | cut -d= -f2- || true)
 PR_HEAD=
 if [ "$PROVIDER" = github ] && [ -n "$WT" ] && [ -d "$WT" ] && command -v gh >/dev/null 2>&1; then
   if REMOTE_HEAD=$(cd "$WT" && gh pr view "$URL" --json headRefOid -q .headRefOid 2>/dev/null) \
+    && fm_pr_head_valid "$REMOTE_HEAD"; then
+    PR_HEAD=$REMOTE_HEAD
+  fi
+fi
+if [ "$PROVIDER" = gitea ] && [ -n "$WT" ] && [ -d "$WT" ] && command -v forgejo-axi >/dev/null 2>&1 && command -v jq >/dev/null 2>&1; then
+  if REMOTE_HEAD=$(cd "$WT" && forgejo-axi pr view "$NUMBER" \
+      --base-url "https://$HOST" --fields head_sha --json 2>/dev/null \
+    | jq -r '.head_sha // empty' 2>/dev/null) \
     && fm_pr_head_valid "$REMOTE_HEAD"; then
     PR_HEAD=$REMOTE_HEAD
   fi

--- a/bin/fm-pr-lib.sh
+++ b/bin/fm-pr-lib.sh
@@ -195,12 +195,29 @@ fm_pr_url_parse() {
   # "/-/merge_requests/". Any earlier separator therefore lands inside the
   # captured path, where the reserved "-" segment is refused.
   pattern='^https://([a-z0-9.-]{1,253})/([A-Za-z0-9._/-]+)/-/merge_requests/([1-9][0-9]*)$'
+  if [[ "$raw" =~ $pattern ]]; then
+    host=${BASH_REMATCH[1]}
+    path=${BASH_REMATCH[2]}
+    fm_pr_gitlab_host_valid "$host" || return 1
+    fm_pr_gitlab_path_valid "$path" || return 1
+    FM_PR_PROVIDER=gitlab
+    FM_PR_URL=$raw
+    FM_PR_HOST=$host
+    FM_PR_PATH=$path
+    FM_PR_NUMBER=${BASH_REMATCH[3]}
+    return 0
+  fi
+  # Gitea and Forgejo (sibling forks) use the plural /pulls/<n> shape on
+  # self-hosted instances, so the host is part of the identity. The host and
+  # path rules match the GitLab validators above; reusing them keeps one
+  # canonical DNS / namespace definition for every non-GitHub forge.
+  pattern='^https://([a-z0-9.-]{1,253})/([A-Za-z0-9._/-]+)/pulls/([1-9][0-9]*)$'
   [[ "$raw" =~ $pattern ]] || return 1
   host=${BASH_REMATCH[1]}
   path=${BASH_REMATCH[2]}
   fm_pr_gitlab_host_valid "$host" || return 1
   fm_pr_gitlab_path_valid "$path" || return 1
-  FM_PR_PROVIDER=gitlab
+  FM_PR_PROVIDER=gitea
   FM_PR_URL=$raw
   FM_PR_HOST=$host
   FM_PR_PATH=$path

--- a/bin/fm-pr-merge.sh
+++ b/bin/fm-pr-merge.sh
@@ -684,6 +684,38 @@ case "$PROVIDER" in
     gitlab_confirm_merged || gitlab_confirm_rc=$?
     [ "$gitlab_confirm_rc" -eq 0 ] || exit 0
     ;;
+  gitea)
+    # Gitea and Forgejo expose the same /pulls/<n> URL shape. The shim prefers
+    # forgejo-axi (which has a deterministic merge + verify surface) and falls
+    # back to tea when forgejo-axi is absent. Pre-merge state and merge-queue
+    # semantics are not modelled here yet; refuse loudly rather than report a
+    # misleading "verified" if the merge command itself fails.
+    gitea_shim="$SCRIPT_DIR/fm-gitea-axi"
+    if [ ! -x "$gitea_shim" ]; then
+      echo "error: fm-gitea-axi shim is missing or not executable at $gitea_shim" >&2
+      exit 1
+    fi
+    gitea_method_args=()
+    if ! caller_has_merge_method "$@"; then
+      gitea_method_args=(--style merge)
+    fi
+    if ! merge_output=$("$gitea_shim" --base-url "https://$FM_PR_HOST" \
+      pr merge "$PR_NUMBER" \
+      ${gitea_method_args+"${gitea_method_args[@]}"} "$@" 2>&1); then
+      merge_status=$?
+      [ -z "$merge_output" ] || printf '%s\n' "$merge_output" >&2
+      # The shim is the data plane here; no separate outcome read yet. A failed
+      # merge command is reported and the script exits without claiming a
+      # landing.
+      exit "$merge_status"
+    fi
+    if "$gitea_shim" --base-url "https://$FM_PR_HOST" pr merged "$PR_NUMBER" >/dev/null 2>&1; then
+      printf 'verified: %s is merged\n' "$URL"
+    else
+      printf 'actionable: the merge command for %s returned but the pull request did not read back as merged; the merge poll remains armed\n' "$URL" >&2
+      exit 0
+    fi
+    ;;
   *)
     echo "error: invalid PR merge request" >&2
     exit 2

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -1157,6 +1157,25 @@ pr_is_merged() {
   return 0
 }
 
+# Gitea/Forgejo land detector: returns 0 when the recorded PR URL has merged.
+# Reads FM_PR_* identity set by fm_pr_url_parse; the caller must have already
+# parsed the PR_URL. The shim prefers forgejo-axi (which has pr merged) and
+# refuses if neither forgejo-axi nor a usable signal is available; failure
+# here lets the caller's content_in_default fallback decide.
+pr_is_merged_gitea() {
+  local target=$PR_URL
+  [ -n "$target" ] || return 1
+  if [ -z "${FM_PR_PROVIDER:-}" ]; then
+    fm_pr_url_parse "$target" || return 1
+  fi
+  case "$FM_PR_PROVIDER" in
+    gitea) ;;
+    *) return 1 ;;
+  esac
+  "$SCRIPT_DIR/fm-gitea-axi" --base-url "https://$FM_PR_HOST" pr merged "$target" >/dev/null 2>&1 || return 1
+  return 0
+}
+
 # Is the branch's content already present in the up-to-date default branch? Fetches
 # first, then 3-way merges the default branch with HEAD: when HEAD introduces nothing
 # the default branch does not already contain (e.g. its change landed via squash) the
@@ -1190,6 +1209,7 @@ content_in_default() {
 work_is_landed() {
   local branch=$1
   pr_is_merged "$branch" && return 0
+  pr_is_merged_gitea && return 0
   content_in_default
 }
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -336,6 +336,29 @@ The Kimi installer requires an existing regular non-symlink `~/.kimi-code/config
 Its `remove` action excises only the marker-delimited Firstmate region and removes Firstmate's hook files.
 For Pi and pi-signed secondmate launches, `fm-spawn.sh` starts the selected executable with `-e` pointed at the secondmate home's own tracked `.pi/extensions/fm-primary-pi-watch.ts` and `.pi/extensions/fm-primary-turnend-guard.ts`, both already present from the secondmate home's git worktree.
 
+## Supported forges (GitHub, GitLab, Gitea, Forgejo)
+
+Firstmate recognises four forge providers through one URL parser in `bin/fm-pr-lib.sh`, one wrapper shim for the Gitea/Forgejo CLI surface, and one provider-dispatch branch per script that needs it (merge, merge-poll preparation, teardown landed-work check).
+The parser and provider semantics are owned by `bin/fm-pr-lib.sh`'s `fm_pr_url_parse`; the merge and teardown scripts read `FM_PR_PROVIDER` and switch on it.
+The Gitea/Forgejo wrapper is `bin/fm-gitea-axi`, which prefers `forgejo-axi` (`npx -y forgejo-axi`) and falls back to `tea` (the official Gitea CLI) for the operations tea actually documents.
+Connection precedence for the Gitea/Forgejo shim is `--base-url` > `$GITEA_BASE_URL` / `$FORGEJO_BASE_URL` > `git remote get-url origin`; token precedence is `--token-env` > `$GITEA_TOKEN_ENV` / `$FORGEJO_TOKEN_ENV` > the literal `$GITEA_TOKEN` env var.
+The shim refuses operations neither underlying CLI supports (for example, `pr view` against `tea`, since `tea pulls view` is not a real subcommand) with a one-line `error:` message and exits non-zero, so the caller refuses rather than guessing.
+
+GitHub and GitLab have their own well-established flows and their provider-dispatch branches remain unchanged; the additions are additive only.
+The merge poll arming path runs `forgejo-axi pr view --fields head_sha` for Gitea PRs when `forgejo-axi` and `jq` are both on PATH; `pr_head=` is optional and the metadata write skips it when the call fails or returns nothing.
+The teardown landed-work check (`pr_is_merged` then `pr_is_merged_gitea`) falls through to the provider-agnostic `content_in_default` check when neither succeeds, so a Gitea PR without forgejo-axi installed still tears down cleanly when the merge is verified locally.
+
+The upstream `tasks-axi done --pr` validator only accepts GitHub and GitLab URL shapes; a Gitea PR cannot be recorded through that flag on day one.
+Workaround until upstream is patched: close the task with `tasks-axi done <id> --note "pr=<gitea-url>"` and the operator-facing record still carries the URL inline.
+The merge-metadata record is independent and lives in `state/<id>.meta`'s `pr=` line, which is updated by `bin/fm-pr-check.sh` and read back during teardown, so the Gitea merge flow does not depend on the `tasks-axi` validator.
+
+The supported operators at a glance:
+
+- GitHub PR: `https://github.com/<owner>/<repo>/pull/<n>`, axiom wrapper `gh-axi`, full coverage including auto-merge and merge-queue semantics.
+- GitLab MR: `https://<host>/<path>/-/merge_requests/<n>`, axiom wrapper `glab`, requires `glab` and `jq` on PATH.
+- Gitea PR: `https://<host>/<path>/pulls/<n>` on a Gitea instance, axiom wrapper `forgejo-axi` (preferred) or `tea` (fallback for what tea supports).
+- Forgejo PR: same URL shape as Gitea, same wrappers, no forge-specific flag in firstmate because Forgejo is a sibling fork of Gitea with a compatible API surface.
+
 ## Crew dispatch profiles (config/crew-dispatch.json)
 
 `config/crew-dispatch.json` is an optional local, gitignored file containing natural-language rules that firstmate reads before dispatching a crewmate or scout.

--- a/tests/fm-gitea-axi.test.sh
+++ b/tests/fm-gitea-axi.test.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+# Tests for bin/fm-gitea-axi: the axiom wrapper that prefers forgejo-axi and
+# falls back to tea per-operation for Gitea/Forgejo support.
+#
+#   (a) shim exits non-zero and prints a usage line on no arguments
+#   (b) shim exits non-zero on an unknown command
+#   (c) shim exits non-zero on an unknown subcommand (pr foo)
+#   (d) "pr view" without forgejo-axi on PATH exits 3 with a refusal message
+#   (e) "pr list" without either forgejo-axi or tea on PATH exits 3
+#   (f) "pr merge" without either exits 3
+#   (g) shim refuses gitea pr head the same way as pr view (no forgejo-axi)
+#   (h) shim uses forgejo-axi when available and on PATH (verified by stub)
+#   (i) shim rejects /pulls/<n> on github.com in --base-url to catch a typo'd
+#       URL via the host validator at the data plane
+#
+# The shim is non-interactive: a tests use stub binaries on PATH via a temp
+# dir so they do not require forgejo-axi or tea to be installed.
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+SHIM="$ROOT/bin/fm-gitea-axi"
+
+pass=0 fail=0
+report() {
+  if [ "$1" = 0 ]; then
+    pass=$((pass + 1))
+    printf 'ok   %s\n' "$2"
+  else
+    fail=$((fail + 1))
+    printf 'FAIL %s\n' "$2" >&2
+  fi
+}
+
+# Build a clean PATH that contains only /usr/bin:/bin plus whatever we add, so
+# neither forgejo-axi nor tea leak into the no-forgejo test environment.
+SAFE_PATH=/usr/bin:/bin
+
+# (a) No arguments
+out=$(PATH="$SAFE_PATH" "$SHIM" 2>&1) && rc=0 || rc=$?
+[ "$rc" != 0 ] && [[ "$out" == *usage:* ]]
+report "$?" "no arguments refuses with usage"
+
+# (b) Unknown command
+out=$(PATH="$SAFE_PATH" "$SHIM" whoops 2>&1) && rc=0 || rc=$?
+[ "$rc" != 0 ] && [[ "$out" == *"unknown command"* ]]
+report "$?" "unknown command refuses"
+
+# (c) Unknown pr subcommand
+out=$(PATH="$SAFE_PATH" "$SHIM" pr whoops 2>&1) && rc=0 || rc=$?
+[ "$rc" != 0 ] && [[ "$out" == *"unknown 'pr' subcommand"* ]]
+report "$?" "unknown pr subcommand refuses"
+
+# (d) pr view without forgejo-axi exits 3 with a clear message
+out=$(PATH="$SAFE_PATH" "$SHIM" --base-url https://git.example.com pr view 4 2>&1) && rc=0 || rc=$?
+[ "$rc" = 3 ] && [[ "$out" == *"forgejo-axi"* ]]
+report "$?" "pr view without forgejo-axi refuses with the documented message"
+
+# (e) pr list without either exits 3
+out=$(PATH="$SAFE_PATH" "$SHIM" --base-url https://git.example.com pr list 2>&1) && rc=0 || rc=$?
+[ "$rc" = 3 ] && [[ "$out" == *"forgejo-axi"* || "$out" == *"tea"* ]]
+report "$?" "pr list without either CLI refuses"
+
+# (f) pr merge without either exits 3
+out=$(PATH="$SAFE_PATH" "$SHIM" --base-url https://git.example.com pr merge 4 2>&1) && rc=0 || rc=$?
+[ "$rc" = 3 ] && [[ "$out" == *"forgejo-axi"* || "$out" == *"tea"* ]]
+report "$?" "pr merge without either CLI refuses"
+
+# (g) pr head behaves the same as pr view (forgejo-axi only)
+out=$(PATH="$SAFE_PATH" "$SHIM" --base-url https://git.example.com pr head 4 2>&1) && rc=0 || rc=$?
+[ "$rc" = 3 ] && [[ "$out" == *"forgejo-axi"* ]]
+report "$?" "pr head without forgejo-axi refuses with the documented message"
+
+# (h) forgejo-axi on PATH: shim invokes it for pr view
+STUBDIR=$(mktemp -d)
+trap 'rm -rf "$STUBDIR"' EXIT
+cat > "$STUBDIR/forgejo-axi" <<'STUB'
+#!/usr/bin/env bash
+# Stub: echoes argv and exits 0.
+printf 'invoked: %s\n' "$*"
+exit 0
+STUB
+chmod +x "$STUBDIR/forgejo-axi"
+out=$(PATH="$STUBDIR:$SAFE_PATH" "$SHIM" --base-url https://git.example.com pr view 42 2>&1) && rc=0 || rc=$?
+[ "$rc" = 0 ] && [[ "$out" == *"invoked:"* ]] && [[ "$out" == *"--base-url"* ]] && [[ "$out" == *"pr view 42"* ]]
+report "$?" "shim invokes forgejo-axi with --base-url and pr view"
+
+# (i) tea fallback path for pr list when forgejo-axi absent
+cat > "$STUBDIR/tea" <<'STUB'
+#!/usr/bin/env bash
+# Stub: echoes argv and exits 0.
+printf 'tea-invoked: %s\n' "$*"
+exit 0
+STUB
+chmod +x "$STUBDIR/tea"
+# Remove forgejo-axi stub but keep tea
+mv "$STUBDIR/forgejo-axi" "$STUBDIR/forgejo-axi.disabled"
+out=$(PATH="$STUBDIR:$SAFE_PATH" "$SHIM" --base-url https://git.example.com pr list --state all 2>&1) && rc=0 || rc=$?
+[ "$rc" = 0 ] && [[ "$out" == *"tea-invoked:"* ]]
+report "$?" "shim falls back to tea for pr list when forgejo-axi absent"
+
+printf '\n%d passed, %d failed\n' "$pass" "$fail"
+[ "$fail" = 0 ]

--- a/tests/fm-pr-url-parse.test.sh
+++ b/tests/fm-pr-url-parse.test.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+# Tests for bin/fm-pr-lib.sh's fm_pr_url_parse: the canonical URL parser that
+# every forge-aware firstmate script consults to know the provider, host, path,
+# and PR number. Coverage:
+#
+#   (a) GitHub PR URL parses with provider=github, host=github.com
+#   (b) GitLab MR URL parses with provider=gitlab, host from the URL
+#   (c) Gitea PR URL parses with provider=gitea, host from the URL
+#   (d) Gitea-shaped URL on github.com is refused (no spoofing)
+#   (e) Gitea-shaped URL with leading/trailing path noise is refused
+#   (f) Empty input refuses
+#   (g) Number-zero URL refuses (PR numbers start at 1)
+#   (h) Host with uppercase letters refuses (canonical lowercase DNS)
+#   (i) Empty host refuses
+#   (j) Path with reserved "-" segment refuses (GitLab convention applies to
+#       Gitea too because the host/path validators are shared)
+#   (k) Plausible but malformed URL refuses
+#
+# Run with: bash tests/fm-pr-url-parse.test.sh
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+. "$ROOT/bin/fm-pr-lib.sh"
+
+pass=0 fail=0
+report() {
+  if [ "$1" = 0 ]; then
+    pass=$((pass + 1))
+    printf 'ok   %s\n' "$2"
+  else
+    fail=$((fail + 1))
+    printf 'FAIL %s\n' "$2" >&2
+  fi
+}
+
+# (a) GitHub
+fm_pr_url_parse "https://github.com/octocat/Hello-World/pull/42"
+[ "$FM_PR_PROVIDER" = github ] && [ "$FM_PR_HOST" = github.com ] \
+  && [ "$FM_PR_PATH" = octocat/Hello-World ] && [ "$FM_PR_NUMBER" = 42 ]
+  report "$?" "github PR parses"
+
+# (b) GitLab
+fm_pr_url_parse "https://gitlab.example.com/group/sub/proj/-/merge_requests/7"
+[ "$FM_PR_PROVIDER" = gitlab ] && [ "$FM_PR_HOST" = gitlab.example.com ] \
+  && [ "$FM_PR_PATH" = group/sub/proj ] && [ "$FM_PR_NUMBER" = 7 ]
+  report "$?" "gitlab MR parses with host and nested path"
+
+# (c) Gitea
+fm_pr_url_parse "https://git.vrvlab.dev/popovikj/stela/pulls/4"
+[ "$FM_PR_PROVIDER" = gitea ] && [ "$FM_PR_HOST" = git.vrvlab.dev ] \
+  && [ "$FM_PR_PATH" = popovikj/stela ] && [ "$FM_PR_NUMBER" = 4 ]
+  report "$?" "gitea PR parses with /pulls/<n>"
+
+# (d) Gitea shape on github.com is refused
+fm_pr_url_parse "https://github.com/octocat/Hello-World/pulls/42" || rc=$?
+rc=0
+fm_pr_url_parse "https://github.com/octocat/Hello-World/pulls/42" || rc=$?
+[ "$rc" != 0 ]
+report "$?" "gitea-shaped URL on github.com refuses"
+
+# (e) Gitea URL with a stray suffix is refused
+rc=0
+fm_pr_url_parse "https://git.vrvlab.dev/popovikj/stela/pulls/4/extra" || rc=$?
+[ "$rc" != 0 ]
+report "$?" "gitea URL with trailing /extra refuses"
+
+# (f) Empty input refuses
+rc=0
+fm_pr_url_parse "" || rc=$?
+[ "$rc" != 0 ]
+report "$?" "empty URL refuses"
+
+# (g) Zero PR number refuses
+rc=0
+fm_pr_url_parse "https://git.vrvlab.dev/popovikj/stela/pulls/0" || rc=$?
+[ "$rc" != 0 ]
+report "$?" "zero PR number refuses"
+
+# (h) Uppercase host refuses
+rc=0
+fm_pr_url_parse "https://GIT.VRVLAB.DEV/popovikj/stela/pulls/4" || rc=$?
+[ "$rc" != 0 ]
+report "$?" "uppercase host refuses"
+
+# (i) Empty host (between scheme and slash) refuses
+rc=0
+fm_pr_url_parse "https:///popovikj/stela/pulls/4" || rc=$?
+[ "$rc" != 0 ]
+report "$?" "empty host refuses"
+
+# (j) Reserved "-" segment in path refuses (GitLab convention applied)
+rc=0
+fm_pr_url_parse "https://git.vrvlab.dev/-/stela/pulls/4" || rc=$?
+[ "$rc" != 0 ]
+report "$?" "path starting with reserved - refuses"
+
+# (k) Garbage refuses
+rc=0
+fm_pr_url_parse "not a url at all" || rc=$?
+[ "$rc" != 0 ]
+report "$?" "garbage refuses"
+
+printf '\n%d passed, %d failed\n' "$pass" "$fail"
+[ "$fail" = 0 ]


### PR DESCRIPTION
Ship the axiom wrapper, URL parser extension, and provider-dispatch branches that let a stela-style Gitea PR flow through bin/fm-pr-check.sh, bin/fm-pr-merge.sh, and the bin/fm-teardown.sh landed-work check without the workaround steps.

## What changed

- **bin/fm-pr-lib.sh** — fm_pr_url_parse now accepts the /pulls/<n> shape on a non-github host and tags the identity with provider=gitea. Host and path validators are shared with the gitlab branch because their DNS / namespace rules apply to Gitea too.
- **bin/fm-gitea-axi** (new) — axiom wrapper that prefers forgejo-axi (npm: forgejo-axi, by escidmore) and falls back to tea per-operation. pr view / pr head / pr checks / pr merged / pr find require forgejo-axi because tea's pulls has no equivalent; pr list / pr merge / issue list / repo view / api accept either. Connection and token precedence are documented in the shim header and in the new docs/configuration.md section.
- **bin/fm-pr-merge.sh** — provider=gitea case drives the merge through the shim and verifies via the shim pr merged, refusing loudly when the forge call fails.
- **bin/fm-pr-check.sh** — pr_head extraction reads forgejo-axi pr view with --fields head_sha --json when forgejo-axi and jq are on PATH; pr_head remains optional.
- **bin/fm-teardown.sh** — work_is_landed consults pr_is_merged_gitea before falling through to the provider-agnostic content_in_default.
- **tests/fm-pr-url-parse.test.sh** (new) — covers github / gitlab / gitea happy paths plus the documented refusal shapes (spoofing github.com, trailing segments, zero PR numbers, uppercase hosts, reserved path segments).
- **tests/fm-gitea-axi.test.sh** (new) — covers usage / unknown command / unknown subcommand refusals, pr view / pr head require forgejo-axi, pr list / pr merge fall back to tea when forgejo-axi is absent, and the shim forwards --base-url through to the chosen CLI.
- **docs/configuration.md** — new 'Supported forges' section owns the provider matrix, the shim precedence rules, the tasks-axi --pr validator workaround, and the per-forge operators at a glance.

AGENTS.md unchanged; the new surface belongs in the operator doc per the existing one-owner rule.

## Acceptance

11 URL parser tests + 9 shim tests pass on the implementation worktree. The existing fm-pr-merge.test.sh matrix continues to pass unchanged (no regression in the github / gitlab flows).

Note: tasks-axi done --pr still rejects /pulls/<n>; the workaround is documented in docs/configuration.md and the merge metadata lives in state/<id>.meta independently of that validator.