### PR TITLE
fix: judge no-mistakes compliance from live PR facts

### DIFF
--- a/.github/workflows/no-mistakes-required.yml
+++ b/.github/workflows/no-mistakes-required.yml
@@ -9,6 +9,7 @@ on:
 
 permissions:
   contents: read
+  pull-requests: read
 
 # GitHub concurrency groups retain at most one pending run, replacing older
 # pending runs even when cancel-in-progress is false. Give body-bearing events
@@ -27,4 +28,4 @@ jobs:
       github.event.pull_request.user.login != 'dependabot[bot]'
     steps:
       - name: Verify no-mistakes signature and pipeline attestation
-        uses: kunchenguid/no-mistakes/.github/actions/require-no-mistakes@32d396ac0f29135daf7fcb9964aba9d5f4e796d6 # post-v1.57.1, untagged (action added in #819)
+        uses: kunchenguid/no-mistakes/.github/actions/require-no-mistakes@76fa0921a9797b09e120c8b5979c4d0e65f88922 # live PR facts action

--- a/tests/fm-no-mistakes-required.test.sh
+++ b/tests/fm-no-mistakes-required.test.sh
@@ -5,7 +5,7 @@ set -u
 # shellcheck source=tests/lib.sh disable=SC1091
 . "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
 
-ACTION_REF=32d396ac0f29135daf7fcb9964aba9d5f4e796d6
+ACTION_REF=76fa0921a9797b09e120c8b5979c4d0e65f88922
 TMP_ROOT=$(fm_test_tmproot fm-no-mistakes-required)
 VERIFY="$TMP_ROOT/verify.py"
 OLD_SHA=1111111111111111111111111111111111111111


### PR DESCRIPTION
## Intent

On firstmate PRs the required "PR must be raised via no-mistakes" check has shown a spurious red verdict (seen on PR 3755 and PR 3796). The pinned require-no-mistakes action judges compliance against the cached workflow event payload, so a workflow run triggered by an event that carries a stale PR body and head SHA (the synchronize run that precedes the attestation restamp) renders a stale "attestation head_sha does not match the current PR head" FAILURE. That failure stays pinned on the head commit and reads as blocking to the maintainer automation even though the PR is actually compliant.

Goal: remove that stale-event verdict. Bump the required-no-mistakes workflow (.github/workflows/no-mistakes-required.yml) to the require-no-mistakes action version that reads the PR body and head SHA live from the GitHub API instead of the cached event payload, and grant the workflow job pull-requests: read so that live lookup works - without it the action fails the gate closed on a 403 rather than judging the stale cached payload. Keep the change to exactly that: the action pin, the pull-requests: read permission, and the matching action-ref pin in the test. This removes the stale-event verdict; it does not claim to remove the underlying behavior that more than one workflow run can fire per push.

## What Changed

- Pin the required no-mistakes gate action to the version that reads current pull request facts from the GitHub API.
- Grant `pull-requests: read` permission and update the regression test to use the matching action revision.

## Risk Assessment

✅ Low: The narrowly scoped pin and permission updates satisfy the stated intent, and the pinned action uses live PR body and head data while failing closed if lookup is unavailable.

## Testing

The configured baseline and focused verifier tests passed; end-to-end API simulations reproduced the old stale-event failure, proved the new pin reads compliant live PR facts, and confirmed denied live access fails closed with `pull-requests: read` guidance.

<details>
<summary>Evidence: Pre-fix stale-event failure reproduction</summary>

Source: [Pre-fix stale-event failure reproduction](https://github.com/haroarthur/firstmate/blob/29acd2f0a95a9014a1087840a7e0ce45bdd98805/.no-mistakes/evidence/fm/require-no-mistakes-live-facts/require-no-mistakes-before-fix-reproduction.txt)

```text
PRE-FIX REPRODUCTION - stale event body, current event head, compliant live PR
cached attestation head: 1111111111111111111111111111111111111111
cached event head:       2222222222222222222222222222222222222222
live API head:           2222222222222222222222222222222222222222
live API requests:       []
exit code:               1
Found no-mistakes signature in PR #3796 body.
::error::Pipeline attestation head_sha does not match the current PR head.

attestation.head_sha: 1111111111111111111111111111111111111111
PR head: 2222222222222222222222222222222222222222

A later push must not pass on an older attestation. Re-run 'git push no-mistakes' so the PR body attestation binds to the current head.

See CONTRIBUTING.md for setup and the full workflow.

PR author: contributor
RESULT - the prior pin reproduces the spurious red verdict and never consults the available live PR endpoint.
```
</details>
<details>
<summary>Evidence: Fixed live-facts and 403 fail-closed verification</summary>

Source: [Fixed live-facts and 403 fail-closed verification](https://github.com/haroarthur/firstmate/blob/29acd2f0a95a9014a1087840a7e0ce45bdd98805/.no-mistakes/evidence/fm/require-no-mistakes-live-facts/require-no-mistakes-live-facts.txt)

```text
Resolved workflow/action contract:
{
  "action": "kunchenguid/no-mistakes/.github/actions/require-no-mistakes@76fa0921a9797b09e120c8b5979c4d0e65f88922",
  "permissions": {
    "contents": "read",
    "pull-requests": "read"
  },
  "token_default": "${{ github.token }}",
  "token_env": "${{ inputs.github-token }}"
}

CASE 1 - stale event, compliant live PR
archived event head: 1111111111111111111111111111111111111111
live API head:       2222222222222222222222222222222222222222
API request:         ['/repos/kunchenguid/firstmate/pulls/3796']
exit code:           0
action outputs:      exempt=false
compliant=true
Found no-mistakes signature in PR #3796 body.
Found structurally compliant pipeline step attestation.
::warning::PR-body attestation is author-editable and is not cryptographic proof that no-mistakes produced it.

CASE 2 - same event, live lookup denied
archived event head: 1111111111111111111111111111111111111111
live API head:       (403 denied)
API request:         ['/repos/kunchenguid/firstmate/pulls/3796']
exit code:           1
action outputs:      exempt=false
compliant=false
exempt=false
::error::Could not verify this PR's live body/head via the GitHub API, so require-no-mistakes cannot safely evaluate compliance: falling back to the workflow's own cached event payload risks certifying a stale, already-superseded verdict if this job was rerun (see verify.py's module docstring).

Add `pull-requests: read` to this workflow's `permissions:` so require-no-mistakes can verify against live PR state, or forward explicit `pr-body`/`pr-head-sha` inputs to bypass the live lookup entirely.

PR author: contributor

RESULT - live PR facts replace stale event facts; denied live lookup fails closed with the required permission named.
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"0fdeca6bab6decd4904cc5c8917c9a74a7f81ee1","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `bin/fm-test-run.sh --changed --exclude-family real-herdr-gated`
- <code>Baseline already completed: `bin/fm-test-run.sh --changed --exclude-family real-herdr-gated`</code>
- `tests/fm-no-mistakes-required.test.sh`
- <code>Parsed the workflow and pinned action as normalized YAML and verified `pull-requests: read`, the action SHA, and GitHub token wiring</code>
- `Executed the old verifier with stale cached facts and a compliant live PR, reproducing the red verdict and confirming no live API request occurred`
- <code>Executed the new verifier against a local GitHub Pull Requests API simulation, confirming live facts produced `compliant=true`</code>
- <code>Repeated the new-verifier simulation with HTTP 403, confirming `compliant=false` and actionable permission guidance</code>
- `git status --short`
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
