### PR TITLE
fix(bin): report a claude worker parked at a permission prompt as waiting on approval

### DIFF
--- a/.agents/skills/harness-adapters/SKILL.md
+++ b/.agents/skills/harness-adapters/SKILL.md
@@ -2,7 +2,7 @@
 name: harness-adapters
 description: >-
   Agent-only reference for firstmate harness operations.
-  Use before spawning or recovering a crewmate or secondmate, handling a trust dialog, sending a harness-specific skill invocation, interrupting or exiting an agent, resuming an exited agent, or verifying a new harness adapter.
+  Use before spawning or recovering a crewmate or secondmate, handling a trust or permission dialog, sending a harness-specific skill invocation, interrupting or exiting an agent, resuming an exited agent, or verifying a new harness adapter.
   Contains verified facts for claude, codex, opencode, pi, pi-signed, grok, kimi, cursor, gemini, muse, and rovo.
 user-invocable: false
 metadata:

--- a/.agents/skills/harness-adapters/references/harness/claude.md
+++ b/.agents/skills/harness-adapters/references/harness/claude.md
@@ -34,6 +34,8 @@ Inspect the pane to identify which dialog is on screen, and report it rather tha
 A turn that stops at Claude's tool-permission dialog fires no closing hook, so the task keeps classifying `busy` and would be read as ordinary work while it waits for a keystroke firstmate cannot send.
 Claude publishes that gate as a structured `Notification` payload carrying `notification_type` `permission_prompt`, distinct from the `idle_prompt` notification a finished turn leaves behind, and `../../../bin/fm-claude-approval-hook.sh` turns it into the approval-gate event that `../../../bin/fm-busy-lib.sh` classifies and `../../../bin/fm-crew-state.sh` reports as `parked`.
 `PostToolUse` closes the gate, because a tool that ran is proof the dialog was answered; `PreToolUse` runs before the dialog and cannot.
+A parked worker surfaces through the ordinary stale wake instead of being absorbed as working, and a steering doorbell waits rather than being typed into the dialog, where its keys would answer it.
+Firstmate cannot answer this gate either, so report the dialog for the operator to clear promptly instead of steering, interrupting, or relaunching the worker.
 `../../../docs/verification/supervision.md` owns the captured payloads and the hook ordering.
 
 This covers the in-session tool gate only.

--- a/.agents/skills/harness-adapters/references/harness/claude.md
+++ b/.agents/skills/harness-adapters/references/harness/claude.md
@@ -6,7 +6,7 @@ Busy hooks verified 2026-07-28 on Claude Code 2.1.220.
 
 | Fact | Value |
 |---|---|
-| Busy | Owned hooks: `UserPromptSubmit` opens while `Stop`, `StopFailure`, and `SessionEnd` close; manual interrupt emits no hook, so control reports delivered keys and live endpoint only, publishes no idle event or cancellation claim, and usually leaves `claude-hook` busy. |
+| Busy | Owned hooks: `UserPromptSubmit` opens while `Stop`, `StopFailure`, and `SessionEnd` close; manual interrupt emits no hook, so control reports delivered keys and live endpoint only, publishes no idle event or cancellation claim, and usually leaves `claude-hook` busy. `Notification` and `PostToolUse` carry the approval gate below. |
 | Exit | `/exit`. |
 | Interrupt | Single Escape. |
 | Skill | `/<skill>`, for example `/no-mistakes`. |
@@ -28,6 +28,16 @@ The once-per-machine bypass-permissions confirmation is a separate dialog, scope
 Never send Enter to that one either: it was observed rendering in the same shape as the trust dialog, with the selection on `No, exit` and the footer `Enter to confirm . Esc to cancel`, so Enter ends the session rather than accepting.
 Firstmate cannot move a selection with Enter, Escape, and C-c alone, so it cannot accept this dialog at all, and an operator accepts it once per machine instead.
 Inspect the pane to identify which dialog is on screen, and report it rather than answering it.
+
+## Approval gate
+
+A turn that stops at Claude's tool-permission dialog fires no closing hook, so the task keeps classifying `busy` and would be read as ordinary work while it waits for a keystroke firstmate cannot send.
+Claude publishes that gate as a structured `Notification` payload carrying `notification_type` `permission_prompt`, distinct from the `idle_prompt` notification a finished turn leaves behind, and `../../../bin/fm-claude-approval-hook.sh` turns it into the approval-gate event that `../../../bin/fm-busy-lib.sh` classifies and `../../../bin/fm-crew-state.sh` reports as `parked`.
+`PostToolUse` closes the gate, because a tool that ran is proof the dialog was answered; `PreToolUse` runs before the dialog and cannot.
+`../../../docs/verification/supervision.md` owns the captured payloads and the hook ordering.
+
+This covers the in-session tool gate only.
+The workspace-trust and bypass-permissions dialogs above are pre-session and emit no hook at all, so they stay the pre-registration and operator problems described there.
 
 ## Composer ghost
 

--- a/.agents/skills/harness-adapters/references/harness/claude.md
+++ b/.agents/skills/harness-adapters/references/harness/claude.md
@@ -6,7 +6,7 @@ Busy hooks verified 2026-07-28 on Claude Code 2.1.220.
 
 | Fact | Value |
 |---|---|
-| Busy | Owned hooks: `UserPromptSubmit` opens while `Stop`, `StopFailure`, and `SessionEnd` close; manual interrupt emits no hook, so control reports delivered keys and live endpoint only, publishes no idle event or cancellation claim, and usually leaves `claude-hook` busy. `Notification` and `PostToolUse` carry the approval gate below. |
+| Busy | Owned hooks: `UserPromptSubmit` opens while `Stop`, `StopFailure`, and `SessionEnd` close; manual interrupt emits no hook, so control reports delivered keys and live endpoint only, publishes no idle event or cancellation claim, and usually leaves `claude-hook` busy. `Notification`, `PostToolUse`, and `PostToolUseFailure` carry the approval gate below. |
 | Exit | `/exit`. |
 | Interrupt | Single Escape. |
 | Skill | `/<skill>`, for example `/no-mistakes`. |
@@ -33,7 +33,7 @@ Inspect the pane to identify which dialog is on screen, and report it rather tha
 
 A turn that stops at Claude's tool-permission dialog fires no closing hook, so the task keeps classifying `busy` and would be read as ordinary work while it waits for a keystroke firstmate cannot send.
 Claude publishes that gate as a structured `Notification` payload carrying `notification_type` `permission_prompt`, distinct from the `idle_prompt` notification a finished turn leaves behind, and `../../../bin/fm-claude-approval-hook.sh` turns it into the approval-gate event that `../../../bin/fm-busy-lib.sh` classifies and `../../../bin/fm-crew-state.sh` reports as `parked`.
-`PostToolUse` closes the gate, because a tool that ran is proof the dialog was answered; `PreToolUse` runs before the dialog and cannot.
+`PostToolUse` or `PostToolUseFailure` closes the gate, because a tool that ran is proof the dialog was answered whatever its outcome; `PreToolUse` runs before the dialog and cannot.
 A parked worker surfaces through the ordinary stale wake instead of being absorbed as working, and a steering doorbell waits rather than being typed into the dialog, where its keys would answer it.
 Firstmate cannot answer this gate either, so report the dialog for the operator to clear promptly instead of steering, interrupting, or relaunching the worker.
 `../../../docs/verification/supervision.md` owns the captured payloads and the hook ordering.

--- a/.agents/skills/stuck-crewmate-recovery/SKILL.md
+++ b/.agents/skills/stuck-crewmate-recovery/SKILL.md
@@ -44,6 +44,7 @@ If the worktree or ownership cannot be reconciled safely, leave all state intact
 Escalate in order:
 
 1. Peek the pane, and check the task's steering inbox (`state/<id>.inbox/`) for unhandled `*.msg` records - a stale wake naming an unread firstmate instruction means the worker never acknowledged a durable steer, and the record itself shows exactly what was intended.
+   A `parked · source: pane` read from `bin/fm-crew-state.sh` means the harness is holding at its own permission dialog: load `harness-adapters` and report the dialog rather than steering, interrupting, or relaunching.
 2. If the crewmate is waiting on a question its brief already answers, answer in one line via `FM_HOME=<this-firstmate-home> bin/fm-send.sh` from an active firstmate session unless `FM_HOME` is already set to the active firstmate home.
 3. If the crewmate is confused or looping, interrupt with `FM_HOME=<this-firstmate-home> bin/fm-control.sh <task-id> interrupt`, then redirect with one corrective line through `fm-send`.
 4. If the crewmate is genuinely wedged after redirection, relaunch it with `FM_HOME=<this-firstmate-home> bin/fm-control.sh <task-id> relaunch --note '<progress so far>'`, which stops the agent, carries the brief plus that note into a replacement in the same local copy, and restores the prior record if the replacement cannot start.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -367,6 +367,7 @@ Resume fleet supervision immediately after the decision lands.
 
 Judge validation by the currently attributed run step through `bin/fm-crew-state.sh`, not by shell liveness or the last status event.
 Running, fixing, or CI states remain working; parked approval or fix-review states require the worker to follow the active gate help; passed or checks-passed is done; failed or cancelled is failed.
+A `parked` read from source `pane` is the harness's own permission dialog rather than a gate; handle it through `harness-adapters`.
 A worker hand-editing, committing, aborting, or restarting during an active validation run duplicates pipeline ownership outside the supersession sequence above; steer it back to the gate response flow.
 The worker reports the PR when CI first becomes green rather than waiting for merge monitoring to finish.
 
@@ -549,7 +550,7 @@ These skills are not captain-invocable; load them only at their precise triggers
 - `diagnostic-reasoning` - load before scoping a reported bug and before acting on a diagnostic report.
 - `ask-user-authority` - load before deciding any ask-user finding.
 - `quota-array-dispatch` - load before choosing among a matched crew-dispatch profile array from current quota-axi default TOON.
-- `harness-adapters` - load before spawning or recovering a crewmate or secondmate, handling a trust dialog, sending a harness-specific skill invocation, interrupting or exiting an agent, resuming an exited agent, or verifying a new harness adapter.
+- `harness-adapters` - load before spawning or recovering a crewmate or secondmate, handling a trust or permission dialog, sending a harness-specific skill invocation, interrupting or exiting an agent, resuming an exited agent, or verifying a new harness adapter.
 - `firstmate-orca` - load before switching to Orca, spawning or supervising Orca-backed work, smoke-testing Orca backend behavior, debugging Orca task state, or reconciling Orca-backed task metadata.
 - `project-management` - load before adding, creating, removing, or initializing a project.
   Cloning or registering a project is add intake and uses the same trigger.

--- a/bin/fm-busy-lib.sh
+++ b/bin/fm-busy-lib.sh
@@ -30,7 +30,8 @@
 # never classify another adapter):
 #   pi-ext           Pi/pi-signed per-task extension (agent_start/agent_settled)
 #   opencode-plugin  OpenCode per-task plugin (session.status)
-#   claude-hook      Claude lifecycle hooks (UserPromptSubmit/Stop/StopFailure/SessionEnd)
+#   claude-hook      Claude lifecycle hooks (UserPromptSubmit/Stop/StopFailure/SessionEnd),
+#                    plus the approval-gate pair below
 #   gemini-hook      Gemini agent hooks (BeforeAgent opens; AfterAgent and
 #                    SessionEnd close)
 #   codex-hook, codex-appserver  reserved: Codex, gated by
@@ -44,6 +45,20 @@
 #   endpoint-gone, herdr-native, grok-regex, rovo-regex, muse-session-log,
 #   cursor-transcript, missing, malformed, gen-mismatch, source-mismatch,
 #   kimi-unverified, codex-unverified, capture-failed, no-target
+#
+# APPROVAL GATE (fm_busy_approval_wait): a turn can stop at a harness dialog
+# that only an operator can answer - Claude's tool-permission prompt is the
+# observed case - and such a turn is still open, so it correctly classifies
+# busy. It is nevertheless making no progress, and supervision that reads it as
+# ordinary work absorbs its quiet pane until the wedge threshold. The gate is
+# therefore recorded as a distinguished EVENT on the ordinary busy record rather
+# than as a fourth state: state and source keep their exact meanings, and one
+# extra predicate exposes the flavour to bin/fm-crew-state.sh, which is the one
+# place a supervisor-facing state is chosen. bin/fm-claude-approval-hook.sh is
+# Claude's adapter for both halves; the gate opens on the harness's own
+# structured permission notification and closes on the next tool that actually
+# ran, or on any ordinary lifecycle event, since every one of them proves the
+# turn moved past the dialog.
 #
 # Classification (fm_busy_classify): busy | idle | unknown | dead, always
 # with the producing source as the second token. Precedence:
@@ -91,6 +106,11 @@
 # Sourcing: set -u and set -e safe; no subshell-unfriendly globals.
 
 FM_BUSY_LIB_VERSION=v1
+
+# The one event token that marks a busy record as parked at an operator-only
+# approval gate, declared once so the adapter that writes it and the predicate
+# that reads it cannot drift.
+FM_BUSY_APPROVAL_EVENT=permission-prompt
 
 # Standalone-Kimi verification gate. Empty means no installed Kimi version
 # has passed live verification, so every standalone Kimi task classifies
@@ -1012,6 +1032,25 @@ fm_busy_classify_meta() {  # <meta-file> <id> <state-dir> [tail40]
     return 0
   fi
   fm_busy_classify "$backend" "$target" "$harness" "$id" "$state" "$tail40"
+}
+
+# fm_busy_approval_wait: 0 iff <id>'s record is a valid, gen-matching, harness-
+# trusted busy record standing at the approval gate. Every other outcome - a
+# missing, malformed, stale, or untrusted record, an idle or unknown state, or
+# any other event - returns 1, so the gate is claimed only on positive evidence
+# and a task whose record cannot be trusted is never reported as waiting on an
+# operator. The harness trust check is the same one classification uses, so one
+# adapter's writer can no more open another adapter's gate than it can classify
+# it.
+fm_busy_approval_wait() {  # <state-dir> <id> <harness>
+  local state=$1 id=$2 harness=$3 out r_state r_source r_event
+  out=$(fm_busy_record_read "$state" "$id") || return 1
+  r_state=${out%% *}; out=${out#* }
+  r_source=${out%% *}; out=${out#* }
+  r_event=${out%% *}
+  [ "$r_state" = busy ] || return 1
+  [ "$r_event" = "$FM_BUSY_APPROVAL_EVENT" ] || return 1
+  fm_busy_source_trusted "$harness" "$r_source"
 }
 
 # fm_busy_is_busy: boolean view for callers that only gate on provable

--- a/bin/fm-busy-lib.sh
+++ b/bin/fm-busy-lib.sh
@@ -53,8 +53,12 @@
 # ordinary work absorbs its quiet pane until the wedge threshold. The gate is
 # therefore recorded as a distinguished EVENT on the ordinary busy record rather
 # than as a fourth state: state and source keep their exact meanings, and one
-# extra predicate exposes the flavour to bin/fm-crew-state.sh, which is the one
-# place a supervisor-facing state is chosen. bin/fm-claude-approval-hook.sh is
+# extra predicate exposes the flavour to the readers that decide what busy
+# buys: bin/fm-crew-state.sh, where the supervisor-facing state is chosen
+# (parked, not working), and the absorb gates in bin/fm-watch.sh and
+# bin/fm-supervise-daemon.sh, which stop counting a gated turn as busy so its
+# quiet pane takes the stale path and surfaces promptly instead of waiting out
+# the wedge threshold. bin/fm-claude-approval-hook.sh is
 # Claude's adapter for both halves; the gate opens on the harness's own
 # structured permission notification and closes on the next tool that actually
 # ran, or on any ordinary lifecycle event, since every one of them proves the

--- a/bin/fm-claude-approval-hook.sh
+++ b/bin/fm-claude-approval-hook.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# fm-claude-approval-hook.sh - Claude's approval-gate adapter for the semantic
+# busy-state contract.
+#
+# Why this exists: Claude's busy source is hook-owned - UserPromptSubmit opens a
+# turn and Stop closes it - so a turn that stops at Claude's own permission
+# dialog fires no closing hook and the task keeps classifying `busy`. Firstmate
+# then reads the worker as working and absorbs its quiet pane as provably-working
+# until the wedge threshold, so a worker that needs one keystroke to continue is
+# only surfaced minutes later, through a possible-wedge reason that does not name
+# the gate. The turn genuinely IS open, so `busy` is not the wrong answer; what
+# was missing is that the turn is parked at a gate nothing in firstmate's key
+# plane can answer.
+#
+# Claude emits that gate as a structured Notification payload carrying
+# notification_type=permission_prompt, which is a semantic source in exactly the
+# sense bin/fm-busy-lib.sh requires: a machine-readable lifecycle event the
+# harness itself publishes, never a reading of rendered pane text. This script is
+# the adapter that turns it into one busy-contract event, and PostToolUse is the
+# resume half: a tool that actually ran proves the gate was answered.
+#
+# Usage: fm-claude-approval-hook.sh <state-dir> <id> --gen <gen>
+#   The hook payload arrives as JSON on stdin. bin/fm-spawn.sh registers this
+#   script for Notification and PostToolUse with the same gen it embeds in the
+#   task's other Claude hooks.
+#
+# Contract with the record owner: this script never writes the record itself.
+# bin/fm-busy-event.sh stays its only writer and bin/fm-busy-lib.sh stays the
+# only owner of the record format, the gen binding, and classification.
+#
+# Always exits 0 and prints nothing on stdout or stderr. A hook that failed
+# loudly here would feed its own diagnostics back into the worker's turn, and a
+# hook that cannot record the gate must leave the worker exactly as it was: the
+# gate then simply stays invisible, which is the behavior that existed before
+# this adapter.
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# shellcheck source=bin/fm-busy-lib.sh
+. "$SCRIPT_DIR/fm-busy-lib.sh" 2>/dev/null || exit 0
+
+STATE=${1:-}
+ID=${2:-}
+GEN=''
+shift 2 2>/dev/null || exit 0
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --gen) GEN=${2:-}; shift 2 || exit 0 ;;
+    *) shift ;;
+  esac
+done
+[ -n "$STATE" ] && [ -n "$ID" ] && [ -n "$GEN" ] || exit 0
+
+# Bounded read: a hook payload is a single small JSON object, and an adapter on
+# the worker's own turn must never block on an unbounded stream.
+PAYLOAD=$(head -c 65536 2>/dev/null) || exit 0
+[ -n "$PAYLOAD" ] || exit 0
+
+# Matched in-process rather than through grep: this runs on the worker's own
+# turn after every tool call, so each avoided fork is latency the worker pays.
+payload_has() {  # <extended-regex>
+  local __re=$1
+  [[ $PAYLOAD =~ $__re ]]
+}
+
+# Two independent positive signals, either of which carries the verdict, so no
+# single vendor string is load-bearing: the typed notification_type field, and
+# the human-readable message naming permission. Claude's other observed
+# notification (notification_type=idle_prompt, message "Claude is waiting for
+# your input") matches neither, which is what keeps an idle composer out of the
+# approval gate.
+notification_is_permission_gate() {
+  payload_has '"notification_type"[[:space:]]*:[[:space:]]*"permission_prompt"' \
+    || payload_has '"message"[[:space:]]*:[[:space:]]*"[^"]*[Pp]ermission'
+}
+
+apply() {  # <event>
+  "$SCRIPT_DIR/fm-busy-event.sh" apply "$STATE" "$ID" busy \
+    --gen "$GEN" --source claude-hook --event "$1" >/dev/null 2>&1 || true
+}
+
+if payload_has '"hook_event_name"[[:space:]]*:[[:space:]]*"Notification"'; then
+  notification_is_permission_gate || exit 0
+  apply "$FM_BUSY_APPROVAL_EVENT"
+  exit 0
+fi
+
+if payload_has '"hook_event_name"[[:space:]]*:[[:space:]]*"PostToolUse"'; then
+  # The resume half. A tool that ran is proof the gate was answered, but this
+  # hook fires after EVERY tool call, so it stays a cheap read that writes only
+  # while the record still stands at the gate. Answering "no" runs no tool, so
+  # that path is closed by the turn's own Stop instead.
+  fm_busy_approval_wait "$STATE" "$ID" claude || exit 0
+  apply approval-answered
+fi
+
+exit 0

--- a/bin/fm-claude-approval-hook.sh
+++ b/bin/fm-claude-approval-hook.sh
@@ -16,13 +16,14 @@
 # notification_type=permission_prompt, which is a semantic source in exactly the
 # sense bin/fm-busy-lib.sh requires: a machine-readable lifecycle event the
 # harness itself publishes, never a reading of rendered pane text. This script is
-# the adapter that turns it into one busy-contract event, and PostToolUse is the
-# resume half: a tool that actually ran proves the gate was answered.
+# the adapter that turns it into one busy-contract event, and PostToolUse or
+# PostToolUseFailure is the resume half: a tool that actually ran proves the gate
+# was answered, whether or not the tool then succeeded.
 #
 # Usage: fm-claude-approval-hook.sh <state-dir> <id> --gen <gen>
 #   The hook payload arrives as JSON on stdin. bin/fm-spawn.sh registers this
-#   script for Notification and PostToolUse with the same gen it embeds in the
-#   task's other Claude hooks.
+#   script for Notification, PostToolUse, and PostToolUseFailure with the same
+#   gen it embeds in the task's other Claude hooks.
 #
 # Contract with the record owner: this script never writes the record itself.
 # bin/fm-busy-event.sh stays its only writer and bin/fm-busy-lib.sh stays the
@@ -86,11 +87,13 @@ if payload_has '"hook_event_name"[[:space:]]*:[[:space:]]*"Notification"'; then
   exit 0
 fi
 
-if payload_has '"hook_event_name"[[:space:]]*:[[:space:]]*"PostToolUse"'; then
-  # The resume half. A tool that ran is proof the gate was answered, but this
-  # hook fires after EVERY tool call, so it stays a cheap read that writes only
-  # while the record still stands at the gate. Answering "no" runs no tool, so
-  # that path is closed by the turn's own Stop instead.
+if payload_has '"hook_event_name"[[:space:]]*:[[:space:]]*"PostToolUse(Failure)?"'; then
+  # The resume half. A tool that ran is proof the gate was answered, and Claude
+  # reports a failed tool through PostToolUseFailure instead of PostToolUse, so
+  # both count: the outcome is irrelevant to the gate. This fires after EVERY
+  # tool call, so it stays a cheap read that writes only while the record still
+  # stands at the gate. Answering "no" runs no tool, so that path is closed by
+  # the turn's own Stop instead.
   fm_busy_approval_wait "$STATE" "$ID" claude || exit 0
   apply approval-answered
 fi

--- a/bin/fm-crew-state.sh
+++ b/bin/fm-crew-state.sh
@@ -58,7 +58,10 @@
 #   4. No run for this crew (pre-validation, or kind=scout): fall back to the
 #      recorded backend's pane busy state, then the status log's last line only
 #      when its verb maps to a recognized run-state. Decision-only events such as
-#      `resolved` never become current state or detail.
+#      `resolved` never become current state or detail. A busy pane whose turn is
+#      parked at an operator-only approval gate (fm_busy_approval_wait in
+#      bin/fm-busy-lib.sh) reports parked rather than working, because nothing
+#      advances there until a human answers the harness's own dialog.
 #   5. Missing meta or torn-down worktree: report unknown · none. If no run is
 #      attributed to this crew, a dead endpoint also reports unknown · none rather
 #      than trusting a stale status log. On tmux and herdr, which own a
@@ -627,7 +630,19 @@ fi
 if [ "$KIND" != secondmate ]; then
   BUSY_VERDICT=$(crew_busy_verdict "$BACKEND_TARGET")
   case "${BUSY_VERDICT%% *}" in
-    busy) emit working pane "harness busy (${BUSY_VERDICT#* })" ;;
+    busy)
+      # A turn parked at an operator-only approval gate is still an open turn,
+      # so the busy contract answers busy and is right to. It is not WORK
+      # though: nothing advances until a human answers a dialog firstmate's key
+      # plane cannot reach. Reporting it as parked - the same state a
+      # no-mistakes gate already uses - is what makes it visible, because
+      # bin/fm-classify-lib.sh reads this one line to decide whether a quiet
+      # pane may be absorbed as provably working, and only `working` may be.
+      if fm_busy_approval_wait "$STATE" "$ID" "$HARNESS"; then
+        emit parked pane "waiting on approval: the harness is holding at a permission prompt only an operator can answer"
+      fi
+      emit working pane "harness busy (${BUSY_VERDICT#* })"
+      ;;
     idle) ;;
     *) emit unknown pane "harness state unavailable ($BUSY_VERDICT)" ;;
   esac

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -2967,7 +2967,9 @@ if [ "$KIND" != secondmate ]; then
       # legacy fm-send --key Escape path records idle/fm-interrupt. Stop keeps
       # the turn-ended NOTIFICATION touch for the watcher. Every
       # hook command tolerates a refused event (|| true) so a stale-gen writer
-      # can never break Claude's own lifecycle.
+      # can never break Claude's own lifecycle. Notification and PostToolUse carry
+      # the approval gate, so a turn that stops at Claude's permission dialog
+      # is no longer read as ordinary work.
       mkdir -p "$WT/.claude"
       busy_cmd_prefix="$(shell_quote "$FM_ROOT/bin/fm-busy-event.sh") apply $(shell_quote "$STATE_REAL") $(shell_quote "$ID")"
       busy_suffix="--gen $(shell_quote "$BUSY_GEN") --source claude-hook"
@@ -2975,8 +2977,16 @@ if [ "$KIND" != secondmate ]; then
       j_stop=$(json_escape "touch $(shell_quote "$TURNEND"); $busy_cmd_prefix idle $busy_suffix --event stop 2>/dev/null || true")
       j_stopfail=$(json_escape "$busy_cmd_prefix idle $busy_suffix --event stop-failure 2>/dev/null || true")
       j_sessionend=$(json_escape "$busy_cmd_prefix idle $busy_suffix --event session-end 2>/dev/null || true")
+      # Approval-gate pair (bin/fm-claude-approval-hook.sh): Notification carries
+      # Claude's own structured permission-prompt event, and PostToolUse proves a
+      # tool ran, which is proof the gate was answered. Both go through one
+      # adapter so the payload rules live in one place, and it is given the same
+      # gen as the lifecycle hooks so an outlived incarnation fails closed in the
+      # writer exactly as they do.
+      approval_cmd="$(shell_quote "$FM_ROOT/bin/fm-claude-approval-hook.sh") $(shell_quote "$STATE_REAL") $(shell_quote "$ID") --gen $(shell_quote "$BUSY_GEN")"
+      j_notify=$(json_escape "$approval_cmd 2>/dev/null || true")
       cat > "$WT/.claude/settings.local.json" <<EOF
-{"hooks":{"UserPromptSubmit":[{"hooks":[{"type":"command","command":"$j_submit"}]}],"Stop":[{"hooks":[{"type":"command","command":"$j_stop"}]}],"StopFailure":[{"hooks":[{"type":"command","command":"$j_stopfail"}]}],"SessionEnd":[{"hooks":[{"type":"command","command":"$j_sessionend"}]}]}}
+{"hooks":{"UserPromptSubmit":[{"hooks":[{"type":"command","command":"$j_submit"}]}],"Stop":[{"hooks":[{"type":"command","command":"$j_stop"}]}],"StopFailure":[{"hooks":[{"type":"command","command":"$j_stopfail"}]}],"SessionEnd":[{"hooks":[{"type":"command","command":"$j_sessionend"}]}],"Notification":[{"hooks":[{"type":"command","command":"$j_notify"}]}],"PostToolUse":[{"hooks":[{"type":"command","command":"$j_notify"}]}]}}
 EOF
       exclude_path '.claude/settings.local.json'
       ;;

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -2967,9 +2967,9 @@ if [ "$KIND" != secondmate ]; then
       # legacy fm-send --key Escape path records idle/fm-interrupt. Stop keeps
       # the turn-ended NOTIFICATION touch for the watcher. Every
       # hook command tolerates a refused event (|| true) so a stale-gen writer
-      # can never break Claude's own lifecycle. Notification and PostToolUse carry
-      # the approval gate, so a turn that stops at Claude's permission dialog
-      # is no longer read as ordinary work.
+      # can never break Claude's own lifecycle. Notification, PostToolUse, and
+      # PostToolUseFailure carry the approval gate, so a turn that stops at
+      # Claude's permission dialog is no longer read as ordinary work.
       mkdir -p "$WT/.claude"
       busy_cmd_prefix="$(shell_quote "$FM_ROOT/bin/fm-busy-event.sh") apply $(shell_quote "$STATE_REAL") $(shell_quote "$ID")"
       busy_suffix="--gen $(shell_quote "$BUSY_GEN") --source claude-hook"
@@ -2977,16 +2977,17 @@ if [ "$KIND" != secondmate ]; then
       j_stop=$(json_escape "touch $(shell_quote "$TURNEND"); $busy_cmd_prefix idle $busy_suffix --event stop 2>/dev/null || true")
       j_stopfail=$(json_escape "$busy_cmd_prefix idle $busy_suffix --event stop-failure 2>/dev/null || true")
       j_sessionend=$(json_escape "$busy_cmd_prefix idle $busy_suffix --event session-end 2>/dev/null || true")
-      # Approval-gate pair (bin/fm-claude-approval-hook.sh): Notification carries
-      # Claude's own structured permission-prompt event, and PostToolUse proves a
-      # tool ran, which is proof the gate was answered. Both go through one
-      # adapter so the payload rules live in one place, and it is given the same
-      # gen as the lifecycle hooks so an outlived incarnation fails closed in the
-      # writer exactly as they do.
+      # Approval gate (bin/fm-claude-approval-hook.sh): Notification carries
+      # Claude's own structured permission-prompt event, and PostToolUse or
+      # PostToolUseFailure proves a tool ran, which is proof the gate was
+      # answered whatever the tool's outcome; Claude fires only one of the two
+      # per call. All go through one adapter so the payload rules live in one
+      # place, and it is given the same gen as the lifecycle hooks so an outlived
+      # incarnation fails closed in the writer exactly as they do.
       approval_cmd="$(shell_quote "$FM_ROOT/bin/fm-claude-approval-hook.sh") $(shell_quote "$STATE_REAL") $(shell_quote "$ID") --gen $(shell_quote "$BUSY_GEN")"
       j_notify=$(json_escape "$approval_cmd 2>/dev/null || true")
       cat > "$WT/.claude/settings.local.json" <<EOF
-{"hooks":{"UserPromptSubmit":[{"hooks":[{"type":"command","command":"$j_submit"}]}],"Stop":[{"hooks":[{"type":"command","command":"$j_stop"}]}],"StopFailure":[{"hooks":[{"type":"command","command":"$j_stopfail"}]}],"SessionEnd":[{"hooks":[{"type":"command","command":"$j_sessionend"}]}],"Notification":[{"hooks":[{"type":"command","command":"$j_notify"}]}],"PostToolUse":[{"hooks":[{"type":"command","command":"$j_notify"}]}]}}
+{"hooks":{"UserPromptSubmit":[{"hooks":[{"type":"command","command":"$j_submit"}]}],"Stop":[{"hooks":[{"type":"command","command":"$j_stop"}]}],"StopFailure":[{"hooks":[{"type":"command","command":"$j_stopfail"}]}],"SessionEnd":[{"hooks":[{"type":"command","command":"$j_sessionend"}]}],"Notification":[{"hooks":[{"type":"command","command":"$j_notify"}]}],"PostToolUse":[{"hooks":[{"type":"command","command":"$j_notify"}]}],"PostToolUseFailure":[{"hooks":[{"type":"command","command":"$j_notify"}]}]}}
 EOF
       exclude_path '.claude/settings.local.json'
       ;;

--- a/bin/fm-supervise-daemon.sh
+++ b/bin/fm-supervise-daemon.sh
@@ -670,7 +670,10 @@ task_window_harness() {  # <window> <state>
 # semantic busy-state contract (bin/fm-busy-lib.sh), 1 when it is not, and 2
 # when the endpoint could not be read at all. Only an exact busy verdict is
 # working: unknown semantic state never becomes busy and never becomes a
-# silent idle, so a stale pane whose state cannot be proven surfaces.
+# silent idle, so a stale pane whose state cannot be proven surfaces. A busy
+# turn parked at an operator-only approval gate (fm_busy_approval_wait) makes
+# no progress either, so it reads 1 and its stale marker escalates rather than
+# being dropped as resumed work.
 stale_window_is_busy() {  # <window> <state>
   local win=$1 state=$2 backend harness label task tail40 verdict
   backend=$(task_window_backend "$win" "$state")
@@ -679,7 +682,8 @@ stale_window_is_busy() {  # <window> <state>
   label="fm-$task"
   tail40=$(fm_backend_capture "$backend" "$win" 40 "$label" 2>/dev/null) || return 2
   verdict=$(fm_busy_classify "$backend" "$win" "$harness" "$task" "$state" "$tail40")
-  [ "${verdict%% *}" = busy ]
+  [ "${verdict%% *}" = busy ] || return 1
+  ! fm_busy_approval_wait "$state" "$task" "$harness"
 }
 
 escalate_add() {  # <state> <distilled-item>

--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -273,6 +273,7 @@ family_for_basename() {
       printf '%s\n' session-bootstrap
       ;;
     fm-afk-pi-herdr-return-e2e.test.sh|\
+    fm-claude-approval-notify-live-e2e.test.sh|\
     fm-claude-stop-autoarm-live-e2e.test.sh|\
     fm-cmux-claude-composer-live-e2e.test.sh|\
     fm-composer-matrix-live-e2e.test.sh|\
@@ -566,6 +567,7 @@ tests/fm-calm-pi-extension.test.sh 256
 tests/fm-check-unregister.test.sh 481
 tests/fm-classify-corr-token.test.sh 38742
 tests/fm-classify-decision-key.test.sh 1167
+tests/fm-claude-approval-notify-live-e2e.test.sh 21
 tests/fm-claude-stop-autoarm-live-e2e.test.sh 21
 tests/fm-claude-stop-autoarm.test.sh 60709
 tests/fm-cmux-claude-composer-live-e2e.test.sh 23
@@ -1354,6 +1356,13 @@ families_for_changed_path() {
     bin/fm-primary-scope-lib.sh|bin/fm-project-mode.sh|bin/fm-promote.sh|\
     bin/fm-ff-lib.sh|bin/fm-gotmp*|bin/*pretool*)
       printf '%s\n' pure-contract-unit
+      ;;
+    bin/fm-claude-approval-hook.sh)
+      # Whether Claude still publishes its permission gate at all is a fact only
+      # a real session can answer, so the live guard is selected alongside the
+      # portable contract suites.
+      printf '%s\n' pure-contract-unit
+      printf '%s\n' live-harness-optin
       ;;
     .agents/skills/quota-array-dispatch/SKILL.md)
       printf '%s\n' pure-contract-unit

--- a/bin/fm-watch.sh
+++ b/bin/fm-watch.sh
@@ -333,7 +333,9 @@ window_key() {  # <window>
 # Quiet when healthy: an absent, empty, or handled inbox costs one directory
 # glob and produces nothing. When the ladder (fm_task_inbox_due_action, the
 # policy owner) reports a due action, a busy pane just waits - the record is
-# durable and the worker will reach a turn boundary - an idle pane gets one
+# durable and the worker will reach a turn boundary - and so does a turn parked
+# at an operator-only approval gate, since a doorbell typed into that dialog
+# would answer it; an idle pane gets one
 # delivery attempt, and a spent attempt budget surfaces as an ordinary stale
 # wake for stuck-crewmate-recovery. If the attempt's ladder write fails while
 # its record remains unhandled, that unwritable state surfaces through the same
@@ -357,7 +359,7 @@ inbox_steer_check() {  # <window> <task>
       ;;
   esac
   tail40=$(fm_backend_capture "$(window_backend "$w")" "$w" 40 "$(window_label "$w")" 2>/dev/null) || tail40=
-  if window_is_busy "$w" "$tail40"; then
+  if window_is_busy "$w" "$tail40" || fm_busy_approval_wait "$STATE" "$task" "$(window_harness "$w")"; then
     return 0
   fi
   case "$verb" in

--- a/bin/fm-watch.sh
+++ b/bin/fm-watch.sh
@@ -254,20 +254,25 @@ hash_pane() {
 # the semantic busy-state contract (bin/fm-busy-lib.sh). Only an exact busy
 # verdict returns 0: idle, unknown, and dead all return 1, so a converted
 # adapter whose semantic state is missing, malformed, stale, or unverified is
-# treated as not-provably-working and surfaces rather than being absorbed.
+# treated as not-provably-working and surfaces rather than being absorbed. A
+# busy turn parked at an operator-only approval gate (fm_busy_approval_wait) is
+# an open turn making no progress, so it too returns 1 and takes the stale path,
+# where fm-crew-state's parked line surfaces it instead of absorbing it.
 # <tail40> is the same bounded capture already read for hashing and is
 # consumed only by the Grok-scoped fallback inside the contract.
 window_is_busy() {  # <window> <tail40>
-  local w=$1 tail40=$2 task meta verdict
+  local w=$1 tail40=$2 task meta harness verdict
   task=$(window_to_task "$w" "$STATE")
   meta="$STATE/$task.meta"
+  harness=$(window_harness "$w")
   if [ -n "$task" ] && [ -f "$meta" ]; then
     verdict=$(fm_busy_classify_meta "$meta" "$task" "$STATE" "$tail40")
   else
-    verdict=$(fm_busy_classify "$(window_backend "$w")" "$w" "$(window_harness "$w")" \
+    verdict=$(fm_busy_classify "$(window_backend "$w")" "$w" "$harness" \
       "${task:-unknown}" "$STATE" "$tail40")
   fi
-  [ "${verdict%% *}" = busy ]
+  [ "${verdict%% *}" = busy ] || return 1
+  ! fm_busy_approval_wait "$STATE" "${task:-unknown}" "$harness"
 }
 
 window_kind() {

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -163,7 +163,7 @@ Codex and standalone Kimi classify unknown behind explicit probes until a semant
 Missing, malformed, stale, untrusted, or unverified semantic state is unknown, never idle, and unknown is never promoted to busy either.
 Ordinary task-state consumers act only on an exact busy verdict, so an unreadable worker surfaces for a closer look instead of being absorbed as still-working or written off as finished.
 A busy record can additionally carry the approval-gate event (`fm_busy_approval_wait` in `bin/fm-busy-lib.sh`): the turn is open but parked at a harness dialog only an operator can answer, so `bin/fm-crew-state.sh` reports it as `parked` rather than `working`, the watcher and daemon stop counting that pane as busy so it surfaces through the ordinary stale path instead of aging to the wedge threshold, and steering doorbells keep waiting so no keystroke lands in the dialog.
-Claude is the adapter that publishes this gate today, through the `Notification` and `PostToolUse` pair owned by `bin/fm-claude-approval-hook.sh`.
+Claude is the adapter that publishes this gate today, through the `Notification`, `PostToolUse`, and `PostToolUseFailure` hooks owned by `bin/fm-claude-approval-hook.sh`.
 Endpoint death is the only process-level override and yields dead; child processes, CPU, process sleep state, and marker modification times are not state signals.
 `state/<id>.turn-ended` files remain wake notifications, not current state.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -162,6 +162,8 @@ Codex and standalone Kimi classify unknown behind explicit probes until a semant
 
 Missing, malformed, stale, untrusted, or unverified semantic state is unknown, never idle, and unknown is never promoted to busy either.
 Ordinary task-state consumers act only on an exact busy verdict, so an unreadable worker surfaces for a closer look instead of being absorbed as still-working or written off as finished.
+A busy record can additionally carry the approval-gate event (`fm_busy_approval_wait` in `bin/fm-busy-lib.sh`): the turn is open but parked at a harness dialog only an operator can answer, so `bin/fm-crew-state.sh` reports it as `parked` rather than `working`, the watcher and daemon stop counting that pane as busy so it surfaces through the ordinary stale path instead of aging to the wedge threshold, and steering doorbells keep waiting so no keystroke lands in the dialog.
+Claude is the adapter that publishes this gate today, through the `Notification` and `PostToolUse` pair owned by `bin/fm-claude-approval-hook.sh`.
 Endpoint death is the only process-level override and yields dead; child processes, CPU, process sleep state, and marker modification times are not state signals.
 `state/<id>.turn-ended` files remain wake notifications, not current state.
 

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -45,7 +45,7 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-primary-scope-lib.sh` | Shared marker-or-plain-checkout primary-home predicate for tracked hooks             |
 | `fm-session-lock-lib.sh` | Shared session-lock harness identity (ancestry walk and holder liveness) for fm-lock.sh and the Claude Stop auto-arm |
 | `fm-claude-stop-autoarm.sh` | Claude Stop `asyncRewake` hook owning tokenless watcher continuity with single-flight exit-2 rewake (docs/watcher-continuity.md) |
-| `fm-claude-approval-hook.sh` | Claude `Notification`/`PostToolUse` adapter opening and closing the busy contract's approval gate so a worker parked at a permission dialog is not read as working |
+| `fm-claude-approval-hook.sh` | Claude `Notification`/`PostToolUse`/`PostToolUseFailure` adapter opening and closing the busy contract's approval gate so a worker parked at a permission dialog is not read as working |
 | `fm-turnend-guard.sh`    | Shared primary turn-end guard predicate so no turn ends blind (docs/turnend-guard.md) |
 | `fm-turnend-guard-grok.sh` | Grok Stop-hook adapter for the primary turn-end guard                              |
 | `fm-kimi-turnend-hook.sh` | Surgically install or remove Kimi's guarded global crew turn-end hook                |

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -45,6 +45,7 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-primary-scope-lib.sh` | Shared marker-or-plain-checkout primary-home predicate for tracked hooks             |
 | `fm-session-lock-lib.sh` | Shared session-lock harness identity (ancestry walk and holder liveness) for fm-lock.sh and the Claude Stop auto-arm |
 | `fm-claude-stop-autoarm.sh` | Claude Stop `asyncRewake` hook owning tokenless watcher continuity with single-flight exit-2 rewake (docs/watcher-continuity.md) |
+| `fm-claude-approval-hook.sh` | Claude `Notification`/`PostToolUse` adapter opening and closing the busy contract's approval gate so a worker parked at a permission dialog is not read as working |
 | `fm-turnend-guard.sh`    | Shared primary turn-end guard predicate so no turn ends blind (docs/turnend-guard.md) |
 | `fm-turnend-guard-grok.sh` | Grok Stop-hook adapter for the primary turn-end guard                              |
 | `fm-kimi-turnend-hook.sh` | Surgically install or remove Kimi's guarded global crew turn-end hook                |

--- a/docs/verification/supervision.md
+++ b/docs/verification/supervision.md
@@ -248,10 +248,13 @@ Deterministic entry points:
 tests/fm-busy-state.test.sh
 tests/fm-busy-adapter-wiring.test.sh
 tests/fm-crew-state.test.sh
+tests/fm-watch-triage.test.sh
+tests/fm-daemon.test.sh
+tests/fm-task-inbox.test.sh
 FM_CLAUDE_APPROVAL_DRIFT=1 tests/fm-claude-approval-notify-live-e2e.test.sh
 ```
 
-The last one is the opt-in guard that refreshes the vendor-payload claim above; run it after a Claude upgrade.
+The watcher, daemon, and inbox suites pin the parked pane surfacing promptly and receiving no doorbell; the last one is the opt-in guard that refreshes the vendor-payload claim above, so run it after a Claude upgrade.
 
 ## Turn-end guard
 

--- a/docs/verification/supervision.md
+++ b/docs/verification/supervision.md
@@ -222,13 +222,36 @@ In this 2026-07-28 Codex 0.145.0 semantic-busy probe, Firstmate-written lifecycl
 Codex also exposes no `StopFailure` hook, so an API-error turn end would need separate coverage even after hook discovery works.
 The app-server protocol schema does define the required lifecycle (`turn/started`, plus a `turn/completed` status of `completed`, `interrupted`, `failed`, or `inProgress`), so the gate is a reachability problem rather than a protocol gap.
 
+### Claude approval gate, 2026-09-05
+
+Claude's hook-owned busy source opens on `UserPromptSubmit` and closes on `Stop`, so a turn that stops at Claude's own tool-permission dialog fires no closing hook and keeps classifying `busy`.
+Reproduced on Claude Code 2.1.261 in an isolated tmux pane wired exactly as `fm-spawn` writes the hooks: with the dialog on screen, `state/<id>.busy-state` read `state=busy source=claude-hook event=user-prompt-submit` and `bin/fm-crew-state.sh` reported `state: working`, which is the verdict [`bin/fm-classify-lib.sh`](../../bin/fm-classify-lib.sh) reads to absorb a quiet pane as provably working.
+
+Claude publishes the gate itself as a structured `Notification` payload, which is what [`bin/fm-claude-approval-hook.sh`](../../bin/fm-claude-approval-hook.sh) consumes.
+Both observed notification types on 2.1.261, captured from a live pane:
+
+```
+{"hook_event_name":"Notification","message":"Claude needs your permission","notification_type":"permission_prompt"}
+{"hook_event_name":"Notification","message":"Claude is waiting for your input","notification_type":"idle_prompt"}
+```
+
+Only the first is an operator gate.
+Hook order for one permission-gated tool call was `PreToolUse` (1788631174), then `Notification` (1788631180), then `PostToolUse` (1788631207), so `PreToolUse` runs before the dialog and cannot close it, and `PostToolUse` is the earliest available proof that the gate was answered.
+With the adapter wired, the same pane read `state: parked · source: pane · waiting on approval` at the dialog and `state: working · source: pane · harness busy (claude-hook)` once the approved tool had run.
+
+The gate therefore closes at the end of the approved tool call rather than at the keystroke that answered it, because Claude emits no hook for the answer itself.
+That window is bounded by the tool's own duration and always closes, on `PostToolUse` or on the turn's own `Stop`, and it over-reports rather than under-reports.
+
 Deterministic entry points:
 
 ```sh
 tests/fm-busy-state.test.sh
 tests/fm-busy-adapter-wiring.test.sh
 tests/fm-crew-state.test.sh
+FM_CLAUDE_APPROVAL_DRIFT=1 tests/fm-claude-approval-notify-live-e2e.test.sh
 ```
+
+The last one is the opt-in guard that refreshes the vendor-payload claim above; run it after a Claude upgrade.
 
 ## Turn-end guard
 

--- a/docs/verification/supervision.md
+++ b/docs/verification/supervision.md
@@ -242,6 +242,14 @@ With the adapter wired, the same pane read `state: parked · source: pane · wai
 The gate therefore closes at the end of the approved tool call rather than at the keystroke that answered it, because Claude emits no hook for the answer itself.
 That window is bounded by the tool's own duration and always closes, on `PostToolUse` or on the turn's own `Stop`, and it over-reports rather than under-reports.
 
+Known limitation, reasoned from Claude's documented hook behaviour and not reproduced live: the resume half closes the gate on any `PostToolUse` payload, not only the one for the gated call.
+Hooks also fire for tool calls inside a subagent, and concurrency-safe tools run in parallel, so a subagent `Read` or a parallel sibling tool that finishes while the main thread still sits at the permission dialog writes `approval-answered` early; the record then reads `busy` again, `bin/fm-crew-state.sh` reports `working`, and the pane is absorbed until the stale threshold, exactly the pre-adapter reading.
+The follow-up is to tie the close to the `tool_use_id` of the gated call, which `PreToolUse`, `Notification`, and `PostToolUse` would have to be correlated on; until then the limitation is confined to turns that mix a permission-gated call with a subagent or a parallel batch.
+
+The workspace-trust half was read on the same Claude Code 2.1.261: a never-seen path raises the trust dialog at launch, and at that dialog the pane reads `state: working` with the composer classified `pending`.
+That reading is unchanged by this change, because the trust dialog is pre-session and emits no hook for the adapter to consume; it is covered by the spawn-time pre-registration in `bin/fm-claude-trust.sh` (#3663), which keeps the dialog from appearing on a spawned worker in the first place.
+The external `CLAUDE.md` import dialog behaves the same: pre-session, no hook, `working` with `pending` composer, and outside what the approval hook can see.
+
 Deterministic entry points:
 
 ```sh

--- a/docs/verification/supervision.md
+++ b/docs/verification/supervision.md
@@ -239,12 +239,13 @@ Only the first is an operator gate.
 Hook order for one permission-gated tool call was `PreToolUse` (1788631174), then `Notification` (1788631180), then `PostToolUse` (1788631207), so `PreToolUse` runs before the dialog and cannot close it, and `PostToolUse` is the earliest available proof that the gate was answered.
 With the adapter wired, the same pane read `state: parked · source: pane · waiting on approval` at the dialog and `state: working · source: pane · harness busy (claude-hook)` once the approved tool had run.
 
-The gate therefore closes at the end of the approved tool call rather than at the keystroke that answered it, because Claude emits no hook for the answer itself.
-That window is bounded by the tool's own duration and always closes, on `PostToolUse` or on the turn's own `Stop`, and it over-reports rather than under-reports.
+The gate therefore closes at the end of the approved tool call, success or failure, rather than at the keystroke that answered it, because Claude emits no hook for the answer itself.
+Claude reports a tool that errored through `PostToolUseFailure` instead of `PostToolUse`, and the installed 2.1.261 binary carries that event's schema (`tool_name`, `tool_use_id`, `error`, `is_interrupt`), so the adapter is registered for both and treats them alike: the tool ran, so the dialog was answered, and its outcome is irrelevant to the gate.
+That window is bounded by the tool's own duration and always closes, on `PostToolUse`, on `PostToolUseFailure`, or on the turn's own `Stop`, and it over-reports rather than under-reports.
 
 Known limitation, reasoned from Claude's documented hook behaviour and not reproduced live: the resume half closes the gate on any `PostToolUse` payload, not only the one for the gated call.
 Hooks also fire for tool calls inside a subagent, and concurrency-safe tools run in parallel, so a subagent `Read` or a parallel sibling tool that finishes while the main thread still sits at the permission dialog writes `approval-answered` early; the record then reads `busy` again, `bin/fm-crew-state.sh` reports `working`, and the pane is absorbed until the stale threshold, exactly the pre-adapter reading.
-The follow-up is to tie the close to the `tool_use_id` of the gated call, which `PreToolUse`, `Notification`, and `PostToolUse` would have to be correlated on; until then the limitation is confined to turns that mix a permission-gated call with a subagent or a parallel batch.
+The follow-up is to tie the close to the `tool_use_id` of the gated call, which `PreToolUse`, `Notification`, `PostToolUse`, and `PostToolUseFailure` would have to be correlated on; until then the limitation is confined to turns that mix a permission-gated call with a subagent or a parallel batch.
 
 The workspace-trust half was read on the same Claude Code 2.1.261: a never-seen path raises the trust dialog at launch, and at that dialog the pane reads `state: working` with the composer classified `pending`.
 That reading is unchanged by this change, because the trust dialog is pre-session and emits no hook for the adapter to consume; it is covered by the spawn-time pre-registration in `bin/fm-claude-trust.sh` (#3663), which keeps the dialog from appearing on a spawned worker in the first place.

--- a/tests/fm-busy-adapter-wiring.test.sh
+++ b/tests/fm-busy-adapter-wiring.test.sh
@@ -264,6 +264,57 @@ test_claude_hooks_semantic_lifecycle() {
   pass "claude hooks open on UserPromptSubmit and close on Stop, StopFailure, and SessionEnd"
 }
 
+# Claude's real Notification payloads, captured live on Claude Code 2.1.261.
+CLAUDE_NOTIFY_PERMISSION='{"session_id":"s1","hook_event_name":"Notification","message":"Claude needs your permission","notification_type":"permission_prompt"}'
+CLAUDE_NOTIFY_IDLE='{"session_id":"s1","hook_event_name":"Notification","message":"Claude is waiting for your input","notification_type":"idle_prompt"}'
+CLAUDE_POST_TOOL_USE='{"session_id":"s1","hook_event_name":"PostToolUse","tool_name":"Bash"}'
+
+feed_claude_hook() {  # <settings.json> <hook-event> <payload>
+  local cmd
+  cmd=$(jq -r ".hooks[\"$2\"][0].hooks[0].command" "$1")
+  [ -n "$cmd" ] && [ "$cmd" != null ] || fail "no $2 hook command in $1"
+  printf '%s' "$3" | sh -c "$cmd"
+}
+
+# A turn that stops at Claude's tool-permission dialog fires no closing hook, so
+# without this pair the task keeps classifying busy and supervision reads a
+# worker that needs one keystroke as ordinary work. The spawn must therefore wire
+# both halves of the gate, and the wiring is what this drives: the commands the
+# spawn actually wrote, fed the payloads Claude actually emits.
+test_claude_approval_gate_wiring() {
+  local rec id=busy-cl-3 out state settings
+  rec=$(make_spawn_case claude-approval claude "$id")
+  read_case_record "$rec"
+  out=$(run_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$id" "$PROJ_DIR")
+  expect_code 0 $? "claude spawn should succeed: $out"
+  state="$HOME_DIR/state"
+  settings="$WT_DIR/.claude/settings.local.json"
+  for ev in Notification PostToolUse; do
+    jq -e ".hooks[\"$ev\"]" "$settings" >/dev/null || fail "claude hook settings lack $ev"
+  done
+
+  feed_claude_hook "$settings" Notification "$CLAUDE_NOTIFY_IDLE" \
+    || fail "the idle notification must not break the hook"
+  fm_busy_approval_wait "$state" "$id" claude \
+    && fail "an idle-prompt notification must not open the approval gate"
+
+  feed_claude_hook "$settings" Notification "$CLAUDE_NOTIFY_PERMISSION" \
+    || fail "the permission notification hook command failed"
+  fm_busy_approval_wait "$state" "$id" claude \
+    || fail "the permission notification must open the approval gate"
+  out=$(classify claude "$id" "$state")
+  [ "$out" = "busy claude-hook" ] \
+    || fail "the gate must leave the turn busy: it is open, just parked, got '$out'"
+
+  feed_claude_hook "$settings" PostToolUse "$CLAUDE_POST_TOOL_USE" \
+    || fail "the PostToolUse hook command failed"
+  fm_busy_approval_wait "$state" "$id" claude \
+    && fail "a tool that ran proves the gate was answered"
+  out=$(classify claude "$id" "$state")
+  [ "$out" = "busy claude-hook" ] || fail "clearing the gate must not end the turn, got '$out'"
+  pass "the spawn wires Claude's permission notification to the approval gate and closes it on a tool that ran"
+}
+
 test_claude_hooks_stale_incarnation_harmless() {
   local rec id=busy-cl-2 out state settings
   rec=$(make_spawn_case claude-stale claude "$id")
@@ -420,6 +471,7 @@ test_pi_extension_stale_incarnation_rejected
 test_kimi_and_grok_install_no_unverified_wiring
 test_opencode_plugin_semantic_lifecycle
 test_claude_hooks_semantic_lifecycle
+test_claude_approval_gate_wiring
 test_claude_hooks_stale_incarnation_harmless
 test_gemini_hooks_semantic_lifecycle
 test_gemini_hooks_stale_incarnation_harmless

--- a/tests/fm-busy-adapter-wiring.test.sh
+++ b/tests/fm-busy-adapter-wiring.test.sh
@@ -268,6 +268,7 @@ test_claude_hooks_semantic_lifecycle() {
 CLAUDE_NOTIFY_PERMISSION='{"session_id":"s1","hook_event_name":"Notification","message":"Claude needs your permission","notification_type":"permission_prompt"}'
 CLAUDE_NOTIFY_IDLE='{"session_id":"s1","hook_event_name":"Notification","message":"Claude is waiting for your input","notification_type":"idle_prompt"}'
 CLAUDE_POST_TOOL_USE='{"session_id":"s1","hook_event_name":"PostToolUse","tool_name":"Bash"}'
+CLAUDE_POST_TOOL_USE_FAILURE='{"session_id":"s1","hook_event_name":"PostToolUseFailure","tool_name":"Bash","tool_use_id":"toolu_01","error":"Exit code 128","is_interrupt":false}'
 
 feed_claude_hook() {  # <settings.json> <hook-event> <payload>
   local cmd
@@ -289,7 +290,7 @@ test_claude_approval_gate_wiring() {
   expect_code 0 $? "claude spawn should succeed: $out"
   state="$HOME_DIR/state"
   settings="$WT_DIR/.claude/settings.local.json"
-  for ev in Notification PostToolUse; do
+  for ev in Notification PostToolUse PostToolUseFailure; do
     jq -e ".hooks[\"$ev\"]" "$settings" >/dev/null || fail "claude hook settings lack $ev"
   done
 
@@ -312,7 +313,16 @@ test_claude_approval_gate_wiring() {
     && fail "a tool that ran proves the gate was answered"
   out=$(classify claude "$id" "$state")
   [ "$out" = "busy claude-hook" ] || fail "clearing the gate must not end the turn, got '$out'"
-  pass "the spawn wires Claude's permission notification to the approval gate and closes it on a tool that ran"
+
+  feed_claude_hook "$settings" Notification "$CLAUDE_NOTIFY_PERMISSION"
+  fm_busy_approval_wait "$state" "$id" claude || fail "the gate did not reopen"
+  feed_claude_hook "$settings" PostToolUseFailure "$CLAUDE_POST_TOOL_USE_FAILURE" \
+    || fail "the PostToolUseFailure hook command failed"
+  fm_busy_approval_wait "$state" "$id" claude \
+    && fail "an approved tool that then failed still proves the gate was answered"
+  out=$(classify claude "$id" "$state")
+  [ "$out" = "busy claude-hook" ] || fail "a failed tool must not end the turn either, got '$out'"
+  pass "the spawn wires Claude's permission notification to the approval gate and closes it on a tool that ran, success or failure"
 }
 
 test_claude_hooks_stale_incarnation_harmless() {

--- a/tests/fm-busy-state.test.sh
+++ b/tests/fm-busy-state.test.sh
@@ -439,6 +439,117 @@ test_boolean_view_never_promotes_unknown() {
   pass "the boolean view reports busy only on an exact busy verdict"
 }
 
+# --- approval gate ------------------------------------------------------------
+
+HOOK="$ROOT/bin/fm-claude-approval-hook.sh"
+
+# Claude's real Notification payload, captured live on Claude Code 2.1.261. Both
+# observed notification types are kept as fixtures because the whole value of
+# this hook is telling them apart: only the permission one is an operator gate,
+# while the idle one fires whenever a finished turn leaves the composer waiting.
+NOTIFY_PERMISSION='{"session_id":"s1","cwd":"/tmp/wt","hook_event_name":"Notification","message":"Claude needs your permission","notification_type":"permission_prompt"}'
+NOTIFY_IDLE='{"session_id":"s1","cwd":"/tmp/wt","hook_event_name":"Notification","message":"Claude is waiting for your input","notification_type":"idle_prompt"}'
+POST_TOOL_USE='{"session_id":"s1","cwd":"/tmp/wt","hook_event_name":"PostToolUse","tool_name":"Bash"}'
+
+test_approval_gate_opens_on_permission_notification() {
+  local state gen
+  state=$(new_state_dir gate-open)
+  gen=$("$EV" arm "$state" t1)
+  "$EV" apply "$state" t1 busy --gen "$gen" --source claude-hook --event user-prompt-submit
+  fm_busy_approval_wait "$state" t1 claude && fail "an ordinary turn must not read as an approval gate"
+  printf '%s' "$NOTIFY_PERMISSION" | "$HOOK" "$state" t1 --gen "$gen" || fail "hook exited non-zero"
+  fm_busy_approval_wait "$state" t1 claude || fail "the permission notification must open the gate"
+  [ "$(fm_busy_classify tmux w1 claude t1 "$state")" = "busy claude-hook" ] \
+    || fail "the gate must stay a busy record: the turn is open, just parked"
+  pass "Claude's permission notification opens the approval gate without changing the busy verdict"
+}
+
+test_approval_gate_ignores_idle_notification() {
+  local state gen
+  state=$(new_state_dir gate-idle-notify)
+  gen=$("$EV" arm "$state" t1)
+  "$EV" apply "$state" t1 busy --gen "$gen" --source claude-hook --event user-prompt-submit
+  printf '%s' "$NOTIFY_IDLE" | "$HOOK" "$state" t1 --gen "$gen" || fail "hook exited non-zero"
+  fm_busy_approval_wait "$state" t1 claude \
+    && fail "an idle-prompt notification is not an operator gate"
+  pass "the idle-prompt notification never opens the approval gate"
+}
+
+test_approval_gate_closed_by_tool_that_ran() {
+  local state gen seq_before seq_after
+  state=$(new_state_dir gate-close)
+  gen=$("$EV" arm "$state" t1)
+  "$EV" apply "$state" t1 busy --gen "$gen" --source claude-hook --event user-prompt-submit
+  seq_before=$(fm_busy_record_read "$state" t1 | awk '{print $4}')
+  printf '%s' "$POST_TOOL_USE" | "$HOOK" "$state" t1 --gen "$gen" || fail "hook exited non-zero"
+  seq_after=$(fm_busy_record_read "$state" t1 | awk '{print $4}')
+  [ "$seq_before" = "$seq_after" ] \
+    || fail "PostToolUse must not write while no gate is open, it fires on every tool call"
+  printf '%s' "$NOTIFY_PERMISSION" | "$HOOK" "$state" t1 --gen "$gen"
+  fm_busy_approval_wait "$state" t1 claude || fail "gate did not open"
+  printf '%s' "$POST_TOOL_USE" | "$HOOK" "$state" t1 --gen "$gen" || fail "hook exited non-zero"
+  fm_busy_approval_wait "$state" t1 claude && fail "a tool that ran proves the gate was answered"
+  [ "$(fm_busy_classify tmux w1 claude t1 "$state")" = "busy claude-hook" ] \
+    || fail "clearing the gate must leave the turn busy, not idle"
+  pass "a tool that actually ran closes the gate, and PostToolUse is a no-op otherwise"
+}
+
+test_approval_gate_closed_by_turn_end() {
+  local state gen
+  state=$(new_state_dir gate-stop)
+  gen=$("$EV" arm "$state" t1)
+  printf '%s' "$NOTIFY_PERMISSION" | "$HOOK" "$state" t1 --gen "$gen"
+  fm_busy_approval_wait "$state" t1 claude || fail "gate did not open"
+  "$EV" apply "$state" t1 idle --gen "$gen" --source claude-hook --event stop
+  fm_busy_approval_wait "$state" t1 claude && fail "an ended turn cannot still be at a gate"
+  pass "the turn's own end closes the approval gate"
+}
+
+test_approval_gate_refuses_untrusted_and_stale_records() {
+  local state gen
+  state=$(new_state_dir gate-trust)
+  gen=$("$EV" arm "$state" t1)
+  printf '%s' "$NOTIFY_PERMISSION" | "$HOOK" "$state" t1 --gen "$gen"
+  fm_busy_approval_wait "$state" t1 claude || fail "gate did not open"
+  fm_busy_approval_wait "$state" t1 opencode \
+    && fail "claude-hook must not open a gate on another adapter's task"
+  printf '%s' "g-other" > "$state/t1.busy-gen"
+  fm_busy_approval_wait "$state" t1 claude \
+    && fail "a record from an outlived incarnation must not claim a gate"
+  printf 'garbage\n' > "$state/t1.busy-state"
+  fm_busy_approval_wait "$state" t1 claude && fail "a malformed record must not claim a gate"
+  pass "the gate is claimed only from a trusted, current, well-formed record"
+}
+
+test_approval_hook_stale_gen_refused_silently() {
+  local state gen out
+  state=$(new_state_dir gate-stale-gen)
+  gen=$("$EV" arm "$state" t1)
+  "$EV" apply "$state" t1 busy --gen "$gen" --source claude-hook --event user-prompt-submit
+  out=$(printf '%s' "$NOTIFY_PERMISSION" | "$HOOK" "$state" t1 --gen g-outlived 2>&1) \
+    || fail "the hook must exit 0 even when its event is refused"
+  [ -z "$out" ] || fail "the hook must stay silent so nothing feeds back into the turn, got '$out'"
+  fm_busy_approval_wait "$state" t1 claude \
+    && fail "an outlived incarnation must not open a gate"
+  pass "an outlived hook is refused silently and opens no gate"
+}
+
+test_approval_hook_tolerates_unusable_input() {
+  local state gen out
+  state=$(new_state_dir gate-bad-input)
+  gen=$("$EV" arm "$state" t1)
+  out=$(printf '' | "$HOOK" "$state" t1 --gen "$gen" 2>&1) || fail "empty payload must exit 0"
+  [ -z "$out" ] || fail "empty payload must stay silent, got '$out'"
+  out=$(printf 'not json at all' | "$HOOK" "$state" t1 --gen "$gen" 2>&1) \
+    || fail "unparseable payload must exit 0"
+  [ -z "$out" ] || fail "unparseable payload must stay silent, got '$out'"
+  out=$(printf '%s' "$NOTIFY_PERMISSION" | "$HOOK" "$state" t1 2>&1) \
+    || fail "a missing gen must exit 0"
+  fm_busy_approval_wait "$state" t1 claude \
+    && fail "no gate may be opened from an unusable invocation"
+  pass "an unusable payload or invocation leaves the record untouched and exits 0"
+}
+
 test_arm_seeds_busy_spawn
 test_apply_advances_seq_and_source
 test_apply_current_gen_reset
@@ -461,5 +572,12 @@ test_dead_endpoint_overrides
 test_herdr_native_busy_only
 test_record_read_leaves_caller_shell_intact
 test_boolean_view_never_promotes_unknown
+test_approval_gate_opens_on_permission_notification
+test_approval_gate_ignores_idle_notification
+test_approval_gate_closed_by_tool_that_ran
+test_approval_gate_closed_by_turn_end
+test_approval_gate_refuses_untrusted_and_stale_records
+test_approval_hook_stale_gen_refused_silently
+test_approval_hook_tolerates_unusable_input
 
 echo "all fm-busy-state tests passed"

--- a/tests/fm-busy-state.test.sh
+++ b/tests/fm-busy-state.test.sh
@@ -450,6 +450,7 @@ HOOK="$ROOT/bin/fm-claude-approval-hook.sh"
 NOTIFY_PERMISSION='{"session_id":"s1","cwd":"/tmp/wt","hook_event_name":"Notification","message":"Claude needs your permission","notification_type":"permission_prompt"}'
 NOTIFY_IDLE='{"session_id":"s1","cwd":"/tmp/wt","hook_event_name":"Notification","message":"Claude is waiting for your input","notification_type":"idle_prompt"}'
 POST_TOOL_USE='{"session_id":"s1","cwd":"/tmp/wt","hook_event_name":"PostToolUse","tool_name":"Bash"}'
+POST_TOOL_USE_FAILURE='{"session_id":"s1","cwd":"/tmp/wt","hook_event_name":"PostToolUseFailure","tool_name":"Bash","tool_use_id":"toolu_01","error":"Exit code 128","is_interrupt":false}'
 
 test_approval_gate_opens_on_permission_notification() {
   local state gen
@@ -492,6 +493,26 @@ test_approval_gate_closed_by_tool_that_ran() {
   [ "$(fm_busy_classify tmux w1 claude t1 "$state")" = "busy claude-hook" ] \
     || fail "clearing the gate must leave the turn busy, not idle"
   pass "a tool that actually ran closes the gate, and PostToolUse is a no-op otherwise"
+}
+
+test_approval_gate_closed_by_tool_that_failed() {
+  local state gen seq_before seq_after
+  state=$(new_state_dir gate-close-failure)
+  gen=$("$EV" arm "$state" t1)
+  "$EV" apply "$state" t1 busy --gen "$gen" --source claude-hook --event user-prompt-submit
+  seq_before=$(fm_busy_record_read "$state" t1 | awk '{print $4}')
+  printf '%s' "$POST_TOOL_USE_FAILURE" | "$HOOK" "$state" t1 --gen "$gen" || fail "hook exited non-zero"
+  seq_after=$(fm_busy_record_read "$state" t1 | awk '{print $4}')
+  [ "$seq_before" = "$seq_after" ] \
+    || fail "PostToolUseFailure must not write while no gate is open"
+  printf '%s' "$NOTIFY_PERMISSION" | "$HOOK" "$state" t1 --gen "$gen"
+  fm_busy_approval_wait "$state" t1 claude || fail "gate did not open"
+  printf '%s' "$POST_TOOL_USE_FAILURE" | "$HOOK" "$state" t1 --gen "$gen" || fail "hook exited non-zero"
+  fm_busy_approval_wait "$state" t1 claude \
+    && fail "an approved tool that then failed still proves the gate was answered"
+  [ "$(fm_busy_classify tmux w1 claude t1 "$state")" = "busy claude-hook" ] \
+    || fail "a failed tool must leave the turn busy, not idle"
+  pass "an approved tool that failed closes the gate through PostToolUseFailure"
 }
 
 test_approval_gate_closed_by_turn_end() {
@@ -575,6 +596,7 @@ test_boolean_view_never_promotes_unknown
 test_approval_gate_opens_on_permission_notification
 test_approval_gate_ignores_idle_notification
 test_approval_gate_closed_by_tool_that_ran
+test_approval_gate_closed_by_tool_that_failed
 test_approval_gate_closed_by_turn_end
 test_approval_gate_refuses_untrusted_and_stale_records
 test_approval_hook_stale_gen_refused_silently

--- a/tests/fm-claude-approval-notify-live-e2e.test.sh
+++ b/tests/fm-claude-approval-notify-live-e2e.test.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+# tests/fm-claude-approval-notify-live-e2e.test.sh - opt-in credentialed drift
+# guard proving the real installed Claude Code still publishes its tool
+# permission gate as a structured Notification payload, and that
+# bin/fm-claude-approval-hook.sh still recognises it.
+#
+# Why this file exists: the approval gate in bin/fm-busy-lib.sh is opened from a
+# field the vendor emits (notification_type=permission_prompt). A stub cannot
+# prove that field is still emitted, and neither can a payload transcribed from
+# a previous release. The failure this guards is quiet by construction - if the
+# payload changes shape, the hook simply never fires and a worker parked at a
+# permission dialog silently goes back to reading as ordinary work - so the
+# guard has to run a real session and refuse to pass without seeing the payload.
+#
+# The portable counterpart in tests/fm-busy-state.test.sh pins the classifier and
+# the adapter's decisions in CI, and tests/fm-busy-adapter-wiring.test.sh pins
+# the spawn's registration. This file pins only the vendor contract those two
+# assume. Standard CI has no harness binary and no credentials, so it is opt-in
+# and on demand: run it after a Claude upgrade and before trusting refreshed
+# per-harness evidence in docs/verification/supervision.md.
+#
+# The lab is fully isolated - its own repository clone, its own linked worktree,
+# its own firstmate home, and its own tmux server - and it never touches a live
+# fleet home, worktree, or session. Claude keeps using its existing managed
+# authentication, and the session is driven to exactly one cheap tool call.
+set -u
+
+if [ "${FM_CLAUDE_APPROVAL_DRIFT:-0}" != 1 ]; then
+  echo "skip: set FM_CLAUDE_APPROVAL_DRIFT=1 to run the Claude permission-notification drift guard"
+  exit 0
+fi
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+LAB=""
+SOCKET="fm-approval-drift-$$"
+REAL_TMUX=""
+
+cleanup() {
+  [ -n "$REAL_TMUX" ] && "$REAL_TMUX" -L "$SOCKET" kill-server >/dev/null 2>&1
+  [ -n "$LAB" ] && rm -rf "$LAB"
+  return 0
+}
+trap cleanup EXIT
+
+fail() { printf 'not ok - %s\n' "$1" >&2; exit 1; }
+
+# An absent harness is reported, never passed over: this guard exists precisely
+# to check something only the real binary can answer.
+command -v claude >/dev/null 2>&1 || fail "claude not installed: this guard checked nothing"
+command -v tmux >/dev/null 2>&1 || fail "tmux not installed: this guard checked nothing"
+command -v jq >/dev/null 2>&1 || fail "jq not installed: this guard checked nothing"
+REAL_TMUX=$(command -v tmux)
+CLAUDE_VERSION=$(claude --version)
+
+LAB=$(mktemp -d "${TMPDIR:-/tmp}/fm-approval-drift.XXXXXX")
+PROJECT="$LAB/project"
+WT="$LAB/wt"
+HOME_DIR="$LAB/fmhome"
+CAPTURE="$LAB/notification.jsonl"
+mkdir -p "$HOME_DIR/state"
+
+# A real linked worktree, because trust pre-registration refuses a primary
+# checkout and every fleet worker runs in a linked worktree anyway.
+git clone -q "$ROOT" "$PROJECT" || fail "could not clone the repository into the lab"
+git -C "$PROJECT" worktree add -q --detach "$WT" >/dev/null 2>&1 \
+  || fail "could not create the lab worktree"
+"$ROOT/bin/fm-claude-trust.sh" "$WT" "$PROJECT" >/dev/null \
+  || fail "could not pre-register workspace trust for the lab worktree"
+
+GEN=$("$ROOT/bin/fm-busy-event.sh" arm "$HOME_DIR/state" drift) \
+  || fail "could not arm the busy contract for the lab task"
+
+# The registration is deliberately a raw capture rather than a copy of what
+# bin/fm-spawn.sh writes: the spawn's wiring is already pinned portably, and
+# what only a live session can answer is whether the payload still carries the
+# gate. The captured payload is then fed through the real adapter below.
+mkdir -p "$WT/.claude"
+cat > "$WT/.claude/settings.local.json" <<JSON
+{"hooks":{"Notification":[{"hooks":[{"type":"command","command":"cat >> $CAPTURE"}]}]}}
+JSON
+
+"$REAL_TMUX" -L "$SOCKET" new-session -d -s drift -x 200 -y 50 -c "$WT" \
+  || fail "could not start the lab tmux session"
+"$REAL_TMUX" -L "$SOCKET" send-keys -t drift:0 \
+  "CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false CLAUDE_CODE_SEND_FEEDBACK=0 claude --permission-mode manual --effort low 'Run this exact shell command with the Bash tool and nothing else: node -e \"console.log(1)\"'" Enter \
+  || fail "could not launch Claude in the lab session"
+
+# Bounded wait: a permission gate that never arrives is exactly the drift this
+# guard exists to catch, so the timeout is a failure, never a skip.
+DEADLINE=$(( $(date +%s) + ${FM_CLAUDE_APPROVAL_DRIFT_TIMEOUT:-180} ))
+while [ ! -s "$CAPTURE" ]; do
+  [ "$(date +%s)" -lt "$DEADLINE" ] || {
+    printf '# last pane:\n' >&2
+    "$REAL_TMUX" -L "$SOCKET" capture-pane -p -t drift:0 >&2 2>/dev/null
+    fail "Claude $CLAUDE_VERSION reached no permission notification: the gate signal firstmate depends on may have changed"
+  }
+  sleep 3
+done
+
+PAYLOAD=$(grep -m1 permission_prompt "$CAPTURE" 2>/dev/null || true)
+[ -n "$PAYLOAD" ] \
+  || fail "Claude $CLAUDE_VERSION emitted a notification without notification_type=permission_prompt: $(cat "$CAPTURE")"
+[ "$(printf '%s' "$PAYLOAD" | jq -r '.hook_event_name')" = Notification ] \
+  || fail "Claude $CLAUDE_VERSION no longer names the permission gate a Notification: $PAYLOAD"
+
+# The adapter must still open the gate from the payload the harness actually
+# emitted, not from the fixture the portable tests use.
+# shellcheck source=bin/fm-busy-lib.sh
+. "$ROOT/bin/fm-busy-lib.sh"
+printf '%s' "$PAYLOAD" | "$ROOT/bin/fm-claude-approval-hook.sh" "$HOME_DIR/state" drift --gen "$GEN" \
+  || fail "the approval hook exited non-zero on a live Claude $CLAUDE_VERSION payload"
+fm_busy_approval_wait "$HOME_DIR/state" drift claude \
+  || fail "the approval gate did not open on a live Claude $CLAUDE_VERSION permission notification: $PAYLOAD"
+
+# Leave the session at no dialog before teardown: 4 is the decline option, and
+# Enter is never sent, because these dialogs start on their refusing choice.
+"$REAL_TMUX" -L "$SOCKET" send-keys -t drift:0 "4" >/dev/null 2>&1
+
+printf 'ok - Claude %s still publishes its tool permission gate as notification_type=permission_prompt and the approval hook opens on it\n' "$CLAUDE_VERSION"

--- a/tests/fm-crew-state.test.sh
+++ b/tests/fm-crew-state.test.sh
@@ -833,6 +833,52 @@ test_no_run_busy_pane() {
   pass "no run + a busy semantic record reads working, attributed to its source"
 }
 
+# A turn parked at Claude's tool-permission dialog is still an open turn, so the
+# busy contract keeps answering busy. It is not work, though, and the supervisor
+# line is where that distinction has to appear: bin/fm-classify-lib.sh absorbs a
+# quiet pane only while this line says working, so a gate reported as working is
+# a gate nobody looks at until the wedge threshold.
+test_no_run_approval_gate_reads_parked() {
+  reset_fakes
+  local d; d=$(new_case approval-gate)
+  make_repo_on_branch "$d/wt" fm/feat-gate
+  make_fakebin "$d" >/dev/null
+  fm_write_meta "$d/state/feat-gate.meta" "window=fm:fm-feat-gate" "worktree=$d/wt" "kind=ship" "harness=claude"
+  FM_FAKE_AXI_STATUS=""
+  FM_FAKE_RUNS_LIST=""
+  FM_FAKE_BUSY=1
+  local gen; gen=$("$ROOT/bin/fm-busy-event.sh" arm "$d/state" feat-gate)
+  "$ROOT/bin/fm-busy-event.sh" apply "$d/state" feat-gate busy --gen "$gen" \
+    --source claude-hook --event permission-prompt
+  local out; out=$(run_crew_state "$d" feat-gate)
+  assert_contains "$out" "state: parked" "an approval gate reads parked, not working"
+  assert_not_contains "$out" "state: working" "an approval gate must not read working"
+  assert_contains "$out" "waiting on approval" "the parked line names the gate"
+  pass "a busy record standing at the approval gate reads parked"
+}
+
+# The resume half: the gate is one event on the ordinary record, so any later
+# lifecycle event returns the crew to plain working without a second mechanism.
+test_no_run_approval_gate_cleared_reads_working() {
+  reset_fakes
+  local d; d=$(new_case approval-cleared)
+  make_repo_on_branch "$d/wt" fm/feat-gate2
+  make_fakebin "$d" >/dev/null
+  fm_write_meta "$d/state/feat-gate2.meta" "window=fm:fm-feat-gate2" "worktree=$d/wt" "kind=ship" "harness=claude"
+  FM_FAKE_AXI_STATUS=""
+  FM_FAKE_RUNS_LIST=""
+  FM_FAKE_BUSY=1
+  local gen; gen=$("$ROOT/bin/fm-busy-event.sh" arm "$d/state" feat-gate2)
+  "$ROOT/bin/fm-busy-event.sh" apply "$d/state" feat-gate2 busy --gen "$gen" \
+    --source claude-hook --event permission-prompt
+  "$ROOT/bin/fm-busy-event.sh" apply "$d/state" feat-gate2 busy --gen "$gen" \
+    --source claude-hook --event approval-answered
+  local out; out=$(run_crew_state "$d" feat-gate2)
+  assert_contains "$out" "state: working" "a cleared gate returns to working"
+  assert_not_contains "$out" "waiting on approval" "a cleared gate stops naming the gate"
+  pass "a later lifecycle event clears the approval gate back to working"
+}
+
 # A converted adapter must NOT read working from rendered footer text: the
 # redesign removed that dependency, so a pane painting "esc to interrupt" with
 # no semantic record is unknown, never working and never silently idle.
@@ -1895,6 +1941,8 @@ test_cross_branch_attribution_picks_most_recent_row
 test_coarse_run_does_not_probe_other_branch_ci_log_for_ready_status
 test_other_branch_run_ignored
 test_no_run_busy_pane
+test_no_run_approval_gate_reads_parked
+test_no_run_approval_gate_cleared_reads_working
 test_no_run_footer_text_alone_is_not_working
 test_no_run_grok_uses_isolated_fallback
 test_no_run_herdr_unknown_uses_backend_capture

--- a/tests/fm-daemon.test.sh
+++ b/tests/fm-daemon.test.sh
@@ -1237,6 +1237,34 @@ test_housekeeping_resumed_stale_cleared() {
   pass "resumed (busy) stale clears its marker without escalating"
 }
 
+# The away-mode mirror of the watcher's approval-gate path: a Claude turn parked
+# at its permission dialog still classifies busy, and before the gate reached
+# stale_window_is_busy the recheck dropped its stale marker as resumed work and
+# never escalated. A gated turn is not resumed work, so the marker escalates.
+test_housekeeping_parked_stale_escalates() {
+  local dir state fakebin win pane key
+  dir=$(make_supercase stale-parked)
+  state="$dir/state"
+  fakebin="$dir/fakebin"
+  win="sess:fm-gate-w6"
+  pane="$dir/pane.txt"
+  printf 'working\n' > "$state/gate-w6.status"
+  printf 'Allow Bash(git switch)? (y/n)\n' > "$pane"
+  fm_write_meta "$state/gate-w6.meta" "window=$win" "worktree=$dir/wt" "kind=ship" "harness=claude"
+  local gen; gen=$("$ROOT/bin/fm-busy-event.sh" arm "$state" gate-w6)
+  "$ROOT/bin/fm-busy-event.sh" apply "$state" gate-w6 busy --gen "$gen" \
+    --source claude-hook --event permission-prompt
+  key=$(printf '%s' "gate-w6" | tr ':/.' '___')
+  echo $(( $(date +%s) - 500 )) > "$state/.subsuper-stale-$key"
+  PATH="$fakebin:$PATH" FM_FAKE_TMUX_WINDOW="$win" FM_FAKE_TMUX_CAPTURE="$pane" \
+    FM_STATE_OVERRIDE="$state" FM_STALE_ESCALATE_SECS=240 housekeeping "$state"
+  [ -s "$state/.subsuper-escalations" ] || fail "a stale pane parked at the approval gate was dropped as resumed work"
+  grep -F "stale persisted" "$state/.subsuper-escalations" >/dev/null \
+    || fail "the parked stale did not escalate as persisted: $(cat "$state/.subsuper-escalations")"
+  [ ! -e "$state/.subsuper-stale-$key" ] || fail "parked stale marker not cleared after escalation"
+  pass "a persistent stale whose busy record is parked at the approval gate escalates instead of clearing"
+}
+
 test_housekeeping_herdr_persistent_stale_resolves_meta() {
   local dir state key
   dir=$(make_supercase stale-herdr-persistent)
@@ -2637,6 +2665,7 @@ test_housekeeping_migrates_watcher_unpaused_marker_to_clear
 test_housekeeping_seeds_pause_marker_from_status
 test_housekeeping_persistent_stale_escalates
 test_housekeeping_resumed_stale_cleared
+test_housekeeping_parked_stale_escalates
 test_housekeeping_paused_resurfaces_and_resets
 test_housekeeping_captain_held_resurfaces_and_resets
 test_housekeeping_paused_resumed_cleared

--- a/tests/fm-task-inbox.test.sh
+++ b/tests/fm-task-inbox.test.sh
@@ -425,6 +425,34 @@ test_watcher_waits_on_busy_pane() {
   pass "watcher: a busy pane just waits - the record is durable and no doorbell is typed"
 }
 
+# A Claude turn parked at its tool-permission dialog is not absorbable as work
+# (the stale path surfaces it), but a doorbell typed into that dialog would
+# answer the operator-only gate on the operator's behalf: digits in the inbox
+# path select numbered options and the trailing Enter confirms one. So the
+# steer check waits on a parked record exactly as it waits on a busy pane, and
+# the worker reads the durable record at its next turn boundary.
+test_watcher_waits_on_parked_pane() {
+  local dir state out log pid rec gen
+  dir=$(setup_watch_case parkedwait)
+  state="$dir/state"; out="$dir/watch.out"; log="$dir/send.log"; : > "$log"
+  fm_write_meta "$state/t1.meta" "window=sess:fm-t1" "kind=ship" "harness=claude"
+  gen=$("$ROOT/bin/fm-busy-event.sh" arm "$state" t1)
+  "$ROOT/bin/fm-busy-event.sh" apply "$state" t1 busy --gen "$gen" \
+    --source claude-hook --event permission-prompt
+  printf 'Allow Bash(git switch)?\n1. Yes\n2. No\n' > "$dir/parked.capture"
+  rec=$(inbox_lib "$state" fm_task_inbox_write "$state" t1 "please continue")
+  age_path "$rec"
+  watch_bg "$state" "$dir/fakebin" "$out" \
+    FM_SEND_LOG="$log" FM_FAKE_TMUX_CAPTURE="$dir/parked.capture" \
+    FM_TASK_INBOX_RING_MAX=99
+  pid=$!
+  sleep 4
+  kill "$pid" 2>/dev/null; wait "$pid" 2>/dev/null
+  [ ! -s "$log" ] || fail "a pane parked at the approval gate must wait, not ring:"$'\n'"$(cat "$log")"
+  [ -f "$rec" ] || fail "the parked wait lost the durable inbox record"
+  pass "watcher: a turn parked at a permission prompt gets no doorbell - the record stays durable for the next turn boundary"
+}
+
 test_watcher_quiet_on_healthy_inbox() {
   local dir state out log pid
   dir=$(setup_watch_case healthy)
@@ -533,6 +561,7 @@ test_fire_and_forget_records_never_enter_the_ladder
 test_ring_ladder_policy
 test_watcher_rerings_idle_pane_quietly
 test_watcher_waits_on_busy_pane
+test_watcher_waits_on_parked_pane
 test_watcher_quiet_on_healthy_inbox
 test_watcher_ack_silences_unwritable_ladder
 test_watcher_surfaces_unwritable_ladder

--- a/tests/fm-watch-triage.test.sh
+++ b/tests/fm-watch-triage.test.sh
@@ -2737,6 +2737,63 @@ test_busy_pane_below_turn_age_bound_is_absorbed() {
   pass "a busy worker below the turn-age bound remains working with no escalation"
 }
 
+# A Claude turn parked at its tool-permission dialog is still an open turn, so
+# its busy record keeps classifying busy - and before the approval gate reached
+# this predicate, the watcher read that as work and sat in the busy branch until
+# BUSY_TURN_MAX_SECS. A gated turn makes no progress, so it must take the stale
+# path on the first stable hash, where fm-crew-state's parked line is not
+# absorbable and the pane surfaces; the resume half (a tool that ran) returns it
+# to ordinary busy absorption.
+test_busy_pane_at_approval_gate_surfaces_promptly() {
+  local dir state fakebin out capture_file window key pane_hash sig gen pid
+  dir=$(make_case busy-approval-gate); state="$dir/state"; fakebin="$dir/fakebin"
+  out="$dir/watch.out"; capture_file="$dir/pane.txt"; window="test:fm-busy-gate"
+  printf 'Allow Bash(git switch)? (y/n)' > "$capture_file"
+  printf 'window=%s\nkind=ship\nharness=claude\n' "$window" > "$state/busy-gate.meta"
+  gen=$("$ROOT/bin/fm-busy-event.sh" arm "$state" busy-gate)
+  "$ROOT/bin/fm-busy-event.sh" apply "$state" busy-gate busy --gen "$gen" \
+    --source claude-hook --event permission-prompt
+  printf 'working: setup complete\n' > "$state/busy-gate.status"
+  sig=$(seen_sig "$state/busy-gate.status"); printf '%s' "$sig" > "$state/.seen-busy-gate_status"
+  key=$(printf '%s' "$window" | tr ':/.' '___')
+  pane_hash=$(hash_text "Allow Bash(git switch)? (y/n)")
+  printf '%s' "$pane_hash" > "$state/.hash-$key"
+  printf '1\n' > "$state/.count-$key"
+  touch "$state/busy-gate.turn-ended"
+  prime_turnend_seen "$state/busy-gate.turn-ended"
+
+  # Phase A: the gate is open. The turn-age and wedge bounds are far away, so
+  # the only route to a wake is the stale path this fix opens.
+  PATH="$fakebin:$PATH" FM_FAKE_TMUX_WINDOW="$window" FM_FAKE_TMUX_CAPTURE="$capture_file" \
+    FM_STATE_OVERRIDE="$state" FM_CREW_STATE_BIN="$fakebin/fm-crew-state.sh" \
+    FM_FAKE_CREW_STATE='state: parked · source: pane · waiting on approval: the harness is holding at a permission prompt only an operator can answer' \
+    FM_BUSY_TURN_MAX_SECS=999 FM_STALE_ESCALATE_SECS=999 FM_POLL=1 FM_SIGNAL_GRACE=1 \
+    FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 "$WATCH" > "$out" &
+  pid=$!
+  wait_for_exit "$pid" 100 || fail "a busy pane parked at the approval gate was absorbed as working: $(cat "$out")"
+  grep -F "stale: $window" "$out" >/dev/null || fail "the approval gate did not surface as a stale wake: $(cat "$out")"
+  [ ! -e "$state/.stale-since-$key" ] || fail "the approval gate started a wedge timer instead of surfacing"
+  ack_stopped_cycle "$state" || fail "could not acknowledge the approval-gate stop"
+
+  # Phase B: a tool ran, so the gate was answered. The same busy record is now
+  # ordinary work again and the same stable pane is absorbed with no wake.
+  "$ROOT/bin/fm-busy-event.sh" apply "$state" busy-gate busy --gen "$gen" \
+    --source claude-hook --event approval-answered
+  : > "$out"
+  PATH="$fakebin:$PATH" FM_FAKE_TMUX_WINDOW="$window" FM_FAKE_TMUX_CAPTURE="$capture_file" \
+    FM_STATE_OVERRIDE="$state" FM_CREW_STATE_BIN="$fakebin/fm-crew-state.sh" \
+    FM_FAKE_CREW_STATE='state: working · source: pane · harness busy (claude-hook)' \
+    FM_BUSY_TURN_MAX_SECS=999 FM_STALE_ESCALATE_SECS=999 FM_POLL=1 FM_SIGNAL_GRACE=1 \
+    FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 "$WATCH" > "$out" &
+  pid=$!
+  if ! wait_poll_cycle "$state" "$pid"; then
+    reap "$pid"; fail "an answered approval gate still surfaced as stale: $(cat "$out")"
+  fi
+  [ ! -s "$out" ] || fail "an answered approval gate printed a wake reason: $(cat "$out")"
+  reap "$pid"
+  pass "a worker parked at Claude's permission prompt surfaces on the first stable hash and is absorbed again once the gate is answered"
+}
+
 test_busy_pane_stable_hash_escalates_past_turn_age_bound() {
   local dir state fakebin out capture_file window key pane_hash sig pid
   dir=$(make_case busy-stable-hash-turn-age); state="$dir/state"; fakebin="$dir/fakebin"
@@ -4160,6 +4217,7 @@ test_nonterminal_stale_provably_working_absorbed_then_escalated
 test_wedge_escalation_marks_demand_deep_inspection_after_threshold
 test_wedge_escalation_resets_when_pane_becomes_active
 test_busy_pane_below_turn_age_bound_is_absorbed
+test_busy_pane_at_approval_gate_surfaces_promptly
 test_busy_pane_stable_hash_escalates_past_turn_age_bound
 test_busy_pane_changing_hash_escalates_past_turn_age_bound
 test_busy_pane_turn_end_touch_resets_age


### PR DESCRIPTION
## Intent

After the planned Firstmate update, reproduce whether a worker waiting at a workspace-trust or permission prompt is still reported as actively working.
Use the clean worker profile and inspect the actual prompt state rather than inferring from process liveness.
If the updated version still misclassifies it, prepare a focused change and PR to the original Firstmate repository through the configured fork; do not accept manual monitoring as the permanent workaround.

Captain's standing words on this (recorded 2026-09-05): "Stop finished workers individually as soon as their deliverable is preserved, and clear permission prompts promptly; inactive or approval-blocked sessions left open are a Firstmate supervision defect. After the next Firstmate update, recheck whether workers still appear busy while waiting on approval; if the defect persists, prepare a focused upstream PR instead of accepting manual monitoring."

Context the captain observed before the update: on 2026-09-03 a Claude worker stopped at a confirmation prompt (git switch, node and similar commands) surfaced only as a "stale" wake after about four minutes, and Firstmate's current-state read kept reporting the worker as working; the captain had to accept the prompt by hand. The update of 2026-09-05 (31cba0d..e075c96) landed "pre-register claude workspace trust at spawn time (#3663)", which may cover the workspace-trust half but says nothing about the permission-prompt half.

## What Changed

- Added `bin/fm-claude-approval-hook.sh`, a Claude hook adapter that `bin/fm-spawn.sh` now registers for `Notification`, `PostToolUse`, and `PostToolUseFailure`: a `permission_prompt` notification records the `permission-prompt` event on the task's busy record, and any tool that then runs (success or failure) closes it with `approval-answered`. `bin/fm-busy-lib.sh` gains the `FM_BUSY_APPROVAL_EVENT` constant and an `fm_busy_approval_wait` predicate that claims the gate only on a valid, gen-matching, harness-trusted busy record.
- `bin/fm-crew-state.sh` now reports a busy pane standing at that gate as `parked · source: pane` instead of `working`; the `window_is_busy` gates in `bin/fm-watch.sh` and `bin/fm-supervise-daemon.sh` stop counting such a pane as busy so it takes the stale path promptly instead of aging to the wedge threshold, and the watcher's inbox steer check holds doorbells while the worker is parked so no keystroke lands in the dialog.
- Documented the approval gate and its known subagent/parallel-tool limitation in `docs/verification/supervision.md`, `docs/architecture.md`, `docs/scripts.md`, `AGENTS.md`, and the `harness-adapters` and `stuck-crewmate-recovery` skills; extended the busy-state, adapter-wiring, crew-state, watch-triage, daemon, and task-inbox test suites, and added the opt-in `tests/fm-claude-approval-notify-live-e2e.test.sh` live guard wired into `bin/fm-test-run.sh`.

## Risk Assessment

✅ Low: The approval gate is a single event token on the existing busy record with one predicate consumed by four readers, every branch of the adapter and the spawn wiring is exercised by behavioral tests fed with the real hook commands and payloads, and the one residual limitation (parallel or subagent tools closing the gate early) was explicitly accepted and documented by the user as a follow-up.

## Testing

Completed 1 recorded test check.

- Outcome: ⚠️ 1 error across 2 runs (1h36m0s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"980edec1b1c2f8f2d3cc6e323418226b7401a6e8","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>🔧 **Review** - 2 issues found → auto-fixed (2) ✅</summary>

- ⚠️ `bin/fm-claude-approval-hook.sh:94` - The resume half closes the approval gate on ANY PostToolUse payload. Concrete path: the main thread launches a background Agent (or a parallel batch such as Read plus WebFetch), then hits a permission-gated Bash call; Notification opens the gate (event=permission-prompt); a Read inside the subagent or the sibling concurrency-safe tool finishes and fires PostToolUse; the hook sees the gate open and writes approval-answered while the dialog is still on screen. fm-crew-state then reports working, window_is_busy/stale_window_is_busy return busy, and the pane is absorbed until the wedge threshold, which is the original defect the intent targets. This is plausible from Claude Code&#39;s documented hook behaviour (hooks fire for subagent tool calls; concurrency-safe tools run in parallel) but was not confirmed live. The smallest honest remedy extends the adapter (for example ignore PostToolUse payloads that carry a subagent identity, or tie the close to the gated tool_use_id) and needs a live check, so it is ask-user rather than auto-fix. Alternatively document it as a known limitation in docs/verification/supervision.md next to the existing over-report note.
- ℹ️ `docs/verification/supervision.md:225` - The intent requires reproducing whether a worker at a workspace-trust OR permission prompt is still reported as working after the update. The new verification section records only the permission dialog reproduction on Claude Code 2.1.261 and says nothing about the trust dialog, which #3663 is assumed to cover. No source omission is proven, but the acceptance record for the trust half is absent; the author should either add the observed post-update trust-dialog reading to the same section or state that it was not reproduced.

🔧 Fix: document approval-gate limitation and trust-dialog reading
1 warning still open:

- ⚠️ `bin/fm-spawn.sh:2989` - The resume half only closes the gate on a successful tool: the adapter is registered for PostToolUse alone, and bin/fm-claude-approval-hook.sh:89 matches hook_event_name &#34;PostToolUse&#34; exactly. Claude Code fires PostToolUse only when a tool completes successfully and a separate PostToolUseFailure event when it errors; the installed 2.1.261 binary carries a PostToolUseFailure hook schema (tool_name, tool_use_id, error, is_interrupt). Concrete path: the worker asks to run `git switch feat`, the operator approves, the branch does not exist so Bash errors (non-zero exit is a tool error), PostToolUseFailure fires, PostToolUse does not, the record keeps event=permission-prompt, Claude reads the error and continues working. Until its next successful tool call or Stop, fm-crew-state reports parked, window_is_busy and stale_window_is_busy return 1, so the watcher surfaces a false &#34;waiting on approval&#34; stale wake and the daemon escalates a stale marker, and inbox_steer_check withholds a doorbell from a worker that is actually at a turn boundary if the turn ended between. It is the inverse of the original defect and bounded, but the doc claim at docs/verification/supervision.md:243 that the window &#34;always closes, on PostToolUse or on the turn&#39;s own Stop&#34; is not true for a failed approved tool. Smallest remedy: register the same adapter command for PostToolUseFailure in the settings hook JSON and accept that hook_event_name in the adapter&#39;s resume branch (a tool that failed still proves the dialog was answered), then amend the doc sentence. The remedy touches bin/fm-claude-approval-hook.sh, which the round-1 instruction said not to change, so it needs authorization rather than an automatic fix; documenting it as a second known limitation is the alternative.

🔧 Fix: close approval gate on PostToolUseFailure too
✅ Re-checked - no issues remain.
</details>

<details>
<summary>⚠️ **Test** - 1 error</summary>

- 🚨 tests failed with exit code 1
- `bin/fm-test-run.sh --changed --exclude-family real-herdr-gated`

🔧 Fix: no branch-caused failures found; four base reruns pending
1 error still open:

- 🚨 tests failed with exit code 1
- `bin/fm-test-run.sh --changed --exclude-family real-herdr-gated`
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>⚠️ **Lint** - 1 warning</summary>

- ⚠️ linter found issues (exit code 1)
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
