### PR TITLE
Fix two steer-delivery defects in firstmate's own tooling, plus the test isolation hole that surfaced them

### DIFF
--- a/bin/fm-composer-lib.sh
+++ b/bin/fm-composer-lib.sh
@@ -530,6 +530,17 @@ fm_composer_classify_content() {  # <bordered> <content> [idle_re] [idle_case] [
       plain_body=${plain_body#*"$plain_glyph"}
     fi
     fm_composer_normalize_trim_var plain_body
+    # A harness may right-align a status hint on the composer row itself,
+    # separated from the input by a run of spaces: cursor-agent draws
+    # `ctrl+c to stop` there for as long as it is working. That furniture is not
+    # input, and leaving it on the row defeats the anchored placeholder match
+    # below, so a busy cursor pane's idle composer read `pending` and every
+    # steer sent while it worked skipped its doorbell. Keep the row's FIRST
+    # column only: with no gap this is the whole row, so every gapless verdict
+    # is unchanged, and the length guard still compares against that column, so
+    # text typed to exactly match the placeholder stays `pending`.
+    plain_body=${plain_body%%"  "*}
+    fm_composer_normalize_trim_var plain_body
     if [ "${#content}" -lt "${#plain_body}" ] \
        && fm_composer_idle_matches "$plain_body" "$idle_re" "$idle_case"; then
       case "$plain_body" in

--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -123,6 +123,15 @@ RUN_STARTED_MS=$(now_ms)
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT" || exit 1
 
+# Scrub the home-selecting overrides out of every test's environment. Each test
+# isolates itself by inventing these, so an inherited value silently wins and
+# aims the suite at a real firstmate home. tests/lib.sh refuses outright when it
+# sees one, but the smoke and e2e scripts here do not source it, so the runner
+# clears them for every script it launches instead. Nothing downstream sets
+# them, so there is nothing legitimate to preserve.
+unset FM_HOME FM_ROOT_OVERRIDE FM_STATE_OVERRIDE FM_DATA_OVERRIDE \
+  FM_PROJECTS_OVERRIDE FM_CONFIG_OVERRIDE
+
 MODE=
 LIST_ONLY=0
 LIST_SCHEDULED=0

--- a/bin/fm-watch.sh
+++ b/bin/fm-watch.sh
@@ -1406,9 +1406,20 @@ elif [ -n "${FM_LOCK_HELD_PID:-}" ] && [ -s "$WATCH_LOCK/pid-identity" ] \
   # not matching is positive proof the holder is gone, so clear the stale lock
   # through the recovery transition (the downtime it records is real) and take
   # it; an absent identity proves nothing and still defers below.
-  if fm_recovery_transition "$STATE/.watcher-down" clear-stale-lock "$WATCH_LOCK" downtime; then
-    fm_lock_try_acquire "$WATCH_LOCK" && watch_lock_held=0
+  stale_watch_pid=$FM_LOCK_HELD_PID
+  stale_watch_home=$(cat "$WATCH_LOCK/fm-home" 2>/dev/null || true)
+  if fm_lock_try_acquire "$WATCH_LOCK.steal"; then
+    watch_steal_owner=${FM_LOCK_OWNER_DIR:-}
+    if [ "$(cat "$WATCH_LOCK/pid" 2>/dev/null || true)" = "$stale_watch_pid" ] \
+      && [ "$(cat "$WATCH_LOCK/fm-home" 2>/dev/null || true)" = "$stale_watch_home" ] \
+      && ! fm_watcher_lock_matches_pid "$STATE" "$WATCH_PATH" "$stale_watch_pid" \
+      && fm_recovery_transition "$STATE/.watcher-down" clear-stale-lock "$WATCH_LOCK" downtime \
+      && fm_lock_try_create "$WATCH_LOCK" "$watch_steal_owner"; then
+      watch_lock_held=0
+    fi
+    fm_lock_release "$WATCH_LOCK.steal"
   fi
+  FM_LOCK_HELD_PID=$(cat "$WATCH_LOCK/pid" 2>/dev/null || true)
 fi
 if [ "$watch_lock_held" -eq 1 ]; then
   BEAT="$STATE/.last-watcher-beat"

--- a/bin/fm-watch.sh
+++ b/bin/fm-watch.sh
@@ -1391,7 +1391,26 @@ if [ "${BASH_SOURCE[0]}" != "$0" ]; then
   return 0
 fi
 
-if ! fm_lock_try_acquire "$WATCH_LOCK"; then
+watch_lock_held=1
+if fm_lock_try_acquire "$WATCH_LOCK"; then
+  watch_lock_held=0
+elif [ -n "${FM_LOCK_HELD_PID:-}" ] && [ -s "$WATCH_LOCK/pid-identity" ] \
+     && ! fm_watcher_lock_matches_pid "$STATE" "$WATCH_PATH" "$FM_LOCK_HELD_PID"; then
+  # A live recorded pid is a peer only while it is still the process this home
+  # recorded. On a machine running several firstmate homes the OS readily
+  # recycles a dead watcher's pid onto a SIBLING home's fm-watch.sh, and
+  # liveness alone then reports that stranger as our peer - while the arm layer
+  # applies this same identity rule (fm_watcher_healthy), sees no watcher, and
+  # starts a child that immediately declines, ending the cycle with no
+  # actionable reason and leaving the home unsupervised. The recorded identity
+  # not matching is positive proof the holder is gone, so clear the stale lock
+  # through the recovery transition (the downtime it records is real) and take
+  # it; an absent identity proves nothing and still defers below.
+  if fm_recovery_transition "$STATE/.watcher-down" clear-stale-lock "$WATCH_LOCK" downtime; then
+    fm_lock_try_acquire "$WATCH_LOCK" && watch_lock_held=0
+  fi
+fi
+if [ "$watch_lock_held" -eq 1 ]; then
   BEAT="$STATE/.last-watcher-beat"
   if [ -n "${FM_LOCK_HELD_PID:-}" ]; then
     if [ -e "$BEAT" ]; then

--- a/docs/verification/runtime-backends.md
+++ b/docs/verification/runtime-backends.md
@@ -1154,6 +1154,15 @@ Reverse video is neither dim nor a dark foreground, so ghost stripping leaves a 
 After teaching the shared classifier the glyph, both placeholders, and the plain-row remnant rule, the same captures read `empty` on the styled cursorless backends, while real typed text - including text typed to exactly match the placeholder - still read `pending`.
 An unstyled capture has no ghost-strip proof and correctly stays `unknown`.
 
+While cursor-agent is WORKING it also right-aligns a dim `ctrl+c to stop` on that same composer row (Composer 2.5, captured live under tmux 2026-09-05):
+
+```
+ESC[48;2;33;36;40m ESC[2m→ ESC[0;7mESC[48;2;33;36;40mAESC[0;2mESC[48;2;33;36;40mdd a follow-upESC[0mESC[48;2;33;36;40m<spaces>ESC[2mctrl+c to stopESC[0m
+```
+
+Ghost stripping removes the hint with the placeholder, but the plain row the remnant is proven against then ends in it and no longer matches the anchored placeholder, so a busy pane's empty composer read `pending`.
+The remnant is now proven against the plain row's first column only, and the same live panes read `empty` while a pane genuinely holding an unsent line still read `pending`.
+
 #### tmux composer verdict, corrected 2026-08-13
 
 The 2026-08-11 record that a Cursor pane's tmux composer verdict is `unknown` in every state described the cursor-ANCHORED read, which remains true: `#{cursor_y}` was 25 with `#{cursor_flag}` 0 on an idle pane, pointing below the footer, so tmux's cursor row is not a composer locator for Cursor.

--- a/tests/fm-backend-herdr.test.sh
+++ b/tests/fm-backend-herdr.test.sh
@@ -3669,10 +3669,13 @@ test_send_text_submit_idle_native_pending_plus_rendered_busy_is_queued() {
 # reports a cursor pane `blocked` in EVERY state - idle, mid-turn, and after -
 # so the idle-baseline native path is structurally unreachable and every typed
 # send lands in the composer branch. Cursor's mid-turn composer row renders its own
-# `Add a follow-up` placeholder beside a right-aligned `ctrl+c to stop`, so the
-# content verdict is `pending` on a composer holding no user text, and every
-# typed steer reported delivery unconfirmed on a message that had actually landed.
-# The bytes below are the real captures from that pane.
+# `Add a follow-up` placeholder beside a right-aligned `ctrl+c to stop`, and that
+# hint used to make the row read `pending` on a composer holding no user text, so
+# every typed steer reported delivery unconfirmed on a message that had actually
+# landed. The classifier now reads the row's input column, so the same capture
+# reads `empty`; the typed capture below is the composer state that genuinely
+# holds a message, and it is what these submit cases exercise the rendered-footer
+# transition with. The bytes below are the real captures from that pane.
 
 # The idle capture: no busy token anywhere, which is the pre-Enter baseline.
 herdr_cursor_idle_plain() {
@@ -3692,21 +3695,34 @@ herdr_cursor_midturn_ansi() {
   printf '%b' ' \033[0m\033[38;2;21;21;21m▄▄▄▄▄▄▄▄▄▄\033[0m\r\n \033[0m\033[48;2;21;21;21m \033[0m\033[2m\033[48;2;21;21;21m→ \033[0m\033[7m\033[48;2;21;21;21mA\033[0m\033[2m\033[48;2;21;21;21mdd a follow-up\033[0m\033[48;2;21;21;21m                   \033[0m\033[2m\033[48;2;21;21;21mctrl+c to stop\033[0m\033[48;2;21;21;21m \033[0m\r\n \033[0m\033[38;2;21;21;21m▀▀▀▀▀▀▀▀▀▀\033[0m\r\n  \033[0m\033[38;5;4m1 task\033[0m\r\n  \033[0m\033[2mCursor Grok 4.5 High\033[0m \033[0m\033[2m·\033[0m \033[0m\033[2m7%%\033[0m           \033[0m\033[38;5;5mRun Everything\033[0m\r\n  \033[0m\033[2m~/.treehouse/curhd-ae68cd/1/curhd · 39418af\033[0m\r\n'
 }
 
-# Non-vacuity anchor for the two submit tests below: the real mid-turn capture
-# genuinely reads `pending`, so the confirmation those tests assert can only be
-# coming from the rendered-footer transition and never from a softened composer
-# verdict. The composer verdict is deliberately NOT relaxed - a right-aligned
-# status token on the composer row is content the shared classifier must keep
-# treating as content for every other caller.
-test_composer_state_cursor_midturn_row_reads_pending() {
+# The same mid-turn row holding text we actually typed: uniformly bright, so it
+# survives ghost stripping at the full width of the input column and is the one
+# state where the composer really does still hold an unsent message.
+herdr_cursor_midturn_typed_ansi() {
+  printf '%b' ' \033[0m\033[38;2;21;21;21m▄▄▄▄▄▄▄▄▄▄\033[0m\r\n \033[0m\033[48;2;21;21;21m \033[0m\033[2m\033[48;2;21;21;21m→ \033[0m\033[38;2;224;222;244mhello captain\033[0m\033[48;2;21;21;21m                   \033[0m\033[2m\033[48;2;21;21;21mctrl+c to stop\033[0m\033[48;2;21;21;21m \033[0m\r\n \033[0m\033[38;2;21;21;21m▀▀▀▀▀▀▀▀▀▀\033[0m\r\n  \033[0m\033[38;5;4m1 task\033[0m\r\n  \033[0m\033[2mCursor Grok 4.5 High\033[0m \033[0m\033[2m·\033[0m \033[0m\033[2m7%%\033[0m           \033[0m\033[38;5;5mRun Everything\033[0m\r\n  \033[0m\033[2m~/.treehouse/curhd-ae68cd/1/curhd · 39418af\033[0m\r\n'
+}
+
+# The two real mid-turn captures, told apart. The placeholder row holds no user
+# text and must read `empty`: the right-aligned `ctrl+c to stop` is furniture
+# cursor-agent draws while it works, and counting it as content made every
+# caller of this verdict wrong at once - fm-send skipped its doorbell for as
+# long as a worker stayed busy, and the away-mode injector deferred with it.
+# The typed row is the same shape genuinely holding a message and still reads
+# `pending`, which is the state the submit cases below drive the rendered-footer
+# transition with.
+test_composer_state_cursor_midturn_rows_are_told_apart() {
   local dir log resp fb out
   dir="$TMP_ROOT/composer-cursor-midturn"; mkdir -p "$dir/responses"; log="$dir/log"; resp="$dir/responses"; : > "$log"
   herdr_cursor_midturn_ansi > "$resp/1.out"
+  herdr_cursor_midturn_typed_ansi > "$resp/2.out"
   fb=$(make_herdr_fakebin "$dir")
   out=$( PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
     bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_composer_state default:w1:p2' "$ROOT" )
-  [ "$out" = pending ] || fail "cursor's mid-turn composer row carries a busy token and must stay 'pending' as composer CONTENT, got '$out'"
-  pass "fm_backend_herdr_composer_state: cursor's mid-turn placeholder-plus-busy-token row reads pending (why delivery needs a separate signal)"
+  [ "$out" = empty ] || fail "cursor's mid-turn placeholder row holds no user text and must read empty, got '$out'"
+  out=$( PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
+    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_composer_state default:w1:p2' "$ROOT" )
+  [ "$out" = pending ] || fail "cursor's mid-turn row holding typed text must stay pending beside the same busy token, got '$out'"
+  pass "fm_backend_herdr_composer_state: cursor's mid-turn busy token is furniture (empty), while typed text beside it stays pending"
 }
 
 test_rendered_busy_state_reads_the_cursor_busy_token() {
@@ -3737,12 +3753,13 @@ test_send_text_submit_confirms_never_idle_native_state_via_footer_transition() {
   # 3: pane read - rendered footer baseline: no busy token, so the pane was NOT
   #    mid-turn before our Enter
   # 4: send-keys enter
-  # 5: pane read - composer content mid-turn: placeholder plus busy token
+  # 5: pane read - composer content mid-turn: our typed message is STILL there,
+  #    so the composer cannot confirm and the footer must
   # 6: pane read - rendered footer now busy: an idle-to-busy transition ACROSS
   #    our Enter, which is the submission proof
   printf '{"result":{"agent":{"agent_status":"blocked"}}}\n' > "$resp/2.out"
   herdr_cursor_idle_plain > "$resp/3.out"
-  herdr_cursor_midturn_ansi > "$resp/5.out"
+  herdr_cursor_midturn_typed_ansi > "$resp/5.out"
   herdr_cursor_midturn_plain > "$resp/6.out"
   fb=$(make_herdr_fakebin "$dir")
   out=$( PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
@@ -3761,8 +3778,8 @@ test_send_text_submit_never_idle_native_state_keeps_pending_without_a_transition
   # borrowing someone else's turn as proof of our delivery.
   printf '{"result":{"agent":{"agent_status":"blocked"}}}\n' > "$resp/2.out"
   herdr_cursor_midturn_plain > "$resp/3.out"
-  herdr_cursor_midturn_ansi > "$resp/5.out"
-  herdr_cursor_midturn_ansi > "$resp/7.out"
+  herdr_cursor_midturn_typed_ansi > "$resp/5.out"
+  herdr_cursor_midturn_typed_ansi > "$resp/7.out"
   fb=$(make_herdr_fakebin "$dir")
   out=$( PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
     bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_send_text_submit default:w1:p2 "hello captain" 2 0.01 0.01' "$ROOT" )
@@ -4635,7 +4652,7 @@ test_send_text_submit_preexisting_working_does_not_confirm_failed_enter
 test_send_text_submit_idle_baseline_does_not_confirm_failed_enter
 test_send_text_submit_idle_native_empty_composer_confirms_delivery
 test_send_text_submit_idle_native_pending_plus_rendered_busy_is_queued
-test_composer_state_cursor_midturn_row_reads_pending
+test_composer_state_cursor_midturn_rows_are_told_apart
 test_rendered_busy_state_reads_the_cursor_busy_token
 test_send_text_submit_confirms_never_idle_native_state_via_footer_transition
 test_send_text_submit_never_idle_native_state_keeps_pending_without_a_transition

--- a/tests/fm-composer-lib.test.sh
+++ b/tests/fm-composer-lib.test.sh
@@ -264,6 +264,50 @@ test_matrix_cursor_reverse_video_placeholder_remnant() {
   pass "matrix: cursor's reverse-video placeholder remnant reads empty; real typed text stays pending"
 }
 
+test_matrix_cursor_busy_hint_beside_placeholder() {
+  # Real BUSY cursor-agent (Composer 2.5) captured byte-for-byte from a live
+  # tmux pane: while it works it right-aligns `ctrl+c to stop` on the composer
+  # row itself, dim (SGR 2), far to the right of the dim `Add a follow-up`
+  # placeholder. Ghost stripping removes both and leaves only the reverse-video
+  # remnant, but the UNSTRIPPED plain row the remnant is proven against then
+  # ends in the hint, so the anchored placeholder no longer matched and an
+  # empty composer read `pending`. fm-send skipped its doorbell for exactly as
+  # long as the worker stayed busy, and five steers in a row arrived only on
+  # the watcher re-ring.
+  local gap row screen plain stripped out
+  gap='                                                  '
+  row="${ESC}[48;2;33;36;40m ${ESC}[2m→ ${ESC}[0;7m${ESC}[48;2;33;36;40mA"
+  row="${row}${ESC}[0;2m${ESC}[48;2;33;36;40mdd a follow-up${ESC}[0m"
+  row="${row}${ESC}[48;2;33;36;40m${gap}${ESC}[2mctrl+c to stop${ESC}[0m"
+  # The doorbell line from earlier deliveries sits in the transcript above the
+  # composer, where it must never reach the verdict.
+  screen=$'  → Firstmate instruction waiting: list /x/y/t.inbox/*.msg and, in numeric order, read and act on each.\n\n'"$row"
+
+  # NON-VACUOUSNESS: the hint really is ghost text that leaves the row, and the
+  # reverse-video remnant really does survive - so this case cannot go quiet if
+  # either signal changes.
+  stripped=$(printf '%s' "$row" | fm_composer_strip_ghost)
+  fm_composer_normalize_trim_var stripped
+  [ "$stripped" = A ] \
+    || fail "the busy composer row must strip to the reverse-video remnant 'A', got '$stripped'"
+  plain=$(printf '%s\n' "$row" | fm_composer_strip_ansi)
+  case "$plain" in *'ctrl+c to stop') : ;; *) fail "fixture lost its right-aligned busy hint" ;; esac
+
+  assert_screen "cursor busy idle composer on tmux" empty "$CAPS_TMUX" "$screen" ''''''
+  assert_screen "cursor busy idle composer on herdr" empty "$CAPS_STYLED" "$screen"
+
+  # The dangerous direction stays closed: text typed to exactly match the
+  # placeholder is uniformly bright, so it survives stripping at the full width
+  # of the input column and must still read pending beside the same hint.
+  local typed
+  typed="${ESC}[48;2;33;36;40m ${ESC}[2m→ ${ESC}[0m${ESC}[38;2;224;222;244mAdd a follow-up${ESC}[0m"
+  typed="${typed}${ESC}[48;2;33;36;40m${gap}${ESC}[2mctrl+c to stop${ESC}[0m"
+  out=$(fm_composer_classify_screen "$CAPS_STYLED" $'transcript\n\n'"$typed")
+  [ "$out" = pending ] \
+    || fail "typed placeholder text beside the busy hint must stay pending, got '$out'"
+  pass "matrix: cursor's right-aligned busy hint no longer makes an idle composer read pending"
+}
+
 test_matrix_herdr_halfblock_rule_bounds_bare_wrap() {
   # Herdr draws a composer's rules with half-block glyphs (▄ above, ▀ below)
   # rather than the box-drawing family. Without treating those as edges, a bare
@@ -616,6 +660,7 @@ test_matrix_claude_bare_nbsp_row
 test_matrix_codex_dim_hint_row
 test_matrix_muse_truecolor_glyph_survives_signal_loss
 test_matrix_cursor_reverse_video_placeholder_remnant
+test_matrix_cursor_busy_hint_beside_placeholder
 test_matrix_herdr_halfblock_rule_bounds_bare_wrap
 test_matrix_pi_separated_needs_identity
 test_matrix_opencode_leftbar_signals

--- a/tests/fm-test-run.test.sh
+++ b/tests/fm-test-run.test.sh
@@ -58,6 +58,50 @@ test_family_selection() {
   pass "family selection returns a proper subset of the suite"
 }
 
+test_inherited_live_home_never_reaches_a_test() {
+  # A shell that exported FM_HOME (a crewmate worktree, an operator terminal)
+  # used to aim the whole suite at that real firstmate home, because every
+  # isolation helper works by INVENTING an override an inherited value wins
+  # against. Both halves of the guard are proven here: the runner scrubs the
+  # overrides for every script it launches, including the smoke and e2e scripts
+  # that never source tests/lib.sh, and tests/lib.sh refuses outright so a
+  # direct `bash tests/<x>.test.sh` cannot slip past either.
+  local probe out status
+  probe=$(fm_test_tmproot fm-test-run-inherited-home) || fail "could not create a fixture root"
+  cat > "$probe/leak.test.sh" <<'SH'
+#!/usr/bin/env bash
+set -u
+printf 'SEEN FM_HOME=[%s] FM_ROOT_OVERRIDE=[%s] FM_STATE_OVERRIDE=[%s]\n' \
+  "${FM_HOME:-}" "${FM_ROOT_OVERRIDE:-}" "${FM_STATE_OVERRIDE:-}"
+printf 'ok - leak probe\n'
+SH
+  chmod +x "$probe/leak.test.sh"
+
+  # NON-VACUOUSNESS: the probe really does report what it inherits, so an empty
+  # reading below is the scrub working and not a silent fixture.
+  out=$(FM_HOME=/live/home bash "$probe/leak.test.sh")
+  case "$out" in
+    *'SEEN FM_HOME=[/live/home]'*) : ;;
+    *) fail "probe cannot observe an inherited FM_HOME, fixture is vacuous: $out" ;;
+  esac
+
+  out=$(FM_HOME=/live/home FM_ROOT_OVERRIDE=/live/root FM_STATE_OVERRIDE=/live/state \
+    "$RUNNER" "$probe/leak.test.sh" 2>&1) || true
+  case "$out" in
+    *'SEEN FM_HOME=[] FM_ROOT_OVERRIDE=[] FM_STATE_OVERRIDE=[]'*) : ;;
+    *) fail "the runner leaked an inherited live home into a test: $out" ;;
+  esac
+
+  status=0
+  out=$(FM_HOME=/live/home bash "$ROOT/tests/fm-lint.test.sh" 2>&1) || status=$?
+  [ "$status" -ne 0 ] || fail "a direct test run inherited a live FM_HOME instead of refusing"
+  case "$out" in
+    *'FM_HOME is set'*) : ;;
+    *) fail "the refusal must name the offending variable, got: $out" ;;
+  esac
+  pass "an inherited live home is scrubbed by the runner and refused on a direct run"
+}
+
 test_single_script_selection() {
   local listed
   listed=$("$RUNNER" --list tests/fm-lint.test.sh)
@@ -1373,6 +1417,7 @@ assert len(doc["scripts"])==3
 test_list_all_exact_suite_coverage
 test_family_selection
 test_single_script_selection
+test_inherited_live_home_never_reaches_a_test
 test_changed_file_selection_is_conservative
 test_changed_runner_surfaces_select_their_family
 test_changed_dependency_selection_and_unmapped_failure

--- a/tests/fm-watcher-lock.test.sh
+++ b/tests/fm-watcher-lock.test.sh
@@ -211,7 +211,7 @@ test_foreign_home_watcher_pid_is_not_a_peer() {
   foreign_pid=$!
   mkdir "$state/.watch.lock"
   printf '%s\n' "$foreign_pid" > "$state/.watch.lock/pid"
-  printf '%s\n' "$dir/other-home" > "$state/.watch.lock/fm-home"
+  printf '%s\n' "$dir" > "$state/.watch.lock/fm-home"
   printf '%s\n' "$WATCH" > "$state/.watch.lock/watcher-path"
   printf '%s\n' "watcher-that-is-gone" > "$state/.watch.lock/pid-identity"
   # A FRESH beacon, so the existing stale-heartbeat branch cannot be what lets
@@ -225,7 +225,7 @@ test_foreign_home_watcher_pid_is_not_a_peer() {
   [ "$(FM_PID_IDENTITY_PID=x bash -c '. "$1"; fm_pid_identity "$2"' _ "$LIB" "$foreign_pid")" != "watcher-that-is-gone" ] \
     || fail "fixture's foreign pid must not carry the recorded identity"
 
-  PATH="$fakebin:$PATH" FM_STATE_OVERRIDE="$state" FM_POLL=5 FM_SIGNAL_GRACE=1 FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 "$WATCH" > "$out" &
+  PATH="$fakebin:$PATH" FM_HOME="$dir" FM_STATE_OVERRIDE="$state" FM_POLL=5 FM_SIGNAL_GRACE=1 FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 "$WATCH" > "$out" &
   pid=$!
   i=0
   live=0

--- a/tests/fm-watcher-lock.test.sh
+++ b/tests/fm-watcher-lock.test.sh
@@ -99,6 +99,99 @@ test_stale_watch_lock_reclaimed() {
   pass "killed watcher stale lock is reclaimed"
 }
 
+test_concurrent_identity_reclaim_keeps_one_watcher() {
+  local dir state fakebin lockdir ready release barrier foreign_pid
+  local out1 out2 pid1 pid2 i live lock_pid lock_present owners survivor
+  dir=$(make_case identity-reclaim-race)
+  state="$dir/state"
+  fakebin="$dir/fakebin"
+  lockdir="$state/.watch.lock"
+  ready="$dir/barrier-ready"
+  release="$dir/barrier-release"
+  out1="$dir/watch-one.out"
+  out2="$dir/watch-two.out"
+
+  sleep 30 &
+  foreign_pid=$!
+  mkdir "$lockdir"
+  printf '%s\n' "$foreign_pid" > "$lockdir/pid"
+  printf '%s\n' "$dir" > "$lockdir/fm-home"
+  printf '%s\n' "$WATCH" > "$lockdir/watcher-path"
+  printf '%s\n' "watcher-that-is-gone" > "$lockdir/pid-identity"
+  touch "$state/.last-watcher-beat"
+
+  FM_STATE_OVERRIDE="$state" bash -c '
+    . "$1"
+    fm_lock_try_acquire "$2" || exit 7
+    : > "$3"
+    while [ ! -e "$4" ]; do sleep 0.05; done
+    fm_lock_release "$2"
+  ' _ "$LIB" "$state/.watcher-down.lock" "$ready" "$release" &
+  barrier=$!
+  i=0
+  while [ "$i" -lt 50 ] && [ ! -e "$ready" ]; do
+    sleep 0.1
+    i=$((i + 1))
+  done
+  [ -e "$ready" ] || fail "reclaim race barrier did not acquire the recovery lock"
+
+  PATH="$fakebin:$PATH" FM_HOME="$dir" FM_STATE_OVERRIDE="$state" FM_POLL=30 FM_SIGNAL_GRACE=1 FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 "$WATCH" > "$out1" &
+  pid1=$!
+  PATH="$fakebin:$PATH" FM_HOME="$dir" FM_STATE_OVERRIDE="$state" FM_POLL=30 FM_SIGNAL_GRACE=1 FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 "$WATCH" > "$out2" &
+  pid2=$!
+  i=0
+  live=2
+  while [ "$i" -lt 50 ]; do
+    live=0
+    is_live_non_zombie "$pid1" && live=$((live + 1))
+    is_live_non_zombie "$pid2" && live=$((live + 1))
+    [ "$live" -eq 1 ] && break
+    sleep 0.1
+    i=$((i + 1))
+  done
+  if [ "$live" -ne 1 ]; then
+    touch "$release"
+    kill "$pid1" "$pid2" "$foreign_pid" 2>/dev/null || true
+    wait "$pid1" "$pid2" "$foreign_pid" 2>/dev/null || true
+    wait "$barrier" 2>/dev/null || true
+    fail "overlapping identity reclaimers both stayed live"
+  fi
+
+  touch "$release"
+  wait "$barrier" || fail "reclaim race barrier failed"
+  i=0
+  lock_pid=
+  while [ "$i" -lt 50 ]; do
+    lock_pid=$(cat "$lockdir/pid" 2>/dev/null || true)
+    case "$lock_pid" in
+      "$pid1"|"$pid2") [ -s "$lockdir/pid-identity" ] && break ;;
+    esac
+    sleep 0.1
+    i=$((i + 1))
+  done
+  live=0
+  survivor=
+  if is_live_non_zombie "$pid1"; then
+    live=$((live + 1))
+    survivor=$pid1
+  fi
+  if is_live_non_zombie "$pid2"; then
+    live=$((live + 1))
+    survivor=$pid2
+  fi
+  lock_present=0
+  [ ! -L "$lockdir" ] || lock_present=1
+  owners=$(find "$state" -maxdepth 1 -type d -name '.watch.lock.owner.*' | wc -l | tr -d '[:space:]')
+  kill "$pid1" "$pid2" "$foreign_pid" 2>/dev/null || true
+  wait "$pid1" "$pid2" "$foreign_pid" 2>/dev/null || true
+  [ "$live" -eq 1 ] || fail "expected exactly one live watcher after concurrent reclaim, got $live"
+  [ "$lock_pid" = "$survivor" ] \
+    || fail "reclaimed lock does not name the surviving watcher (got '$lock_pid')"
+  [ "$lock_present" -eq 1 ] || fail "concurrent reclaim left no watcher lock"
+  [ "$owners" -eq 1 ] || fail "concurrent reclaim left $owners watcher lock owners"
+  pass "concurrent identity reclaim leaves one live watcher and one lock"
+}
+
 test_foreign_home_watcher_pid_is_not_a_peer() {
   # Pid reuse across sibling firstmate homes. A watcher dies, the OS recycles
   # its pid onto another home's fm-watch.sh, and the dead watcher's lock is
@@ -1164,6 +1257,7 @@ test_pid_identity_is_locale_invariant
 test_proc_pid_identity_ignores_wall_clock_and_detects_pid_reuse
 test_msys_pid_identity_uses_proc
 test_stale_watch_lock_reclaimed
+test_concurrent_identity_reclaim_keeps_one_watcher
 test_foreign_home_watcher_pid_is_not_a_peer
 test_stale_watch_reclaim_publishes_before_clear
 test_live_stale_watch_lock_is_actionable

--- a/tests/fm-watcher-lock.test.sh
+++ b/tests/fm-watcher-lock.test.sh
@@ -99,6 +99,63 @@ test_stale_watch_lock_reclaimed() {
   pass "killed watcher stale lock is reclaimed"
 }
 
+test_foreign_home_watcher_pid_is_not_a_peer() {
+  # Pid reuse across sibling firstmate homes. A watcher dies, the OS recycles
+  # its pid onto another home's fm-watch.sh, and the dead watcher's lock is
+  # still here naming that number. Liveness alone reports the stranger as our
+  # peer, so the watcher declines and the arm layer - which applies the identity
+  # rule and correctly sees no watcher - reports a cycle that ended with no
+  # actionable reason, leaving the home unsupervised. The recorded identity is
+  # the proof: it belongs to the process we started, never to whatever now
+  # holds that number.
+  local dir state fakebin out foreign_pid pid live lock_pid i
+  dir=$(make_case foreign-home-pid)
+  state="$dir/state"
+  fakebin="$dir/fakebin"
+  out="$dir/watch.out"
+
+  sleep 30 &
+  foreign_pid=$!
+  mkdir "$state/.watch.lock"
+  printf '%s\n' "$foreign_pid" > "$state/.watch.lock/pid"
+  printf '%s\n' "$dir/other-home" > "$state/.watch.lock/fm-home"
+  printf '%s\n' "$WATCH" > "$state/.watch.lock/watcher-path"
+  printf '%s\n' "watcher-that-is-gone" > "$state/.watch.lock/pid-identity"
+  # A FRESH beacon, so the existing stale-heartbeat branch cannot be what lets
+  # this through - only the identity rule can.
+  touch "$state/.last-watcher-beat"
+
+  # NON-VACUOUSNESS: the recorded pid really is alive, so liveness alone would
+  # report it as a peer, and its real identity really does differ from the one
+  # the lock records.
+  kill -0 "$foreign_pid" 2>/dev/null || fail "fixture's foreign watcher pid is not alive"
+  [ "$(FM_PID_IDENTITY_PID=x bash -c '. "$1"; fm_pid_identity "$2"' _ "$LIB" "$foreign_pid")" != "watcher-that-is-gone" ] \
+    || fail "fixture's foreign pid must not carry the recorded identity"
+
+  PATH="$fakebin:$PATH" FM_STATE_OVERRIDE="$state" FM_POLL=5 FM_SIGNAL_GRACE=1 FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 "$WATCH" > "$out" &
+  pid=$!
+  i=0
+  live=0
+  lock_pid=
+  while [ "$i" -lt 50 ]; do
+    live=0
+    is_live_non_zombie "$pid" && live=1
+    lock_pid=$(cat "$state/.watch.lock/pid" 2>/dev/null || true)
+    [ "$live" -eq 1 ] && [ "$lock_pid" != "$foreign_pid" ] && break
+    sleep 0.1
+    i=$((i + 1))
+  done
+  kill "$pid" 2>/dev/null || true
+  wait "$pid" 2>/dev/null || true
+  kill "$foreign_pid" 2>/dev/null || true
+  wait "$foreign_pid" 2>/dev/null || true
+  grep -F 'already running' "$out" >/dev/null 2>&1 \
+    && fail "a sibling home's watcher pid was reported as this home's peer"
+  [ "$live" -eq 1 ] || fail "watcher did not arm behind a recycled foreign pid"
+  [ "$lock_pid" != "$foreign_pid" ] || fail "stale watch lock pid was not replaced"
+  pass "a live pid that is not this home's recorded watcher is no peer"
+}
+
 test_live_stale_watch_lock_is_actionable() {
   local dir state fakebin out err status
   dir=$(make_case live-stale-lock)
@@ -1107,6 +1164,7 @@ test_pid_identity_is_locale_invariant
 test_proc_pid_identity_ignores_wall_clock_and_detects_pid_reuse
 test_msys_pid_identity_uses_proc
 test_stale_watch_lock_reclaimed
+test_foreign_home_watcher_pid_is_not_a_peer
 test_stale_watch_reclaim_publishes_before_clear
 test_live_stale_watch_lock_is_actionable
 test_guard_warnings

--- a/tests/lib.sh
+++ b/tests/lib.sh
@@ -35,6 +35,26 @@ FM_TEST_LIB_SOURCED=1
 # strips this to verify real refusal.
 export FM_GATE_REFUSE_BYPASS=1
 
+# Refuse to run against a REAL firstmate home. Every isolation helper below
+# works by inventing an override, which an inherited value silently wins
+# against - wake-helpers.sh only invents FM_ROOT_OVERRIDE when none is set - so
+# a shell that exported these (a crewmate worktree, an operator terminal) aimed
+# the whole suite at that live home: real state files written, config deleted,
+# the running watcher's lock stolen. Nothing in the suite, CI, or
+# bin/fm-test-run.sh sets them for a test, so any value here is ambient and
+# unintended. Refuse loudly rather than isolate around it, because a suite that
+# quietly relocates a home the operator meant to use is its own surprise.
+for _fm_test_live_home_var in FM_HOME FM_ROOT_OVERRIDE FM_STATE_OVERRIDE \
+  FM_DATA_OVERRIDE FM_PROJECTS_OVERRIDE FM_CONFIG_OVERRIDE; do
+  if [ -n "${!_fm_test_live_home_var:-}" ]; then
+    printf 'not ok - %s is set (%s); the test suite must never run against a real firstmate home. Clear it and retry, e.g. env -u %s bash %s\n' \
+      "$_fm_test_live_home_var" "${!_fm_test_live_home_var}" \
+      "$_fm_test_live_home_var" "${BASH_SOURCE[1]:-$0}" >&2
+    exit 1
+  fi
+done
+unset _fm_test_live_home_var
+
 # Resolve the repo root from this library's own location. Consumed by sourcing
 # test files, not by this library, so it reads as "unused" here.
 # shellcheck disable=SC2034


### PR DESCRIPTION
## 1. A busy cursor pane's empty composer read `pending`, so steers lost their doorbell

While cursor-agent is working it right-aligns a dim `ctrl+c to stop` on the composer row itself, beside its dim `Add a follow-up` placeholder. Ghost stripping removes both and leaves only the reverse-video remnant, but that remnant is proven against the *unstripped* plain row, which then ends in the hint and no longer matches the anchored placeholder - so an empty composer classified `pending`. `fm_task_inbox_ring` skips the doorbell on exactly that verdict, so for as long as a worker stayed busy every steer went in durably and silently, and the watcher's re-ring skipped for the same reason; five records in a row on one task, one delivered about fifteen minutes late. The fix proves the remnant against the plain row's **first column** only. With no gap that is the whole row, so every existing verdict is unchanged, and the length guard still compares against that column, so text typed to exactly match the placeholder stays `pending`. Reproduced and verified against live tmux Cursor panes: the false ones now read `empty`, while a pane genuinely holding an unsent line still reads `pending`. Covered by a new case in `tests/fm-composer-lib.test.sh` built from the byte-exact live capture, with non-vacuity anchors on both the surviving remnant and the hint.

This corrects a prior expectation rather than only adding one. `tests/fm-backend-herdr.test.sh` pinned the same mid-turn row as `pending` and recorded that the shared verdict was "deliberately NOT relaxed - a right-aligned status token on the composer row is content". That token is furniture, never user input, so the expectation pinned this defect; it was scoped around at the time by adding herdr's rendered-footer signal instead. The third commit asserts the corrected verdict, tells the placeholder row and a typed row apart, and re-anchors both herdr submit cases on a typed capture so the rendered-footer transition they exercise is still reached through a genuinely pending composer rather than passing vacuously. Please sanity-check that call - it is the one judgement here that overturns a documented decision.

## 2. A recycled pid from a sibling home was reported as this home's watcher

The watcher's singleton check treated any live pid recorded in the lock as a running peer. When a watcher dies and the OS recycles its pid onto a sibling firstmate home's `fm-watch.sh` - routine on a machine running several homes - the stale lock still named that number, so `fm-watch.sh` reported `already running pid <N>` and declined. The arm layer applies the identity rule (`fm_watcher_healthy`), correctly saw no watcher, started a child that immediately declined, and reported `FAILED - cycle ended without an actionable reason`, leaving the home unsupervised; observed twice in five minutes. The fix requires the recorded pid to still be the process this home recorded (`fm_watcher_lock_matches_pid`, the same rule the arm layer already uses) before treating it as a peer, and clears the proven-stale lock through the existing recovery transition so the downtime it records is preserved. An absent recorded identity proves nothing and still defers exactly as before. `tests/fm-watcher-lock.test.sh` gains a case with a live foreign pid, a mismatched recorded identity and a *fresh* beacon - so only the identity rule can let it through - which fails without the fix and passes with it.

## 3. The test suite could run against a real firstmate home

Every test isolates itself by *inventing* `FM_HOME` and friends, and an inherited value silently wins - `tests/wake-helpers.sh` only invents `FM_ROOT_OVERRIDE` when none is set. A shell that had exported them therefore aimed the whole suite at that live home: real state files written, config deleted, and the running watcher's lock stolen out from under it. This is not hypothetical - it is how the defect was found. `tests/lib.sh` now refuses outright when one of those overrides is set, so a direct `bash tests/<x>.test.sh` cannot slip past; the 26 smoke and e2e scripts do not source it, so `bin/fm-test-run.sh` clears the same overrides for every script it launches. Nothing in the suite, CI, or the runner sets them for a test, so there is nothing legitimate to preserve. One test in `tests/fm-test-run.test.sh` proves both halves, with a probe that first demonstrates it can observe an inherited value so the scrubbed reading cannot pass vacuously.

## Verification

`bin/fm-lint.sh` clean throughout (ShellCheck 0.11.0, actionlint 1.7.12).

Full-suite counts are **not** included, and I would rather say so than round up: the host ran out of memory and killed `--all` four separate times (twice with another suite alongside, once alone, once as serial `--jobs 1` lanes). Please let CI's regression lanes be the authority here. What did complete, all under a scrubbed environment:

- `--all` on this branch: **444 ok, 0 failures** before the kill.
- `--lane portable-parallel-1 --jobs 1`: **171 ok, 0 failures** before the kill.
- The suites covering this diff, run together under `--jobs 1`: **269 ok, 2 failures**, both reproduced on untouched `upstream/main` (see below). Per suite: `fm-composer-ghost` exit 0, `fm-watcher-lock` exit 0 (97 ok), `fm-backend-herdr` exit 0 (182 ok), `fm-send-inbox` exit 0 (12 ok), `fm-test-run` exit 0 (30 ok).
- A clean `upstream/main` baseline run for comparison: 701 ok, 3 failures, none of them related to these changes. Two failures reproduce identically on this branch and on untouched `upstream/main` on macOS Bash 3.2: `a half-block rule row must count as a structural edge` (an existing fixture uses `\uXXXX` escapes, which Bash 3.2's `printf` does not expand) and `guard repair line did not source the X-mode cadence config`. They are pre-existing and out of scope here. A third, `re-arm stayed live instead of surfacing durable wakes and the still-open remote decision`, is the host OOM killer SIGKILLing the watcher child (`Killed: 9` in the log); it reproduces identically on untouched `upstream/main` under the same memory pressure, so it is environmental rather than a regression in the watcher change.

Defect 1 was additionally verified against live tmux Cursor panes rather than fixtures alone: the panes that were falsely skipping doorbells now read `empty`, while a pane genuinely holding an unsent line still reads `pending`.
