### PR TITLE
fix(pi): hide internal pending notification previews

### DIFF
--- a/.pi/extensions/fm-pending-notifications.ts
+++ b/.pi/extensions/fm-pending-notifications.ts
@@ -1,0 +1,13 @@
+// Pending notification visibility is independent of Calm's transcript preference.
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { installPendingNotificationLayout } from "./lib/fm-pending-notification-layout.ts";
+
+export default function (pi: ExtensionAPI): void {
+  try {
+    const layout = installPendingNotificationLayout();
+    pi.on("session_start", () => layout.refresh());
+    pi.on("session_shutdown", () => layout.dispose());
+  } catch (error) {
+    console.error(`Firstmate: pending-notification presentation adapter unavailable, skipping. ${String(error)}`);
+  }
+}

--- a/.pi/extensions/lib/fm-pending-notification-layout.ts
+++ b/.pi/extensions/lib/fm-pending-notification-layout.ts
@@ -1,0 +1,173 @@
+// Pi 0.85.1 has no supported pending-row renderer. Probe its presentation seams,
+// retain stock components, and change only their rendered height. In particular,
+// getAllQueuedMessages() drops images, so text alone must never authorize hiding.
+// Read the agent's full pending messages at render time: Pi emits queue_update
+// BEFORE adding the full message. Never mutate, drain, or replace either queue.
+import * as Pi from "@earendil-works/pi-coding-agent";
+import { Spacer, TruncatedText, type Component } from "@earendil-works/pi-tui";
+import { classifyFirstmateCurrentOperationalText } from "./fm-operational-input.ts";
+
+type Queues = { steering: string[]; followUp: string[] };
+type Mode = {
+  pendingMessagesContainer: { children: Component[] };
+  getAllQueuedMessages(): Queues;
+  session: { agent: unknown };
+  ui: { requestRender(): void };
+};
+type Prototype = {
+  updatePendingMessagesDisplay(this: Mode): void;
+  createExtensionUIContext(this: Mode): unknown;
+};
+type Patch = {
+  owner: symbol;
+  active: boolean;
+  modes: Set<WeakRef<Mode>>;
+  refresh(mode: Mode): void;
+};
+const PATCH = Symbol.for("firstmate:pending-notification-layout:v1");
+
+// Structural extraction only; the operational protocol remains owned by the
+// canonical parser. Unknown roles/content and image-bearing inputs stay visible.
+function userText(message: unknown): { text: string; textOnly: boolean } | undefined {
+  if (!message || typeof message !== "object") return undefined;
+  const { role, content } = message as { role?: unknown; content?: unknown };
+  if (role !== "user") return undefined;
+  if (typeof content === "string") return { text: content, textOnly: true };
+  if (!Array.isArray(content)) return undefined;
+  const texts = content.filter((block) => block?.type === "text" && typeof block.text === "string");
+  return { text: texts.map((block) => block.text).join("\n"), textOnly: texts.length > 0 && texts.length === content.length };
+}
+
+export function installPendingNotificationLayout(): { refresh(): void; dispose(): void } {
+  const registry = globalThis as typeof globalThis & { [key: symbol]: Patch | undefined };
+  const owner = Symbol();
+  let patch = registry[PATCH];
+  if (!patch) {
+    const prototype = Pi.InteractiveMode?.prototype as unknown as Prototype | undefined;
+    if (!prototype || typeof prototype.updatePendingMessagesDisplay !== "function" ||
+        typeof prototype.createExtensionUIContext !== "function") {
+      throw new Error(`Pi ${Pi.VERSION ?? "unknown"} requires InteractiveMode.updatePendingMessagesDisplay and createExtensionUIContext`);
+    }
+    const originalUpdate = prototype.updatePendingMessagesDisplay;
+    const originalContext = prototype.createExtensionUIContext;
+    const seen = new WeakSet<Mode>();
+    const decorated = new WeakSet<Component>();
+    const diagnostics = new Set<string>();
+    // Bound cached parser results; repeated repaints must not spawn per-row shells.
+    const classifications = new Map<string, boolean>();
+    const diagnostic = (reason: string): void => {
+      if (diagnostics.has(reason)) return;
+      diagnostics.add(reason);
+      console.error(`Firstmate: pending-notification presentation adapter unavailable, keeping stock rows. Pi ${Pi.VERSION ?? "unknown"}: ${reason}`);
+    };
+    const state: Patch = {
+      owner, active: true, modes: new Set(),
+      refresh(mode) {
+        if (!seen.has(mode)) {
+          seen.add(mode);
+          state.modes.add(new WeakRef(mode));
+        }
+        try {
+          const children = mode.pendingMessagesContainer?.children;
+          const queues = mode.getAllQueuedMessages();
+          if (!Array.isArray(children) || !Array.isArray(queues.steering) || !Array.isArray(queues.followUp)) {
+            throw new Error("Pi pending container or queue snapshot changed");
+          }
+          const rows = [
+            ...queues.steering.map((text) => ({ text, kind: "steering" as const })),
+            ...queues.followUp.map((text) => ({ text, kind: "followUp" as const })),
+          ];
+          if (!rows.length || decorated.has(children[0])) return;
+          if (children.length < rows.length + 2 || !(children[0] instanceof Spacer) ||
+              !children.slice(1, rows.length + 2).every((child) => child instanceof TruncatedText)) {
+            throw new Error("Pi pending row/spacer/hint layout changed");
+          }
+          const operational = rows.map(({ text }) => {
+            if (typeof text !== "string") throw new Error("Pi pending text shape changed");
+            if (!text.includes("\u2063")) return false;
+            if (!classifications.has(text)) {
+              if (classifications.size >= 256) classifications.clear();
+              classifications.set(text, classifyFirstmateCurrentOperationalText(text) !== undefined);
+            }
+            return classifications.get(text)!;
+          });
+          // Bind each row to its exact snapshot before hiding anything. A vendor
+          // reorder with the same component classes must also degrade visibly.
+          rows.forEach((row, index) => {
+            const formatted = (children[index + 1] as unknown as { text?: unknown }).text;
+            const label = row.kind === "steering" ? "Steering" : "Follow-up";
+            if (typeof formatted !== "string" ||
+                formatted.replace(/^(?:\x1b\[[0-9;]*m)+/, "").replace(/(?:\x1b\[[0-9;]*m)+$/, "") !== `${label}: ${row.text}`) {
+              throw new Error("Pi pending row identity changed");
+            }
+          });
+          const hidden = (index: number): boolean => {
+            if (!state.active || !operational[index]) return false;
+            const row = rows[index];
+            const agent = mode.session.agent as Record<string, { messages?: unknown }>;
+            const messages = agent?.[`${row.kind}Queue`]?.messages;
+            if (!Array.isArray(messages)) {
+              diagnostic("Pi agent pending message metadata unavailable");
+              return false;
+            }
+            const matches = messages.map(userText).filter((item) => item?.text === row.text);
+            // Duplicate text plus an image is deliberately ambiguous: keep all
+            // matching previews. Missing/in-flight and compaction-only rows stay.
+            return matches.length === rows.filter((item) => item.kind === row.kind && item.text === row.text).length &&
+              matches.every((item) => item!.textOnly);
+          };
+          const collapse = (component: Component, hide: () => boolean): void => {
+            const render = component.render;
+            component.render = function (width): string[] {
+              try { if (hide()) return []; }
+              catch { diagnostic("Pi pending metadata shape changed"); }
+              return render.call(this, width);
+            };
+            decorated.add(component);
+          };
+          rows.forEach((_row, index) => collapse(children[index + 1], () => hidden(index)));
+          const allHidden = (): boolean => state.active && rows.every((_row, index) => hidden(index));
+          collapse(children[0], allHidden);
+          collapse(children[rows.length + 1], allHidden);
+        } catch (error) {
+          diagnostic(String(error));
+        }
+      },
+    };
+    prototype.updatePendingMessagesDisplay = function (): void {
+      originalUpdate.call(this);
+      state.refresh(this);
+    };
+    prototype.createExtensionUIContext = function (): unknown {
+      const context = originalContext.call(this);
+      state.refresh(this);
+      return context;
+    };
+    registry[PATCH] = patch = state;
+  }
+  patch.owner = owner;
+  patch.active = true;
+  const current = patch;
+  const refresh = (): void => {
+    if (current.owner !== owner) return;
+    for (const ref of current.modes) {
+      const mode = ref.deref();
+      if (!mode) { current.modes.delete(ref); continue; }
+      current.refresh(mode);
+      mode.ui.requestRender();
+    }
+  };
+  refresh();
+  return {
+    refresh() {
+      if (current.owner !== owner) return;
+      current.active = true;
+      refresh();
+    },
+    dispose() {
+      if (current.owner !== owner) return;
+      current.active = false;
+      refresh();
+    },
+  };
+}

--- a/docs/calm-mode-feasibility.md
+++ b/docs/calm-mode-feasibility.md
@@ -147,6 +147,29 @@ An adjacent two-notification run retained the same two-row neighboring-assistant
 Calm off, an absent Calm preference, and an absent Calm extension retained ordinary rows.
 The current exact marker and the narrow bare-U+2063 `Supervisor escalate (` compatibility shape hid under Calm, while quoted markers, ASCII `FIRSTMATE_OP:` without U+2063, ordinary text before the current marker, unrelated text after U+2063, and image-bearing input remained visible.
 
+## Pending-notification presentation
+
+The pending area is separate from `addMessageToChat`, so Calm's transcript adapter cannot collapse queued follow-ups.
+Pi 0.85.1's documented extension UI, Markdown transformers, and message renderers expose no pending-preview filter.
+`InteractiveMode.updatePendingMessagesDisplay` builds a spacer, one `TruncatedText` per steering and follow-up string, and an edit-all hint in `pendingMessagesContainer`.
+Its `getAllQueuedMessages` snapshot omits images, and `AgentSession._queueSteer` and `_queueFollowUp` emit `queue_update` before adding full content to the agent queue.
+Filtering that snapshot's strings alone would therefore hide image-bearing user input with matching text.
+
+`.pi/extensions/fm-pending-notifications.ts` owns the independent lifecycle, and `.pi/extensions/lib/fm-pending-notification-layout.ts` owns the capability-probed component adapter.
+It decorates only stock row render methods after native pending layout or extension UI binding, validates each component's identity against the exact queue snapshot, and uses the existing canonical operational parser.
+Full `Agent.steeringQueue.messages` and `followUpQueue.messages` are inspected only during rendering, after synchronous queue publication has completed.
+Unknown metadata or ambiguous matches retain the original component rendering.
+The stock container, including pending bash components, remains intact; its normal layout computes zero height for hidden rows and their otherwise orphaned spacer and hint.
+No input, provider, queue mutation, acknowledgement, or delivery method is intercepted.
+The global patch is idempotent across extension reloads, generation-owned activation prevents stale shutdown from disabling its replacement, and shutdown restores stock row rendering.
+These exported classes and private metadata fields are capability dependencies, not a numeric version guarantee.
+The operator contract and conservative visibility limits live in [calm.md](calm.md#pending-notifications).
+
+The installed-package and deterministic native TUI regression is `tests/fm-calm-pi-extension.test.sh --pending-notifications`.
+It compares stock and adapted pending geometry, retains one genuine queued message among forty internal notifications, checks exact ordered consumption and session/provider/export data, and exercises resize, reload, and Pi's actual dequeue key.
+Component checks additionally cover Calm on/off, image-bearing and duplicate-text ambiguity, steering previews, ordinary near misses, pending bash rows, repeated activation, and unavailable metadata or presentation seams.
+Current dated evidence is recorded in [runtime-backends.md](verification/runtime-backends.md#pi-pending-notification-presentation).
+
 ## Calm working presentation
 
 Calm replaces Pi's stock working row with a small animated boat while Calm is on and one logical agent run is active.

--- a/docs/calm.md
+++ b/docs/calm.md
@@ -25,11 +25,21 @@ Outside Pi's same-name built-in override collision described below, Calm changes
 Calm's built-in wrappers preserve Pi's execution behavior, and input delivery, ordering, model context, session storage, diagnostics, and `/export` and `/share` operation remain unchanged.
 Every hidden Firstmate input remains available to the model and in serialized session data and exported artifacts.
 Legacy operational custom messages remain in session data and Pi's sidebar tree, although the main HTML transcript may omit them.
-Toggling Calm off restores ordinary rendering, and `Ctrl+O` expansion state is preserved.
+Toggling Calm off restores ordinary transcript rendering, and `Ctrl+O` expansion state is preserved.
 
 Pi's supported presentation API does not expose a global transcript filter.
 Expanded reasoning and its reserved spacing, built-in tool images, user-bash rows, skill and summary rows, generic status notices, and other arbitrary custom-tool or extension rows remain visible.
 These are supported-API boundaries rather than hidden-content failures.
+
+## Pending notifications
+
+Firstmate hides verified internal notification previews above Pi's editor independently of `/calm`.
+Genuine queued messages remain visible, and an internal-only queue occupies no rows or empty spacing.
+The normal edit-all-queued-messages shortcut still restores every queued message, including hidden notifications.
+Delivery, queue order, user roles, model context, session records, and exports remain unchanged.
+Image-bearing messages and ambiguous previews stay visible; this includes identical text shared by an internal notification and an image-bearing input, and compaction-only previews without full pending-message metadata.
+If Pi changes the required presentation or metadata seam, Firstmate logs a diagnostic and leaves the affected rows visible.
+The implementation and compatibility evidence are in [calm-mode-feasibility.md](calm-mode-feasibility.md#pending-notification-presentation).
 
 ## Pi compatibility
 

--- a/docs/verification/runtime-backends.md
+++ b/docs/verification/runtime-backends.md
@@ -1428,3 +1428,23 @@ It names the installed version and the floor rather than degrading quietly, and 
 The same guard against the pre-change extension in the same lab measured a 676.9 ms worst keystroke echo while delivering two outcomes and a 295.3 ms worst echo with nothing to deliver, against a 49.2 ms extension-free floor, and failed as designed.
 Measured through the same real `fm_branch_report` tool and real `bin/` scripts with a 1 ms interval timer, the largest single block of the JavaScript thread fell from 273 ms to 2.0 ms for a routine outcome, from 286 ms to 2.0 ms for a captain outcome, and from 134 ms to 1.9 ms for main's acknowledgement, against a 1.3-2.2 ms idle-loop floor.
 Those absolute figures are specific to this host and Pi version; the guards assert the relationship (delivery must stay in the class of the same machine's own floor) rather than a remembered millisecond number.
+
+## Pi pending-notification presentation
+
+Verified on 2026-09-05 with Pi 0.85.1, Node 22.22.2, and a deterministic provider in an isolated native Pi TUI on a private tmux socket.
+The pending adapter's mechanism and supported limits are owned by [calm-mode-feasibility.md](../calm-mode-feasibility.md#pending-notification-presentation).
+
+```sh
+bash tests/fm-calm-pi-extension.test.sh --pending-notifications
+tests/fm-pi-primary-types.test.sh
+```
+
+```text
+native pending components: 43 stock rows -> 3 mixed rows -> 0 internal-only rows; queues unchanged
+ok - Pi native pending UI hides 40 internal notifications with mixed and empty spacing, preserves actual queue consumption/order/context/session data, resize, reload, and dequeue
+ok - tracked Pi extensions pass strict no-emit typecheck against Pi 0.85.1
+```
+
+The native stock and adapted runs each persisted and consumed the forty internal follow-ups plus one genuine queued message exactly once in order, retained matching user-role provider context and HTML export entries, and left queue and session snapshots unchanged by rendering.
+The native viewport was checked at 100 by 36 and after resizing to 64 by 28; the component comparison also covered widths 40 and 180, Calm on/off, image-bearing duplicate-text ambiguity, steering previews, pending bash rows, and missing metadata or presentation APIs.
+The complete Calm suite on this installed Pi fails its separate `read collapsed rendering changed while calm mode was off` assertion even with the unchanged baseline test and extensions; the focused pending result is not a claim that all Calm rendering is verified on 0.85.1.

--- a/tests/assets/pi-pending-notifications.ts
+++ b/tests/assets/pi-pending-notifications.ts
@@ -1,0 +1,224 @@
+// Native Pi fixture for fm-calm-pi-extension.test.sh. No credentials or network.
+import assert from "node:assert/strict";
+import { appendFileSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import * as Pi from "@earendil-works/pi-coding-agent";
+import { Container, Text } from "@earendil-works/pi-tui";
+import { Agent } from "@earendil-works/pi-agent-core";
+import { createAssistantMessageEventStream } from "@earendil-works/pi-ai";
+import pendingExtension from "./.pi/extensions/fm-pending-notifications.ts";
+import { installPendingNotificationLayout } from "./.pi/extensions/lib/fm-pending-notification-layout.ts";
+import { encodeFirstmateOperationalInput } from "./.pi/extensions/lib/fm-operational-input.ts";
+import { setCalmPresentation } from "./.pi/extensions/lib/fm-calm-visibility.ts";
+
+const internal = Array.from({ length: 40 }, (_, i) => encodeFirstmateOperationalInput("watcher", `PENDING_INTERNAL_${i}`));
+const genuine = "GENUINE_QUEUED_MESSAGE";
+const text = (message) => typeof message.content === "string" ? message.content : message.content.filter(b => b.type === "text").map(b => b.text).join("\n");
+const user = (content) => ({ role: "user", content: [{ type: "text", text: content }], timestamp: 1 });
+
+export function componentChecks() {
+  Pi.initTheme("dark");
+  // Actual installed Pi renderer and Agent queues; no mocked renderer output.
+  const prototype = Pi.InteractiveMode.prototype;
+  const stockUpdate = prototype.updatePendingMessagesDisplay;
+  const agent = new Agent();
+  let steering = [];
+  let followUp = [...internal, genuine];
+  const mode = Object.create(prototype);
+  Object.defineProperty(mode, "session", { value: { agent }, configurable: true });
+  mode.pendingMessagesContainer = new Container();
+  mode.getAllQueuedMessages = () => ({ steering: [...steering], followUp: [...followUp] });
+  mode.getAppKeyDisplay = () => "alt+up";
+  mode.ui = { requestRender() {} };
+  for (const item of followUp) agent.followUp(user(item));
+  stockUpdate.call(mode);
+  const stock = mode.pendingMessagesContainer.render(100);
+  assert.equal(stock.length, 43);
+  const before = JSON.stringify(agent);
+  let layout = installPendingNotificationLayout();
+  mode.updatePendingMessagesDisplay();
+  for (const calm of [true, false]) {
+    setCalmPresentation(calm);
+    for (const width of [40, 100, 180]) {
+      const lines = mode.pendingMessagesContainer.render(width);
+      assert.equal(lines.length, 3);
+      assert(lines.join("\n").includes(genuine));
+      assert(!lines.join("\n").includes("PENDING_INTERNAL_"));
+      assert(lines.join("\n").includes("edit all queued"));
+    }
+  }
+  assert.equal(JSON.stringify(agent), before);
+  layout.dispose();
+  assert.deepEqual(mode.pendingMessagesContainer.render(100), stock);
+  layout.refresh();
+  assert.equal(mode.pendingMessagesContainer.render(100).length, 3);
+  const retired = layout;
+  layout = installPendingNotificationLayout();
+  retired.dispose();
+  assert.equal(mode.pendingMessagesContainer.render(100).length, 3);
+
+  // Stock queue edit/dequeue: all internal text remains recoverable, in order.
+  let editorText = "draft";
+  mode.editor = { getText: () => editorText, setText: value => { editorText = value; } };
+  mode.clearAllQueues = () => {
+    const result = mode.getAllQueuedMessages();
+    steering = []; followUp = []; agent.clearAllQueues();
+    return result;
+  };
+  assert.equal(mode.restoreQueuedMessagesToEditor(), 41);
+  assert.equal(editorText, [...internal, genuine, "draft"].join("\n\n"));
+  assert.deepEqual(mode.pendingMessagesContainer.render(100), []);
+
+  followUp = [...internal];
+  for (const item of followUp) agent.followUp(user(item));
+  mode.updatePendingMessagesDisplay();
+  assert.deepEqual(mode.pendingMessagesContainer.render(100), []);
+  // Pending user-bash components share the container and must remain intact.
+  const bash = new Text("PENDING_USER_BASH", 0, 0);
+  mode.pendingMessagesContainer.addChild(bash);
+  assert(mode.pendingMessagesContainer.render(100).join("\n").includes("PENDING_USER_BASH"));
+
+  const nearMisses = [
+    `quoted ${internal[0]}`, internal[0].slice(1), `\u2063Captain note`,
+    "\u2063FIRSTMATE_OP: v2 watcher: near miss", "\u2063FIRSTMATE_OP: v1 unknown: near miss",
+  ];
+  steering = [internal[1], ...nearMisses];
+  for (const item of steering) agent.steer(user(item));
+  const image = user(internal[0]);
+  image.content.push({ type: "image", data: "fixture", mimeType: "image/png" });
+  followUp.push(internal[0]); agent.followUp(image);
+  mode.updatePendingMessagesDisplay();
+  const rendered = mode.pendingMessagesContainer.render(180).join("\n");
+  for (const item of nearMisses) assert(rendered.includes(item));
+  assert.equal(rendered.split("Follow-up:").length - 1, 2, "identical text with an image must keep both previews");
+  assert(!rendered.includes(`Steering: ${internal[1]}`));
+  const originalQueue = agent.followUpQueue;
+  agent.followUpQueue = undefined;
+  const errors = [];
+  const originalError = console.error;
+  console.error = line => errors.push(line);
+  assert(mode.pendingMessagesContainer.render(100).join("\n").includes("PENDING_INTERNAL_39"));
+  mode.pendingMessagesContainer.render(100);
+  console.error = originalError;
+  assert.equal(errors.length, 1);
+  assert(errors[0].includes("pending message metadata unavailable"));
+  agent.followUpQueue = originalQueue;
+  stockUpdate.call(mode);
+  const rowChildren = mode.pendingMessagesContainer.children;
+  [rowChildren[1], rowChildren[2]] = [rowChildren[2], rowChildren[1]];
+  const reorderedStock = mode.pendingMessagesContainer.render(180);
+  errors.length = 0;
+  console.error = line => errors.push(line);
+  layout.refresh();
+  console.error = originalError;
+  assert.deepEqual(mode.pendingMessagesContainer.render(180), reorderedStock);
+  assert(errors.some(line => line.includes("pending row identity changed")));
+  layout.dispose();
+  const registryKey = Symbol.for("firstmate:pending-notification-layout:v1");
+  const savedRegistry = globalThis[registryKey];
+  const savedUpdate = prototype.updatePendingMessagesDisplay;
+  delete globalThis[registryKey];
+  prototype.updatePendingMessagesDisplay = undefined;
+  errors.length = 0;
+  console.error = line => errors.push(line);
+  pendingExtension({ on() { throw new Error("unavailable adapter registered lifecycle handlers"); } });
+  console.error = originalError;
+  prototype.updatePendingMessagesDisplay = savedUpdate;
+  globalThis[registryKey] = savedRegistry;
+  assert.equal(errors.length, 1);
+  assert(errors[0].includes("presentation adapter unavailable, skipping"));
+  console.log("native pending components: 43 stock rows -> 3 mixed rows -> 0 internal-only rows; queues unchanged");
+}
+
+export default function (pi) {
+  let mode;
+  const prototype = Pi.InteractiveMode.prototype;
+  const originalContext = prototype.createExtensionUIContext;
+  prototype.createExtensionUIContext = function (...args) {
+    mode = this;
+    return originalContext.apply(this, args);
+  };
+  const originalUpdate = prototype.updatePendingMessagesDisplay;
+  prototype.updatePendingMessagesDisplay = function (...args) {
+    mode = this;
+    return originalUpdate.apply(this, args);
+  };
+  const dir = process.env.PENDING_TEST_DIR;
+  let release;
+  let expected = [];
+  let initial = true;
+  let consumed = [];
+  pi.on("session_start", (event) => writeFileSync(join(dir, "ready"), event.reason));
+  pi.on("message_start", event => {
+    if (event.message.role === "user") consumed.push(text(event.message));
+  });
+  pi.on("agent_settled", () => writeFileSync(join(dir, "settled.json"), JSON.stringify(consumed)));
+  pi.registerProvider("pending-test", {
+    baseUrl: "http://127.0.0.1/unused", apiKey: "test-only", api: "pending-test-api",
+    models: [{ id: "deterministic", name: "Pending test", reasoning: false, input: ["text", "image"],
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 }, contextWindow: 131072, maxTokens: 64 }],
+    streamSimple(model, context) {
+      const stream = createAssistantMessageEventStream();
+      const gated = initial; initial = false;
+      const output = { role: "assistant", content: [], api: model.api, provider: model.provider, model: model.id,
+        usage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, totalTokens: 0,
+          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 } },
+        stopReason: "stop", timestamp: Date.now() };
+      void (async () => {
+        stream.push({ type: "start", partial: output });
+        if (gated) await new Promise(resolve => { release = resolve; writeFileSync(join(dir, "streaming"), "yes"); });
+        appendFileSync(join(dir, "contexts.jsonl"), JSON.stringify(context.messages.filter(m => m.role === "user").map(text)) + "\n");
+        output.content.push({ type: "text", text: "PENDING_TEST_RESPONSE" });
+        stream.push({ type: "done", reason: "stop", message: output }); stream.end();
+      })();
+      return stream;
+    },
+  });
+  pi.registerShortcut("alt+e", {
+    handler: async ctx => {
+      try {
+        assert.equal(ctx.ui.getEditorText(), expected.join("\n\n"));
+        assert.deepEqual(mode.getAllQueuedMessages(), { steering: [], followUp: [] });
+        ctx.ui.setEditorText("");
+        writeFileSync(join(dir, "edited"), "yes");
+      } catch (error) { writeFileSync(join(dir, "failure"), String(error.stack)); }
+    },
+  });
+  pi.registerCommand("pending-test", {
+    handler: async (args, ctx) => {
+      const [command, label] = args.trim().split(/\s+/);
+      try {
+        if (command === "start") {
+          expected = []; consumed = []; initial = true;
+          await pi.setModel(ctx.modelRegistry.find("pending-test", "deterministic"));
+          pi.sendUserMessage("PENDING_TEST_START");
+        } else if (command === "seed") {
+          for (const item of internal) pi.sendUserMessage(item, { deliverAs: "followUp" });
+          if (label !== "internal") pi.sendUserMessage(genuine, { deliverAs: "followUp" });
+          expected = [...internal, ...(label === "internal" ? [] : [genuine])];
+        } else if (command === "inspect") {
+          const before = JSON.stringify(mode.getAllQueuedMessages());
+          const sessionBefore = JSON.stringify(ctx.sessionManager.getEntries());
+          const lines = mode.pendingMessagesContainer.render(100);
+          assert.equal(JSON.stringify(mode.getAllQueuedMessages()), before);
+          assert.equal(JSON.stringify(ctx.sessionManager.getEntries()), sessionBefore);
+          assert.deepEqual(mode.getAllQueuedMessages().followUp, expected);
+          writeFileSync(join(dir, `${label}.json`), JSON.stringify({ lines, queue: JSON.parse(before), session: ctx.sessionManager.getSessionFile() }));
+        } else if (command === "release") {
+          release();
+        } else if (command === "check") {
+          assert.deepEqual(consumed, ["PENDING_TEST_START", ...expected]);
+          const persisted = ctx.sessionManager.getEntries().filter(e => e.type === "message" && e.message.role === "user").map(e => text(e.message));
+          assert.deepEqual(persisted, consumed);
+          const contexts = readFileSync(join(dir, "contexts.jsonl"), "utf8").trim().split("\n").map(line => JSON.parse(line));
+          assert.deepEqual(contexts.at(-1), consumed);
+          assert.equal(contexts.length, expected.length + 1);
+          writeFileSync(join(dir, "checked"), "yes");
+        }
+      } catch (error) {
+        writeFileSync(join(dir, "failure"), String(error.stack));
+        throw error;
+      }
+    },
+  });
+}

--- a/tests/fm-calm-pi-extension.test.sh
+++ b/tests/fm-calm-pi-extension.test.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 # Focused rendering, lifecycle, persistence, and interactive TUI checks for /calm.
+# Pass --pending-notifications to run only the independent pending-row checks.
 set -u
 
 # shellcheck source=tests/lib.sh
@@ -3966,6 +3967,133 @@ JS
   tmux -L "$TMUX_SOCKET" send-keys -t "$TMUX_SESSION" M-s
   pass "Pi calm native E2E replaces the stock working row with a moving, resize-clamped working ship that freezes and resumes across two working periods in one Pi session, clears on abort, keeps captain turns visible, hides exact operational user rows without changing persistence, restores stock rendering Calm-off, survives restart, and preserves export plus Ctrl+O behavior"
 }
+
+# --pending-notifications runs only the independent pending-row regression.
+test_pending_notifications() {
+  local fixture="$TMP_ROOT/pending" config="$TMP_ROOT/pending-config" label
+  if ! command -v node >/dev/null 2>&1 || ! command -v pi >/dev/null 2>&1 || ! command -v tmux >/dev/null 2>&1; then
+    echo "skip: node, pi, and tmux required for native pending-notification checks"
+    return
+  fi
+  if [ ! -f "$PI_PACKAGE_DIR/package.json" ]; then
+    echo "skip: installed @earendil-works/pi-coding-agent package not found"
+    return
+  fi
+  mkdir -p "$fixture/.pi/extensions/lib" "$fixture/node_modules/@earendil-works" "$config" "$fixture/home"
+  cp "$ROOT/tests/assets/pi-pending-notifications.ts" "$fixture/probe.ts"
+  cp "$ROOT/.pi/extensions/fm-pending-notifications.ts" "$fixture/.pi/extensions/"
+  cp "$ROOT/.pi/extensions/lib/fm-pending-notification-layout.ts" "$fixture/.pi/extensions/lib/"
+  cp "$VISIBILITY" "$PI_OPERATIONAL_INPUT" "$fixture/.pi/extensions/lib/"
+  ln -s "$PI_PACKAGE_DIR" "$fixture/node_modules/@earendil-works/pi-coding-agent"
+  for label in pi-tui pi-ai pi-agent-core; do
+    ln -s "$PI_PACKAGE_DIR/node_modules/@earendil-works/$label" "$fixture/node_modules/@earendil-works/$label"
+  done
+  printf '%s\n' '{"type":"module"}' > "$fixture/package.json"
+  printf '%s\n' '{"followUpMode":"one-at-a-time","quietStartup":true,"terminal":{"clearOnShrink":false}}' > "$config/settings.json"
+  printf '%s\n' '{"tui.input.submit":"alt+s"}' > "$config/keybindings.json"
+  (cd "$fixture" && FM_OPERATIONAL_INPUT_SCRIPT="$OPERATIONAL_INPUT" PI_CODING_AGENT_DIR="$config" \
+    node --input-type=module -e 'const p = await import("./probe.ts"); p.componentChecks();') \
+    || fail "native pending component contract failed"
+
+  pending_send() {
+    tmux -L "$TMUX_SOCKET" send-keys -t "$TMUX_SESSION" -l "$1"
+    tmux -L "$TMUX_SOCKET" send-keys -t "$TMUX_SESSION" M-s
+  }
+  pending_wait() {
+    local name=$1 n=0
+    while [ "$n" -lt 200 ]; do
+      [ ! -f "$fixture/$label/failure" ] || fail "native pending fixture: $(cat "$fixture/$label/failure")"
+      [ ! -f "$fixture/$label/$name" ] || return 0
+      sleep 0.1
+      n=$((n + 1))
+    done
+    tmux -L "$TMUX_SOCKET" capture-pane -p -t "$TMUX_SESSION" -S -100 >&2 || true
+    fail "Pi pending $label did not produce $name"
+  }
+  for label in stock fixed; do
+    mkdir -p "$fixture/$label"
+    local extension=""
+    [ "$label" = stock ] || extension='-e ./.pi/extensions/fm-pending-notifications.ts'
+    tmux -L "$TMUX_SOCKET" new-session -d -s "$TMUX_SESSION" -x 100 -y 36 \
+      "cd '$fixture' && env FM_HOME='$fixture/home' PENDING_TEST_DIR='$fixture/$label' PI_CODING_AGENT_DIR='$config' FM_OPERATIONAL_INPUT_SCRIPT='$OPERATIONAL_INPUT' PI_OFFLINE=1 pi --approve --no-context-files --no-skills --no-prompt-templates --no-extensions $extension -e ./probe.ts --session-dir '$fixture/$label/sessions'"
+    pending_wait ready
+    pending_send '/pending-test start'
+    pending_wait streaming
+    pending_send '/pending-test seed mixed'
+    pending_send '/pending-test inspect mixed'
+    pending_wait mixed.json
+    node --input-type=module - "$fixture/$label/mixed.json" "$label" <<'JS' || fail "native pending viewport shape failed"
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+const record = JSON.parse(readFileSync(process.argv[2]));
+assert.equal(record.queue.followUp.length, 41);
+assert.equal(record.lines.length, process.argv[3] === "stock" ? 43 : 3);
+assert(record.lines.join("\n").includes("GENUINE_QUEUED_MESSAGE"));
+assert.equal(record.lines.join("\n").includes("PENDING_INTERNAL_"), process.argv[3] === "stock");
+JS
+    tmux -L "$TMUX_SOCKET" capture-pane -p -t "$TMUX_SESSION" > "$fixture/$label/viewport.txt"
+    if [ "$label" = fixed ]; then
+      assert_not_contains "$(cat "$fixture/$label/viewport.txt")" 'PENDING_INTERNAL_' "pending notifications still occupy the real viewport"
+      assert_contains "$(cat "$fixture/$label/viewport.txt")" 'GENUINE_QUEUED_MESSAGE' "genuine pending message missing in real viewport"
+      tmux -L "$TMUX_SOCKET" resize-window -t "$TMUX_SESSION" -x 64 -y 28
+      pending_send '/pending-test inspect resized'
+      pending_wait resized.json
+      tmux -L "$TMUX_SOCKET" capture-pane -p -t "$TMUX_SESSION" > "$fixture/$label/resized.txt"
+      assert_not_contains "$(cat "$fixture/$label/resized.txt")" 'PENDING_INTERNAL_' "resize restored hidden pending rows"
+    fi
+    pending_send '/pending-test release'
+    pending_wait settled.json
+    pending_send '/pending-test check'
+    pending_wait checked
+    pending_send "/export $fixture/$label/export.html"
+    pending_wait export.html
+    node --input-type=module - "$fixture/$label/export.html" "$fixture/$label/settled.json" <<'JS' || fail "pending adapter changed exported user messages"
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+const html = readFileSync(process.argv[2], "utf8");
+const match = html.match(/<script id="session-data" type="application\/json">([^<]+)<\/script>/);
+assert(match);
+const exported = JSON.parse(Buffer.from(match[1], "base64").toString("utf8"));
+const entries = exported.session?.entries ?? exported.entries;
+const users = entries.filter(e => e.type === "message" && e.message.role === "user").map(e =>
+  typeof e.message.content === "string" ? e.message.content : e.message.content.filter(b => b.type === "text").map(b => b.text).join("\n"));
+assert.deepEqual(users, JSON.parse(readFileSync(process.argv[3])));
+JS
+    # Reload is permitted only while Pi is idle. It must load the same adapter
+    # once and hide a new queue without retaining the old session's row state.
+    if [ "$label" = fixed ]; then
+      rm "$fixture/$label/ready" "$fixture/$label/streaming" "$fixture/$label/settled.json"
+      pending_send /reload
+      pending_wait ready
+      wait_for_text "$fixture/$label/reloaded.txt" "Reloaded keybindings" || fail "Pi reload did not restore editor"
+      assert_contains "$(cat "$fixture/$label/ready")" reload 'Pi did not reload the extension runtime'
+      pending_send '/pending-test start'
+      pending_wait streaming
+      pending_send '/pending-test seed internal'
+      pending_send '/pending-test inspect hidden'
+      pending_wait hidden.json
+      node --input-type=module - "$fixture/$label/hidden.json" <<'JS' || fail "internal-only pending rows retained spacing"
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+const record = JSON.parse(readFileSync(process.argv[2]));
+assert.equal(record.queue.followUp.length, 40);
+assert.deepEqual(record.lines, []);
+JS
+      # Exercise Pi's actual dequeue key, then use a registered shortcut to
+      # inspect the editor without submitting its recovered contents.
+      tmux -L "$TMUX_SOCKET" send-keys -t "$TMUX_SESSION" M-Up
+      tmux -L "$TMUX_SOCKET" send-keys -t "$TMUX_SESSION" M-e
+      pending_wait edited
+      pending_send '/pending-test release'
+      pending_wait settled.json
+    fi
+    tmux -L "$TMUX_SOCKET" kill-session -t "$TMUX_SESSION"
+  done
+  pass "Pi native pending UI hides 40 internal notifications with mixed and empty spacing, preserves actual queue consumption/order/context/session data, resize, reload, and dequeue"
+}
+
+test_pending_notifications
+if [ "${1:-}" = --pending-notifications ]; then exit 0; fi
 
 test_home_resolution
 test_pi_compat_no_upper_bound

--- a/tests/fm-pi-primary-types.test.sh
+++ b/tests/fm-pi-primary-types.test.sh
@@ -29,6 +29,8 @@ trap cleanup EXIT
 mkdir -p "$TMP_ROOT/lib" "$TMP_ROOT/node_modules/@earendil-works" "$TMP_ROOT/node_modules/@types"
 cp "$ROOT/.pi/extensions/fm-branch-supervision.ts" "$TMP_ROOT/fm-branch-supervision.ts"
 cp "$ROOT/.pi/extensions/fm-calm.ts" "$TMP_ROOT/fm-calm.ts"
+cp "$ROOT/.pi/extensions/fm-pending-notifications.ts" "$TMP_ROOT/fm-pending-notifications.ts"
+cp "$ROOT/.pi/extensions/lib/fm-pending-notification-layout.ts" "$TMP_ROOT/lib/fm-pending-notification-layout.ts"
 cp "$ROOT/.pi/extensions/fm-primary-pi-watch.ts" "$TMP_ROOT/fm-primary-pi-watch.ts"
 cp "$ROOT/.pi/extensions/fm-primary-turnend-guard.ts" "$TMP_ROOT/fm-primary-turnend-guard.ts"
 cp "$ROOT/.pi/extensions/lib/fm-branch-dispatch.ts" "$TMP_ROOT/lib/fm-branch-dispatch.ts"


### PR DESCRIPTION
Queued Firstmate notifications can fill Pi's viewport while it is working. Hide only verified internal pending previews independently of Calm: forty notifications plus one genuine message now use 3 rows instead of 43; internal-only queues use zero rows.

The capability-probed adapter changes stock component height only. Queues, delivery, user roles, context, persistence, exports, and dequeue behavior remain intact. Image-bearing or ambiguous previews stay visible; unavailable seams emit a diagnostic.

Validated with native Pi 0.85.1 deterministic TUI tests, strict types, parser tests, pinned lint, and docs checks. The broader Calm suite's existing `read` renderer parity failure also reproduces on the unchanged baseline.

Direct PR under an explicit validation-gate waiver; no no-mistakes attestation. No merge requested.
