### PR TITLE
fix(trust): trust secondmate pool worktrees of the parent's clone

### DIFF
--- a/.github/workflows/no-mistakes-required.yml
+++ b/.github/workflows/no-mistakes-required.yml
@@ -9,6 +9,7 @@ on:
 
 permissions:
   contents: read
+  pull-requests: read
 
 # GitHub concurrency groups retain at most one pending run, replacing older
 # pending runs even when cancel-in-progress is false. Give body-bearing events
@@ -27,4 +28,4 @@ jobs:
       github.event.pull_request.user.login != 'dependabot[bot]'
     steps:
       - name: Verify no-mistakes signature and pipeline attestation
-        uses: kunchenguid/no-mistakes/.github/actions/require-no-mistakes@32d396ac0f29135daf7fcb9964aba9d5f4e796d6 # post-v1.57.1, untagged (action added in #819)
+        uses: kunchenguid/no-mistakes/.github/actions/require-no-mistakes@76fa0921a9797b09e120c8b5979c4d0e65f88922 # live PR facts action

--- a/bin/fm-claude-trust.sh
+++ b/bin/fm-claude-trust.sh
@@ -69,6 +69,10 @@ unset CDPATH \
   GIT_DISCOVERY_ACROSS_FILESYSTEM GIT_CONFIG GIT_CONFIG_GLOBAL \
   GIT_CONFIG_SYSTEM GIT_CONFIG_NOSYSTEM GIT_CONFIG_COUNT
 
+SCRIPT_DIR=$(cd -P -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)
+# shellcheck source=bin/fm-secondmate-parent-lib.sh
+. "$SCRIPT_DIR/fm-secondmate-parent-lib.sh"
+
 [ "$#" -eq 2 ] || { echo "usage: fm-claude-trust.sh <worktree> <project>" >&2; exit 2; }
 WT_ARG=$1
 PROJ_ARG=$2
@@ -137,9 +141,34 @@ WT_COMMON=$(common_dir_of "$WT_REAL") || true
 [ -n "$WT_COMMON" ] || refuse "'$WT_REAL' has no resolvable git common directory"
 [ "$WT_GIT_DIR" != "$WT_COMMON" ] || refuse "'$WT_REAL' is a primary checkout, not an isolated worktree"
 
+# A secondmate home's task worktrees come from a shared pool that links against
+# the SAME project's clone in the PARENT home, not this home's own
+# projects/<name> clone, so their common dir matches the parent clone rather than
+# PROJ_REAL. Accept exactly that one additional owner: resolve the parent home
+# from this home's durable secondmate binding, take <parent-home>/projects/<name>
+# for the same project name, and require its resolved common dir to equal the
+# worktree's. This is not a name, origin-URL, or path-prefix match: the git
+# common dirs must be identical after resolution, exactly as the same-home test
+# is. A main home has no binding, so this never fires there and today's single
+# same-home test stands unchanged.
+worktree_belongs_to_parent_clone() {
+  local home=${FM_HOME:-} name parent_clone parent_common
+  [ -n "$home" ] || return 1
+  fm_secondmate_parent_record_parse "$home/.fm-secondmate-parent" || return 1
+  [ "$FM_SECONDMATE_PARENT_ROUTE" = local ] || return 1
+  [ -n "$FM_SECONDMATE_PARENT_HOME" ] || return 1
+  name=$(basename -- "$PROJ_REAL")
+  parent_clone="$FM_SECONDMATE_PARENT_HOME/projects/$name"
+  parent_common=$(common_dir_of "$parent_clone") || return 1
+  [ -n "$parent_common" ] || return 1
+  [ "$WT_COMMON" = "$parent_common" ]
+}
+
 PROJ_COMMON=$(common_dir_of "$PROJ_REAL") || true
 [ -n "$PROJ_COMMON" ] || refuse "project '$PROJ_REAL' is not inside a git repository"
-[ "$WT_COMMON" = "$PROJ_COMMON" ] || refuse "'$WT_REAL' is not a worktree of project '$PROJ_REAL'"
+if [ "$WT_COMMON" != "$PROJ_COMMON" ]; then
+  worktree_belongs_to_parent_clone || refuse "'$WT_REAL' is not a worktree of project '$PROJ_REAL'"
+fi
 
 # The store write needs node, and a missing interpreter refuses like every other
 # failure here. Degrading instead would launch a worker straight into the dialog

--- a/docs/verification/runtime-backends.md
+++ b/docs/verification/runtime-backends.md
@@ -274,7 +274,7 @@ That warning rendered in the same shape as the trust dialog, with the selection 
 That gate is not a production blocker, because a normal environment has already accepted it and the treatment arm above ran against the real config and saw neither dialog.
 This change does not address that warning and does not claim to.
 
-`bin/fm-spawn.sh` therefore pre-registers the task worktree through `bin/fm-claude-trust.sh` before launch, and `tests/fm-claude-trust.test.sh` pins both halves of the scope contract: a fresh worktree is trusted, and an out-of-scope path is refused.
+`bin/fm-spawn.sh` therefore pre-registers the task worktree through `bin/fm-claude-trust.sh` before launch, and `tests/fm-claude-trust.test.sh` pins the scope contract: a fresh same-home worktree is trusted, a secondmate home's pooled worktree of its parent's clone is trusted through the durable parent binding and a git common-dir comparison, and an out-of-scope path - including an unrelated repository's worktree even with a parent binding present - is refused.
 That automated spawn case runs against a fake claude, so it asserts the store entry and the launch command and nothing more; the live arms above are what establish that the entry actually suppresses the dialog.
 The composer-classification record below observes the same gate from the other side, where an untrusted worktree left Claude, Grok, and Muse unverified because the guard reads a first-launch trust dialog as an unreadable composer.
 

--- a/tests/fm-calm-pi-extension.test.sh
+++ b/tests/fm-calm-pi-extension.test.sh
@@ -1818,7 +1818,23 @@ TS
       fail "Pi follow-up $label case did not process the monitoring notification"
     fi
 
-    pane=$(tmux -L "$TMUX_SOCKET" capture-pane -p -t "$TMUX_SESSION" -S - 2>/dev/null || true)
+    # The session file records the handled turn before Pi's TUI finishes
+    # repainting, so an immediate capture can catch a transient frame that has
+    # cleared the chat back to the startup screen (captain answer count 0) or is
+    # mid-redraw. Poll the rendered pane until it settles into the final frame -
+    # captain answer, prompt, and handled result all present - before asserting.
+    pane=""
+    i=0
+    while [ "$i" -lt 120 ]; do
+      pane=$(tmux -L "$TMUX_SOCKET" capture-pane -p -t "$TMUX_SESSION" -S - 2>/dev/null || true)
+      if [ "$(printf '%s\n' "$pane" | grep -Fc "CAPTAIN_ANSWER_$label" || true)" -eq 1 ] \
+        && printf '%s\n' "$pane" | grep -Fq "CAPTAIN_PROMPT_$label" \
+        && printf '%s\n' "$pane" | grep -Fq "MONITOR_HANDLED_${label}_ONE"; then
+        break
+      fi
+      sleep 0.05
+      i=$((i + 1))
+    done
     [ "$(printf '%s\n' "$pane" | grep -Fc "CAPTAIN_ANSWER_$label" || true)" -eq 1 ] \
       || fail "Pi follow-up $label case rendered a duplicate captain answer"
     assert_contains "$pane" "CAPTAIN_PROMPT_$label" "Pi follow-up $label case hid the genuine captain prompt"

--- a/tests/fm-claude-trust.test.sh
+++ b/tests/fm-claude-trust.test.sh
@@ -440,6 +440,69 @@ test_claude_spawn_pretrusts_its_worktree_and_reaches_the_brief() {
   pass "fm-spawn.sh: a claude spawn pre-trusts its worktree and launches with the brief"
 }
 
+# A secondmate home's task worktrees are pooled worktrees of the SAME project's
+# clone in the PARENT home, not of this home's own projects/<name> clone, so
+# their git common dir matches the parent clone. Trust pre-registration must
+# accept that owner - resolved exactly through the durable parent binding and a
+# common-dir comparison - or no claude worker can launch in a secondmate home.
+test_parent_pool_worktree_is_trusted() {
+  local case_dir parent_home sub_home config project parent_clone sub_clone pool_wt out
+  case_dir="$TMP_ROOT/parent-pool"
+  parent_home="$case_dir/parent-home"
+  sub_home="$case_dir/sub-home"
+  config="$case_dir/claude-config"
+  project=analytics
+  parent_clone="$parent_home/projects/$project"
+  sub_clone="$sub_home/projects/$project"
+  pool_wt="$case_dir/treehouse/$project-abc123/1"
+  mkdir -p "$config" "$parent_home/projects" "$sub_home/projects" "$case_dir/treehouse/$project-abc123"
+  # The parent home's clone, and a pooled worktree linked against it.
+  fm_git_init_commit "$parent_clone"
+  git -C "$parent_clone" worktree add --quiet -b pool-1 "$pool_wt"
+  # The secondmate home's own clone of the same project: a SEPARATE repository,
+  # so its common dir differs from the pooled worktree's and the same-home test
+  # alone would refuse the worktree.
+  fm_git_init_commit "$sub_clone"
+  # The durable local parent binding this home resolves the parent from.
+  printf 'schema=fm-secondmate-parent.v1\nroute=local\nparent_home=%s\n' "$parent_home" \
+    > "$sub_home/.fm-secondmate-parent"
+  out=$(FM_HOME="$sub_home" CLAUDE_CONFIG_DIR="$config" HOME="$config" \
+    "$TRUST" "$pool_wt" "$sub_clone" 2>&1)
+  expect_code 0 $? "a pooled worktree of the parent's clone must be trusted in a secondmate home: $out"
+  assert_contains "$out" "trusted:" "registration did not report what it trusted"
+  assert_trusted "$config/.claude.json" "$pool_wt" "the parent-pool worktree was not recorded as trusted"
+  pass "fm-claude-trust.sh: trusts a secondmate pool worktree of the parent's clone"
+}
+
+# The parent path widens the accepted owner to exactly one clone; a pooled
+# worktree of an UNRELATED repository shares neither this home's clone nor the
+# parent's, so it stays refused even with a valid parent binding present.
+test_unrelated_pool_worktree_is_refused_in_secondmate_home() {
+  local case_dir parent_home sub_home config project sub_clone unrelated unrelated_wt out
+  case_dir="$TMP_ROOT/parent-pool-foreign"
+  parent_home="$case_dir/parent-home"
+  sub_home="$case_dir/sub-home"
+  config="$case_dir/claude-config"
+  project=analytics
+  sub_clone="$sub_home/projects/$project"
+  unrelated="$case_dir/unrelated-repo"
+  unrelated_wt="$case_dir/unrelated-wt"
+  mkdir -p "$config" "$parent_home/projects" "$sub_home/projects"
+  fm_git_init_commit "$parent_home/projects/$project"
+  fm_git_init_commit "$sub_clone"
+  # A worktree of a wholly unrelated repository, not the parent's clone.
+  fm_git_init_commit "$unrelated"
+  git -C "$unrelated" worktree add --quiet -b unrelated-1 "$unrelated_wt"
+  printf 'schema=fm-secondmate-parent.v1\nroute=local\nparent_home=%s\n' "$parent_home" \
+    > "$sub_home/.fm-secondmate-parent"
+  out=$(FM_HOME="$sub_home" CLAUDE_CONFIG_DIR="$config" HOME="$config" \
+    "$TRUST" "$unrelated_wt" "$sub_clone" 2>&1)
+  expect_code 1 $? "an unrelated repository's worktree must still be refused in a secondmate home: $out"
+  assert_contains "$out" "is not a worktree of project" "the refusal did not name the project mismatch"
+  assert_not_trusted "$config/.claude.json" "$unrelated_wt" "an unrelated repository's worktree was trusted"
+  pass "fm-claude-trust.sh: refuses an unrelated pool worktree even with a parent binding"
+}
+
 test_fresh_worktree_is_trusted
 test_registration_is_idempotent
 test_primary_checkout_is_refused
@@ -460,3 +523,5 @@ test_missing_node_is_refused
 test_scope_refusal_stays_fail_closed_without_node
 test_claude_spawn_pretrusts_its_worktree_and_reaches_the_brief
 test_refused_spawn_leaves_no_task_state
+test_parent_pool_worktree_is_trusted
+test_unrelated_pool_worktree_is_refused_in_secondmate_home

--- a/tests/fm-no-mistakes-required.test.sh
+++ b/tests/fm-no-mistakes-required.test.sh
@@ -5,7 +5,7 @@ set -u
 # shellcheck source=tests/lib.sh disable=SC1091
 . "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
 
-ACTION_REF=32d396ac0f29135daf7fcb9964aba9d5f4e796d6
+ACTION_REF=76fa0921a9797b09e120c8b5979c4d0e65f88922
 TMP_ROOT=$(fm_test_tmproot fm-no-mistakes-required)
 VERIFY="$TMP_ROOT/verify.py"
 OLD_SHA=1111111111111111111111111111111111111111

--- a/tests/fm-tmux-agent-liveness.test.sh
+++ b/tests/fm-tmux-agent-liveness.test.sh
@@ -23,12 +23,32 @@ fail() { printf 'not ok - %s\n' "$1" >&2; cleanup_all; exit 1; }
 pass() { printf 'ok - %s\n' "$1"; }
 
 command -v tmux >/dev/null 2>&1 || { echo "skip: tmux not found"; exit 0; }
-SLEEP_BIN=$(command -v sleep) || { echo "skip: sleep not found"; exit 0; }
 
 REAL_TMUX=$(command -v tmux)
 SOCKET="fm-liveness-$$"
 LAB=$(mktemp -d "${TMPDIR:-/tmp}/fm-liveness.XXXXXX")
 SESSION=liveness
+
+# The stand-in "harness" binaries below are symlinks whose LINK NAME is the
+# executable identity under test, exec'd as `<name> <seconds>`. A multi-call
+# coreutils `sleep` (e.g. Nix's) dispatches on argv[0], so under a renamed
+# symlink it prints "coreutils: unknown program <name>" and exits 1 - the pane
+# dies at once and every case misreads as dead. Pick the FIRST sleep that still
+# runs correctly when invoked through a renamed symlink; a standalone /bin/sleep
+# does, the coreutils multi-call one does not.
+SLEEP_BIN=
+for _sleep_candidate in /bin/sleep /usr/bin/sleep "$(command -v sleep 2>/dev/null)"; do
+  [ -n "$_sleep_candidate" ] && [ -x "$_sleep_candidate" ] || continue
+  _probe_dir=$(mktemp -d "${TMPDIR:-/tmp}/fm-liveness-probe.XXXXXX") || continue
+  ln -s "$_sleep_candidate" "$_probe_dir/probe-link"
+  if ( cd "$_probe_dir" && ./probe-link 0 ) >/dev/null 2>&1; then
+    SLEEP_BIN=$_sleep_candidate
+    rm -rf "$_probe_dir"
+    break
+  fi
+  rm -rf "$_probe_dir"
+done
+[ -n "$SLEEP_BIN" ] || { echo "skip: no argv0-independent sleep binary found"; exit 0; }
 
 cleanup_all() {
   "$REAL_TMUX" -L "$SOCKET" kill-server >/dev/null 2>&1 || true


### PR DESCRIPTION
## Intent

Captain context, 2026-09-05: the Codex weekly quota is exhausted until 2026-09-07 and the agreed fallback is Claude Opus 4.8 for every worker. That fallback cannot launch inside the two secondmate homes. Both mates reported the same refusal today when spawning or relaunching with --harness claude: "refusing to pre-register Claude trust: <pool worktree> is not a worktree of project <this home's projects/<name>>". The pooled treehouse worktrees (for example ~/.treehouse/analytics-de7c41/<n>) share the MAIN home's clone common dir (~/firstmate/projects/analytics/.git), while bin/fm-claude-trust.sh's structural check requires the worktree to belong to the secondmate home's own projects/<name> clone. Codex spawns skip that step and work. Consequence: no Claude crewmate or scout can run in a secondmate home, so the analytics home's board hosts had to fall back to Grok and its playbook research scout is parked.

## What Changed

- `bin/fm-claude-trust.sh` now accepts one additional worktree owner: when a worktree's git common dir does not match this home's `projects/<name>` clone, it resolves the parent home from the durable `.fm-secondmate-parent` local binding and trusts the worktree only when its common dir is identical to `<parent-home>/projects/<name>`'s, so pooled treehouse worktrees sharing the parent clone can pre-register Claude trust while unrelated repositories stay refused.
- Added `tests/fm-claude-trust.test.sh` cases pinning both halves of the widened contract (a parent-pool worktree is trusted, an unrelated repo's worktree is still refused even with a parent binding) and reworded the scope-contract note in `docs/verification/runtime-backends.md` to match.
- Bumped the `require-no-mistakes` action pin (workflow and `fm-no-mistakes-required.test.sh`) and granted the workflow `pull-requests: read`; stabilized two flaky tests by polling the Pi follow-up pane until it settles and by probing for an argv0-independent `sleep` binary in the tmux liveness test.

## Risk Assessment

✅ Low: The change is well-bounded and structural: it adds exactly one additional trust owner gated by a resolved git-common-dir equality through a durable, symlink-rejecting parent binding, preserves every prior structural refusal, satisfies the authoritative intent, and is covered by behavioral accept/refuse tests.

## Testing

Baseline `bin/fm-test-run.sh --changed --exclude-family real-herdr-gated` already passed. I ran the two suites most relevant to the intent: the trust suite (all 22 cases green, including the two new behavioral tests that spawn a real parent clone, a pooled git worktree, a separate secondmate clone, and a durable parent binding) and the tmux liveness suite from round 1 (all 14 green). I confirmed the new trust tests are true regressions by reverting only bin/fm-claude-trust.sh to the base commit, reproducing the exact 'is not a worktree of project' refusal named in the user intent, then restoring the fix to green. This is a CLI/behavioral change with no UI surface, so the evidence is a before/after CLI transcript rather than a visual artifact. Working tree left clean.

<details>
<summary>Evidence: Claude trust pooled-worktree before/after CLI transcript</summary>

Source: [Claude trust pooled-worktree before/after CLI transcript](https://github.com/haroarthur/firstmate/blob/77bb16845bc377d53775017a3abd2d72ed2792f5/.no-mistakes/evidence/fm/fix-claude-trust-pooled-worktree/claude-trust-pooled-worktree.txt)

```text
=== Claude trust pooled-worktree fix: end-to-end behavioral evidence ===

User intent: a secondmate home's pooled treehouse worktrees share the PARENT
home's clone common dir, so trust pre-registration wrongly refused them and no
Claude worker/scout could launch in a secondmate home.

--- BEFORE FIX (bin/fm-claude-trust.sh at base af8c4b6) ---
not ok - a pooled worktree of the parent's clone must be trusted in a secondmate home: error: refusing to pre-register Claude trust: '/tmp/fm-claude-trust.P2ZG58/parent-pool/treehouse/analytics-abc123/1' is not a worktree of project '/tmp/fm-claude-trust.P2ZG58/parent-pool/sub-home/projects/analytics': expected exit 0, got 1

--- AFTER FIX (target 381ccfd) ---
ok - fm-claude-trust.sh: trusts a secondmate pool worktree of the parent's clone
ok - fm-claude-trust.sh: refuses an unrelated pool worktree even with a parent binding

The pooled-worktree acceptance test fails before the fix with the exact
'is not a worktree of project' refusal from the report, and passes after;
the unrelated-worktree test confirms the widened owner stays fail-closed.
```
</details>
<details>
<summary>Evidence: Regression: pooled-worktree test fails before fix, passes after</summary>

```text
BEFORE FIX: not ok - a pooled worktree of the parent's clone must be trusted in a secondmate home: error: refusing to pre-register Claude trust: '.../analytics-abc123/1' is not a worktree of project '.../sub-home/projects/analytics': expected exit 0, got 1
AFTER FIX: ok - fm-claude-trust.sh: trusts a secondmate pool worktree of the parent's clone
AFTER FIX: ok - fm-claude-trust.sh: refuses an unrelated pool worktree even with a parent binding
```
</details>
- Outcome: 🔧 1 issue found → auto-fixed ✅ across 2 runs (32m9s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"d4c3bb4f49b37f4c21e45988773dd1a7b57cd5bb","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>⚠️ **Review** - 1 info</summary>

- ℹ️ `bin/fm-claude-trust.sh:22` - The top-of-file safety docstring (bin/fm-claude-trust.sh:22-29) still states the invariant as the worktree &#34;sharing &lt;project&gt;&#39;s common dir&#34; and enumerates &#34;a worktree of an unrelated repo&#34; among what is &#34;each refused,&#34; but the new worktree_belongs_to_parent_clone path now also accepts a worktree whose common dir matches the PARENT home&#39;s projects/&lt;name&gt; clone. The inline comment at 144-153 documents the new owner, but the authoritative SAFETY PROPERTY header no longer describes the full accepted set, which could mislead a future maintainer of this security-sensitive file into treating the parent-clone case as a bug. Non-functional documentation accuracy only; behavior is correct and well-tested.
</details>

<details>
<summary>🔧 **Test** - 1 issue found → auto-fixed ✅</summary>

- 🚨 tests failed with exit code 1
- `bin/fm-test-run.sh --changed --exclude-family real-herdr-gated`

🔧 Fix: probe for argv0-independent sleep in tmux liveness test
✅ Re-checked - no issues remain.
- `bin/fm-test-run.sh --changed --exclude-family real-herdr-gated`
- <code>`bash tests/fm-claude-trust.test.sh` (22/22 ok, incl. new `test_parent_pool_worktree_is_trusted` and `test_unrelated_pool_worktree_is_refused_in_secondmate_home`)</code>
- <code>`bash tests/fm-tmux-agent-liveness.test.sh` (14/14 ok, round-1 argv0-independent sleep fix)</code>
- <code>Regression proof: reverted `bin/fm-claude-trust.sh` to base af8c4b6 -&gt; `test_parent_pool_worktree_is_trusted` fails with &#39;is not a worktree of project&#39;; restored fix -&gt; passes</code>
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
