### PR TITLE
test(tests): consolidate fake toolchain stubs into shared fixtures.sh builders

### DIFF
--- a/tests/fixtures.sh
+++ b/tests/fixtures.sh
@@ -33,6 +33,9 @@ export FM_TEST_NO_MISTAKES_FAKE_VERSION="no-mistakes version v${FM_TEST_NO_MISTA
 export FM_TEST_NO_MISTAKES_FAKE_VERSION_TS="${FM_TEST_NO_MISTAKES_FAKE_VERSION} 2026-06-27T00:02:18Z"
 export FM_TEST_GH_AXI_VERSION=0.1.29
 export FM_TEST_QUOTA_AXI_VERSION=0.1.29
+# Production floor lives in bin/fm-tasks-axi-lib.sh (FM_TASKS_AXI_MIN). Keep
+# this equal to that floor so a bump is one constant here plus that pin.
+export FM_TEST_TASKS_AXI_VERSION=0.2.4
 
 # --- fake no-mistakes -------------------------------------------------------
 
@@ -123,12 +126,12 @@ SH
 }
 
 # fm_test_fake_tasks_axi <fakebin> [version] [archive-body] [multi-id]
-# Answers --version (default 0.2.4), the two capability helps the backlog gate
-# probes (`update --help` advertises --body-file and, unless archive-body is
-# "no", --archive-body; `mv --help` shows the multi-id usage unless multi-id
-# is "no"), and exits 0 for every other invocation.
+# Answers --version (default FM_TEST_TASKS_AXI_VERSION), the two capability
+# helps the backlog gate probes (`update --help` advertises --body-file and,
+# unless archive-body is "no", --archive-body; `mv --help` shows the multi-id
+# usage unless multi-id is "no"), and exits 0 for every other invocation.
 fm_test_fake_tasks_axi() {
-  local fakebin=$1 version=${2:-0.2.4} archive_body=${3:-yes} multi_id=${4:-yes} archive_line mv_usage
+  local fakebin=$1 version=${2:-$FM_TEST_TASKS_AXI_VERSION} archive_body=${3:-yes} multi_id=${4:-yes} archive_line mv_usage
   archive_line='  --archive-body'
   [ "$archive_body" = yes ] || archive_line=
   mv_usage='usage: tasks-axi mv <id> [<id>...] --to <path-or-dir>'

--- a/tests/fixtures.sh
+++ b/tests/fixtures.sh
@@ -27,21 +27,25 @@ FM_TEST_FIXTURES_SOURCED=1
 # equal to that floor so a bump is one constant here plus that production pin.
 export FM_TEST_NO_MISTAKES_VERSION=1.46.0
 export FM_TEST_NO_MISTAKES_FAKE_VERSION="no-mistakes version v${FM_TEST_NO_MISTAKES_VERSION} (fake)"
+# The timestamped form is the default banner: it is the shape the real CLI
+# prints, and the suites that pin a banner (bootstrap, session-start) pin this
+# form. Override a single case with FM_FAKE_NO_MISTAKES_VERSION.
 export FM_TEST_NO_MISTAKES_FAKE_VERSION_TS="${FM_TEST_NO_MISTAKES_FAKE_VERSION} 2026-06-27T00:02:18Z"
 export FM_TEST_GH_AXI_VERSION=0.1.29
+export FM_TEST_QUOTA_AXI_VERSION=0.1.29
 
 # --- fake no-mistakes -------------------------------------------------------
 
 # fm_test_fake_no_mistakes <fakebin>
-# Drops a no-mistakes stub that answers --version with
-# FM_TEST_NO_MISTAKES_FAKE_VERSION (or FM_FAKE_NO_MISTAKES_VERSION when set)
-# and exits 0 for every other invocation.
+# Drops a no-mistakes stub that answers --version with the shared timestamped
+# banner (or FM_FAKE_NO_MISTAKES_VERSION when set) and exits 0 for every other
+# invocation.
 fm_test_fake_no_mistakes() {
   local fakebin=$1
   cat > "$fakebin/no-mistakes" <<SH
 #!/usr/bin/env bash
 if [ "\${1:-}" = --version ]; then
-  printf '%s\\n' "\${FM_FAKE_NO_MISTAKES_VERSION:-$FM_TEST_NO_MISTAKES_FAKE_VERSION}"
+  printf '%s\\n' "\${FM_FAKE_NO_MISTAKES_VERSION:-$FM_TEST_NO_MISTAKES_FAKE_VERSION_TS}"
   exit 0
 fi
 exit 0
@@ -87,6 +91,67 @@ SH
 fm_test_fake_gh_axi() {
   local fakebin=$1
   fm_fake_version_tool "$fakebin" gh-axi FM_FAKE_GH_AXI_VERSION "$FM_TEST_GH_AXI_VERSION"
+}
+
+# fm_test_fake_quota_axi <fakebin>
+# Answers --version with FM_FAKE_QUOTA_AXI_VERSION or FM_TEST_QUOTA_AXI_VERSION.
+fm_test_fake_quota_axi() {
+  local fakebin=$1
+  fm_fake_version_tool "$fakebin" quota-axi FM_FAKE_QUOTA_AXI_VERSION "$FM_TEST_QUOTA_AXI_VERSION"
+}
+
+# fm_test_fake_treehouse <fakebin> [default-usage]
+# Answers `get --help` with <default-usage> (default: the lease-capable form)
+# and exits 0 otherwise. FM_FAKE_TREEHOUSE_LEASE_HELP=1 switches the help to
+# the lease-holder form, so a suite can drive both sides of spawn's
+# capability detection without owning a private copy of the stub.
+fm_test_fake_treehouse() {
+  local fakebin=$1 usage=${2:-Usage: treehouse get [--lease]}
+  cat > "$fakebin/treehouse" <<SH
+#!/usr/bin/env bash
+if [ "\${1:-}" = get ] && [ "\${2:-}" = --help ]; then
+  if [ "\${FM_FAKE_TREEHOUSE_LEASE_HELP:-}" = 1 ]; then
+    printf '%s\\n' 'Usage: treehouse get [--lease] [--lease-holder <holder>]'
+  else
+    printf '%s\\n' '$usage'
+  fi
+  exit 0
+fi
+exit 0
+SH
+  chmod +x "$fakebin/treehouse"
+}
+
+# fm_test_fake_tasks_axi <fakebin> [version] [archive-body] [multi-id]
+# Answers --version (default 0.2.4), the two capability helps the backlog gate
+# probes (`update --help` advertises --body-file and, unless archive-body is
+# "no", --archive-body; `mv --help` shows the multi-id usage unless multi-id
+# is "no"), and exits 0 for every other invocation.
+fm_test_fake_tasks_axi() {
+  local fakebin=$1 version=${2:-0.2.4} archive_body=${3:-yes} multi_id=${4:-yes} archive_line mv_usage
+  archive_line='  --archive-body'
+  [ "$archive_body" = yes ] || archive_line=
+  mv_usage='usage: tasks-axi mv <id> [<id>...] --to <path-or-dir>'
+  [ "$multi_id" = yes ] || mv_usage='usage: tasks-axi mv <id> --to <path-or-dir>'
+  cat > "$fakebin/tasks-axi" <<SH
+#!/usr/bin/env bash
+if [ "\${1:-}" = --version ]; then
+  printf '%s\\n' '$version'
+  exit 0
+fi
+if [ "\${1:-}" = update ] && [ "\${2:-}" = --help ]; then
+  printf '%s\\n' 'usage: tasks-axi update <id> [flags]'
+  printf '%s\\n' '  --body-file <path>'
+  [ -z '$archive_line' ] || printf '%s\\n' '$archive_line'
+  exit 0
+fi
+if [ "\${1:-}" = mv ] && [ "\${2:-}" = --help ]; then
+  printf '%s\\n' '$mv_usage'
+  exit 0
+fi
+exit 0
+SH
+  chmod +x "$fakebin/tasks-axi"
 }
 
 # --- fake tmux / ssh / sleep ------------------------------------------------

--- a/tests/fixtures.sh
+++ b/tests/fixtures.sh
@@ -6,9 +6,9 @@
 #   . "$(dirname "${BASH_SOURCE[0]}")/fixtures.sh"
 #
 # Generic reporters, temp roots, git fixtures, and fail/pass/fm_test_cleanup
-# come from tests/lib.sh, pulled in below. This file owns the shared fake
-# no-mistakes, gh, gh-axi, tmux, ssh, and spawn-world helpers. Wake-queue mocks
-# stay in wake-helpers.sh; secondmate-lifecycle mocks stay in
+# come from tests/lib.sh, pulled in below. This file owns the shared fake-CLI
+# builders - every fm_test_fake_* below - and the spawn-world helpers.
+# Wake-queue mocks stay in wake-helpers.sh; secondmate-lifecycle mocks stay in
 # secondmate-helpers.sh.
 #
 # FM_TEST_NO_MISTAKES_VERSION is the single default version for the shared fake
@@ -73,7 +73,7 @@ SH
   chmod +x "$fakebin/no-mistakes"
 }
 
-# --- fake gh / gh-axi -------------------------------------------------------
+# --- fake gh / axi CLIs / treehouse -----------------------------------------
 
 # fm_test_fake_gh <fakebin>
 # Authenticates (`gh auth status` exits 0) and otherwise exits 0.
@@ -157,7 +157,7 @@ SH
   chmod +x "$fakebin/tasks-axi"
 }
 
-# --- fake tmux / ssh / sleep ------------------------------------------------
+# --- fake tmux / ssh / sleep / uname / curl / hashers -----------------------
 
 # fm_test_fake_tmux_spawn <fakebin>
 # Spawn-world tmux: pane_current_path from FM_FAKE_PANE_PATH, session named

--- a/tests/fixtures.sh
+++ b/tests/fixtures.sh
@@ -287,6 +287,93 @@ SH
   chmod +x "$fakebin/sleep"
 }
 
+# fm_test_fake_uname <fakebin>
+# Answers -s/-m with FM_TEST_UNAME_S / FM_TEST_UNAME_M (Linux/x86_64 default).
+fm_test_fake_uname() {
+  local fakebin=$1
+  cat > "$fakebin/uname" <<'SH'
+#!/usr/bin/env bash
+case "${1:-}" in
+  -s) printf '%s\n' "${FM_TEST_UNAME_S:-Linux}" ;;
+  -m) printf '%s\n' "${FM_TEST_UNAME_M:-x86_64}" ;;
+  *) printf '%s\n' "${FM_TEST_UNAME_S:-Linux}" ;;
+esac
+SH
+  chmod +x "$fakebin/uname"
+}
+
+# fm_test_fake_curl <fakebin>
+# Download stub for installer tests: counts calls to CURL_COUNT, logs each URL
+# to CURL_URL_LOG, exits 22 for the first CURL_FAIL_UNTIL calls, else writes an
+# empty file to the -o target.
+fm_test_fake_curl() {
+  local fakebin=$1
+  cat > "$fakebin/curl" <<'SH'
+#!/usr/bin/env bash
+count=0
+[ ! -f "${CURL_COUNT:-}" ] || count=$(cat "$CURL_COUNT")
+count=$((count + 1))
+[ -z "${CURL_COUNT:-}" ] || printf '%s\n' "$count" > "$CURL_COUNT"
+url=
+out=
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    -o)
+      out=$2
+      shift 2
+      ;;
+    -*)
+      shift
+      ;;
+    *)
+      url=$1
+      shift
+      ;;
+  esac
+done
+[ -z "${CURL_URL_LOG:-}" ] || printf '%s\n' "$url" >> "$CURL_URL_LOG"
+fail_until=${CURL_FAIL_UNTIL:-0}
+[ "$count" -gt "$fail_until" ] || exit 22
+: > "$out"
+exit 0
+SH
+  chmod +x "$fakebin/curl"
+}
+
+# fm_test_fake_hasher <fakebin> <name>
+# sha256-style hasher stub: logs "$self $*" to HASHER_LOG and prints
+# SHA256_STUB_HASH for the file (shasum requires -a 256).
+fm_test_fake_hasher() {
+  local fakebin=$1 name=$2
+  cat > "$fakebin/$name" <<'SH'
+#!/usr/bin/env bash
+self=${0##*/}
+if [ -n "${HASHER_LOG:-}" ]; then
+  printf '%s\n' "$self $*" >> "$HASHER_LOG"
+fi
+file=$1
+if [ "$self" = shasum ]; then
+  algo=
+  file=
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      -a)
+        algo=$2
+        shift 2
+        ;;
+      *)
+        file=$1
+        shift
+        ;;
+    esac
+  done
+  [ "$algo" = 256 ] || exit 1
+fi
+printf '%s  %s\n' "${SHA256_STUB_HASH:?}" "$file"
+SH
+  chmod +x "$fakebin/$name"
+}
+
 # --- spawn-world ------------------------------------------------------------
 
 # fm_test_spawn_home <home> [harness]

--- a/tests/fm-backend-herdr.test.sh
+++ b/tests/fm-backend-herdr.test.sh
@@ -78,6 +78,26 @@ SH
   printf '%s\n' "$fb"
 }
 
+# herdr_run <dir> [K=V ...] <adapter-fn> [args...]
+# Source the adapter and run <adapter-fn> against a canned-response case world
+# (dir with log, responses/, and the make_herdr_fakebin stub - installed here
+# only when absent, so a case that deletes or replaces the stub stays in
+# control of what runs). Leading K=V arguments apply to this one call only.
+herdr_run() {
+  local dir=$1
+  shift
+  local -a e=(PATH="$dir/fakebin:$PATH" FM_HERDR_LOG="$dir/log" FM_HERDR_RESPONSES="$dir/responses")
+  while [ $# -gt 0 ] && [ "${1#*=}" != "$1" ]; do
+    e+=("$1")
+    shift
+  done
+  [ -x "$dir/fakebin/herdr" ] || make_herdr_fakebin "$dir" >/dev/null
+  local fn=$1
+  shift
+  # shellcheck disable=SC2016  # $0/$@ are expanded by the inner bash, by design
+  env "${e[@]}" bash -c '. "$0/bin/backends/herdr.sh"; '"$fn"' "$@"' "$ROOT" "$@"
+}
+
 # make_herdr_server_env_fakebin: a stateful server stub that records only the
 # long-lived server launch environment, then reports the server as running.
 make_herdr_server_env_fakebin() {  # <dir> -> echoes fakebin dir
@@ -237,100 +257,69 @@ herdr_env() {  # <name>
 
 # --- version_check / tool_check ----------------------------------------------
 
-test_version_check_accepts_current_protocol() {
-  local dir log resp fb status
-  dir="$TMP_ROOT/version-ok"; mkdir -p "$dir/responses"; log="$dir/log"; resp="$dir/responses"; : > "$log"
-  printf '{"client":{"version":"0.7.1","channel":"stable","protocol":14}}\n' > "$resp/1.out"
-  fb=$(make_herdr_fakebin "$dir")
-  PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" FM_HERDR_SCRIPT_STATUS=1 \
-    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_version_check' "$ROOT"
-  status=$?
-  expect_code 0 "$status" "version_check should accept protocol 14 (>= the verified minimum)"
-  assert_contains "$(cat "$log")" $'\x1f''status'$'\x1f''--json' "version_check did not call herdr status --json"
-  pass "fm_backend_herdr_version_check: accepts the current protocol (14)"
-}
+test_version_check_matrix() {
+  # One behavior check per contract clause of fm_backend_herdr_version_check:
+  # accepts the current protocol, refuses an old protocol naming it, and
+  # refuses loudly when the CLI is absent.
+  local dir out status
 
-test_version_check_refuses_old_protocol() {
-  local dir log resp fb out status
-  dir="$TMP_ROOT/version-old"; mkdir -p "$dir/responses"; log="$dir/log"; resp="$dir/responses"; : > "$log"
-  printf '{"client":{"version":"0.3.0","channel":"stable","protocol":5}}\n' > "$resp/1.out"
-  fb=$(make_herdr_fakebin "$dir")
-  out=$( PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" FM_HERDR_SCRIPT_STATUS=1 \
-    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_version_check' "$ROOT" 2>&1 )
+  dir="$TMP_ROOT/version-ok"; mkdir -p "$dir/responses"; : > "$dir/log"
+  printf '{"client":{"version":"0.7.1","channel":"stable","protocol":14}}\n' > "$dir/responses/1.out"
+  herdr_run "$dir" FM_HERDR_SCRIPT_STATUS=1 fm_backend_herdr_version_check
+  expect_code 0 $? "version_check should accept protocol 14 (>= the verified minimum)"
+  assert_contains "$(cat "$dir/log")" $'\x1f''status'$'\x1f''--json' "version_check did not call herdr status --json"
+
+  dir="$TMP_ROOT/version-old"; mkdir -p "$dir/responses"; : > "$dir/log"
+  printf '{"client":{"version":"0.3.0","channel":"stable","protocol":5}}\n' > "$dir/responses/1.out"
+  out=$( herdr_run "$dir" FM_HERDR_SCRIPT_STATUS=1 fm_backend_herdr_version_check 2>&1 )
   status=$?
   [ "$status" -ne 0 ] || fail "version_check should refuse protocol 5 (below min)"
   assert_contains "$out" "protocol 5" "version_check error did not name the rejected protocol"
-  pass "fm_backend_herdr_version_check: refuses an old protocol loudly"
-}
 
-test_version_check_refuses_missing_herdr() {
-  local dir out status
   dir="$TMP_ROOT/version-missing"; mkdir -p "$dir/empty-fakebin"
   out=$( PATH="$dir/empty-fakebin:/usr/bin:/bin" \
     bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_version_check' "$ROOT" 2>&1 )
   status=$?
   [ "$status" -ne 0 ] || fail "version_check should refuse when herdr is not installed"
   assert_contains "$out" "not installed" "version_check did not report herdr as missing"
-  pass "fm_backend_herdr_version_check: refuses loudly when herdr is not installed"
+  pass "fm_backend_herdr_version_check: accepts current protocol, refuses old and missing"
 }
 
 # --- workspace_label: per-firstmate-HOME resolution (P3, herdr-sm-spaces-k4) -
 
-test_workspace_label_primary_home_no_marker() {
-  local home
-  home="$TMP_ROOT/primary-home-no-marker"; mkdir -p "$home"
+test_workspace_label_matrix() {
+  # One behavior check per contract clause of fm_backend_herdr_workspace_label:
+  # the label is 'firstmate' for a primary home and '2ndmate-<id>' for a
+  # secondmate home, the marker id is whitespace-trimmed, an empty marker falls
+  # back to the primary label, and two different homes never collide.
+  local home out out2
+  local case marker expect
+  while IFS='|' read -r case marker expect; do
+    [ -n "$case" ] || continue
+    home="$TMP_ROOT/label-$case"; rm -rf "$home"; mkdir -p "$home"
+    if [ "$marker" != - ]; then printf '%b' "$marker" > "$home/.fm-secondmate-home"; fi
+    out=$( FM_HOME="$home" bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_workspace_label' "$ROOT" )
+    [ "$out" = "$expect" ] || fail "workspace_label case '$case': expected '$expect', got '$out'"
+  done <<'CASES'
+primary-no-marker|-|firstmate
+secondmate-marker-id|sshhip-h7\n|2ndmate-sshhip-h7
+secondmate-marker-trims|  sshhip-h7  \n\n|2ndmate-sshhip-h7
+secondmate-marker-empty||firstmate
+CASES
+  home="$TMP_ROOT/label-alpha"; mkdir -p "$home"; printf 'alpha-a1\n' > "$home/.fm-secondmate-home"
   out=$( FM_HOME="$home" bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_workspace_label' "$ROOT" )
-  [ "$out" = "firstmate" ] || fail "a primary home (no .fm-secondmate-home marker) should resolve to label 'firstmate', got '$out'"
-  pass "fm_backend_herdr_workspace_label: a primary home (no marker) resolves to 'firstmate'"
-}
-
-test_workspace_label_secondmate_home_uses_marker_id() {
-  local home
-  home="$TMP_ROOT/secondmate-home"; mkdir -p "$home"
-  printf 'sshhip-h7\n' > "$home/.fm-secondmate-home"
-  out=$( FM_HOME="$home" bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_workspace_label' "$ROOT" )
-  [ "$out" = "2ndmate-sshhip-h7" ] || fail "a secondmate home should resolve to '2ndmate-<id>', got '$out'"
-  pass "fm_backend_herdr_workspace_label: a secondmate home (.fm-secondmate-home) resolves to '2ndmate-<id>'"
-}
-
-test_workspace_label_secondmate_marker_trims_whitespace() {
-  local home
-  home="$TMP_ROOT/secondmate-home-ws"; mkdir -p "$home"
-  printf '  sshhip-h7  \n\n' > "$home/.fm-secondmate-home"
-  out=$( FM_HOME="$home" bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_workspace_label' "$ROOT" )
-  [ "$out" = "2ndmate-sshhip-h7" ] || fail "the marker id should be trimmed of surrounding whitespace, got '$out'"
-  pass "fm_backend_herdr_workspace_label: trims whitespace around the marker's secondmate id"
-}
-
-test_workspace_label_empty_marker_falls_back_to_primary() {
-  local home
-  home="$TMP_ROOT/secondmate-home-empty"; mkdir -p "$home"
-  : > "$home/.fm-secondmate-home"
-  out=$( FM_HOME="$home" bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_workspace_label' "$ROOT" )
-  [ "$out" = "firstmate" ] || fail "an empty/unreadable marker should fall back to 'firstmate', got '$out'"
-  pass "fm_backend_herdr_workspace_label: an empty marker file falls back to the primary label 'firstmate'"
-}
-
-test_workspace_label_different_secondmates_get_different_labels() {
-  local home1 home2 out1 out2
-  home1="$TMP_ROOT/secondmate-a"; mkdir -p "$home1"; printf 'alpha-a1\n' > "$home1/.fm-secondmate-home"
-  home2="$TMP_ROOT/secondmate-b"; mkdir -p "$home2"; printf 'bravo-b2\n' > "$home2/.fm-secondmate-home"
-  out1=$( FM_HOME="$home1" bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_workspace_label' "$ROOT" )
-  out2=$( FM_HOME="$home2" bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_workspace_label' "$ROOT" )
-  [ "$out1" = "2ndmate-alpha-a1" ] || fail "secondmate home1 label mismatch: $out1"
+  home="$TMP_ROOT/label-bravo"; mkdir -p "$home"; printf 'bravo-b2\n' > "$home/.fm-secondmate-home"
+  out2=$( FM_HOME="$home" bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_workspace_label' "$ROOT" )
+  [ "$out" = "2ndmate-alpha-a1" ] || fail "secondmate home1 label mismatch: $out"
   [ "$out2" = "2ndmate-bravo-b2" ] || fail "secondmate home2 label mismatch: $out2"
-  [ "$out1" != "$out2" ] || fail "two different secondmate homes must not collide on the same label"
-  pass "fm_backend_herdr_workspace_label: two different secondmate homes get two different, non-colliding labels"
+  [ "$out" != "$out2" ] || fail "two different secondmate homes must not collide on the same label"
+  pass "fm_backend_herdr_workspace_label: primary/secondmate/trim/empty clauses and no cross-home collision"
 }
-
-# --- fm_backend_herdr_cli: session targeting (2026-07-02 incident fix) -------
 
 test_cli_helper_sets_env_and_appends_trailing_session_flag() {
   local dir log resp fb
   dir="$TMP_ROOT/cli-helper"; mkdir -p "$dir/responses"; log="$dir/log"; resp="$dir/responses"; : > "$log"
-  fb=$(make_herdr_fakebin "$dir")
-  PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
-    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_cli fmtest workspace list' "$ROOT"
+  herdr_run "$dir" fm_backend_herdr_cli fmtest workspace list
   expect_code 0 $? "fm_backend_herdr_cli should succeed"
   assert_contains "$(cat "$log")" "HERDR_SESSION=fmtest"$'\x1f''workspace'$'\x1f''list' \
     "fm_backend_herdr_cli did not set the HERDR_SESSION env var"
@@ -859,11 +848,9 @@ SH
 # the spawn, never quietly degrade back to picking a workspace by label.
 
 test_launcher_identity_absent_without_a_herdr_pane() {
-  local dir log resp fb status
+  local dir log resp status
   dir="$TMP_ROOT/launcher-none"; mkdir -p "$dir/responses"; log="$dir/log"; resp="$dir/responses"; : > "$log"
-  fb=$(make_herdr_fakebin "$dir")
-  ( PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
-    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_launcher_identity fmtest' "$ROOT" )
+  ( herdr_run "$dir" fm_backend_herdr_launcher_identity fmtest )
   status=$?
   expect_code 2 "$status" "a process with no herdr pane must report 'no launcher to inherit' (2), not a refusal"
   [ ! -s "$log" ] || fail "resolving an absent launcher identity must not call herdr at all"$'\n'"$(cat "$log")"
@@ -871,12 +858,9 @@ test_launcher_identity_absent_without_a_herdr_pane() {
 }
 
 test_launcher_identity_absent_when_herdr_env_alone_is_set() {
-  local dir log resp fb status
+  local dir log resp status
   dir="$TMP_ROOT/launcher-env-only"; mkdir -p "$dir/responses"; log="$dir/log"; resp="$dir/responses"; : > "$log"
-  fb=$(make_herdr_fakebin "$dir")
-  ( PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" HERDR_ENV=1 \
-    \
-    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_launcher_identity fmtest' "$ROOT" )
+  ( herdr_run "$dir" HERDR_ENV=1 fm_backend_herdr_launcher_identity fmtest )
   status=$?
   expect_code 2 "$status" "HERDR_ENV=1 alone is a backend-selection marker, not a parent binding"
   pass "fm_backend_herdr_launcher_identity: HERDR_ENV=1 without a pane id selects the backend but binds no parent"
@@ -902,12 +886,9 @@ test_launcher_identity_resolves_the_exact_pane_tab_and_workspace() {
 }
 
 test_launcher_identity_refuses_a_pane_from_another_session_name() {
-  local dir log resp fb out status
+  local dir log resp out status
   dir="$TMP_ROOT/launcher-xsession"; mkdir -p "$dir/responses"; log="$dir/log"; resp="$dir/responses"; : > "$log"
-  fb=$(make_herdr_fakebin "$dir")
-  out=$( PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
-    HERDR_ENV=1 HERDR_PANE_ID=w7:p3 HERDR_SESSION=someother \
-    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_launcher_identity fmtest' "$ROOT" 2>&1 )
+  out=$( herdr_run "$dir" HERDR_ENV=1 HERDR_PANE_ID=w7:p3 HERDR_SESSION=someother fm_backend_herdr_launcher_identity fmtest 2>&1 )
   status=$?
   expect_code 1 "$status" "a launcher pane naming another herdr session must refuse"
   assert_contains "$out" "cross-session parent identity" "the cross-session refusal did not explain itself"
@@ -916,12 +897,9 @@ test_launcher_identity_refuses_a_pane_from_another_session_name() {
 }
 
 test_launcher_identity_refuses_a_missing_server_socket() {
-  local dir log resp fb out status
+  local dir log resp out status
   dir="$TMP_ROOT/launcher-no-socket"; mkdir -p "$dir/responses"; log="$dir/log"; resp="$dir/responses"; : > "$log"
-  fb=$(make_herdr_fakebin "$dir")
-  out=$( PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
-    HERDR_ENV=1 HERDR_PANE_ID=w7:p3 HERDR_SESSION=fmtest \
-    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_launcher_identity fmtest' "$ROOT" 2>&1 )
+  out=$( herdr_run "$dir" HERDR_ENV=1 HERDR_PANE_ID=w7:p3 HERDR_SESSION=fmtest fm_backend_herdr_launcher_identity fmtest 2>&1 )
   status=$?
   expect_code 1 "$status" "a launcher pane without an injected server socket must refuse"
   assert_contains "$out" "no injected socket identity" "the missing-socket refusal did not explain itself"
@@ -930,14 +908,11 @@ test_launcher_identity_refuses_a_missing_server_socket() {
 }
 
 test_launcher_identity_refuses_a_pane_from_another_server_socket() {
-  local dir log resp fb out status
+  local dir log resp out status
   dir="$TMP_ROOT/launcher-xsocket"; mkdir -p "$dir/responses"; log="$dir/log"; resp="$dir/responses"; : > "$log"
   # 1: session list --json, resolving THIS session's own socket.
   printf '{"sessions":[{"name":"fmtest","running":true,"socket_path":"/tmp/fm-herdr-unit/fmtest.sock"}]}\n' > "$resp/1.out"
-  fb=$(make_herdr_fakebin "$dir")
-  out=$( PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
-    HERDR_ENV=1 HERDR_PANE_ID=w7:p3 HERDR_SESSION=fmtest HERDR_SOCKET_PATH=/tmp/fm-herdr-unit/other.sock \
-    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_launcher_identity fmtest' "$ROOT" 2>&1 )
+  out=$( herdr_run "$dir" HERDR_ENV=1 HERDR_PANE_ID=w7:p3 HERDR_SESSION=fmtest HERDR_SOCKET_PATH=/tmp/fm-herdr-unit/other.sock fm_backend_herdr_launcher_identity fmtest 2>&1 )
   status=$?
   expect_code 1 "$status" "a launcher pane on a different herdr server socket must refuse"
   assert_contains "$out" "cross-session parent identity" "the cross-socket refusal did not explain itself"
@@ -946,14 +921,11 @@ test_launcher_identity_refuses_a_pane_from_another_server_socket() {
 }
 
 test_launcher_identity_refuses_an_unreadable_pane() {
-  local dir log resp fb out status
+  local dir log resp out status
   dir="$TMP_ROOT/launcher-stale"; mkdir -p "$dir/responses"; log="$dir/log"; resp="$dir/responses"; : > "$log"
   printf '{"sessions":[{"name":"fmtest","running":true,"socket_path":"/tmp/fm-herdr-unit/fmtest.sock"}]}\n' > "$resp/1.out"
   printf '1\n' > "$resp/2.exit"
-  fb=$(make_herdr_fakebin "$dir")
-  out=$( PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
-    HERDR_ENV=1 HERDR_PANE_ID=w7:p3 HERDR_SESSION=fmtest HERDR_SOCKET_PATH=/tmp/fm-herdr-unit/fmtest.sock \
-    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_launcher_identity fmtest' "$ROOT" 2>&1 )
+  out=$( herdr_run "$dir" HERDR_ENV=1 HERDR_PANE_ID=w7:p3 HERDR_SESSION=fmtest HERDR_SOCKET_PATH=/tmp/fm-herdr-unit/fmtest.sock fm_backend_herdr_launcher_identity fmtest 2>&1 )
   status=$?
   expect_code 1 "$status" "a launcher pane that no longer reads must refuse, not fall back to a label search"
   assert_contains "$out" "w7:p3" "the stale-pane refusal did not name the pane it could not resolve"
@@ -961,16 +933,13 @@ test_launcher_identity_refuses_an_unreadable_pane() {
 }
 
 test_launcher_identity_refuses_a_pane_and_tab_that_disagree() {
-  local dir log resp fb out status
+  local dir log resp out status
   dir="$TMP_ROOT/launcher-contradictory"; mkdir -p "$dir/responses"; log="$dir/log"; resp="$dir/responses"; : > "$log"
   printf '{"sessions":[{"name":"fmtest","running":true,"socket_path":"/tmp/fm-herdr-unit/fmtest.sock"}]}\n' > "$resp/1.out"
   printf '{"result":{"pane":{"pane_id":"w7:p3","tab_id":"w7:t3","workspace_id":"w7"}}}\n' > "$resp/2.out"
   # The tab claims a DIFFERENT owning workspace than the pane just did.
   printf '{"result":{"tab":{"tab_id":"w7:t3","workspace_id":"w9"}}}\n' > "$resp/3.out"
-  fb=$(make_herdr_fakebin "$dir")
-  out=$( PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
-    HERDR_ENV=1 HERDR_PANE_ID=w7:p3 HERDR_SESSION=fmtest HERDR_SOCKET_PATH=/tmp/fm-herdr-unit/fmtest.sock \
-    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_launcher_identity fmtest' "$ROOT" 2>&1 )
+  out=$( herdr_run "$dir" HERDR_ENV=1 HERDR_PANE_ID=w7:p3 HERDR_SESSION=fmtest HERDR_SOCKET_PATH=/tmp/fm-herdr-unit/fmtest.sock fm_backend_herdr_launcher_identity fmtest 2>&1 )
   status=$?
   expect_code 1 "$status" "a pane and tab that disagree about their workspace must refuse"
   assert_contains "$out" "contradictory parent identity" "the contradictory-identity refusal did not explain itself"
@@ -978,16 +947,13 @@ test_launcher_identity_refuses_a_pane_and_tab_that_disagree() {
 }
 
 test_launcher_identity_refuses_a_workspace_missing_from_the_session() {
-  local dir log resp fb out status
+  local dir log resp out status
   dir="$TMP_ROOT/launcher-gone"; mkdir -p "$dir/responses"; log="$dir/log"; resp="$dir/responses"; : > "$log"
   printf '{"sessions":[{"name":"fmtest","running":true,"socket_path":"/tmp/fm-herdr-unit/fmtest.sock"}]}\n' > "$resp/1.out"
   printf '{"result":{"pane":{"pane_id":"w7:p3","tab_id":"w7:t3","workspace_id":"w7"}}}\n' > "$resp/2.out"
   printf '{"result":{"tab":{"tab_id":"w7:t3","workspace_id":"w7"}}}\n' > "$resp/3.out"
   printf '{"result":{"workspaces":[{"workspace_id":"w1","label":"firstmate"}]}}\n' > "$resp/4.out"
-  fb=$(make_herdr_fakebin "$dir")
-  out=$( PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
-    HERDR_ENV=1 HERDR_PANE_ID=w7:p3 HERDR_SESSION=fmtest HERDR_SOCKET_PATH=/tmp/fm-herdr-unit/fmtest.sock \
-    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_launcher_identity fmtest' "$ROOT" 2>&1 )
+  out=$( herdr_run "$dir" HERDR_ENV=1 HERDR_PANE_ID=w7:p3 HERDR_SESSION=fmtest HERDR_SOCKET_PATH=/tmp/fm-herdr-unit/fmtest.sock fm_backend_herdr_launcher_identity fmtest 2>&1 )
   status=$?
   expect_code 1 "$status" "a launcher workspace absent from the session listing must refuse"
   assert_contains "$out" "stale parent identity" "the stale-workspace refusal did not explain itself"
@@ -997,28 +963,23 @@ test_launcher_identity_refuses_a_workspace_missing_from_the_session() {
 # --- workspace_ensure placement ---------------------------------------------
 
 test_workspace_ensure_prefers_the_launcher_over_the_first_label_match() {
-  local dir log resp fb out
+  local dir log resp out
   dir="$TMP_ROOT/ensure-launcher"; mkdir -p "$dir/responses"; log="$dir/log"; resp="$dir/responses"; : > "$log"
   printf '{"sessions":[{"name":"fmtest","running":true,"socket_path":"/tmp/fm-herdr-unit/fmtest.sock"}]}\n' > "$resp/1.out"
   printf '{"result":{"pane":{"pane_id":"w7:p3","tab_id":"w7:t3","workspace_id":"w7"}}}\n' > "$resp/2.out"
   printf '{"result":{"tab":{"tab_id":"w7:t3","workspace_id":"w7"}}}\n' > "$resp/3.out"
   printf '{"result":{"workspaces":[{"workspace_id":"w1","label":"firstmate"},{"workspace_id":"w7","label":"firstmate"}]}}\n' > "$resp/4.out"
-  fb=$(make_herdr_fakebin "$dir")
-  out=$( PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
-    HERDR_ENV=1 HERDR_PANE_ID=w7:p3 HERDR_SESSION=fmtest HERDR_SOCKET_PATH=/tmp/fm-herdr-unit/fmtest.sock \
-    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_workspace_ensure fmtest /tmp' "$ROOT" )
+  out=$( herdr_run "$dir" HERDR_ENV=1 HERDR_PANE_ID=w7:p3 HERDR_SESSION=fmtest HERDR_SOCKET_PATH=/tmp/fm-herdr-unit/fmtest.sock fm_backend_herdr_workspace_ensure fmtest /tmp )
   [ "$out" = w7 ] || fail "workspace_ensure should place the worker in the launcher's own workspace w7, got '$out'"
   assert_not_contains "$(cat "$log")" $'\x1f''workspace'$'\x1f''create' "the launcher's existing workspace must be reused, not duplicated"
   pass "fm_backend_herdr_workspace_ensure: places a worker in the launcher's exact workspace, not the first same-labeled one"
 }
 
 test_workspace_ensure_refuses_an_ambiguous_label_with_no_launcher() {
-  local dir log resp fb out status
+  local dir log resp out status
   dir="$TMP_ROOT/ensure-ambiguous"; mkdir -p "$dir/responses"; log="$dir/log"; resp="$dir/responses"; : > "$log"
   printf '{"result":{"workspaces":[{"workspace_id":"w1","label":"firstmate"},{"workspace_id":"w7","label":"firstmate"}]}}\n' > "$resp/1.out"
-  fb=$(make_herdr_fakebin "$dir")
-  out=$( PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" HERDR_SESSION=fmtest \
-    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_workspace_ensure fmtest /tmp' "$ROOT" 2>&1 )
+  out=$( herdr_run "$dir" HERDR_SESSION=fmtest fm_backend_herdr_workspace_ensure fmtest /tmp 2>&1 )
   status=$?
   expect_code 3 "$status" "two same-labeled home workspaces with no launcher identity must refuse"
   assert_contains "$out" "labeled 'firstmate'" "the ambiguity refusal did not name the duplicated label"
@@ -1028,27 +989,22 @@ test_workspace_ensure_refuses_an_ambiguous_label_with_no_launcher() {
 }
 
 test_workspace_ensure_other_home_ignores_the_launcher_identity() {
-  local dir log resp fb out
+  local dir log resp out
   dir="$TMP_ROOT/ensure-other-home"; mkdir -p "$dir/responses"; log="$dir/log"; resp="$dir/responses"; : > "$log"
   # Only a workspace list: the launcher's own pane is never consulted, because a
   # --secondmate launch stands up a different home's workspace by design.
   printf '{"result":{"workspaces":[{"workspace_id":"w1","label":"firstmate"}]}}\n' > "$resp/1.out"
-  fb=$(make_herdr_fakebin "$dir")
-  out=$( PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
-    HERDR_ENV=1 HERDR_PANE_ID=w7:p3 HERDR_SESSION=fmtest \
-    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_workspace_ensure fmtest /tmp other-home' "$ROOT" )
+  out=$( herdr_run "$dir" HERDR_ENV=1 HERDR_PANE_ID=w7:p3 HERDR_SESSION=fmtest fm_backend_herdr_workspace_ensure fmtest /tmp other-home )
   [ "$out" = w1 ] || fail "an other-home container should resolve by this home's own label, got '$out'"
   assert_not_contains "$(cat "$log")" $'\x1f''pane'$'\x1f''get' "an other-home container must not inherit the launcher's workspace"
   pass "fm_backend_herdr_workspace_ensure: a --secondmate container resolves that home's own workspace, not the launcher's"
 }
 
 test_container_ensure_refuses_an_ambiguous_home_label() {
-  local dir log resp fb out status
+  local dir log resp out status
   dir="$TMP_ROOT/container-ambiguous"; mkdir -p "$dir/responses"; log="$dir/log"; resp="$dir/responses"; : > "$log"
   printf '{"result":{"workspaces":[{"workspace_id":"w1","label":"firstmate"},{"workspace_id":"w7","label":"firstmate"}]}}\n' > "$resp/1.out"
-  fb=$(make_herdr_fakebin "$dir")
-  out=$( PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" HERDR_SESSION=fmtest \
-    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_container_ensure /tmp' "$ROOT" 2>&1 )
+  out=$( herdr_run "$dir" HERDR_SESSION=fmtest fm_backend_herdr_container_ensure /tmp 2>&1 )
   status=$?
   [ "$status" -ne 0 ] || fail "container_ensure must fail when the home workspace is ambiguous"
   assert_contains "$out" "labeled 'firstmate'" "container_ensure buried the specific ambiguity it refused"
@@ -1059,7 +1015,7 @@ test_container_ensure_refuses_an_ambiguous_home_label() {
 # --- container_ensure / create_task ------------------------------------------
 
 test_container_ensure_starts_server_and_workspace() {
-  local dir log resp fb out
+  local dir log resp out
   dir="$TMP_ROOT/container"; mkdir -p "$dir/responses"; log="$dir/log"; resp="$dir/responses"; : > "$log"
   # 1: version_check status --json (server not running yet, irrelevant to client check)
   printf '{"client":{"version":"0.7.1","protocol":14}}\n' > "$resp/1.out"
@@ -1073,9 +1029,7 @@ test_container_ensure_starts_server_and_workspace() {
   # 6: workspace create -> w1, seeding default tab w1:t9 (real herdr returns
   # the seeded tab/pane ids in the SAME response - verified empirically).
   printf '{"result":{"workspace":{"workspace_id":"w1","label":"firstmate"},"tab":{"tab_id":"w1:t9"},"root_pane":{"pane_id":"w1:p9"}}}\n' > "$resp/6.out"
-  fb=$(make_herdr_fakebin "$dir")
-  out=$( PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" FM_HERDR_SCRIPT_STATUS=1 HERDR_SESSION=fmtest \
-    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_container_ensure /tmp' "$ROOT" )
+  out=$( herdr_run "$dir" FM_HERDR_SCRIPT_STATUS=1 HERDR_SESSION=fmtest fm_backend_herdr_container_ensure /tmp )
   [ "$out" = $'fmtest:w1\tw1:t9' ] || fail "container_ensure should echo '<session>:<workspace_id>\\t<seeded_default_tab_id>', got '$out'"
   assert_contains "$(cat "$log")" "HERDR_SESSION=fmtest"$'\x1f''server' "container_ensure did not start the herdr server"
   assert_contains "$(cat "$log")" $'\x1f''workspace'$'\x1f''create'$'\x1f''--cwd'$'\x1f''/tmp'$'\x1f''--label'$'\x1f''firstmate' \
@@ -1105,26 +1059,22 @@ test_server_ensure_scrubs_home_and_harness_identity() {
 }
 
 test_container_ensure_reuses_existing_workspace() {
-  local dir log resp fb out
+  local dir log resp out
   dir="$TMP_ROOT/container-reuse"; mkdir -p "$dir/responses"; log="$dir/log"; resp="$dir/responses"; : > "$log"
   printf '{"client":{"version":"0.7.1","protocol":14}}\n' > "$resp/1.out"
   printf '{"server":{"running":true}}\n' > "$resp/2.out"
   printf '{"result":{"workspaces":[{"workspace_id":"w9","label":"firstmate"}]}}\n' > "$resp/3.out"
-  fb=$(make_herdr_fakebin "$dir")
-  out=$( PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" FM_HERDR_SCRIPT_STATUS=1 HERDR_SESSION=fmtest \
-    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_container_ensure /tmp' "$ROOT" )
+  out=$( herdr_run "$dir" FM_HERDR_SCRIPT_STATUS=1 HERDR_SESSION=fmtest fm_backend_herdr_container_ensure /tmp )
   [ "$out" = $'fmtest:w9\t' ] || fail "container_ensure should reuse the existing firstmate workspace id with an EMPTY seeded-tab field (an ADOPTED workspace is never a prune candidate), got '$out'"
   assert_not_contains "$(cat "$log")" $'\x1f''workspace'$'\x1f''create' "container_ensure should not create a workspace that already exists"
   pass "fm_backend_herdr_container_ensure: reuses an existing firstmate workspace without recreating it, and reports no seeded default tab (adopted, not created)"
 }
 
 test_create_task_refuses_duplicate_label() {
-  local dir log resp fb out status
+  local dir log resp out status
   dir="$TMP_ROOT/dup-task"; mkdir -p "$dir/responses"; log="$dir/log"; resp="$dir/responses"; : > "$log"
   printf '{"result":{"tabs":[{"tab_id":"w1:t2","label":"fm-dup1","workspace_id":"w1"}]}}\n' > "$resp/1.out"
-  fb=$(make_herdr_fakebin "$dir")
-  out=$( PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
-    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_create_task fmtest:w1 fm-dup1 /tmp/proj' "$ROOT" 2>&1 )
+  out=$( herdr_run "$dir" fm_backend_herdr_create_task fmtest:w1 fm-dup1 /tmp/proj 2>&1 )
   status=$?
   [ "$status" -ne 0 ] || fail "create_task should refuse an existing tab label (herdr itself does not enforce uniqueness)"
   assert_contains "$out" "already exists" "create_task did not report the duplicate label"
@@ -1146,7 +1096,7 @@ test_create_task_refuses_duplicate_label() {
 # closing).
 
 test_create_task_refuses_duplicate_label_when_agent_live() {
-  local dir log resp fb out status
+  local dir log resp out status
   dir="$TMP_ROOT/dup-live"; mkdir -p "$dir/responses"; log="$dir/log"; resp="$dir/responses"; : > "$log"
   # 1: tab list -> an existing same-labeled tab
   printf '{"result":{"tabs":[{"tab_id":"w1:t2","label":"fm-dup1","workspace_id":"w1"}]}}\n' > "$resp/1.out"
@@ -1158,9 +1108,7 @@ test_create_task_refuses_duplicate_label_when_agent_live() {
   printf '{"result":{"agent":{"agent_status":"idle"}}}\n' > "$resp/4.out"
   # 5: pane process-info -> a live Pi process backs that registration (#4115)
   printf '%s\n' '{"result":{"type":"pane_process_info","process_info":{"pane_id":"w1:p2","shell_pid":4242,"foreground_process_group_id":4243,"foreground_processes":[{"pid":4243,"name":"node","argv0":"pi"}]}}}' > "$resp/5.out"
-  fb=$(make_herdr_fakebin "$dir")
-  out=$( PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
-    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_create_task fmtest:w1 fm-dup1 /tmp/proj' "$ROOT" 2>&1 )
+  out=$( herdr_run "$dir" fm_backend_herdr_create_task fmtest:w1 fm-dup1 /tmp/proj 2>&1 )
   status=$?
   [ "$status" -ne 0 ] || fail "create_task should still refuse when the duplicate's pane hosts a live (even idle) registered agent"
   assert_contains "$out" "already exists" "create_task did not report the duplicate label for a live agent"
@@ -1170,7 +1118,7 @@ test_create_task_refuses_duplicate_label_when_agent_live() {
 }
 
 test_create_task_refuses_when_any_duplicate_label_is_live() {
-  local dir log resp fb out status
+  local dir log resp out status
   dir="$TMP_ROOT/dup-mixed-live"; mkdir -p "$dir/responses"; log="$dir/log"; resp="$dir/responses"; : > "$log"
   printf '{"result":{"tabs":[{"tab_id":"w1:t2","label":"fm-mixed1","workspace_id":"w1"},{"tab_id":"w1:t3","label":"fm-mixed1","workspace_id":"w1"}]}}\n' > "$resp/1.out"
   printf '{"result":{"panes":[{"pane_id":"w1:p2","tab_id":"w1:t2"},{"pane_id":"w1:p3","tab_id":"w1:t3"}]}}\n' > "$resp/2.out"
@@ -1181,9 +1129,7 @@ test_create_task_refuses_when_any_duplicate_label_is_live() {
   printf '{"result":{"agent":{"agent_status":"idle"}}}\n' > "$resp/7.out"
   # 8: pane process-info -> a live Pi process backs that registration (#4115)
   printf '%s\n' '{"result":{"type":"pane_process_info","process_info":{"pane_id":"w1:p3","shell_pid":4242,"foreground_process_group_id":4243,"foreground_processes":[{"pid":4243,"name":"node","argv0":"pi"}]}}}' > "$resp/8.out"
-  fb=$(make_herdr_fakebin "$dir")
-  out=$( PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
-    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_create_task fmtest:w1 fm-mixed1 /tmp/proj' "$ROOT" 2>&1 )
+  out=$( herdr_run "$dir" fm_backend_herdr_create_task fmtest:w1 fm-mixed1 /tmp/proj 2>&1 )
   status=$?
   [ "$status" -ne 0 ] || fail "create_task must refuse when any same-labeled tab hosts a live registered agent"
   assert_contains "$out" "already exists" "create_task did not report the duplicate label when one duplicate was live"
@@ -1193,7 +1139,7 @@ test_create_task_refuses_when_any_duplicate_label_is_live() {
 }
 
 test_create_task_closes_and_replaces_dead_pane_husk() {
-  local dir log resp fb out status tab pane
+  local dir log resp out status tab pane
   dir="$TMP_ROOT/husk-dead"; mkdir -p "$dir/responses"; log="$dir/log"; resp="$dir/responses"; : > "$log"
   printf '{"result":{"tabs":[{"tab_id":"w1:t2","label":"fm-husk1","workspace_id":"w1"}]}}\n' > "$resp/1.out"
   printf '{"result":{"panes":[{"pane_id":"w1:p2","tab_id":"w1:t2"}]}}\n' > "$resp/2.out"
@@ -1202,9 +1148,7 @@ test_create_task_closes_and_replaces_dead_pane_husk() {
   # 4: tab create -> the replacement tab (created BEFORE the husk is closed)
   printf '{"result":{"tab":{"tab_id":"w1:t3"},"root_pane":{"pane_id":"w1:p3"}}}\n' > "$resp/4.out"
   printf '{"result":{"tabs":[{"tab_id":"w1:t3","label":"fm-husk1","workspace_id":"w1"}]}}\n' > "$resp/6.out"
-  fb=$(make_herdr_fakebin "$dir")
-  out=$( PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
-    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_create_task fmtest:w1 fm-husk1 /tmp/proj' "$ROOT" ) \
+  out=$( herdr_run "$dir" fm_backend_herdr_create_task fmtest:w1 fm-husk1 /tmp/proj ) \
     || fail "create_task should close-and-replace a dead-pane husk instead of refusing"
   read -r tab pane <<EOF
 $out
@@ -1219,7 +1163,7 @@ EOF
 }
 
 test_create_task_closes_and_replaces_no_agent_husk() {
-  local dir log resp fb out status tab pane
+  local dir log resp out status tab pane
   dir="$TMP_ROOT/husk-no-agent"; mkdir -p "$dir/responses"; log="$dir/log"; resp="$dir/responses"; : > "$log"
   printf '{"result":{"tabs":[{"tab_id":"w1:t2","label":"fm-husk2","workspace_id":"w1"}]}}\n' > "$resp/1.out"
   printf '{"result":{"panes":[{"pane_id":"w1:p2","tab_id":"w1:t2"}]}}\n' > "$resp/2.out"
@@ -1230,9 +1174,7 @@ test_create_task_closes_and_replaces_no_agent_husk() {
   # 5: tab create -> the replacement tab (created BEFORE the husk is closed)
   printf '{"result":{"tab":{"tab_id":"w1:t3"},"root_pane":{"pane_id":"w1:p3"}}}\n' > "$resp/5.out"
   printf '{"result":{"tabs":[{"tab_id":"w1:t3","label":"fm-husk2","workspace_id":"w1"}]}}\n' > "$resp/7.out"
-  fb=$(make_herdr_fakebin "$dir")
-  out=$( PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
-    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_create_task fmtest:w1 fm-husk2 /tmp/proj' "$ROOT" ) \
+  out=$( herdr_run "$dir" fm_backend_herdr_create_task fmtest:w1 fm-husk2 /tmp/proj ) \
     || fail "create_task should close-and-replace a no-agent husk (restored plain shell) instead of refusing"
   read -r tab pane <<EOF
 $out
@@ -1247,7 +1189,7 @@ EOF
 }
 
 test_create_task_closes_all_duplicate_husks_after_replacement() {
-  local dir log resp fb out tab pane create_line close_p2_line close_p3_line
+  local dir log resp out tab pane create_line close_p2_line close_p3_line
   dir="$TMP_ROOT/husk-multiple"; mkdir -p "$dir/responses"; log="$dir/log"; resp="$dir/responses"; : > "$log"
   printf '{"result":{"tabs":[{"tab_id":"w1:t2","label":"fm-husk-many","workspace_id":"w1"},{"tab_id":"w1:t3","label":"fm-husk-many","workspace_id":"w1"}]}}\n' > "$resp/1.out"
   printf '{"result":{"panes":[{"pane_id":"w1:p2","tab_id":"w1:t2"},{"pane_id":"w1:p3","tab_id":"w1:t3"}]}}\n' > "$resp/2.out"
@@ -1258,9 +1200,7 @@ test_create_task_closes_all_duplicate_husks_after_replacement() {
   printf '{"error":{"code":"agent_not_found","message":"agent target w1:p3 not found"}}\n' > "$resp/7.out"
   printf '{"result":{"tab":{"tab_id":"w1:t4"},"root_pane":{"pane_id":"w1:p4"}}}\n' > "$resp/8.out"
   printf '{"result":{"tabs":[{"tab_id":"w1:t4","label":"fm-husk-many","workspace_id":"w1"}]}}\n' > "$resp/11.out"
-  fb=$(make_herdr_fakebin "$dir")
-  out=$( PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
-    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_create_task fmtest:w1 fm-husk-many /tmp/proj' "$ROOT" ) \
+  out=$( herdr_run "$dir" fm_backend_herdr_create_task fmtest:w1 fm-husk-many /tmp/proj ) \
     || fail "create_task should close-and-replace all same-labeled husks after creating a replacement"
   read -r tab pane <<EOF
 $out
@@ -1281,7 +1221,7 @@ EOF
 }
 
 test_create_task_refuses_when_preexisting_husk_tab_remains() {
-  local dir log resp fb out status
+  local dir log resp out status
   dir="$TMP_ROOT/husk-close-fails"; mkdir -p "$dir/responses"; log="$dir/log"; resp="$dir/responses"; : > "$log"
   printf '{"result":{"tabs":[{"tab_id":"w1:t2","label":"fm-stale-husk","workspace_id":"w1"}]}}\n' > "$resp/1.out"
   printf '{"result":{"panes":[{"pane_id":"w1:p2","tab_id":"w1:t2"}]}}\n' > "$resp/2.out"
@@ -1290,9 +1230,7 @@ test_create_task_refuses_when_preexisting_husk_tab_remains() {
   printf '{"result":{"tab":{"tab_id":"w1:t3"},"root_pane":{"pane_id":"w1:p3"}}}\n' > "$resp/5.out"
   printf '1\n' > "$resp/6.exit"
   printf '{"result":{"tabs":[{"tab_id":"w1:t2","label":"fm-stale-husk","workspace_id":"w1"},{"tab_id":"w1:t3","label":"fm-stale-husk","workspace_id":"w1"}]}}\n' > "$resp/7.out"
-  fb=$(make_herdr_fakebin "$dir")
-  out=$( PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
-    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_create_task fmtest:w1 fm-stale-husk /tmp/proj' "$ROOT" 2>&1 )
+  out=$( herdr_run "$dir" fm_backend_herdr_create_task fmtest:w1 fm-stale-husk /tmp/proj 2>&1 )
   status=$?
   [ "$status" -ne 0 ] || fail "create_task must fail when a preexisting same-labeled husk remains after close-and-replace"
   assert_contains "$out" "failed to remove preexisting herdr tab" "create_task did not report the stale preexisting husk tab"
@@ -1305,16 +1243,14 @@ test_create_task_refuses_when_agent_state_ambiguous() {
   # An unexpected error code from agent get (neither agent_not_found nor a
   # successful read) must not be misread as a husk - fail-safe toward
   # refusal, exactly like today's unconditional-refusal behavior.
-  local dir log resp fb out status
+  local dir log resp out status
   dir="$TMP_ROOT/husk-ambiguous"; mkdir -p "$dir/responses"; log="$dir/log"; resp="$dir/responses"; : > "$log"
   printf '{"result":{"tabs":[{"tab_id":"w1:t2","label":"fm-ambig1","workspace_id":"w1"}]}}\n' > "$resp/1.out"
   printf '{"result":{"panes":[{"pane_id":"w1:p2","tab_id":"w1:t2"}]}}\n' > "$resp/2.out"
   printf '{"result":{"pane":{"pane_id":"w1:p2"}}}\n' > "$resp/3.out"
   # 4: agent get -> an unrecognized error code, not agent_not_found
   printf '{"error":{"code":"internal_error","message":"transient failure"}}\n' > "$resp/4.out"
-  fb=$(make_herdr_fakebin "$dir")
-  out=$( PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
-    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_create_task fmtest:w1 fm-ambig1 /tmp/proj' "$ROOT" 2>&1 )
+  out=$( herdr_run "$dir" fm_backend_herdr_create_task fmtest:w1 fm-ambig1 /tmp/proj 2>&1 )
   status=$?
   [ "$status" -ne 0 ] || fail "create_task must refuse (fail-safe) when the agent state cannot be classified confidently, not treat it as a husk"
   assert_contains "$out" "already exists" "create_task did not report the duplicate label for an ambiguous state"
@@ -1331,16 +1267,14 @@ test_create_task_husk_replacement_creates_before_closing() {
   # legitimately be that workspace's only tab. Verified here by log order
   # rather than by state, since herdr's destroy-on-last-tab-close side effect
   # is not modeled by the canned-response fake.
-  local dir log resp fb out create_line close_line
+  local dir log resp out create_line close_line
   dir="$TMP_ROOT/husk-order"; mkdir -p "$dir/responses"; log="$dir/log"; resp="$dir/responses"; : > "$log"
   printf '{"result":{"tabs":[{"tab_id":"w1:t2","label":"fm-order1","workspace_id":"w1"}]}}\n' > "$resp/1.out"
   printf '{"result":{"panes":[{"pane_id":"w1:p2","tab_id":"w1:t2"}]}}\n' > "$resp/2.out"
   printf '{"error":{"code":"pane_not_found","message":"pane w1:p2 not found"}}\n' > "$resp/3.out"
   printf '{"result":{"tab":{"tab_id":"w1:t3"},"root_pane":{"pane_id":"w1:p3"}}}\n' > "$resp/4.out"
   printf '{"result":{"tabs":[{"tab_id":"w1:t3","label":"fm-order1","workspace_id":"w1"}]}}\n' > "$resp/6.out"
-  fb=$(make_herdr_fakebin "$dir")
-  out=$( PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
-    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_create_task fmtest:w1 fm-order1 /tmp/proj' "$ROOT" ) \
+  out=$( herdr_run "$dir" fm_backend_herdr_create_task fmtest:w1 fm-order1 /tmp/proj ) \
     || fail "create_task should close-and-replace the dead-pane husk"
   create_line=$(grep -n $'\x1f''tab'$'\x1f''create' "$log" | head -1 | cut -d: -f1)
   close_line=$(grep -n $'\x1f''tab'$'\x1f''close' "$log" | head -1 | cut -d: -f1)
@@ -1351,13 +1285,11 @@ test_create_task_husk_replacement_creates_before_closing() {
 }
 
 test_create_task_creates_and_parses_ids() {
-  local dir log resp fb out
+  local dir log resp out
   dir="$TMP_ROOT/create-task"; mkdir -p "$dir/responses"; log="$dir/log"; resp="$dir/responses"; : > "$log"
   printf '{"result":{"tabs":[]}}\n' > "$resp/1.out"
   printf '{"result":{"tab":{"tab_id":"w1:t2"},"root_pane":{"pane_id":"w1:p2"}}}\n' > "$resp/2.out"
-  fb=$(make_herdr_fakebin "$dir")
-  out=$( PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
-    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_create_task fmtest:w1 fm-newtask /tmp/proj' "$ROOT" )
+  out=$( herdr_run "$dir" fm_backend_herdr_create_task fmtest:w1 fm-newtask /tmp/proj )
   [ "$out" = "w1:t2 w1:p2" ] || fail "create_task should echo '<tab_id> <pane_id>', got '$out'"
   assert_contains "$(cat "$log")" $'\x1f''tab'$'\x1f''create'$'\x1f''--workspace'$'\x1f''w1'$'\x1f''--cwd'$'\x1f''/tmp/proj'$'\x1f''--label'$'\x1f''fm-newtask' \
     "create_task did not call tab create with workspace/cwd/label"
@@ -1369,15 +1301,13 @@ test_create_task_creates_and_parses_ids() {
 # --- container_ensure / create_task: --no-focus and per-home label ----------
 
 test_container_ensure_creates_with_no_focus_flag() {
-  local dir log resp fb out
+  local dir log resp out
   dir="$TMP_ROOT/container-no-focus"; mkdir -p "$dir/responses"; log="$dir/log"; resp="$dir/responses"; : > "$log"
   printf '{"client":{"version":"0.7.1","protocol":14}}\n' > "$resp/1.out"
   printf '{"server":{"running":true}}\n' > "$resp/2.out"
   printf '{"result":{"workspaces":[]}}\n' > "$resp/3.out"
   printf '{"result":{"workspace":{"workspace_id":"w1","label":"firstmate"},"tab":{"tab_id":"w1:t1"},"root_pane":{"pane_id":"w1:p1"}}}\n' > "$resp/4.out"
-  fb=$(make_herdr_fakebin "$dir")
-  out=$( PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" FM_HERDR_SCRIPT_STATUS=1 HERDR_SESSION=fmtest \
-    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_container_ensure /tmp' "$ROOT" )
+  out=$( herdr_run "$dir" FM_HERDR_SCRIPT_STATUS=1 HERDR_SESSION=fmtest fm_backend_herdr_container_ensure /tmp )
   [ "$out" = $'fmtest:w1\tw1:t1' ] || fail "container_ensure should still echo '<session>:<workspace_id>\\t<seeded_default_tab_id>', got '$out'"
   assert_contains "$(cat "$log")" $'\x1f''workspace'$'\x1f''create'$'\x1f''--cwd'$'\x1f''/tmp'$'\x1f''--label'$'\x1f''firstmate'$'\x1f''--no-focus' \
     "container_ensure's workspace create did not pass --no-focus (focus-safety: never steal the captain's attention on spawn)"
@@ -1402,13 +1332,11 @@ test_container_ensure_uses_secondmate_home_label() {
 }
 
 test_create_task_creates_with_no_focus_flag() {
-  local dir log resp fb out
+  local dir log resp out
   dir="$TMP_ROOT/create-task-no-focus"; mkdir -p "$dir/responses"; log="$dir/log"; resp="$dir/responses"; : > "$log"
   printf '{"result":{"tabs":[]}}\n' > "$resp/1.out"
   printf '{"result":{"tab":{"tab_id":"w1:t2"},"root_pane":{"pane_id":"w1:p2"}}}\n' > "$resp/2.out"
-  fb=$(make_herdr_fakebin "$dir")
-  out=$( PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
-    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_create_task fmtest:w1 fm-newtask /tmp/proj' "$ROOT" )
+  out=$( herdr_run "$dir" fm_backend_herdr_create_task fmtest:w1 fm-newtask /tmp/proj )
   [ "$out" = "w1:t2 w1:p2" ] || fail "create_task should still echo '<tab_id> <pane_id>', got '$out'"
   assert_contains "$(cat "$log")" $'\x1f''tab'$'\x1f''create'$'\x1f''--workspace'$'\x1f''w1'$'\x1f''--cwd'$'\x1f''/tmp/proj'$'\x1f''--label'$'\x1f''fm-newtask'$'\x1f''--no-focus' \
     "create_task's tab create did not pass --no-focus"
@@ -1902,21 +1830,19 @@ test_projection_create_never_closes_a_concurrent_same_label_tab() {
 }
 
 test_projection_focus_snapshot_requires_exact_workspace_and_tab() {
-  local dir log resp fb out
+  local dir log resp out
   dir="$TMP_ROOT/projection-focus-snapshot"; mkdir -p "$dir/responses"
   log="$dir/log"; resp="$dir/responses"; : > "$log"
   printf '%s\n' '{"result":{"workspaces":[{"workspace_id":"w1","active_tab_id":"w1:t1","focused":false},{"workspace_id":"w2","active_tab_id":"w2:t2","focused":true}]}}' > "$resp/1.out"
   printf '%s\n' '{"result":{"tabs":[{"tab_id":"w2:t1","focused":false},{"tab_id":"w2:t2","focused":true}]}}' > "$resp/2.out"
-  fb=$(make_herdr_fakebin "$dir")
-  out=$(PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
-    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_projection_focus_snapshot fmtest' "$ROOT") \
+  out=$( herdr_run "$dir" fm_backend_herdr_projection_focus_snapshot fmtest ) \
     || fail "an exact active workspace and tab should produce a focus snapshot"
   [ "$out" = $'w2\tw2:t2' ] || fail "focus snapshot did not preserve exact response IDs: $out"
   pass "herdr presentation focus: snapshot requires one exact active workspace and tab"
 }
 
 test_projection_close_restores_exact_prior_focus() {
-  local dir log resp fb out status
+  local dir log resp out status
   dir="$TMP_ROOT/projection-focus-restore"; mkdir -p "$dir/responses"
   log="$dir/log"; resp="$dir/responses"; : > "$log"
   printf '%s\n' '{"result":{"workspaces":[{"workspace_id":"w1","active_tab_id":"w1:t1","focused":false},{"workspace_id":"w2","active_tab_id":"w2:t2","focused":true},{"workspace_id":"w9","active_tab_id":"w9:t2","focused":false}]}}' > "$resp/1.out"
@@ -1932,9 +1858,7 @@ test_projection_close_restores_exact_prior_focus() {
   printf '%s\n' '{"result":{"tab":{"tab_id":"w2:t2","workspace_id":"w2","focused":true}}}' > "$resp/10.out"
   printf '%s\n' '{"result":{"workspaces":[{"workspace_id":"w1","active_tab_id":"w1:t1","focused":false},{"workspace_id":"w2","active_tab_id":"w2:t2","focused":true},{"workspace_id":"w3","active_tab_id":"w3:t1","focused":false}]}}' > "$resp/11.out"
   printf '%s\n' '{"result":{"tabs":[{"tab_id":"w2:t1","focused":false},{"tab_id":"w2:t2","focused":true}]}}' > "$resp/12.out"
-  fb=$(make_herdr_fakebin "$dir")
-  out=$(PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
-    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_projection_close_pane_focus_preserving fmtest w9:p2' "$ROOT" 2>&1)
+  out=$( herdr_run "$dir" fm_backend_herdr_projection_close_pane_focus_preserving fmtest w9:p2 2>&1 )
   status=$?
   [ "$status" -eq 0 ] || fail "an exact non-active projection close should succeed after restoring focus: $out"
   assert_contains "$(cat "$log")" $'pane\x1fclose\x1fw9:p2' \
@@ -1947,7 +1871,7 @@ test_projection_close_restores_exact_prior_focus() {
 }
 
 test_projection_close_refuses_active_tab() {
-  local dir log resp fb out status
+  local dir log resp out status
   dir="$TMP_ROOT/projection-focus-active-refusal"; mkdir -p "$dir/responses"
   log="$dir/log"; resp="$dir/responses"; : > "$log"
   printf '%s\n' '{"result":{"workspaces":[{"workspace_id":"w9","active_tab_id":"w9:t2","focused":true}]}}' > "$resp/1.out"
@@ -1956,10 +1880,8 @@ test_projection_close_refuses_active_tab() {
   printf '%s\n' '{"result":{"tabs":[{"tab_id":"w9:t1","workspace_id":"w9"},{"tab_id":"w9:t2","workspace_id":"w9"}]}}' > "$resp/4.out"
   cp "$resp/1.out" "$resp/5.out"
   cp "$resp/2.out" "$resp/6.out"
-  fb=$(make_herdr_fakebin "$dir")
-  out=$(PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
-    FM_FAKE_HERDR_FOREGROUND_REASON=cleared \
-    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_projection_close_pane_focus_preserving fmtest w9:p2' "$ROOT" 2>&1)
+  out=$( herdr_run "$dir" FM_FAKE_HERDR_FOREGROUND_REASON=cleared \
+    fm_backend_herdr_projection_close_pane_focus_preserving fmtest w9:p2 2>&1 )
   status=$?
   [ "$status" -ne 0 ] || fail "cleanup must refuse when a live client is viewing the active tab"
   assert_contains "$out" "target is the captain's active tab" \
@@ -1997,7 +1919,7 @@ test_projection_close_refuses_unknown_foreground_reason() {
 }
 
 test_projection_close_allows_stale_active_tab_without_foreground_client() {
-  local dir log resp fb out status
+  local dir log resp out status
   dir="$TMP_ROOT/projection-focus-stale-active-allow"; mkdir -p "$dir/responses"
   log="$dir/log"; resp="$dir/responses"; : > "$log"
   printf '%s\n' '{"result":{"workspaces":[{"workspace_id":"w9","active_tab_id":"w9:t2","focused":true}]}}' > "$resp/1.out"
@@ -2006,9 +1928,7 @@ test_projection_close_allows_stale_active_tab_without_foreground_client() {
   printf '%s\n' '{"result":{"tabs":[{"tab_id":"w9:t1","workspace_id":"w9"},{"tab_id":"w9:t2","workspace_id":"w9"}]}}' > "$resp/4.out"
   : > "$resp/5.out"
   printf '%s\n' '{"error":{"code":"pane_not_found"}}' > "$resp/6.out"
-  fb=$(make_herdr_fakebin "$dir")
-  out=$(PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
-    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_projection_close_pane_focus_preserving fmtest w9:p2' "$ROOT" 2>&1)
+  out=$( herdr_run "$dir" fm_backend_herdr_projection_close_pane_focus_preserving fmtest w9:p2 2>&1 )
   status=$?
   [ "$status" -eq 0 ] || fail "cleanup must close a persisted-focused tab when no live client is attached: $out"
   assert_not_contains "$out" "target is the captain's active tab" \
@@ -2023,7 +1943,7 @@ test_projection_close_allows_stale_active_tab_without_foreground_client() {
 }
 
 test_projection_close_reports_focus_restore_failure() {
-  local dir log resp fb out status
+  local dir log resp out status
   dir="$TMP_ROOT/projection-focus-restore-failure"; mkdir -p "$dir/responses"
   log="$dir/log"; resp="$dir/responses"; : > "$log"
   printf '%s\n' '{"result":{"workspaces":[{"workspace_id":"w1","active_tab_id":"w1:t1","focused":true},{"workspace_id":"w9","active_tab_id":"w9:t2","focused":false}]}}' > "$resp/1.out"
@@ -2038,9 +1958,7 @@ test_projection_close_reports_focus_restore_failure() {
   : > "$resp/10.out"
   cp "$resp/7.out" "$resp/11.out"
   cp "$resp/8.out" "$resp/12.out"
-  fb=$(make_herdr_fakebin "$dir")
-  out=$(PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
-    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_projection_close_pane_focus_preserving fmtest w9:p2' "$ROOT" 2>&1)
+  out=$( herdr_run "$dir" fm_backend_herdr_projection_close_pane_focus_preserving fmtest w9:p2 2>&1 )
   status=$?
   [ "$status" -eq 2 ] || fail "cleanup did not distinguish post-close focus uncertainty: $status"
   assert_contains "$out" "did not restore the exact prior workspace and tab" \
@@ -2223,7 +2141,7 @@ death_process_info_fixture() {  # <pane> <pid>
 }
 
 test_projection_close_emptying_after_focus_uses_pane_death_without_move() {
-  local dir log resp fb out status bgpid
+  local dir log resp out status bgpid
   dir="$TMP_ROOT/close-death-after"; mkdir -p "$dir/responses"
   log="$dir/log"; resp="$dir/responses"; : > "$log"
   # w1 focused; target w2 sits after it (r > a), so no repositioning is needed.
@@ -2239,12 +2157,7 @@ test_projection_close_emptying_after_focus_uses_pane_death_without_move() {
   printf '%s\n' '{"result":{"workspaces":[{"workspace_id":"w1","active_tab_id":"w1:t1","focused":true},{"workspace_id":"w3","active_tab_id":"w3:t1","focused":false}]}}' > "$resp/9.out"
   printf '%s\n' '{"result":{"tabs":[{"tab_id":"w1:t1","focused":true}]}}' > "$resp/10.out"
   make_death_lab "$dir" "$bgpid"
-  fb=$(make_herdr_fakebin "$dir")
-  out=$(PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
-    FM_HERDR_PS_BIN="$dir/ps" FM_BACKEND_HERDR_WORKSPACE_MOVER="$dir/mover" \
-    FM_FAKE_MOVER_LOG="$dir/mover.log" FM_FAKE_MOVER_RESPONSE="$dir/no-response" \
-    FM_BACKEND_HERDR_DEATH_CLOSE_POLLS=2 \
-    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_projection_close_pane_focus_preserving fmtest w2:p2' "$ROOT" 2>&1)
+  out=$( herdr_run "$dir" FM_HERDR_PS_BIN="$dir/ps" FM_BACKEND_HERDR_WORKSPACE_MOVER="$dir/mover" FM_FAKE_MOVER_LOG="$dir/mover.log" FM_FAKE_MOVER_RESPONSE="$dir/no-response" FM_BACKEND_HERDR_DEATH_CLOSE_POLLS=2 fm_backend_herdr_projection_close_pane_focus_preserving fmtest w2:p2 2>&1 )
   status=$?
   kill "$bgpid" 2>/dev/null || true; wait "$bgpid" 2>/dev/null || true
   [ "$status" -eq 0 ] || fail "emptying close behind focus should succeed through the pane-death path: $out"
@@ -2256,7 +2169,7 @@ test_projection_close_emptying_after_focus_uses_pane_death_without_move() {
 }
 
 test_projection_close_emptying_before_focus_repositions_then_uses_pane_death() {
-  local dir log resp fb out status bgpid mover_line
+  local dir log resp out status bgpid mover_line
   dir="$TMP_ROOT/close-death-before"; mkdir -p "$dir/responses"
   log="$dir/log"; resp="$dir/responses"; : > "$log"
   # Target w1 sits BEFORE the focused w2, which is not last: reposition first.
@@ -2278,12 +2191,7 @@ test_projection_close_emptying_before_focus_repositions_then_uses_pane_death() {
   printf '%s\n' '{"result":{"tabs":[{"tab_id":"w2:t1","focused":true}]}}' > "$resp/14.out"
   make_death_lab "$dir" "$bgpid"
   printf '%s\n' '{"id":"fm-workspace-move","result":{"type":"workspace_list","workspaces":[{"workspace_id":"w2","focused":true},{"workspace_id":"w3","focused":false},{"workspace_id":"w1","focused":false}]}}' > "$dir/mover-response"
-  fb=$(make_herdr_fakebin "$dir")
-  out=$(PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" FM_HERDR_SCRIPT_STATUS=1 \
-    FM_HERDR_PS_BIN="$dir/ps" FM_BACKEND_HERDR_WORKSPACE_MOVER="$dir/mover" \
-    FM_FAKE_MOVER_LOG="$dir/mover.log" FM_FAKE_MOVER_RESPONSE="$dir/mover-response" \
-    FM_BACKEND_HERDR_DEATH_CLOSE_POLLS=2 \
-    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_projection_close_pane_focus_preserving fmtest w1:p1' "$ROOT" 2>&1)
+  out=$( herdr_run "$dir" FM_HERDR_SCRIPT_STATUS=1 FM_HERDR_PS_BIN="$dir/ps" FM_BACKEND_HERDR_WORKSPACE_MOVER="$dir/mover" FM_FAKE_MOVER_LOG="$dir/mover.log" FM_FAKE_MOVER_RESPONSE="$dir/mover-response" FM_BACKEND_HERDR_DEATH_CLOSE_POLLS=2 fm_backend_herdr_projection_close_pane_focus_preserving fmtest w1:p1 2>&1 )
   status=$?
   kill "$bgpid" 2>/dev/null || true; wait "$bgpid" 2>/dev/null || true
   [ "$status" -eq 0 ] || fail "repositioned emptying close should succeed through the pane-death path: $out"
@@ -2297,7 +2205,7 @@ test_projection_close_emptying_before_focus_repositions_then_uses_pane_death() {
 }
 
 test_projection_close_emptying_before_last_focus_needs_no_move() {
-  local dir log resp fb out status bgpid
+  local dir log resp out status bgpid
   dir="$TMP_ROOT/close-death-focus-last"; mkdir -p "$dir/responses"
   log="$dir/log"; resp="$dir/responses"; : > "$log"
   # Focused w3 is LAST, so the pane-death clamp preserves it without a move.
@@ -2313,12 +2221,7 @@ test_projection_close_emptying_before_last_focus_needs_no_move() {
   printf '%s\n' '{"result":{"workspaces":[{"workspace_id":"w2","active_tab_id":"w2:t1","focused":false},{"workspace_id":"w3","active_tab_id":"w3:t1","focused":true}]}}' > "$resp/9.out"
   printf '%s\n' '{"result":{"tabs":[{"tab_id":"w3:t1","focused":true}]}}' > "$resp/10.out"
   make_death_lab "$dir" "$bgpid"
-  fb=$(make_herdr_fakebin "$dir")
-  out=$(PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
-    FM_HERDR_PS_BIN="$dir/ps" FM_BACKEND_HERDR_WORKSPACE_MOVER="$dir/mover" \
-    FM_FAKE_MOVER_LOG="$dir/mover.log" FM_FAKE_MOVER_RESPONSE="$dir/no-response" \
-    FM_BACKEND_HERDR_DEATH_CLOSE_POLLS=2 \
-    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_projection_close_pane_focus_preserving fmtest w1:p1' "$ROOT" 2>&1)
+  out=$( herdr_run "$dir" FM_HERDR_PS_BIN="$dir/ps" FM_BACKEND_HERDR_WORKSPACE_MOVER="$dir/mover" FM_FAKE_MOVER_LOG="$dir/mover.log" FM_FAKE_MOVER_RESPONSE="$dir/no-response" FM_BACKEND_HERDR_DEATH_CLOSE_POLLS=2 fm_backend_herdr_projection_close_pane_focus_preserving fmtest w1:p1 2>&1 )
   status=$?
   kill "$bgpid" 2>/dev/null || true; wait "$bgpid" 2>/dev/null || true
   [ "$status" -eq 0 ] || fail "emptying close with last focus should succeed through the pane-death path: $out"
@@ -2329,7 +2232,7 @@ test_projection_close_emptying_before_last_focus_needs_no_move() {
 }
 
 test_projection_close_emptying_last_workspace_needs_no_move() {
-  local dir log resp fb out status bgpid
+  local dir log resp out status bgpid
   dir="$TMP_ROOT/close-death-target-last"; mkdir -p "$dir/responses"
   log="$dir/log"; resp="$dir/responses"; : > "$log"
   # Target w3 is already last (r > a), so no repositioning is needed.
@@ -2345,12 +2248,7 @@ test_projection_close_emptying_last_workspace_needs_no_move() {
   printf '%s\n' '{"result":{"workspaces":[{"workspace_id":"w1","active_tab_id":"w1:t1","focused":true},{"workspace_id":"w2","active_tab_id":"w2:t1","focused":false}]}}' > "$resp/9.out"
   printf '%s\n' '{"result":{"tabs":[{"tab_id":"w1:t1","focused":true}]}}' > "$resp/10.out"
   make_death_lab "$dir" "$bgpid"
-  fb=$(make_herdr_fakebin "$dir")
-  out=$(PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
-    FM_HERDR_PS_BIN="$dir/ps" FM_BACKEND_HERDR_WORKSPACE_MOVER="$dir/mover" \
-    FM_FAKE_MOVER_LOG="$dir/mover.log" FM_FAKE_MOVER_RESPONSE="$dir/no-response" \
-    FM_BACKEND_HERDR_DEATH_CLOSE_POLLS=2 \
-    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_projection_close_pane_focus_preserving fmtest w3:p1' "$ROOT" 2>&1)
+  out=$( herdr_run "$dir" FM_HERDR_PS_BIN="$dir/ps" FM_BACKEND_HERDR_WORKSPACE_MOVER="$dir/mover" FM_FAKE_MOVER_LOG="$dir/mover.log" FM_FAKE_MOVER_RESPONSE="$dir/no-response" FM_BACKEND_HERDR_DEATH_CLOSE_POLLS=2 fm_backend_herdr_projection_close_pane_focus_preserving fmtest w3:p1 2>&1 )
   status=$?
   kill "$bgpid" 2>/dev/null || true; wait "$bgpid" 2>/dev/null || true
   [ "$status" -eq 0 ] || fail "last-workspace emptying close should succeed through the pane-death path: $out"
@@ -2360,7 +2258,7 @@ test_projection_close_emptying_last_workspace_needs_no_move() {
 }
 
 test_projection_close_non_emptying_stays_plain_without_proof_or_move() {
-  local dir log resp fb out status bgpid
+  local dir log resp out status bgpid
   dir="$TMP_ROOT/close-non-emptying"; mkdir -p "$dir/responses"
   log="$dir/log"; resp="$dir/responses"; : > "$log"
   printf '%s\n' '{"result":{"workspaces":[{"workspace_id":"w1","active_tab_id":"w1:t1","focused":true},{"workspace_id":"w2","active_tab_id":"w2:t2","focused":false}]}}' > "$resp/1.out"
@@ -2372,12 +2270,7 @@ test_projection_close_non_emptying_stays_plain_without_proof_or_move() {
   printf '%s\n' '{"result":{"tabs":[{"tab_id":"w1:t1","focused":true}]}}' > "$resp/8.out"
   sleep 300 & bgpid=$!
   make_death_lab "$dir" "$bgpid"
-  fb=$(make_herdr_fakebin "$dir")
-  out=$(PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
-    FM_HERDR_PS_BIN="$dir/ps" FM_BACKEND_HERDR_WORKSPACE_MOVER="$dir/mover" \
-    FM_FAKE_MOVER_LOG="$dir/mover.log" FM_FAKE_MOVER_RESPONSE="$dir/no-response" \
-    FM_BACKEND_HERDR_DEATH_CLOSE_POLLS=2 \
-    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_projection_close_pane_focus_preserving fmtest w2:p2' "$ROOT" 2>&1)
+  out=$( herdr_run "$dir" FM_HERDR_PS_BIN="$dir/ps" FM_BACKEND_HERDR_WORKSPACE_MOVER="$dir/mover" FM_FAKE_MOVER_LOG="$dir/mover.log" FM_FAKE_MOVER_RESPONSE="$dir/no-response" FM_BACKEND_HERDR_DEATH_CLOSE_POLLS=2 fm_backend_herdr_projection_close_pane_focus_preserving fmtest w2:p2 2>&1 )
   status=$?
   [ "$status" -eq 0 ] || fail "non-emptying close should succeed through the plain close: $out"
   assert_contains "$(cat "$log")" $'pane\x1fclose\x1fw2:p2' "non-emptying close did not use the plain close"
@@ -2413,7 +2306,7 @@ test_projection_close_plain_without_move_requires_structured_removal() {
 }
 
 test_projection_close_ambiguous_positions_fall_back_to_plain_close() {
-  local dir log resp fb out status bgpid
+  local dir log resp out status bgpid
   dir="$TMP_ROOT/close-ambiguous-positions"; mkdir -p "$dir/responses"
   log="$dir/log"; resp="$dir/responses"; : > "$log"
   printf '%s\n' '{"result":{"workspaces":[{"workspace_id":"w1","active_tab_id":"w1:t1","focused":true}]}}' > "$resp/1.out"
@@ -2428,12 +2321,7 @@ test_projection_close_ambiguous_positions_fall_back_to_plain_close() {
   printf '%s\n' '{"result":{"tabs":[{"tab_id":"w1:t1","focused":true}]}}' > "$resp/10.out"
   sleep 300 & bgpid=$!
   make_death_lab "$dir" "$bgpid"
-  fb=$(make_herdr_fakebin "$dir")
-  out=$(PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
-    FM_HERDR_PS_BIN="$dir/ps" FM_BACKEND_HERDR_WORKSPACE_MOVER="$dir/mover" \
-    FM_FAKE_MOVER_LOG="$dir/mover.log" FM_FAKE_MOVER_RESPONSE="$dir/no-response" \
-    FM_BACKEND_HERDR_DEATH_CLOSE_POLLS=2 \
-    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_projection_close_pane_focus_preserving fmtest w2:p2' "$ROOT" 2>&1)
+  out=$( herdr_run "$dir" FM_HERDR_PS_BIN="$dir/ps" FM_BACKEND_HERDR_WORKSPACE_MOVER="$dir/mover" FM_FAKE_MOVER_LOG="$dir/mover.log" FM_FAKE_MOVER_RESPONSE="$dir/no-response" FM_BACKEND_HERDR_DEATH_CLOSE_POLLS=2 fm_backend_herdr_projection_close_pane_focus_preserving fmtest w2:p2 2>&1 )
   status=$?
   [ "$status" -eq 0 ] || fail "an ambiguous position snapshot should fall back to the plain close: $out"
   assert_contains "$(cat "$log")" $'pane\x1fclose\x1fw2:p2' "ambiguous positions did not use the plain close"
@@ -2445,7 +2333,7 @@ test_projection_close_ambiguous_positions_fall_back_to_plain_close() {
 }
 
 test_projection_close_move_failure_falls_back_to_plain_close() {
-  local dir log resp fb out status bgpid
+  local dir log resp out status bgpid
   dir="$TMP_ROOT/close-move-failure"; mkdir -p "$dir/responses"
   log="$dir/log"; resp="$dir/responses"; : > "$log"
   printf '%s\n' '{"result":{"workspaces":[{"workspace_id":"w1","active_tab_id":"w1:t1","focused":false},{"workspace_id":"w2","active_tab_id":"w2:t1","focused":true},{"workspace_id":"w3","active_tab_id":"w3:t1","focused":false}]}}' > "$resp/1.out"
@@ -2464,12 +2352,7 @@ test_projection_close_move_failure_falls_back_to_plain_close() {
   printf '%s\n' '{"result":{"tabs":[{"tab_id":"w2:t1","focused":true}]}}' > "$resp/14.out"
   sleep 300 & bgpid=$!
   make_death_lab "$dir" "$bgpid"
-  fb=$(make_herdr_fakebin "$dir")
-  out=$(PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" FM_HERDR_SCRIPT_STATUS=1 \
-    FM_HERDR_PS_BIN="$dir/ps" FM_BACKEND_HERDR_WORKSPACE_MOVER="$dir/mover" \
-    FM_FAKE_MOVER_LOG="$dir/mover.log" FM_FAKE_MOVER_RESPONSE="$dir/no-response" \
-    FM_BACKEND_HERDR_DEATH_CLOSE_POLLS=2 \
-    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_projection_close_pane_focus_preserving fmtest w1:p1' "$ROOT" 2>&1)
+  out=$( herdr_run "$dir" FM_HERDR_SCRIPT_STATUS=1 FM_HERDR_PS_BIN="$dir/ps" FM_BACKEND_HERDR_WORKSPACE_MOVER="$dir/mover" FM_FAKE_MOVER_LOG="$dir/mover.log" FM_FAKE_MOVER_RESPONSE="$dir/no-response" FM_BACKEND_HERDR_DEATH_CLOSE_POLLS=2 fm_backend_herdr_projection_close_pane_focus_preserving fmtest w1:p1 2>&1 )
   status=$?
   [ "$status" -eq 0 ] || fail "a failed repositioning move should fall back to the plain close: $out"
   assert_contains "$out" "could not move the doomed workspace behind the focused one" \
@@ -2482,7 +2365,7 @@ test_projection_close_move_failure_falls_back_to_plain_close() {
 }
 
 test_projection_close_busy_pane_falls_back_to_plain_close() {
-  local dir log resp fb out status bgpid
+  local dir log resp out status bgpid
   dir="$TMP_ROOT/close-busy-pane"; mkdir -p "$dir/responses"
   log="$dir/log"; resp="$dir/responses"; : > "$log"
   printf '%s\n' '{"result":{"workspaces":[{"workspace_id":"w1","active_tab_id":"w1:t1","focused":true},{"workspace_id":"w2","active_tab_id":"w2:t2","focused":false}]}}' > "$resp/1.out"
@@ -2498,12 +2381,7 @@ test_projection_close_busy_pane_falls_back_to_plain_close() {
   printf '%s\n' '{"result":{"workspaces":[{"workspace_id":"w1","active_tab_id":"w1:t1","focused":true}]}}' > "$resp/10.out"
   printf '%s\n' '{"result":{"tabs":[{"tab_id":"w1:t1","focused":true}]}}' > "$resp/11.out"
   make_death_lab "$dir" "$bgpid"
-  fb=$(make_herdr_fakebin "$dir")
-  out=$(PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
-    FM_HERDR_PS_BIN="$dir/ps" FM_BACKEND_HERDR_WORKSPACE_MOVER="$dir/mover" \
-    FM_FAKE_MOVER_LOG="$dir/mover.log" FM_FAKE_MOVER_RESPONSE="$dir/no-response" \
-    FM_BACKEND_HERDR_DEATH_CLOSE_POLLS=2 FM_BACKEND_HERDR_IDLE_SHELL_PROOF_POLLS=1 \
-    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_projection_close_pane_focus_preserving fmtest w2:p2' "$ROOT" 2>&1)
+  out=$( herdr_run "$dir" FM_HERDR_PS_BIN="$dir/ps" FM_BACKEND_HERDR_WORKSPACE_MOVER="$dir/mover" FM_FAKE_MOVER_LOG="$dir/mover.log" FM_FAKE_MOVER_RESPONSE="$dir/no-response" FM_BACKEND_HERDR_DEATH_CLOSE_POLLS=2 FM_BACKEND_HERDR_IDLE_SHELL_PROOF_POLLS=1 fm_backend_herdr_projection_close_pane_focus_preserving fmtest w2:p2 2>&1 )
   status=$?
   [ "$status" -eq 0 ] || fail "a busy pane should fall back to the plain close: $out"
   assert_contains "$(cat "$log")" $'pane\x1fclose\x1fw2:p2' "a busy pane did not use the plain close"
@@ -2513,7 +2391,7 @@ test_projection_close_busy_pane_falls_back_to_plain_close() {
 }
 
 test_projection_close_transient_prompt_helper_settles_then_uses_pane_death() {
-  local dir log resp fb out status bgpid
+  local dir log resp out status bgpid
   dir="$TMP_ROOT/close-transient-helper"; mkdir -p "$dir/responses"
   log="$dir/log"; resp="$dir/responses"; : > "$log"
   printf '%s\n' '{"result":{"workspaces":[{"workspace_id":"w1","active_tab_id":"w1:t1","focused":true},{"workspace_id":"w2","active_tab_id":"w2:t2","focused":false}]}}' > "$resp/1.out"
@@ -2532,12 +2410,7 @@ test_projection_close_transient_prompt_helper_settles_then_uses_pane_death() {
   printf '%s\n' '{"result":{"workspaces":[{"workspace_id":"w1","active_tab_id":"w1:t1","focused":true}]}}' > "$resp/10.out"
   printf '%s\n' '{"result":{"tabs":[{"tab_id":"w1:t1","focused":true}]}}' > "$resp/11.out"
   make_death_lab "$dir" "$bgpid"
-  fb=$(make_herdr_fakebin "$dir")
-  out=$(PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
-    FM_HERDR_PS_BIN="$dir/ps" FM_BACKEND_HERDR_WORKSPACE_MOVER="$dir/mover" \
-    FM_FAKE_MOVER_LOG="$dir/mover.log" FM_FAKE_MOVER_RESPONSE="$dir/no-response" \
-    FM_BACKEND_HERDR_DEATH_CLOSE_POLLS=2 FM_BACKEND_HERDR_IDLE_SHELL_PROOF_POLLS=3 \
-    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_projection_close_pane_focus_preserving fmtest w2:p2' "$ROOT" 2>&1)
+  out=$( herdr_run "$dir" FM_HERDR_PS_BIN="$dir/ps" FM_BACKEND_HERDR_WORKSPACE_MOVER="$dir/mover" FM_FAKE_MOVER_LOG="$dir/mover.log" FM_FAKE_MOVER_RESPONSE="$dir/no-response" FM_BACKEND_HERDR_DEATH_CLOSE_POLLS=2 FM_BACKEND_HERDR_IDLE_SHELL_PROOF_POLLS=3 fm_backend_herdr_projection_close_pane_focus_preserving fmtest w2:p2 2>&1 )
   status=$?
   kill "$bgpid" 2>/dev/null || true; wait "$bgpid" 2>/dev/null || true
   [ "$status" -eq 0 ] || fail "a transient prompt helper should settle into the pane-death path: $out"
@@ -2549,7 +2422,7 @@ test_projection_close_transient_prompt_helper_settles_then_uses_pane_death() {
 }
 
 test_projection_close_death_escalates_sigkill_after_sighup_survival() {
-  local dir log resp fb out status bgpid
+  local dir log resp out status bgpid
   dir="$TMP_ROOT/close-death-escalate"; mkdir -p "$dir/responses"
   log="$dir/log"; resp="$dir/responses"; : > "$log"
   printf '%s\n' '{"result":{"workspaces":[{"workspace_id":"w1","active_tab_id":"w1:t1","focused":true},{"workspace_id":"w2","active_tab_id":"w2:t2","focused":false}]}}' > "$resp/1.out"
@@ -2567,12 +2440,7 @@ test_projection_close_death_escalates_sigkill_after_sighup_survival() {
   printf '%s\n' '{"result":{"workspaces":[{"workspace_id":"w1","active_tab_id":"w1:t1","focused":true}]}}' > "$resp/12.out"
   printf '%s\n' '{"result":{"tabs":[{"tab_id":"w1:t1","focused":true}]}}' > "$resp/13.out"
   make_death_lab "$dir" "$bgpid"
-  fb=$(make_herdr_fakebin "$dir")
-  out=$(PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
-    FM_HERDR_PS_BIN="$dir/ps" FM_BACKEND_HERDR_WORKSPACE_MOVER="$dir/mover" \
-    FM_FAKE_MOVER_LOG="$dir/mover.log" FM_FAKE_MOVER_RESPONSE="$dir/no-response" \
-    FM_BACKEND_HERDR_DEATH_CLOSE_POLLS=2 \
-    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_projection_close_pane_focus_preserving fmtest w2:p2' "$ROOT" 2>&1)
+  out=$( herdr_run "$dir" FM_HERDR_PS_BIN="$dir/ps" FM_BACKEND_HERDR_WORKSPACE_MOVER="$dir/mover" FM_FAKE_MOVER_LOG="$dir/mover.log" FM_FAKE_MOVER_RESPONSE="$dir/no-response" FM_BACKEND_HERDR_DEATH_CLOSE_POLLS=2 fm_backend_herdr_projection_close_pane_focus_preserving fmtest w2:p2 2>&1 )
   status=$?
   [ "$status" -eq 0 ] || fail "a SIGHUP-surviving shell should be finished by the SIGKILL escalation: $out"
   assert_not_contains "$(cat "$log")" $'pane\x1fclose' "the SIGKILL escalation used the focus-unsafe explicit close"
@@ -2585,7 +2453,7 @@ test_projection_close_death_escalates_sigkill_after_sighup_survival() {
 }
 
 test_projection_close_death_failure_falls_back_to_plain_close() {
-  local dir log resp fb out status bgpid
+  local dir log resp out status bgpid
   dir="$TMP_ROOT/close-death-fallback"; mkdir -p "$dir/responses"
   log="$dir/log"; resp="$dir/responses"; : > "$log"
   printf '%s\n' '{"result":{"workspaces":[{"workspace_id":"w1","active_tab_id":"w1:t1","focused":true},{"workspace_id":"w2","active_tab_id":"w2:t2","focused":false}]}}' > "$resp/1.out"
@@ -2605,12 +2473,7 @@ test_projection_close_death_failure_falls_back_to_plain_close() {
   printf '%s\n' '{"result":{"workspaces":[{"workspace_id":"w1","active_tab_id":"w1:t1","focused":true}]}}' > "$resp/15.out"
   printf '%s\n' '{"result":{"tabs":[{"tab_id":"w1:t1","focused":true}]}}' > "$resp/16.out"
   make_death_lab "$dir" "$bgpid"
-  fb=$(make_herdr_fakebin "$dir")
-  out=$(PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
-    FM_HERDR_PS_BIN="$dir/ps" FM_BACKEND_HERDR_WORKSPACE_MOVER="$dir/mover" \
-    FM_FAKE_MOVER_LOG="$dir/mover.log" FM_FAKE_MOVER_RESPONSE="$dir/no-response" \
-    FM_BACKEND_HERDR_DEATH_CLOSE_POLLS=2 \
-    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_projection_close_pane_focus_preserving fmtest w2:p2' "$ROOT" 2>&1)
+  out=$( herdr_run "$dir" FM_HERDR_PS_BIN="$dir/ps" FM_BACKEND_HERDR_WORKSPACE_MOVER="$dir/mover" FM_FAKE_MOVER_LOG="$dir/mover.log" FM_FAKE_MOVER_RESPONSE="$dir/no-response" FM_BACKEND_HERDR_DEATH_CLOSE_POLLS=2 fm_backend_herdr_projection_close_pane_focus_preserving fmtest w2:p2 2>&1 )
   status=$?
   [ "$status" -eq 0 ] || fail "an unkillable shell should fall back to the plain close: $out"
   assert_contains "$(cat "$log")" $'pane\x1fclose\x1fw2:p2' "a failed pane-death close did not use the plain close fallback"
@@ -2619,7 +2482,7 @@ test_projection_close_death_failure_falls_back_to_plain_close() {
 }
 
 test_projection_close_death_still_restores_a_stolen_focus() {
-  local dir log resp fb out status bgpid
+  local dir log resp out status bgpid
   dir="$TMP_ROOT/close-death-restore"; mkdir -p "$dir/responses"
   log="$dir/log"; resp="$dir/responses"; : > "$log"
   printf '%s\n' '{"result":{"workspaces":[{"workspace_id":"w1","active_tab_id":"w1:t1","focused":true},{"workspace_id":"w2","active_tab_id":"w2:t2","focused":false},{"workspace_id":"w3","active_tab_id":"w3:t1","focused":false}]}}' > "$resp/1.out"
@@ -2638,12 +2501,7 @@ test_projection_close_death_still_restores_a_stolen_focus() {
   printf '%s\n' '{"result":{"workspaces":[{"workspace_id":"w1","active_tab_id":"w1:t1","focused":true},{"workspace_id":"w3","active_tab_id":"w3:t1","focused":false}]}}' > "$resp/13.out"
   printf '%s\n' '{"result":{"tabs":[{"tab_id":"w1:t1","focused":true}]}}' > "$resp/14.out"
   make_death_lab "$dir" "$bgpid"
-  fb=$(make_herdr_fakebin "$dir")
-  out=$(PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
-    FM_HERDR_PS_BIN="$dir/ps" FM_BACKEND_HERDR_WORKSPACE_MOVER="$dir/mover" \
-    FM_FAKE_MOVER_LOG="$dir/mover.log" FM_FAKE_MOVER_RESPONSE="$dir/no-response" \
-    FM_BACKEND_HERDR_DEATH_CLOSE_POLLS=2 \
-    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_projection_close_pane_focus_preserving fmtest w2:p2' "$ROOT" 2>&1)
+  out=$( herdr_run "$dir" FM_HERDR_PS_BIN="$dir/ps" FM_BACKEND_HERDR_WORKSPACE_MOVER="$dir/mover" FM_FAKE_MOVER_LOG="$dir/mover.log" FM_FAKE_MOVER_RESPONSE="$dir/no-response" FM_BACKEND_HERDR_DEATH_CLOSE_POLLS=2 fm_backend_herdr_projection_close_pane_focus_preserving fmtest w2:p2 2>&1 )
   status=$?
   [ "$status" -eq 0 ] || fail "the pane-death close with a restored backstop should succeed: $out"
   assert_contains "$(cat "$log")" $'tab\x1ffocus\x1fw1:t1' "the backstop did not restore the exact prior tab"
@@ -2651,7 +2509,7 @@ test_projection_close_death_still_restores_a_stolen_focus() {
 }
 
 test_projection_close_death_never_sigkills_a_reused_pid() {
-  local dir log resp fb out status bgpid
+  local dir log resp out status bgpid
   dir="$TMP_ROOT/close-death-pid-reuse"; mkdir -p "$dir/responses"
   log="$dir/log"; resp="$dir/responses"; : > "$log"
   printf '%s\n' '{"result":{"workspaces":[{"workspace_id":"w1","active_tab_id":"w1:t1","focused":true},{"workspace_id":"w2","active_tab_id":"w2:t2","focused":false}]}}' > "$resp/1.out"
@@ -2673,12 +2531,7 @@ test_projection_close_death_never_sigkills_a_reused_pid() {
   printf '%s\n' '{"result":{"workspaces":[{"workspace_id":"w1","active_tab_id":"w1:t1","focused":true}]}}' > "$resp/13.out"
   printf '%s\n' '{"result":{"tabs":[{"tab_id":"w1:t1","focused":true}]}}' > "$resp/14.out"
   make_death_lab "$dir" "$bgpid"
-  fb=$(make_herdr_fakebin "$dir")
-  out=$(PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
-    FM_HERDR_PS_BIN="$dir/ps" FM_BACKEND_HERDR_WORKSPACE_MOVER="$dir/mover" \
-    FM_FAKE_MOVER_LOG="$dir/mover.log" FM_FAKE_MOVER_RESPONSE="$dir/no-response" \
-    FM_BACKEND_HERDR_DEATH_CLOSE_POLLS=2 \
-    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_projection_close_pane_focus_preserving fmtest w2:p2' "$ROOT" 2>&1)
+  out=$( herdr_run "$dir" FM_HERDR_PS_BIN="$dir/ps" FM_BACKEND_HERDR_WORKSPACE_MOVER="$dir/mover" FM_FAKE_MOVER_LOG="$dir/mover.log" FM_FAKE_MOVER_RESPONSE="$dir/no-response" FM_BACKEND_HERDR_DEATH_CLOSE_POLLS=2 fm_backend_herdr_projection_close_pane_focus_preserving fmtest w2:p2 2>&1 )
   status=$?
   if ! kill -0 "$bgpid" 2>/dev/null; then
     wait "$bgpid" 2>/dev/null || true
@@ -2691,7 +2544,7 @@ test_projection_close_death_never_sigkills_a_reused_pid() {
 }
 
 assert_projection_close_failed_removal_rolls_back_the_reposition() {
-  local mode=$1 dir log resp fb out status bgpid
+  local mode=$1 dir log resp out status bgpid
   dir="$TMP_ROOT/close-move-rollback-$mode"; mkdir -p "$dir/responses"
   log="$dir/log"; resp="$dir/responses"; : > "$log"
   # Doomed w1 sits BEFORE the focused w2 (not last): the plan repositions it
@@ -2734,13 +2587,7 @@ assert_projection_close_failed_removal_rolls_back_the_reposition() {
   make_death_lab "$dir" "$bgpid"
   printf '%s\n' '{"id":"fm-workspace-move","result":{"type":"workspace_list","workspaces":[{"workspace_id":"w2","focused":true},{"workspace_id":"w3","focused":false},{"workspace_id":"w1","focused":false}]}}' > "$dir/mover-response"
   printf '%s\n' '{"id":"fm-workspace-move","result":{"type":"workspace_list","workspaces":[{"workspace_id":"w1","focused":false},{"workspace_id":"w2","focused":true},{"workspace_id":"w3","focused":false}]}}' > "$dir/mover-response-2"
-  fb=$(make_herdr_fakebin "$dir")
-  out=$(PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" FM_HERDR_SCRIPT_STATUS=1 \
-    FM_HERDR_PS_BIN="$dir/ps" FM_BACKEND_HERDR_WORKSPACE_MOVER="$dir/mover" \
-    FM_FAKE_MOVER_LOG="$dir/mover.log" FM_FAKE_MOVER_RESPONSE="$dir/mover-response" \
-    FM_FAKE_MOVER_RESPONSE_2="$dir/mover-response-2" \
-    FM_BACKEND_HERDR_DEATH_CLOSE_POLLS=2 \
-    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_projection_close_pane_focus_preserving fmtest w1:p1' "$ROOT" 2>&1)
+  out=$( herdr_run "$dir" FM_HERDR_SCRIPT_STATUS=1 FM_HERDR_PS_BIN="$dir/ps" FM_BACKEND_HERDR_WORKSPACE_MOVER="$dir/mover" FM_FAKE_MOVER_LOG="$dir/mover.log" FM_FAKE_MOVER_RESPONSE="$dir/mover-response" FM_FAKE_MOVER_RESPONSE_2="$dir/mover-response-2" FM_BACKEND_HERDR_DEATH_CLOSE_POLLS=2 fm_backend_herdr_projection_close_pane_focus_preserving fmtest w1:p1 2>&1 )
   status=$?
   kill -KILL "$bgpid" 2>/dev/null || true; wait "$bgpid" 2>/dev/null || true
   [ "$status" -ne 0 ] || fail "an unconfirmed removal must report failure: $out"
@@ -2916,7 +2763,7 @@ test_endpoint_confirmed_gone_gates_on_structured_presence() {
 }
 
 test_projection_seeded_prune_refuses_active_tab() {
-  local dir log resp fb out status
+  local dir log resp out status
   dir="$TMP_ROOT/projection-seeded-focus-active-refusal"; mkdir -p "$dir/responses"
   log="$dir/log"; resp="$dir/responses"; : > "$log"
   printf '%s\n' '{"result":{"tabs":[{"tab_id":"w9:t1","label":"1","workspace_id":"w9","focused":true},{"tab_id":"w9:t2","label":"fm-task","workspace_id":"w9","focused":false}]}}' > "$resp/1.out"
@@ -2928,10 +2775,8 @@ test_projection_seeded_prune_refuses_active_tab() {
   cp "$resp/1.out" "$resp/7.out"
   cp "$resp/4.out" "$resp/8.out"
   cp "$resp/5.out" "$resp/9.out"
-  fb=$(make_herdr_fakebin "$dir")
-  out=$(PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
-    FM_FAKE_HERDR_FOREGROUND_REASON=cleared \
-    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_workspace_prune_seeded_default_tab fmtest w9 w9:t1 focus-preserving' "$ROOT" 2>&1)
+  out=$( herdr_run "$dir" FM_FAKE_HERDR_FOREGROUND_REASON=cleared \
+    fm_backend_herdr_workspace_prune_seeded_default_tab fmtest w9 w9:t1 focus-preserving 2>&1 )
   status=$?
   [ "$status" -ne 0 ] || fail "projected seeded pruning must refuse the active tab"
   assert_contains "$out" "target is the captain's active tab" \
@@ -3026,7 +2871,7 @@ SH
 }
 
 test_projection_order_foreign_legacy_child_is_read_only() {
-  local dir log resp fb mover out status
+  local dir log resp mover out status
   dir="$TMP_ROOT/projection-order-foreign-legacy"; mkdir -p "$dir/responses"
   log="$dir/log"; resp="$dir/responses"; mover="$dir/mover"; : > "$log"
   printf '%s\n' '{"result":{"workspaces":[{"workspace_id":"w1","label":"firstmate"},{"workspace_id":"w2","label":"2ndmate-alpha"},{"workspace_id":"w3","label":"2ndmate-bravo/foreign · p:AbCdEfGhIjKlMnOpQrStUv"},{"workspace_id":"w4","label":"└ new-alpha · p:ZyXwVuTsRqPoNmLkJiHgFe"}]}}' > "$resp/1.out"
@@ -3036,10 +2881,7 @@ echo called > "$FM_FAKE_MOVER_CALLED"
 exit 0
 SH
   chmod +x "$mover"
-  fb=$(make_herdr_fakebin "$dir")
-  out=$(PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
-    FM_BACKEND_HERDR_WORKSPACE_MOVER="$mover" FM_FAKE_MOVER_CALLED="$dir/called" \
-    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_projection_order_best_effort fmtest w4 2ndmate-alpha' "$ROOT" 2>&1)
+  out=$( herdr_run "$dir" FM_BACKEND_HERDR_WORKSPACE_MOVER="$mover" FM_FAKE_MOVER_CALLED="$dir/called" fm_backend_herdr_projection_order_best_effort fmtest w4 2ndmate-alpha 2>&1 )
   status=$?
   [ "$status" -eq 0 ] || fail "foreign legacy ordering must not fail the spawn"
   assert_contains "$out" "ambiguous workspace layout" "foreign legacy child did not warn"
@@ -3134,7 +2976,7 @@ SH
 }
 
 test_projection_order_ambiguous_existing_block_is_read_only() {
-  local dir log resp fb mover out status
+  local dir log resp mover out status
   dir="$TMP_ROOT/projection-order-ambiguous"; mkdir -p "$dir/responses"
   log="$dir/log"; resp="$dir/responses"; mover="$dir/mover"; : > "$log"
   # Detached legacy child after the next parent breaks the contiguous block.
@@ -3145,10 +2987,7 @@ echo called > "$FM_FAKE_MOVER_CALLED"
 exit 0
 SH
   chmod +x "$mover"
-  fb=$(make_herdr_fakebin "$dir")
-  out=$(PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
-    FM_BACKEND_HERDR_WORKSPACE_MOVER="$mover" FM_FAKE_MOVER_CALLED="$dir/called" \
-    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_projection_order_best_effort fmtest w4 firstmate' "$ROOT" 2>&1)
+  out=$( herdr_run "$dir" FM_BACKEND_HERDR_WORKSPACE_MOVER="$mover" FM_FAKE_MOVER_CALLED="$dir/called" fm_backend_herdr_projection_order_best_effort fmtest w4 firstmate 2>&1 )
   status=$?
   [ "$status" -eq 0 ] || fail "ambiguous projection ordering must not fail the spawn"
   assert_contains "$out" "ambiguous workspace layout" "ambiguous projection layout did not warn"
@@ -3159,7 +2998,7 @@ SH
 }
 
 test_projection_order_anchors_the_parent_by_exact_id() {
-  local dir log resp fb mover layout out status
+  local dir log resp mover layout out status
   layout='{"result":{"workspaces":[{"workspace_id":"w1","label":"firstmate","focused":false},{"workspace_id":"w7","label":"firstmate","focused":false},{"workspace_id":"wH","label":"human-notes","focused":false},{"workspace_id":"w8","label":"└ new · p:ZyXwVuTsRqPoNmLkJiHgFe","focused":false}]}}'
 
   # Without the exact parent id, two same-labeled parents make the whole layout
@@ -3173,10 +3012,7 @@ echo called > "$FM_FAKE_MOVER_CALLED"
 exit 0
 SH
   chmod +x "$mover"
-  fb=$(make_herdr_fakebin "$dir")
-  out=$(PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
-    FM_BACKEND_HERDR_WORKSPACE_MOVER="$mover" FM_FAKE_MOVER_CALLED="$dir/called" \
-    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_projection_order_best_effort fmtest w8 firstmate' "$ROOT" 2>&1)
+  out=$( herdr_run "$dir" FM_BACKEND_HERDR_WORKSPACE_MOVER="$mover" FM_FAKE_MOVER_CALLED="$dir/called" fm_backend_herdr_projection_order_best_effort fmtest w8 firstmate 2>&1 )
   status=$?
   [ "$status" -eq 0 ] || fail "ambiguous projection ordering must not fail the spawn"
   assert_contains "$out" "ambiguous workspace layout" "a duplicated parent label should make label-anchored ordering step aside"
@@ -3194,10 +3030,7 @@ echo called > "$FM_FAKE_MOVER_CALLED"
 exit 0
 SH
   chmod +x "$mover"
-  fb=$(make_herdr_fakebin "$dir")
-  out=$(PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
-    FM_BACKEND_HERDR_WORKSPACE_MOVER="$mover" FM_FAKE_MOVER_CALLED="$dir/called" \
-    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_projection_order_best_effort fmtest w8 firstmate w7' "$ROOT" 2>&1)
+  out=$( herdr_run "$dir" FM_BACKEND_HERDR_WORKSPACE_MOVER="$mover" FM_FAKE_MOVER_CALLED="$dir/called" fm_backend_herdr_projection_order_best_effort fmtest w8 firstmate w7 2>&1 )
   status=$?
   [ "$status" -eq 0 ] || fail "exact-parent projection ordering must not fail the spawn"
   assert_not_contains "$out" "ambiguous workspace layout" "the exact parent id should have resolved the duplicated label"
@@ -3207,7 +3040,7 @@ SH
 }
 
 test_projection_order_foreign_new_child_before_parent_is_read_only() {
-  local dir log resp fb mover out status
+  local dir log resp mover out status
   dir="$TMP_ROOT/projection-order-foreign-new"; mkdir -p "$dir/responses"
   log="$dir/log"; resp="$dir/responses"; mover="$dir/mover"; : > "$log"
   printf '%s\n' '{"result":{"workspaces":[{"workspace_id":"w1","label":"firstmate","focused":true},{"workspace_id":"wH","label":"human-notes","focused":false},{"workspace_id":"w2","label":"└ foreign · p:AbCdEfGhIjKlMnOpQrStUv","focused":false},{"workspace_id":"w3","label":"2ndmate-alpha","focused":false},{"workspace_id":"w4","label":"└ new · p:ZyXwVuTsRqPoNmLkJiHgFe","focused":false}]}}' > "$resp/1.out"
@@ -3217,10 +3050,7 @@ echo called > "$FM_FAKE_MOVER_CALLED"
 exit 0
 SH
   chmod +x "$mover"
-  fb=$(make_herdr_fakebin "$dir")
-  out=$(PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
-    FM_BACKEND_HERDR_WORKSPACE_MOVER="$mover" FM_FAKE_MOVER_CALLED="$dir/called" \
-    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_projection_order_best_effort fmtest w4 firstmate' "$ROOT" 2>&1)
+  out=$( herdr_run "$dir" FM_BACKEND_HERDR_WORKSPACE_MOVER="$mover" FM_FAKE_MOVER_CALLED="$dir/called" fm_backend_herdr_projection_order_best_effort fmtest w4 firstmate 2>&1 )
   status=$?
   [ "$status" -eq 0 ] || fail "foreign new-child ordering must not fail the spawn"
   assert_contains "$out" "ambiguous workspace layout" "foreign new child before its parent did not warn"
@@ -3231,7 +3061,7 @@ SH
 }
 
 test_projection_order_missing_parent_is_read_only() {
-  local dir log resp fb mover out status
+  local dir log resp mover out status
   dir="$TMP_ROOT/projection-order-missing-parent"; mkdir -p "$dir/responses"
   log="$dir/log"; resp="$dir/responses"; mover="$dir/mover"; : > "$log"
   printf '%s\n' '{"result":{"workspaces":[{"workspace_id":"w1","label":"firstmate"},{"workspace_id":"w2","label":"└ new · p:ZyXwVuTsRqPoNmLkJiHgFe"}]}}' > "$resp/1.out"
@@ -3241,10 +3071,7 @@ echo called > "$FM_FAKE_MOVER_CALLED"
 exit 0
 SH
   chmod +x "$mover"
-  fb=$(make_herdr_fakebin "$dir")
-  out=$(PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
-    FM_BACKEND_HERDR_WORKSPACE_MOVER="$mover" FM_FAKE_MOVER_CALLED="$dir/called" \
-    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_projection_order_best_effort fmtest w2 2ndmate-missing' "$ROOT" 2>&1)
+  out=$( herdr_run "$dir" FM_BACKEND_HERDR_WORKSPACE_MOVER="$mover" FM_FAKE_MOVER_CALLED="$dir/called" fm_backend_herdr_projection_order_best_effort fmtest w2 2ndmate-missing 2>&1 )
   status=$?
   [ "$status" -eq 0 ] || fail "missing parent must not fail the spawn"
   assert_contains "$out" "ambiguous workspace layout" "missing parent did not warn"
@@ -3253,7 +3080,7 @@ SH
 }
 
 test_presentation_session_lock_path_is_shared_across_homes() {
-  local dir log resp fb path_a path_b path_other path_tmp path_private
+  local dir log resp path_a path_b path_other path_tmp path_private
   dir="$TMP_ROOT/presentation-session-lock"; mkdir -p "$dir/responses" "$dir/sockdir"
   log="$dir/log"; resp="$dir/responses"; : > "$log"
   : > "$dir/sockdir/fmtest.sock"
@@ -3261,12 +3088,9 @@ test_presentation_session_lock_path_is_shared_across_homes() {
   printf '%s\n' "{\"sessions\":[{\"name\":\"fmtest\",\"running\":true,\"socket_path\":\"$dir/sockdir/fmtest.sock\"}]}" > "$resp/2.out"
   printf '%s\n' "{\"sessions\":[{\"name\":\"other\",\"running\":true,\"socket_path\":\"$dir/sockdir/other.sock\"}]}" > "$resp/3.out"
   : > "$dir/sockdir/other.sock"
-  fb=$(make_herdr_fakebin "$dir")
-  path_a=$(PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
-    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_presentation_session_lock_path fmtest' "$ROOT") \
+  path_a=$( herdr_run "$dir" fm_backend_herdr_presentation_session_lock_path fmtest ) \
     || fail "session lock path resolution failed for home A"
-  path_b=$(PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
-    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_presentation_session_lock_path fmtest' "$ROOT") \
+  path_b=$( herdr_run "$dir" fm_backend_herdr_presentation_session_lock_path fmtest ) \
     || fail "session lock path resolution failed for home B"
   [ "$path_a" = "$path_b" ] || fail "same session/socket must resolve one shared lock path"
   case "$path_a" in
@@ -3276,8 +3100,7 @@ test_presentation_session_lock_path_is_shared_across_homes() {
   case "$path_a" in
     */state/*) fail "session lock path must not live under a home state directory: $path_a" ;;
   esac
-  path_other=$(PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
-    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_presentation_session_lock_path other' "$ROOT") \
+  path_other=$( herdr_run "$dir" fm_backend_herdr_presentation_session_lock_path other ) \
     || fail "session lock path resolution failed for a different session"
   [ "$path_other" != "$path_a" ] || fail "different sessions must not share one lock path"
   # Symlink parents such as /tmp -> /private/tmp must not split the lock identity.
@@ -3285,11 +3108,9 @@ test_presentation_session_lock_path_is_shared_across_homes() {
     : > /tmp/fm-herdr-lock-canon-$$.sock
     printf '%s\n' '{"sessions":[{"name":"canon","running":true,"socket_path":"/tmp/fm-herdr-lock-canon-'"$$"'.sock"}]}' > "$resp/4.out"
     printf '%s\n' "{\"sessions\":[{\"name\":\"canon\",\"running\":true,\"socket_path\":\"$(cd /tmp && pwd -P)/fm-herdr-lock-canon-$$.sock\"}]}" > "$resp/5.out"
-    path_tmp=$(PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
-      bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_presentation_session_lock_path canon' "$ROOT") \
+    path_tmp=$( herdr_run "$dir" fm_backend_herdr_presentation_session_lock_path canon ) \
       || fail "lock path with /tmp socket failed"
-    path_private=$(PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
-      bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_presentation_session_lock_path canon' "$ROOT") \
+    path_private=$( herdr_run "$dir" fm_backend_herdr_presentation_session_lock_path canon ) \
       || fail "lock path with canonical socket failed"
     rm -f /tmp/fm-herdr-lock-canon-$$.sock
     [ "$path_tmp" = "$path_private" ] \
@@ -3299,20 +3120,17 @@ test_presentation_session_lock_path_is_shared_across_homes() {
 }
 
 test_presentation_session_lock_path_rejects_malformed_socket() {
-  local dir log resp fb path status
+  local dir log resp path status
   dir="$TMP_ROOT/presentation-malformed-socket"; mkdir -p "$dir/responses"
   log="$dir/log"; resp="$dir/responses"; : > "$log"
   printf '%s\n' '{"sessions":[{"name":"fmtest","running":true,"socket_path":null}]}' > "$resp/1.out"
   printf '%s\n' '{"sessions":[{"name":"fmtest","running":true}]}' > "$resp/2.out"
-  fb=$(make_herdr_fakebin "$dir")
-  path=$(PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
-    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_presentation_session_lock_path fmtest' "$ROOT" 2>&1)
+  path=$( herdr_run "$dir" fm_backend_herdr_presentation_session_lock_path fmtest 2>&1 )
   status=$?
   [ "$status" -ne 0 ] || fail "null socket_path must refuse the presentation lock path"
   [ -z "$path" ] || fail "null socket_path returned a lock path: $path"
   case "$path" in *null*) fail "null socket_path leaked into a lock path: $path" ;; esac
-  path=$(PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
-    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_presentation_session_lock_path fmtest' "$ROOT" 2>&1)
+  path=$( herdr_run "$dir" fm_backend_herdr_presentation_session_lock_path fmtest 2>&1 )
   status=$?
   [ "$status" -ne 0 ] || fail "missing socket_path must refuse the presentation lock path"
   [ -z "$path" ] || fail "missing socket_path returned a lock path: $path"
@@ -3320,7 +3138,7 @@ test_presentation_session_lock_path_rejects_malformed_socket() {
 }
 
 test_projection_order_rejects_malformed_socket() {
-  local dir log resp fb mover out status
+  local dir log resp mover out status
   dir="$TMP_ROOT/projection-order-malformed-socket"; mkdir -p "$dir/responses"
   log="$dir/log"; resp="$dir/responses"; mover="$dir/mover"; : > "$log"
   printf '%s\n' '{"result":{"workspaces":[{"workspace_id":"w1","label":"firstmate"},{"workspace_id":"wH","label":"2ndmate-alpha"},{"workspace_id":"w2","label":"└ new · p:ZyXwVuTsRqPoNmLkJiHgFe"}]}}' > "$resp/1.out"
@@ -3334,10 +3152,7 @@ echo called > "$FM_FAKE_MOVER_CALLED"
 exit 0
 SH
   chmod +x "$mover"
-  fb=$(make_herdr_fakebin "$dir")
-  out=$(PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" FM_HERDR_SCRIPT_STATUS=1 \
-    FM_BACKEND_HERDR_WORKSPACE_MOVER="$mover" FM_FAKE_MOVER_CALLED="$dir/called" \
-    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_projection_order_best_effort fmtest w2 firstmate' "$ROOT" 2>&1)
+  out=$( herdr_run "$dir" FM_HERDR_SCRIPT_STATUS=1 FM_BACKEND_HERDR_WORKSPACE_MOVER="$mover" FM_FAKE_MOVER_CALLED="$dir/called" fm_backend_herdr_projection_order_best_effort fmtest w2 firstmate 2>&1 )
   status=$?
   [ "$status" -eq 0 ] || fail "malformed ordering socket must not fail the spawn"
   assert_contains "$out" "ambiguous named session socket" "malformed ordering socket did not warn"
@@ -3489,7 +3304,7 @@ test_projection_reclaim_replaces_only_exact_husk_and_advances_binding() {
 }
 
 test_projection_recovery_is_read_only_and_refuses_live_duplicate_risk() {
-  local dir state log resp fb token journal out status calls
+  local dir state log resp token journal out status calls
   dir="$TMP_ROOT/projection-recovery"; state="$dir/state"; mkdir -p "$dir/responses" "$state"
   log="$dir/log"; resp="$dir/responses"; : > "$log"
   token=$(bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_projection_journal_create "$1" task-p3' "$ROOT" "$state")
@@ -3501,9 +3316,7 @@ test_projection_recovery_is_read_only_and_refuses_live_duplicate_risk() {
   printf '{"result":{"panes":[{"pane_id":"w2:p1","tab_id":"w2:t1"}]}}\n' > "$resp/5.out"
   printf '{"result":{"pane":{"pane_id":"w2:p1"}}}\n' > "$resp/6.out"
   printf '{"error":{"code":"agent_not_found"}}\n' > "$resp/7.out"
-  fb=$(make_herdr_fakebin "$dir")
-  PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
-    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_projection_recovery_allows_flat fmtest "$1" task-p3' "$ROOT" "$journal" \
+  herdr_run "$dir" fm_backend_herdr_projection_recovery_allows_flat fmtest "$journal" task-p3 \
     >/dev/null || fail "agent-free duplicate token matches should allow flat fallback"
   calls=$(cat "$log")
   assert_not_contains "$calls" $'workspace\x1fcreate' "recovery inspection created a workspace"
@@ -3519,8 +3332,7 @@ test_projection_recovery_is_read_only_and_refuses_live_duplicate_risk() {
   printf '{"result":{"agent":{"agent_status":"idle"}}}\n' > "$resp/4.out"
   # 5: process-info -> a live harness backs the registration (issue #4115)
   printf '{"result":{"type":"pane_process_info","process_info":{"pane_id":"w1:p1","shell_pid":4242,"foreground_process_group_id":4243,"foreground_processes":[{"pid":4243,"name":"node","argv0":"pi"}]}}}\n' > "$resp/5.out"
-  out=$(PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
-    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_projection_recovery_allows_flat fmtest "$1" task-p3' "$ROOT" "$journal" 2>&1)
+  out=$( herdr_run "$dir" fm_backend_herdr_projection_recovery_allows_flat fmtest "$journal" task-p3 2>&1 )
   status=$?
   [ "$status" -ne 0 ] || fail "a token match with a live registered agent must refuse duplicate launch"
   assert_contains "$out" "has a live pane" "live duplicate refusal did not explain the risk"
@@ -3593,15 +3405,13 @@ test_normalize_key() {
 # --- capture / send_key / kill / current_path --------------------------------
 
 test_capture_calls_pane_read() {
-  local dir log resp fb out
+  local dir log resp out
   dir="$TMP_ROOT/capture"; mkdir -p "$dir/responses"; log="$dir/log"; resp="$dir/responses"; : > "$log"
   printf 'line one\nline two\nline three\n' > "$resp/1.out"
-  fb=$(make_herdr_fakebin "$dir")
   # Requesting 250 (already >= the 200 floor) passes straight through as the
   # fetch bound; the adapter then trims to the caller's requested 250 lines
   # locally, so all 3 fake lines survive.
-  out=$( PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
-    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_capture default:w1:p2 250' "$ROOT" )
+  out=$( herdr_run "$dir" fm_backend_herdr_capture default:w1:p2 250 )
   [ "$out" = $'line one\nline two\nline three' ] || fail "capture did not pass through pane read output, got '$out'"
   assert_contains "$(cat "$log")" "HERDR_SESSION=default"$'\x1f''pane'$'\x1f''read'$'\x1f''w1:p2'$'\x1f''--source'$'\x1f''recent'$'\x1f''--lines'$'\x1f''250' \
     "capture did not call pane read with the right pane id and line bound"
@@ -3609,16 +3419,14 @@ test_capture_calls_pane_read() {
 }
 
 test_capture_works_around_small_lines_bug() {
-  local dir log resp fb out
+  local dir log resp out
   # Verified herdr v0.7.1 bug (herdr-verification-p2.md): `pane read --lines N`
   # for a small N (below the pane's viewport height) returns EMPTY, not the
   # last N lines. The adapter must never ask herdr for a small --lines bound -
   # it always fetches >= 200 and trims locally with tail.
   dir="$TMP_ROOT/capture-small"; mkdir -p "$dir/responses"; log="$dir/log"; resp="$dir/responses"; : > "$log"
   printf 'a\nb\nc\nd\ne\n' > "$resp/1.out"
-  fb=$(make_herdr_fakebin "$dir")
-  out=$( PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
-    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_capture default:w1:p2 2' "$ROOT" )
+  out=$( herdr_run "$dir" fm_backend_herdr_capture default:w1:p2 2 )
   [ "$out" = $'d\ne' ] || fail "a small --lines request should still return the last N lines (trimmed locally), got '$out'"
   assert_contains "$(cat "$log")" $'\x1f''--lines'$'\x1f''200' \
     "capture should request a generous fetch (>=200), never the caller's small N, from herdr's own --lines flag"
@@ -3626,12 +3434,10 @@ test_capture_works_around_small_lines_bug() {
 }
 
 test_capture_preserves_pane_read_failure() {
-  local dir log resp fb out status
+  local dir log resp out status
   dir="$TMP_ROOT/capture-fail"; mkdir -p "$dir/responses"; log="$dir/log"; resp="$dir/responses"; : > "$log"
   printf '1\n' > "$resp/1.exit"
-  fb=$(make_herdr_fakebin "$dir")
-  out=$( PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
-    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_capture default:w1:p2 2' "$ROOT" 2>&1 )
+  out=$( herdr_run "$dir" fm_backend_herdr_capture default:w1:p2 2 2>&1 )
   status=$?
   [ "$status" -ne 0 ] || fail "capture should fail when pane read fails, got output '$out'"
   assert_contains "$(cat "$log")" "HERDR_SESSION=default"$'\x1f''status'$'\x1f''--json' \
@@ -3644,9 +3450,7 @@ test_capture_preserves_pane_read_failure() {
 test_send_key_normalizes_and_targets_pane() {
   local dir log resp fb
   dir="$TMP_ROOT/sendkey"; mkdir -p "$dir/responses"; log="$dir/log"; resp="$dir/responses"; : > "$log"
-  fb=$(make_herdr_fakebin "$dir")
-  PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
-    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_send_key default:w1:p2 Escape' "$ROOT"
+  herdr_run "$dir" fm_backend_herdr_send_key default:w1:p2 Escape
   expect_code 0 $? "send_key should succeed"
   assert_contains "$(cat "$log")" $'\x1f''pane'$'\x1f''send-keys'$'\x1f''w1:p2'$'\x1f''escape' "send_key did not normalize Escape to escape"
   pass "fm_backend_herdr_send_key: normalizes the key and targets the right pane"
@@ -3672,15 +3476,13 @@ test_kill_is_best_effort() {
 }
 
 test_current_path_reads_cwd() {
-  local dir log resp fb out
+  local dir log resp out
   dir="$TMP_ROOT/cwd"; mkdir -p "$dir/responses"; log="$dir/log"; resp="$dir/responses"; : > "$log"
   # Verified pitfall (herdr-verification-p2.md): .result.pane.cwd is frozen at
   # pane-creation time and never updates; .foreground_cwd tracks the live
   # running process (e.g. a treehouse get subshell) and is what must be read.
   printf '{"result":{"pane":{"cwd":"/tmp/pane-creation-dir","foreground_cwd":"/tmp/fake-worktree"}}}\n' > "$resp/1.out"
-  fb=$(make_herdr_fakebin "$dir")
-  out=$( PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
-    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_current_path default:w1:p2' "$ROOT" )
+  out=$( herdr_run "$dir" fm_backend_herdr_current_path default:w1:p2 )
   [ "$out" = "/tmp/fake-worktree" ] || fail "current_path should read foreground_cwd (the live process), not the frozen creation-time cwd, got '$out'"
   assert_contains "$(cat "$log")" $'\x1f''pane'$'\x1f''get'$'\x1f''w1:p2' "current_path did not call pane get"
   pass "fm_backend_herdr_current_path: reads pane foreground_cwd (the live running process), not the frozen creation-time cwd"
@@ -3689,42 +3491,34 @@ test_current_path_reads_cwd() {
 # --- busy_state (semantic agent state) ---------------------------------------
 
 test_busy_state_working_maps_to_busy() {
-  local dir log resp fb out
+  local dir log resp out
   dir="$TMP_ROOT/busy-working"; mkdir -p "$dir/responses"; log="$dir/log"; resp="$dir/responses"; : > "$log"
   printf '{"result":{"agent":{"agent_status":"working"}}}\n' > "$resp/1.out"
-  fb=$(make_herdr_fakebin "$dir")
-  out=$( PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
-    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_busy_state default:w1:p2' "$ROOT" )
+  out=$( herdr_run "$dir" fm_backend_herdr_busy_state default:w1:p2 )
   [ "$out" = busy ] || fail "agent_status=working should map to busy, got '$out'"
   assert_contains "$(cat "$log")" $'\x1f''agent'$'\x1f''get'$'\x1f''w1:p2' "busy_state did not call agent get"
   pass "fm_backend_herdr_busy_state: working -> busy"
 }
 
 test_busy_state_done_and_blocked_map_to_idle() {
-  local dir log resp fb out
+  local dir log resp out
   dir="$TMP_ROOT/busy-done"; mkdir -p "$dir/responses"; log="$dir/log"; resp="$dir/responses"; : > "$log"
   printf '{"result":{"agent":{"agent_status":"done"}}}\n' > "$resp/1.out"
-  fb=$(make_herdr_fakebin "$dir")
-  out=$( PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
-    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_busy_state default:w1:p2' "$ROOT" )
+  out=$( herdr_run "$dir" fm_backend_herdr_busy_state default:w1:p2 )
   [ "$out" = idle ] || fail "agent_status=done should map to idle, got '$out'"
 
   dir="$TMP_ROOT/busy-blocked"; mkdir -p "$dir/responses"; log="$dir/log"; resp="$dir/responses"; : > "$log"
   printf '{"result":{"agent":{"agent_status":"blocked"}}}\n' > "$resp/1.out"
-  fb=$(make_herdr_fakebin "$dir")
-  out=$( PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
-    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_busy_state default:w1:p2' "$ROOT" )
+  out=$( herdr_run "$dir" fm_backend_herdr_busy_state default:w1:p2 )
   [ "$out" = idle ] || fail "agent_status=blocked should map to idle (stuck waiting on the human, not grinding), got '$out'"
   pass "fm_backend_herdr_busy_state: done -> idle, blocked -> idle (surfaced like a stale pane, not suppressed as busy)"
 }
 
 test_busy_state_unknown_on_no_agent() {
-  local dir log resp fb out
+  local dir log resp out
   dir="$TMP_ROOT/busy-unknown"; mkdir -p "$dir/responses"; log="$dir/log"; resp="$dir/responses"; : > "$log"
   printf '1\n' > "$resp/1.exit"
-  fb=$(make_herdr_fakebin "$dir")
-  out=$( PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
-    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_busy_state default:w1:p2' "$ROOT" )
+  out=$( herdr_run "$dir" fm_backend_herdr_busy_state default:w1:p2 )
   [ "$out" = unknown ] || fail "a failed agent get should report unknown (the fallback-to-regex cue), got '$out'"
   pass "fm_backend_herdr_busy_state: unparseable/absent agent state reports unknown, the regex-fallback cue"
 }
@@ -3732,34 +3526,28 @@ test_busy_state_unknown_on_no_agent() {
 # --- composer_state: structural border-row classification --------------------
 
 test_composer_state_bare_prompt_is_empty() {
-  local dir log resp fb out
+  local dir log resp out
   dir="$TMP_ROOT/composer-bare"; mkdir -p "$dir/responses"; log="$dir/log"; resp="$dir/responses"; : > "$log"
   printf '  ╭────────────────────────╮\n  │ ❯                      │\n  ╰──────── Composer ──────╯\n\n  Shift+Tab:mode\n' > "$resp/1.out"
-  fb=$(make_herdr_fakebin "$dir")
-  out=$( PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
-    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_composer_state default:w1:p2' "$ROOT" )
+  out=$( herdr_run "$dir" fm_backend_herdr_composer_state default:w1:p2 )
   [ "$out" = empty ] || fail "a bare prompt glyph should read as empty, got '$out'"
   pass "fm_backend_herdr_composer_state: a bare '❯' composer row reads empty"
 }
 
 test_composer_state_styled_placeholder_draft_is_pending() {
-  local dir log resp fb out
+  local dir log resp out
   dir="$TMP_ROOT/composer-ghost"; mkdir -p "$dir/responses"; log="$dir/log"; resp="$dir/responses"; : > "$log"
   printf '  ╭────────────────────────╮\n  │ ❯ Type a message...    │\n  ╰──────── Composer ──────╯\n' > "$resp/1.out"
-  fb=$(make_herdr_fakebin "$dir")
-  out=$( PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
-    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_composer_state default:w1:p2' "$ROOT" )
+  out=$( herdr_run "$dir" fm_backend_herdr_composer_state default:w1:p2 )
   [ "$out" = pending ] || fail "bright placeholder-like text in a styled capture should remain pending, got '$out'"
   pass "fm_backend_herdr_composer_state: bright placeholder-like text stays pending rather than being mistaken for an idle ghost"
 }
 
 test_composer_state_real_text_is_pending() {
-  local dir log resp fb out
+  local dir log resp out
   dir="$TMP_ROOT/composer-pending"; mkdir -p "$dir/responses"; log="$dir/log"; resp="$dir/responses"; : > "$log"
   printf '  ╭────────────────────────╮\n  │ ❯ hello captain        │\n  ╰──────── Composer ──────╯\n\n  Enter:send\n' > "$resp/1.out"
-  fb=$(make_herdr_fakebin "$dir")
-  out=$( PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
-    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_composer_state default:w1:p2' "$ROOT" )
+  out=$( herdr_run "$dir" fm_backend_herdr_composer_state default:w1:p2 )
   [ "$out" = pending ] || fail "real unsubmitted text should read as pending, got '$out'"
   pass "fm_backend_herdr_composer_state: real composer text reads pending"
 }
@@ -3773,23 +3561,19 @@ test_composer_state_real_text_is_pending() {
 # declared this "submitted". The structural composer-row read must still call
 # this pending.
 test_composer_state_popup_placeholder_fill_is_pending() {
-  local dir log resp fb out
+  local dir log resp out
   dir="$TMP_ROOT/composer-popup-placeholder"; mkdir -p "$dir/responses"; log="$dir/log"; resp="$dir/responses"; : > "$log"
   printf '  ╭──────────────────────────────────────╮\n  │ ❯ /compact compaction instructions   │\n  ╰──────────────── Composer ────────────╯\n\n  Enter:send\n' > "$resp/1.out"
-  fb=$(make_herdr_fakebin "$dir")
-  out=$( PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
-    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_composer_state default:w1:p2' "$ROOT" )
+  out=$( herdr_run "$dir" fm_backend_herdr_composer_state default:w1:p2 )
   [ "$out" = pending ] || fail "a popup-close-with-placeholder-fill must still read as pending (not yet submitted), got '$out'"
   pass "fm_backend_herdr_composer_state: a slash-command popup's argument-hint placeholder still reads pending (the incident fix)"
 }
 
 test_composer_state_unknown_on_capture_failure() {
-  local dir log resp fb out status
+  local dir log resp out status
   dir="$TMP_ROOT/composer-capture-fail"; mkdir -p "$dir/responses"; log="$dir/log"; resp="$dir/responses"; : > "$log"
   printf '1\n' > "$resp/1.exit"
-  fb=$(make_herdr_fakebin "$dir")
-  out=$( PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
-    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_composer_state default:w1:p2' "$ROOT" )
+  out=$( herdr_run "$dir" fm_backend_herdr_composer_state default:w1:p2 )
   status=$?
   [ "$status" -eq 0 ] || fail "composer_state should not itself fail the caller"
   [ "$out" = unknown ] || fail "an unreadable pane should read as unknown, got '$out'"
@@ -3797,16 +3581,14 @@ test_composer_state_unknown_on_capture_failure() {
 }
 
 test_composer_state_unknown_when_no_composer_row_found() {
-  local dir log resp fb out glyph idx=1
+  local dir log resp out glyph idx=1
   dir="$TMP_ROOT/composer-no-row"; mkdir -p "$dir/responses"; log="$dir/log"; resp="$dir/responses"; : > "$log"
   for glyph in '>' '$' '%' '#'; do
     printf '%s \n' "$glyph" > "$resp/$idx.out"
     idx=$((idx + 1))
   done
-  fb=$(make_herdr_fakebin "$dir")
   for glyph in '>' '$' '%' '#'; do
-    out=$( PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
-      bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_composer_state default:w1:p2' "$ROOT" )
+    out=$( herdr_run "$dir" fm_backend_herdr_composer_state default:w1:p2 )
     [ "$out" = unknown ] || fail "a bare shell prompt '$glyph' should read as unknown, got '$out'"
   done
   pass "fm_backend_herdr_composer_state: reports unknown for bare shell prompts with no composer row"
@@ -3817,13 +3599,11 @@ test_composer_state_unknown_when_no_composer_row_found() {
 # carries only a reverse-video cursor. This exact shape was `unknown` for 4555s
 # during the 2026-07-14 incident, so the safe injector never attempted submit.
 test_composer_state_pi_separator_idle_is_empty() {
-  local dir log resp fb out calls
+  local dir log resp out calls
   dir="$TMP_ROOT/composer-pi-separated-idle"; mkdir -p "$dir/responses"; log="$dir/log"; resp="$dir/responses"; : > "$log"
   printf '│ stale bordered transcript row │\n\x1b[0m\x1b[38;2;129;162;190m─────────────────────────────────────────────────────\x1b[0m\n\x1b[0m\x1b[7m \x1b[0m                                                    \n\x1b[0m\x1b[38;2;129;162;190m─────────────────────────────────────────────────────\x1b[0m\n\x1b[0m\x1b[38;2;102;102;102m~/synthetic-primary (main)\x1b[0m\n' > "$resp/1.out"
   printf '{"result":{"agent":{"agent":"pi","agent_status":"idle"}}}\n' > "$resp/2.out"
-  fb=$(make_herdr_fakebin "$dir")
-  out=$( PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
-    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_composer_state lab:w1:p2' "$ROOT" )
+  out=$( herdr_run "$dir" fm_backend_herdr_composer_state lab:w1:p2 )
   [ "$out" = empty ] || fail "an idle native Pi separator composer should read empty, got '$out'"
   calls=$(grep -c $'\x1f''agent'$'\x1f''get' "$log")
   [ "$calls" -eq 1 ] || fail "Pi separator recognition must corroborate identity exactly once, made $calls agent calls"
@@ -3840,44 +3620,38 @@ test_composer_state_pi_separator_idle_is_empty() {
 # verdict: the away-mode injection guard (bin/fm-supervise-daemon.sh) and
 # fm-send's pre-type refusal both proceed ONLY on an affirmative `empty`.
 test_composer_state_pi_parked_prompt_is_not_empty() {
-  local dir log resp fb out
+  local dir log resp out
   dir="$TMP_ROOT/composer-pi-parked-prompt"; mkdir -p "$dir/responses"; log="$dir/log"; resp="$dir/responses"; : > "$log"
   printf 'Should I keep going?\n  1. Yes, continue\n\x1b[7m  2. Stop, do not act\x1b[0m\n\x1b[0m\x1b[38;2;129;162;190m─────────────────────────────────────────────────────\x1b[0m\n\x1b[0m\x1b[7m \x1b[0m                                                    \n\x1b[0m\x1b[38;2;129;162;190m─────────────────────────────────────────────────────\x1b[0m\n' > "$resp/1.out"
   printf '{"result":{"agent":{"agent":"pi","agent_status":"blocked"}}}\n' > "$resp/2.out"
-  fb=$(make_herdr_fakebin "$dir")
-  out=$( PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
-    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_composer_state lab:w1:p2' "$ROOT" )
+  out=$( herdr_run "$dir" fm_backend_herdr_composer_state lab:w1:p2 )
   [ "$out" != empty ] \
     || fail "a pi pane parked on a prompt must not report an affirmatively empty composer, got '$out'"
   pass "fm_backend_herdr_composer_state: a blocked pi pane parked on a prompt is not an empty composer"
 }
 
 test_composer_state_pi_separator_real_text_is_pending() {
-  local dir log resp fb out
+  local dir log resp out
   dir="$TMP_ROOT/composer-pi-separated-pending"; mkdir -p "$dir/responses"; log="$dir/log"; resp="$dir/responses"; : > "$log"
   printf '\x1b[38;2;129;162;190m─────────────────────────────────────────────────────\x1b[0m\nprivacy safe human draft\x1b[7m \x1b[0m\n\x1b[38;2;129;162;190m─────────────────────────────────────────────────────\x1b[0m\n' > "$resp/1.out"
   printf '{"result":{"agent":{"agent":"pi","agent_status":"done"}}}\n' > "$resp/2.out"
-  fb=$(make_herdr_fakebin "$dir")
-  out=$( PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
-    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_composer_state lab:w1:p2' "$ROOT" )
+  out=$( herdr_run "$dir" fm_backend_herdr_composer_state lab:w1:p2 )
   [ "$out" = pending ] || fail "real text in a native Pi separator composer should read pending, got '$out'"
   pass "fm_backend_herdr_composer_state: real Pi composer text remains pending"
 }
 
 test_composer_state_pi_incomplete_separator_below_stale_generic_is_unknown() {
-  local dir log resp fb out
+  local dir log resp out
   dir="$TMP_ROOT/composer-pi-separated-incomplete"; mkdir -p "$dir/responses"; log="$dir/log"; resp="$dir/responses"; : > "$log"
   printf '│   │\n─────────────────────────────────────────────────────\n\n' > "$resp/1.out"
   printf '{"result":{"agent":{"agent":"pi","agent_status":"idle"}}}\n' > "$resp/2.out"
-  fb=$(make_herdr_fakebin "$dir")
-  out=$( PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
-    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_composer_state lab:w1:p2' "$ROOT" )
+  out=$( herdr_run "$dir" fm_backend_herdr_composer_state lab:w1:p2 )
   [ "$out" = unknown ] || fail "an incomplete Pi separator below a stale generic row should remain unknown, got '$out'"
   pass "fm_backend_herdr_composer_state: an incomplete lower Pi separator cannot inherit a stale empty row"
 }
 
 test_composer_state_pi_separator_requires_safe_native_identity() {
-  local dir log resp fb out status case_id idx=0
+  local dir log resp out status case_id idx=0
   for case_id in working non-pi unreadable over-tall; do
     dir="$TMP_ROOT/composer-pi-separated-$case_id"; mkdir -p "$dir/responses"; log="$dir/log"; resp="$dir/responses"; : > "$log"
     if [ "$case_id" = over-tall ]; then
@@ -3895,9 +3669,7 @@ test_composer_state_pi_separator_requires_safe_native_identity() {
       unreadable) printf '1\n' > "$resp/2.exit" ;;
       over-tall) printf '{"result":{"agent":{"agent":"pi","agent_status":"idle"}}}\n' > "$resp/2.out" ;;
     esac
-    fb=$(make_herdr_fakebin "$dir")
-    out=$( PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
-      bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_composer_state lab:w1:p2' "$ROOT" )
+    out=$( herdr_run "$dir" fm_backend_herdr_composer_state lab:w1:p2 )
     [ "$out" = unknown ] || fail "unsafe Pi separator case '$case_id' must remain unknown, got '$out'"
   done
   pass "fm_backend_herdr_composer_state: Pi separators never authorize working, non-Pi, unreadable, or over-tall targets"
@@ -3917,23 +3689,19 @@ test_composer_state_pi_separator_requires_safe_native_identity() {
 # state/.subsuper-escalations and the same digest was redelivered every cycle.
 
 test_composer_state_claude_unbordered_prompt_is_empty() {
-  local dir log resp fb out
+  local dir log resp out
   dir="$TMP_ROOT/composer-claude-bare-empty"; mkdir -p "$dir/responses"; log="$dir/log"; resp="$dir/responses"; : > "$log"
   printf '  20\n  21\n\n\xe2\x9c\xbb Worked for 2s\n\n\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\n\xe2\x9d\xaf\n\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\n  Opus 4.8 (1M context)   \xe2\x96\x8d               3%%\n  \xe2\x86\x90 for agents\n' > "$resp/1.out"
-  fb=$(make_herdr_fakebin "$dir")
-  out=$( PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
-    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_composer_state default:w1:p2' "$ROOT" )
+  out=$( herdr_run "$dir" fm_backend_herdr_composer_state default:w1:p2 )
   [ "$out" = empty ] || fail "a genuinely idle, unbordered real-claude '❯' prompt row (no border glyph anywhere in view) should read empty, got '$out' (regression: this used to read 'unknown' forever, which is exactly what broke escalate_flush's buffer-clear)"
   pass "fm_backend_herdr_composer_state: a real-claude unbordered '❯' prompt row (no border box in view) reads empty"
 }
 
 test_composer_state_claude_unbordered_prompt_is_pending() {
-  local dir log resp fb out
+  local dir log resp out
   dir="$TMP_ROOT/composer-claude-bare-pending"; mkdir -p "$dir/responses"; log="$dir/log"; resp="$dir/responses"; : > "$log"
   printf '  20\n  21\n\n\xe2\x9c\xbb Worked for 2s\n\n\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\n\xe2\x9d\xaf hello there this is a test message\n\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\n' > "$resp/1.out"
-  fb=$(make_herdr_fakebin "$dir")
-  out=$( PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
-    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_composer_state default:w1:p2' "$ROOT" )
+  out=$( herdr_run "$dir" fm_backend_herdr_composer_state default:w1:p2 )
   [ "$out" = pending ] || fail "real unsubmitted text in an unbordered real-claude prompt row should read pending, got '$out'"
   pass "fm_backend_herdr_composer_state: a real-claude unbordered '❯ <text>' prompt row reads pending"
 }
@@ -3949,12 +3717,10 @@ test_composer_state_claude_unbordered_prompt_is_pending() {
 # docs/herdr-backend.md). The live, bottom-most row must win regardless of
 # shape.
 test_composer_state_bare_prompt_below_stale_bordered_banner_wins() {
-  local dir log resp fb out
+  local dir log resp out
   dir="$TMP_ROOT/composer-banner-priority"; mkdir -p "$dir/responses"; log="$dir/log"; resp="$dir/responses"; : > "$log"
   printf '\xe2\x95\xad\xe2\x94\x80 Claude Code \xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x95\xae\n\xe2\x94\x82           Welcome back Kun!           \xe2\x94\x82\n\xe2\x94\x82                                       \xe2\x94\x82\n\xe2\x95\xb0\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x95\xaf\n\n\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\n\xe2\x9d\xaf still typing captain\n\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\n' > "$resp/1.out"
-  fb=$(make_herdr_fakebin "$dir")
-  out=$( PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
-    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_composer_state default:w1:p2' "$ROOT" )
+  out=$( herdr_run "$dir" fm_backend_herdr_composer_state default:w1:p2 )
   [ "$out" = pending ] || fail "the live unbordered prompt row below a stale bordered banner must win (pending, real text present), got '$out'"
   pass "fm_backend_herdr_composer_state: a live unbordered prompt row below a stale bordered decorative box still wins (not misread as the box's own row)"
 }
@@ -3972,12 +3738,10 @@ test_composer_state_bare_prompt_below_stale_bordered_banner_wins() {
 # ANSI-aware owner now drops the dim ghost and the row reads empty (safe to
 # inject).
 test_composer_state_claude_dim_prompt_suggestion_ghost_is_empty() {
-  local dir log resp fb out
+  local dir log resp out
   dir="$TMP_ROOT/composer-claude-dim-ghost"; mkdir -p "$dir/responses"; log="$dir/log"; resp="$dir/responses"; : > "$log"
   printf '\xe2\x9c\xbb Brewed for 2m 40s\n\n\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\n\xe2\x9d\xaf \x1b[0m\x1b[2mwhat did the wheelhouse healing verification find?\x1b[0m\n\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\n  Fable 5                 80%%\n' > "$resp/1.out"
-  fb=$(make_herdr_fakebin "$dir")
-  out=$( PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
-    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_composer_state default:w1:p3' "$ROOT" )
+  out=$( herdr_run "$dir" fm_backend_herdr_composer_state default:w1:p3 )
   [ "$out" = empty ] || fail "the overnight shape - claude's SGR-2 dim prompt-suggestion ghost after a bare '❯' - must read empty, got '$out' (regression: this false-pending wedged away-mode injection all night)"
   pass "fm_backend_herdr_composer_state: claude's dim prompt-suggestion ghost (the overnight wedge shape) reads empty"
 }
@@ -3986,12 +3750,10 @@ test_composer_state_claude_dim_prompt_suggestion_ghost_is_empty() {
 # it must still read pending, so the ghost fix never weakens real-input
 # protection.
 test_composer_state_claude_dim_ghost_row_with_real_text_is_pending() {
-  local dir log resp fb out
+  local dir log resp out
   dir="$TMP_ROOT/composer-claude-dim-ghost-real"; mkdir -p "$dir/responses"; log="$dir/log"; resp="$dir/responses"; : > "$log"
   printf '\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\n\xe2\x9d\xaf land pr 416 now\n\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\n  Fable 5                 80%%\n' > "$resp/1.out"
-  fb=$(make_herdr_fakebin "$dir")
-  out=$( PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
-    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_composer_state default:w1:p3' "$ROOT" )
+  out=$( herdr_run "$dir" fm_backend_herdr_composer_state default:w1:p3 )
   [ "$out" = pending ] || fail "real normal-intensity text after '❯' must still read pending, got '$out'"
   pass "fm_backend_herdr_composer_state: real typed text on the same claude prompt row still reads pending"
 }
@@ -4003,57 +3765,47 @@ test_composer_state_claude_dim_ghost_row_with_real_text_is_pending() {
 # 38;2;110;106;134; real input is the BRIGHT 38;2;224;222;244), while the "❯"
 # prompt glyph stays bright. The dark placeholder drops and the row reads empty.
 test_composer_state_grok_dark_truecolor_placeholder_is_empty() {
-  local dir log resp fb out
+  local dir log resp out
   dir="$TMP_ROOT/composer-grok-truecolor-ghost"; mkdir -p "$dir/responses"; log="$dir/log"; resp="$dir/responses"; : > "$log"
   printf '  \x1b[38;2;86;82;110m\xe2\x95\xad\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x95\xae\x1b[39m\n  \x1b[38;2;86;82;110m\xe2\x94\x82\x1b[38;2;224;222;244m \xe2\x9d\xaf \x1b[38;2;50;47;70mType a message...\x1b[38;2;86;82;110m \xe2\x94\x82\x1b[39m\n  \x1b[38;2;86;82;110m\xe2\x95\xb0\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x95\xaf\x1b[39m\n' > "$resp/1.out"
-  fb=$(make_herdr_fakebin "$dir")
-  out=$( PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
-    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_composer_state default:w1:p2' "$ROOT" )
+  out=$( herdr_run "$dir" fm_backend_herdr_composer_state default:w1:p2 )
   [ "$out" = empty ] || fail "a grok bordered composer whose only content is a dark-truecolor placeholder must read empty, got '$out'"
   pass "fm_backend_herdr_composer_state: grok's dark-truecolor placeholder (the TRUECOLOR gap) reads empty"
 }
 
 # grok's bordered composer with REAL bright typed input must still read pending.
 test_composer_state_grok_bright_truecolor_real_text_is_pending() {
-  local dir log resp fb out
+  local dir log resp out
   dir="$TMP_ROOT/composer-grok-truecolor-real"; mkdir -p "$dir/responses"; log="$dir/log"; resp="$dir/responses"; : > "$log"
   printf '  \x1b[38;2;86;82;110m\xe2\x95\xad\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x95\xae\x1b[39m\n  \x1b[38;2;86;82;110m\xe2\x94\x82\x1b[38;2;224;222;244m \xe2\x9d\xaf fix the login bug \x1b[38;2;86;82;110m\xe2\x94\x82\x1b[39m\n  \x1b[38;2;86;82;110m\xe2\x95\xb0\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x95\xaf\x1b[39m\n' > "$resp/1.out"
-  fb=$(make_herdr_fakebin "$dir")
-  out=$( PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
-    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_composer_state default:w1:p2' "$ROOT" )
+  out=$( herdr_run "$dir" fm_backend_herdr_composer_state default:w1:p2 )
   [ "$out" = pending ] || fail "real bright typed text in a grok bordered composer must read pending, got '$out'"
   pass "fm_backend_herdr_composer_state: grok's real bright typed input still reads pending"
 }
 
 test_composer_state_codex_bare_prompt_glyph_is_empty() {
-  local dir log resp fb out
+  local dir log resp out
   dir="$TMP_ROOT/composer-codex-bare"; mkdir -p "$dir/responses"; log="$dir/log"; resp="$dir/responses"; : > "$log"
   printf '\xe2\x80\xa2 You have 2 usage limit resets available.\n\n\xe2\x80\xba\n\n  gpt-5.5 xhigh \xc2\xb7 Context 100%% left\n' > "$resp/1.out"
-  fb=$(make_herdr_fakebin "$dir")
-  out=$( PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
-    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_composer_state default:w1:p2' "$ROOT" )
+  out=$( herdr_run "$dir" fm_backend_herdr_composer_state default:w1:p2 )
   [ "$out" = empty ] || fail "a bare '›' (codex) prompt glyph with no trailing text should read empty, got '$out'"
   pass "fm_backend_herdr_composer_state: a real-codex unbordered '›' prompt row reads empty"
 }
 
 test_composer_state_codex_faint_suggestion_is_empty() {
-  local dir log resp fb out
+  local dir log resp out
   dir="$TMP_ROOT/composer-codex-faint-suggestion"; mkdir -p "$dir/responses"; log="$dir/log"; resp="$dir/responses"; : > "$log"
   printf '\xe2\x80\xa2 You have 2 usage limit resets available. Run /usage\nto use one.\n\n\x1b[0m\x1b[1m\xe2\x80\xba \x1b[0m\x1b[2mFind and fix a bug in @filename\x1b[0m\n\n  gpt-5.5 xhigh \xc2\xb7 Context 100%% left\n' > "$resp/1.out"
-  fb=$(make_herdr_fakebin "$dir")
-  out=$( PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
-    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_composer_state default:w1:p2' "$ROOT" )
+  out=$( herdr_run "$dir" fm_backend_herdr_composer_state default:w1:p2 )
   [ "$out" = empty ] || fail "a faint real-codex ghost suggestion should read empty, not pending, got '$out'"
   pass "fm_backend_herdr_composer_state: a faint real-codex ghost suggestion reads empty"
 }
 
 test_composer_state_codex_non_faint_same_text_is_pending() {
-  local dir log resp fb out
+  local dir log resp out
   dir="$TMP_ROOT/composer-codex-non-faint-same-text"; mkdir -p "$dir/responses"; log="$dir/log"; resp="$dir/responses"; : > "$log"
   printf '\xe2\x80\xa2 You have 2 usage limit resets available. Run /usage\nto use one.\n\n\x1b[0m\x1b[1m\xe2\x80\xba \x1b[0mFind and fix a bug in @filename\n\n  gpt-5.5 xhigh \xc2\xb7 Context 100%% left\n' > "$resp/1.out"
-  fb=$(make_herdr_fakebin "$dir")
-  out=$( PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
-    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_composer_state default:w1:p2' "$ROOT" )
+  out=$( herdr_run "$dir" fm_backend_herdr_composer_state default:w1:p2 )
   [ "$out" = pending ] || fail "the same words without faint styling should still protect real typed input, got '$out'"
   pass "fm_backend_herdr_composer_state: non-faint codex prompt text still reads pending"
 }
@@ -4064,12 +3816,10 @@ test_composer_state_codex_non_faint_same_text_is_pending() {
 # (docs/herdr-backend.md "Native agent-state submit confirmation").
 
 test_wait_for_working_returns_busy_on_first_poll() {
-  local dir log resp fb out calls
+  local dir log resp out calls
   dir="$TMP_ROOT/wait-busy-first"; mkdir -p "$dir/responses"; log="$dir/log"; resp="$dir/responses"; : > "$log"
   printf '{"result":{"agent":{"agent_status":"working"}}}\n' > "$resp/1.out"
-  fb=$(make_herdr_fakebin "$dir")
-  out=$( PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
-    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_wait_for_working default w1:p2 1 5' "$ROOT" )
+  out=$( herdr_run "$dir" fm_backend_herdr_wait_for_working default w1:p2 1 5 )
   [ "$out" = busy ] || fail "wait_for_working should report busy once 'working' is observed, got '$out'"
   calls=$(grep -c $'\x1f''agent'$'\x1f''get' "$log")
   [ "$calls" -eq 1 ] || fail "wait_for_working should short-circuit on the FIRST busy poll instead of consuming the whole budget, made $calls call(s)"
@@ -4077,7 +3827,7 @@ test_wait_for_working_returns_busy_on_first_poll() {
 }
 
 test_wait_for_working_catches_a_slow_transition_mid_window() {
-  local dir log resp fb out calls
+  local dir log resp out calls
   dir="$TMP_ROOT/wait-busy-slow"; mkdir -p "$dir/responses"; log="$dir/log"; resp="$dir/responses"; : > "$log"
   # Two idle samples, then working on the third - a transition that would be
   # MISSED by a single check-at-the-end design (the old composer approach's
@@ -4085,9 +3835,7 @@ test_wait_for_working_catches_a_slow_transition_mid_window() {
   printf '{"result":{"agent":{"agent_status":"idle"}}}\n' > "$resp/1.out"
   printf '{"result":{"agent":{"agent_status":"idle"}}}\n' > "$resp/2.out"
   printf '{"result":{"agent":{"agent_status":"working"}}}\n' > "$resp/3.out"
-  fb=$(make_herdr_fakebin "$dir")
-  out=$( PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
-    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_wait_for_working default w1:p2 0.03 3' "$ROOT" )
+  out=$( herdr_run "$dir" fm_backend_herdr_wait_for_working default w1:p2 0.03 3 )
   [ "$out" = busy ] || fail "wait_for_working should catch a transition that lands on a later sample within the SAME window, got '$out'"
   calls=$(grep -c $'\x1f''agent'$'\x1f''get' "$log")
   [ "$calls" -eq 3 ] || fail "expected exactly 3 agent-get polls (idle, idle, working), got $calls"
@@ -4133,36 +3881,30 @@ test_send_text_submit_applies_herdr_minimum_confirm_budget() {
 }
 
 test_wait_for_working_returns_idle_when_never_busy_but_readable() {
-  local dir log resp fb out
+  local dir log resp out
   dir="$TMP_ROOT/wait-idle"; mkdir -p "$dir/responses"; log="$dir/log"; resp="$dir/responses"; : > "$log"
   printf '{"result":{"agent":{"agent_status":"idle"}}}\n' > "$resp/1.out"
   printf '{"result":{"agent":{"agent_status":"idle"}}}\n' > "$resp/2.out"
-  fb=$(make_herdr_fakebin "$dir")
-  out=$( PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
-    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_wait_for_working default w1:p2 0.02 2' "$ROOT" )
+  out=$( herdr_run "$dir" fm_backend_herdr_wait_for_working default w1:p2 0.02 2 )
   [ "$out" = idle ] || fail "wait_for_working should report idle when the target was legibly read but never busy, got '$out'"
   pass "fm_backend_herdr_wait_for_working: reports 'idle' (readable, genuinely not yet working) when 'busy' never appears"
 }
 
 test_wait_for_working_returns_unknown_when_never_readable() {
-  local dir log resp fb out
+  local dir log resp out
   dir="$TMP_ROOT/wait-unknown"; mkdir -p "$dir/responses"; log="$dir/log"; resp="$dir/responses"; : > "$log"
   printf '1\n' > "$resp/1.exit"
   printf '1\n' > "$resp/2.exit"
-  fb=$(make_herdr_fakebin "$dir")
-  out=$( PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
-    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_wait_for_working default w1:p2 0.02 2' "$ROOT" )
+  out=$( herdr_run "$dir" fm_backend_herdr_wait_for_working default w1:p2 0.02 2 )
   [ "$out" = unknown ] || fail "wait_for_working should report unknown when every poll fails to read the target, got '$out'"
   pass "fm_backend_herdr_wait_for_working: reports 'unknown' (a hard read failure, not a timing race) only when EVERY poll in the window fails"
 }
 
 test_wait_for_working_treats_blocked_as_submit_active() {
-  local dir log resp fb out
+  local dir log resp out
   dir="$TMP_ROOT/wait-blocked"; mkdir -p "$dir/responses"; log="$dir/log"; resp="$dir/responses"; : > "$log"
   printf '{"result":{"agent":{"agent_status":"blocked"}}}\n' > "$resp/1.out"
-  fb=$(make_herdr_fakebin "$dir")
-  out=$( PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
-    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_wait_for_working default w1:p2 0.01 1' "$ROOT" )
+  out=$( herdr_run "$dir" fm_backend_herdr_wait_for_working default w1:p2 0.01 1 )
   [ "$out" = busy ] || fail "wait_for_working should treat a post-Enter blocked state as submit-active, got '$out'"
   pass "fm_backend_herdr_wait_for_working: treats blocked as submit-active for confirmation without changing watcher busy-state semantics"
 }
@@ -4179,7 +3921,7 @@ test_wait_for_working_treats_blocked_as_submit_active() {
 # test_send_text_submit_slow_transition_within_one_enter_needs_no_extra_enter.
 
 test_send_text_submit_detects_landed_send() {
-  local dir log resp fb out enter_count
+  local dir log resp out enter_count
   dir="$TMP_ROOT/submit-ok"; mkdir -p "$dir/responses"; log="$dir/log"; resp="$dir/responses"; : > "$log"
   # 1: send-text (literal, no output)
   # 2: agent get - pre-Enter baseline is idle
@@ -4187,9 +3929,7 @@ test_send_text_submit_detects_landed_send() {
   # 4: agent get - agent_status working (a real turn started: submitted)
   printf '{"result":{"agent":{"agent_status":"idle"}}}\n' > "$resp/2.out"
   printf '{"result":{"agent":{"agent_status":"working"}}}\n' > "$resp/4.out"
-  fb=$(make_herdr_fakebin "$dir")
-  out=$( PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" FM_BACKEND_HERDR_SUBMIT_POLLS=1 \
-    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_send_text_submit default:w1:p2 "hello captain" 3 0.01 0.01' "$ROOT" )
+  out=$( herdr_run "$dir" FM_BACKEND_HERDR_SUBMIT_POLLS=1 fm_backend_herdr_send_text_submit default:w1:p2 "hello captain" 3 0.01 0.01 )
   [ "$out" = empty ] || fail "send_text_submit should report empty (submitted) once agent_status reports working, got '$out'"
   assert_contains "$(cat "$log")" $'\x1f''pane'$'\x1f''send-text'$'\x1f''w1:p2'$'\x1f''hello captain' "send_text_submit did not type the literal text first"
   enter_count=$(grep -c $'\x1f''pane'$'\x1f''send-keys'$'\x1f''w1:p2'$'\x1f''enter' "$log")
@@ -4199,7 +3939,7 @@ test_send_text_submit_detects_landed_send() {
 }
 
 test_send_text_submit_detects_swallowed_enter() {
-  local dir log resp fb out
+  local dir log resp out
   dir="$TMP_ROOT/submit-swallow"; mkdir -p "$dir/responses"; log="$dir/log"; resp="$dir/responses"; : > "$log"
   # Every post-Enter agent-get read still reports idle, and the composer still
   # holds the typed text: a genuine swallow, not a queued Enter.
@@ -4210,9 +3950,7 @@ test_send_text_submit_detects_swallowed_enter() {
   printf '  \xe2\x9d\xaf hello captain\n' > "$resp/8.out"
   printf '{"result":{"agent":{"agent_status":"idle"}}}\n' > "$resp/9.out"
   printf '  ready\n' > "$resp/10.out"
-  fb=$(make_herdr_fakebin "$dir")
-  out=$( PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" FM_BACKEND_HERDR_SUBMIT_POLLS=1 \
-    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_send_text_submit default:w1:p2 "hello captain" 2 0.01 0.01' "$ROOT" )
+  out=$( herdr_run "$dir" FM_BACKEND_HERDR_SUBMIT_POLLS=1 fm_backend_herdr_send_text_submit default:w1:p2 "hello captain" 2 0.01 0.01 )
   [ "$out" = pending ] || fail "send_text_submit should report pending once retries are exhausted with agent_status never going busy and the composer still holding the text, got '$out'"
   pass "fm_backend_herdr_send_text_submit: reports 'pending' when agent_status stays idle and the composer still holds unsent text after retried Enters (swallowed)"
 }
@@ -4224,7 +3962,7 @@ test_send_text_submit_detects_swallowed_enter() {
 # for Enter #1, and the retry loop sends a genuine second Enter exactly as it
 # would for any other swallowed Enter.
 test_send_text_submit_popup_autocomplete_requires_second_enter() {
-  local dir log resp fb out enter_count
+  local dir log resp out enter_count
   dir="$TMP_ROOT/submit-popup-autocomplete"; mkdir -p "$dir/responses"; log="$dir/log"; resp="$dir/responses"; : > "$log"
   # 1: send-text "/compact"
   # 2: agent get - pre-Enter baseline is idle
@@ -4238,9 +3976,7 @@ test_send_text_submit_popup_autocomplete_requires_second_enter() {
   # 6: send-keys enter (#2) - actually submits
   # 7: agent get -> working (submitted)
   printf '{"result":{"agent":{"agent_status":"working"}}}\n' > "$resp/7.out"
-  fb=$(make_herdr_fakebin "$dir")
-  out=$( PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" FM_BACKEND_HERDR_SUBMIT_POLLS=1 \
-    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_send_text_submit default:w1:p2 "/compact" 3 0.01 1.2' "$ROOT" )
+  out=$( herdr_run "$dir" FM_BACKEND_HERDR_SUBMIT_POLLS=1 fm_backend_herdr_send_text_submit default:w1:p2 "/compact" 3 0.01 1.2 )
   [ "$out" = empty ] || fail "send_text_submit should eventually report empty once the SECOND Enter actually starts a turn, got '$out'"
   enter_count=$(grep -c $'\x1f''pane'$'\x1f''send-keys'$'\x1f''w1:p2'$'\x1f''enter' "$log")
   [ "$enter_count" -eq 2 ] || fail "send_text_submit must send a SECOND Enter after the popup-placeholder fill's agent_status still reads idle, got $enter_count Enter(s)"
@@ -4248,14 +3984,12 @@ test_send_text_submit_popup_autocomplete_requires_second_enter() {
 }
 
 test_send_text_submit_confirms_blocked_after_enter() {
-  local dir log resp fb out enter_count
+  local dir log resp out enter_count
   dir="$TMP_ROOT/submit-blocked"; mkdir -p "$dir/responses"; log="$dir/log"; resp="$dir/responses"; : > "$log"
   printf '{"result":{"agent":{"agent_status":"idle"}}}\n' > "$resp/2.out"
   printf '{"result":{"agent":{"agent_status":"blocked"}}}\n' > "$resp/3.out"
   printf '{"result":{"agent":{"agent_status":"blocked"}}}\n' > "$resp/4.out"
-  fb=$(make_herdr_fakebin "$dir")
-  out=$( PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" FM_BACKEND_HERDR_SUBMIT_POLLS=1 \
-    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_send_text_submit default:w1:p2 "needs approval" 3 0.01 0.01' "$ROOT" )
+  out=$( herdr_run "$dir" FM_BACKEND_HERDR_SUBMIT_POLLS=1 fm_backend_herdr_send_text_submit default:w1:p2 "needs approval" 3 0.01 0.01 )
   [ "$out" = empty ] || fail "send_text_submit should treat a blocked state after Enter as a confirmed delivered prompt, got '$out'"
   enter_count=$(grep -c $'\x1f''pane'$'\x1f''send-keys'$'\x1f''w1:p2'$'\x1f''enter' "$log")
   [ "$enter_count" -eq 1 ] || fail "blocked after Enter must not provoke a retry into the prompt, sent $enter_count Enter(s)"
@@ -4263,7 +3997,7 @@ test_send_text_submit_confirms_blocked_after_enter() {
 }
 
 test_send_text_submit_preexisting_working_pending_is_queued_enter() {
-  local dir log resp fb out enter_count
+  local dir log resp out enter_count
   dir="$TMP_ROOT/submit-preexisting-working-queued"; mkdir -p "$dir/responses"; log="$dir/log"; resp="$dir/responses"; : > "$log"
   # Native working + proven pending after the retry budget is the OpenCode
   # busy-queued Enter: the harness accepted Enter and will submit when the
@@ -4273,9 +4007,7 @@ test_send_text_submit_preexisting_working_pending_is_queued_enter() {
   printf '  ready\n' > "$resp/3.out"
   printf '  \xe2\x9d\xaf hello captain\n' > "$resp/5.out"
   printf '{"result":{"agent":{"agent_status":"working"}}}\n' > "$resp/6.out"
-  fb=$(make_herdr_fakebin "$dir")
-  out=$( PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
-    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_send_text_submit default:w1:p2 "hello captain" 1 0.01 0.01' "$ROOT" )
+  out=$( herdr_run "$dir" fm_backend_herdr_send_text_submit default:w1:p2 "hello captain" 1 0.01 0.01 )
   [ "$out" = empty ] || fail "a working native baseline plus proven pending after retries is a queued Enter, got '$out'"
   enter_count=$(grep -c $'\x1f''pane'$'\x1f''send-keys'$'\x1f''w1:p2'$'\x1f''enter' "$log")
   [ "$enter_count" -eq 1 ] || fail "queued-Enter confirmation should use the configured retry count, sent $enter_count Enter(s)"
@@ -4283,16 +4015,14 @@ test_send_text_submit_preexisting_working_pending_is_queued_enter() {
 }
 
 test_send_text_submit_preexisting_working_does_not_confirm_failed_enter() {
-  local dir log resp fb out enter_count
+  local dir log resp out enter_count
   dir="$TMP_ROOT/submit-preexisting-working-enter-failed"; mkdir -p "$dir/responses"; log="$dir/log"; resp="$dir/responses"; : > "$log"
   printf '{"result":{"agent":{"agent_status":"working"}}}\n' > "$resp/2.out"
   printf '  ready\n' > "$resp/3.out"
   printf '1\n' > "$resp/4.exit"
   printf '  \xe2\x9d\xaf hello captain\n' > "$resp/5.out"
   printf '{"result":{"agent":{"agent_status":"working"}}}\n' > "$resp/6.out"
-  fb=$(make_herdr_fakebin "$dir")
-  out=$( PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
-    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_send_text_submit default:w1:p2 "hello captain" 1 0.01 0.01' "$ROOT" )
+  out=$( herdr_run "$dir" fm_backend_herdr_send_text_submit default:w1:p2 "hello captain" 1 0.01 0.01 )
   [ "$out" = send-failed ] || fail "a failed Enter must not be reported as queued delivery merely because native status is working, got '$out'"
   enter_count=$(grep -c $'\x1f''pane'$'\x1f''send-keys'$'\x1f''w1:p2'$'\x1f''enter' "$log")
   [ "$enter_count" -eq 1 ] || fail "send_text_submit should attempt the configured number of Enters, made $enter_count attempt(s)"
@@ -4300,14 +4030,12 @@ test_send_text_submit_preexisting_working_does_not_confirm_failed_enter() {
 }
 
 test_send_text_submit_idle_baseline_does_not_confirm_failed_enter() {
-  local dir log resp fb out enter_count
+  local dir log resp out enter_count
   dir="$TMP_ROOT/submit-idle-enter-failed"; mkdir -p "$dir/responses"; log="$dir/log"; resp="$dir/responses"; : > "$log"
   printf '{"result":{"agent":{"agent_status":"idle"}}}\n' > "$resp/2.out"
   printf '1\n' > "$resp/3.exit"
   printf '{"result":{"agent":{"agent_status":"working"}}}\n' > "$resp/4.out"
-  fb=$(make_herdr_fakebin "$dir")
-  out=$( PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" FM_BACKEND_HERDR_SUBMIT_POLLS=1 \
-    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_send_text_submit default:w1:p2 "hello captain" 1 0.01 0.01' "$ROOT" )
+  out=$( herdr_run "$dir" FM_BACKEND_HERDR_SUBMIT_POLLS=1 fm_backend_herdr_send_text_submit default:w1:p2 "hello captain" 1 0.01 0.01 )
   [ "$out" = send-failed ] || fail "a failed Enter must not borrow a later native transition as delivery proof, got '$out'"
   enter_count=$(grep -c $'\x1f''pane'$'\x1f''send-keys'$'\x1f''w1:p2'$'\x1f''enter' "$log")
   [ "$enter_count" -eq 1 ] || fail "send_text_submit should attempt the configured number of Enters, made $enter_count attempt(s)"
@@ -4316,7 +4044,7 @@ test_send_text_submit_idle_baseline_does_not_confirm_failed_enter() {
 }
 
 test_send_text_submit_idle_native_empty_composer_confirms_delivery() {
-  local dir log resp fb out enter_count
+  local dir log resp out enter_count
   dir="$TMP_ROOT/submit-idle-native-empty-composer"; mkdir -p "$dir/responses"; log="$dir/log"; resp="$dir/responses"; : > "$log"
   # Live Claude on Herdr 0.8.0 keeps agent_status idle through a landed turn.
   # After Enter, native wait_for_working stays idle and the composer clears:
@@ -4324,9 +4052,7 @@ test_send_text_submit_idle_native_empty_composer_confirms_delivery() {
   printf '{"result":{"agent":{"agent_status":"idle"}}}\n' > "$resp/2.out"
   printf '{"result":{"agent":{"agent_status":"idle"}}}\n' > "$resp/4.out"
   printf '  \xe2\x9d\xaf\n' > "$resp/5.out"
-  fb=$(make_herdr_fakebin "$dir")
-  out=$( PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" FM_BACKEND_HERDR_SUBMIT_POLLS=1 \
-    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_send_text_submit default:w1:p2 "hello captain" 3 0.01 0.01' "$ROOT" )
+  out=$( herdr_run "$dir" FM_BACKEND_HERDR_SUBMIT_POLLS=1 fm_backend_herdr_send_text_submit default:w1:p2 "hello captain" 3 0.01 0.01 )
   [ "$out" = empty ] || fail "an idle native status plus a cleared composer must confirm delivery, got '$out'"
   enter_count=$(grep -c $'\x1f''pane'$'\x1f''send-keys'$'\x1f''w1:p2'$'\x1f''enter' "$log")
   [ "$enter_count" -eq 1 ] || fail "a cleared composer should confirm without extra Enters, sent $enter_count Enter(s)"
@@ -4334,7 +4060,7 @@ test_send_text_submit_idle_native_empty_composer_confirms_delivery() {
 }
 
 test_send_text_submit_idle_native_pending_plus_rendered_busy_is_queued() {
-  local dir log resp fb out
+  local dir log resp out
   dir="$TMP_ROOT/submit-idle-native-rendered-busy-queued"; mkdir -p "$dir/responses"; log="$dir/log"; resp="$dir/responses"; : > "$log"
   # Idle native baseline (Claude never leaves idle) with proven pending text
   # and a generating footer after retries is a queued follow-up Enter.
@@ -4343,9 +4069,7 @@ test_send_text_submit_idle_native_pending_plus_rendered_busy_is_queued() {
   printf '  \xe2\x9d\xaf hello captain\n' > "$resp/5.out"
   printf '{"result":{"agent":{"agent_status":"idle"}}}\n' > "$resp/6.out"
   printf 'thinking... esc to interrupt\n' > "$resp/7.out"
-  fb=$(make_herdr_fakebin "$dir")
-  out=$( PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" FM_BACKEND_HERDR_SUBMIT_POLLS=1 \
-    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_send_text_submit default:w1:p2 "hello captain" 1 0.01 0.01' "$ROOT" )
+  out=$( herdr_run "$dir" FM_BACKEND_HERDR_SUBMIT_POLLS=1 fm_backend_herdr_send_text_submit default:w1:p2 "hello captain" 1 0.01 0.01 )
   [ "$out" = empty ] || fail "idle native + proven pending + rendered busy after retries is a queued Enter, got '$out'"
   pass "fm_backend_herdr_send_text_submit: idle native baseline uses a rendered busy footer to confirm a queued Enter"
 }
@@ -4385,29 +4109,23 @@ herdr_cursor_midturn_ansi() {
 # status token on the composer row is content the shared classifier must keep
 # treating as content for every other caller.
 test_composer_state_cursor_midturn_row_reads_pending() {
-  local dir log resp fb out
+  local dir log resp out
   dir="$TMP_ROOT/composer-cursor-midturn"; mkdir -p "$dir/responses"; log="$dir/log"; resp="$dir/responses"; : > "$log"
   herdr_cursor_midturn_ansi > "$resp/1.out"
-  fb=$(make_herdr_fakebin "$dir")
-  out=$( PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
-    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_composer_state default:w1:p2' "$ROOT" )
+  out=$( herdr_run "$dir" fm_backend_herdr_composer_state default:w1:p2 )
   [ "$out" = pending ] || fail "cursor's mid-turn composer row carries a busy token and must stay 'pending' as composer CONTENT, got '$out'"
   pass "fm_backend_herdr_composer_state: cursor's mid-turn placeholder-plus-busy-token row reads pending (why delivery needs a separate signal)"
 }
 
 test_rendered_busy_state_reads_the_cursor_busy_token() {
-  local dir log resp fb idle_out busy_out fail_out
+  local dir log resp idle_out busy_out fail_out
   dir="$TMP_ROOT/rendered-busy"; mkdir -p "$dir/responses"; log="$dir/log"; resp="$dir/responses"; : > "$log"
   herdr_cursor_idle_plain > "$resp/1.out"
   herdr_cursor_midturn_plain > "$resp/2.out"
   printf '1\n' > "$resp/3.exit"
-  fb=$(make_herdr_fakebin "$dir")
-  idle_out=$( PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
-    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_rendered_busy_state default:w1:p2' "$ROOT" )
-  busy_out=$( PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
-    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_rendered_busy_state default:w1:p2' "$ROOT" )
-  fail_out=$( PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
-    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_rendered_busy_state default:w1:p2' "$ROOT" )
+  idle_out=$( herdr_run "$dir" fm_backend_herdr_rendered_busy_state default:w1:p2 )
+  busy_out=$( herdr_run "$dir" fm_backend_herdr_rendered_busy_state default:w1:p2 )
+  fail_out=$( herdr_run "$dir" fm_backend_herdr_rendered_busy_state default:w1:p2 )
   [ "$idle_out" = idle ] || fail "an idle cursor pane renders no busy token and must read idle, got '$idle_out'"
   [ "$busy_out" = busy ] || fail "a mid-turn cursor pane renders 'ctrl+c to stop' and must read busy, got '$busy_out'"
   [ "$fail_out" = unknown ] || fail "an unreadable pane must read unknown, never idle, got '$fail_out'"
@@ -4415,7 +4133,7 @@ test_rendered_busy_state_reads_the_cursor_busy_token() {
 }
 
 test_send_text_submit_confirms_never_idle_native_state_via_footer_transition() {
-  local dir log resp fb out enter_count
+  local dir log resp out enter_count
   dir="$TMP_ROOT/submit-cursor-footer-transition"; mkdir -p "$dir/responses"; log="$dir/log"; resp="$dir/responses"; : > "$log"
   # 1: send-text
   # 2: agent get - cursor is `blocked` even while idle, so the native
@@ -4430,9 +4148,7 @@ test_send_text_submit_confirms_never_idle_native_state_via_footer_transition() {
   herdr_cursor_idle_plain > "$resp/3.out"
   herdr_cursor_midturn_ansi > "$resp/5.out"
   herdr_cursor_midturn_plain > "$resp/6.out"
-  fb=$(make_herdr_fakebin "$dir")
-  out=$( PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
-    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_send_text_submit default:w1:p2 "hello captain" 3 0.01 0.01' "$ROOT" )
+  out=$( herdr_run "$dir" fm_backend_herdr_send_text_submit default:w1:p2 "hello captain" 3 0.01 0.01 )
   [ "$out" = empty ] || fail "an idle-to-busy rendered-footer transition must confirm the submit for a harness whose native state never goes idle, got '$out'"
   enter_count=$(grep -c $'\x1f''pane'$'\x1f''send-keys'$'\x1f''w1:p2'$'\x1f''enter' "$log")
   [ "$enter_count" -eq 1 ] || fail "a confirmed submit must not send a needless extra Enter, sent $enter_count Enter(s)"
@@ -4440,7 +4156,7 @@ test_send_text_submit_confirms_never_idle_native_state_via_footer_transition() {
 }
 
 test_send_text_submit_never_idle_native_state_keeps_pending_without_a_transition() {
-  local dir log resp fb out
+  local dir log resp out
   dir="$TMP_ROOT/submit-cursor-no-transition"; mkdir -p "$dir/responses"; log="$dir/log"; resp="$dir/responses"; : > "$log"
   # The pane was ALREADY mid-turn before our Enter, so its busy footer is not
   # evidence about OUR message: the verdict must stay pending rather than
@@ -4449,9 +4165,7 @@ test_send_text_submit_never_idle_native_state_keeps_pending_without_a_transition
   herdr_cursor_midturn_plain > "$resp/3.out"
   herdr_cursor_midturn_ansi > "$resp/5.out"
   herdr_cursor_midturn_ansi > "$resp/7.out"
-  fb=$(make_herdr_fakebin "$dir")
-  out=$( PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
-    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_send_text_submit default:w1:p2 "hello captain" 2 0.01 0.01' "$ROOT" )
+  out=$( herdr_run "$dir" fm_backend_herdr_send_text_submit default:w1:p2 "hello captain" 2 0.01 0.01 )
   [ "$out" = pending ] || fail "a pane already busy before our Enter must not confirm from that same busy footer, got '$out'"
   pass "fm_backend_herdr_send_text_submit: an already-busy footer baseline is never accepted as proof that this Enter landed"
 }
@@ -4461,13 +4175,11 @@ test_send_text_submit_never_idle_native_state_keeps_pending_without_a_transition
 # submit must confirm from native agent-state rather than composer scraping.
 # The pre-injection composer guard has its own faint-suggestion coverage below.
 test_send_text_submit_confirms_despite_codex_idle_tip_composer() {
-  local dir log resp fb out
+  local dir log resp out
   dir="$TMP_ROOT/submit-codex-idle-tip"; mkdir -p "$dir/responses"; log="$dir/log"; resp="$dir/responses"; : > "$log"
   printf '{"result":{"agent":{"agent_status":"idle"}}}\n' > "$resp/2.out"
   printf '{"result":{"agent":{"agent_status":"working"}}}\n' > "$resp/4.out"
-  fb=$(make_herdr_fakebin "$dir")
-  out=$( PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" FM_BACKEND_HERDR_SUBMIT_POLLS=1 \
-    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_send_text_submit default:w1:p2 "reply with just OK" 3 0.01 0.01' "$ROOT" )
+  out=$( herdr_run "$dir" FM_BACKEND_HERDR_SUBMIT_POLLS=1 fm_backend_herdr_send_text_submit default:w1:p2 "reply with just OK" 3 0.01 0.01 )
   [ "$out" = empty ] || fail "send_text_submit should confirm via agent_status alone even for a harness whose idle composer shows dynamic tip text, got '$out'"
   [ "$(grep -c $'\x1f''pane'$'\x1f''read' "$log")" -eq 0 ] || fail "send_text_submit must never call 'pane read' - a codex-style dynamic idle-tip composer can never mislead a confirmation path that does not read it"
   pass "fm_backend_herdr_send_text_submit: confirms submission via native agent-state alone, immune to a codex-style dynamic idle-tip composer that would have misread as 'pending' under the old composer-based confirmation"
@@ -4479,12 +4191,10 @@ test_send_text_submit_confirms_despite_codex_idle_tip_composer() {
 # The guard must ignore that faint suggestion text, otherwise away-mode
 # escalation delivery defers forever even though the human has typed nothing.
 test_composer_state_codex_dynamic_idle_tip_reads_empty_when_faint() {
-  local dir log resp fb out
+  local dir log resp out
   dir="$TMP_ROOT/composer-codex-dynamic-tip"; mkdir -p "$dir/responses"; log="$dir/log"; resp="$dir/responses"; : > "$log"
   printf '\xe2\x80\xa2 OK\n\n\n\x1b[0m\x1b[1m\xe2\x80\xba \x1b[0m\x1b[2mSummarize recent commits\x1b[0m\n\n  gpt-5.5 xhigh \xc2\xb7 Context 97%% left \xc2\xb7 /private/tmp \xc2\xb7 2\xe2\x80\xa6\n' > "$resp/1.out"
-  fb=$(make_herdr_fakebin "$dir")
-  out=$( PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
-    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_composer_state default:w1:p2' "$ROOT" )
+  out=$( herdr_run "$dir" fm_backend_herdr_composer_state default:w1:p2 )
   [ "$out" = empty ] || fail "a faint real-codex dynamic idle-tip row should read empty, got '$out'"
   pass "fm_backend_herdr_composer_state: a faint real-codex dynamic idle-tip composer row reads empty"
 }
@@ -4512,16 +4222,14 @@ test_composer_state_guard_still_refuses_real_pending_text_after_submit_confirmat
 # above covers the primitive directly; this proves the caller wires it
 # correctly).
 test_send_text_submit_slow_transition_within_one_enter_needs_no_extra_enter() {
-  local dir log resp fb out enter_count
+  local dir log resp out enter_count
   dir="$TMP_ROOT/submit-slow-transition"; mkdir -p "$dir/responses"; log="$dir/log"; resp="$dir/responses"; : > "$log"
   # 1: send-text  2: baseline idle  3: send-keys enter  4,5: agent get -> idle  6: agent get -> working
   printf '{"result":{"agent":{"agent_status":"idle"}}}\n' > "$resp/2.out"
   printf '{"result":{"agent":{"agent_status":"idle"}}}\n' > "$resp/4.out"
   printf '{"result":{"agent":{"agent_status":"idle"}}}\n' > "$resp/5.out"
   printf '{"result":{"agent":{"agent_status":"working"}}}\n' > "$resp/6.out"
-  fb=$(make_herdr_fakebin "$dir")
-  out=$( PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" FM_BACKEND_HERDR_SUBMIT_POLLS=3 \
-    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_send_text_submit default:w1:p2 "hello captain" 3 0.03 0.01' "$ROOT" )
+  out=$( herdr_run "$dir" FM_BACKEND_HERDR_SUBMIT_POLLS=3 fm_backend_herdr_send_text_submit default:w1:p2 "hello captain" 3 0.03 0.01 )
   [ "$out" = empty ] || fail "send_text_submit should confirm once a later sample within the SAME Enter attempt observes working, got '$out'"
   enter_count=$(grep -c $'\x1f''pane'$'\x1f''send-keys'$'\x1f''w1:p2'$'\x1f''enter' "$log")
   [ "$enter_count" -eq 1 ] || fail "a slow (but within-budget) transition must not provoke a needless extra Enter, sent $enter_count Enter(s)"
@@ -4529,24 +4237,20 @@ test_send_text_submit_slow_transition_within_one_enter_needs_no_extra_enter() {
 }
 
 test_send_text_submit_send_failed() {
-  local dir log resp fb out
+  local dir log resp out
   dir="$TMP_ROOT/submit-fail"; mkdir -p "$dir/responses"; log="$dir/log"; resp="$dir/responses"; : > "$log"
   printf '1\n' > "$resp/1.exit"
-  fb=$(make_herdr_fakebin "$dir")
-  out=$( PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" FM_BACKEND_HERDR_SUBMIT_POLLS=1 \
-    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_send_text_submit default:w1:p2 "x" 2 0.01 0.01' "$ROOT" )
+  out=$( herdr_run "$dir" FM_BACKEND_HERDR_SUBMIT_POLLS=1 fm_backend_herdr_send_text_submit default:w1:p2 "x" 2 0.01 0.01 )
   [ "$out" = send-failed ] || fail "send_text_submit should report send-failed when the literal send itself fails, got '$out'"
   pass "fm_backend_herdr_send_text_submit: reports 'send-failed' when the literal send-text call itself errors"
 }
 
 test_send_text_submit_unknown_on_capture_failure() {
-  local dir log resp fb out enter_count
+  local dir log resp out enter_count
   dir="$TMP_ROOT/submit-read-fail"; mkdir -p "$dir/responses"; log="$dir/log"; resp="$dir/responses"; : > "$log"
   printf '{"result":{"agent":{"agent_status":"idle"}}}\n' > "$resp/2.out"
   printf '1\n' > "$resp/4.exit"
-  fb=$(make_herdr_fakebin "$dir")
-  out=$( PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" FM_BACKEND_HERDR_SUBMIT_POLLS=1 \
-    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_send_text_submit default:w1:p2 "x" 2 0.01 0.01' "$ROOT" )
+  out=$( herdr_run "$dir" FM_BACKEND_HERDR_SUBMIT_POLLS=1 fm_backend_herdr_send_text_submit default:w1:p2 "x" 2 0.01 0.01 )
   [ "$out" = unknown ] || fail "send_text_submit should report unknown when the post-Enter agent-get read fails, got '$out'"
   enter_count=$(grep -c $'\x1f''pane'$'\x1f''send-keys'$'\x1f''w1:p2'$'\x1f''enter' "$log")
   [ "$enter_count" -eq 1 ] || fail "send_text_submit must never retry past an unreadable target (that is a hard I/O failure, not a timing race), sent $enter_count Enter(s)"
@@ -4554,14 +4258,12 @@ test_send_text_submit_unknown_on_capture_failure() {
 }
 
 test_send_text_submit_unknown_on_composer_capture_failure() {
-  local dir log resp fb out enter_count
+  local dir log resp out enter_count
   dir="$TMP_ROOT/submit-composer-read-fail"; mkdir -p "$dir/responses"; log="$dir/log"; resp="$dir/responses"; : > "$log"
   printf '{"result":{"agent":{"agent_status":"idle"}}}\n' > "$resp/2.out"
   printf '{"result":{"agent":{"agent_status":"idle"}}}\n' > "$resp/4.out"
   printf '1\n' > "$resp/5.exit"
-  fb=$(make_herdr_fakebin "$dir")
-  out=$( PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" FM_BACKEND_HERDR_SUBMIT_POLLS=1 \
-    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_send_text_submit default:w1:p2 "x" 2 0.01 0.01' "$ROOT" )
+  out=$( herdr_run "$dir" FM_BACKEND_HERDR_SUBMIT_POLLS=1 fm_backend_herdr_send_text_submit default:w1:p2 "x" 2 0.01 0.01 )
   [ "$out" = unknown ] || fail "send_text_submit should report unknown when native status stays idle but the composer cannot be read, got '$out'"
   enter_count=$(grep -c $'\x1f''pane'$'\x1f''send-keys'$'\x1f''w1:p2'$'\x1f''enter' "$log")
   [ "$enter_count" -eq 1 ] || fail "send_text_submit must not retry Enter after composer verification becomes unreadable, sent $enter_count Enter(s)"
@@ -5170,14 +4872,8 @@ test_wait_transition_clean_timeout_returns_1() {
 # shellcheck source=bin/fm-backend.sh
 . "$ROOT/bin/fm-backend.sh"
 
-test_version_check_accepts_current_protocol
-test_version_check_refuses_old_protocol
-test_version_check_refuses_missing_herdr
-test_workspace_label_primary_home_no_marker
-test_workspace_label_secondmate_home_uses_marker_id
-test_workspace_label_secondmate_marker_trims_whitespace
-test_workspace_label_empty_marker_falls_back_to_primary
-test_workspace_label_different_secondmates_get_different_labels
+test_version_check_matrix
+test_workspace_label_matrix
 test_cli_helper_sets_env_and_appends_trailing_session_flag
 test_agent_state_bypasses_a_stale_client_shadowing_a_compatible_one
 test_recovery_grade_read_widens_only_at_its_own_boundary

--- a/tests/fm-backend-herdr.test.sh
+++ b/tests/fm-backend-herdr.test.sh
@@ -80,9 +80,11 @@ SH
 
 # herdr_run <dir> [K=V ...] <adapter-fn> [args...]
 # Source the adapter and run <adapter-fn> against a canned-response case world
-# (dir with log, responses/, and the make_herdr_fakebin stub - installed here
-# only when absent, so a case that deletes or replaces the stub stays in
-# control of what runs). Leading K=V arguments apply to this one call only.
+# (dir with log, responses/, and the make_herdr_fakebin stub - re-installed
+# here whenever it is missing, so a case that REPLACES the stub stays in
+# control of what runs, but a case that needs herdr absent must point PATH at
+# a stub-free dir instead of deleting it). Leading K=V arguments apply to this
+# one call only.
 herdr_run() {
   local dir=$1
   shift

--- a/tests/fm-bootstrap.test.sh
+++ b/tests/fm-bootstrap.test.sh
@@ -23,8 +23,8 @@
 # twice.
 set -u
 
-# shellcheck source=tests/lib.sh disable=SC1091
-. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+# shellcheck source=tests/fixtures.sh disable=SC1091
+. "$(dirname "${BASH_SOURCE[0]}")/fixtures.sh"
 
 BASE_PATH=${FM_TEST_BASE_PATH:-/usr/bin:/bin:/usr/sbin:/sbin}
 TMP_ROOT=$(fm_test_tmproot fm-bootstrap-tests)
@@ -46,88 +46,13 @@ make_fake_toolchain() {
   fakebin=$(fm_fakebin "$dir")
   fm_fake_exit0 "$fakebin" tmux node chrome-devtools-axi
   fm_fake_version_tool "$fakebin" lavish-axi FM_FAKE_LAVISH_AXI_VERSION 0.1.46
-  cat > "$fakebin/gh-axi" <<'SH'
-#!/usr/bin/env bash
-if [ "${1:-}" = --version ]; then
-  printf '%s\n' "${FM_FAKE_GH_AXI_VERSION:-0.1.29}"
-  exit 0
-fi
-exit 0
-SH
-  chmod +x "$fakebin/gh-axi"
-  cat > "$fakebin/gh" <<'SH'
-#!/usr/bin/env bash
-if [ "${1:-}" = auth ] && [ "${2:-}" = status ]; then
-  exit 0
-fi
-exit 0
-SH
-  chmod +x "$fakebin/gh"
-  cat > "$fakebin/treehouse" <<'SH'
-#!/usr/bin/env bash
-if [ "${1:-}" = get ] && [ "${2:-}" = --help ]; then
-  if [ "${FM_FAKE_TREEHOUSE_LEASE_HELP:-}" = 1 ]; then
-    printf '%s\n' 'Usage: treehouse get [--lease] [--lease-holder <holder>]'
-  else
-    printf '%s\n' 'Usage: treehouse get'
-  fi
-  exit 0
-fi
-exit 0
-SH
-  chmod +x "$fakebin/treehouse"
-  cat > "$fakebin/no-mistakes" <<'SH'
-#!/usr/bin/env bash
-if [ "${1:-}" = --version ]; then
-  printf '%s\n' "${FM_FAKE_NO_MISTAKES_VERSION:-no-mistakes version v1.46.0 (fake) 2026-06-27T00:02:18Z}"
-  exit 0
-fi
-exit 0
-SH
-  chmod +x "$fakebin/no-mistakes"
-  add_tasks_axi "$fakebin" "0.2.4"
-  add_quota_axi "$fakebin"
+  fm_test_fake_gh_axi "$fakebin"
+  fm_test_fake_gh "$fakebin"
+  fm_test_fake_treehouse "$fakebin" 'Usage: treehouse get'
+  fm_test_fake_no_mistakes "$fakebin"
+  fm_test_fake_tasks_axi "$fakebin"
+  fm_test_fake_quota_axi "$fakebin"
   printf '%s\n' "$fakebin"
-}
-
-add_quota_axi() {
-  local fakebin=$1
-  cat > "$fakebin/quota-axi" <<'SH'
-#!/usr/bin/env bash
-if [ "${1:-}" = --version ]; then
-  printf '%s\n' "${FM_FAKE_QUOTA_AXI_VERSION:-0.1.29}"
-  exit 0
-fi
-exit 0
-SH
-  chmod +x "$fakebin/quota-axi"
-}
-
-add_tasks_axi() {
-  local fakebin=$1 version=$2 archive_body=${3:-yes} multi_id=${4:-yes} archive_line mv_usage
-  archive_line=""
-  [ "$archive_body" = yes ] && archive_line='  --archive-body'
-  mv_usage='usage: tasks-axi mv <id> [<id>...] --to <path-or-dir>'
-  [ "$multi_id" = yes ] || mv_usage='usage: tasks-axi mv <id> --to <path-or-dir>'
-  cat > "$fakebin/tasks-axi" <<SH
-#!/usr/bin/env bash
-if [ "\${1:-}" = --version ]; then
-  printf '%s\n' '$version'
-  exit 0
-fi
-if [ "\${1:-}" = update ] && [ "\${2:-}" = --help ]; then
-  printf '%s\n' 'usage: tasks-axi update <id> [flags]'
-  printf '%s\n' '  --body-file <path>'
-  [ -z '$archive_line' ] || printf '%s\n' '$archive_line'
-  exit 0
-fi
-if [ "\${1:-}" = mv ] && [ "\${2:-}" = --help ]; then
-  printf '%s\n' '$mv_usage'
-  exit 0
-fi
-exit 0
-SH
-  chmod +x "$fakebin/tasks-axi"
 }
 
 add_real_jq() {
@@ -274,7 +199,7 @@ test_bootstrap_reporting() {
           tasks=${tasks%:nomulti}
           ;;
       esac
-      add_tasks_axi "$fakebin" "$tasks" "$archive_body" "$multi_id"
+      fm_test_fake_tasks_axi "$fakebin" "$tasks" "$archive_body" "$multi_id"
     fi
     if [ "$quota" = "0" ]; then
       rm -f "$fakebin/quota-axi"
@@ -432,7 +357,7 @@ test_tasks_axi_min_version() {
         version=${version%:nomulti}
         ;;
     esac
-    add_tasks_axi "$fakebin" "$version" "$archive_body" "$multi_id"
+    fm_test_fake_tasks_axi "$fakebin" "$version" "$archive_body" "$multi_id"
     out=$(PATH="$fakebin:$BASE_PATH" FM_HOME="$case_dir/home" FM_ROOT_OVERRIDE="$case_dir/home" \
       FM_FAKE_TREEHOUSE_LEASE_HELP=1 "$ROOT/bin/fm-bootstrap.sh")
     case "$mode" in

--- a/tests/fm-lint-workflows.test.sh
+++ b/tests/fm-lint-workflows.test.sh
@@ -7,8 +7,8 @@
 # workflow YAML lint, and the broken workflow could not report its own breakage.
 set -u
 
-# shellcheck source=tests/lib.sh
-. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+# shellcheck source=tests/fixtures.sh
+. "$(dirname "${BASH_SOURCE[0]}")/fixtures.sh"
 
 LINT_WF="$ROOT/bin/fm-lint-workflows.sh"
 LINT="$ROOT/bin/fm-lint.sh"
@@ -23,83 +23,8 @@ ACTIONLINT_SHA_LINUX_ARM64=325e971b6ba9bfa504672e29be93c24981eeb1c07576d730e9f7c
 ACTIONLINT_SHA_DARWIN_AMD64=5b44c3bc2255115c9b69e30efc0fecdf498fdb63c5d58e17084fd5f16324c644
 ACTIONLINT_SHA_DARWIN_ARM64=aba9ced2dee8d27fecca3dc7feb1a7f9a52caefa1eb46f3271ea66b6e0e6953f
 
-fm_install_stub_uname() {
-  local fakebin=$1
-  cat > "$fakebin/uname" <<'SH'
-#!/usr/bin/env bash
-case "${1:-}" in
-  -s) printf '%s\n' "${FM_TEST_UNAME_S:-Linux}" ;;
-  -m) printf '%s\n' "${FM_TEST_UNAME_M:-x86_64}" ;;
-  *) printf '%s\n' "${FM_TEST_UNAME_S:-Linux}" ;;
-esac
-SH
-  chmod +x "$fakebin/uname"
-}
 
-fm_install_stub_curl() {
-  local fakebin=$1
-  cat > "$fakebin/curl" <<'SH'
-#!/usr/bin/env bash
-count=0
-[ ! -f "${CURL_COUNT:-}" ] || count=$(cat "$CURL_COUNT")
-count=$((count + 1))
-[ -z "${CURL_COUNT:-}" ] || printf '%s\n' "$count" > "$CURL_COUNT"
-url=
-out=
-while [ "$#" -gt 0 ]; do
-  case "$1" in
-    -o)
-      out=$2
-      shift 2
-      ;;
-    -*)
-      shift
-      ;;
-    *)
-      url=$1
-      shift
-      ;;
-  esac
-done
-[ -z "${CURL_URL_LOG:-}" ] || printf '%s\n' "$url" >> "$CURL_URL_LOG"
-fail_until=${CURL_FAIL_UNTIL:-0}
-[ "$count" -gt "$fail_until" ] || exit 22
-: > "$out"
-exit 0
-SH
-  chmod +x "$fakebin/curl"
-}
 
-fm_install_stub_hasher() {
-  local fakebin=$1 name=$2
-  cat > "$fakebin/$name" <<'SH'
-#!/usr/bin/env bash
-self=${0##*/}
-if [ -n "${HASHER_LOG:-}" ]; then
-  printf '%s\n' "$self $*" >> "$HASHER_LOG"
-fi
-file=$1
-if [ "$self" = shasum ]; then
-  algo=
-  file=
-  while [ "$#" -gt 0 ]; do
-    case "$1" in
-      -a)
-        algo=$2
-        shift 2
-        ;;
-      *)
-        file=$1
-        shift
-        ;;
-    esac
-  done
-  [ "$algo" = 256 ] || exit 1
-fi
-printf '%s  %s\n' "${SHA256_STUB_HASH:?}" "$file"
-SH
-  chmod +x "$fakebin/$name"
-}
 
 fm_install_stub_tar_actionlint() {
   local fakebin=$1
@@ -121,10 +46,6 @@ SH
   chmod +x "$fakebin/tar"
 }
 
-fm_install_stub_sleep() {
-  local fakebin=$1
-  fm_fake_exit0 "$fakebin" sleep
-}
 
 write_valid_workflow() {
   local path=$1
@@ -294,11 +215,11 @@ test_installer_retries_transient_download_failure() {
   fakebin=$(fm_fakebin "$tmp")
   destination="$tmp/bin"
 
-  fm_install_stub_uname "$fakebin"
-  fm_install_stub_curl "$fakebin"
-  fm_install_stub_hasher "$fakebin" sha256sum
+  fm_test_fake_uname "$fakebin"
+  fm_test_fake_curl "$fakebin"
+  fm_test_fake_hasher "$fakebin" sha256sum
   fm_install_stub_tar_actionlint "$fakebin"
-  fm_install_stub_sleep "$fakebin"
+  fm_test_fake_sleep_noop "$fakebin"
 
   out=$(CURL_COUNT="$tmp/curl-count" CURL_FAIL_UNTIL=3 \
     SHA256_STUB_HASH="$ACTIONLINT_SHA_LINUX_AMD64" \
@@ -318,11 +239,11 @@ test_installer_selects_platform_archive_url_and_checksum() {
   destination="$tmp/bin"
   url_log="$tmp/curl-url.log"
 
-  fm_install_stub_uname "$fakebin"
-  fm_install_stub_curl "$fakebin"
-  fm_install_stub_hasher "$fakebin" sha256sum
+  fm_test_fake_uname "$fakebin"
+  fm_test_fake_curl "$fakebin"
+  fm_test_fake_hasher "$fakebin" sha256sum
   fm_install_stub_tar_actionlint "$fakebin"
-  fm_install_stub_sleep "$fakebin"
+  fm_test_fake_sleep_noop "$fakebin"
 
   while IFS=$'\t' read -r uname_s uname_m archive sha; do
     [ -n "$uname_s" ] || continue
@@ -357,11 +278,11 @@ test_installer_rejects_wrong_checksum() {
   fakebin=$(fm_fakebin "$tmp")
   destination="$tmp/bin"
 
-  fm_install_stub_uname "$fakebin"
-  fm_install_stub_curl "$fakebin"
-  fm_install_stub_hasher "$fakebin" sha256sum
+  fm_test_fake_uname "$fakebin"
+  fm_test_fake_curl "$fakebin"
+  fm_test_fake_hasher "$fakebin" sha256sum
   fm_install_stub_tar_actionlint "$fakebin"
-  fm_install_stub_sleep "$fakebin"
+  fm_test_fake_sleep_noop "$fakebin"
 
   rc=0
   out=$(SHA256_STUB_HASH=0000000000000000000000000000000000000000000000000000000000000000 \
@@ -387,11 +308,11 @@ test_installer_falls_back_to_shasum() {
   for tool in bash dirname mktemp rm awk mkdir install cat chmod; do
     ln -s "$(command -v "$tool")" "$fakebin/$tool"
   done
-  fm_install_stub_uname "$fakebin"
-  fm_install_stub_curl "$fakebin"
-  fm_install_stub_hasher "$fakebin" shasum
+  fm_test_fake_uname "$fakebin"
+  fm_test_fake_curl "$fakebin"
+  fm_test_fake_hasher "$fakebin" shasum
   fm_install_stub_tar_actionlint "$fakebin"
-  fm_install_stub_sleep "$fakebin"
+  fm_test_fake_sleep_noop "$fakebin"
 
   : > "$hasher_log"
   out=$(CURL_URL_LOG="$tmp/curl-url.log" HASHER_LOG="$hasher_log" \
@@ -411,12 +332,12 @@ test_installer_prefers_sha256sum_over_shasum() {
   destination="$tmp/bin"
   hasher_log="$tmp/hasher.log"
 
-  fm_install_stub_uname "$fakebin"
-  fm_install_stub_curl "$fakebin"
-  fm_install_stub_hasher "$fakebin" sha256sum
-  fm_install_stub_hasher "$fakebin" shasum
+  fm_test_fake_uname "$fakebin"
+  fm_test_fake_curl "$fakebin"
+  fm_test_fake_hasher "$fakebin" sha256sum
+  fm_test_fake_hasher "$fakebin" shasum
   fm_install_stub_tar_actionlint "$fakebin"
-  fm_install_stub_sleep "$fakebin"
+  fm_test_fake_sleep_noop "$fakebin"
 
   : > "$hasher_log"
   PATH="$fakebin:$PATH" HASHER_LOG="$hasher_log" \
@@ -437,8 +358,8 @@ test_installer_rejects_unsupported_platform() {
   fakebin=$(fm_fakebin "$tmp")
   destination="$tmp/bin"
 
-  fm_install_stub_uname "$fakebin"
-  fm_install_stub_curl "$fakebin"
+  fm_test_fake_uname "$fakebin"
+  fm_test_fake_curl "$fakebin"
 
   rc=0
   out=$(FM_TEST_UNAME_S=FreeBSD FM_TEST_UNAME_M=amd64 \

--- a/tests/fm-lint-workflows.test.sh
+++ b/tests/fm-lint-workflows.test.sh
@@ -123,11 +123,7 @@ SH
 
 fm_install_stub_sleep() {
   local fakebin=$1
-  cat > "$fakebin/sleep" <<'SH'
-#!/usr/bin/env bash
-exit 0
-SH
-  chmod +x "$fakebin/sleep"
+  fm_fake_exit0 "$fakebin" sleep
 }
 
 write_valid_workflow() {

--- a/tests/fm-lint.test.sh
+++ b/tests/fm-lint.test.sh
@@ -137,11 +137,7 @@ SH
 
 fm_install_stub_sleep() {
   local fakebin=$1
-  cat > "$fakebin/sleep" <<'SH'
-#!/usr/bin/env bash
-exit 0
-SH
-  chmod +x "$fakebin/sleep"
+  fm_fake_exit0 "$fakebin" sleep
 }
 
 # True only when the resolved shellcheck is exactly the pinned version, so the

--- a/tests/fm-lint.test.sh
+++ b/tests/fm-lint.test.sh
@@ -14,8 +14,8 @@
 # gates resolve it, so command, file set, config, AND version all match.
 set -u
 
-# shellcheck source=tests/lib.sh
-. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+# shellcheck source=tests/fixtures.sh
+. "$(dirname "${BASH_SOURCE[0]}")/fixtures.sh"
 
 LINT="$ROOT/bin/fm-lint.sh"
 INSTALLER="$ROOT/bin/fm-install-shellcheck.sh"
@@ -30,89 +30,14 @@ SHELLCHECK_SHA_LINUX_AARCH64=12b331c1d2db6b9eb13cfca64306b1b157a86eb69db83023e26
 SHELLCHECK_SHA_DARWIN_X86_64=3c89db4edcab7cf1c27bff178882e0f6f27f7afdf54e859fa041fca10febe4c6
 SHELLCHECK_SHA_DARWIN_AARCH64=56affdd8de5527894dca6dc3d7e0a99a873b0f004d7aabc30ae407d3f48b0a79
 
-# fm_install_stub_uname <fakebin>: uname -s / uname -m from FM_TEST_UNAME_S/M.
-fm_install_stub_uname() {
-  local fakebin=$1
-  cat > "$fakebin/uname" <<'SH'
-#!/usr/bin/env bash
-case "${1:-}" in
-  -s) printf '%s\n' "${FM_TEST_UNAME_S:-Linux}" ;;
-  -m) printf '%s\n' "${FM_TEST_UNAME_M:-x86_64}" ;;
-  *) printf '%s\n' "${FM_TEST_UNAME_S:-Linux}" ;;
-esac
-SH
-  chmod +x "$fakebin/uname"
-}
+# fm_test_fake_uname <fakebin>: uname -s / uname -m from FM_TEST_UNAME_S/M.
 
-# fm_install_stub_curl <fakebin>: log the URL, fail CURL_FAIL_UNTIL times, then
+# fm_test_fake_curl <fakebin>: log the URL, fail CURL_FAIL_UNTIL times, then
 # write an empty file at -o. CURL_COUNT and CURL_URL_LOG are paths the stub
 # updates when invoked.
-fm_install_stub_curl() {
-  local fakebin=$1
-  cat > "$fakebin/curl" <<'SH'
-#!/usr/bin/env bash
-count=0
-[ ! -f "${CURL_COUNT:-}" ] || count=$(cat "$CURL_COUNT")
-count=$((count + 1))
-[ -z "${CURL_COUNT:-}" ] || printf '%s\n' "$count" > "$CURL_COUNT"
-url=
-out=
-while [ "$#" -gt 0 ]; do
-  case "$1" in
-    -o)
-      out=$2
-      shift 2
-      ;;
-    -*)
-      shift
-      ;;
-    *)
-      url=$1
-      shift
-      ;;
-  esac
-done
-[ -z "${CURL_URL_LOG:-}" ] || printf '%s\n' "$url" >> "$CURL_URL_LOG"
-fail_until=${CURL_FAIL_UNTIL:-0}
-[ "$count" -gt "$fail_until" ] || exit 22
-: > "$out"
-exit 0
-SH
-  chmod +x "$fakebin/curl"
-}
 
-# fm_install_stub_hasher <fakebin> <name>: sha256sum or shasum stub that prints
+# fm_test_fake_hasher <fakebin> <name>: sha256sum or shasum stub that prints
 # SHA256_STUB_HASH and records the invocation on HASHER_LOG. shasum requires -a 256.
-fm_install_stub_hasher() {
-  local fakebin=$1 name=$2
-  cat > "$fakebin/$name" <<'SH'
-#!/usr/bin/env bash
-self=${0##*/}
-if [ -n "${HASHER_LOG:-}" ]; then
-  printf '%s\n' "$self $*" >> "$HASHER_LOG"
-fi
-file=$1
-if [ "$self" = shasum ]; then
-  algo=
-  file=
-  while [ "$#" -gt 0 ]; do
-    case "$1" in
-      -a)
-        algo=$2
-        shift 2
-        ;;
-      *)
-        file=$1
-        shift
-        ;;
-    esac
-  done
-  [ "$algo" = 256 ] || exit 1
-fi
-printf '%s  %s\n' "${SHA256_STUB_HASH:?}" "$file"
-SH
-  chmod +x "$fakebin/$name"
-}
 
 fm_install_stub_tar_shellcheck() {
   local fakebin=$1
@@ -135,10 +60,6 @@ SH
   chmod +x "$fakebin/tar"
 }
 
-fm_install_stub_sleep() {
-  local fakebin=$1
-  fm_fake_exit0 "$fakebin" sleep
-}
 
 # True only when the resolved shellcheck is exactly the pinned version, so the
 # lint-running tests below match what CI enforces instead of a runner default.
@@ -775,11 +696,11 @@ test_installer_retries_transient_download_failure() {
   fakebin=$(fm_fakebin "$tmp")
   destination="$tmp/bin"
 
-  fm_install_stub_uname "$fakebin"
-  fm_install_stub_curl "$fakebin"
-  fm_install_stub_hasher "$fakebin" sha256sum
+  fm_test_fake_uname "$fakebin"
+  fm_test_fake_curl "$fakebin"
+  fm_test_fake_hasher "$fakebin" sha256sum
   fm_install_stub_tar_shellcheck "$fakebin"
-  fm_install_stub_sleep "$fakebin"
+  fm_test_fake_sleep_noop "$fakebin"
 
   # Reproduce the CI incident: the release endpoint returned 503 for all three
   # formerly configured attempts before recovering. Force linux/x86_64 so the
@@ -802,11 +723,11 @@ test_installer_selects_platform_archive_url_and_checksum() {
   destination="$tmp/bin"
   url_log="$tmp/curl-url.log"
 
-  fm_install_stub_uname "$fakebin"
-  fm_install_stub_curl "$fakebin"
-  fm_install_stub_hasher "$fakebin" sha256sum
+  fm_test_fake_uname "$fakebin"
+  fm_test_fake_curl "$fakebin"
+  fm_test_fake_hasher "$fakebin" sha256sum
   fm_install_stub_tar_shellcheck "$fakebin"
-  fm_install_stub_sleep "$fakebin"
+  fm_test_fake_sleep_noop "$fakebin"
 
   while IFS=$'\t' read -r uname_s uname_m archive sha; do
     [ -n "$uname_s" ] || continue
@@ -841,11 +762,11 @@ test_installer_rejects_wrong_checksum() {
   fakebin=$(fm_fakebin "$tmp")
   destination="$tmp/bin"
 
-  fm_install_stub_uname "$fakebin"
-  fm_install_stub_curl "$fakebin"
-  fm_install_stub_hasher "$fakebin" sha256sum
+  fm_test_fake_uname "$fakebin"
+  fm_test_fake_curl "$fakebin"
+  fm_test_fake_hasher "$fakebin" sha256sum
   fm_install_stub_tar_shellcheck "$fakebin"
-  fm_install_stub_sleep "$fakebin"
+  fm_test_fake_sleep_noop "$fakebin"
 
   rc=0
   out=$(SHA256_STUB_HASH=0000000000000000000000000000000000000000000000000000000000000000 \
@@ -871,11 +792,11 @@ test_installer_falls_back_to_shasum() {
   for tool in bash dirname mktemp rm awk mkdir install cat chmod; do
     ln -s "$(command -v "$tool")" "$fakebin/$tool"
   done
-  fm_install_stub_uname "$fakebin"
-  fm_install_stub_curl "$fakebin"
-  fm_install_stub_hasher "$fakebin" shasum
+  fm_test_fake_uname "$fakebin"
+  fm_test_fake_curl "$fakebin"
+  fm_test_fake_hasher "$fakebin" shasum
   fm_install_stub_tar_shellcheck "$fakebin"
-  fm_install_stub_sleep "$fakebin"
+  fm_test_fake_sleep_noop "$fakebin"
 
   # Restricted PATH: shasum is present, sha256sum is not.
   : > "$hasher_log"
@@ -896,12 +817,12 @@ test_installer_prefers_sha256sum_over_shasum() {
   destination="$tmp/bin"
   hasher_log="$tmp/hasher.log"
 
-  fm_install_stub_uname "$fakebin"
-  fm_install_stub_curl "$fakebin"
-  fm_install_stub_hasher "$fakebin" sha256sum
-  fm_install_stub_hasher "$fakebin" shasum
+  fm_test_fake_uname "$fakebin"
+  fm_test_fake_curl "$fakebin"
+  fm_test_fake_hasher "$fakebin" sha256sum
+  fm_test_fake_hasher "$fakebin" shasum
   fm_install_stub_tar_shellcheck "$fakebin"
-  fm_install_stub_sleep "$fakebin"
+  fm_test_fake_sleep_noop "$fakebin"
 
   : > "$hasher_log"
   PATH="$fakebin:$PATH" HASHER_LOG="$hasher_log" \
@@ -922,8 +843,8 @@ test_installer_rejects_unsupported_platform() {
   fakebin=$(fm_fakebin "$tmp")
   destination="$tmp/bin"
 
-  fm_install_stub_uname "$fakebin"
-  fm_install_stub_curl "$fakebin"
+  fm_test_fake_uname "$fakebin"
+  fm_test_fake_curl "$fakebin"
 
   rc=0
   out=$(FM_TEST_UNAME_S=FreeBSD FM_TEST_UNAME_M=amd64 \

--- a/tests/fm-pending-reply.test.sh
+++ b/tests/fm-pending-reply.test.sh
@@ -77,11 +77,7 @@ esac
 exit 0
 SH
   chmod +x "$fb/tmux"
-  cat > "$fb/sleep" <<'SH'
-#!/usr/bin/env bash
-exit 0
-SH
-  chmod +x "$fb/sleep"
+  fm_fake_exit0 "$fb" sleep
   printf '%s\n' "$fb"
 }
 

--- a/tests/fm-pr-check-security.test.sh
+++ b/tests/fm-pr-check-security.test.sh
@@ -566,11 +566,7 @@ test_valid_recording_and_merge_derivation() {
   fm_pr_poll_artifacts_valid "$dir/home/state" Task_A.1 "$POLL" \
     || fail "safe lifecycle-compatible task ID did not publish an authenticated poll"
   rm -rf "$dir/wt"
-  cat > "$dir/fakebin/tmux" <<'SH'
-#!/usr/bin/env bash
-exit 0
-SH
-  chmod 0700 "$dir/fakebin/tmux"
+  fm_fake_exit0 "$dir/fakebin" tmux
   touch "$dir/home/state/.last-watcher-beat"
   FM_HOME="$dir/home" FM_ROOT_OVERRIDE="$ROOT" PATH="$dir/fakebin:$BASE_PATH" \
     "$TEARDOWN" Task_A.1 --force > "$dir/teardown.out" 2> "$dir/teardown.err" \
@@ -587,11 +583,7 @@ SH
       "project=$dir/project" \
       'kind=ship' \
       'mode=local-only'
-    cat > "$dir/fakebin/tmux" <<'SH'
-#!/usr/bin/env bash
-exit 0
-SH
-    chmod 0700 "$dir/fakebin/tmux"
+    fm_fake_exit0 "$dir/fakebin" tmux
     touch "$dir/home/state/.last-watcher-beat"
     mkdir "$dir/home/state/$id.check.sh"
     set +e
@@ -1200,11 +1192,7 @@ test_teardown_removes_poll_artifacts() {
   printf 'data\n' > "$dir/home/state/task-a.pr-poll"
   printf 'registration\n' > "$dir/home/state/task-a.pr-poll-registration"
   printf 'trust\n' > "$dir/home/state/task-a.check-trust"
-  cat > "$fakebin/tmux" <<'SH'
-#!/usr/bin/env bash
-exit 0
-SH
-  chmod +x "$fakebin/tmux"
+  fm_fake_exit0 "$fakebin" tmux
   touch "$dir/home/state/.last-watcher-beat"
 
   FM_HOME="$dir/home" FM_ROOT_OVERRIDE="$ROOT" PATH="$fakebin:$BASE_PATH" \
@@ -1231,11 +1219,7 @@ SH
   fm_pr_poll_retirement_publish "$dir/home/state" task-a "$POLL" merged \
     || fail "could not publish teardown receipt fixture"
   rm -f "$dir/home/state/task-a.check.sh"
-  cat > "$fakebin/tmux" <<'SH'
-#!/usr/bin/env bash
-exit 0
-SH
-  chmod +x "$fakebin/tmux"
+  fm_fake_exit0 "$fakebin" tmux
   touch "$dir/home/state/.last-watcher-beat"
   FM_HOME="$dir/home" FM_ROOT_OVERRIDE="$ROOT" PATH="$fakebin:$BASE_PATH" \
     "$TEARDOWN" task-a --force > "$dir/teardown.out" 2> "$dir/teardown.err" \

--- a/tests/fm-remote-doctor.test.sh
+++ b/tests/fm-remote-doctor.test.sh
@@ -278,20 +278,13 @@ case "${1:-}:${2:-}" in
   mv:--help) printf '%s\n' 'usage: tasks-axi mv <id> [<id>...]' ;;
 esac
 SH
-  cat > "$CASE_BIN/treehouse" <<'SH'
-#!/usr/bin/env bash
-exit 0
-SH
+  fm_fake_exit0 "$CASE_BIN" treehouse
   cat > "$CASE_BIN/claude" <<'SH'
 #!/usr/bin/env bash
 exit 0
 SH
   chmod +x "$CASE_BIN/uname" "$CASE_BIN/launchctl" "$CASE_BIN/dscl" "$CASE_BIN/tasks-axi" "$CASE_BIN/treehouse" "$CASE_BIN/claude"
-  cat > "$CASE_BIN/sleep" <<'SH'
-#!/usr/bin/env bash
-exit 0
-SH
-  chmod +x "$CASE_BIN/sleep"
+  fm_fake_exit0 "$CASE_BIN" sleep
 }
 
 # doctor [args...] -> runs the real doctor against the current fixture,

--- a/tests/fm-secondmate-harness.test.sh
+++ b/tests/fm-secondmate-harness.test.sh
@@ -427,11 +427,7 @@ test_propagate_lib() {
 make_noop_tmux() {
   local dir=$1 fakebin="$1/fakebin"
   mkdir -p "$fakebin"
-  cat > "$fakebin/tmux" <<'SH'
-#!/usr/bin/env bash
-exit 0
-SH
-  chmod +x "$fakebin/tmux"
+  fm_fake_exit0 "$fakebin" tmux
   # BASE_PATH deliberately omits the developer's node, which the trust
   # registration below needs, so link the real one in rather than presenting a
   # node-less spawn host no real fleet member looks like.

--- a/tests/fm-secondmate-harness.test.sh
+++ b/tests/fm-secondmate-harness.test.sh
@@ -43,8 +43,8 @@
 #      flags still win.
 set -u
 
-# shellcheck source=tests/lib.sh
-. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+# shellcheck source=tests/fixtures.sh
+. "$(dirname "${BASH_SOURCE[0]}")/fixtures.sh"
 # shellcheck source=/dev/null
 . "$ROOT/bin/fm-ff-lib.sh"
 # shellcheck source=/dev/null
@@ -1063,15 +1063,7 @@ make_fake_toolchain() {
   mkdir -p "$fakebin"
   fm_fake_exit0 "$fakebin" node chrome-devtools-axi
   fm_fake_version_tool "$fakebin" lavish-axi FM_FAKE_LAVISH_AXI_VERSION 0.1.46
-  cat > "$fakebin/gh-axi" <<'SH'
-#!/usr/bin/env bash
-if [ "${1:-}" = --version ]; then
-  printf '%s\n' '0.1.29'
-  exit 0
-fi
-exit 0
-SH
-  chmod +x "$fakebin/gh-axi"
+  fm_test_fake_gh_axi "$fakebin"
   # tmux fake supports fm-send's composer-verified submit path and optional
   # FM_FAKE_TMUX_LOG / FM_FAKE_TMUX_FAIL_LITERAL for reread-nudge assertions.
   cat > "$fakebin/tmux" <<'SH'
@@ -1100,47 +1092,11 @@ esac
 exit 0
 SH
   chmod +x "$fakebin/tmux"
-  cat > "$fakebin/gh" <<'SH'
-#!/usr/bin/env bash
-exit 0
-SH
-  chmod +x "$fakebin/gh"
-  cat > "$fakebin/treehouse" <<'SH'
-#!/usr/bin/env bash
-if [ "${1:-}" = get ] && [ "${2:-}" = --help ]; then
-  printf '%s\n' 'Usage: treehouse get [--lease]'
-fi
-exit 0
-SH
-  chmod +x "$fakebin/treehouse"
-  cat > "$fakebin/no-mistakes" <<'SH'
-#!/usr/bin/env bash
-if [ "${1:-}" = --version ]; then
-  printf '%s\n' 'no-mistakes version v1.46.0 (fake)'
-  exit 0
-fi
-exit 0
-SH
-  chmod +x "$fakebin/no-mistakes"
-  cat > "$fakebin/tasks-axi" <<'SH'
-#!/usr/bin/env bash
-case "${1:-} ${2:-}" in
-  "--version ") printf '%s\n' '0.2.4' ;;
-  "update --help") printf '%s\n' 'usage: tasks-axi update <id> [flags]' '  --archive-body' ;;
-  "mv --help") printf '%s\n' 'usage: tasks-axi mv <id> [<id>...] --to <path-or-dir>' ;;
-esac
-exit 0
-SH
-  chmod +x "$fakebin/tasks-axi"
-  cat > "$fakebin/quota-axi" <<'SH'
-#!/usr/bin/env bash
-if [ "${1:-}" = --version ]; then
-  printf '%s\n' '0.1.29'
-  exit 0
-fi
-exit 0
-SH
-  chmod +x "$fakebin/quota-axi"
+  fm_test_fake_gh "$fakebin"
+  fm_test_fake_treehouse "$fakebin"
+  fm_test_fake_no_mistakes "$fakebin"
+  fm_test_fake_tasks_axi "$fakebin"
+  fm_test_fake_quota_axi "$fakebin"
   printf '%s\n' "$fakebin"
 }
 

--- a/tests/fm-secondmate-liveness.test.sh
+++ b/tests/fm-secondmate-liveness.test.sh
@@ -32,8 +32,8 @@
 #     secondmates never spawn secondmates), it is a silent no-op.
 set -u
 
-# shellcheck source=tests/lib.sh
-. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+# shellcheck source=tests/fixtures.sh
+. "$(dirname "${BASH_SOURCE[0]}")/fixtures.sh"
 
 BASE_PATH=${FM_TEST_BASE_PATH:-/usr/bin:/bin:/usr/sbin:/sbin}
 fm_git_identity fmtest fmtest@example.com
@@ -208,56 +208,12 @@ make_toolchain() {
   fakebin=$(fm_fakebin "$dir")
   fm_fake_exit0 "$fakebin" node chrome-devtools-axi pi-signed
   fm_fake_version_tool "$fakebin" lavish-axi FM_FAKE_LAVISH_AXI_VERSION 0.1.46
-  cat > "$fakebin/gh-axi" <<'SH'
-#!/usr/bin/env bash
-if [ "${1:-}" = --version ]; then
-  printf '%s\n' '0.1.29'
-  exit 0
-fi
-exit 0
-SH
-  chmod +x "$fakebin/gh-axi"
-  cat > "$fakebin/gh" <<'SH'
-#!/usr/bin/env bash
-exit 0
-SH
-  chmod +x "$fakebin/gh"
-  cat > "$fakebin/treehouse" <<'SH'
-#!/usr/bin/env bash
-if [ "${1:-}" = get ] && [ "${2:-}" = --help ]; then
-  printf '%s\n' 'Usage: treehouse get [--lease]'
-fi
-exit 0
-SH
-  chmod +x "$fakebin/treehouse"
-  cat > "$fakebin/no-mistakes" <<'SH'
-#!/usr/bin/env bash
-if [ "${1:-}" = --version ]; then
-  printf '%s\n' 'no-mistakes version v1.46.0 (fake)'
-  exit 0
-fi
-exit 0
-SH
-  chmod +x "$fakebin/no-mistakes"
-  cat > "$fakebin/tasks-axi" <<'SH'
-#!/usr/bin/env bash
-case "${1:-} ${2:-}" in
-  "--version ") printf '%s\n' '0.2.4' ;;
-  "update --help") printf '%s\n' 'usage: tasks-axi update <id> [flags]' '  --archive-body' ;;
-  "mv --help") printf '%s\n' 'usage: tasks-axi mv <id> [<id>...] --to <path-or-dir>' ;;
-esac
-exit 0
-SH
-  chmod +x "$fakebin/tasks-axi"
-  cat > "$fakebin/quota-axi" <<'SH'
-#!/usr/bin/env bash
-if [ "${1:-}" = --version ]; then
-  printf '%s\n' '0.1.29'
-  exit 0
-fi
-exit 0
-SH
-  chmod +x "$fakebin/quota-axi"
+  fm_test_fake_gh_axi "$fakebin"
+  fm_test_fake_gh "$fakebin"
+  fm_test_fake_treehouse "$fakebin"
+  fm_test_fake_no_mistakes "$fakebin"
+  fm_test_fake_tasks_axi "$fakebin"
+  fm_test_fake_quota_axi "$fakebin"
   printf '%s\n' "$fakebin"
 }
 

--- a/tests/fm-secondmate-liveness.test.sh
+++ b/tests/fm-secondmate-liveness.test.sh
@@ -162,10 +162,14 @@ SH
 test_herdr_agent_state_preserves_husk_classifier() {
   local pane_state expected out
 
+  # The server-running probe is pinned to 'unknown' so the mapping stays
+  # host-independent: a developer machine with a real herdr CLI answers
+  # `status --json` for an unregistered session with running:false, which
+  # would otherwise leak 'stopped' in and flip the unknown row to 'missing'.
   for row in 'dead missing' 'no-agent dead' 'live alive' 'unknown unreadable'; do
     pane_state=${row%% *}
     expected=${row#* }
-    out=$(FM_TEST_PANE_STATE="$pane_state" bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_pane_agent_state() { printf "%s" "$FM_TEST_PANE_STATE"; }; fm_backend_herdr_agent_state "sess:p1"' "$ROOT")
+    out=$(FM_TEST_PANE_STATE="$pane_state" bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_pane_agent_state() { printf "%s" "$FM_TEST_PANE_STATE"; }; fm_backend_herdr_server_running_state() { printf unknown; }; fm_backend_herdr_agent_state "sess:p1"' "$ROOT")
     [ "$out" = "$expected" ] || fail "Herdr pane state $pane_state should map to $expected, got '$out'"
   done
 

--- a/tests/fm-secondmate-sync.test.sh
+++ b/tests/fm-secondmate-sync.test.sh
@@ -28,8 +28,8 @@
 #     is unchanged, and a launch never re-targets that copy.
 set -u
 
-# shellcheck source=tests/lib.sh
-. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+# shellcheck source=tests/fixtures.sh
+. "$(dirname "${BASH_SOURCE[0]}")/fixtures.sh"
 # shellcheck source=tests/remote-herdr-fixture.sh
 . "$(dirname "${BASH_SOURCE[0]}")/remote-herdr-fixture.sh"
 
@@ -323,15 +323,7 @@ make_fake_toolchain() {
   mkdir -p "$fakebin"
   fm_fake_exit0 "$fakebin" node chrome-devtools-axi
   fm_fake_version_tool "$fakebin" lavish-axi FM_FAKE_LAVISH_AXI_VERSION 0.1.46
-  cat > "$fakebin/gh-axi" <<'SH'
-#!/usr/bin/env bash
-if [ "${1:-}" = --version ]; then
-  printf '%s\n' '0.1.29'
-  exit 0
-fi
-exit 0
-SH
-  chmod +x "$fakebin/gh-axi"
+  fm_test_fake_gh_axi "$fakebin"
   cat > "$fakebin/tmux" <<'SH'
 #!/usr/bin/env bash
 if [ -n "${FM_FAKE_TMUX_LOG:-}" ]; then
@@ -354,38 +346,10 @@ esac
 exit 0
 SH
   chmod +x "$fakebin/tmux"
-  cat > "$fakebin/gh" <<'SH'
-#!/usr/bin/env bash
-exit 0
-SH
-  chmod +x "$fakebin/gh"
-  cat > "$fakebin/treehouse" <<'SH'
-#!/usr/bin/env bash
-if [ "${1:-}" = get ] && [ "${2:-}" = --help ]; then
-  printf '%s\n' 'Usage: treehouse get [--lease]'
-fi
-exit 0
-SH
-  chmod +x "$fakebin/treehouse"
-  cat > "$fakebin/no-mistakes" <<'SH'
-#!/usr/bin/env bash
-if [ "${1:-}" = --version ]; then
-  printf '%s\n' 'no-mistakes version v1.46.0 (fake)'
-  exit 0
-fi
-exit 0
-SH
-  chmod +x "$fakebin/no-mistakes"
-  cat > "$fakebin/tasks-axi" <<'SH'
-#!/usr/bin/env bash
-case "${1:-} ${2:-}" in
-  "--version ") printf '%s\n' '0.2.4' ;;
-  "update --help") printf '%s\n' 'usage: tasks-axi update <id> [flags]' '  --archive-body' ;;
-  "mv --help") printf '%s\n' 'usage: tasks-axi mv <id> [<id>...] --to <path-or-dir>' ;;
-esac
-exit 0
-SH
-  chmod +x "$fakebin/tasks-axi"
+  fm_test_fake_gh "$fakebin"
+  fm_test_fake_treehouse "$fakebin"
+  fm_test_fake_no_mistakes "$fakebin"
+  fm_test_fake_tasks_axi "$fakebin"
   cat > "$fakebin/quota-axi" <<'SH'
 #!/usr/bin/env bash
 if [ "${1:-}" = --version ]; then

--- a/tests/fm-secondmate-sync.test.sh
+++ b/tests/fm-secondmate-sync.test.sh
@@ -736,11 +736,7 @@ test_spawn_fast_forwards_before_launch() {
   # tmux stub: accept every subcommand, print nothing (so no window pre-exists).
   fakebin="$w/fakebin"
   mkdir -p "$fakebin"
-  cat > "$fakebin/tmux" <<'SH'
-#!/usr/bin/env bash
-exit 0
-SH
-  chmod +x "$fakebin/tmux"
+  fm_fake_exit0 "$fakebin" tmux
 
   PATH="$fakebin:$BASE_PATH" TMUX='' \
     FM_ROOT_OVERRIDE="$w/main" FM_HOME="$w/home" \
@@ -770,11 +766,7 @@ test_spawn_warns_when_sync_skipped_before_launch() {
   fakebin="$w/fakebin"
   err="$w/spawn.err"
   mkdir -p "$fakebin"
-  cat > "$fakebin/tmux" <<'SH'
-#!/usr/bin/env bash
-exit 0
-SH
-  chmod +x "$fakebin/tmux"
+  fm_fake_exit0 "$fakebin" tmux
 
   PATH="$fakebin:$BASE_PATH" TMUX='' \
     FM_ROOT_OVERRIDE="$w/main" FM_HOME="$w/home" \

--- a/tests/fm-send-inbox.test.sh
+++ b/tests/fm-send-inbox.test.sh
@@ -77,11 +77,7 @@ esac
 exit 0
 SH
   chmod +x "$fb/tmux"
-  cat > "$fb/sleep" <<'SH'
-#!/usr/bin/env bash
-exit 0
-SH
-  chmod +x "$fb/sleep"
+  fm_fake_exit0 "$fb" sleep
   printf '%s\n' "$fb"
 }
 

--- a/tests/fm-send-remote-delivery.test.sh
+++ b/tests/fm-send-remote-delivery.test.sh
@@ -92,11 +92,7 @@ esac
 exit 0
 SH
   chmod +x "$fb/tmux"
-  cat > "$fb/sleep" <<'SH'
-#!/usr/bin/env bash
-exit 0
-SH
-  chmod +x "$fb/sleep"
+  fm_fake_exit0 "$fb" sleep
   cat > "$fb/fake-ssh" <<'SH'
 #!/usr/bin/env bash
 set -u

--- a/tests/fm-send-resolve-key.test.sh
+++ b/tests/fm-send-resolve-key.test.sh
@@ -79,11 +79,7 @@ esac
 exit 0
 SH
   chmod +x "$fb/tmux"
-  cat > "$fb/sleep" <<'SH'
-#!/usr/bin/env bash
-exit 0
-SH
-  chmod +x "$fb/sleep"
+  fm_fake_exit0 "$fb" sleep
   # Stub ssh transport for the remote-secondmate legs, selected via FM_SSH_BIN.
   # Records the full remote invocation and exits FM_FAKE_SSH_RC (default 0).
   cat > "$fb/fake-ssh" <<'SH'

--- a/tests/fm-send-secondmate-marker.test.sh
+++ b/tests/fm-send-secondmate-marker.test.sh
@@ -64,11 +64,7 @@ esac
 exit 0
 SH
   chmod +x "$fb/tmux"
-  cat > "$fb/sleep" <<'SH'
-#!/usr/bin/env bash
-exit 0
-SH
-  chmod +x "$fb/sleep"
+  fm_fake_exit0 "$fb" sleep
   printf '%s\n' "$fb"
 }
 

--- a/tests/fm-send-strict.test.sh
+++ b/tests/fm-send-strict.test.sh
@@ -77,11 +77,7 @@ case "${1:-} ${2:-}" in
 esac
 SH
   chmod +x "$fb/herdr"
-  cat > "$fb/sleep" <<'SH'
-#!/usr/bin/env bash
-exit 0
-SH
-  chmod +x "$fb/sleep"
+  fm_fake_exit0 "$fb" sleep
   printf '%s\n' "$fb"
 }
 

--- a/tests/fm-session-start.test.sh
+++ b/tests/fm-session-start.test.sh
@@ -31,8 +31,8 @@
 #     compatibility verdict is paid for once per session start
 set -u
 
-# shellcheck source=tests/lib.sh
-. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+# shellcheck source=tests/fixtures.sh
+. "$(dirname "${BASH_SOURCE[0]}")/fixtures.sh"
 # shellcheck source=tests/wake-helpers.sh
 . "$(dirname "${BASH_SOURCE[0]}")/wake-helpers.sh"
 
@@ -73,38 +73,10 @@ make_fake_toolchain() {
   local fakebin=$1
   fm_fake_exit0 "$fakebin" tmux node chrome-devtools-axi
   fm_fake_version_tool "$fakebin" lavish-axi FM_FAKE_LAVISH_AXI_VERSION 0.1.46
-  cat > "$fakebin/gh-axi" <<'SH'
-#!/usr/bin/env bash
-if [ "${1:-}" = --version ]; then
-  printf '%s\n' '0.1.29'
-  exit 0
-fi
-exit 0
-SH
-  chmod +x "$fakebin/gh-axi"
-  cat > "$fakebin/gh" <<'SH'
-#!/usr/bin/env bash
-exit 0
-SH
-  chmod +x "$fakebin/gh"
-  cat > "$fakebin/treehouse" <<'SH'
-#!/usr/bin/env bash
-if [ "${1:-}" = get ] && [ "${2:-}" = --help ]; then
-  printf '%s\n' 'Usage: treehouse get [--lease]'
-  exit 0
-fi
-exit 0
-SH
-  chmod +x "$fakebin/treehouse"
-  cat > "$fakebin/no-mistakes" <<'SH'
-#!/usr/bin/env bash
-if [ "${1:-}" = --version ]; then
-  printf '%s\n' 'no-mistakes version v1.46.0 (fake) 2026-06-27T00:02:18Z'
-  exit 0
-fi
-exit 0
-SH
-  chmod +x "$fakebin/no-mistakes"
+  fm_test_fake_gh_axi "$fakebin"
+  fm_test_fake_gh "$fakebin"
+  fm_test_fake_treehouse "$fakebin"
+  fm_test_fake_no_mistakes "$fakebin"
   printf '%s\n' manual > "${fakebin%/*}/home-placeholder" 2>/dev/null || true
 }
 

--- a/tests/fm-shared-captain-inheritance.test.sh
+++ b/tests/fm-shared-captain-inheritance.test.sh
@@ -5,8 +5,8 @@
 # data/captain.md and data/learnings.md remain domain-local in every home.
 set -u
 
-# shellcheck source=tests/lib.sh
-. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+# shellcheck source=tests/fixtures.sh
+. "$(dirname "${BASH_SOURCE[0]}")/fixtures.sh"
 
 # shellcheck source=/dev/null
 . "$ROOT/bin/fm-config-inherit-lib.sh"
@@ -208,11 +208,7 @@ make_fake_spawn_toolchain() {
   local dir=$1 fakebin
   fakebin="$dir/fakebin"
   mkdir -p "$fakebin"
-  cat > "$fakebin/tmux" <<'SH'
-#!/usr/bin/env bash
-exit 0
-SH
-  chmod +x "$fakebin/tmux"
+  fm_fake_exit0 "$fakebin" tmux
   printf '%s\n' "$fakebin"
 }
 
@@ -221,40 +217,10 @@ add_bootstrap_compatible_tools() {
   local fakebin=$1
   fm_fake_exit0 "$fakebin" node chrome-devtools-axi gh treehouse
   fm_fake_version_tool "$fakebin" lavish-axi FM_FAKE_LAVISH_AXI_VERSION 0.1.46
-  cat > "$fakebin/gh-axi" <<'SH'
-#!/usr/bin/env bash
-if [ "${1:-}" = --version ]; then
-  printf '%s\n' '0.1.29'
-  exit 0
-fi
-exit 0
-SH
-  cat > "$fakebin/no-mistakes" <<'SH'
-#!/usr/bin/env bash
-if [ "${1:-}" = --version ]; then
-  printf '%s\n' 'no-mistakes version v1.46.0 (fake)'
-  exit 0
-fi
-exit 0
-SH
-  cat > "$fakebin/tasks-axi" <<'SH'
-#!/usr/bin/env bash
-case "${1:-} ${2:-}" in
-  "--version ") printf '%s\n' '0.2.4' ;;
-  "update --help") printf '%s\n' 'usage: tasks-axi update <id> [flags]' '  --archive-body' ;;
-  "mv --help") printf '%s\n' 'usage: tasks-axi mv <id> [<id>...] --to <path-or-dir>' ;;
-esac
-exit 0
-SH
-  cat > "$fakebin/quota-axi" <<'SH'
-#!/usr/bin/env bash
-if [ "${1:-}" = --version ]; then
-  printf '%s\n' '0.1.29'
-  exit 0
-fi
-exit 0
-SH
-  chmod +x "$fakebin/gh-axi" "$fakebin/no-mistakes" "$fakebin/tasks-axi" "$fakebin/quota-axi"
+  fm_test_fake_gh_axi "$fakebin"
+  fm_test_fake_no_mistakes "$fakebin"
+  fm_test_fake_tasks_axi "$fakebin"
+  fm_test_fake_quota_axi "$fakebin"
 }
 
 new_git_world() {

--- a/tests/fm-startup-memory-budget.test.sh
+++ b/tests/fm-startup-memory-budget.test.sh
@@ -3,8 +3,8 @@
 # accounting command, primary-to-secondmate convergence, and exact reread bytes.
 set -u
 
-# shellcheck source=tests/lib.sh
-. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+# shellcheck source=tests/fixtures.sh
+. "$(dirname "${BASH_SOURCE[0]}")/fixtures.sh"
 
 BASE_PATH=${FM_TEST_BASE_PATH:-/usr/bin:/bin:/usr/sbin:/sbin}
 TMP_ROOT=$(fm_test_tmproot fm-startup-memory-budget)
@@ -17,13 +17,7 @@ make_fake_toolchain() {
   fakebin=$(fm_fakebin "$dir")
   fm_fake_exit0 "$fakebin" node chrome-devtools-axi
   fm_fake_version_tool "$fakebin" lavish-axi FM_FAKE_LAVISH_AXI_VERSION 0.1.46
-  cat > "$fakebin/gh-axi" <<'SH'
-#!/usr/bin/env bash
-if [ "${1:-}" = --version ]; then
-  printf '%s\n' '0.1.29'
-fi
-exit 0
-SH
+  fm_test_fake_gh_axi "$fakebin"
   cat > "$fakebin/quota-axi" <<'SH'
 #!/usr/bin/env bash
 if [ "${1:-}" = --version ]; then
@@ -31,22 +25,9 @@ if [ "${1:-}" = --version ]; then
 fi
 exit 0
 SH
-  cat > "$fakebin/gh" <<'SH'
-#!/usr/bin/env bash
-exit 0
-SH
-  cat > "$fakebin/treehouse" <<'SH'
-#!/usr/bin/env bash
-if [ "${1:-}" = get ] && [ "${2:-}" = --help ]; then
-  printf '%s\n' 'Usage: treehouse get [--lease]'
-fi
-SH
-  cat > "$fakebin/no-mistakes" <<'SH'
-#!/usr/bin/env bash
-if [ "${1:-}" = --version ]; then
-  printf '%s\n' 'no-mistakes version v1.46.0 (fake)'
-fi
-SH
+  fm_test_fake_gh "$fakebin"
+  fm_test_fake_treehouse "$fakebin"
+  fm_test_fake_no_mistakes "$fakebin"
   cat > "$fakebin/tasks-axi" <<'SH'
 #!/usr/bin/env bash
 case "${1:-}:${2:-}" in

--- a/tests/fm-test-fixtures.test.sh
+++ b/tests/fm-test-fixtures.test.sh
@@ -267,6 +267,34 @@ test_fake_treehouse_and_tasks_axi() {
   pass "fake treehouse and tasks-axi answer the capability helps suites probe"
 }
 
+test_fake_uname_curl_hasher() {
+  local fakebin out log
+  fakebin=$(fm_fakebin "$TMP_ROOT/lint")
+  fm_test_fake_uname "$fakebin"
+  out=$("$fakebin/uname" -s)
+  [ "$out" = Linux ] || fail "fake uname -s should default to Linux, got '$out'"
+  out=$(FM_TEST_UNAME_M=arm64 "$fakebin/uname" -m)
+  [ "$out" = arm64 ] || fail "FM_TEST_UNAME_M should override the machine, got '$out'"
+  log="$TMP_ROOT/lint/curls"
+  : > "$log"
+  fm_test_fake_curl "$fakebin"
+  CURL_COUNT="$log.count" CURL_URL_LOG="$log" "$fakebin/curl" -o "$TMP_ROOT/lint/dl" https://example.test/a
+  expect_code 0 $? "fake curl should succeed by default"
+  assert_grep 'https://example.test/a' "$log" "fake curl did not log its URL"
+  assert_grep '1' "$log.count" "fake curl did not count its call"
+  CURL_COUNT="$log.count" CURL_FAIL_UNTIL=2 "$fakebin/curl" -o "$TMP_ROOT/lint/dl" https://example.test/b; rc=$?
+  expect_code 22 "$rc" "fake curl should fail while under CURL_FAIL_UNTIL"
+  fm_test_fake_hasher "$fakebin" sha256sum
+  out=$(SHA256_STUB_HASH=abc123 "$fakebin/sha256sum" "$log")
+  case "$out" in 'abc123  '*) ;; *) fail "fake hasher should print <hash>  <file>, got '$out'" ;; esac
+  fm_test_fake_hasher "$fakebin" shasum
+  SHA256_STUB_HASH=abc123 "$fakebin/shasum" -a 256 "$log" >/dev/null
+  expect_code 0 $? "fake shasum should accept -a 256"
+  SHA256_STUB_HASH=abc123 "$fakebin/shasum" -a 1 "$log" >/dev/null 2>&1; rc=$?
+  expect_code 1 "$rc" "fake shasum should refuse a non-256 algorithm"
+  pass "fake uname/curl/hasher answer the installer suites' probes"
+}
+
 test_spawn_tmux_and_fakebin() {
   local fakebin out log
   fakebin=$(make_spawn_fakebin "$TMP_ROOT/spawn" gh-axi)
@@ -327,6 +355,7 @@ test_no_mistakes_version_constant
 test_no_mistakes_init_doctor_markers
 test_fake_gh_and_gh_axi
 test_fake_treehouse_and_tasks_axi
+test_fake_uname_curl_hasher
 test_spawn_tmux_and_fakebin
 test_send_stubs_and_ssh
 test_spawn_home_layout

--- a/tests/fm-test-fixtures.test.sh
+++ b/tests/fm-test-fixtures.test.sh
@@ -173,16 +173,16 @@ test_no_mistakes_version_constant() {
   fakebin=$(fm_fakebin "$TMP_ROOT/nm")
   fm_test_fake_no_mistakes "$fakebin"
   out=$("$fakebin/no-mistakes" --version)
-  [ "$out" = "$FM_TEST_NO_MISTAKES_FAKE_VERSION" ] || \
-    fail "fake no-mistakes --version should be the shared constant, got '$out'"
-  out=$(FM_FAKE_NO_MISTAKES_VERSION="$FM_TEST_NO_MISTAKES_FAKE_VERSION_TS" \
-    "$fakebin/no-mistakes" --version)
   [ "$out" = "$FM_TEST_NO_MISTAKES_FAKE_VERSION_TS" ] || \
-    fail "timestamped banner override should round-trip, got '$out'"
+    fail "fake no-mistakes --version should default to the shared timestamped banner, got '$out'"
   case "$out" in
     "$FM_TEST_NO_MISTAKES_FAKE_VERSION "*) ;;
     *) fail "timestamped banner '$out' is not the shared constant plus a suffix" ;;
   esac
+  out=$(FM_FAKE_NO_MISTAKES_VERSION="$FM_TEST_NO_MISTAKES_FAKE_VERSION" \
+    "$fakebin/no-mistakes" --version)
+  [ "$out" = "$FM_TEST_NO_MISTAKES_FAKE_VERSION" ] || \
+    fail "banner override should round-trip, got '$out'"
   out=$(FM_FAKE_NO_MISTAKES_VERSION='no-mistakes version v9.9.9 (fake)' \
     "$fakebin/no-mistakes" --version)
   [ "$out" = 'no-mistakes version v9.9.9 (fake)' ] || \
@@ -213,6 +213,7 @@ test_fake_gh_and_gh_axi() {
   fakebin=$(fm_fakebin "$TMP_ROOT/gh")
   fm_test_fake_gh "$fakebin"
   fm_test_fake_gh_axi "$fakebin"
+  fm_test_fake_quota_axi "$fakebin"
   "$fakebin/gh" auth status
   expect_code 0 $? "fake gh auth status should succeed"
   "$fakebin/gh" pr list
@@ -222,7 +223,48 @@ test_fake_gh_and_gh_axi() {
     fail "fake gh-axi --version should be $FM_TEST_GH_AXI_VERSION, got '$out'"
   out=$(FM_FAKE_GH_AXI_VERSION=0.9.9 "$fakebin/gh-axi" --version)
   [ "$out" = 0.9.9 ] || fail "FM_FAKE_GH_AXI_VERSION should override, got '$out'"
-  pass "fake gh authenticates and fake gh-axi reports the shared version"
+  out=$("$fakebin/quota-axi" --version)
+  [ "$out" = "$FM_TEST_QUOTA_AXI_VERSION" ] || \
+    fail "fake quota-axi --version should be $FM_TEST_QUOTA_AXI_VERSION, got '$out'"
+  out=$(FM_FAKE_QUOTA_AXI_VERSION=0.8.8 "$fakebin/quota-axi" --version)
+  [ "$out" = 0.8.8 ] || fail "FM_FAKE_QUOTA_AXI_VERSION should override, got '$out'"
+  pass "fake gh authenticates; fake gh-axi/quota-axi report the shared version"
+}
+
+test_fake_treehouse_and_tasks_axi() {
+  local fakebin out
+  fakebin=$(fm_fakebin "$TMP_ROOT/caps")
+  fm_test_fake_treehouse "$fakebin"
+  out=$("$fakebin/treehouse" get --help)
+  [ "$out" = 'Usage: treehouse get [--lease]' ] || \
+    fail "default treehouse help should advertise the lease form, got '$out'"
+  out=$(FM_FAKE_TREEHOUSE_LEASE_HELP=1 "$fakebin/treehouse" get --help)
+  [ "$out" = 'Usage: treehouse get [--lease] [--lease-holder <holder>]' ] || \
+    fail "FM_FAKE_TREEHOUSE_LEASE_HELP should switch the lease-holder form, got '$out'"
+  out=$("$fakebin/treehouse" return --force /tmp/wt)
+  expect_code 0 $? "fake treehouse other verbs should exit 0"
+  fm_test_fake_treehouse "$fakebin" 'Usage: treehouse get'
+  out=$("$fakebin/treehouse" get --help)
+  [ "$out" = 'Usage: treehouse get' ] || \
+    fail "a suite's non-lease default usage should be honored, got '$out'"
+  fm_test_fake_tasks_axi "$fakebin"
+  out=$("$fakebin/tasks-axi" --version)
+  [ "$out" = 0.2.4 ] || fail "fake tasks-axi --version should be 0.2.4, got '$out'"
+  out=$("$fakebin/tasks-axi" update --help)
+  assert_contains "$out" '  --body-file <path>' "update help should advertise --body-file"
+  assert_contains "$out" '  --archive-body' "update help should advertise --archive-body"
+  out=$("$fakebin/tasks-axi" mv --help)
+  assert_contains "$out" '[<id>...]' "mv help should advertise the multi-id form"
+  fm_test_fake_tasks_axi "$fakebin" 9.9.9 no no
+  out=$("$fakebin/tasks-axi" --version)
+  [ "$out" = 9.9.9 ] || fail "version override should round-trip, got '$out'"
+  out=$("$fakebin/tasks-axi" update --help)
+  assert_not_contains "$out" '  --archive-body' "archive-body=no must drop the capability line"
+  out=$("$fakebin/tasks-axi" mv --help)
+  assert_not_contains "$out" '[<id>...]' "multi-id=no must drop the multi-id usage"
+  "$fakebin/tasks-axi" hold t1
+  expect_code 0 $? "fake tasks-axi other verbs should exit 0"
+  pass "fake treehouse and tasks-axi answer the capability helps suites probe"
 }
 
 test_spawn_tmux_and_fakebin() {
@@ -284,6 +326,7 @@ test_touch_epoch_preserves_repeated_dst_hour
 test_no_mistakes_version_constant
 test_no_mistakes_init_doctor_markers
 test_fake_gh_and_gh_axi
+test_fake_treehouse_and_tasks_axi
 test_spawn_tmux_and_fakebin
 test_send_stubs_and_ssh
 test_spawn_home_layout

--- a/tests/fm-test-fixtures.test.sh
+++ b/tests/fm-test-fixtures.test.sh
@@ -249,7 +249,8 @@ test_fake_treehouse_and_tasks_axi() {
     fail "a suite's non-lease default usage should be honored, got '$out'"
   fm_test_fake_tasks_axi "$fakebin"
   out=$("$fakebin/tasks-axi" --version)
-  [ "$out" = 0.2.4 ] || fail "fake tasks-axi --version should be 0.2.4, got '$out'"
+  [ "$out" = "$FM_TEST_TASKS_AXI_VERSION" ] || \
+    fail "fake tasks-axi --version should be $FM_TEST_TASKS_AXI_VERSION, got '$out'"
   out=$("$fakebin/tasks-axi" update --help)
   assert_contains "$out" '  --body-file <path>' "update help should advertise --body-file"
   assert_contains "$out" '  --archive-body' "update help should advertise --archive-body"
@@ -268,7 +269,7 @@ test_fake_treehouse_and_tasks_axi() {
 }
 
 test_fake_uname_curl_hasher() {
-  local fakebin out log
+  local fakebin out log rc
   fakebin=$(fm_fakebin "$TMP_ROOT/lint")
   fm_test_fake_uname "$fakebin"
   out=$("$fakebin/uname" -s)
@@ -281,7 +282,8 @@ test_fake_uname_curl_hasher() {
   CURL_COUNT="$log.count" CURL_URL_LOG="$log" "$fakebin/curl" -o "$TMP_ROOT/lint/dl" https://example.test/a
   expect_code 0 $? "fake curl should succeed by default"
   assert_grep 'https://example.test/a' "$log" "fake curl did not log its URL"
-  assert_grep '1' "$log.count" "fake curl did not count its call"
+  [ "$(cat "$log.count")" = 1 ] || \
+    fail "fake curl should have counted exactly 1 call, got '$(cat "$log.count")'"
   CURL_COUNT="$log.count" CURL_FAIL_UNTIL=2 "$fakebin/curl" -o "$TMP_ROOT/lint/dl" https://example.test/b; rc=$?
   expect_code 22 "$rc" "fake curl should fail while under CURL_FAIL_UNTIL"
   fm_test_fake_hasher "$fakebin" sha256sum

--- a/tests/fm-watch-recovery-loop.test.sh
+++ b/tests/fm-watch-recovery-loop.test.sh
@@ -72,11 +72,7 @@ test_unacknowledged_recovery_is_announced_once_per_generation() {
   mkdir -p "$repo/bin" "$home/state" "$home/config" "$fakebin"
   install_pi_watch_extension_fixture "$repo"
   plugin="$repo/.pi/extensions/fm-primary-pi-watch.ts"
-  cat > "$fakebin/tmux" <<'SH'
-#!/usr/bin/env bash
-exit 0
-SH
-  chmod +x "$fakebin/tmux"
+  fm_fake_exit0 "$fakebin" tmux
   cat > "$repo/bin/fm-watch-arm.sh" <<SH
 #!/usr/bin/env bash
 if [ "\${1:-}" = --handling-delivered ]; then

--- a/tests/fm-x-mode.test.sh
+++ b/tests/fm-x-mode.test.sh
@@ -10,8 +10,8 @@
 # band; this suite pins the client logic and the activation contract.
 set -u
 
-# shellcheck source=tests/lib.sh
-. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+# shellcheck source=tests/fixtures.sh
+. "$(dirname "${BASH_SOURCE[0]}")/fixtures.sh"
 
 BASE_PATH=${FM_TEST_BASE_PATH:-/usr/bin:/bin:/usr/sbin:/sbin}
 # The client under test uses the real jq; make it resolvable regardless of where
@@ -785,36 +785,13 @@ test_bootstrap_reports_missing_x_dependency() {
   fakebin=$(fm_fakebin "$home")
   fm_fake_exit0 "$fakebin" tmux node no-mistakes chrome-devtools-axi curl
   fm_fake_version_tool "$fakebin" lavish-axi FM_FAKE_LAVISH_AXI_VERSION 0.1.46
-  cat > "$fakebin/gh-axi" <<'SH'
-#!/usr/bin/env bash
-if [ "${1:-}" = --version ]; then
-  printf '%s\n' '0.1.29'
-  exit 0
-fi
-exit 0
-SH
-  chmod +x "$fakebin/gh-axi"
+  fm_test_fake_gh_axi "$fakebin"
   for tool in dirname grep tail; do
     tool_path=$(command -v "$tool") || fail "test host must provide $tool"
     ln -s "$tool_path" "$fakebin/$tool"
   done
-  cat > "$fakebin/gh" <<'SH'
-#!/usr/bin/env bash
-if [ "${1:-}" = auth ] && [ "${2:-}" = status ]; then
-  exit 0
-fi
-exit 0
-SH
-  chmod +x "$fakebin/gh"
-  cat > "$fakebin/treehouse" <<'SH'
-#!/usr/bin/env bash
-if [ "${1:-}" = get ] && [ "${2:-}" = --help ]; then
-  printf '%s\n' 'Usage: treehouse get [--lease] [--lease-holder <holder>]'
-  exit 0
-fi
-exit 0
-SH
-  chmod +x "$fakebin/treehouse"
+  fm_test_fake_gh "$fakebin"
+  fm_test_fake_treehouse "$fakebin" 'Usage: treehouse get [--lease] [--lease-holder <holder>]'
   printf 'FMX_PAIRING_TOKEN=tok-missing\n' > "$home/.env"
   out=$(PATH="$fakebin" FM_HOME="$home" FM_ROOT_OVERRIDE="$home" \
     "$BASH" "$ROOT/bin/fm-bootstrap.sh" 2>/dev/null)


### PR DESCRIPTION
## Intent

Babysit https://github.com/kunchenguid/firstmate/pull/3795 until Kun merges it. That PR consolidates hand-rolled fake toolchain stubs into shared tests/fixtures.sh builders. Captain (2026-09-16): RETAIN the current published head 5aa33aca with the history breach recorded; old heads stay as tags; no restoration churn. Never force-push. Never merge red. Merge is Kun's.

## What Changed

- Added shared fake-CLI builders to `tests/fixtures.sh`: `fm_test_fake_quota_axi`, `fm_test_fake_treehouse`, `fm_test_fake_tasks_axi` (with capability-help switches), `fm_test_fake_uname`, `fm_test_fake_curl`, `fm_test_fake_hasher`, and `fm_fake_exit0`, plus a timestamped default `--version` banner for the fake no-mistakes stub so suites that pin banners share one canonical form.
- Replaced hand-rolled per-suite stubs (gh, gh-axi, quota-axi, tasks-axi, treehouse, tmux, ssh, sleep, uname, curl, hashers, exit-0 tools) across the bootstrap, secondmate-family, lint, send, session-start, startup-memory-budget, x-mode, and pr-check-security suites with the shared builders; the shared lint installers now come from `fixtures.sh`.
- Refactored `tests/fm-backend-herdr.test.sh` around a single `herdr_run` adapter driver and folded per-function tests into clause matrices (version_check, workspace_label, etc.), trimming the suite by several hundred lines; updated `tests/fm-test-fixtures.test.sh` assertions to cover the new builders.

Net effect is test-infrastructure-only (-1268/+667 lines): one source of truth for fake toolchains, no production code touched.

## Risk Assessment

✅ Low: A well-bounded tests-only refactor with behavioral parity verified at every consumer boundary; the two findings are informational latent-fragility and partial-dedup notes with no reachable failure today.

## Testing

Ran the 21 test suites affected by the shared-fixture consolidation via the project's own runner (all passed) plus the fixtures behavior suite, and produced behavioral evidence that a stub built by the consolidated fm_test_fake_tasks_axi builder is correctly consumed by the real production capability gate in bin/fm-tasks-axi-lib.sh (passes full-capability, refuses reduced-capability); no failures, no setup fixes needed, worktree left clean.

<details>
<summary>Evidence: Full run of the 21 consolidated suites (21/21 passed, 0 failed, 0 gate-skipped)</summary>

Source: [Full run of the 21 consolidated suites (21/21 passed, 0 failed, 0 gate-skipped)](https://github.com/RooseveltAdvisors/firstmate/blob/7805533b0e27b3bc14568ff59e6b0375922a650d/.no-mistakes/evidence/fm/fm-ponytail-r1-tests-20260905-v2/consolidated-suites-run.log)

```text
FM_TEST_BEGIN 2026-09-16T04:02:09Z tests/fm-backend-herdr.test.sh family=backend-dispatch expected_gate_skip=none
FM_TEST_BEGIN 2026-09-16T04:02:09Z tests/fm-lint.test.sh family=pure-contract-unit expected_gate_skip=none
FM_TEST_BEGIN 2026-09-16T04:02:09Z tests/fm-send-strict.test.sh family=backend-dispatch expected_gate_skip=none
FM_TEST_BEGIN 2026-09-16T04:02:09Z tests/fm-x-mode.test.sh family=pr-forge expected_gate_skip=none
ok - fm-send strict: exact task/lane ids resolve through home metadata
ok - fm-send --key: exit status follows delivery, and an undelivered key never reports success
ok - fm-send strict: unset FM_HOME fails before target resolution
ok - fm-send strict: unresolvable selectors do not fall back to tmux
ok - fm-send strict: prefixless herdr pane ids are rejected before tmux fallback
ok - fm-send strict: unmatched single-colon explicit targets must verify live before sending
ok - fm-send strict: fm-prefixed Herdr sessions remain explicit backend targets
ok - fm-send strict: healthy fm-<id> sends record the steer and ring once
FM_TEST_END 2026-09-16T04:02:13Z tests/fm-send-strict.test.sh exit=0 duration_ms=4346 gate_skip=false
ok - fm_backend_herdr_version_check: accepts current protocol, refuses old and missing
ok - fm_backend_herdr_workspace_label: primary/secondmate/trim/empty clauses and no cross-home collision
ok - fm_backend_herdr_cli: sets HERDR_SESSION AND appends a trailing --session flag on every call
ok - herdr client selection: a live pane behind a stale shadowing client reads alive
ok - herdr recovery-grade read: a stopped server means missing there, and nowhere else
ok - herdr stale registration: a shell-only pane with a lingering Pi record is agent-free with an explicit reason
ok - herdr stale registration: no registered status can outrank a shell-only process view
ok - herdr stale registration: a registered agent with a live Pi foreground process still reads alive
ok - herdr stale registration: only a shell-only pane demotes a registration
ok - herdr stale registration: a transient prompt helper settles into stale-agent instead of reading live
ok - herdr stale registration: an exhausted settle window still reads a non-shell foreground as live
Terminated
ok - herdr stale registration: an agent process outside the foreground group still counts as alive
Terminated
ok - herdr stale registration: the descendant walk reads a spaced executable path whole
ok - herdr stale registration: an unreadable process view refuses instead of guessing either way
ok - herdr stale registration: an empty foreground list over a real shell is not unreadable, it settles via the descendant walk
ok - herdr stale registration: presentation reclaim never closes a stale-registration pane
ok - herdr stale registration: busy_state proves a working record at process level before reporting busy
ok - herdr client selection: one selected client is reused per process
ok - herdr client selection: selected clients remain scoped to their session
ok - herdr client selection: only protocol_mismatch triggers reselection; other failures pass through untouched
ok - herdr client selection: the happy path makes no extra call
ok - herdr client status: .server.compatible, legacy protocol equality, unknown, and stopped shapes all normalize
ok - fm_backend_herdr_launcher_identity: a firstmate not running inside herdr has no launcher workspace to inherit
ok - fm_backend_herdr_launcher_identity: HERDR_ENV=1 without a pane id selects the backend but binds no parent
ok - fm_backend_herdr_launcher_identity: resolves the launcher's exact workspace even when a same-labeled workspace sorts first
ok - fm_backend_herdr_launcher_identity: refuses a launcher pane that names a different herdr session
ok - fm_backend_herdr_launcher_identity: refuses a claimed pane without exact server identity
ok - fm_backend_herdr_launcher_identity: refuses a launcher pane whose injected socket belongs to another herdr server
ok - fm_backend_herdr_launcher_identity: refuses when the launcher's own pane no longer resolves
ok - fm_backend_herdr_launcher_identity: refuses when the launcher's pane and tab disagree about their workspace
ok - fm_backend_herdr_launcher_identity: refuses when the launcher's workspace is gone from its own session
ok - fm_backend_herdr_workspace_ensure: places a worker in the launcher's exact workspace, not the first same-labeled one
ok - fm_backend_herdr_workspace_ensure: refuses to guess between two same-labeled home workspaces
ok - fm_backend_herdr_workspace_ensure: a --secondmate container resolves that home's own workspace, not the launcher's
ok - fm_backend_herdr_container_ensure: surfaces the exact ambiguous-placement refusal instead of a generic failure
ok - fm_backend_herdr_container_ensure: version-gates, starts the server, ensures the firstmate workspace, echoes session:workspace_id + the seeded default tab id
ok - fm_backend_herdr_server_ensure: scrubs home and harness identity without disturbing unrelated environment or session routing
ok - fm_backend_herdr_container_ensure: reuses an existing firstmate workspace without recreating it, and reports no seeded default tab (adopted, not created)
ok - fm_backend_herdr_container_ensure: workspace create passes --no-focus
ok - fm_backend_herdr_container_ensure: creates the workspace under the SECONDMATE home's own label, not 'firstmate'
ok - fm_backend_herdr_create_task: prunes exactly the seeded default tab container_ensure identified, once the first real task tab exists
ok - herdr repeated spawn/teardown: one persistent firstmate workspace reused, zero orphans, default tab pruned, create ran once
ok - fm_backend_herdr_create_task: an ADOPTED workspace's pre-existing tab is never pruned (the created-vs-adopted gate)
ok - fm_backend_herdr_create_task: the label-collision startup-workspace scenario (2026-07-02 incident) leaves the captain's live tab untouched
ok - fm_backend_herdr_workspace_prune_seeded_default_tab: refuses to close the seeded default tab when its pane reports a working agent (defense in depth)
ok - fm_backend_herdr_create_task: refuses a duplicate tab label (herdr's own tab create has no uniqueness check)
ok - fm_backend_herdr_create_task: a same-labeled tab with a live (even idle) registered agent still refuses exactly as before
ok - fm_backend_herdr_create_task: scans every same-labeled tab and refuses if any duplicate is live
ok - fm_backend_herdr_create_task: closes and replaces a same-labeled tab whose pane is dead (pane_not_found)
ok - fm_backend_herdr_create_task: closes and replaces a same-labeled tab whose pane is alive but hosts no registered agent (a restored plain shell)
ok - fm_backend_herdr_create_task: closes every confirmed same-labeled husk only after creating the replacement
ok - fm_backend_herdr_create_task: refuses success when a preexisting husk tab remains after replacement
ok - fm_backend_herdr_create_task: refuses (fail-safe) rather than guessing when the duplicate's agent state cannot be classified confidently
ok - fm_backend_herdr_create_task: creates the replacement tab BEFORE closing the husk tab, never the reverse
ok - fm_backend_herdr_create_task: creates a tab and parses tab_id/pane_id from the JSON response, prunes nothing when no seeded tab id is given
ok - fm_backend_herdr_create_task: tab create passes --no-focus
ok - herdr presentation: a home that set nothing gets the projection by default at or above the floor
ok - herdr presentation: an unconfigured home below the floor falls back flat with one naming warning
ok - herdr presentation: an unreadable client release falls back flat instead of guessing
ok - herdr presentation: a deliberate opt-in is never silently downgraded below the floor
ok - herdr presentation: an explicit off opts the home out
ok - herdr presentation: an unrecognized value warns and follows the default instead of failing a spawn
ok - herdr presentation: the below-floor warning is one per home per release, not one per spawn
ok - herdr presentation: warning marker publication is atomic, symlink-safe, and fails visible
ok - herdr presentation: client and selected server floors compose conservatively without overriding explicit opt-in
o

... [69572 bytes truncated] ...

e path creates pending and embeds corr
ok - status-pointed document resolves the expectation
ok - optional helper report resolves without being required for correctness
ok - backend busy/idle observation covers Pi/Claude paths without conversation scrape
ok - tmux and zellij unknown states use bounded capture fallback
ok - pending replies scope Kimi capture fallback by recorded harness
ok - tick skips terminal records and reuses target observations
ok - correlations are reused only for matching open task records
ok - tick end-to-end: miss -> one recovery -> escalate -> durable
ok - failed transport discards undelivered expectation only
ok - a remote repost waits for the reply channel and still fires on a real miss
ok - a mirrored correlated remote reply resolves without any repost
ok - same-basename self-home corr= is restated onto the parent channel and resolves
ok - same-basename reply resolves at the recovery failure boundary
ok - a child-file mate-home sighting is not copied and still escalates
ok - mechanical helper writes the parent channel from verb, corr, and note
ok - remote parent-replies.status is not classified as wrong-home
ok - local parent-replies.status remains wrong-home evidence
ok - an escalated correlation stays retryable only while undelivered
ok - all pending-reply tests passed
FM_TEST_END 2026-09-16T04:10:11Z tests/fm-pending-reply.test.sh exit=0 duration_ms=15225 gate_skip=false
ok - fm-send remote: a text steer lands as a durable remote inbox record and exits 0 at enqueue
ok - fm-send remote: the printed correlation-reusing resend deduplicates onto the same record
ok - fm-send remote: a failed retry cannot erase an earlier ambiguous delivery
ok - fm-send remote: fire-and-forget delivery is idempotent without reply recovery
ok - remote control: send revalidates endpoint ownership under the metadata lock
ok - fm-send remote: enqueue revalidates the parent route under its metadata lock
ok - fm-send remote: expected host is enforced by final route validation
ok - fm-send remote: a --resolve-key answer closes its decision at enqueue
ok - fm-send remote: every remote text, harness-native included, rides the inbox
ok - fm-send remote: a real remote failure still fails loudly with the remote diagnostics
ok - fm-send remote: exit 3 from the remote leg is a failure, never a delivery claim
ok - fm-send remote: ssh 255 fails with resend-safe guidance and preserves the expectation
ok - fm-send remote: the remote leg is budget-bounded and stays idempotent across the bound
ok - fm-send local: an unconfirmed submit exits 3 with an honest non-error report
ok - fm-send local: an unconfirmed submit still never closes a --resolve-key decision
ok - fm-send local: an unconfirmed secondmate send keeps its reply expectation armed
all fm-send-remote-delivery tests passed
FM_TEST_END 2026-09-16T04:10:18Z tests/fm-send-remote-delivery.test.sh exit=0 duration_ms=22305 gate_skip=false
FM_TEST_BEGIN 2026-09-16T04:10:18Z tests/fm-send-inbox.test.sh family=backend-dispatch expected_gate_skip=none
ok - fm-send inbox: the payload is recorded durably and only the doorbell is typed
ok - fm-send inbox: newlines are legal and the terminal can no longer truncate a steer
ok - fm-send inbox: a re-send is a new durable record, never a retyped payload
ok - fm-send inbox: a visibly pending composer skips the ring, and the steer stays durably sent
ok - fm-send inbox: a failed doorbell is still a durably sent steer
ok - fm-send planes: slash and codex $skill invocations stay typed; plain $-text rides the inbox
ok - fm-send planes: an explicit backend target keeps the typed plane
ok - fm-send planes: the --key lifecycle path never touches the inbox
ok - fm-send inbox: a secondmate steer records marker+corr in the body and is delivered at enqueue
ok - fm-send inbox: lost reply bookkeeping never invites a resend, and the delivered steer is never duplicated
ok - fm-send inbox: metadata lock contention fails bounded without enqueue
ok - fm-send inbox: an unwritable record is a loud local failure that leaves no false expectation
ok - fm-send: an empty or whitespace-only text steer refuses before marking, recording, or typing
FM_TEST_END 2026-09-16T04:10:57Z tests/fm-send-inbox.test.sh exit=0 duration_ms=39081 gate_skip=false
FM_TEST_BEGIN 2026-09-16T04:10:57Z tests/fm-send-resolve-key.test.sh family=backend-dispatch expected_gate_skip=none
ok - fm-send --resolve-key: the answer send itself closes the open decision
ok - fm-send --resolve-key: the close never re-wakes its own home, later lines still do
ok - fm-send --resolve-key: a colon-first stated key is open under that key and answerable
ok - fm-send --resolve-key: an answer that starts a workstream leaves no orphaned decision
ok - fm-send: a send without --resolve-key never closes a decision, and working/done still cannot
ok - fm-send --resolve-key: a key that is not open refuses loudly before anything is sent
ok - fm-send --resolve-key: the close happens at enqueue, surviving a failed doorbell
ok - fm-send --resolve-key: a failed enqueue never closes the decision
ok - fm-send --resolve-key: one answer closes each named key and only those
ok - fm-send --resolve-key: a marked local-secondmate answer closes with the plain answer text
ok - fm-send --resolve-key: a remote-secondmate answer closes the same local ledger, transport-only difference
ok - fm-send --resolve-key: a remote reply's leading [corr=...] tag no longer blocks closing its stated key
ok - fm-send --resolve-key: a failed remote transport never closes the decision
ok - fm-send --resolve-key: --key, empty message, explicit targets, and malformed keys refuse loudly
ok - fm-send --resolve-key: a reserved pending-reply key actually closes through the operator path
ok - fm-send --resolve-key: an unrelated writer cannot close or hijack a reserved key, and the operator close still can
ok - fm-send --resolve-key: a reserved key this send cannot close refuses loudly before anything is sent
ok - fm-send --resolve-key: an overlong decision key refuses before sending
ok - fm-send --resolve-key: failed-close recovery commands safely quote operator text and paths
ok - fm-send --resolve-key: a remote secondmate reserved-key close is the same local ledger append
FM_TEST_END 2026-09-16T04:11:24Z tests/fm-send-resolve-key.test.sh exit=0 duration_ms=26627 gate_skip=false
FM_TEST_SUMMARY total=21 failed=0 skipped_gate=0 duration_ms=555368
FM_TEST_SUMMARY_FAMILY family=backend-dispatch count=4 duration_ms=85071 failed=0
FM_TEST_SUMMARY_FAMILY family=pr-forge count=2 duration_ms=110566 failed=0
FM_TEST_SUMMARY_FAMILY family=pure-contract-unit count=2 duration_ms=72880 failed=0
FM_TEST_SUMMARY_FAMILY family=secondmate count=7 duration_ms=207779 failed=0
FM_TEST_SUMMARY_FAMILY family=session-bootstrap count=2 duration_ms=128690 failed=0
FM_TEST_SUMMARY_FAMILY family=standalone count=3 duration_ms=38624 failed=0
FM_TEST_SUMMARY_FAMILY family=watcher-wake-lock count=1 duration_ms=57279 failed=0
FM_TEST_SLOWEST rank=1 script=tests/fm-secondmate-harness.test.sh duration_ms=133018
FM_TEST_SLOWEST rank=2 script=tests/fm-session-start.test.sh duration_ms=108226
FM_TEST_SLOWEST rank=3 script=tests/fm-pr-check-security.test.sh duration_ms=95546
FM_TEST_SLOWEST rank=4 script=tests/fm-lint.test.sh duration_ms=72562
FM_TEST_SLOWEST rank=5 script=tests/fm-watch-recovery-loop.test.sh duration_ms=57279
FM_TEST_SLOWEST rank=6 script=tests/fm-secondmate-sync.test.sh duration_ms=44635
FM_TEST_SLOWEST rank=7 script=tests/fm-send-inbox.test.sh duration_ms=39081
FM_TEST_SLOWEST rank=8 script=tests/fm-send-resolve-key.test.sh duration_ms=26627
FM_TEST_SLOWEST rank=9 script=tests/fm-send-remote-delivery.test.sh duration_ms=22305
FM_TEST_SLOWEST rank=10 script=tests/fm-bootstrap.test.sh duration_ms=20464
FM_TEST_SLOWEST rank=11 script=tests/fm-pending-reply.test.sh duration_ms=15225
FM_TEST_SLOWEST rank=12 script=tests/fm-x-mode.test.sh duration_ms=15020
FM_TEST_SLOWEST rank=13 script=tests/fm-backend-herdr.test.sh duration_ms=15017
FM_TEST_SLOWEST rank=14 script=tests/fm-remote-doctor.test.sh duration_ms=8394
FM_TEST_SLOWEST rank=15 script=tests/fm-startup-memory-budget.test.sh duration_ms=6050
```
</details>
<details>
<summary>Evidence: Focused fixtures behavior-suite run (tests/fm-test-fixtures.test.sh)</summary>

Source: [Focused fixtures behavior-suite run (tests/fm-test-fixtures.test.sh)](https://github.com/RooseveltAdvisors/firstmate/blob/7805533b0e27b3bc14568ff59e6b0375922a650d/.no-mistakes/evidence/fm/fm-ponytail-r1-tests-20260905-v2/fixtures-run.log)

```text
FM_TEST_BEGIN 2026-09-16T04:00:46Z tests/fm-test-fixtures.test.sh family=standalone expected_gate_skip=none
ok - runner and shared helpers isolate host Git config and preserve explicit config and outside commits
ok - fm_touch_epoch preserves both epochs in the repeated DST hour
ok - fake no-mistakes --version is the shared constant and overridable
ok - init/doctor no-mistakes stub touches markers and refuses other verbs
ok - fake gh authenticates; fake gh-axi/quota-axi report the shared version
ok - fake treehouse and tasks-axi answer the capability helps suites probe
ok - fake uname/curl/hasher answer the installer suites' probes
ok - spawn fakebin answers pane path, logs -l payloads, and installs extra tools
ok - send stubs log typed text and fake ssh records argv with a controllable exit
ok - spawn-home layout writes harness pin, beat, and brief
FM_TEST_END 2026-09-16T04:00:47Z tests/fm-test-fixtures.test.sh exit=0 duration_ms=1133 gate_skip=false
FM_TEST_SUMMARY total=1 failed=0 skipped_gate=0 duration_ms=1167
FM_TEST_SUMMARY_FAMILY family=standalone count=1 duration_ms=1133 failed=0
FM_TEST_SLOWEST rank=1 script=tests/fm-test-fixtures.test.sh duration_ms=1133
fm-test-run: wrote timing artifact: ~/.no-mistakes/evidence/01M2M512ZDBVX2D24JRZH07AMT/fixtures-run.json
```
</details>
<details>
<summary>Evidence: fm-test-run.sh timing JSON artifact for the fixtures suite</summary>

Source: [fm-test-run.sh timing JSON artifact for the fixtures suite](https://github.com/RooseveltAdvisors/firstmate/blob/7805533b0e27b3bc14568ff59e6b0375922a650d/.no-mistakes/evidence/fm/fm-ponytail-r1-tests-20260905-v2/fixtures-run.json)

```text
{
  "families": [
    {
      "count": 1,
      "duration_ms": 1133,
      "failed": 0,
      "name": "standalone"
    }
  ],
  "finished_at": "2026-09-16T04:00:47Z",
  "run_id": "fm-test-run-1789531246502-1898762",
  "scripts": [
    {
      "duration_ms": 1133,
      "exit": 0,
      "expected_gate_skip": "none",
      "family": "standalone",
      "gate_skip": false,
      "gate_skip_reason": "",
      "path": "tests/fm-test-fixtures.test.sh"
    }
  ],
  "selection": "scripts;jobs=1",
  "started_at": "2026-09-16T04:00:46Z",
  "summary": {
    "duration_ms": 1167,
    "failed": 0,
    "skipped_gate": 0,
    "total": 1
  }
}
```
</details>
<details>
<summary>Evidence: Shared fm_test_fake_tasks_axi stub driven end-to-end against the real production gate (bin/fm-tasks-axi-lib.sh)</summary>

Source: [Shared fm_test_fake_tasks_axi stub driven end-to-end against the real production gate (bin/fm-tasks-axi-lib.sh)](https://github.com/RooseveltAdvisors/firstmate/blob/7805533b0e27b3bc14568ff59e6b0375922a650d/.no-mistakes/evidence/fm/fm-ponytail-r1-tests-20260905-v2/shared-tasks-axi-stub-vs-real-gate.log)

<code>full-capability shared stub: real gate PASSES&#10;reduced-capability shared stub: real gate REFUSES (observes capability helps)&#10;shared stub --version -&gt; 0.2.4</code>

```text
full-capability shared stub: real gate PASSES
reduced-capability shared stub: real gate REFUSES (observes capability helps)
shared stub --version -> 0.2.4
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"e26998943fe1d9924101b5aa6eaf85e37b9dd43a","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"skipped"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>⏭️ **Rebase** - skipped</summary>

Step was skipped.
</details>

<details>
<summary>⚠️ **Review** - 2 infos</summary>

- ℹ️ `tests/fm-backend-herdr.test.sh:93` - herdr_run&#39;s leading-K=V detection ([ &#34;${1#*=}&#34; != &#34;$1&#34; ]) treats ANY argument containing &#39;=&#39; as an environment assignment, so a future adapter argument whose value contains &#39;=&#39; (e.g. send-text content like &#39;a=b&#39; or a label with &#39;=&#39;) would be silently routed into env instead of reaching the adapter function&#39;s args. All 121 current call sites pass only &#39;=&#39;-free positional args (pane ids, labels, paths, keys like HERDR_SOCKET_PATH=/tmp/...), so no reachable failure exists today; a stricter pattern (e.g. match ^[A-Za-z_][A-Za-z0-9_]*=) would remove the latent trap.
- ℹ️ `tests/fm-backend-herdr.test.sh:376` - The commit message claims the suite is driven through &#39;one herdr_run adapter driver&#39;, but 28 call sites still hand-roll fb=$(make_herdr_fakebin ...) plus PATH/FM_HERDR_LOG/FM_HERDR_RESPONSES wiring (mostly inside nested helper functions and multi-clause aggregate tests). Behavior is identical and the sites are all still live (fb is used), so this is an incomplete-dedup note, not a defect.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`bin/fm-test-run.sh` over the 21 suites touched by the consolidation (fm-test-fixtures, fm-backend-herdr, fm-bootstrap, fm-lint, fm-lint-workflows, fm-pending-reply, fm-pr-check-security, fm-remote-doctor, fm-secondmate-harness/liveness/sync, fm-send-inbox/remote-delivery/resolve-key/secondmate-marker/strict, fm-session-start, fm-shared-captain-inheritance, fm-startup-memory-budget, fm-watch-recovery-loop, fm-x-mode) — 21/21 passed, no gate skips</code>
- <code>`bin/fm-test-run.sh tests/fm-test-fixtures.test.sh` — the fixtures behavior suite (asserts on stub output/exit/filesystem effects, per its header) passed, covering the new shared builders fake no-mistakes, gh/gh-axi/quota-axi, treehouse, tasks-axi, uname/curl/hasher, and spawn/send stubs</code>
- <code>Manual end-to-end demo: built a fakebin via the shared `fm_test_fake_tasks_axi` builder and drove the real consumer `bin/fm-tasks-axi-lib.sh` `fm_tasks_axi_compatible_probe` against it — full-capability stub passes the real gate, reduced-capability (no --archive-body, single-id mv) stub refuses it, and `tasks-axi --version` returns the shared constant</code>
- <code>`git status --porcelain` after all runs — worktree clean, no transient artifacts left in the tree</code>
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
