### PR TITLE
fix(bin): make fm-spawn's treehouse enter-wait env-overridable (FM_SPAWN_ENTER_WAIT_SECS)

### DIFF
--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -56,7 +56,11 @@
 #   Spawn-capable backends are the reference tmux adapter and experimental
 #   herdr, zellij, orca, and cmux. Orca owns both the task worktree and
 #   terminal, so ship/scout Orca spawns do not run treehouse get; cmux is a
-#   session provider only, exactly like herdr/zellij, so it does. An
+#   session provider only, exactly like herdr/zellij, so it does. For those
+#   treehouse-get backends, FM_SPAWN_ENTER_WAIT_SECS (positive integer, default
+#   60) bounds how long the spawn waits for the pane to enter the pooled
+#   worktree; raise it when recycling a stale pooled slot fetches origin first
+#   and that fetch alone can exceed the default under load. An
 #   auto-detected herdr or cmux spawn prints a loud stderr notice;
 #   auto-detected tmux stays silent; zellij and orca are never auto-detected.
 #   codex-app is not a known backend yet; docs/codex-app-backend.md owns that
@@ -2569,8 +2573,12 @@ elif [ "$KIND" != secondmate ] && [ "$BACKEND" != orca ]; then
   # a mismatch just becomes the new candidate rather than resetting the wait, so a
   # pane that is already settled by the first real read only costs the one existing
   # inter-poll sleep as confirmation, not a whole extra cycle on top.
+  enter_wait=${FM_SPAWN_ENTER_WAIT_SECS:-60}
+  case "$enter_wait" in
+    ''|*[!0-9]*|0) echo "error: FM_SPAWN_ENTER_WAIT_SECS must be a positive integer, got '${FM_SPAWN_ENTER_WAIT_SECS:-}'" >&2; exit 1 ;;
+  esac
   candidate=""
-  for _ in $(seq 1 60); do
+  for _ in $(seq 1 "$enter_wait"); do
     p=$(spawn_current_path "$WT_TARGET" || true)
     if [ -n "$p" ]; then
       p_real=$(real_path_or_raw "$p")
@@ -2589,7 +2597,7 @@ elif [ "$KIND" != secondmate ] && [ "$BACKEND" != orca ]; then
     sleep 1
   done
   if [ -z "$WT" ]; then
-    echo "error: treehouse get did not enter a worktree within 60s; inspect window $T" >&2
+    echo "error: treehouse get did not enter a worktree within ${enter_wait}s; inspect window $T" >&2
     exit 1
   fi
 

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -333,6 +333,9 @@ fm_refuse_if_gate_agent
 # Skip the watcher guard when re-exec'd for one pair of a batch (FM_SPAWN_NO_GUARD is
 # set by the batch loop below), so the guard runs once for the batch, not once per pair.
 [ -n "${FM_SPAWN_NO_GUARD:-}" ] || "$FM_ROOT/bin/fm-guard.sh" || true
+ENTER_WAIT=${FM_SPAWN_ENTER_WAIT_SECS:-60}
+case "$ENTER_WAIT" in ''|*[!0-9]*) echo "error: FM_SPAWN_ENTER_WAIT_SECS must be a positive integer, got '${FM_SPAWN_ENTER_WAIT_SECS:-}'" >&2; exit 1 ;; esac
+[ "$ENTER_WAIT" -gt 0 ] || { echo "error: FM_SPAWN_ENTER_WAIT_SECS must be a positive integer, got '${FM_SPAWN_ENTER_WAIT_SECS:-}'" >&2; exit 1; }
 KIND=ship
 KIND_SET=0
 HARNESS_ARG=
@@ -2573,12 +2576,8 @@ elif [ "$KIND" != secondmate ] && [ "$BACKEND" != orca ]; then
   # a mismatch just becomes the new candidate rather than resetting the wait, so a
   # pane that is already settled by the first real read only costs the one existing
   # inter-poll sleep as confirmation, not a whole extra cycle on top.
-  enter_wait=${FM_SPAWN_ENTER_WAIT_SECS:-60}
-  case "$enter_wait" in
-    ''|*[!0-9]*|0) echo "error: FM_SPAWN_ENTER_WAIT_SECS must be a positive integer, got '${FM_SPAWN_ENTER_WAIT_SECS:-}'" >&2; exit 1 ;;
-  esac
   candidate=""
-  for _ in $(seq 1 "$enter_wait"); do
+  for _ in $(seq 1 "$ENTER_WAIT"); do
     p=$(spawn_current_path "$WT_TARGET" || true)
     if [ -n "$p" ]; then
       p_real=$(real_path_or_raw "$p")
@@ -2597,7 +2596,7 @@ elif [ "$KIND" != secondmate ] && [ "$BACKEND" != orca ]; then
     sleep 1
   done
   if [ -z "$WT" ]; then
-    echo "error: treehouse get did not enter a worktree within ${enter_wait}s; inspect window $T" >&2
+    echo "error: treehouse get did not enter a worktree within ${ENTER_WAIT}s; inspect window $T" >&2
     exit 1
   fi
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -886,6 +886,7 @@ FM_WATCH_TRIAGE_LOG_MAX_BYTES=262144   # size cap for the watcher's absorbed-wak
 FM_FLEET_SYNC_BOOTSTRAP_TIMEOUT=     # optional seconds allowed for bootstrap's best-effort clone refresh; unset/blank defaults to max(20, 5 + 3 * origin-backed-project-count)
 FM_FLEET_PRUNE=1        # set to 0 to skip pruning local branches whose upstream is gone
 FM_STALE_WORKTREE_LOCK_AGE_SECS=30       # min mtime age before fm-teardown.sh treats a leftover worktree git index.lock as provably stale
+FM_SPAWN_ENTER_WAIT_SECS=60               # positive integer seconds fm-spawn.sh waits for a treehouse-get backend's pane to enter the pooled worktree before failing; raise it when recycling a stale pooled slot fetches origin first and that fetch alone exceeds the default under load
 FM_TREEHOUSE_RETURN_LOCK_RETRIES=3        # retries after a treehouse return fails on the transient git index.lock signature
 FM_TREEHOUSE_RETURN_LOCK_RETRY_WAIT_SECS=1 # seconds fm-teardown.sh waits before each retry after that signature
 FM_STALE_WORKTREE_LOCK_RETRY_WAIT_SECS=   # legacy alias for FM_TREEHOUSE_RETURN_LOCK_RETRY_WAIT_SECS when the new variable is unset

--- a/tests/fm-spawn-worktree-settle.test.sh
+++ b/tests/fm-spawn-worktree-settle.test.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 # Regression test for the fm-spawn.sh treehouse-get worktree-detection settle
-# loop (bin/fm-spawn.sh, the `for _ in $(seq 1 60)` loop after `treehouse get`).
+# loop (bin/fm-spawn.sh, the `for _ in $(seq 1 "$ENTER_WAIT")` loop after
+# `treehouse get`).
 #
 # On some tmux/WSL setups a brand-new window's pane_current_path transiently
 # reports a stale, unrelated-but-real path on the very first poll, before the
@@ -30,6 +31,7 @@ make_settle_fakebin() {
   cat > "$fakebin/tmux" <<'SH'
 #!/usr/bin/env bash
 set -u
+[ -z "${FM_FAKE_TMUX_LOG:-}" ] || printf '%s\n' "$*" >> "$FM_FAKE_TMUX_LOG"
 case "$*" in
   *"#{pane_current_path}"*)
     countfile="${FM_FAKE_PANE_COUNTFILE:?FM_FAKE_PANE_COUNTFILE unset}"
@@ -159,14 +161,7 @@ test_enter_wait_override_changes_the_bound() {
 
   start=$(date +%s)
   # Point the fake pane at the project itself so it never enters a worktree.
-  out=$(FM_SPAWN_ENTER_WAIT_SECS=1 FM_ROOT_OVERRIDE='' FM_HOME="$HOME_DIR" \
-    FM_STATE_OVERRIDE="$HOME_DIR/state" FM_DATA_OVERRIDE="$HOME_DIR/data" \
-    FM_PROJECTS_OVERRIDE="$HOME_DIR/projects" FM_CONFIG_OVERRIDE="$HOME_DIR/config" \
-    FM_SPAWN_NO_GUARD=1 TMUX="fake,1,0" \
-    FM_FAKE_PANE_PATH="$PROJ_DIR" FM_FAKE_PANE_STALE="$PROJ_DIR" \
-    FM_FAKE_PANE_STALE_READS=0 FM_FAKE_PANE_COUNTFILE="$COUNTFILE" \
-    PATH="$FAKEBIN_DIR:$PATH" \
-    "$SPAWN" "$id" "$PROJ_DIR" --mode no-mistakes --yolo off 2>&1)
+  out=$(FM_SPAWN_ENTER_WAIT_SECS=1 WT_DIR="$PROJ_DIR" STALE_DIR="$PROJ_DIR" run_settle_spawn "$id")
   status=$?
   end=$(date +%s)
   elapsed=$((end - start))
@@ -176,19 +171,26 @@ test_enter_wait_override_changes_the_bound() {
   pass "FM_SPAWN_ENTER_WAIT_SECS bounds the treehouse-enter wait loop"
 }
 
-# A non-positive-integer override is refused before any loop runs.
+# A non-positive-integer override (including all-digit zero like 00) is refused
+# before the endpoint window exists or treehouse get is sent.
 test_enter_wait_invalid_is_refused() {
-  local rec id out status
-  id=enter-wait-invalid-z4
-  rec=$(make_settle_case enter-wait-invalid "$id" 0)
-  read_settle_record "$rec"
+  local rec id out status bad tmux_log
+  for bad in nope 00; do
+    id="enter-wait-invalid-$bad-z4"
+    rec=$(make_settle_case "enter-wait-invalid-$bad" "$id" 0)
+    read_settle_record "$rec"
+    tmux_log="$HOME_DIR/tmux-calls.log"
+    : > "$tmux_log"
 
-  out=$(FM_SPAWN_ENTER_WAIT_SECS=nope run_settle_spawn "$id")
-  status=$?
-  expect_code 1 "$status" "spawn should refuse a non-integer enter-wait"
-  assert_contains "$out" "FM_SPAWN_ENTER_WAIT_SECS must be a positive integer" \
-    "spawn did not refuse the invalid enter-wait value"
-  pass "a non-positive-integer FM_SPAWN_ENTER_WAIT_SECS is refused"
+    out=$(FM_SPAWN_ENTER_WAIT_SECS="$bad" FM_FAKE_TMUX_LOG="$tmux_log" run_settle_spawn "$id")
+    status=$?
+    expect_code 1 "$status" "spawn should refuse enter-wait '$bad'"
+    assert_contains "$out" "FM_SPAWN_ENTER_WAIT_SECS must be a positive integer, got '$bad'" \
+      "spawn did not refuse enter-wait '$bad'"
+    assert_no_grep "new-window" "$tmux_log" "enter-wait '$bad' was refused only after creating the endpoint window"
+    assert_no_grep "treehouse get" "$tmux_log" "enter-wait '$bad' was refused only after sending treehouse get"
+  done
+  pass "a non-positive-integer FM_SPAWN_ENTER_WAIT_SECS is refused before any endpoint exists"
 }
 
 test_single_stale_first_read_is_not_accepted

--- a/tests/fm-spawn-worktree-settle.test.sh
+++ b/tests/fm-spawn-worktree-settle.test.sh
@@ -148,7 +148,52 @@ test_already_settled_pane_costs_one_confirm_sleep() {
   pass "an already-settled pane confirms via the existing inter-poll sleep, not an extra full cycle"
 }
 
+# FM_SPAWN_ENTER_WAIT_SECS overrides the enter-wait bound: with the pane never
+# leaving the project (candidate never settles), the loop exhausts and the
+# failure names the configured bound, proving the override drives the loop.
+test_enter_wait_override_changes_the_bound() {
+  local rec id out status start end elapsed
+  id=enter-wait-override-z3
+  rec=$(make_settle_case enter-wait-override "$id" 0)
+  read_settle_record "$rec"
+
+  start=$(date +%s)
+  # Point the fake pane at the project itself so it never enters a worktree.
+  out=$(FM_SPAWN_ENTER_WAIT_SECS=1 FM_ROOT_OVERRIDE='' FM_HOME="$HOME_DIR" \
+    FM_STATE_OVERRIDE="$HOME_DIR/state" FM_DATA_OVERRIDE="$HOME_DIR/data" \
+    FM_PROJECTS_OVERRIDE="$HOME_DIR/projects" FM_CONFIG_OVERRIDE="$HOME_DIR/config" \
+    FM_SPAWN_NO_GUARD=1 TMUX="fake,1,0" \
+    FM_FAKE_PANE_PATH="$PROJ_DIR" FM_FAKE_PANE_STALE="$PROJ_DIR" \
+    FM_FAKE_PANE_STALE_READS=0 FM_FAKE_PANE_COUNTFILE="$COUNTFILE" \
+    PATH="$FAKEBIN_DIR:$PATH" \
+    "$SPAWN" "$id" "$PROJ_DIR" --mode no-mistakes --yolo off 2>&1)
+  status=$?
+  end=$(date +%s)
+  elapsed=$((end - start))
+  expect_code 1 "$status" "spawn should fail when the pane never enters a worktree"
+  assert_contains "$out" "within 1s" "failure did not report the overridden enter-wait bound"
+  [ "$elapsed" -le 5 ] || fail "enter-wait=1 loop took ${elapsed}s - the override did not bound the loop"
+  pass "FM_SPAWN_ENTER_WAIT_SECS bounds the treehouse-enter wait loop"
+}
+
+# A non-positive-integer override is refused before any loop runs.
+test_enter_wait_invalid_is_refused() {
+  local rec id out status
+  id=enter-wait-invalid-z4
+  rec=$(make_settle_case enter-wait-invalid "$id" 0)
+  read_settle_record "$rec"
+
+  out=$(FM_SPAWN_ENTER_WAIT_SECS=nope run_settle_spawn "$id")
+  status=$?
+  expect_code 1 "$status" "spawn should refuse a non-integer enter-wait"
+  assert_contains "$out" "FM_SPAWN_ENTER_WAIT_SECS must be a positive integer" \
+    "spawn did not refuse the invalid enter-wait value"
+  pass "a non-positive-integer FM_SPAWN_ENTER_WAIT_SECS is refused"
+}
+
 test_single_stale_first_read_is_not_accepted
 test_already_settled_pane_costs_one_confirm_sleep
+test_enter_wait_override_changes_the_bound
+test_enter_wait_invalid_is_refused
 
 echo "# all fm-spawn-worktree-settle tests passed"


### PR DESCRIPTION
On 2026-09-04, six secondmate spawns failed while Treehouse recycled stale pooled worktree slots. Recycling fetches origin before entering the worktree; under node/network load, that fetch exceeded the hard-coded 60-second enter wait.

Read `FM_SPAWN_ENTER_WAIT_SECS` as a positive integer for the loop bound and timeout message, validating it before endpoint creation and rejecting zero values including `00`. Document the knob in the script header and configuration reference, and extend the spawn regression coverage. The default remains 60 seconds, and the two-consecutive-reads logic is unchanged.

Validation: the prior no-mistakes review passed with 0 findings. The attribution-only commit rewrite preserves both reviewed commit trees; `git diff 48dfabd..HEAD` is empty.
