### PR TITLE
ci: bump require-no-mistakes action to read live PR facts

### DIFF
--- a/.github/workflows/no-mistakes-required.yml
+++ b/.github/workflows/no-mistakes-required.yml
@@ -9,6 +9,7 @@ on:
 
 permissions:
   contents: read
+  pull-requests: read
 
 # GitHub concurrency groups retain at most one pending run, replacing older
 # pending runs even when cancel-in-progress is false. Give body-bearing events
@@ -27,4 +28,4 @@ jobs:
       github.event.pull_request.user.login != 'dependabot[bot]'
     steps:
       - name: Verify no-mistakes signature and pipeline attestation
-        uses: kunchenguid/no-mistakes/.github/actions/require-no-mistakes@32d396ac0f29135daf7fcb9964aba9d5f4e796d6 # post-v1.57.1, untagged (action added in #819)
+        uses: kunchenguid/no-mistakes/.github/actions/require-no-mistakes@76fa0921a9797b09e120c8b5979c4d0e65f88922 # live PR facts action

--- a/tests/fm-calm-pi-extension.test.sh
+++ b/tests/fm-calm-pi-extension.test.sh
@@ -1818,7 +1818,23 @@ TS
       fail "Pi follow-up $label case did not process the monitoring notification"
     fi
 
-    pane=$(tmux -L "$TMUX_SOCKET" capture-pane -p -t "$TMUX_SESSION" -S - 2>/dev/null || true)
+    # The session file records the handled turn before Pi's TUI finishes
+    # repainting, so an immediate capture can catch a transient frame that has
+    # cleared the chat back to the startup screen (captain answer count 0) or is
+    # mid-redraw. Poll the rendered pane until it settles into the final frame -
+    # captain answer, prompt, and handled result all present - before asserting.
+    pane=""
+    i=0
+    while [ "$i" -lt 120 ]; do
+      pane=$(tmux -L "$TMUX_SOCKET" capture-pane -p -t "$TMUX_SESSION" -S - 2>/dev/null || true)
+      if [ "$(printf '%s\n' "$pane" | grep -Fc "CAPTAIN_ANSWER_$label" || true)" -eq 1 ] \
+        && printf '%s\n' "$pane" | grep -Fq "CAPTAIN_PROMPT_$label" \
+        && printf '%s\n' "$pane" | grep -Fq "MONITOR_HANDLED_${label}_ONE"; then
+        break
+      fi
+      sleep 0.05
+      i=$((i + 1))
+    done
     [ "$(printf '%s\n' "$pane" | grep -Fc "CAPTAIN_ANSWER_$label" || true)" -eq 1 ] \
       || fail "Pi follow-up $label case rendered a duplicate captain answer"
     assert_contains "$pane" "CAPTAIN_PROMPT_$label" "Pi follow-up $label case hid the genuine captain prompt"

--- a/tests/fm-no-mistakes-required.test.sh
+++ b/tests/fm-no-mistakes-required.test.sh
@@ -5,7 +5,7 @@ set -u
 # shellcheck source=tests/lib.sh disable=SC1091
 . "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
 
-ACTION_REF=32d396ac0f29135daf7fcb9964aba9d5f4e796d6
+ACTION_REF=76fa0921a9797b09e120c8b5979c4d0e65f88922
 TMP_ROOT=$(fm_test_tmproot fm-no-mistakes-required)
 VERIFY="$TMP_ROOT/verify.py"
 OLD_SHA=1111111111111111111111111111111111111111

--- a/tests/fm-pr-check-security.test.sh
+++ b/tests/fm-pr-check-security.test.sh
@@ -1436,6 +1436,28 @@ poll_artifact_snapshot() {
   done
 }
 
+# Emit the captured evidence for a failed bounded watcher cycle: its exit code
+# (124 means run_watcher_bounded's alarm fired, i.e. a timeout rather than a
+# genuine non-zero exit), both captured streams, and the relevant state files.
+# Diagnostics only - it never changes what a caller asserts.
+dump_watcher_cycle() {  # <label> <rc> <dir> <state>
+  local label=$1 rc=$2 dir=$3 state=$4 f
+  printf 'watcher cycle %s exit=%s\n' "$label" "$rc" >&2
+  printf -- '--- stdout (%s.out) ---\n' "$label" >&2
+  cat "$dir/$label.out" >&2 2>/dev/null || true
+  printf -- '--- stderr (%s.err) ---\n' "$label" >&2
+  cat "$dir/$label.err" >&2 2>/dev/null || true
+  printf -- '--- state listing (%s) ---\n' "$state" >&2
+  ls -la "$state" >&2 2>/dev/null || true
+  for f in .wake-queue .last-check; do
+    [ -e "$state/$f" ] || continue
+    printf -- '--- %s ---\n' "$f" >&2
+    cat "$state/$f" >&2 2>/dev/null || true
+  done
+  printf -- '--- poll artifacts ---\n' >&2
+  poll_artifact_snapshot "$state" task-a >&2 2>/dev/null || true
+}
+
 test_merged_poll_retires_once() {
   local dir state rc first second meta_before
   dir=$(make_case merged-retirement-once)
@@ -1939,7 +1961,10 @@ test_external_merge_transition_retires_only_terminal_poll() {
     esac
     rc=$?
     set -e
-    [ "$rc" -eq 0 ] || fail "$label watcher cycle failed: $(cat "$dir/$label.err")"
+    if [ "$rc" -ne 0 ]; then
+      dump_watcher_cycle "$label" "$rc" "$dir" "$state"
+      fail "$label watcher cycle failed (exit $rc)"
+    fi
     case "$(cat "$dir/$label.out")" in check:*z-stop.check.sh:*stop-cycle) ;; *) fail "$label did not reach the control check" ;; esac
     [ "$(poll_artifact_snapshot "$state" task-a)" = "$before" ] || fail "$label changed the armed poll"
     ack_watcher_cycle "$state" || fail "$label control wake acknowledgement failed"


### PR DESCRIPTION
## Intent

On PR https://github.com/kunchenguid/firstmate/pull/3755 the "PR must be raised via no-mistakes" check still shows red, and clearing the stale run manually was not workable ("This won't work" - only the maintainer could clear it).

Root cause: every no-mistakes pipeline push to a firstmate PR fires two runs of the workflow .github/workflows/no-mistakes-required.yml - one on the synchronize event and one on the edited event that follows the attestation restamp seconds later. The pinned require-no-mistakes action reads the PR body from the cached event payload, so the synchronize run judges a stale attestation ("Pipeline attestation head_sha does not match the current PR head") and fails, while the edited run passes. Both check runs stay on the head commit and the maintainer's automation reads the failure as blocking. Observed on PR 3755 head 68dfad2 at 02:13Z (failure completed one second after the success) and on PR 3796.

Goal: stop the race so a firstmate PR no longer shows a spurious red required-no-mistakes check. Have the required-no-mistakes workflow use a require-no-mistakes action version that reads the live PR body and head SHA from the GitHub API instead of the cached event payload, and grant the workflow job the pull-requests: read permission that live lookup needs (it fails the gate closed on a 403 rather than judging the stale cached payload).

## What Changed

- Repin the `require-no-mistakes` action in `.github/workflows/no-mistakes-required.yml` to `76fa0921` (live PR facts) and grant the job `pull-requests: read`, so the required check reads the PR body and head SHA from the GitHub API instead of the cached event payload and no longer races a stale `synchronize` run against the `edited` restamp.
- Update `ACTION_REF` in `tests/fm-no-mistakes-required.test.sh` to match the new action pin.
- Settle the Pi follow-up pane in `tests/fm-calm-pi-extension.test.sh` by polling the rendered tmux frame until the captain answer, prompt, and handled marker are all present before the duplicate-answer assertion.
- Add a `dump_watcher_cycle` diagnostics helper in `tests/fm-pr-check-security.test.sh` that emits the exit code, captured streams, and state files when a bounded watcher cycle fails.

## Risk Assessment

✅ Low: The change is a well-bounded CI workflow pin bump plus matching permission grant that directly implements the stated intent, accompanied by behavior-based test adjustments (an authorized settle-before-assert fix and a failure-path diagnostic helper) with no correctness, security, or simplification defects found.

## Testing

The baseline changed-suite run was already green. I additionally ran the pinned-action regression test (which fetches the new ref's verifier live and passes), parsed the workflow YAML into a semantic model to confirm the `pull-requests: read` grant and the new action pin, and behaviorally exercised the pinned verify.py exactly as the firstmate workflow calls it (no explicit inputs, so it uses the live lookup) against a local stand-in GitHub API - showing it fails closed on a 403 rather than certifying a passing-but-stale cached payload, judges live PR state on success, and names both SHAs on a head/attestation mismatch. A before/after grep confirms the old pin had no live-lookup path while the new pin does, so the fix meaningfully closes the staleness race. This is a CI-workflow config change with no rendered UI surface, so evidence is CLI transcripts and the parsed semantic model rather than screenshots. All checks passed; no findings.

<details>
<summary>Evidence: Live-path behavior transcript (403 fail-closed / 200 live-judge / head-mismatch)</summary>

Source: [Live-path behavior transcript (403 fail-closed / 200 live-judge / head-mismatch)](https://github.com/haroarthur/firstmate/blob/7a6b2c1371f6bfc37badb8346193700a9b817f90/.no-mistakes/evidence/fm/bump-require-no-mistakes-action/live-path-behavior-transcript.txt)

```text
========================================================================
SCENARIO A: live lookup 403s (workflow lacks pull-requests: read)
Cached event payload contains a VALID attestation that would PASS if judged.
========================================================================
exit code: 1
::error::Could not verify this PR's live body/head via the GitHub API, so require-no-mistakes cannot safely evaluate compliance: falling back to the workflow's own cached event payload risks certifying a stale, already-superseded verdict if this job was rerun (see verify.py's module docstring).

Add `pull-requests: read` to this workflow's `permissions:` so require-no-mistakes can verify against live PR state, or forward explicit `pr-body`/`pr-head-sha` inputs to bypass the live lookup entirely.

PR author: someone
>>> PASS: failed CLOSED, did NOT certify the passing cached payload

========================================================================
SCENARIO B: live lookup 200 with a FRESH body bound to live head
Cached payload head differs; action must judge LIVE state, not cache.
========================================================================
exit code: 0
Found no-mistakes signature in PR #3755 body.
Found structurally compliant pipeline step attestation.
::warning::PR-body attestation is author-editable and is not cryptographic proof that no-mistakes produced it.
>>> PASS: judged LIVE PR state and passed

========================================================================
SCENARIO C: live lookup 200 but live head has ADVANCED past attestation
(the race the fix targets: stale attestation vs current head)
========================================================================
exit code: 1
Found no-mistakes signature in PR #3755 body.
::error::Pipeline attestation head_sha does not match the current PR head.

attestation.head_sha: 1111111111111111111111111111111111111111
PR head: 2222222222222222222222222222222222222222

A later push must not pass on an older attestation. Re-run 'git push no-mistakes' so the PR body attestation binds to the current head.

See CONTRIBUTING.md for setup and the full workflow.

PR author: someone
>>> PASS: live head/attestation mismatch named both SHAs and failed

ALL LIVE-PATH SCENARIOS PASSED
```
</details>
<details>
<summary>Evidence: Workflow YAML semantic model (permission + pin assertions)</summary>

Source: [Workflow YAML semantic model (permission + pin assertions)](https://github.com/haroarthur/firstmate/blob/7a6b2c1371f6bfc37badb8346193700a9b817f90/.no-mistakes/evidence/fm/bump-require-no-mistakes-action/workflow-semantic-model.txt)

```text
# Semantic parse of .github/workflows/no-mistakes-required.yml (target commit)

permissions: {"contents": "read", "pull-requests": "read"}
job 'check' step uses: kunchenguid/no-mistakes/.github/actions/require-no-mistakes@76fa0921a9797b09e120c8b5979c4d0e65f88922

ASSERTIONS PASSED:
  - permissions.pull-requests == 'read'  (live-lookup grant)
  - require-no-mistakes pinned to @76fa0921... (live PR facts action)
```
</details>
<details>
<summary>Evidence: Old-vs-new action contrast (cached payload vs live lookup)</summary>

Source: [Old-vs-new action contrast (cached payload vs live lookup)](https://github.com/haroarthur/firstmate/blob/7a6b2c1371f6bfc37badb8346193700a9b817f90/.no-mistakes/evidence/fm/bump-require-no-mistakes-action/old-vs-new-action-contrast.txt)

```text
# require-no-mistakes verify.py: OLD pin vs NEW pin

OLD pin 32d396ac (pre-change) live-lookup symbols (live_pr_facts/urllib.request/GITHUB_API_URL):
0
  -> 0 = old action judged the CACHED event payload (the staleness race)

NEW pin 76fa0921 (this change) live-lookup symbols:
7
  -> >0 = new action reads live PR body/head from the GitHub API
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"6e7000598dfd500337c8c16b13192fa3c566ad24","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `bin/fm-test-run.sh --changed --exclude-family real-herdr-gated`
- <code>`tests/fm-no-mistakes-required.test.sh` (fetches new pin 76fa0921 verify.py live; 3/3 pass)</code>
- <code>Semantic parse of `.github/workflows/no-mistakes-required.yml`: asserted `permissions.pull-requests == &#39;read&#39;` and job pinned to `require-no-mistakes@76fa0921a9797b09e120c8b5979c4d0e65f88922`</code>
- `Behavioral drive of pinned verify.py as the workflow invokes it (zero explicit inputs → live path) against a local stand-in GitHub API: A) 403 fails closed without certifying a passing cached payload, B) 200 fresh body judged live and passes, C) 200 with live head advanced past attestation fails naming both SHAs`
- `Old-vs-new contrast: old pin 32d396ac verify.py has 0 live-lookup symbols vs 7 in new pin (grep on live_pr_facts/urllib.request/GITHUB_API_URL)`
- <code>Baseline `bin/fm-test-run.sh --changed --exclude-family real-herdr-gated` (already green) covers the supporting Pi follow-up and watcher-diagnostics test edits</code>
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
