### PR TITLE
fix(bin): scope the worker role contract for ship and scout launches

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,8 @@
 # Firstmate
 
+This is the supervisor contract for primary firstmates and persistent secondmates.
+An explicitly assigned ship or scout worker follows its launch brief's worker role instead of this contract, including when its task copy is Firstmate itself; merely storing a brief in a home does not select that role.
+
 You are the first mate.
 The user is the captain.
 This file is your entire job description.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 # Firstmate
 
 This is the supervisor contract for primary firstmates and persistent secondmates.
-An explicitly assigned ship or scout worker follows its launch brief's worker role instead of this contract, including when its task copy is Firstmate itself; merely storing a brief in a home does not select that role.
+Merely storing a ship or scout brief in a home does not select the worker role for the agent running here.
 
 You are the first mate.
 The user is the captain.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,7 +35,7 @@ See the [no-mistakes quick start](https://kunchenguid.github.io/no-mistakes/star
 ## Repo conventions
 
 - This repo is a template for running a firstmate orchestrator agent.
-  `AGENTS.md` is the agent's main job description and names when to load bundled firstmate skills; `CLAUDE.md` is a real `@AGENTS.md` pointer to it, and `.claude/skills` is a symlink to `.agents/skills`.
+  [`AGENTS.md`](AGENTS.md) owns the supervisor contract, role boundary, and bundled firstmate skill triggers; `CLAUDE.md` is a real `@AGENTS.md` pointer to it, and `.claude/skills` is a symlink to `.agents/skills`.
 - Only shared material is tracked: `AGENTS.md`, `README.md`, `CONTRIBUTING.md`, `.tasks.toml`, `.github/workflows/`, `bin/`, `.agents/skills/`, and `skills/`.
   `.agents/skills/` holds agent-loaded skills that assume a live firstmate home and carry `metadata.internal: true` so installers such as [skills.sh](https://skills.sh) hide them from discovery; `skills/` holds standalone, installer-facing public skills with no firstmate dependency (see the README's "Two-tier skill layout").
   Everything personal to one captain's fleet (`.env`, `data/`, `state/`, `config/`, `projects/`, `.no-mistakes/`) is gitignored; never commit it.

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ firstmate is not a model, not a harness, not a skill, not an MCP server, and not
 firstmate is an agent distro for running a crew of agents.
 An agent distro is a portable directory of instructions, skills, tooling, policies, and state conventions that turns a general-purpose agent into a specialized one.
 There is no app to install: the cloned repo is the distro - `AGENTS.md`, bundled firstmate skills, and helper scripts that any terminal coding agent can follow.
-Launching a supported harness inside it instantiates your first mate - and makes you the captain.
+Launching a supported harness inside it for your primary session instantiates your first mate - and makes you the captain.
 
 ## Features
 
@@ -219,7 +219,7 @@ Firstmate's skills live in two separate places with different audiences:
 - [docs/supervision-protocols/](docs/supervision-protocols/) - rendered primary-harness watcher protocols for Claude, Codex, OpenCode, Pi and `pi-signed`, Grok, Cursor, and unknown harness fallback.
 - [docs/scripts.md](docs/scripts.md) - the `bin/` toolbelt reference.
 - [docs/documentation-audiences.md](docs/documentation-audiences.md) - documentation audiences and the machine-checked placement boundary.
-- [`AGENTS.md`](AGENTS.md) - the distro's always-loaded operating contract and routing index for conditional procedures.
+- [`AGENTS.md`](AGENTS.md) - the supervisor contract, role boundary, and routing index for conditional procedures.
 - [CONTRIBUTING.md](CONTRIBUTING.md) - how to contribute, including the dev/test commands.
 
 ## Contributing

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -64,6 +64,8 @@
 # it carries the AGENTS.md authoring bar (widely useful knowledge only, pointers
 # over copied detail) and defers self-governance recognition and insertion to
 # fm-ensure-agents-md.sh's contract.
+# Ship/scout role scope comes from fm_brief_worker_role in fm-dod-lib.sh;
+# its Firstmate-only exception does not change other projects' instructions.
 # Refuses to overwrite an existing brief.
 set -eu
 
@@ -307,6 +309,7 @@ exit 0
 fi
 
 REPO=${POS[1]}
+WORKER_ROLE=$(fm_brief_worker_role)
 
 if [ "$HERDR_LAB" -eq 1 ]; then
 HERDR_LAB_HELPER=$(shell_quote "$FM_ROOT/bin/fm-herdr-lab.sh")
@@ -353,6 +356,8 @@ TASK_SECTION=${TASK_SECTION%$'\n'}
 if [ "$KIND" = scout ]; then
 cat > "$BRIEF" <<EOF
 You are a crewmate: an autonomous worker agent managed by firstmate. Work on your own; do not wait for a human.
+
+$WORKER_ROLE
 
 $TASK_SECTION
 
@@ -428,6 +433,8 @@ DOD=$(fm_dod_block "$MODE" "$ID") || exit 1
 
 cat > "$BRIEF" <<EOF
 You are a crewmate: an autonomous worker agent managed by firstmate. Work on your own; do not wait for a human.
+
+$WORKER_ROLE
 
 $TASK_SECTION
 

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -64,8 +64,9 @@
 # it carries the AGENTS.md authoring bar (widely useful knowledge only, pointers
 # over copied detail) and defers self-governance recognition and insertion to
 # fm-ensure-agents-md.sh's contract.
-# Ship/scout role scope comes from fm_brief_worker_role in fm-dod-lib.sh;
-# its Firstmate-only exception does not change other projects' instructions.
+# Scaffolds carry no role scope: fm-spawn.sh supplies fm_brief_worker_role from
+# fm-dod-lib.sh to every ship/scout launch brief, so this file never becomes a
+# second owner of a contract that must stay current across relaunches.
 # Refuses to overwrite an existing brief.
 set -eu
 
@@ -309,7 +310,6 @@ exit 0
 fi
 
 REPO=${POS[1]}
-WORKER_ROLE=$(fm_brief_worker_role)
 
 if [ "$HERDR_LAB" -eq 1 ]; then
 HERDR_LAB_HELPER=$(shell_quote "$FM_ROOT/bin/fm-herdr-lab.sh")
@@ -356,8 +356,6 @@ TASK_SECTION=${TASK_SECTION%$'\n'}
 if [ "$KIND" = scout ]; then
 cat > "$BRIEF" <<EOF
 You are a crewmate: an autonomous worker agent managed by firstmate. Work on your own; do not wait for a human.
-
-$WORKER_ROLE
 
 $TASK_SECTION
 
@@ -433,8 +431,6 @@ DOD=$(fm_dod_block "$MODE" "$ID") || exit 1
 
 cat > "$BRIEF" <<EOF
 You are a crewmate: an autonomous worker agent managed by firstmate. Work on your own; do not wait for a human.
-
-$WORKER_ROLE
 
 $TASK_SECTION
 

--- a/bin/fm-dod-lib.sh
+++ b/bin/fm-dod-lib.sh
@@ -25,13 +25,13 @@
 # fm_brief_worker_role owns the ship/scout role scope. bin/fm-spawn.sh is its one
 # emitter, supplying it to every ship/scout launch brief and never to a
 # secondmate charter. Like fm_brief_intent_overlay it is a distinctly titled
-# launch section that states its own precedence, so a brief that authors its own
-# role wording is superseded rather than duplicated.
+# launch section that states its own precedence for Firstmate tasks, so a brief
+# that authors its own role wording is superseded rather than duplicated.
 
 fm_brief_worker_role() {
   cat <<'EOF'
 # Current worker role contract
-This section supersedes every earlier brief instruction about your role and identity.
+When this task works on Firstmate itself, this section supersedes every earlier brief instruction about your role and identity.
 When this task works on Firstmate itself, the repository root `AGENTS.md` (also imported by `CLAUDE.md`) is the primary/secondmate supervisor's contract: follow this brief instead of that supervisor contract.
 For that Firstmate task, do the assigned work yourself and report to firstmate; do not adopt the supervisor identity, delegate the task, run fleet supervision, or address the captain.
 This exception preserves this brief's safety and authority boundaries and applicable contributor guidance, including `CONTRIBUTING.md` and `firstmate-coding-guidelines` for Firstmate changes.

--- a/bin/fm-dod-lib.sh
+++ b/bin/fm-dod-lib.sh
@@ -22,6 +22,18 @@
 # restating the rule.
 # Every heredoc here stays outside a command substitution: `VAR=$(cat <<EOF ...)`
 # breaks parsing of the whole file on Bash 3.2 (tests/fm-brief.test.sh).
+# fm_brief_worker_role owns the ship/scout role scope, emitted by fm-brief.sh
+# and supplied to legacy worker briefs by fm-spawn.sh, never to secondmates.
+
+fm_brief_worker_role() {
+  cat <<'EOF'
+# Worker role
+When this task works on Firstmate itself, the repository root `AGENTS.md` (also imported by `CLAUDE.md`) is the primary/secondmate supervisor's contract: follow this brief instead of that supervisor contract.
+For that Firstmate task, do the assigned work yourself and report to firstmate; do not adopt the supervisor identity, delegate the task, run fleet supervision, or address the captain.
+This exception preserves this brief's safety and authority boundaries and applicable contributor guidance, including `CONTRIBUTING.md` and `firstmate-coding-guidelines` for Firstmate changes.
+Other projects retain their own instructions unchanged.
+EOF
+}
 
 # Return 0 when a Task subsection still consists only of its scaffold
 # placeholder. A missing file and legacy briefs carry no such placeholders.

--- a/bin/fm-dod-lib.sh
+++ b/bin/fm-dod-lib.sh
@@ -22,12 +22,16 @@
 # restating the rule.
 # Every heredoc here stays outside a command substitution: `VAR=$(cat <<EOF ...)`
 # breaks parsing of the whole file on Bash 3.2 (tests/fm-brief.test.sh).
-# fm_brief_worker_role owns the ship/scout role scope, emitted by fm-brief.sh
-# and supplied to legacy worker briefs by fm-spawn.sh, never to secondmates.
+# fm_brief_worker_role owns the ship/scout role scope. bin/fm-spawn.sh is its one
+# emitter, supplying it to every ship/scout launch brief and never to a
+# secondmate charter. Like fm_brief_intent_overlay it is a distinctly titled
+# launch section that states its own precedence, so a brief that authors its own
+# role wording is superseded rather than duplicated.
 
 fm_brief_worker_role() {
   cat <<'EOF'
-# Worker role
+# Current worker role contract
+This section supersedes every earlier brief instruction about your role and identity.
 When this task works on Firstmate itself, the repository root `AGENTS.md` (also imported by `CLAUDE.md`) is the primary/secondmate supervisor's contract: follow this brief instead of that supervisor contract.
 For that Firstmate task, do the assigned work yourself and report to firstmate; do not adopt the supervisor identity, delegate the task, run fleet supervision, or address the captain.
 This exception preserves this brief's safety and authority boundaries and applicable contributor guidance, including `CONTRIBUTING.md` and `firstmate-coding-guidelines` for Firstmate changes.

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -23,9 +23,9 @@
 #   notice is printed and the spawn continues.
 #   no-mistakes-prod-only is a registry policy rather than a task mode and is
 #   refused as a flag value.
-#   Ship/scout launches also supply fm-dod-lib.sh's worker role scope when a
-#   legacy brief lacks it, using the same private launch-brief overlay. This
-#   never rewrites a project's instruction files or a secondmate's charter.
+#   Ship/scout launches always supply fm-dod-lib.sh's current worker role scope
+#   using the same private launch-brief overlay. This never rewrites a project's
+#   instruction files or a secondmate's charter.
 #        fm-spawn.sh <task-id> --relaunch [--harness <name>] [--model <name>] [--effort <level>]
 #   --relaunch launches a replacement agent for an EXISTING task into that
 #   task's own recorded endpoint and worktree instead of creating either. It is
@@ -2044,26 +2044,21 @@ if [ "$KIND" = ship ] || [ "$KIND" = scout ]; then
   fi
   # Use the existing launch-brief overlay for every worker kind, including
   # pre-scope briefs and relaunches. Charters never enter this worker path.
-  if { [ "$KIND" = ship ] && [ "$MODE" = no-mistakes ]; } ||
-     ! fm_brief_heading_present "$BRIEF" '# Worker role'; then
-    SOURCE_BRIEF=$BRIEF
-    BRIEF="$DATA/$ID/launch-brief.md"
-    BRIEF_TMP="$DATA/$ID/.launch-brief.md.${BASHPID:-$$}"
-    {
-      cat "$SOURCE_BRIEF"
-      if ! fm_brief_heading_present "$SOURCE_BRIEF" '# Worker role'; then
-        printf '\n'
-        fm_brief_worker_role
-      fi
-      if [ "$KIND" = ship ] && [ "$MODE" = no-mistakes ]; then
-        fm_brief_intent_overlay "$CAPTAIN_INTENT"
-      fi
-    } > "$BRIEF_TMP" || { rm -f -- "$BRIEF_TMP"; echo "error: could not render current launch contract for $SOURCE_BRIEF" >&2; exit 1; }
-    if ! mv "$BRIEF_TMP" "$BRIEF"; then
-      rm -f -- "$BRIEF_TMP"
-      echo "error: could not publish current intent contract for $SOURCE_BRIEF" >&2
-      exit 1
+  SOURCE_BRIEF=$BRIEF
+  BRIEF="$DATA/$ID/launch-brief.md"
+  BRIEF_TMP="$DATA/$ID/.launch-brief.md.${BASHPID:-$$}"
+  {
+    cat "$SOURCE_BRIEF"
+    printf '\n'
+    fm_brief_worker_role
+    if [ "$KIND" = ship ] && [ "$MODE" = no-mistakes ]; then
+      fm_brief_intent_overlay "$CAPTAIN_INTENT"
     fi
+  } > "$BRIEF_TMP" || { rm -f -- "$BRIEF_TMP"; echo "error: could not render current launch contract for $SOURCE_BRIEF" >&2; exit 1; }
+  if ! mv "$BRIEF_TMP" "$BRIEF"; then
+    rm -f -- "$BRIEF_TMP"
+    echo "error: could not publish current intent contract for $SOURCE_BRIEF" >&2
+    exit 1
   fi
 fi
 

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -2057,7 +2057,7 @@ if [ "$KIND" = ship ] || [ "$KIND" = scout ]; then
   } > "$BRIEF_TMP" || { rm -f -- "$BRIEF_TMP"; echo "error: could not render current launch contract for $SOURCE_BRIEF" >&2; exit 1; }
   if ! mv "$BRIEF_TMP" "$BRIEF"; then
     rm -f -- "$BRIEF_TMP"
-    echo "error: could not publish current intent contract for $SOURCE_BRIEF" >&2
+    echo "error: could not publish current launch contract for $SOURCE_BRIEF" >&2
     exit 1
   fi
 fi

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -23,6 +23,9 @@
 #   notice is printed and the spawn continues.
 #   no-mistakes-prod-only is a registry policy rather than a task mode and is
 #   refused as a flag value.
+#   Ship/scout launches also supply fm-dod-lib.sh's worker role scope when a
+#   legacy brief lacks it, using the same private launch-brief overlay. This
+#   never rewrites a project's instruction files or a secondmate's charter.
 #        fm-spawn.sh <task-id> --relaunch [--harness <name>] [--model <name>] [--effort <level>]
 #   --relaunch launches a replacement agent for an EXISTING task into that
 #   task's own recorded endpoint and worktree instead of creating either. It is
@@ -2038,13 +2041,24 @@ if [ "$KIND" = ship ] || [ "$KIND" = scout ]; then
         exit 1
       fi
     fi
+  fi
+  # Use the existing launch-brief overlay for every worker kind, including
+  # pre-scope briefs and relaunches. Charters never enter this worker path.
+  if { [ "$KIND" = ship ] && [ "$MODE" = no-mistakes ]; } ||
+     ! fm_brief_heading_present "$BRIEF" '# Worker role'; then
     SOURCE_BRIEF=$BRIEF
     BRIEF="$DATA/$ID/launch-brief.md"
     BRIEF_TMP="$DATA/$ID/.launch-brief.md.${BASHPID:-$$}"
     {
       cat "$SOURCE_BRIEF"
-      fm_brief_intent_overlay "$CAPTAIN_INTENT"
-    } > "$BRIEF_TMP" || { rm -f -- "$BRIEF_TMP"; echo "error: could not render current intent contract for $SOURCE_BRIEF" >&2; exit 1; }
+      if ! fm_brief_heading_present "$SOURCE_BRIEF" '# Worker role'; then
+        printf '\n'
+        fm_brief_worker_role
+      fi
+      if [ "$KIND" = ship ] && [ "$MODE" = no-mistakes ]; then
+        fm_brief_intent_overlay "$CAPTAIN_INTENT"
+      fi
+    } > "$BRIEF_TMP" || { rm -f -- "$BRIEF_TMP"; echo "error: could not render current launch contract for $SOURCE_BRIEF" >&2; exit 1; }
     if ! mv "$BRIEF_TMP" "$BRIEF"; then
       rm -f -- "$BRIEF_TMP"
       echo "error: could not publish current intent contract for $SOURCE_BRIEF" >&2

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -14,13 +14,13 @@
 #   scaffolded before that line existed warns once and launches on the flag. A
 #   ship or scout spawn also refuses leftover `{TASK}` / `{FIRSTMATE_SPEC}`
 #   placeholders, an empty Task, or an incomplete pair of Task subsections.
-#   For a no-mistakes ship, spawn renders `launch-brief.md` with the current
-#   `--intent` contract and the extracted captain intent. A legacy mixed Task is
-#   accepted there only under bin/fm-dod-lib.sh's provenance-marking rules;
-#   unmarked legacy Tasks stop for migration rather than becoming intent. That
-#   library owns the parsing and intent rules. When the explicit mode carries
-#   less rigor than the project's standing posture, a loud one-line deviation
-#   notice is printed and the spawn continues.
+#   Every ship or scout spawn renders `launch-brief.md`; for a no-mistakes ship
+#   it also carries the current `--intent` contract and the extracted captain
+#   intent. A legacy mixed Task is accepted there only under bin/fm-dod-lib.sh's
+#   provenance-marking rules; unmarked legacy Tasks stop for migration rather
+#   than becoming intent. That library owns the parsing and intent rules. When
+#   the explicit mode carries less rigor than the project's standing posture, a
+#   loud one-line deviation notice is printed and the spawn continues.
 #   no-mistakes-prod-only is a registry policy rather than a task mode and is
 #   refused as a flag value.
 #   Ship/scout launches always supply fm-dod-lib.sh's current worker role scope

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -2048,12 +2048,12 @@ if [ "$KIND" = ship ] || [ "$KIND" = scout ]; then
   BRIEF="$DATA/$ID/launch-brief.md"
   BRIEF_TMP="$DATA/$ID/.launch-brief.md.${BASHPID:-$$}"
   {
-    cat "$SOURCE_BRIEF"
-    printf '\n'
-    fm_brief_worker_role
-    if [ "$KIND" = ship ] && [ "$MODE" = no-mistakes ]; then
-      fm_brief_intent_overlay "$CAPTAIN_INTENT"
-    fi
+    cat "$SOURCE_BRIEF" &&
+      printf '\n' &&
+      fm_brief_worker_role &&
+      if [ "$KIND" = ship ] && [ "$MODE" = no-mistakes ]; then
+        fm_brief_intent_overlay "$CAPTAIN_INTENT"
+      fi
   } > "$BRIEF_TMP" || { rm -f -- "$BRIEF_TMP"; echo "error: could not render current launch contract for $SOURCE_BRIEF" >&2; exit 1; }
   if ! mv "$BRIEF_TMP" "$BRIEF"; then
     rm -f -- "$BRIEF_TMP"

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -4,7 +4,7 @@ How firstmate works, in depth.
 
 The [README](../README.md) carries the high-level diagram and a short synopsis.
 This document expands every part of it.
-firstmate's always-loaded operating contract and routing index for conditional procedures is [`AGENTS.md`](../AGENTS.md); this is the human-facing companion.
+firstmate's supervisor contract and routing index for conditional procedures is [`AGENTS.md`](../AGENTS.md); this is the human-facing companion.
 
 ## Event-driven supervision
 

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -33,7 +33,7 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-captain-hold.sh`     | Hold tasks for the captain, record the captain's answers, gate investigation completion, and report record divergence between the status log and the backlog |
 | `fm-decision-hold.sh`    | One-release compatibility shim mapping the retired decision commands onto fm-captain-hold.sh |
 | `fm-brief.sh`            | Scaffold ship (explicit `--mode`), scout, secondmate-charter, and Herdr-lab briefs, with Captain's intent and Firstmate spec subsections on ship/scout |
-| `fm-dod-lib.sh`          | One owner of the ship definition of done and of the no-mistakes `--intent` contract |
+| [`fm-dod-lib.sh`](../bin/fm-dod-lib.sh) | Own ship/scout worker role scope, ship definitions of done, and the no-mistakes `--intent` contract |
 | `fm-herdr-lab.sh`        | Provision and guardedly operate an isolated, never-default Herdr lab session         |
 | `fm-install-herdr.sh`    | Install CI's exact-version Herdr pin with official asset URL, SHA-256, and protocol checks |
 | `fm-install-treehouse.sh`| Install CI's exact-version Treehouse pin for real-Herdr E2E that needs spawn worktrees |

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -856,18 +856,16 @@ test_worker_role_scope() {
       FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$kind" arbitrary-project-name --mode "$kind" >/dev/null || fail "$kind scaffold failed"
     fi
     brief="$home/data/$kind/brief.md"
-    assert_grep '# Worker role' "$brief" "$kind omitted the worker role contract"
-    assert_grep 'When this task works on Firstmate itself' "$brief" "$kind did not scope the exception to Firstmate"
-    assert_grep 'follow this brief instead of that supervisor contract' "$brief" "$kind did not neutralize the supervisor role"
-    assert_grep 'Other projects retain their own instructions unchanged' "$brief" "$kind displaced unrelated project guidance"
+    assert_no_grep '# Current worker role contract' "$brief" "$kind scaffolded a second owner of the role scope fm-spawn.sh delivers"
   done
   FM_HOME="$home" FM_SECONDMATE_CHARTER='Supervise assigned work.' \
     "$ROOT/bin/fm-brief.sh" supervisor --secondmate --no-projects >/dev/null || fail "secondmate scaffold failed"
   brief="$home/data/supervisor/brief.md"
-  assert_no_grep '# Worker role' "$brief" "secondmate received the worker exception"
+  assert_no_grep '# Current worker role contract' "$brief" "secondmate received the worker exception"
+  assert_no_grep 'do not adopt the supervisor identity' "$brief" "secondmate received the worker exception"
   assert_grep "The local \`AGENTS.md\` is your job description" "$brief" "secondmate lost its supervisor contract"
   assert_grep 'That file is your parent channel' "$brief" "secondmate lost its parent channel"
-  pass "fm-brief: worker role scope preserves secondmate and other-project instructions"
+  pass "fm-brief: scaffolds leave the worker role scope to the launch boundary and keep the secondmate contract"
 }
 
 test_worker_role_scope

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -846,6 +846,31 @@ test_scout_and_secondmate_scaffold() {
   pass "fm-brief: scout and secondmate code paths still scaffold well-formed briefs"
 }
 
+test_worker_role_scope() {
+  local kind home brief
+  home="$TMP_ROOT/worker-role"
+  for kind in no-mistakes direct-PR local-only scout; do
+    if [ "$kind" = scout ]; then
+      FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$kind" arbitrary-project-name --scout >/dev/null || fail "scout scaffold failed"
+    else
+      FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$kind" arbitrary-project-name --mode "$kind" >/dev/null || fail "$kind scaffold failed"
+    fi
+    brief="$home/data/$kind/brief.md"
+    assert_grep '# Worker role' "$brief" "$kind omitted the worker role contract"
+    assert_grep 'When this task works on Firstmate itself' "$brief" "$kind did not scope the exception to Firstmate"
+    assert_grep 'follow this brief instead of that supervisor contract' "$brief" "$kind did not neutralize the supervisor role"
+    assert_grep 'Other projects retain their own instructions unchanged' "$brief" "$kind displaced unrelated project guidance"
+  done
+  FM_HOME="$home" FM_SECONDMATE_CHARTER='Supervise assigned work.' \
+    "$ROOT/bin/fm-brief.sh" supervisor --secondmate --no-projects >/dev/null || fail "secondmate scaffold failed"
+  brief="$home/data/supervisor/brief.md"
+  assert_no_grep '# Worker role' "$brief" "secondmate received the worker exception"
+  assert_grep "The local \`AGENTS.md\` is your job description" "$brief" "secondmate lost its supervisor contract"
+  assert_grep 'That file is your parent channel' "$brief" "secondmate lost its parent channel"
+  pass "fm-brief: worker role scope preserves secondmate and other-project instructions"
+}
+
+test_worker_role_scope
 test_script_parses
 test_no_heredoc_in_command_substitution
 test_help_includes_entire_header

--- a/tests/fm-spawn-dispatch-profile.test.sh
+++ b/tests/fm-spawn-dispatch-profile.test.sh
@@ -1030,6 +1030,7 @@ test_worker_launch_delivers_role_scope() {
   local rec id out launch kind prompt brief_kind brief content
   for brief_kind in heading legacy scaffold; do
   for kind in no-mistakes direct-PR local-only scout; do
+    [ "$brief_kind" = heading ] && [ "$kind" != no-mistakes ] && continue
     id="role-launch-$brief_kind-$kind"
     rec=$(make_spawn_case "$id" codex)
     read_case_record "$rec"
@@ -1073,8 +1074,6 @@ SH
     [ "$(grep -c '^# Current worker role contract$' "$prompt")" -eq 1 ] ||
       fail "$brief_kind $kind duplicated the delivered worker contract"
     if [ "$brief_kind" = heading ]; then
-      assert_grep 'This section supersedes every earlier brief instruction about your role' "$prompt" \
-        "$kind command left the authored role section without a precedence rule"
       assert_grep 'Follow the project instructions' "$prompt" "$kind command dropped the authored role section"
     fi
     cmp -s "$CASE_DIR/brief-before" "$HOME_DIR/data/$id/brief.md" || fail "spawn rewrote the authored brief"

--- a/tests/fm-spawn-dispatch-profile.test.sh
+++ b/tests/fm-spawn-dispatch-profile.test.sh
@@ -693,6 +693,8 @@ test_pi_signed_persistent_secondmate_uses_pi_extensions_and_identity() {
   sm="$CASE_DIR/secondmate-home"
   make_seeded_secondmate_home "$sm" "$id"
   sm=$(cd "$sm" && pwd -P)
+  cp "$ROOT/AGENTS.md" "$sm/AGENTS.md"
+  cp "$sm/data/charter.md" "$CASE_DIR/charter-before"
 
   out=$(run_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" "$id" "$sm" --secondmate)
   status=$?
@@ -700,7 +702,11 @@ test_pi_signed_persistent_secondmate_uses_pi_extensions_and_identity() {
   assert_contains "$out" "spawned $id harness=pi-signed kind=secondmate" \
     "pi-signed secondmate spawn did not preserve its runtime identity"
   assert_meta_profile "$HOME_DIR/state/$id.meta" pi-signed default default
+  cmp -s "$ROOT/AGENTS.md" "$sm/AGENTS.md" || fail "secondmate launch rewrote the supervisor contract"
+  cmp -s "$CASE_DIR/charter-before" "$sm/data/charter.md" || fail "secondmate launch rewrote the charter"
+  assert_absent "$HOME_DIR/data/$id/launch-brief.md" "secondmate launch received a worker overlay"
   launch=$(cat "$LAUNCH_LOG")
+  assert_contains "$launch" "< '$sm/data/charter.md'" "secondmate launch lost its original charter"
   assert_contains "$launch" "FM_PI_HARNESS=pi-signed '$FAKEBIN_DIR/pi-signed' --tui-mode regular -e '$sm/.pi/extensions/fm-primary-turnend-guard.ts' -e '$sm/.pi/extensions/fm-primary-pi-watch.ts'" \
     "pi-signed secondmate did not force the regular TUI with Pi's primary extension launch shape"
   pass "pi-signed is a distinct persistent secondmate runtime with shared Pi supervision semantics"
@@ -1014,6 +1020,33 @@ test_launch_environment_inaccessible_config_refuses
 test_launch_environment_inherited_by_secondmate
 test_launch_environment_inheritance_preserves_on_source_errors
 
+test_worker_launch_delivers_role_scope() {
+  local rec id out launch kind prompt
+  for kind in no-mistakes direct-PR local-only scout; do
+    id="role-launch-$kind"
+    rec=$(make_spawn_case "$id" codex "$id")
+    read_case_record "$rec"
+    cat > "$FAKEBIN_DIR/codex" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n' "$@" > "$FM_ROLE_PROMPT"
+SH
+    chmod +x "$FAKEBIN_DIR/codex"
+    if [ "$kind" = scout ]; then
+      out=$(run_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" "$id" "$PROJ_DIR" --scout)
+    else
+      out=$(run_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" "$id" "$PROJ_DIR" --mode "$kind" --yolo off)
+    fi
+    expect_code 0 "$?" "$kind worker spawn failed: $out"
+    launch=$(cat "$LAUNCH_LOG")
+    prompt="$CASE_DIR/prompt"
+    FM_ROLE_PROMPT="$prompt" PATH="$FAKEBIN_DIR:$PATH" bash -c "$launch" || fail "could not consume $kind launch command"
+    assert_grep 'follow this brief instead of that supervisor contract' "$prompt" "$kind command did not deliver the role correction"
+    assert_grep 'brief for' "$prompt" "$kind command lost the task"
+  done
+  pass "fm-spawn: actual ship/scout launch commands deliver the worker role contract"
+}
+
+test_worker_launch_delivers_role_scope
 test_no_profile_keeps_claude_profile_defaults
 test_non_cursor_launch_clears_inherited_cursor_markers
 test_relative_home_overrides_launch_with_absolute_cross_process_paths

--- a/tests/fm-spawn-dispatch-profile.test.sh
+++ b/tests/fm-spawn-dispatch-profile.test.sh
@@ -1023,13 +1023,16 @@ test_launch_environment_inheritance_preserves_on_source_errors
 
 test_worker_launch_delivers_role_scope() {
   local rec id out launch kind prompt brief_kind brief content
-  for brief_kind in legacy scaffold; do
+  for brief_kind in heading legacy scaffold; do
   for kind in no-mistakes direct-PR local-only scout; do
     id="role-launch-$brief_kind-$kind"
     rec=$(make_spawn_case "$id" codex)
     read_case_record "$rec"
-    if [ "$brief_kind" = legacy ]; then
+    if [ "$brief_kind" != scaffold ]; then
       fm_test_spawn_brief "$HOME_DIR" "$id"
+      if [ "$brief_kind" = heading ]; then
+        printf '\n# Worker role\nFollow the project instructions.\n' >> "$HOME_DIR/data/$id/brief.md"
+      fi
     else
       if [ "$kind" = scout ]; then
         FM_HOME="$HOME_DIR" "$ROOT/bin/fm-brief.sh" "$id" arbitrary-project-name --scout >/dev/null || fail "scout scaffold failed"
@@ -1057,9 +1060,10 @@ SH
     launch=$(cat "$LAUNCH_LOG")
     prompt="$CASE_DIR/prompt"
     FM_ROLE_PROMPT="$prompt" PATH="$FAKEBIN_DIR:$PATH" bash -c "$launch" || fail "could not consume $kind launch command"
+    # The final prompt delivered to the harness is the generated interface.
+    # An authored role heading must not suppress the current worker contract.
     assert_grep 'follow this brief instead of that supervisor contract' "$prompt" "$kind command did not deliver the role correction"
     assert_grep 'brief for' "$prompt" "$kind command lost the task"
-    [ "$(grep -c '^# Worker role$' "$prompt")" -eq 1 ] || fail "$brief_kind $kind duplicated the delivered worker contract"
     cmp -s "$CASE_DIR/brief-before" "$HOME_DIR/data/$id/brief.md" || fail "spawn rewrote the authored brief"
     if [ "${FM_TEST_EVIDENCE:-0}" = 1 ]; then
       printf '# evidence begin: %s %s worker\n%s\n' "$brief_kind" "$kind" "$out"

--- a/tests/fm-spawn-dispatch-profile.test.sh
+++ b/tests/fm-spawn-dispatch-profile.test.sh
@@ -33,6 +33,11 @@ SH
 make_spawn_fakebin() {
   local dir=$1 fakebin
   fakebin=$(fm_test_make_spawn_fakebin "$dir")
+  cat > "$fakebin/timeout" <<'SH'
+#!/usr/bin/env bash
+shift
+exec "$@"
+SH
   cat > "$fakebin/cursor-agent" <<'SH'
 #!/usr/bin/env bash
 if [ "${1:-}" = --list-models ]; then
@@ -41,7 +46,7 @@ if [ "${1:-}" = --list-models ]; then
 fi
 exit 0
 SH
-  chmod +x "$fakebin/cursor-agent"
+  chmod +x "$fakebin/timeout" "$fakebin/cursor-agent"
   make_spawn_pi_probe "$fakebin" pi
   make_spawn_pi_probe "$fakebin" pi-signed
   printf '%s\n' "$fakebin"
@@ -1061,9 +1066,17 @@ SH
     prompt="$CASE_DIR/prompt"
     FM_ROLE_PROMPT="$prompt" PATH="$FAKEBIN_DIR:$PATH" bash -c "$launch" || fail "could not consume $kind launch command"
     # The final prompt delivered to the harness is the generated interface.
-    # An authored role heading must not suppress the current worker contract.
+    # An authored role heading must neither suppress nor duplicate the current
+    # worker contract; the launch section is its single, superseding owner.
     assert_grep 'follow this brief instead of that supervisor contract' "$prompt" "$kind command did not deliver the role correction"
     assert_grep 'brief for' "$prompt" "$kind command lost the task"
+    [ "$(grep -c '^# Current worker role contract$' "$prompt")" -eq 1 ] ||
+      fail "$brief_kind $kind duplicated the delivered worker contract"
+    if [ "$brief_kind" = heading ]; then
+      assert_grep 'This section supersedes every earlier brief instruction about your role' "$prompt" \
+        "$kind command left the authored role section without a precedence rule"
+      assert_grep 'Follow the project instructions' "$prompt" "$kind command dropped the authored role section"
+    fi
     cmp -s "$CASE_DIR/brief-before" "$HOME_DIR/data/$id/brief.md" || fail "spawn rewrote the authored brief"
     if [ "${FM_TEST_EVIDENCE:-0}" = 1 ]; then
       printf '# evidence begin: %s %s worker\n%s\n' "$brief_kind" "$kind" "$out"

--- a/tests/fm-spawn-dispatch-profile.test.sh
+++ b/tests/fm-spawn-dispatch-profile.test.sh
@@ -33,11 +33,6 @@ SH
 make_spawn_fakebin() {
   local dir=$1 fakebin
   fakebin=$(fm_test_make_spawn_fakebin "$dir")
-  cat > "$fakebin/timeout" <<'SH'
-#!/usr/bin/env bash
-shift
-exec "$@"
-SH
   cat > "$fakebin/cursor-agent" <<'SH'
 #!/usr/bin/env bash
 if [ "${1:-}" = --list-models ]; then
@@ -46,7 +41,7 @@ if [ "${1:-}" = --list-models ]; then
 fi
 exit 0
 SH
-  chmod +x "$fakebin/timeout" "$fakebin/cursor-agent"
+  chmod +x "$fakebin/cursor-agent"
   make_spawn_pi_probe "$fakebin" pi
   make_spawn_pi_probe "$fakebin" pi-signed
   printf '%s\n' "$fakebin"
@@ -709,6 +704,12 @@ test_pi_signed_persistent_secondmate_uses_pi_extensions_and_identity() {
   assert_contains "$launch" "< '$sm/data/charter.md'" "secondmate launch lost its original charter"
   assert_contains "$launch" "FM_PI_HARNESS=pi-signed '$FAKEBIN_DIR/pi-signed' --tui-mode regular -e '$sm/.pi/extensions/fm-primary-turnend-guard.ts' -e '$sm/.pi/extensions/fm-primary-pi-watch.ts'" \
     "pi-signed secondmate did not force the regular TUI with Pi's primary extension launch shape"
+  if [ "${FM_TEST_EVIDENCE:-0}" = 1 ]; then
+    printf '# evidence begin: persistent secondmate\n%s\n' "$out"
+    printf 'launch command:\n%s\noriginal charter:\n' "$launch"
+    cat "$sm/data/charter.md"
+    printf 'supervisor AGENTS.md and charter remain byte-identical; no worker overlay created\n# evidence end\n'
+  fi
   pass "pi-signed is a distinct persistent secondmate runtime with shared Pi supervision semantics"
 }
 
@@ -1021,11 +1022,27 @@ test_launch_environment_inherited_by_secondmate
 test_launch_environment_inheritance_preserves_on_source_errors
 
 test_worker_launch_delivers_role_scope() {
-  local rec id out launch kind prompt
+  local rec id out launch kind prompt brief_kind brief content
+  for brief_kind in legacy scaffold; do
   for kind in no-mistakes direct-PR local-only scout; do
-    id="role-launch-$kind"
-    rec=$(make_spawn_case "$id" codex "$id")
+    id="role-launch-$brief_kind-$kind"
+    rec=$(make_spawn_case "$id" codex)
     read_case_record "$rec"
+    if [ "$brief_kind" = legacy ]; then
+      fm_test_spawn_brief "$HOME_DIR" "$id"
+    else
+      if [ "$kind" = scout ]; then
+        FM_HOME="$HOME_DIR" "$ROOT/bin/fm-brief.sh" "$id" arbitrary-project-name --scout >/dev/null || fail "scout scaffold failed"
+      else
+        FM_HOME="$HOME_DIR" "$ROOT/bin/fm-brief.sh" "$id" arbitrary-project-name --mode "$kind" >/dev/null || fail "$kind scaffold failed"
+      fi
+      brief="$HOME_DIR/data/$id/brief.md"
+      content=$(cat "$brief")
+      content=${content//'{TASK}'/brief for $id}
+      content=${content//'{FIRSTMATE_SPEC}'/Exercise the spawn behavior under test.}
+      printf '%s\n' "$content" > "$brief"
+    fi
+    cp "$HOME_DIR/data/$id/brief.md" "$CASE_DIR/brief-before"
     cat > "$FAKEBIN_DIR/codex" <<'SH'
 #!/usr/bin/env bash
 printf '%s\n' "$@" > "$FM_ROLE_PROMPT"
@@ -1042,6 +1059,15 @@ SH
     FM_ROLE_PROMPT="$prompt" PATH="$FAKEBIN_DIR:$PATH" bash -c "$launch" || fail "could not consume $kind launch command"
     assert_grep 'follow this brief instead of that supervisor contract' "$prompt" "$kind command did not deliver the role correction"
     assert_grep 'brief for' "$prompt" "$kind command lost the task"
+    [ "$(grep -c '^# Worker role$' "$prompt")" -eq 1 ] || fail "$brief_kind $kind duplicated the delivered worker contract"
+    cmp -s "$CASE_DIR/brief-before" "$HOME_DIR/data/$id/brief.md" || fail "spawn rewrote the authored brief"
+    if [ "${FM_TEST_EVIDENCE:-0}" = 1 ]; then
+      printf '# evidence begin: %s %s worker\n%s\n' "$brief_kind" "$kind" "$out"
+      printf 'launch command executed with an argv-capture harness:\n%s\nreceived arguments and final prompt:\n' "$launch"
+      cat "$prompt"
+      printf 'authored brief remains byte-identical\n# evidence end\n'
+    fi
+  done
   done
   pass "fm-spawn: actual ship/scout launch commands deliver the worker role contract"
 }

--- a/tests/fm-task-delivery.test.sh
+++ b/tests/fm-task-delivery.test.sh
@@ -747,6 +747,47 @@ EOF
   pass "fm-spawn/fm-promote: leftover Task placeholders are refused until both subsections are filled"
 }
 
+test_spawn_refreshes_legacy_worker_roles() {
+  local rec home proj fakebin kind id out brief project_kind
+  rec=$(make_home worker-roles)
+  IFS='|' read -r home proj fakebin <<EOF
+$rec
+EOF
+  # AGENTS.md and its import are instruction inputs, not implementation-source
+  # assertions: launching a worker must never rewrite either project's files.
+  cp "$ROOT/AGENTS.md" "$home/AGENTS.md"
+  for project_kind in firstmate unrelated; do
+    if [ "$project_kind" = firstmate ]; then
+      cp "$ROOT/AGENTS.md" "$proj/AGENTS.md"
+    else
+      printf 'Use this project coding standard.\n' > "$proj/AGENTS.md"
+    fi
+    printf '@AGENTS.md\n' > "$proj/CLAUDE.md"
+    cp "$proj/AGENTS.md" "$proj/agents-before"
+    for kind in no-mistakes direct-PR local-only scout; do
+      id="roles-$project_kind-$kind"
+      write_brief "$home" "$id"
+      if [ "$kind" = scout ]; then
+        out=$(run_spawn "$home" "$fakebin" "$id" "$proj" codex --scout)
+      else
+        out=$(run_spawn "$home" "$fakebin" "$id" "$proj" codex --mode "$kind" --yolo off)
+      fi
+      assert_not_contains "$out" 'could not render' "worker role rendering failed"
+      brief="$home/data/$id/launch-brief.md"
+      assert_present "$brief" "$project_kind $kind did not refresh the legacy launch brief"
+      assert_grep 'follow this brief instead of that supervisor contract' "$brief" "$project_kind $kind omitted worker authority"
+      assert_grep 'When this task works on Firstmate itself' "$brief" "$project_kind $kind made the exception unconditional"
+      assert_grep 'Other projects retain their own instructions unchanged' "$brief" "$project_kind $kind displaced project guidance"
+      assert_no_grep '# Worker role' "$home/data/$id/brief.md" "spawn rewrote the source brief"
+      cmp -s "$proj/agents-before" "$proj/AGENTS.md" || fail "spawn changed project AGENTS.md"
+      [ "$(cat "$proj/CLAUDE.md")" = '@AGENTS.md' ] || fail "spawn changed the project import"
+    done
+  done
+  cmp -s "$ROOT/AGENTS.md" "$home/AGENTS.md" || fail "worker spawn changed the primary contract"
+  pass "fm-spawn: every legacy worker receives scoped role instructions without changing project or primary instructions"
+}
+
+test_spawn_refreshes_legacy_worker_roles
 test_ship_spawn_requires_a_valid_delivery_contract
 test_scout_and_secondmate_refuse_delivery_flags
 test_spawn_refuses_a_brief_mode_mismatch

--- a/tests/fm-task-delivery.test.sh
+++ b/tests/fm-task-delivery.test.sh
@@ -778,6 +778,8 @@ EOF
       assert_grep 'follow this brief instead of that supervisor contract' "$brief" "$project_kind $kind omitted worker authority"
       assert_grep 'When this task works on Firstmate itself' "$brief" "$project_kind $kind made the exception unconditional"
       assert_grep 'Other projects retain their own instructions unchanged' "$brief" "$project_kind $kind displaced project guidance"
+      ! grep -q '^This section supersedes every earlier brief instruction about your role' "$brief" ||
+        fail "$project_kind $kind revoked the brief's own role for a task that is not Firstmate"
       assert_no_grep '# Current worker role contract' "$home/data/$id/brief.md" "spawn rewrote the source brief"
       cmp -s "$proj/agents-before" "$proj/AGENTS.md" || fail "spawn changed project AGENTS.md"
       [ "$(cat "$proj/CLAUDE.md")" = '@AGENTS.md' ] || fail "spawn changed the project import"

--- a/tests/fm-task-delivery.test.sh
+++ b/tests/fm-task-delivery.test.sh
@@ -778,7 +778,7 @@ EOF
       assert_grep 'follow this brief instead of that supervisor contract' "$brief" "$project_kind $kind omitted worker authority"
       assert_grep 'When this task works on Firstmate itself' "$brief" "$project_kind $kind made the exception unconditional"
       assert_grep 'Other projects retain their own instructions unchanged' "$brief" "$project_kind $kind displaced project guidance"
-      assert_no_grep '# Worker role' "$home/data/$id/brief.md" "spawn rewrote the source brief"
+      assert_no_grep '# Current worker role contract' "$home/data/$id/brief.md" "spawn rewrote the source brief"
       cmp -s "$proj/agents-before" "$proj/AGENTS.md" || fail "spawn changed project AGENTS.md"
       [ "$(cat "$proj/CLAUDE.md")" = '@AGENTS.md' ] || fail "spawn changed the project import"
     done


### PR DESCRIPTION
## Intent

Upstream issue https://github.com/kunchenguid/firstmate/issues/3739, triaged ready-for-pr with contract-class restore on main 1820316b: the root AGENTS.md assigns the firstmate supervisor identity unconditionally (identity plus hard rules 1-5) while bin/fm-brief.sh scout and ship scaffolds assign a crewmate identity with no neutralization when the task copy is a Firstmate checkout, so a Firstmate-repo worker inherits the supervisor's contract as its own.
Accepted scope, the maintainer's words in substance: the smallest clear correction - Firstmate-repo ship and scout worker launches must not treat the supervisor-only root as their controlling identity, corrected at the firstmate instruction or spawn boundary (brief-owned neutralization or a load-boundary correction), proven to preserve the primary and secondmate supervisor contracts and unrelated projects' own instructions. The broader constitution and supervisor-document split is separate architecture and must not be bundled. Fix at the firstmate boundary, not one harness's loader quirk.

## What Changed

- `bin/fm-dod-lib.sh` gains `fm_brief_worker_role`, a titled launch-brief section that applies only when the task works on Firstmate itself: it supersedes earlier brief role wording, tells the worker to follow the brief instead of the repo-root supervisor `AGENTS.md` (and its `CLAUDE.md` import), forbids adopting the supervisor identity, and states that other projects keep their own instructions.
- `bin/fm-spawn.sh` now renders `launch-brief.md` for every ship and scout spawn instead of only no-mistakes ships, appending that role section and, for no-mistakes ships, the existing `--intent` overlay; the authored source brief, project instruction files, and secondmate charters are left byte-identical, and error wording moved from "intent contract" to "launch contract".
- Docs (`AGENTS.md`, `README.md`, `CONTRIBUTING.md`, `docs/architecture.md`, `docs/scripts.md`) restate the root `AGENTS.md` as the primary/secondmate supervisor contract rather than an unconditional operating contract; `bin/fm-brief.sh` records that scaffolds carry no role scope. Tests assert scaffolds omit the role section, that launched ship/scout prompts carry exactly one role section across scaffold, legacy, and authored-heading briefs, and that secondmate launches receive no worker overlay.

## Risk Assessment

⚠️ Medium: The code paths check out and every prior finding is verifiably fixed, but the change alters the delivered prompt and repoints $BRIEF to launch-brief.md for every ship and scout launch in the fleet, and its correctness rests partly on natural-language precedence wording that two earlier rounds already had to correct.

## Testing

Beyond the already-green baseline (`bin/fm-test-run.sh --changed --exclude-family real-herdr-gated`), I ran the three suites this change touches with the repo's `FM_TEST_EVIDENCE=1` convention and then demonstrated the intent end-to-end by driving real `fm-spawn.sh` launches and executing the captured launch commands against an argv-capturing harness, so the recorded text is the exact prompt a worker process receives. A Firstmate-checkout ship worker now gets the worker role contract redirecting it off the supervisor `AGENTS.md` while keeping its crewmate identity; an unrelated-project scout keeps that identity un-revoked because every supersession clause is Firstmate-gated, and its project instruction files are byte-identical after launch; a persistent secondmate gets its charter with no worker overlay and an untouched supervisor contract. I also proved the new assertion fails on the pre-fix source and passes on the target, and fault-injected a brief-read failure to show the render guard, previously dead for scout/direct-PR/local-only launches, now refuses the spawn instead of shipping a truncated brief. There is no GUI or rendered surface in this change — the end-user surface is the prompt text handed to a CLI agent harness, which I captured verbatim rather than as a DOM or selector summary. Everything passed and no transient files were left in the worktree.

<details>
<summary>Evidence: Exact prompt delivered to a ship worker whose task copy is a Firstmate checkout</summary>

Source: [Exact prompt delivered to a ship worker whose task copy is a Firstmate checkout](https://github.com/tiago-peixoto/firstmate/blob/c9bef1422a19ff73049d0cc9bd3b3257850a620b/.no-mistakes/evidence/fm/firstmate-role-aware-context-split-r2/delivered-prompt-firstmate-ship.txt)

The full captured prompt is in the linked evidence file; it is omitted here because it reproduces an entire launch brief.
</details>

<details>
<summary>Evidence: Exact prompt delivered to a scout worker on an unrelated project (crewmate identity intact)</summary>

Source: [Exact prompt delivered to a scout worker on an unrelated project (crewmate identity intact)](https://github.com/tiago-peixoto/firstmate/blob/c9bef1422a19ff73049d0cc9bd3b3257850a620b/.no-mistakes/evidence/fm/firstmate-role-aware-context-split-r2/delivered-prompt-unrelated-scout.txt)

The full captured prompt is in the linked evidence file; it is omitted here because it reproduces an entire launch brief.
</details>

<details>
<summary>Evidence: End-to-end launch transcript: Firstmate ship, unrelated scout, secondmate, primary contract</summary>

Source: [End-to-end launch transcript: Firstmate ship, unrelated scout, secondmate, primary contract](https://github.com/tiago-peixoto/firstmate/blob/c9bef1422a19ff73049d0cc9bd3b3257850a620b/.no-mistakes/evidence/fm/firstmate-role-aware-context-split-r2/end-to-end-launch-transcript.txt)

The full captured prompt is in the linked evidence file; it is omitted here because it reproduces an entire launch brief.
</details>

<details>
<summary>Evidence: Render guard now refuses a failed scout render instead of publishing a truncated brief</summary>

Source: [Render guard now refuses a failed scout render instead of publishing a truncated brief](https://github.com/tiago-peixoto/firstmate/blob/c9bef1422a19ff73049d0cc9bd3b3257850a620b/.no-mistakes/evidence/fm/firstmate-role-aware-context-split-r2/render-guard-fault-injection.txt)

```text
Render-guard reachability for a non-no-mistakes launch (scout), by fault injection.
A PATH stub makes the single 'cat <brief>' that renders launch-brief.md fail with an
I/O error after emitting partial output; every other cat use passes through.

=== PRE-FIX (30a8593) ===
cat: /private/var/folders/r8/cylyt7xd7t50y9x5wc05my380000gn/T/fm-guard2.yZshn2/c/home/data/guard-1/brief.md: Input/output error
spawned guard-1 harness=codex kind=scout window=firstmate:fm-guard-1 worktree=/private/var/folders/r8/cylyt7xd7t50y9x5wc05my380000gn/T/fm-guard2.yZshn2/c/wt
spawn exit=0
launch-brief.md published: yes
--- truncated brief a worker would have received ---
partial 
# Current worker role contract
This section supersedes every earlier brief instruction about your role and identity.
When this task works on Firstmate itself, the repository root `AGENTS.md` (also imported by `CLAUDE.md`) is the primary/secondmate supervisor's contract: follow this brief instead of that supervisor contract.
For that Firstmate task, do the assigned work yourself and report to firstmate; do not adopt the supervisor identity, delegate the task, run fleet supervision, or address the captain.
This exception preserves this brief's safety and authority boundaries and applicable contributor guidance, including `CONTRIBUTING.md` and `firstmate-coding-guidelines` for Firstmate changes.
Other projects retain their own instructions unchanged.
--- end ---
launch command issued to a harness: yes

=== TARGET (694e87f) ===
cat: /private/var/folders/r8/cylyt7xd7t50y9x5wc05my380000gn/T/fm-guard2.fFHVtw/c/home/data/guard-1/brief.md: Input/output error
error: could not render current launch contract for /private/var/folders/r8/cylyt7xd7t50y9x5wc05my380000gn/T/fm-guard2.fFHVtw/c/home/data/guard-1/brief.md
spawn exit=1
launch-brief.md published: no
launch command issued to a harness: no
```
</details>
<details>
<summary>Evidence: Regression fails on pre-fix source, passes on target</summary>

Source: [Regression fails on pre-fix source, passes on target](https://github.com/tiago-peixoto/firstmate/blob/c9bef1422a19ff73049d0cc9bd3b3257850a620b/.no-mistakes/evidence/fm/firstmate-role-aware-context-split-r2/regression-fails-before-fix.txt)

```text
Regression proof: the new assertions fail on the pre-fix source and pass on the target.

== tests/fm-task-delivery.test.sh (target test file) run against bin/ from 30a8593 ==
$ git archive 30a8593 | tar -x -C /tmp/nm-prefix && cp tests/fm-task-delivery.test.sh /tmp/nm-prefix/tests/
$ (cd /tmp/nm-prefix && bash tests/fm-task-delivery.test.sh)
not ok - firstmate no-mistakes revoked the brief's own role for a task that is not Firstmate
exit=

== same test file on the target commit 694e87f ==
$ bash tests/fm-task-delivery.test.sh
ok - fm-project-mode: the conditional policy is accepted, mapped for mechanical callers, and readable raw
ok - fm-spawn/fm-promote: leftover Task placeholders are refused until both subsections are filled
# all fm-task-delivery tests passed
```
</details>
<details>
<summary>Evidence: Worker role contract as an unrelated-project scout receives it (Firstmate-gated, identity preserved)</summary>

```text
$ fm-spawn.sh acme-2 <acme-web> --scout
spawned acme-2 harness=codex kind=scout window=firstmate:fm-acme-2

--- delivered prompt: crewmate identity NOT revoked ---
4:FIRSTMATE_OP: v1 launch-brief: You are a crewmate: an autonomous worker agent managed by firstmate. Work on your own; do not wait for a human.

--- delivered prompt: every supersession clause is Firstmate-gated ---
64:When this task works on Firstmate itself, this section supersedes every earlier brief instruction about your role and identity.
68:Other projects retain their own instructions unchanged.

--- unrelated project instructions untouched ---
project AGENTS.md unchanged: yes
Use two-space indent and run make check.
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"be858004e0ecc834760fc081f9f73e7586e1b115","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>🔧 **Rebase** - 1 issue found → auto-fixed ✅</summary>

- ⚠️ `tests/fm-spawn-dispatch-profile.test.sh` - merge conflict rebasing onto origin/main

🔧 Fix applied.
✅ Re-checked - no issues remain.
</details>

<details>
<summary>⚠️ **Review** - 1 info</summary>

- ⚠️ `bin/fm-spawn.sh:2053` - The change introduces two emission points for the same rule: fm-brief.sh injects $WORKER_ROLE into every scaffolded ship/scout brief (bin/fm-brief.sh:312, 360, 437) and fm-spawn.sh unconditionally appends fm_brief_worker_role to the launch brief. Verified concretely: `fm-brief.sh demo some-project --mode local-only` then the real overlay concatenation (`cat brief; printf &#39;\n&#39;; fm_brief_worker_role`) yields `grep -c &#39;^# Worker role$&#39;` == 2, so every freshly scaffolded worker is handed the same 5-line contract twice. Commit a30fd4a removed the guard AND removed the test assertion `[ &#34;$(grep -c &#39;^# Worker role$&#39; &#34;$prompt&#34;)&#34; -eq 1 ]` that would have caught it, so the suite now passes with duplicates. The same unconditional append also stacks the stock block on a brief that carries its own `# Worker role` section (exactly the `heading` case the new test creates) producing two same-level sections with no precedence rule - unlike fm_brief_intent_overlay, which states &#39;This section supersedes every earlier brief instruction&#39;. The intent requires the correction at one boundary (&#39;brief-owned neutralization OR a load-boundary correction&#39;); no requirement needs both. Smallest honest remedy: remove the scaffold-time component (bin/fm-brief.sh:312 and the two `$WORKER_ROLE` heredoc insertions) and let the launch overlay be the single owner - it already covers legacy briefs, relaunches, and always delivers current text, and dropping it also removes the conflicting-section case. The alternative (restore the dedup guard) keeps two owners, so it is the weaker fix. This is a decision about delivered prompt content, so it needs the author.
- ⚠️ `tests/fm-spawn-dispatch-profile.test.sh:35` - make_spawn_fakebin&#39;s PATH shim for `timeout` was deleted (in the &#39;document&#39; commit 4b0cdcd), which is unrelated to the worker-role intent; origin/main still has it. bin/fm-cursor-lib.sh:91-94 fails closed when neither `timeout` nor `gtimeout` is on PATH, so without the shim the cursor catalog probe becomes host-dependent: on a macOS host without GNU coreutils, fm_cursor_list_models returns 1, fm-spawn.sh:1546 skips the model check, the spawn succeeds, and test_cursor_refuses_model_absent_from_live_catalog (line 519, expects exit 1 plus &#34;Cursor model &#39;cursor-grok-4.5&#39; is not available&#34;) fails. It passes on Linux CI and on hosts with coreutils, which is exactly what makes the loss of hermeticity easy to miss. The shim also made the probe deterministic rather than a real subprocess timer. Remedy is to restore the six deleted lines, but since this was a deliberate deletion with no stated reason, it needs the author&#39;s confirmation rather than a silent revert.
- ℹ️ `bin/fm-dod-lib.sh:26` - The ownership comment says the role scope is &#39;supplied to legacy worker briefs by fm-spawn.sh&#39;, which described the heading-bypass behavior that commit a30fd4a removed. fm-spawn.sh now supplies it to every ship/scout launch brief, legacy or scaffolded. In a file whose header comments are the declared single-owner contract for these blocks (and which fm-spawn.sh:26 and fm-brief.sh:67 now point at), the stale wording misstates which briefs the boundary covers. Fix: say it is supplied to every ship/scout launch brief, never to secondmates.

🔧 Fix: make launch overlay sole owner of worker role contract
2 issues (1 warning, 1 info) still open:

- ℹ️ `bin/fm-spawn.sh:2060` - The overlay block was widened from no-mistakes ships only to every ship/scout launch, and the render failure message on line 2057 was updated to say &#34;current launch contract&#34; — but the publish failure message one branch below still says &#34;could not publish current intent contract&#34;. Concrete sequence: spawn a scout (or a direct-PR/local-only ship); the worker role block is rendered to BRIEF_TMP, then `mv` fails (read-only data dir, ENOSPC on rename, cross-device data dir). The operator sees &#34;error: could not publish current intent contract for .../brief.md&#34; for a task kind that has no `--intent` contract at all — `fm_brief_intent_overlay` is explicitly skipped for it at line 2054. Mechanical, non-functional: change &#34;intent&#34; to &#34;launch&#34; so both arms of the same overlay name the same thing. No test pins this string (grep across tests/ found none).
- ⚠️ `tests/fm-spawn-dispatch-profile.test.sh:1039` - Simplification: the `heading` brief_kind is a test dimension the intent does not require. It appends a literal `# Worker role` section to the brief and re-runs all four worker kinds — 4 extra real spawns, each building its own git worktree via make_spawn_case, on top of the 8 the `legacy` and `scaffold` dimensions already cover. That heading was chosen because it was the stock section title in commit 894e4e2, but this same change renamed the emitted section to `# Current worker role contract` (bin/fm-dod-lib.sh:33), so no code path in the tree produces `# Worker role` any more and no released brief can carry it. Of its three assertions, two are tautological across the whole matrix: the dedup count (line 1073) already runs for all 12 cases, and &#39;This section supersedes every earlier brief instruction about your role&#39; (line 1076) is unconditionally present in the stock block, so it cannot fail in the heading case without failing everywhere. Only `assert_grep &#39;Follow the project instructions&#39;` is unique, and it proves a single general property — the overlay appends rather than replaces authored brief content — which one case demonstrates as well as four. Narrower form: run the heading shape for one kind (or fold the &#39;authored content survives&#39; assertion into the `legacy` dimension) and drop the extra spawns. This is delivered-test-scope, not a defect, so it needs the author.

🔧 Fix: narrow heading test dimension and fix publish error wording
3 warnings still open:

- ⚠️ `bin/fm-spawn.sh:2057` - The overlay&#39;s render-failure guard is unreachable for scout, direct-PR, and local-only launches. The brace group now ends with `if [ &#34;$KIND&#34; = ship ] &amp;&amp; [ &#34;$MODE&#34; = no-mistakes ]; then fm_brief_intent_overlay ...; fi` (lines 2054-2056). A `{ ...; }` group exits with the status of its last command, and an `if` whose condition is false and that has no else branch exits 0 — so for every kind except a no-mistakes ship the group returns 0 no matter what happened inside it, and `|| { rm -f -- &#34;$BRIEF_TMP&#34;; echo &#34;error: could not render current launch contract...&#34;; exit 1; }` on line 2057 can never fire. Before this change the last command in the group was `fm_brief_intent_overlay`, which did carry the write status, and the block only ran for no-mistakes ships, so the guard was intact. Concrete failing sequence: run `fm-spawn.sh s1 ~/projects/acme --scout` (or a `--mode local-only` ship) when the data filesystem is full. The `&gt; &#34;$BRIEF_TMP&#34;` open succeeds, `cat &#34;$SOURCE_BRIEF&#34;` fails partway with ENOSPC and returns 1, `fm_brief_worker_role` also fails, the trailing `if` returns 0, the guard is skipped, and `mv` publishes a truncated or empty `launch-brief.md`. The spawn then continues: for a ship the missing `Delivery contract: mode=` line only produces the line-2082 warning, and for a scout there is no further check at all, so a worker is launched on a brief with no task. The same masking applies to any mid-write I/O error or to `$SOURCE_BRIEF` becoming unreadable between the line-2023 `-f` check and the `cat`. The new test&#39;s `assert_not_contains &#34;$out&#34; &#39;could not render&#39;` passes either way, so it does not cover this. Remedy is mechanical and stays inside the change: make the group&#39;s status reflect every write, e.g. chain the four pieces with `&amp;&amp;` and end on a command that always runs (`{ cat &#34;$SOURCE_BRIEF&#34; &amp;&amp; printf &#39;\n&#39; &amp;&amp; fm_brief_worker_role &amp;&amp; { [ &#34;$KIND&#34; != ship ] || [ &#34;$MODE&#34; != no-mistakes ] || fm_brief_intent_overlay &#34;$CAPTAIN_INTENT&#34;; }; } &gt; &#34;$BRIEF_TMP&#34; || ...`).
- ⚠️ `bin/fm-dod-lib.sh:34` - The section&#39;s first sentence, &#34;This section supersedes every earlier brief instruction about your role and identity.&#34;, is unconditional, but every clause below it that supplies a replacement role is gated on &#34;When this task works on Firstmate itself&#34; (lines 35-37). Because bin/fm-spawn.sh:2053 now emits this block on every ship and scout launch, a worker on an unrelated project receives a section that revokes its brief&#39;s role assignment and gives it nothing back. Concrete sequence: `fm-spawn.sh acme-1 ~/projects/acme --mode local-only --yolo off` against a brief scaffolded by fm-brief.sh, whose first line is `You are a crewmate: an autonomous worker agent managed by firstmate. Work on your own; do not wait for a human.` (bin/fm-brief.sh:433 for ships, :358 for scouts). The delivered prompt ends with a block asserting it supersedes that identity line; the only clause that applies to a non-Firstmate task is line 38, &#34;Other projects retain their own instructions unchanged&#34;, which restores the project&#39;s own instruction files, not the brief&#39;s crewmate role. Contrast fm_brief_intent_overlay (line 148), whose identically-shaped supersession sentence is safe because that overlay is only emitted for the no-mistakes ships it actually has content for. This exceeds the accepted scope, which limits the correction to &#34;Firstmate-repo ship and scout worker launches&#34; and requires that unrelated projects&#39; own instructions be preserved. Narrower form: gate the supersession on the same condition as the rest of the block, e.g. &#34;When this task works on Firstmate itself, this section supersedes every earlier brief instruction about your role and identity.&#34; This is delivered prompt wording the author chose deliberately, so it needs their confirmation rather than a silent edit.
- ⚠️ `AGENTS.md:3` - Simplification: the two-sentence preamble is a second, hand-maintained statement of the boundary the launch overlay already delivers. Line 4&#39;s first clause — &#34;An explicitly assigned ship or scout worker follows its launch brief&#39;s worker role instead of this contract, including when its task copy is Firstmate itself&#34; — states from the supervisor side exactly what bin/fm-dod-lib.sh:35 states from the worker side (&#34;follow this brief instead of that supervisor contract&#34;), with no test or code path keeping the two wordings in sync. The accepted scope offers the two correction sites as alternatives, not as a pair: &#34;corrected at the firstmate instruction or spawn boundary (brief-owned neutralization or a load-boundary correction)&#34;. The spawn-boundary overlay is the half this branch tests, and it is loader-independent and covers legacy briefs and relaunches, so it satisfies the requirement on its own. Recommended remedy is to drop the duplicated clause and keep the overlay as the single owner, consistent with the ownership comment the branch added at bin/fm-dod-lib.sh:25. One caveat that makes this the author&#39;s call rather than a mechanical cut: line 4&#39;s second clause, &#34;merely storing a brief in a home does not select that role&#34;, has no equivalent in the overlay and is what keeps a secondmate whose home holds data/&lt;id&gt;/brief.md from reading itself as a worker, so it should be retained if the rest is removed.

🔧 Fix: gate role supersession, fix render guard, drop AGENTS twin
1 info still open:

- ℹ️ `tests/fm-task-delivery.test.sh:781` - The regression pinning the round-3 fix is a single literal-anchored negative grep: `! grep -q &#39;^This section supersedes every earlier brief instruction about your role&#39;`. It does fail-before/pass-after for the exact reverted wording, but it is the only assertion carrying that coverage — the positive `assert_grep &#39;When this task works on Firstmate itself&#39;` on line 779 cannot detect the regression, because bin/fm-dod-lib.sh:35 (the second line of the block) also begins with that phrase and would satisfy it even if line 34 were unconditional again. Concrete way the test passes with the code wrong: reword bin/fm-dod-lib.sh:34 to an equally unconditional &#34;This section replaces every earlier brief instruction about your role and identity.&#34; — the anchor no longer matches, line 779 still matches via line 35, and a non-Firstmate worker&#39;s brief-assigned role is revoked again with the suite green. The test already has the material to assert the actual property the fix instruction named: `write_brief` (line 48) puts `You are a crewmate.` as the launch brief&#39;s first line, so the launch brief can be asserted to still carry an unrevoked crewmate identity — e.g. assert `You are a crewmate.` is present and that every occurrence of a &#34;supersedes ... role and identity&#34; sentence is on a line that also carries the `When this task works on Firstmate itself` gate. This is a mechanical test strengthening with no behavior change.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `bin/fm-test-run.sh --changed --exclude-family real-herdr-gated`
- <code>`FM_TEST_EVIDENCE=1 bash tests/fm-spawn-dispatch-profile.test.sh` — 32 tests pass, including `test_worker_launch_delivers_role_scope` and the secondmate case; evidence blocks print each delivered prompt</code>
- <code>`FM_TEST_EVIDENCE=1 bash tests/fm-task-delivery.test.sh` — passes, including the new `test_spawn_refreshes_legacy_worker_roles` across firstmate/unrelated projects x no-mistakes/direct-PR/local-only/scout</code>
- <code>`FM_TEST_EVIDENCE=1 bash tests/fm-brief.test.sh` — passes, including `test_worker_role_scope` (scaffolds carry no role section; secondmate charter keeps its supervisor contract)</code>
- <code>Manual end-to-end: drove real `bin/fm-spawn.sh` launches via `tests/fixtures.sh` (real git worktrees, fake tmux capturing the literal launch command), then executed each captured launch command against an argv-capturing `codex` stub to record the exact prompt string delivered to the harness</code>
- <code>Manual scenario A — `fm-spawn.sh acme-1 &lt;firstmate-checkout&gt; --mode no-mistakes --yolo off`: delivered prompt keeps the brief&#39;s crewmate identity and appends the worker role contract redirecting away from the root `AGENTS.md`; the project&#39;s `AGENTS.md`/`CLAUDE.md` are byte-identical after launch</code>
- <code>Manual scenario B — `fm-spawn.sh acme-2 &lt;unrelated-project&gt; --scout`: delivered prompt retains `You are a crewmate`, every supersession clause is gated on &#34;When this task works on Firstmate itself&#34;, and the project&#39;s own `AGENTS.md` is unchanged</code>
- <code>Manual scenario C — `fm-spawn.sh sm-1 &lt;secondmate-home&gt; --secondmate`: launch command reads `data/charter.md` directly, no `launch-brief.md` overlay is created, and the secondmate&#39;s supervisor `AGENTS.md` and charter are byte-identical</code>
- <code>Fail-before/pass-after: extracted `bin/` from pre-fix commit 30a8593 into a scratch tree with the target test file — `not ok - firstmate no-mistakes revoked the brief&#39;s own role for a task that is not Firstmate`; same file passes on 694e87f</code>
- <code>Fault injection for the render guard: PATH stub failing the single `cat &lt;brief&gt;` that renders `launch-brief.md` — pre-fix a scout spawn exits 0 and publishes a truncated brief to a live harness; on target it prints `error: could not render current launch contract`, exits 1, publishes nothing, and issues no launch command</code>
</details>

<details>
<summary>⚠️ **Document** - 1 info</summary>

- ℹ️ `AGENTS.md:94` - Judgment call left unfixed: AGENTS.md&#39;s data/ inventory lists `&lt;id&gt;/brief.md` and `&lt;id&gt;/report.md` but not `&lt;id&gt;/launch-brief.md`, which this change widened from no-mistakes ships only to every ship and scout launch, so the delivered prompt is now always a file the inventory does not name. I did not add it: the omission predates this branch (launch-brief.md already existed for no-mistakes ships at the base commit), bin/fm-spawn.sh&#39;s header owns launch-brief mechanics and now states the rendering rule, and AGENTS.md is under explicit size discipline per firstmate-coding-guidelines. Adding a line would trade a token cost on every fleet session for a fact firstmate can reach through the spawn header; a maintainer who values inventory completeness over that discipline may want the one-line entry instead.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>