### PR TITLE
test: stabilize remote-job heartbeat readiness coverage

### DIFF
--- a/tests/fm-remote-job.test.sh
+++ b/tests/fm-remote-job.test.sh
@@ -243,7 +243,7 @@ done
   || fail "the active-job readiness fixture did not begin running"
 ACTIVE_WORKER_PID=$(cat "$STATE_ROOT/worker.pid")
 touch -t 200001010000 "$STATE_ROOT/worker.ready"
-for _ in $(seq 1 40); do
+for _ in $(seq 1 100); do
   fm_remote_job_probe "$ACCOUNT_HOME" && break
   sleep 0.05
 done

--- a/tests/fm-remote-job.test.sh
+++ b/tests/fm-remote-job.test.sh
@@ -59,6 +59,13 @@ cat > "$REMOTE_ROOT/bin/fm-delay-job.sh" <<'SH'
 sleep "$1"
 printf 'ran\n' > "$2"
 SH
+cat > "$REMOTE_ROOT/bin/fm-held-job.sh" <<'SH'
+#!/bin/bash
+while [ ! -e "$1" ]; do
+  sleep 0.05
+done
+printf 'ran\n' > "$2"
+SH
 cat > "$REMOTE_ROOT/bin/fm-touch-job.sh" <<'SH'
 #!/bin/bash
 printf 'ran\n' > "$1"
@@ -230,9 +237,10 @@ assert_absent "$FAKE_PERL_LOG" "the worker invoked an unavailable Perl runtime"
 pass "the worker preserves bounded argv and stdin in an empty environment"
 
 ACTIVE_SIDE_EFFECT="$TMP_ROOT/active-side-effect"
-FM_REMOTE_JOB_TIMEOUT=10
+ACTIVE_RELEASE="$TMP_ROOT/active-release"
+FM_REMOTE_JOB_TIMEOUT=15
 fm_remote_job_stage "$ACCOUNT_HOME" "$REMOTE_ROOT" "$REMOTE_HOME" \
-  fm-delay-job.sh 4 "$ACTIVE_SIDE_EFFECT" < /dev/null > /dev/null
+  fm-held-job.sh "$ACTIVE_RELEASE" "$ACTIVE_SIDE_EFFECT" < /dev/null > /dev/null
 JOB_ID=$FM_REMOTE_JOB_ID
 JOB_DIR="$STATE_ROOT/jobs/$JOB_ID"
 for _ in $(seq 1 100); do
@@ -248,9 +256,12 @@ for _ in $(seq 1 100); do
   sleep 0.05
 done
 fm_remote_job_probe "$ACCOUNT_HOME" || fail "the active worker did not refresh its readiness heartbeat"
+[ "$(fm_remote_job_read_state "$JOB_DIR" 2>/dev/null || true)" = running ] \
+  || fail "the heartbeat probe succeeded after the active job stopped running"
 fm_remote_job_ensure_worker "$REMOTE_ROOT" "$ACCOUNT_HOME" || fail "$FM_REMOTE_JOB_ERROR"
 [ "$(cat "$STATE_ROOT/worker.pid")" = "$ACTIVE_WORKER_PID" ] \
   || fail "ensure replaced a healthy worker during an active job"
+touch "$ACTIVE_RELEASE"
 fm_remote_job_wait "$ACCOUNT_HOME" "$JOB_ID" || fail "$FM_REMOTE_JOB_ERROR"
 [ "$FM_REMOTE_JOB_EXIT" -eq 0 ] || fail "the active job did not complete after the readiness probe"
 assert_present "$ACTIVE_SIDE_EFFECT" "the active job was interrupted by the concurrent readiness check"


### PR DESCRIPTION
## Intent

Fix the sole red CI check blocking PR 7: tests/fm-remote-job.test.sh has an already-diagnosed insufficient readiness-heartbeat wait at the loop formerly using 40 x 0.05s. Give that wait a reasonable budget of at least the same 100 x 0.05s used by the immediately preceding worker-start wait. Do not change the final heartbeat assertion or weaken what the test requires; if the test still fails with this reasonable budget, stop and report evidence rather than increasing the number until it passes. Review comparable bounded waits in the behavior-test family and report whether this inconsistency is isolated or repeated; the review found it isolated among comparable remote-job readiness/state waits. The PR body must include this rationale, textually or equivalently: "un rojo permanente en CI que todos aprenden a ignorar es peor que no tener la prueba, porque el dia que se rompa de verdad nadie va a mirar." Deliver through no-mistakes, preserving its validation and CI gates. Open the PR against josecarvallo/firstmate with base main, not the read-only parent repository, and verify the created PR destination after creation.

## What Changed

- Extend the active-worker heartbeat poll from 40 to 100 × 0.05s attempts, matching comparable remote-job readiness/state waits; this was the isolated short wait.
- Hold the fixture job until explicitly released and verify it remains running when the heartbeat probe succeeds, preventing early completion from masking the readiness check.
- Captain, the final heartbeat assertion remains unchanged. Rationale: “un rojo permanente en CI que todos aprenden a ignorar es peor que no tener la prueba, porque el dia que se rompa de verdad nadie va a mirar.”

## Risk Assessment

✅ Low: Captain, this test-only change preserves the required probe budget and final assertion while ensuring the held job remains running when the refreshed heartbeat is observed.

## Testing

The supplied changed-test baseline and fresh focused remote-job test passed; controlled end-to-end timing evidence showed the former 40-attempt window expire, the 100-attempt window succeed at attempt 47 while the job remained running, the same worker stay in service, and the released job complete successfully.

<details>
<summary>Evidence: Focused remote-job behavior test</summary>

Source: [Focused remote-job behavior test](https://github.com/josecarvallo/firstmate/blob/719528401d484da768387ed21e59bb49ebf0a8a8/.no-mistakes/evidence/fm/firstmate-espera-corta-en-prueba-de-trabajo-remoto/focused-fm-remote-job.log)

```text
FM_TEST_BEGIN 2026-09-05T21:26:11Z tests/fm-remote-job.test.sh family=secondmate expected_gate_skip=none
ok - default queue and execution bounds independently cover long polls
ok - operator PATH excludes a symlinked local bin
ok - operator PATH honors nvm defaults with a deterministic fallback
ok - operator PATH resolves the authorized Nix profile bin link
ok - operator PATH orders discovered tool installs deterministically
ok - the worker preserves bounded argv and stdin in an empty environment
ok - active jobs keep the worker ready for concurrent requests
ok - ensure replaces a live worker after its code changes
ok - worker identity binds the canonical configured code root
ok - stale ownership is reclaimed without signaling a reused pid
ok - the worker enforces the job timeout and publishes its result
ok - the worker expires queued jobs before they can mutate
ok - queued jobs receive a fresh bounded execution window
ok - a queued short command preempts a running long poll instead of waiting its window
ok - a poll re-armed after preemption reads the same cursor with nothing lost
ok - sibling polls never preempt each other into a re-arm churn loop
ok - worker shutdown terminates the active command tree before replacement
ok - Linux supervision recovers crashes and stops orphaned commands
ok - pre-execution validation obeys the job timeout
ok - the worker drains bounded output without changing command results
ok - the worker refuses symlinked job fields before command execution
ok - failed shutdown quarantines ownership against replacement workers
ok - quarantine recovery refuses unverifiable supervisors and ignores reused pids
ok - a repeatedly signalled shutdown still releases ownership for the next worker
ok - barely healthy worker failures remain bounded by the restart guard
ALL TESTS PASSED
FM_TEST_END 2026-09-05T21:27:19Z tests/fm-remote-job.test.sh exit=0 duration_ms=67733 gate_skip=false
FM_TEST_SUMMARY total=1 failed=0 skipped_gate=0 duration_ms=67824
FM_TEST_SUMMARY_FAMILY family=secondmate count=1 duration_ms=67733 failed=0
FM_TEST_SLOWEST rank=1 script=tests/fm-remote-job.test.sh duration_ms=67733
```
</details>
<details>
<summary>Evidence: Active-job heartbeat timing demonstration</summary>

Source: [Active-job heartbeat timing demonstration](https://github.com/josecarvallo/firstmate/blob/719528401d484da768387ed21e59bb49ebf0a8a8/.no-mistakes/evidence/fm/firstmate-espera-corta-en-prueba-de-trabajo-remoto/active-heartbeat-timing-transcript.txt)

<code>scenario=active remote job under a controlled 6-second worker cycle&#10;job_state_before_stale=running&#10;probe_after_40x0.05s=expired_without_readiness&#10;probe_success_attempt=47 (within 100x0.05s)&#10;job_state_at_probe_success=running&#10;worker_pid_before=61036&#10;worker_pid_after_ensure=61036&#10;worker_reused=yes&#10;job_exit_after_release=0&#10;held_job_side_effect=ran</code>

```text
scenario=active remote job under a controlled 6-second worker cycle
job_state_before_stale=running
stale_heartbeat_mtime=946695600
probe_after_40x0.05s=expired_without_readiness
probe_success_attempt=47 (within 100x0.05s)
refreshed_heartbeat_mtime=1788643930
job_state_at_probe_success=running
worker_pid_before=61036
worker_pid_after_ensure=61036
worker_reused=yes
job_exit_after_release=0
held_job_side_effect=ran
result=40-attempt budget expired; 100-attempt budget observed readiness while the same job was still running
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"b7c42f8dd37a4189e4e732f9edde7305852f0940","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed ✅</summary>

- 🚨 `tests/fm-remote-job.test.sh:246` - Intent requires “Do not … weaken what the test requires,” but changing `seq 1 40` to `seq 1 100` gives the heartbeat 5 seconds while the active fixture at line 235 runs only 4 seconds. A regression that executes the lane synchronously would refresh the heartbeat after the job finishes at ~4 seconds and this test would now pass, despite losing readiness during active work. Keep the 100-iteration budget, but assert the job is still `running` when the heartbeat probe succeeds or hold the fixture open explicitly.

🔧 Fix: test: strengthen active heartbeat fixture invariants
✅ Re-checked - no issues remain.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `bin/fm-test-run.sh --changed --exclude-family real-herdr-gated`
- <code>Supplied baseline: `bin/fm-test-run.sh --changed --exclude-family real-herdr-gated` (successful).</code>
- `bin/fm-test-run.sh tests/fm-remote-job.test.sh`
- <code>Controlled `bash -s` executable-interface scenario: started `fm-remote-job-worker.sh` with a six-second cycle, staged a held job, made `worker.ready` stale, checked attempts 40 and 100, verified running state and stable worker PID, then released the job and verified exit 0 plus its side effect.</code>
- <code>Reviewed bounded readiness/state waits with `rg` across `tests/fm-remote-job*.test.sh`; the shorter 40-attempt readiness wait was isolated among comparable remote-job waits.</code>
- <code>Verified target commit `b7c42f8dd37a4189e4e732f9edde7305852f0940`, a clean source tree, and no surviving evidence-fixture worker processes.</code>
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
