### PR TITLE
fix(bin): stop ringing steering doorbells into dead panes

### DIFF
--- a/bin/fm-remote-secondmate-control.sh
+++ b/bin/fm-remote-secondmate-control.sh
@@ -286,6 +286,7 @@ cmd_send() {
   case "$ring_rc" in
     1) printf 'notice: doorbell skipped (composer visibly holds pending text); the steer is durably recorded at %s\n' "$rec" >&2 ;;
     2) printf 'notice: doorbell did not reach %s; the steer is durably recorded at %s\n' "$REMOTE_ENDPOINT_TARGET" "$rec" >&2 ;;
+    3) printf 'notice: doorbell not typed because the agent in %s has exited; the steer is durably recorded at %s for recovery\n' "$REMOTE_ENDPOINT_TARGET" "$rec" >&2 ;;
   esac
 }
 

--- a/bin/fm-secondmate-restart.sh
+++ b/bin/fm-secondmate-restart.sh
@@ -324,16 +324,25 @@ done
 while [ "$((pending_count + restart_active_count))" -gt 0 ]; do
   now=$(date +%s)
   next_wait=$PERSIST_POLL
+  # Resolve every arrived answer before processing any timeout. Delivery of a
+  # later fleet request can outlast an earlier mate's deadline under load; that
+  # expired mate must not hold an already-confirmed mate behind its fallback.
+  i=0
+  while [ "$i" -lt "${#IDS[@]}" ]; do
+    if [ "${PLAN[i]}" = persisted-pending ] \
+      && fm_pending_reply_try_resolve "$STATE" "${CORR[i]}"; then
+      pending_count=$((pending_count - 1))
+      launch_restart "$i"
+    fi
+    i=$((i + 1))
+  done
   i=0
   while [ "$i" -lt "${#IDS[@]}" ]; do
     if [ "${PLAN[i]}" != persisted-pending ]; then
       i=$((i + 1))
       continue
     fi
-    if fm_pending_reply_try_resolve "$STATE" "${CORR[i]}"; then
-      pending_count=$((pending_count - 1))
-      launch_restart "$i"
-    elif [ "$now" -ge "${DEADLINE[i]}" ]; then
+    if [ "$now" -ge "${DEADLINE[i]}" ]; then
       fall_back_to_nudge "${IDS[$i]}" \
         "it did not confirm within ${PERSIST_WAIT}s that its open work is written down, so its conversation was not spent"
       PLAN[i]="done"

--- a/bin/fm-secondmate-restart.sh
+++ b/bin/fm-secondmate-restart.sh
@@ -343,10 +343,17 @@ while [ "$((pending_count + restart_active_count))" -gt 0 ]; do
       continue
     fi
     if [ "$now" -ge "${DEADLINE[i]}" ]; then
-      fall_back_to_nudge "${IDS[$i]}" \
-        "it did not confirm within ${PERSIST_WAIT}s that its open work is written down, so its conversation was not spent"
-      PLAN[i]="done"
-      pending_count=$((pending_count - 1))
+      # A reply can land after the fleet-wide resolution pass. Recheck at the
+      # timeout decision so an answer already on disk wins over the fallback.
+      if fm_pending_reply_try_resolve "$STATE" "${CORR[i]}"; then
+        pending_count=$((pending_count - 1))
+        launch_restart "$i"
+      else
+        fall_back_to_nudge "${IDS[$i]}" \
+          "it did not confirm within ${PERSIST_WAIT}s that its open work is written down, so its conversation was not spent"
+        PLAN[i]="done"
+        pending_count=$((pending_count - 1))
+      fi
     else
       remaining=$((DEADLINE[i] - now))
       [ "$remaining" -ge "$next_wait" ] || next_wait=$remaining

--- a/bin/fm-send.sh
+++ b/bin/fm-send.sh
@@ -1008,6 +1008,7 @@ else
     case "$ring_rc" in
       1) echo "fm-send: doorbell skipped (composer visibly holds pending text); the steer is durably recorded at $INBOX_RECORD and the watcher will re-ring" >&2 ;;
       2) echo "fm-send: doorbell did not reach $T; the steer is durably recorded at $INBOX_RECORD and the watcher will re-ring" >&2 ;;
+      3) echo "fm-send: doorbell not typed because the agent in $T has exited; the steer is durably recorded at $INBOX_RECORD for recovery (stuck-crewmate-recovery), and the watcher will not re-ring a dead pane" >&2 ;;
     esac
     exit 0
   fi

--- a/bin/fm-send.sh
+++ b/bin/fm-send.sh
@@ -43,9 +43,11 @@
 # instruction. There is no delivered-unconfirmed
 # outcome on this plane: "did the doorbell land" is no longer the question -
 # "was the message acted on" is, and that is answered asynchronously for an
-# ordinary record by the worker's acknowledgement move into handled/, with the
-# watcher re-ringing an unacknowledged message and escalating a stuck one. An
-# explicit fire-and-forget record is excluded from that ladder.
+# ordinary record by the worker's acknowledgement move into handled/. The
+# watcher re-rings an unacknowledged message while its endpoint remains
+# available, escalates after the bounded ladder, and instead routes a positively
+# dead or missing endpoint directly to recovery without typing. An explicit
+# fire-and-forget record is excluded from that ladder.
 # bin/fm-task-inbox-lib.sh owns the record format, the doorbell line, and the
 # re-ring ladder. The composer pre-check before the ring is ADVISORY only: when
 # the composer visibly holds pending text the ring is skipped with a notice and
@@ -1002,7 +1004,8 @@ else
       fm_send_feed_resolved_holds "$RESOLVE_ANSWER_TEXT" || exit 1
     fi
     # Ring the doorbell, best-effort: no ring outcome changes the exit status,
-    # because the watcher's re-ring ladder owns loss detection from here.
+    # because the watcher owns loss detection from here, either through its
+    # bounded re-ring ladder or direct unavailable-endpoint recovery.
     ring_rc=0
     fm_task_inbox_ring "$TARGET_BACKEND" "$T" "$INBOX_RECORD" "$EXPECTED_LABEL" || ring_rc=$?
     case "$ring_rc" in

--- a/bin/fm-task-inbox-lib.sh
+++ b/bin/fm-task-inbox-lib.sh
@@ -265,12 +265,12 @@ fm_task_inbox_doorbell_line() {  # <record-path>
     "$quoted" "$quoted"
 }
 
-# Ring the doorbell, best-effort: one dead-agent pre-check, one advisory
+# Ring the doorbell, best-effort: one endpoint-liveness pre-check, one advisory
 # composer pre-check, then the backend's submit machinery with a minimal retry
 # budget, verdict discarded.
 # Returns 0 rang, 1 skipped because the composer PROVENLY holds pending text
 # (the watcher re-rings later), 2 the backend send failed, 3 skipped because
-# the endpoint's agent is positively dead (nothing typed; recovery owns the
+# the endpoint is positively dead or missing (nothing typed; recovery owns the
 # record). No return value is delivery proof; the acknowledgement move is the
 # only delivery signal.
 # The skip is deliberately narrow: only an exact `pending` verdict defers,
@@ -282,7 +282,7 @@ fm_task_inbox_doorbell_line() {  # <record-path>
 fm_task_inbox_ring() {  # <backend> <target> <record-path> [expected-label]
   local backend=$1 target=$2 rec=$3 label=${4:-} line cstate verdict
   case "$(fm_backend_agent_state "$backend" "$target" 2>/dev/null || true)" in
-    dead) return 3 ;;
+    dead|missing) return 3 ;;
   esac
   if ! line=$(fm_task_inbox_doorbell_line "$rec"); then
     return 2

--- a/bin/fm-task-inbox-lib.sh
+++ b/bin/fm-task-inbox-lib.sh
@@ -249,13 +249,12 @@ fm_task_inbox_body() {  # <record-path>
 # still receives the complete instruction in the line itself. The leading `: `
 # is the POSIX shell no-op, so the same line typed into a pane whose agent has
 # exited (a bare shell) runs nothing; see the dead-pane note in the header.
-# Keep the line free of shell metacharacters that `:` would still evaluate
-# (no `;`, `&`, `|`, `$`, backticks, or redirections).
 fm_task_inbox_doorbell_line() {  # <record-path>
-  local dir=${1%/*} abs
+  local dir=${1%/*} abs quoted
   abs=$(cd "$dir" 2>/dev/null && pwd) || abs=$dir
-  printf ': Firstmate instruction waiting: list %s/*.msg and, in numeric order, read and act on each, then mv each handled file to %s/handled/.' \
-    "$abs" "$abs"
+  quoted=$(printf '%s' "$abs" | sed "s/'/'\\\\''/g")
+  printf ": Firstmate instruction waiting: list '%s'/*.msg and, in numeric order, read and act on each, then mv each handled file to '%s'/handled/." \
+    "$quoted" "$quoted"
 }
 
 # Ring the doorbell, best-effort: one dead-agent pre-check, one advisory

--- a/bin/fm-task-inbox-lib.sh
+++ b/bin/fm-task-inbox-lib.sh
@@ -291,6 +291,10 @@ fm_task_inbox_ring() {  # <backend> <target> <record-path> [expected-label]
   case "$cstate" in
     pending) return 1 ;;
   esac
+  # Accepted residual race: terminal input and Enter are separate delivery
+  # steps, so an agent exiting after the liveness check could leave a bare
+  # shell only a suffix; the `: ` prefix protects complete lines only. Do not
+  # add process-bound atomic delivery here unless an incident reopens this.
   if ! verdict=$(fm_backend_send_text_submit "$backend" "$target" "$line" 1 0.4 0.3 "$label" 2>/dev/null); then
     return 2
   fi

--- a/bin/fm-task-inbox-lib.sh
+++ b/bin/fm-task-inbox-lib.sh
@@ -13,12 +13,14 @@
 #
 # Design (captain-adopted, data/fm-send-reliability-reframe-s1/report.md): the
 # payload moves to the filesystem, which is reliable; the terminal carries only
-# a short constant doorbell line, which does not need to be reliable because
-# ringing it again is free. A duplicated doorbell is a no-op by construction
-# (the worker finds the inbox empty or already handled), a swallowed doorbell
-# is detected by the absence of the worker's acknowledgement and re-rung on a
-# bounded schedule, and a worker that never acknowledges surfaces through the
-# ordinary stale wake into stuck-crewmate-recovery.
+# a short constant doorbell line. While the endpoint remains available, that
+# line does not need to be reliable because ringing it again is free. A
+# duplicated doorbell is a no-op by construction (the worker finds the inbox
+# empty or already handled), and a swallowed doorbell is detected by the
+# absence of the worker's acknowledgement and re-rung on a bounded schedule.
+# A positively dead or missing endpoint bypasses that schedule without being
+# typed into, and its unhandled record surfaces through the ordinary stale wake
+# into stuck-crewmate-recovery.
 #
 # Layout under <state-dir>:
 #   <task>.inbox/NNN.msg       one durable steer, numeric sequence, atomic rename
@@ -46,14 +48,15 @@
 # FM_TASK_INBOX_GRACE_SECS is due one delivery attempt per grace period; an
 # attempt may ring or be skipped to protect proven pending composer text. After
 # FM_TASK_INBOX_RING_MAX attempts without an acknowledgement it escalates. The
-# caller owns the busy check (a busy pane just waits - the record is durable and
-# the worker reaches a turn boundary) and the wake emission; this library owns
-# only the schedule. If attempt bookkeeping cannot be persisted while the record
-# remains unhandled, the caller surfaces that failure instead of retrying
-# silently; a concurrently removed inbox is a quiet no-op. Escalation
-# deliberately queues the wake before writing the
-# deduplication marker: normal polls surface a message once, while a crash or
-# marker failure may produce a rare duplicate rather than silently lose a wake.
+# caller owns the busy and recovery-grade endpoint checks: a busy pane waits,
+# while a positively dead or missing endpoint skips delivery and the ladder and
+# escalates directly. This library owns only the schedule and escalation marker.
+# If attempt bookkeeping cannot be persisted while the record remains unhandled,
+# the caller surfaces that failure instead of retrying silently; a concurrently
+# removed inbox is a quiet no-op. Escalation deliberately queues the wake before
+# writing the deduplication marker: normal polls surface a message once, while a
+# crash or marker failure may produce a rare duplicate rather than silently lose
+# a wake.
 #
 # Inbox paths containing bytes outside printable ASCII are unsupported. The
 # doorbell refuses them rather than sending terminal control bytes to a pane.
@@ -391,10 +394,11 @@ EOF
 
 # Advance the ladder after a delivery attempt. A failed ring or a composer-
 # protected skip still consumes budget so neither an unreadable pane nor a
-# permanently blocked composer can retry silently forever (a positively dead
-# pane never enters the ladder: the watcher escalates it directly). A concurrently removed inbox is
-# a successful no-op; otherwise failure means the caller must surface the
-# unwritable ladder while the record remains unhandled.
+# permanently blocked composer can retry silently forever. A positively dead or
+# missing endpoint never enters the ladder: the watcher escalates it directly.
+# A concurrently removed inbox is a successful no-op; otherwise failure means
+# the caller must surface the unwritable ladder while the record remains
+# unhandled.
 fm_task_inbox_record_ring() {  # <state-dir> <task-id> <record-path>
   local dir base ladder rec_base count last
   dir=$(fm_task_inbox_dir "$1" "$2")

--- a/bin/fm-task-inbox-lib.sh
+++ b/bin/fm-task-inbox-lib.sh
@@ -55,6 +55,9 @@
 # deduplication marker: normal polls surface a message once, while a crash or
 # marker failure may produce a rare duplicate rather than silently lose a wake.
 #
+# Inbox paths containing bytes outside printable ASCII are unsupported. The
+# doorbell refuses them rather than sending terminal control bytes to a pane.
+#
 # fm_task_inbox_ring requires bin/fm-backend.sh's dispatch (sourced below); the
 # other helpers are dependency-light. Sourced by bin/fm-send.sh, bin/fm-watch.sh,
 # and tests. No side effects on source beyond its sourced libraries.
@@ -249,9 +252,14 @@ fm_task_inbox_body() {  # <record-path>
 # still receives the complete instruction in the line itself. The leading `: `
 # is the POSIX shell no-op, so the same line typed into a pane whose agent has
 # exited (a bare shell) runs nothing; see the dead-pane note in the header.
+# A non-printable path fails without output so terminal controls never reach
+# the pane's line discipline.
 fm_task_inbox_doorbell_line() {  # <record-path>
-  local dir=${1%/*} abs quoted
+  local dir=${1%/*} abs quoted LC_ALL=C
   abs=$(cd "$dir" 2>/dev/null && pwd) || abs=$dir
+  case "$abs" in
+    *[![:print:]]*) return 1 ;;
+  esac
   quoted=$(printf '%s' "$abs" | sed "s/'/'\\\\''/g")
   printf ": Firstmate instruction waiting: list '%s'/*.msg and, in numeric order, read and act on each, then mv each handled file to '%s'/handled/." \
     "$quoted" "$quoted"
@@ -276,7 +284,9 @@ fm_task_inbox_ring() {  # <backend> <target> <record-path> [expected-label]
   case "$(fm_backend_agent_state "$backend" "$target" 2>/dev/null || true)" in
     dead) return 3 ;;
   esac
-  line=$(fm_task_inbox_doorbell_line "$rec")
+  if ! line=$(fm_task_inbox_doorbell_line "$rec"); then
+    return 2
+  fi
   cstate=$(fm_backend_composer_state "$backend" "$target" "$label" 2>/dev/null) || cstate=unknown
   case "$cstate" in
     pending) return 1 ;;

--- a/bin/fm-task-inbox-lib.sh
+++ b/bin/fm-task-inbox-lib.sh
@@ -246,19 +246,26 @@ fm_task_inbox_body() {  # <record-path>
 
 # The constant self-describing doorbell line for the inbox containing a record.
 # Self-describing on purpose: a worker whose brief predates the inbox contract
-# still receives the complete instruction in the line itself.
+# still receives the complete instruction in the line itself. The leading `: `
+# is the POSIX shell no-op, so the same line typed into a pane whose agent has
+# exited (a bare shell) runs nothing; see the dead-pane note in the header.
+# Keep the line free of shell metacharacters that `:` would still evaluate
+# (no `;`, `&`, `|`, `$`, backticks, or redirections).
 fm_task_inbox_doorbell_line() {  # <record-path>
   local dir=${1%/*} abs
   abs=$(cd "$dir" 2>/dev/null && pwd) || abs=$dir
-  printf 'Firstmate instruction waiting: list %s/*.msg and, in numeric order, read and act on each, then mv each handled file to %s/handled/.' \
+  printf ': Firstmate instruction waiting: list %s/*.msg and, in numeric order, read and act on each, then mv each handled file to %s/handled/.' \
     "$abs" "$abs"
 }
 
-# Ring the doorbell, best-effort: one advisory composer pre-check, then the
-# backend's submit machinery with a minimal retry budget, verdict discarded.
+# Ring the doorbell, best-effort: one dead-agent pre-check, one advisory
+# composer pre-check, then the backend's submit machinery with a minimal retry
+# budget, verdict discarded.
 # Returns 0 rang, 1 skipped because the composer PROVENLY holds pending text
-# (the watcher re-rings later), 2 the backend send failed. No return value is
-# delivery proof; the acknowledgement move is the only delivery signal.
+# (the watcher re-rings later), 2 the backend send failed, 3 skipped because
+# the endpoint's agent is positively dead (nothing typed; recovery owns the
+# record). No return value is delivery proof; the acknowledgement move is the
+# only delivery signal.
 # The skip is deliberately narrow: only an exact `pending` verdict defers,
 # because there our Enter could submit someone's real half-typed content.
 # `pending-unproven` and `unknown` still ring - the worst outcome is a garbled
@@ -267,6 +274,9 @@ fm_task_inbox_doorbell_line() {  # <record-path>
 # positively identify (that classifier is advisory here by design).
 fm_task_inbox_ring() {  # <backend> <target> <record-path> [expected-label]
   local backend=$1 target=$2 rec=$3 label=${4:-} line cstate verdict
+  case "$(fm_backend_agent_state "$backend" "$target" 2>/dev/null || true)" in
+    dead) return 3 ;;
+  esac
   line=$(fm_task_inbox_doorbell_line "$rec")
   cstate=$(fm_backend_composer_state "$backend" "$target" "$label" 2>/dev/null) || cstate=unknown
   case "$cstate" in
@@ -338,8 +348,11 @@ fm_task_inbox_due_action() {  # <state-dir> <task-id>
   IFS=$(printf '\t') read -r rec_base count last <<EOF
 $ladder
 EOF
-  if [ "$rec_base" != "$base" ]; then
-    # A different (or first) oldest message: the previous ladder is stale.
+  if [ -n "$rec_base" ] && [ "$rec_base" != "$base" ]; then
+    # A different oldest message: the previous ladder is stale. An absent
+    # ladder is left alone so a dead-pane escalation, which never rings and so
+    # never writes one, keeps its marker (the marker check below still ignores
+    # a marker naming some other message).
     count=0
     last=0
     rm -f "$dir/.escalated" 2>/dev/null || true
@@ -364,8 +377,9 @@ EOF
 }
 
 # Advance the ladder after a delivery attempt. A failed ring or a composer-
-# protected skip still consumes budget so neither a dead pane nor permanently
-# blocked composer can retry silently forever. A concurrently removed inbox is
+# protected skip still consumes budget so neither an unreadable pane nor a
+# permanently blocked composer can retry silently forever (a positively dead
+# pane never enters the ladder: the watcher escalates it directly). A concurrently removed inbox is
 # a successful no-op; otherwise failure means the caller must surface the
 # unwritable ladder while the record remains unhandled.
 fm_task_inbox_record_ring() {  # <state-dir> <task-id> <record-path>

--- a/bin/fm-watch.sh
+++ b/bin/fm-watch.sh
@@ -129,8 +129,9 @@ mkdir -p "$STATE"
 # shellcheck source=bin/fm-busy-lib.sh
 . "$SCRIPT_DIR/fm-busy-lib.sh"
 # Steering-inbox loss detection: bin/fm-task-inbox-lib.sh owns the record,
-# doorbell, and re-ring ladder contracts; this watcher only supplies the busy
-# gate and the wake emission (inbox_steer_check below).
+# doorbell, re-ring ladder, and unavailable-endpoint contracts; this watcher
+# supplies their live endpoint and busy checks plus wake emission
+# (inbox_steer_check below).
 # shellcheck source=bin/fm-task-inbox-lib.sh
 . "$SCRIPT_DIR/fm-task-inbox-lib.sh"
 

--- a/bin/fm-watch.sh
+++ b/bin/fm-watch.sh
@@ -330,7 +330,9 @@ window_key() {  # <window>
 # policy owner) reports a due action, a busy pane just waits - the record is
 # durable and the worker will reach a turn boundary - an idle pane gets one
 # delivery attempt, and a spent attempt budget surfaces as an ordinary stale
-# wake for stuck-crewmate-recovery. If the attempt's ladder write fails while
+# wake for stuck-crewmate-recovery, and a pane whose agent is positively dead
+# skips the ladder altogether: it is never typed into and surfaces as that same
+# stale wake exactly once. If the attempt's ladder write fails while
 # its record remains unhandled, that unwritable state surfaces through the same
 # stale path instead of silently re-ringing forever; acknowledgement or teardown
 # still makes the race quiet. The attempt is data-plane typing or a
@@ -359,6 +361,24 @@ inbox_steer_check() {  # <window> <task>
     ring)
       ring_rc=0
       fm_task_inbox_ring "$(window_backend "$w")" "$w" "$rec" "$(window_label "$w")" || ring_rc=$?
+      if [ "$ring_rc" -eq 3 ]; then
+        # Positively dead agent: nothing was typed, and re-ringing a bare shell
+        # can never be acknowledged, so the ladder is capped here - one stale
+        # wake for recovery, then quiet until the record is handled or the
+        # inbox changes. The record itself stays for stuck-crewmate-recovery.
+        reason="stale: $w (unread firstmate instruction: $rec is unhandled and the worker's agent has exited, so the doorbell was not typed; recover the worker)"
+        if [ ! -d "${rec%/*}" ] || [ ! -f "$rec" ]; then
+          fm_task_inbox_due_action "$STATE" "$task" >/dev/null || true
+          return 0
+        fi
+        fm_wake_append stale "$w" "$reason" || exit 1
+        if ! fm_task_inbox_record_escalated "$STATE" "$task" "$rec"; then
+          echo "error: stale wake was queued for $task but its inbox escalation marker could not be written" >&2
+          exit 1
+        fi
+        wake "$reason"
+        return 0
+      fi
       if ! fm_task_inbox_record_ring "$STATE" "$task" "$rec"; then
         if [ ! -f "$rec" ]; then
           fm_task_inbox_due_action "$STATE" "$task" >/dev/null || true

--- a/bin/fm-watch.sh
+++ b/bin/fm-watch.sh
@@ -324,6 +324,21 @@ window_key() {  # <window>
   printf '%s' "${key//./_}"
 }
 
+inbox_steer_escalate_unavailable() {  # <window> <task> <record>
+  local w=$1 task=$2 rec=$3 reason
+  reason="stale: $w (unread firstmate instruction: $rec is unhandled and the worker's agent has exited or its endpoint is missing, so the doorbell was not typed; recover the worker)"
+  if [ ! -d "${rec%/*}" ] || [ ! -f "$rec" ]; then
+    fm_task_inbox_due_action "$STATE" "$task" >/dev/null || true
+    return 0
+  fi
+  fm_wake_append stale "$w" "$reason" || exit 1
+  if ! fm_task_inbox_record_escalated "$STATE" "$task" "$rec"; then
+    echo "error: stale wake was queued for $task but its inbox escalation marker could not be written" >&2
+    exit 1
+  fi
+  wake "$reason"
+}
+
 # Steering-inbox loss detection, one cheap check per recorded window per poll.
 # Quiet when healthy: an absent, empty, or handled inbox costs one directory
 # glob and produces nothing. When the ladder (fm_task_inbox_due_action, the
@@ -331,8 +346,8 @@ window_key() {  # <window>
 # durable and the worker will reach a turn boundary - an idle pane gets one
 # delivery attempt, and a spent attempt budget surfaces as an ordinary stale
 # wake for stuck-crewmate-recovery, and a pane whose agent is positively dead
-# skips the ladder altogether: it is never typed into and surfaces as that same
-# stale wake exactly once. If the attempt's ladder write fails while
+# or missing skips the ladder altogether: it is never typed into and surfaces
+# as that same stale wake exactly once. If the attempt's ladder write fails while
 # its record remains unhandled, that unwritable state surfaces through the same
 # stale path instead of silently re-ringing forever; acknowledgement or teardown
 # still makes the race quiet. The attempt is data-plane typing or a
@@ -341,7 +356,7 @@ window_key() {  # <window>
 # too: their pane-staleness exemption is about quiet panes being healthy,
 # while an unacknowledged instruction past the ladder is a stuck steer.
 inbox_steer_check() {  # <window> <task>
-  local w=$1 task=$2 action verb rec count tail40 reason ring_rc
+  local w=$1 task=$2 action verb rec count tail40 reason ring_rc backend agent_state
   action=$(fm_task_inbox_due_action "$STATE" "$task") || return 0
   verb=${action%% *}
   [ "$verb" != quiet ] || return 0
@@ -353,30 +368,24 @@ inbox_steer_check() {  # <window> <task>
       rec=${rec% *}
       ;;
   esac
-  tail40=$(fm_backend_capture "$(window_backend "$w")" "$w" 40 "$(window_label "$w")" 2>/dev/null) || tail40=
+  backend=$(window_backend "$w")
+  agent_state=$(fm_backend_agent_state "$backend" "$w" 2>/dev/null || true)
+  case "$agent_state" in
+    dead|missing)
+      inbox_steer_escalate_unavailable "$w" "$task" "$rec"
+      return 0
+      ;;
+  esac
+  tail40=$(fm_backend_capture "$backend" "$w" 40 "$(window_label "$w")" 2>/dev/null) || tail40=
   if window_is_busy "$w" "$tail40"; then
     return 0
   fi
   case "$verb" in
     ring)
       ring_rc=0
-      fm_task_inbox_ring "$(window_backend "$w")" "$w" "$rec" "$(window_label "$w")" || ring_rc=$?
+      fm_task_inbox_ring "$backend" "$w" "$rec" "$(window_label "$w")" || ring_rc=$?
       if [ "$ring_rc" -eq 3 ]; then
-        # Positively dead agent: nothing was typed, and re-ringing a bare shell
-        # can never be acknowledged, so the ladder is capped here - one stale
-        # wake for recovery, then quiet until the record is handled or the
-        # inbox changes. The record itself stays for stuck-crewmate-recovery.
-        reason="stale: $w (unread firstmate instruction: $rec is unhandled and the worker's agent has exited, so the doorbell was not typed; recover the worker)"
-        if [ ! -d "${rec%/*}" ] || [ ! -f "$rec" ]; then
-          fm_task_inbox_due_action "$STATE" "$task" >/dev/null || true
-          return 0
-        fi
-        fm_wake_append stale "$w" "$reason" || exit 1
-        if ! fm_task_inbox_record_escalated "$STATE" "$task" "$rec"; then
-          echo "error: stale wake was queued for $task but its inbox escalation marker could not be written" >&2
-          exit 1
-        fi
-        wake "$reason"
+        inbox_steer_escalate_unavailable "$w" "$task" "$rec"
         return 0
       fi
       if ! fm_task_inbox_record_ring "$STATE" "$task" "$rec"; then

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -144,7 +144,7 @@ Unsupported supervisor backends refuse at daemon startup.
 Stalled escalation delivery writes `state/.subsuper-inject-wedged` and attempts a configured backend-independent active alert after `FM_MAX_DEFER_SECS` instead of silently deferring forever.
 On an unmarked return, `bin/fm-afk-return.sh` owns ordered shutdown, durable catch-up evidence, and the fail-closed gate that keeps ordinary work behind every live firstmate-actionable blocker.
 `fm-send.sh` delivers every remote text steer and ordinary local text steer as a durable steering-inbox record plus a best-effort constant doorbell line (`bin/fm-task-inbox-lib.sh`).
-The doorbell line is a shell no-op and is never typed into a pane whose agent is positively dead; that record surfaces once for recovery instead of walking the re-ring ladder (`bin/fm-task-inbox-lib.sh` header).
+The doorbell line is a shell no-op and is never typed into an endpoint classified as dead or missing; that record surfaces once for recovery instead of walking the re-ring ladder (`bin/fm-task-inbox-lib.sh` header).
 Its local-only typed plane - harness-native invocations and explicit backend targets - selects a pre-Enter popup-settle for slash commands and for codex `$...` skill invocations using metadata-routed target `harness=` values, then adds its own `FM_SEND_SETTLE` pause after successful typed sends so immediate peeks catch the receiving turn starting; the sub-supervisor uses only the shared submit core and does not pay that post-submit pause.
 
 Text for a worker to read and commands that drive a worker's process are separate planes.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -144,6 +144,7 @@ Unsupported supervisor backends refuse at daemon startup.
 Stalled escalation delivery writes `state/.subsuper-inject-wedged` and attempts a configured backend-independent active alert after `FM_MAX_DEFER_SECS` instead of silently deferring forever.
 On an unmarked return, `bin/fm-afk-return.sh` owns ordered shutdown, durable catch-up evidence, and the fail-closed gate that keeps ordinary work behind every live firstmate-actionable blocker.
 `fm-send.sh` delivers every remote text steer and ordinary local text steer as a durable steering-inbox record plus a best-effort constant doorbell line (`bin/fm-task-inbox-lib.sh`).
+The doorbell line is a shell no-op and is never typed into a pane whose agent is positively dead; that record surfaces once for recovery instead of walking the re-ring ladder (`bin/fm-task-inbox-lib.sh` header).
 Its local-only typed plane - harness-native invocations and explicit backend targets - selects a pre-Enter popup-settle for slash commands and for codex `$...` skill invocations using metadata-routed target `harness=` values, then adds its own `FM_SEND_SETTLE` pause after successful typed sends so immediate peeks catch the receiving turn starting; the sub-supervisor uses only the shared submit core and does not pay that post-submit pause.
 
 Text for a worker to read and commands that drive a worker's process are separate planes.

--- a/tests/fm-backend-orca.test.sh
+++ b/tests/fm-backend-orca.test.sh
@@ -769,7 +769,7 @@ test_peek_send_and_crew_state_route_through_orca_meta() {
   [ "$body" = "hello orca" ] || fail "Orca task inbox did not preserve the send body, got '$body'"
   assert_not_contains "$(cat "$LOG")" $'--text\x1fhello orca\x1f' \
     "send typed the payload instead of recording it"
-  assert_contains "$(cat "$LOG")" $'orca\x1f''terminal'$'\x1f''send'$'\x1f''--terminal'$'\x1f''term-io'$'\x1f''--text'$'\x1f''Firstmate instruction waiting:' \
+  assert_contains "$(cat "$LOG")" $'orca\x1f''terminal'$'\x1f''send'$'\x1f''--terminal'$'\x1f''term-io'$'\x1f''--text'$'\x1f'': Firstmate instruction waiting:' \
     "send did not ring the inbox doorbell through the recorded Orca terminal"
   assert_contains "$(cat "$LOG")" $'orca\x1f''terminal'$'\x1f''send'$'\x1f''--terminal'$'\x1f''term-io'$'\x1f''--text'$'\x1f\x1f''--enter'$'\x1f''--json' \
     "send did not submit the doorbell through the recorded Orca terminal"

--- a/tests/fm-gate-refuse.test.sh
+++ b/tests/fm-gate-refuse.test.sh
@@ -256,7 +256,7 @@ test_send_refuses_and_admits() {
     || fail "send: normal steer was not durably enqueued"
   assert_not_contains "$(cat "$log")" "literal=1 arg=hello captain" \
     "send: normal steer payload must not be typed"
-  assert_contains "$(cat "$log")" "target=sess:fm-lane-ok literal=1 arg=Firstmate instruction waiting" \
+  assert_contains "$(cat "$log")" "target=sess:fm-lane-ok literal=1 arg=: Firstmate instruction waiting" \
     "send: normal steer should ring the durable inbox doorbell"
   pass "fm-send: refuses on marker and gate-worktree backstop; a normal steer uses the inbox"
 }

--- a/tests/fm-gate-refuse.test.sh
+++ b/tests/fm-gate-refuse.test.sh
@@ -206,6 +206,7 @@ case "${1:-}" in
     for a in "$@"; do case "$a" in *cursor_y*) printf '1\n'; exit 0 ;; esac; done
     printf '%%1\n'; exit 0 ;;
   capture-pane) printf '╭────╮\n│    │\n╰────╯\n'; exit 0 ;;
+  list-windows) printf 'fm-lane-ok\n'; exit 0 ;;
 esac
 exit 0
 SH

--- a/tests/fm-secondmate-harness.test.sh
+++ b/tests/fm-secondmate-harness.test.sh
@@ -1065,6 +1065,10 @@ if [ -n "${FM_FAKE_TMUX_LOG:-}" ]; then
   printf '%s\n' "$*" >> "$FM_FAKE_TMUX_LOG"
 fi
 case "$*" in
+  list-windows*)
+    sed -n 's/^window=[^:]*://p' "${FM_HOME:?}"/state/*.meta
+    exit 0
+    ;;
   *display-message*'#{pane_current_command}'*) printf '%s\n' codex; exit 0 ;;
   *display-message*'#{pane_id}'*) printf '%s\n' '%1'; exit 0 ;;
   *display-message*'#{cursor_y}'*) printf '%s\n' 0; exit 0 ;;

--- a/tests/fm-secondmate-lifecycle-e2e.test.sh
+++ b/tests/fm-secondmate-lifecycle-e2e.test.sh
@@ -137,8 +137,10 @@ phase_send() {
   : > "$LOG"
   printf '❯\n' > "$PANE"
   # The meta window (firstmate:fm-design) must win over a foreign same-named
-  # window returned by list-windows.
-  PATH="$FAKEBIN:$PATH" FM_HOME="$HOME_DIR" FM_FAKE_TMUX_WINDOW="other-session:fm-design" \
+  # window returned by list-windows. Include the recorded endpoint in the fake
+  # inventory so the recovery-grade liveness check can verify it exists.
+  PATH="$FAKEBIN:$PATH" FM_HOME="$HOME_DIR" FM_FAKE_TMUX_WINDOW="firstmate:fm-design
+other-session:fm-design" \
     FM_FAKE_TMUX_LOG="$LOG" FM_FAKE_TMUX_CAPTURE="$PANE" \
     "$ROOT/bin/fm-send.sh" fm-design 'route this work' >/dev/null 2>&1 \
     || fail "fm-send failed for a bare firstmate window with home metadata"

--- a/tests/fm-secondmate-lifecycle-e2e.test.sh
+++ b/tests/fm-secondmate-lifecycle-e2e.test.sh
@@ -150,7 +150,7 @@ phase_send() {
   body=$(bash -c '. "$1"; fm_task_inbox_body "$2"' _ "$ROOT/bin/fm-task-inbox-lib.sh" "$record")
   assert_contains "$body" '[fm-from-firstmate]' "the inbox request was not marked as from-firstmate"
   assert_contains "$body" 'route this work' "the original request text did not survive the marker"
-  assert_grep 'send-keys -t firstmate:fm-design -l Firstmate instruction waiting:' "$LOG" "send did not ring the window recorded in this home's meta"
+  assert_grep 'send-keys -t firstmate:fm-design -l : Firstmate instruction waiting:' "$LOG" "send did not ring the window recorded in this home's meta"
   assert_no_grep 'route this work' "$LOG" "send typed the payload instead of only the doorbell"
   assert_no_grep 'send-keys -t other-session:fm-design' "$LOG" "send targeted a foreign same-named window"
   pass "send: a bare fm-<id> secondmate enqueues a marked request and rings the meta window"

--- a/tests/fm-secondmate-restart.test.sh
+++ b/tests/fm-secondmate-restart.test.sh
@@ -68,9 +68,9 @@ case "${1:-}" in
           if [ -e "$D/remote-relaunch-start" ] && [ ! -e "$D/remote-relaunch-end" ]; then
             : > "$D/local-relaunch-during-remote"
           fi
-          printf 'zsh' > "$D/command"
+          printf 'zsh' > "$D/command.$target"
           ;;
-        *'encode launch-brief'*) cat "$D/becomes" > "$D/command" ;;
+        *'encode launch-brief'*) cat "$D/becomes" > "$D/command.$target" ;;
         ': Firstmate instruction waiting: list '*)
           printf 'doorbell\n' >> "$D/rings"
           if [ -x "$D/on-doorbell" ]; then
@@ -95,12 +95,18 @@ case "${1:-}" in
     fi
     exit 0 ;;
   display-message)
+    target=
+    prev=
     for a in "$@"; do
+      if [ "$prev" = -t ]; then target=$a; fi
       case "$a" in
         *cursor_y*) printf '1\n'; exit 0 ;;
-        *pane_current_command*) cat "$D/command"; printf '\n'; exit 0 ;;
+        *pane_current_command*)
+          if [ -f "$D/command.$target" ]; then cat "$D/command.$target"; else cat "$D/command"; fi
+          printf '\n'; exit 0 ;;
         *pane_current_path*) cat "$D/cwd"; printf '\n'; exit 0 ;;
       esac
+      prev=$a
     done
     printf 'fakepane\n'; exit 0 ;;
   capture-pane) printf '> \n'; exit 0 ;;
@@ -159,7 +165,7 @@ add_local_mate() {
     echo "home=$smhome"
     [ -z "$backend" ] || echo "backend=$backend"
   } > "$home/state/$id.meta"
-  printf '%s\n' "fm-$id" > "$dir/fake/windows"
+  printf '%s\n' "fm-$id" >> "$dir/fake/windows"
   printf '%s' "$smhome" > "$dir/fake/cwd"
 }
 

--- a/tests/fm-secondmate-restart.test.sh
+++ b/tests/fm-secondmate-restart.test.sh
@@ -316,6 +316,43 @@ test_arrived_answer_precedes_deadline_check() {
   pass "T2b an arrived persist answer is resolved before timeout"
 }
 
+# --- T2c: an answer arriving between resolution and timeout wins -------------
+test_answer_between_resolution_and_timeout_wins() {
+  local dir out rc
+  dir=$(new_case answer-at-timeout-decision)
+  add_local_mate "$dir" sm1
+
+  # Delay the modelled answer until the first resolution attempt has completed
+  # its unsuccessful status scan. The real pending-reply machinery publishes
+  # that scan signature with mv; this wrapper appends the correlated answer only
+  # after that publication, reproducing the boundary race deterministically.
+  cat > "$dir/fakebin/mv" <<'SH'
+#!/usr/bin/env bash
+set -u
+/bin/mv "$@" || exit $?
+target=${!#}
+case "$target" in
+  "${FM_FAKE_DIR%/fake}"/home/state/pending-replies/*)
+    if [ ! -e "$FM_FAKE_DIR/answer-after-scan" ] \
+      && grep -q '^parent_status_scan_signature=.' "$target"; then
+      : > "$FM_FAKE_DIR/answer-after-scan"
+      corr=${target##*/}
+      status=$(sed -n 's/^parent_status=//p' "$target")
+      printf 'done [corr=%s]: open records written down\n' "$corr" >> "$status"
+    fi
+    ;;
+esac
+SH
+  chmod +x "$dir/fakebin/mv"
+
+  out=$(FM_TEST_PERSIST_WAIT=0 run_restart "$dir" sm1); rc=$?
+
+  expect_code 0 "$rc" "an answer already on disk at the timeout decision must release the gate"$'\n'"$out"
+  assert_contains "$out" "restarted: sm1" "the reply that raced the timeout was ignored"
+  assert_not_contains "$out" "nudged: sm1" "a confirmed mate must not take the timeout fallback"
+  pass "T2c a reply between the preliminary scan and timeout decision wins"
+}
+
 # --- T3: a runtime that cannot prove a restart never gets one ----------------
 test_unprovable_runtime_falls_back() {
   local dir out rc
@@ -770,6 +807,7 @@ test_already_current_unprovable_mate_stays_on_the_nudge_path() {
 test_persist_gates_and_asks_only_for_open_records
 test_persist_precedes_restart
 test_arrived_answer_precedes_deadline_check
+test_answer_between_resolution_and_timeout_wins
 test_unprovable_runtime_falls_back
 test_unknown_mate_is_accounted_for
 test_refused_restart_falls_back_without_claiming_a_reload

--- a/tests/fm-secondmate-restart.test.sh
+++ b/tests/fm-secondmate-restart.test.sh
@@ -71,7 +71,7 @@ case "${1:-}" in
           printf 'zsh' > "$D/command"
           ;;
         *'encode launch-brief'*) cat "$D/becomes" > "$D/command" ;;
-        'Firstmate instruction waiting: list '*)
+        ': Firstmate instruction waiting: list '*)
           printf 'doorbell\n' >> "$D/rings"
           if [ -x "$D/on-doorbell" ]; then
             "$D/on-doorbell" "$payload"
@@ -284,7 +284,7 @@ test_persist_precedes_restart() {
   assert_contains "$out" "summary: 1 of 1 restarted, 0 nudged, 0 unreached" "the summary should report the reload"
   # The pane transcript orders the two phases: the instruction doorbell first,
   # the harness exit command only after it.
-  doorbell_line=$(grep -n '^Firstmate instruction waiting: ' "$dir/fake/literal" | head -1 | cut -d: -f1)
+  doorbell_line=$(grep -n '^: Firstmate instruction waiting: ' "$dir/fake/literal" | head -1 | cut -d: -f1)
   exit_line=$(grep -n '^/exit$' "$dir/fake/literal" | head -1 | cut -d: -f1)
   [ -n "$doorbell_line" ] || fail "the persist request never reached the mate"
   [ -n "$exit_line" ] || fail "the mate was never stopped, so it was not restarted"
@@ -553,7 +553,7 @@ test_persist_waits_are_polled_together() {
 
   expect_code 3 "$rc" "the unanswered mate should fall back after the confirmed mate restarts"$'\n'"$out"
   exit_line=$(grep -n '^/exit$' "$dir/fake/literal" | head -1 | cut -d: -f1)
-  nudge_line=$(grep -n '^Firstmate instruction waiting: ' "$dir/fake/literal" | tail -1 | cut -d: -f1)
+  nudge_line=$(grep -n '^: Firstmate instruction waiting: ' "$dir/fake/literal" | tail -1 | cut -d: -f1)
   [ -n "$exit_line" ] && [ -n "$nudge_line" ] && [ "$exit_line" -lt "$nudge_line" ] \
     || fail "the first mate's timeout held the confirmed second mate behind it: $out"
   pass "T10 pending persist answers are polled as one fleet"
@@ -712,7 +712,7 @@ test_already_current_mate_restarts_end_to_end() {
   assert_contains "$out" "summary: 1 of 1 restarted, 0 nudged, 0 unreached" \
     "the pass must report the reload it performed"
   # Persist strictly before replace, read off the pane transcript.
-  doorbell_line=$(grep -n '^Firstmate instruction waiting: ' "$dir/fake/literal" | head -1 | cut -d: -f1)
+  doorbell_line=$(grep -n '^: Firstmate instruction waiting: ' "$dir/fake/literal" | head -1 | cut -d: -f1)
   exit_line=$(grep -n '^/exit$' "$dir/fake/literal" | head -1 | cut -d: -f1)
   [ -n "$doorbell_line" ] || fail "the persist request never reached the already-current mate"
   [ -n "$exit_line" ] || fail "the already-current mate was never stopped, so it was not restarted"

--- a/tests/fm-send-inbox.test.sh
+++ b/tests/fm-send-inbox.test.sh
@@ -72,7 +72,7 @@ case "${1:-}" in
       printf '╭────╮\n│    │\n╰────╯\n'
     fi
     exit 0 ;;
-  list-windows) exit 0 ;;
+  list-windows) printf 'fm-t1\n'; exit 0 ;;
 esac
 exit 0
 SH

--- a/tests/fm-send-inbox.test.sh
+++ b/tests/fm-send-inbox.test.sh
@@ -124,7 +124,7 @@ test_text_steer_rides_inbox() {
   body=$(record_body _ "$rec")
   [ "$body" = "please rebase onto main" ] || fail "the recorded body differs: $body"
   typed=$(cat "$dir/send.log")
-  assert_contains "$typed" "Firstmate instruction waiting: list $dir/home/state/t1.inbox/*.msg" \
+  assert_contains "$typed" "Firstmate instruction waiting: list '$dir/home/state/t1.inbox'/*.msg" \
     "the doorbell should direct the worker to drain the inbox"
   case "$typed" in
     *"please rebase onto main"*) fail "the payload must never be typed:"$'\n'"$typed" ;;

--- a/tests/fm-send-popup-settle.test.sh
+++ b/tests/fm-send-popup-settle.test.sh
@@ -57,7 +57,7 @@ case "${1:-}" in
     for a in "$@"; do case "$a" in *cursor_y*) printf '1\n'; exit 0 ;; esac; done
     printf 'fakepane\n'; exit 0 ;;
   capture-pane) printf '╭────╮\n│    │\n╰────╯\n'; exit 0 ;;
-  list-windows) exit 0 ;;
+  list-windows) printf 'win\n'; exit 0 ;;
 esac
 exit 0
 SH

--- a/tests/fm-send-resolve-key.test.sh
+++ b/tests/fm-send-resolve-key.test.sh
@@ -72,7 +72,9 @@ case "${1:-}" in
     for a in "$@"; do case "$a" in *cursor_y*) printf '1\n'; exit 0 ;; esac; done
     printf 'fakepane\n'; exit 0 ;;
   capture-pane) printf '╭────╮\n│    │\n╰────╯\n'; exit 0 ;;
-  list-windows) exit 0 ;;
+  list-windows)
+    printf '%s\n' fm-t1 fm-t2 fm-t3 fm-t4 fm-t5 fm-t6 fm-t7 fm-t8 fm-t9 fm-mate
+    exit 0 ;;
 esac
 exit 0
 SH

--- a/tests/fm-send-strict.test.sh
+++ b/tests/fm-send-strict.test.sh
@@ -60,7 +60,7 @@ case "${1:-}" in
     printf '╭────╮\n│    │\n╰────╯\n'
     exit 0 ;;
   list-windows)
-    printf 'foreign:%s\n' "${FM_FAKE_TMUX_WINDOW:-fm-lost}"
+    printf 'foreign:%s\nfm-mpf-lane-m8\nfm-lane-ok\n' "${FM_FAKE_TMUX_WINDOW:-fm-lost}"
     exit 0 ;;
 esac
 exit 0

--- a/tests/fm-send-strict.test.sh
+++ b/tests/fm-send-strict.test.sh
@@ -101,7 +101,7 @@ test_exact_lane_id_send_still_works() {
     "$SEND" mpf-lane-m8 "lost dispatch" >/dev/null 2>"$err"; rc=$?
   expect_code 0 "$rc" "exact task id send should succeed when metadata exists"
   got=$(cat "$log")
-  assert_contains "$got" "target=sess:fm-mpf-lane-m8 literal=1 arg=Firstmate instruction waiting" \
+  assert_contains "$got" "target=sess:fm-mpf-lane-m8 literal=1 arg=: Firstmate instruction waiting" \
     "exact id should ring the doorbell at the meta target"
   assert_contains "$got" "target=sess:fm-mpf-lane-m8 literal=0 arg=Enter" "exact id should submit the doorbell with Enter"
   grep -qF 'lost dispatch' "$home/state/mpf-lane-m8.inbox/001.msg" \
@@ -194,7 +194,7 @@ test_healthy_fm_id_send_still_works() {
     "$SEND" fm-lane-ok "hello captain" >/dev/null 2>"$err"; rc=$?
   expect_code 0 "$rc" "healthy fm-id send should succeed"
   got=$(cat "$log")
-  assert_contains "$got" "target=sess:fm-lane-ok literal=1 arg=Firstmate instruction waiting" \
+  assert_contains "$got" "target=sess:fm-lane-ok literal=1 arg=: Firstmate instruction waiting" \
     "healthy send should ring the doorbell at the meta target"
   assert_contains "$got" "target=sess:fm-lane-ok literal=0 arg=Enter" "healthy send should submit the doorbell with Enter"
   grep -qF 'hello captain' "$home/state/lane-ok.inbox/001.msg" \

--- a/tests/fm-spawn-dispatch-profile.test.sh
+++ b/tests/fm-spawn-dispatch-profile.test.sh
@@ -827,7 +827,7 @@ SH
       [ -x "$pane_shell" ] || continue
       pane_path=$(env -i HOME="$HOME_DIR/user-home" PATH=/usr/bin:/bin TERM=xterm \
         TMUX=synthetic-pane GOTMPDIR=/synthetic/gotmp \
-        "$pane_shell" -c 'printf %s "$PATH"') \
+        "$pane_shell" -c "printf %s \"\$PATH\"") \
         || fail "could not read $pane_shell startup PATH"
       result=$(env -i HOME="$HOME_DIR/user-home" PATH=/usr/bin:/bin TERM=xterm \
       TMUX=synthetic-pane GOTMPDIR=/synthetic/gotmp \

--- a/tests/fm-spawn-dispatch-profile.test.sh
+++ b/tests/fm-spawn-dispatch-profile.test.sh
@@ -799,7 +799,7 @@ test_active_dispatch_profile_does_not_block_secondmate_launch() {
 # fake backend records delivery, while real shells exercise the env boundary.
 # No developer environment or credential values are inspected by these probes.
 test_launch_environment_allowlist() {
-  local setting rec id out status probe result expected launch value pane_shell
+  local setting rec id out status probe result expected launch value pane_shell pane_path
   # shellcheck disable=SC2016
   value='synthetic value; $(touch SHOULD_NOT_EXIST) `false` "quoted"'
   for setting in absent missing-config enabled empty; do
@@ -825,6 +825,10 @@ SH
     launch=$(cat "$LAUNCH_LOG")
     for pane_shell in /bin/sh /bin/bash /bin/zsh; do
       [ -x "$pane_shell" ] || continue
+      pane_path=$(env -i HOME="$HOME_DIR/user-home" PATH=/usr/bin:/bin TERM=xterm \
+        TMUX=synthetic-pane GOTMPDIR=/synthetic/gotmp \
+        "$pane_shell" -c 'printf %s "$PATH"') \
+        || fail "could not read $pane_shell startup PATH"
       result=$(env -i HOME="$HOME_DIR/user-home" PATH=/usr/bin:/bin TERM=xterm \
       TMUX=synthetic-pane GOTMPDIR=/synthetic/gotmp \
       FM_TEST_AMBIENT_SENTINEL=synthetic-unrelated FM_TEST_ALLOWED="$value" FM_TEST_EMPTY='' \
@@ -834,7 +838,7 @@ SH
         enabled) expected=$(printf '%s\n' unset "$value" '' unset) ;;
         empty) expected=$(printf '%s\n' unset unset unset unset) ;;
       esac
-      expected="$expected"$'\n'"$HOME_DIR/user-home"$'\n/usr/bin:/bin\nxterm\nsynthetic-pane\n/synthetic/gotmp'
+      expected="$expected"$'\n'"$HOME_DIR/user-home"$'\n'"$pane_path"$'\nxterm\nsynthetic-pane\n/synthetic/gotmp'
       [ "$result" = "$expected" ] || fail "allowlist=$setting worker environment mismatch: $result"
     done
     pass "allowlist=$setting preserves the operational floor and filters only when opted in"

--- a/tests/fm-startup-memory-budget.test.sh
+++ b/tests/fm-startup-memory-budget.test.sh
@@ -62,6 +62,7 @@ case "$*" in
   *display-message*'#{pane_current_command}'*) printf '%s\n' codex ;;
   *display-message*'#{pane_id}'*) printf '%s\n' '%1' ;;
   *display-message*'#{cursor_y}'*) printf '%s\n' 0 ;;
+  *list-windows*) printf '%s\n' fm-sm ;;
   *capture-pane*) printf '❯\n' ;;
 esac
 exit 0
@@ -279,7 +280,7 @@ test_primary_budget_converges_with_exact_reread_and_safe_failures() {
     "budget propagation did not enqueue the pointer to its exact reread generation"
   assert_contains "$(<"$log")" "Firstmate instruction waiting: list " \
     "budget propagation did not ring the durable inbox doorbell"
-  assert_contains "$(<"$log")" "/state/sm.inbox/*.msg" \
+  assert_contains "$(<"$log")" "/state/sm.inbox'/*.msg" \
     "budget propagation doorbell did not identify the durable inbox"
 
   outside="$world/unsafe-budget"

--- a/tests/fm-task-inbox.test.sh
+++ b/tests/fm-task-inbox.test.sh
@@ -224,7 +224,8 @@ test_doorbell_rejects_terminal_controls() {
     state="$dir/${control}touch marker; # $label/state"
     mkdir -p "$state"
     rec=$(inbox_lib "$state" fm_task_inbox_write "$state" t1 "please continue")
-    doorbell= rc=0
+    doorbell=
+    rc=0
     doorbell=$(inbox_lib "$state" fm_task_inbox_doorbell_line "$rec") || rc=$?
     [ "$rc" -ne 0 ] || fail "a $label path should make doorbell construction fail"
     [ -z "$doorbell" ] || fail "a rejected $label path emitted doorbell bytes"

--- a/tests/fm-task-inbox.test.sh
+++ b/tests/fm-task-inbox.test.sh
@@ -162,9 +162,9 @@ test_write_is_durable_and_exact() {
   doorbell2=$(inbox_lib "$state" fm_task_inbox_doorbell_line "$rec2")
   [ "$doorbell" = "$doorbell2" ] \
     || fail "every record in one inbox should ring the same drain-all doorbell"
-  assert_contains "$doorbell" "$state/t1.inbox/*.msg" "doorbell should name all unhandled records"
+  assert_contains "$doorbell" "'$state/t1.inbox'/*.msg" "doorbell should quote and name all unhandled records"
   assert_contains "$doorbell" "numeric order" "doorbell should require ordered processing"
-  assert_contains "$doorbell" "$state/t1.inbox/handled/" "doorbell should name the handled dir"
+  assert_contains "$doorbell" "'$state/t1.inbox'/handled/" "doorbell should quote and name the handled dir"
   assert_contains "$doorbell" "Firstmate instruction waiting" "doorbell should be self-describing"
   case "$doorbell" in
     *$'\n'*) fail "the doorbell must be a single line" ;;
@@ -176,8 +176,9 @@ test_write_is_durable_and_exact() {
 # command line. Execute the real line in real shells and assert it is inert:
 # exit 0, no output, and nothing in the inbox touched.
 test_doorbell_is_a_shell_noop() {
-  local state rec doorbell sh out before after
-  state="$TMP_ROOT/noop/state"
+  local state rec doorbell sh out before after marker
+  state="$TMP_ROOT/noop/x; touch marker; #'s space/state"
+  marker="$state/marker"
   mkdir -p "$state"
   rec=$(inbox_lib "$state" fm_task_inbox_write "$state" t1 "please continue")
   doorbell=$(inbox_lib "$state" fm_task_inbox_doorbell_line "$rec")
@@ -185,24 +186,28 @@ test_doorbell_is_a_shell_noop() {
     ': '*) ;;
     *) fail "the doorbell must start with the shell no-op prefix, got: $doorbell" ;;
   esac
+  assert_contains "$doorbell" "'\\''s space/state/t1.inbox'" \
+    "the doorbell should escape an embedded single quote in its quoted path"
   before=$(ls -R "$state/t1.inbox")
   for sh in sh bash zsh; do
     command -v "$sh" >/dev/null 2>&1 || continue
     out=$(cd "$state" && "$sh" -c "$doorbell" 2>&1) \
-      || fail "$sh executed the doorbell with a non-zero status: $out"
-    [ -z "$out" ] || fail "$sh produced output while executing the doorbell: $out"
+      || fail "$sh executed the hostile-path doorbell with a non-zero status: $out"
+    [ -z "$out" ] || fail "$sh produced output while executing the hostile-path doorbell: $out"
+    [ ! -e "$marker" ] || fail "$sh executed shell syntax embedded in the inbox path"
   done
   # An interactive-style zsh with the line fed on stdin, the closest portable
   # stand-in for a dead pane's login shell reading typed keystrokes.
   if command -v zsh >/dev/null 2>&1; then
     out=$(cd "$state" && printf '%s\n' "$doorbell" | zsh -s 2>&1) \
-      || fail "zsh reading the doorbell from stdin failed: $out"
-    [ -z "$out" ] || fail "zsh printed while reading the doorbell: $out"
+      || fail "zsh reading the hostile-path doorbell from stdin failed: $out"
+    [ -z "$out" ] || fail "zsh printed while reading the hostile-path doorbell: $out"
+    [ ! -e "$marker" ] || fail "zsh executed shell syntax from the stdin doorbell"
   fi
   after=$(ls -R "$state/t1.inbox")
   [ "$before" = "$after" ] || fail "executing the doorbell changed the inbox:"$'\n'"$after"
   [ -f "$rec" ] || fail "executing the doorbell removed the unhandled record"
-  pass "inbox: the doorbell line executes as a no-op in a bare shell"
+  pass "inbox: a hostile-path doorbell executes as a no-op in bare shells"
 }
 
 # fm_task_inbox_ring against a backend whose agent classifies dead: nothing is
@@ -468,7 +473,7 @@ test_watcher_rerings_idle_pane_quietly() {
     sleep 0.1
     i=$((i + 1))
   done
-  grep -qF "Firstmate instruction waiting: list $state/t1.inbox/*.msg" "$log" \
+  grep -qF "Firstmate instruction waiting: list '$state/t1.inbox'/*.msg" "$log" \
     || { kill "$pid" 2>/dev/null; fail "the watcher never re-rang the doorbell:"$'\n'"$(cat "$log")"; }
   kill -0 "$pid" 2>/dev/null \
     || fail "a healthy re-ring must not wake firstmate (watcher exited):"$'\n'"$(cat "$out")"

--- a/tests/fm-task-inbox.test.sh
+++ b/tests/fm-task-inbox.test.sh
@@ -210,6 +210,36 @@ test_doorbell_is_a_shell_noop() {
   pass "inbox: a hostile-path doorbell executes as a no-op in bare shells"
 }
 
+test_doorbell_rejects_terminal_controls() {
+  local dir state rec doorbell control label log marker rc
+  dir="$TMP_ROOT/control-path"
+  marker="$dir/marker"
+  mkdir -p "$dir"
+  make_watch_stubs "$dir" >/dev/null
+  for label in etx esc; do
+    case "$label" in
+      etx) control=$'\003' ;;
+      esc) control=$'\033' ;;
+    esac
+    state="$dir/${control}touch marker; # $label/state"
+    mkdir -p "$state"
+    rec=$(inbox_lib "$state" fm_task_inbox_write "$state" t1 "please continue")
+    doorbell= rc=0
+    doorbell=$(inbox_lib "$state" fm_task_inbox_doorbell_line "$rec") || rc=$?
+    [ "$rc" -ne 0 ] || fail "a $label path should make doorbell construction fail"
+    [ -z "$doorbell" ] || fail "a rejected $label path emitted doorbell bytes"
+    log="$dir/$label.send.log"; : > "$log"
+    rc=0
+    PATH="$dir/fakebin:$PATH" FM_SEND_LOG="$log" \
+      inbox_lib "$state" fm_task_inbox_ring tmux sess:fm-t1 "$rec" fm-t1 || rc=$?
+    [ "$rc" = 2 ] || fail "a rejected $label path should return send-failed status 2, got $rc"
+    [ ! -s "$log" ] || fail "a $label path reached send-keys:"$'\n'"$(cat "$log")"
+    [ ! -e "$marker" ] || fail "a $label path executed its crafted command"
+    [ -f "$rec" ] || fail "rejecting a $label path removed the durable record"
+  done
+  pass "inbox: terminal-control paths are rejected without typing"
+}
+
 # fm_task_inbox_ring against a backend whose agent classifies dead: nothing is
 # typed and the distinct return code lets callers route to recovery. A missing
 # or unreadable endpoint still rings, so a blind classifier never starves a
@@ -635,6 +665,7 @@ test_watcher_dead_pane_escalates_once_without_ringing() {
 
 test_write_is_durable_and_exact
 test_doorbell_is_a_shell_noop
+test_doorbell_rejects_terminal_controls
 test_ring_skips_dead_agent
 test_idempotent_write_dedups_exact_body
 test_idempotent_write_follows_concurrent_ack

--- a/tests/fm-task-inbox.test.sh
+++ b/tests/fm-task-inbox.test.sh
@@ -97,7 +97,7 @@ case "${1:-}" in
       printf '╭────╮\n│    │\n╰────╯\n'
     fi
     exit 0 ;;
-  list-windows) [ -z "${FM_FAKE_TMUX_AGENT:-}" ] || printf 'fm-t1\n'; exit 0 ;;
+  list-windows) [ "${FM_FAKE_TMUX_MISSING:-0}" = 1 ] || printf 'fm-t1\n'; exit 0 ;;
 esac
 exit 0
 SH
@@ -240,9 +240,9 @@ test_doorbell_rejects_terminal_controls() {
   pass "inbox: terminal-control paths are rejected without typing"
 }
 
-# fm_task_inbox_ring against a backend whose agent classifies dead: nothing is
-# typed and the distinct return code lets callers route to recovery. A missing
-# or unreadable endpoint still rings, so a blind classifier never starves a
+# fm_task_inbox_ring against a backend whose agent classifies dead or missing:
+# nothing is typed and the distinct return code lets callers route to recovery.
+# An unreadable endpoint still rings, so a blind classifier never starves a
 # live worker.
 test_ring_skips_dead_agent() {
   local dir state rec log rc
@@ -259,6 +259,12 @@ test_ring_skips_dead_agent() {
   [ ! -s "$log" ] || fail "a dead pane was typed into:"$'\n'"$(cat "$log")"
   [ -f "$rec" ] || fail "skipping the ring must leave the durable record in place"
   rc=0
+  PATH="$dir/fakebin:$PATH" FM_SEND_LOG="$log" FM_FAKE_TMUX_MISSING=1 \
+    inbox_lib "$state" fm_task_inbox_ring tmux sess:fm-t1 "$rec" fm-t1 || rc=$?
+  [ "$rc" = 3 ] || fail "a missing endpoint should return 3 from the ring, got $rc"
+  [ ! -s "$log" ] || fail "a missing endpoint was typed into:"$'\n'"$(cat "$log")"
+  [ -f "$rec" ] || fail "skipping a missing endpoint must leave the durable record in place"
+  rc=0
   PATH="$dir/fakebin:$PATH" FM_SEND_LOG="$log" FM_FAKE_TMUX_AGENT=claude \
     inbox_lib "$state" fm_task_inbox_ring tmux sess:fm-t1 "$rec" fm-t1 || rc=$?
   [ "$rc" = 0 ] || fail "a live agent should still be rung, got $rc"
@@ -269,7 +275,7 @@ test_ring_skips_dead_agent() {
     inbox_lib "$state" fm_task_inbox_ring tmux sess:fm-t1 "$rec" fm-t1 || rc=$?
   [ "$rc" = 0 ] || fail "an endpoint the classifier cannot see should still be rung, got $rc"
   grep -qF 'Firstmate instruction waiting' "$log" || fail "an unclassifiable endpoint did not receive the doorbell"
-  pass "inbox: the ring skips a positively dead agent and still rings live or unclassifiable endpoints"
+  pass "inbox: the ring skips dead or missing endpoints and still rings live or unclassifiable endpoints"
 }
 
 test_idempotent_write_dedups_exact_body() {
@@ -663,6 +669,28 @@ test_watcher_dead_pane_escalates_once_without_ringing() {
   pass "watcher: a positively dead pane is never typed into and surfaces exactly one stale wake"
 }
 
+test_watcher_dead_pane_ignores_stale_busy_state() {
+  local dir state out log pid rec
+  dir=$(setup_watch_case dead-pane-busy)
+  state="$dir/state"; out="$dir/watch.out"; log="$dir/send.log"; : > "$log"
+  printf 'some output\nBUSYTOKEN active\n' > "$dir/busy.capture"
+  rec=$(inbox_lib "$state" fm_task_inbox_write "$state" t1 "please continue")
+  age_path "$rec"
+  watch_bg "$state" "$dir/fakebin" "$out" \
+    FM_SEND_LOG="$log" FM_FAKE_TMUX_CAPTURE="$dir/busy.capture" \
+    FM_FAKE_TMUX_AGENT=zsh FM_BUSY_REGEX=BUSYTOKEN FM_TASK_INBOX_RING_MAX=99
+  pid=$!
+  wait_watcher_gone "$pid" \
+    || { kill "$pid" 2>/dev/null; fail "stale busy state hid a dead pane's unhandled instruction"; }
+  [ ! -s "$log" ] || fail "a busy-marked dead pane was typed into:"$'\n'"$(cat "$log")"
+  [ "$(grep -cF 'unread firstmate instruction' "$state/.wake-queue" 2>/dev/null || true)" = 1 ] \
+    || fail "a busy-marked dead pane should surface exactly once:"$'\n'"$(cat "$state/.wake-queue" 2>/dev/null)"
+  [ -f "$rec" ] || fail "the durable record must survive stale busy-state recovery"
+  [ "$(cat "$state/t1.inbox/.escalated")" = "${rec##*/}" ] \
+    || fail "stale busy-state recovery should suppress repeated surfacing"
+  pass "watcher: dead-pane recovery overrides stale busy state"
+}
+
 test_write_is_durable_and_exact
 test_doorbell_is_a_shell_noop
 test_doorbell_rejects_terminal_controls
@@ -682,3 +710,4 @@ test_watcher_ack_silences_unwritable_ladder
 test_watcher_surfaces_unwritable_ladder
 test_watcher_escalates_once_after_budget
 test_watcher_dead_pane_escalates_once_without_ringing
+test_watcher_dead_pane_ignores_stale_busy_state

--- a/tests/fm-task-inbox.test.sh
+++ b/tests/fm-task-inbox.test.sh
@@ -23,6 +23,9 @@
 #      pane, stays silent on a healthy/empty inbox, surfaces unwritable ladder
 #      bookkeeping only while its record remains unhandled, and emits exactly
 #      one stale wake once the ring budget is spent.
+#   6. Dead panes: the doorbell line is a shell no-op when executed by a bare
+#      shell, the ring skips an agent the backend classifies dead, and the
+#      watcher surfaces such a record exactly once instead of re-ringing.
 set -u
 
 # shellcheck source=tests/wake-helpers.sh
@@ -50,7 +53,10 @@ inbox_lib() {  # <state> <function> [args...]
 
 # A fake tmux for the watcher cases: capture-pane replays FM_FAKE_TMUX_CAPTURE,
 # display-message yields a numeric cursor row, and every literal send-keys is
-# logged to FM_SEND_LOG so a doorbell ring is observable.
+# logged to FM_SEND_LOG so a doorbell ring is observable. With
+# FM_FAKE_TMUX_AGENT set, the inventory lists window fm-t1 and its
+# #{pane_current_command} answers with that value, so `zsh` makes
+# fm_backend_tmux_agent_state read the pane as a dead bare shell.
 make_watch_stubs() {  # <dir> -> echoes fakebin dir
   local dir=$1 fb="$1/fakebin"
   mkdir -p "$fb"
@@ -76,7 +82,13 @@ case "${1:-}" in
     fi
     exit 0 ;;
   display-message)
-    for a in "$@"; do case "$a" in *cursor_y*) printf '1\n'; exit 0 ;; esac; done
+    for a in "$@"; do
+      case "$a" in
+        *cursor_y*) printf '1\n'; exit 0 ;;
+        *pane_current_command*) [ -z "${FM_FAKE_TMUX_AGENT:-}" ] || { printf '%s\n' "$FM_FAKE_TMUX_AGENT"; exit 0; } ;;
+        *pane_tty*) [ -z "${FM_FAKE_TMUX_AGENT:-}" ] || { printf '\n'; exit 0; } ;;
+      esac
+    done
     printf 'fakepane\n'; exit 0 ;;
   capture-pane)
     if [ -n "${FM_FAKE_TMUX_CAPTURE:-}" ] && [ -f "$FM_FAKE_TMUX_CAPTURE" ]; then
@@ -85,7 +97,7 @@ case "${1:-}" in
       printf '╭────╮\n│    │\n╰────╯\n'
     fi
     exit 0 ;;
-  list-windows) exit 0 ;;
+  list-windows) [ -z "${FM_FAKE_TMUX_AGENT:-}" ] || printf 'fm-t1\n'; exit 0 ;;
 esac
 exit 0
 SH
@@ -158,6 +170,71 @@ test_write_is_durable_and_exact() {
     *$'\n'*) fail "the doorbell must be a single line" ;;
   esac
   pass "inbox: a steer is written durably and round-trips byte-exact with a self-describing doorbell"
+}
+
+# The doorbell may land in a pane whose agent has exited, where it is a shell
+# command line. Execute the real line in real shells and assert it is inert:
+# exit 0, no output, and nothing in the inbox touched.
+test_doorbell_is_a_shell_noop() {
+  local state rec doorbell sh out before after
+  state="$TMP_ROOT/noop/state"
+  mkdir -p "$state"
+  rec=$(inbox_lib "$state" fm_task_inbox_write "$state" t1 "please continue")
+  doorbell=$(inbox_lib "$state" fm_task_inbox_doorbell_line "$rec")
+  case "$doorbell" in
+    ': '*) ;;
+    *) fail "the doorbell must start with the shell no-op prefix, got: $doorbell" ;;
+  esac
+  before=$(ls -R "$state/t1.inbox")
+  for sh in sh bash zsh; do
+    command -v "$sh" >/dev/null 2>&1 || continue
+    out=$(cd "$state" && "$sh" -c "$doorbell" 2>&1) \
+      || fail "$sh executed the doorbell with a non-zero status: $out"
+    [ -z "$out" ] || fail "$sh produced output while executing the doorbell: $out"
+  done
+  # An interactive-style zsh with the line fed on stdin, the closest portable
+  # stand-in for a dead pane's login shell reading typed keystrokes.
+  if command -v zsh >/dev/null 2>&1; then
+    out=$(cd "$state" && printf '%s\n' "$doorbell" | zsh -s 2>&1) \
+      || fail "zsh reading the doorbell from stdin failed: $out"
+    [ -z "$out" ] || fail "zsh printed while reading the doorbell: $out"
+  fi
+  after=$(ls -R "$state/t1.inbox")
+  [ "$before" = "$after" ] || fail "executing the doorbell changed the inbox:"$'\n'"$after"
+  [ -f "$rec" ] || fail "executing the doorbell removed the unhandled record"
+  pass "inbox: the doorbell line executes as a no-op in a bare shell"
+}
+
+# fm_task_inbox_ring against a backend whose agent classifies dead: nothing is
+# typed and the distinct return code lets callers route to recovery. A missing
+# or unreadable endpoint still rings, so a blind classifier never starves a
+# live worker.
+test_ring_skips_dead_agent() {
+  local dir state rec log rc
+  dir="$TMP_ROOT/ring-dead"
+  state="$dir/state"
+  mkdir -p "$state"
+  make_watch_stubs "$dir" >/dev/null
+  rec=$(inbox_lib "$state" fm_task_inbox_write "$state" t1 "please continue")
+  log="$dir/send.log"; : > "$log"
+  rc=0
+  PATH="$dir/fakebin:$PATH" FM_SEND_LOG="$log" FM_FAKE_TMUX_AGENT=zsh \
+    inbox_lib "$state" fm_task_inbox_ring tmux sess:fm-t1 "$rec" fm-t1 || rc=$?
+  [ "$rc" = 3 ] || fail "a dead agent should return 3 from the ring, got $rc"
+  [ ! -s "$log" ] || fail "a dead pane was typed into:"$'\n'"$(cat "$log")"
+  [ -f "$rec" ] || fail "skipping the ring must leave the durable record in place"
+  rc=0
+  PATH="$dir/fakebin:$PATH" FM_SEND_LOG="$log" FM_FAKE_TMUX_AGENT=claude \
+    inbox_lib "$state" fm_task_inbox_ring tmux sess:fm-t1 "$rec" fm-t1 || rc=$?
+  [ "$rc" = 0 ] || fail "a live agent should still be rung, got $rc"
+  grep -qF 'Firstmate instruction waiting' "$log" || fail "a live agent did not receive the doorbell"
+  : > "$log"
+  rc=0
+  PATH="$dir/fakebin:$PATH" FM_SEND_LOG="$log" \
+    inbox_lib "$state" fm_task_inbox_ring tmux sess:fm-t1 "$rec" fm-t1 || rc=$?
+  [ "$rc" = 0 ] || fail "an endpoint the classifier cannot see should still be rung, got $rc"
+  grep -qF 'Firstmate instruction waiting' "$log" || fail "an unclassifiable endpoint did not receive the doorbell"
+  pass "inbox: the ring skips a positively dead agent and still rings live or unclassifiable endpoints"
 }
 
 test_idempotent_write_dedups_exact_body() {
@@ -522,7 +599,38 @@ test_watcher_escalates_once_after_budget() {
   pass "watcher: a spent ring budget emits exactly one ordinary stale wake for recovery"
 }
 
+test_watcher_dead_pane_escalates_once_without_ringing() {
+  local dir state out log pid rec
+  dir=$(setup_watch_case dead-pane)
+  state="$dir/state"; out="$dir/watch.out"; log="$dir/send.log"; : > "$log"
+  rec=$(inbox_lib "$state" fm_task_inbox_write "$state" t1 "please continue")
+  age_path "$rec"
+  watch_bg "$state" "$dir/fakebin" "$out" \
+    FM_SEND_LOG="$log" FM_FAKE_TMUX_CAPTURE="$(idle_capture "$dir")" \
+    FM_FAKE_TMUX_AGENT=zsh FM_TASK_INBOX_RING_MAX=99
+  pid=$!
+  wait_watcher_gone "$pid" \
+    || { kill "$pid" 2>/dev/null; fail "the watcher never surfaced a dead pane's unhandled instruction"; }
+  [ ! -s "$log" ] || fail "a dead pane was typed into:"$'\n'"$(cat "$log")"
+  [ "$(grep -cF 'unread firstmate instruction' "$state/.wake-queue" 2>/dev/null || true)" = 1 ] \
+    || fail "a dead pane should surface exactly one stale wake:"$'\n'"$(cat "$state/.wake-queue" 2>/dev/null)"
+  grep -qF "agent has exited" "$state/.wake-queue" \
+    || fail "the stale wake should say the agent has exited:"$'\n'"$(cat "$state/.wake-queue")"
+  grep -qF "$rec" "$state/.wake-queue" || fail "the stale wake should name the record path"
+  [ -f "$rec" ] || fail "the durable record must survive for recovery"
+  [ "$(cat "$state/t1.inbox/.escalated")" = "${rec##*/}" ] \
+    || fail "the escalation marker should suppress further surfacing of this record"
+  [ ! -e "$state/t1.inbox/.ring-state" ] || fail "a dead pane must not enter the re-ring ladder"
+  # The ladder is capped: nothing further is due for this record, so no later
+  # poll rings the dead pane or queues a second wake.
+  [ "$(inbox_lib "$state" fm_task_inbox_due_action "$state" t1)" = quiet ] \
+    || fail "a dead pane already surfaced must be quiet on later polls"
+  pass "watcher: a positively dead pane is never typed into and surfaces exactly one stale wake"
+}
+
 test_write_is_durable_and_exact
+test_doorbell_is_a_shell_noop
+test_ring_skips_dead_agent
 test_idempotent_write_dedups_exact_body
 test_idempotent_write_follows_concurrent_ack
 test_handled_mv_dedups_by_sequence
@@ -537,3 +645,4 @@ test_watcher_quiet_on_healthy_inbox
 test_watcher_ack_silences_unwritable_ladder
 test_watcher_surfaces_unwritable_ladder
 test_watcher_escalates_once_after_budget
+test_watcher_dead_pane_escalates_once_without_ringing

--- a/tests/secondmate-helpers.sh
+++ b/tests/secondmate-helpers.sh
@@ -31,9 +31,26 @@ case "${1:-}" in
     exit 0
     ;;
   list-windows)
-    if [ -n "${FM_FAKE_TMUX_WINDOW:-}" ]; then
-      printf '%s\n' "$FM_FAKE_TMUX_WINDOW"
-    fi
+    session=
+    prev=
+    for arg in "$@"; do
+      if [ "$prev" = -t ]; then session=$arg; break; fi
+      prev=$arg
+    done
+    while IFS= read -r recorded; do
+      [ -n "$recorded" ] || continue
+      if [ -z "$session" ]; then
+        printf '%s\n' "$recorded"
+        continue
+      fi
+      case "$recorded" in
+        "$session":*) printf '%s\n' "${recorded#*:}" ;;
+        *:*) ;;
+        *) printf '%s\n' "$recorded" ;;
+      esac
+    done <<EOF
+${FM_FAKE_TMUX_WINDOW:-}
+EOF
     exit 0
     ;;
   display-message)


### PR DESCRIPTION
## Intent

Stop the wasteful doorbells to dead panes with a simple, reliable fix in the firstmate repo. A dead worker's pane must never execute doorbell text as commands, and no dead endpoint may be re-rung forever.

## What Changed

- Make steering doorbells shell-safe no-ops, quote inbox paths, and reject paths containing terminal-control bytes.
- Skip dead or missing endpoints and escalate their durable inbox records once for recovery instead of repeatedly re-ringing them.
- Process confirmed secondmate persistence replies before applying fleet restart timeouts.

## Risk Assessment

⚠️ Medium: The fix is well-bounded and recovery is finite, but terminal delivery retains the explicitly accepted narrow agent-exit race documented at the submission boundary.

## Testing

Completed 1 recorded test check.

- Outcome: ⚠️ 1 error across 4 runs (3h0m29s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"bbda691ae0b62b14e1c366e40d4dba5ff0b24779","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed (4) ✅</summary>

- 🚨 `bin/fm-task-inbox-lib.sh:257` - The required invariant “A dead worker&#39;s pane must never execute doorbell text as commands” is still violated because the new `: ` prefix embeds `$abs` unquoted. For an allowed FM_HOME such as `/tmp/fm; touch /tmp/doorbell-ran; #`, a worker that exits after the liveness check causes the shell to parse and execute `touch`. Quote or safely encode both generated paths so arbitrary valid path bytes cannot introduce shell syntax.

🔧 Fix: Quote doorbell paths against shell injection
1 error still open:

- 🚨 `bin/fm-task-inbox-lib.sh:255` - The required invariant “A dead worker&#39;s pane must never execute doorbell text as commands” remains violated for valid paths containing terminal control bytes. Shell quoting does not neutralize the TTY line discipline: an ETX/Ctrl-C byte in `$abs` can clear the leading `: ` after `tmux send-keys -l`, leaving a crafted suffix such as `touch marker; #` to execute when Enter is sent. The existing `sh -c` regression bypasses this terminal boundary. Require explicit approval for the path policy, then encode paths into terminal-safe printable text or reject control-byte paths before constructing the doorbell.

🔧 Fix: Reject terminal-control paths before ringing
1 error still open:

- 🚨 `bin/fm-task-inbox-lib.sh:294` - The required invariant “A dead worker&#39;s pane must never execute doorbell text as commands” remains violated during an agent-to-shell transition. After the liveness check reports alive, `fm_backend_send_text_submit` delivers the line as individual terminal input and later sends Enter; if the agent consumes the prefix and exits while the remaining suffix is delivered, the shell can receive and execute a suffix such as `mv each handled file to &#39;&lt;inbox&gt;&#39;/handled/.`. With matching files in the pane&#39;s working directory, this causes real mutation. The leading `:` only protects delivery of the complete line. A durable remedy needs authorization because it requires process-bound/atomic delivery at the shared backend submission boundary or another protocol guaranteeing every partial suffix is inert.

🔧 Fix: Document accepted partial doorbell delivery race
2 errors still open:

- 🚨 `bin/fm-task-inbox-lib.sh:284` - The liveness guard skips only `dead`, although the shared backend contract also treats `missing` as authoritative recovery evidence. For a tmux window omitted from the verified session inventory, `fm_backend_agent_state` returns `missing`, after which this function continues into composer capture and submission; the tmux classifier explicitly warns that an absent named target can fall back to the active window, so an unrelated agent can receive and act on this inbox doorbell. Treat both `dead` and `missing` as non-ringable recovery states at this shared boundary.
- 🚨 `bin/fm-watch.sh:357` - The new dead-agent recovery branch is unreachable when a crashed worker leaves a trusted `busy` record behind. Concrete sequence: the agent records busy, exits abruptly to a shell without settling, then receives an inbox record; the initial ring returns 3, but every watcher poll returns here before `fm_task_inbox_ring` performs its live process check. The pane-staleness path also trusts the same busy record, so the instruction is never rung or surfaced for recovery. Check recovery-grade agent liveness before the semantic busy early-return and route a confirmed dead agent through the one-time escalation path.

🔧 Fix: Skip unavailable endpoints before busy-state handling
✅ Re-checked - no issues remain.
</details>

<details>
<summary>⚠️ **Test** - 1 error</summary>

- 🚨 tests failed with exit code 1
- `bin/fm-test-run.sh --changed --exclude-family real-herdr-gated`

🔧 Fix: Respect shell startup PATH in environment allowlist test
1 error still open:

- 🚨 tests failed with exit code 1
- `bin/fm-test-run.sh --changed --exclude-family real-herdr-gated`

🔧 Fix: Fix doorbell test fixtures for endpoint liveness
1 error still open:

- 🚨 tests failed with exit code 1
- `bin/fm-test-run.sh --changed --exclude-family real-herdr-gated`

🔧 Fix: Prioritize confirmed restarts and clean shell test syntax
1 error still open:

- 🚨 tests failed with exit code 1
- `bin/fm-test-run.sh --changed --exclude-family real-herdr-gated`
</details>

<details>
<summary>⚠️ **Document** - 1 warning</summary>

- ⚠️ `bin/fm-send.sh:1014` - The user-facing notice says the agent exited and names only a dead pane, although return code 3 also covers a missing endpoint; the remote notice at bin/fm-remote-secondmate-control.sh:289 has the same mismatch. Executable strings were outside this documentation-only phase.

🔧 Fix: Verify doorbell recovery documentation
1 warning still open:

- ⚠️ `bin/fm-send.sh:1014` - The notice still says only that the agent exited, although return code 3 also covers a missing endpoint; bin/fm-remote-secondmate-control.sh:289 has the same mismatch, but changing executable output is outside this documentation-only phase.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
