### PR TITLE
fix: accept composite Orca worktree identities

### DIFF
--- a/bin/fm-backend.sh
+++ b/bin/fm-backend.sh
@@ -388,6 +388,30 @@ fm_backend_endpoint_atom_valid() {  # <value>
   esac
 }
 
+# Orca has returned both an opaque atom and a composite <atom>::<absolute-path>
+# as its worktree identifier.
+# Keep the opaque compatibility form, but validate each half of the composite
+# independently so the generic atom boundary remains strict for every caller.
+fm_backend_orca_worktree_id_valid() {  # <value>
+  local value=$1 worktree_id worktree_path
+  case "$value" in
+    *::*::*) return 1 ;;
+    *::*)
+      worktree_id=${value%%::*}
+      worktree_path=${value#*::}
+      fm_backend_endpoint_atom_valid "$worktree_id" || return 1
+      case "$worktree_path" in
+        /*) ;;
+        *) return 1 ;;
+      esac
+      case "$worktree_path" in
+        *[!A-Za-z0-9._@%+/\ -]*) return 1 ;;
+      esac
+      ;;
+    *) fm_backend_endpoint_atom_valid "$value" ;;
+  esac
+}
+
 fm_backend_validate_task_endpoint() {  # <meta-file> <task-id>
   local meta=$1 id=$2 backend_count backend window worktree project binding_count binding
   local session pane recorded_session workspace tab terminal worktree_id surface
@@ -508,7 +532,7 @@ fm_backend_validate_task_endpoint() {  # <meta-file> <task-id>
       }
       if [ "$window" != "fm-$id" ] \
         || ! fm_backend_endpoint_atom_valid "$terminal" \
-        || ! fm_backend_endpoint_atom_valid "$worktree_id"; then
+        || ! fm_backend_orca_worktree_id_valid "$worktree_id"; then
         echo "REFUSED: Orca endpoint metadata for task $id is malformed or inconsistent; preserving task state." >&2
         return 1
       fi

--- a/bin/fm-backend.sh
+++ b/bin/fm-backend.sh
@@ -388,10 +388,9 @@ fm_backend_endpoint_atom_valid() {  # <value>
   esac
 }
 
-# Orca has returned both an opaque atom and a composite <atom>::<absolute-path>
-# as its worktree identifier.
-# Keep the opaque compatibility form, but validate each half of the composite
-# independently so the generic atom boundary remains strict for every caller.
+# Orca metadata records <atom>::<absolute-path> as one worktree identifier.
+# Spaces are valid path characters; safety depends on every consumer preserving
+# the complete value as one quoted argument.
 fm_backend_orca_worktree_id_valid() {  # <value>
   local value=$1 worktree_id worktree_path
   case "$value" in
@@ -408,7 +407,7 @@ fm_backend_orca_worktree_id_valid() {  # <value>
         *[!A-Za-z0-9._@%+/\ -]*) return 1 ;;
       esac
       ;;
-    *) fm_backend_endpoint_atom_valid "$value" ;;
+    *) return 1 ;;
   esac
 }
 

--- a/docs/orca-backend.md
+++ b/docs/orca-backend.md
@@ -36,12 +36,15 @@ The normal isolation and unlanded-work refusal rules still apply.
 backend=orca
 window=fm-<id>
 terminal=<orca terminal handle>
-orca_worktree_id=<orca worktree id>
+orca_worktree_id=<safe opaque atom>::<absolute Orca worktree path>
 worktree=<absolute Orca worktree path>
 ```
 
 `window=` remains the caller-facing Firstmate alias.
-`terminal=` and `orca_worktree_id=` are the backend authority used by operation and cleanup paths.
+`orca_worktree_id=` is one composite identity whose left half follows Firstmate's shell-safe opaque-atom grammar and whose right half is the absolute worktree path.
+Exactly one `::` separator is required; bare atoms, empty halves, relative paths, extra separators, and shell command metacharacters other than ASCII space in the path are refused before operation or cleanup dispatch.
+ASCII spaces remain valid path characters, and every consumer preserves the complete composite as one quoted argument.
+`terminal=` and the composite `orca_worktree_id=` are the backend authority used by operation and cleanup paths.
 
 ## Current lifecycle and safety
 
@@ -78,6 +81,8 @@ It never raw-deletes an Orca worktree.
 
 ```sh
 tests/fm-backend-orca.test.sh
+tests/fm-control.test.sh
+tests/fm-teardown-endpoint-safety.test.sh
 tests/fm-backend.test.sh
 tests/fm-bootstrap.test.sh
 ```

--- a/tests/fm-backend-orca.test.sh
+++ b/tests/fm-backend-orca.test.sh
@@ -522,7 +522,8 @@ test_spawn_writes_orca_metadata_and_launches_harness() {
   log="$LOG"
   printf '1\n' > "$RESP/1.exit"
   printf '{"ok":true,"result":{"repo":{"id":"repo-spawn"}}}\n' > "$RESP/2.out"
-  printf '{"ok":true,"result":{"worktree":{"id":"wt-spawn","path":"%s"},"terminal":{"handle":"term-spawn"}}}\n' "$wt" > "$RESP/3.out"
+  printf '{"ok":true,"result":{"worktree":{"id":"wt-spawn::%s","path":"%s"},"terminal":{"handle":"term-spawn"}}}\n' \
+    "$wt" "$wt" > "$RESP/3.out"
   out=$( HOME="$SPAWN_HOME" CLAUDE_CONFIG_DIR='' PATH="$FB:$PATH" FM_ORCA_LOG="$LOG" FM_ORCA_RESPONSES="$RESP" \
     FM_ROOT_OVERRIDE="$ROOT" FM_STATE_OVERRIDE="$state" FM_DATA_OVERRIDE="$data" FM_CONFIG_OVERRIDE="$config" \
     FM_PROJECTS_OVERRIDE="$TMP_ROOT/unused-projects" FM_SPAWN_NO_GUARD=1 \
@@ -533,7 +534,7 @@ test_spawn_writes_orca_metadata_and_launches_harness() {
   assert_grep "backend=orca" "$state/$id.meta" "meta missing backend=orca"
   assert_grep "window=fm-$id" "$state/$id.meta" "meta missing stable Orca window alias"
   assert_grep "terminal=term-spawn" "$state/$id.meta" "meta missing terminal handle"
-  assert_grep "orca_worktree_id=wt-spawn" "$state/$id.meta" "meta missing Orca worktree id"
+  assert_grep "orca_worktree_id=wt-spawn::$wt" "$state/$id.meta" "meta missing Orca worktree id"
   assert_grep "worktree=$wt" "$state/$id.meta" "meta missing Orca worktree path"
   assert_not_contains "$(cat "$log")" $'orca\x1f''terminal'$'\x1f''create' \
     "spawn should reuse the implicit terminal returned by Orca worktree creation"
@@ -615,7 +616,8 @@ test_spawn_refuses_orca_nonisolated_worktree() {
   orca_case bad-spawn
   printf '1\n' > "$RESP/1.exit"
   printf '{"ok":true,"result":{"repo":{"id":"repo-bad"}}}\n' > "$RESP/2.out"
-  printf '{"ok":true,"result":{"worktree":{"id":"wt-bad","path":"%s"},"terminal":{"handle":"term-bad"}}}\n' "$proj" > "$RESP/3.out"
+  printf '{"ok":true,"result":{"worktree":{"id":"wt-bad::%s","path":"%s"},"terminal":{"handle":"term-bad"}}}\n' \
+    "$proj" "$proj" > "$RESP/3.out"
   out=$( HOME="$SPAWN_HOME" CLAUDE_CONFIG_DIR='' PATH="$FB:$PATH" FM_ORCA_LOG="$LOG" FM_ORCA_RESPONSES="$RESP" \
     FM_ROOT_OVERRIDE="$ROOT" FM_STATE_OVERRIDE="$state" FM_DATA_OVERRIDE="$data" FM_CONFIG_OVERRIDE="$config" \
     FM_PROJECTS_OVERRIDE="$TMP_ROOT/unused-projects" FM_SPAWN_NO_GUARD=1 \
@@ -629,7 +631,8 @@ test_spawn_refuses_orca_nonisolated_worktree() {
     "Orca spawn should validate the worktree before creating a terminal"
   assert_contains "$(cat "$LOG")" $'orca\x1f''terminal'$'\x1f''close'$'\x1f''--terminal'$'\x1f''term-bad'$'\x1f''--json' \
     "Orca spawn should close the implicit terminal after validation aborts"
-  assert_contains "$(cat "$LOG")" $'orca\x1f''worktree'$'\x1f''rm'$'\x1f''--worktree'$'\x1f''id:wt-bad'$'\x1f''--force'$'\x1f''--json' \
+  assert_contains "$(cat "$LOG")" \
+    $'orca\x1f''worktree'$'\x1f''rm'$'\x1f''--worktree'$'\x1f''id:wt-bad::'"$proj"$'\x1f''--force'$'\x1f''--json' \
     "Orca spawn should remove the worktree after validation aborts"
   pass "fm-spawn.sh --backend orca: refuses non-isolated worktrees and closes implicit terminals"
 }
@@ -649,7 +652,8 @@ test_spawn_removes_orca_worktree_when_terminal_create_fails() {
   orca_case terminal-fail
   printf '1\n' > "$RESP/1.exit"
   printf '{"ok":true,"result":{"repo":{"id":"repo-terminal-fail"}}}\n' > "$RESP/2.out"
-  printf '{"ok":true,"result":{"worktree":{"id":"wt-terminal-fail","path":"%s"}}}\n' "$wt" > "$RESP/3.out"
+  printf '{"ok":true,"result":{"worktree":{"id":"wt-terminal-fail::%s","path":"%s"}}}\n' \
+    "$wt" "$wt" > "$RESP/3.out"
   printf '1\n' > "$RESP/4.exit"
   out=$( HOME="$SPAWN_HOME" CLAUDE_CONFIG_DIR='' PATH="$FB:$PATH" FM_ORCA_LOG="$LOG" FM_ORCA_RESPONSES="$RESP" \
     FM_ROOT_OVERRIDE="$ROOT" FM_STATE_OVERRIDE="$state" FM_DATA_OVERRIDE="$data" FM_CONFIG_OVERRIDE="$config" \
@@ -658,9 +662,11 @@ test_spawn_removes_orca_worktree_when_terminal_create_fails() {
   status=$?
   [ "$status" -ne 0 ] || fail "Orca spawn should fail when terminal creation fails"
   assert_absent "$state/$id.meta" "terminal-create abort should not record metadata after successful cleanup"
-  assert_contains "$(cat "$LOG")" $'orca\x1f''terminal'$'\x1f''create'$'\x1f''--worktree'$'\x1f''id:wt-terminal-fail'$'\x1f''--title'$'\x1f'"fm-$id"$'\x1f''--json' \
+  assert_contains "$(cat "$LOG")" \
+    $'orca\x1f''terminal'$'\x1f''create'$'\x1f''--worktree'$'\x1f''id:wt-terminal-fail::'"$wt"$'\x1f''--title'$'\x1f'"fm-$id"$'\x1f''--json' \
     "Orca spawn should attempt terminal creation before abort cleanup"
-  assert_contains "$(cat "$LOG")" $'orca\x1f''worktree'$'\x1f''rm'$'\x1f''--worktree'$'\x1f''id:wt-terminal-fail'$'\x1f''--force'$'\x1f''--json' \
+  assert_contains "$(cat "$LOG")" \
+    $'orca\x1f''worktree'$'\x1f''rm'$'\x1f''--worktree'$'\x1f''id:wt-terminal-fail::'"$wt"$'\x1f''--force'$'\x1f''--json' \
     "Orca spawn should remove the worktree when terminal creation fails"
   assert_not_contains "$(cat "$LOG")" $'orca\x1f''terminal'$'\x1f''close' \
     "Orca spawn should not close a terminal when no handle was recorded"
@@ -682,7 +688,8 @@ test_spawn_preserves_orca_metadata_when_abort_cleanup_fails() {
   orca_case cleanup-fail
   printf '1\n' > "$RESP/1.exit"
   printf '{"ok":true,"result":{"repo":{"id":"repo-cleanup-fail"}}}\n' > "$RESP/2.out"
-  printf '{"ok":true,"result":{"worktree":{"id":"wt-cleanup-fail","path":"%s"}}}\n' "$wt" > "$RESP/3.out"
+  printf '{"ok":true,"result":{"worktree":{"id":"wt-cleanup-fail::%s","path":"%s"}}}\n' \
+    "$wt" "$wt" > "$RESP/3.out"
   printf '1\n' > "$RESP/4.exit"
   printf '1\n' > "$RESP/5.exit"
   out=$( HOME="$SPAWN_HOME" CLAUDE_CONFIG_DIR='' PATH="$FB:$PATH" FM_ORCA_LOG="$LOG" FM_ORCA_RESPONSES="$RESP" \
@@ -691,12 +698,13 @@ test_spawn_preserves_orca_metadata_when_abort_cleanup_fails() {
     "$ROOT/bin/fm-spawn.sh" "$id" "$proj" claude --mode no-mistakes --yolo off --backend orca 2>&1 )
   status=$?
   [ "$status" -ne 0 ] || fail "Orca spawn should fail when terminal creation and abort cleanup fail"
-  assert_contains "$(cat "$LOG")" $'orca\x1f''worktree'$'\x1f''rm'$'\x1f''--worktree'$'\x1f''id:wt-cleanup-fail'$'\x1f''--force'$'\x1f''--json' \
+  assert_contains "$(cat "$LOG")" \
+    $'orca\x1f''worktree'$'\x1f''rm'$'\x1f''--worktree'$'\x1f''id:wt-cleanup-fail::'"$wt"$'\x1f''--force'$'\x1f''--json' \
     "Orca spawn should attempt helper cleanup before preserving metadata"
   assert_present "$state/$id.meta" "failed Orca abort cleanup should preserve metadata"
   assert_grep "window=fm-$id" "$state/$id.meta" "preserved metadata missing stable window alias"
   assert_grep "backend=orca" "$state/$id.meta" "preserved metadata missing backend=orca"
-  assert_grep "orca_worktree_id=wt-cleanup-fail" "$state/$id.meta" "preserved metadata missing Orca worktree id"
+  assert_grep "orca_worktree_id=wt-cleanup-fail::$wt" "$state/$id.meta" "preserved metadata missing Orca worktree id"
   assert_no_grep "terminal=" "$state/$id.meta" "preserved metadata should not invent a terminal handle"
   pass "fm-spawn.sh --backend orca: preserves metadata when abort cleanup fails"
 }
@@ -715,7 +723,8 @@ test_spawn_releases_orca_resources_when_metadata_write_fails() {
   orca_case meta-fail
   printf '1\n' > "$RESP/1.exit"
   printf '{"ok":true,"result":{"repo":{"id":"repo-meta-fail"}}}\n' > "$RESP/2.out"
-  printf '{"ok":true,"result":{"worktree":{"id":"wt-meta-fail","path":"%s"}}}\n' "$wt" > "$RESP/3.out"
+  printf '{"ok":true,"result":{"worktree":{"id":"wt-meta-fail::%s","path":"%s"}}}\n' \
+    "$wt" "$wt" > "$RESP/3.out"
   printf '{"ok":true,"result":{"terminal":{"handle":"term-meta-fail"}}}\n' > "$RESP/4.out"
   out=$( HOME="$SPAWN_HOME" CLAUDE_CONFIG_DIR='' PATH="$FB:$PATH" FM_ORCA_LOG="$LOG" FM_ORCA_RESPONSES="$RESP" \
     FM_ROOT_OVERRIDE="$ROOT" FM_STATE_OVERRIDE="$state" FM_DATA_OVERRIDE="$data" FM_CONFIG_OVERRIDE="$config" \
@@ -727,7 +736,8 @@ test_spawn_releases_orca_resources_when_metadata_write_fails() {
     "spawn should report metadata publication failure without relying on platform-specific mv output"
   assert_contains "$(cat "$LOG")" $'orca\x1f''terminal'$'\x1f''close'$'\x1f''--terminal'$'\x1f''term-meta-fail'$'\x1f''--json' \
     "Orca spawn should close the recorded terminal when a later abort occurs"
-  assert_contains "$(cat "$LOG")" $'orca\x1f''worktree'$'\x1f''rm'$'\x1f''--worktree'$'\x1f''id:wt-meta-fail'$'\x1f''--force'$'\x1f''--json' \
+  assert_contains "$(cat "$LOG")" \
+    $'orca\x1f''worktree'$'\x1f''rm'$'\x1f''--worktree'$'\x1f''id:wt-meta-fail::'"$wt"$'\x1f''--force'$'\x1f''--json' \
     "Orca spawn should remove the recorded worktree when a later abort occurs"
   [ ! -f "$state/$id.meta" ] || fail "metadata-write abort should not publish a regular metadata file"
   pass "fm-spawn.sh --backend orca: releases terminal and worktree on later aborts"
@@ -820,11 +830,11 @@ test_scout_teardown_removes_orca_worktree_via_helper() {
   local proj wt data state config id out rc neutral worktree_id
   id="orcateardownz3"
   proj="$TMP_ROOT/teardown-project"
-  wt="$TMP_ROOT/teardown-wt"
+  wt="$TMP_ROOT/teardown worktree"
   data="$TMP_ROOT/teardown-data"
   state="$TMP_ROOT/teardown-state"
   config="$TMP_ROOT/teardown-config"
-  worktree_id="839d4e34-8224-4ef8-a1bd-056a615b57d7::$wt"
+  worktree_id="worktree-10::$wt"
   fm_git_worktree "$proj" "$wt" "fm/$id"
   mkdir -p "$data/$id" "$state" "$config"
   printf 'report\n' > "$data/$id/report.md"
@@ -871,10 +881,11 @@ test_scout_teardown_refuses_orca_id_path_mismatch() {
   fm_write_meta "$state/$id.meta" \
     "window=fm-$id" "endpoint_task_id=$id" "terminal=term-scout-mismatch" "worktree=$wt" "project=$proj" \
     "harness=claude" "kind=scout" "mode=no-mistakes" "yolo=off" \
-    "backend=orca" "orca_worktree_id=wt-scout-mismatch" \
+    "backend=orca" "orca_worktree_id=wt-scout-mismatch::$wt" \
     "decisions_reviewed=1" "decision_keys="
   orca_case scout-mismatch
-  printf '{"ok":true,"result":{"worktree":{"id":"wt-scout-mismatch","path":"%s"}}}\n' "$other_wt" > "$RESP/1.out"
+  printf '{"ok":true,"result":{"worktree":{"id":"wt-scout-mismatch::%s","path":"%s"}}}\n' \
+    "$wt" "$other_wt" > "$RESP/1.out"
   neutral=$(neutral_fm_root "$CASE_DIR/neutral")
   set +e
   out=$( PATH="$FB:$PATH" FM_ORCA_LOG="$LOG" FM_ORCA_RESPONSES="$RESP" \
@@ -907,7 +918,7 @@ test_teardown_removes_orca_worktree_when_path_missing() {
   fm_write_meta "$state/$id.meta" \
     "window=fm-$id" "endpoint_task_id=$id" "terminal=term-missing-path" "worktree=$wt" "project=$proj" \
     "harness=claude" "kind=scout" "mode=no-mistakes" "yolo=off" \
-    "backend=orca" "orca_worktree_id=wt-missing-path" \
+    "backend=orca" "orca_worktree_id=wt-missing-path::$wt" \
     "decisions_reviewed=1" "decision_keys="
   orca_case missing-path
   neutral=$(neutral_fm_root "$CASE_DIR/neutral")
@@ -920,7 +931,8 @@ test_teardown_removes_orca_worktree_when_path_missing() {
   expect_code 0 "$rc" "Orca teardown should release helpers even when the path is absent"$'\n'"$out"
   assert_contains "$(cat "$LOG")" $'orca\x1f''terminal'$'\x1f''close'$'\x1f''--terminal'$'\x1f''term-missing-path'$'\x1f''--json' \
     "teardown did not close the recorded Orca terminal when the path was absent"
-  assert_contains "$(cat "$LOG")" $'orca\x1f''worktree'$'\x1f''rm'$'\x1f''--worktree'$'\x1f''id:wt-missing-path'$'\x1f''--force'$'\x1f''--json' \
+  assert_contains "$(cat "$LOG")" \
+    $'orca\x1f''worktree'$'\x1f''rm'$'\x1f''--worktree'$'\x1f''id:wt-missing-path::'"$wt"$'\x1f''--force'$'\x1f''--json' \
     "teardown did not remove the recorded Orca worktree when the path was absent"
   assert_absent "$state/$id.meta" "successful helper cleanup should remove task metadata"
   pass "fm-teardown.sh backend=orca: releases terminal/worktree when path is absent"
@@ -940,7 +952,7 @@ test_teardown_preserves_metadata_when_orca_remove_error_json() {
   fm_write_meta "$state/$id.meta" \
     "window=fm-$id" "endpoint_task_id=$id" "terminal=term-remove-error" "worktree=$wt" "project=$proj" \
     "harness=claude" "kind=scout" "mode=no-mistakes" "yolo=off" \
-    "backend=orca" "orca_worktree_id=wt-remove-error" \
+    "backend=orca" "orca_worktree_id=wt-remove-error::$wt" \
     "decisions_reviewed=1" "decision_keys="
   orca_case remove-error-teardown
   printf '{"ok":true,"result":{}}\n' > "$RESP/1.out"
@@ -971,7 +983,7 @@ test_scout_teardown_refuses_orca_missing_report_when_path_missing() {
   fm_write_meta "$state/$id.meta" \
     "window=fm-$id" "endpoint_task_id=$id" "terminal=term-missing-report" "worktree=$wt" "project=$proj" \
     "harness=claude" "kind=scout" "mode=no-mistakes" "yolo=off" \
-    "backend=orca" "orca_worktree_id=wt-missing-report"
+    "backend=orca" "orca_worktree_id=wt-missing-report::$wt"
   orca_case missing-report
   neutral=$(neutral_fm_root "$CASE_DIR/neutral")
   set +e
@@ -1001,7 +1013,7 @@ test_ship_teardown_refuses_orca_missing_worktree_path() {
   fm_write_meta "$state/$id.meta" \
     "window=fm-$id" "endpoint_task_id=$id" "terminal=term-missing-ship" "worktree=$wt" "project=$proj" \
     "harness=claude" "kind=ship" "mode=no-mistakes" "yolo=off" \
-    "backend=orca" "orca_worktree_id=wt-missing-ship"
+    "backend=orca" "orca_worktree_id=wt-missing-ship::$wt"
   orca_case missing-ship-path
   neutral=$(neutral_fm_root "$CASE_DIR/neutral")
   set +e
@@ -1032,9 +1044,10 @@ test_ship_teardown_removes_orca_worktree_when_id_path_matches() {
   fm_write_meta "$state/$id.meta" \
     "window=fm-$id" "endpoint_task_id=$id" "terminal=term-ship-match" "worktree=$wt" "project=$proj" \
     "harness=claude" "kind=ship" "mode=local-only" "yolo=off" \
-    "backend=orca" "orca_worktree_id=wt-ship-match"
+    "backend=orca" "orca_worktree_id=wt-ship-match::$wt"
   orca_case ship-match
-  printf '{"ok":true,"result":{"worktree":{"id":"wt-ship-match","path":"%s"}}}\n' "$wt" > "$RESP/1.out"
+  printf '{"ok":true,"result":{"worktree":{"id":"wt-ship-match::%s","path":"%s"}}}\n' \
+    "$wt" "$wt" > "$RESP/1.out"
   neutral=$(neutral_fm_root "$CASE_DIR/neutral")
   set +e
   out=$( PATH="$FB:$PATH" FM_ORCA_LOG="$LOG" FM_ORCA_RESPONSES="$RESP" \
@@ -1043,11 +1056,13 @@ test_ship_teardown_removes_orca_worktree_when_id_path_matches() {
   rc=$?
   set -e
   expect_code 0 "$rc" "Orca ship teardown should succeed when the id path matches the inspected worktree"$'\n'"$out"
-  assert_contains "$(cat "$LOG")" $'orca\x1f''worktree'$'\x1f''show'$'\x1f''--worktree'$'\x1f''id:wt-ship-match'$'\x1f''--json' \
+  assert_contains "$(cat "$LOG")" \
+    $'orca\x1f''worktree'$'\x1f''show'$'\x1f''--worktree'$'\x1f''id:wt-ship-match::'"$wt"$'\x1f''--json' \
     "teardown did not resolve the Orca worktree id before removal"
   assert_contains "$(cat "$LOG")" $'orca\x1f''terminal'$'\x1f''close'$'\x1f''--terminal'$'\x1f''term-ship-match'$'\x1f''--json' \
     "teardown did not close the matched Orca terminal"
-  assert_contains "$(cat "$LOG")" $'orca\x1f''worktree'$'\x1f''rm'$'\x1f''--worktree'$'\x1f''id:wt-ship-match'$'\x1f''--force'$'\x1f''--json' \
+  assert_contains "$(cat "$LOG")" \
+    $'orca\x1f''worktree'$'\x1f''rm'$'\x1f''--worktree'$'\x1f''id:wt-ship-match::'"$wt"$'\x1f''--force'$'\x1f''--json' \
     "teardown did not remove the matched Orca worktree"
   assert_absent "$state/$id.meta" "successful matched teardown should remove task metadata"
   pass "fm-teardown.sh backend=orca: ship teardown requires a matching Orca id path"
@@ -1067,7 +1082,7 @@ test_ship_teardown_refuses_orca_unresolvable_worktree_id() {
   fm_write_meta "$state/$id.meta" \
     "window=fm-$id" "endpoint_task_id=$id" "terminal=term-ship-unresolved" "worktree=$wt" "project=$proj" \
     "harness=claude" "kind=ship" "mode=local-only" "yolo=off" \
-    "backend=orca" "orca_worktree_id=wt-ship-unresolved"
+    "backend=orca" "orca_worktree_id=wt-ship-unresolved::$wt"
   orca_case ship-unresolved
   printf '1\n' > "$RESP/1.exit"
   neutral=$(neutral_fm_root "$CASE_DIR/neutral")
@@ -1078,9 +1093,10 @@ test_ship_teardown_refuses_orca_unresolvable_worktree_id() {
   rc=$?
   set -e
   [ "$rc" -ne 0 ] || fail "Orca ship teardown should refuse when the worktree id cannot be resolved"
-  assert_contains "$out" "cannot resolve Orca worktree id wt-ship-unresolved" \
+  assert_contains "$out" "cannot resolve Orca worktree id wt-ship-unresolved::$wt" \
     "unresolvable Orca worktree id refusal should explain the fail-closed check"
-  assert_contains "$(cat "$LOG")" $'orca\x1f''worktree'$'\x1f''show'$'\x1f''--worktree'$'\x1f''id:wt-ship-unresolved'$'\x1f''--json' \
+  assert_contains "$(cat "$LOG")" \
+    $'orca\x1f''worktree'$'\x1f''show'$'\x1f''--worktree'$'\x1f''id:wt-ship-unresolved::'"$wt"$'\x1f''--json' \
     "teardown did not attempt to resolve the Orca worktree id"
   assert_not_contains "$(cat "$LOG")" $'orca\x1f''terminal'$'\x1f''close' \
     "refused unresolved Orca ship teardown should not close terminals"
@@ -1106,9 +1122,10 @@ test_ship_teardown_refuses_orca_id_path_mismatch() {
   fm_write_meta "$state/$id.meta" \
     "window=fm-$id" "endpoint_task_id=$id" "terminal=term-ship-mismatch" "worktree=$wt" "project=$proj" \
     "harness=claude" "kind=ship" "mode=local-only" "yolo=off" \
-    "backend=orca" "orca_worktree_id=wt-ship-mismatch"
+    "backend=orca" "orca_worktree_id=wt-ship-mismatch::$wt"
   orca_case ship-mismatch
-  printf '{"ok":true,"result":{"worktree":{"id":"wt-ship-mismatch","path":"%s"}}}\n' "$other_wt" > "$RESP/1.out"
+  printf '{"ok":true,"result":{"worktree":{"id":"wt-ship-mismatch::%s","path":"%s"}}}\n' \
+    "$wt" "$other_wt" > "$RESP/1.out"
   neutral=$(neutral_fm_root "$CASE_DIR/neutral")
   set +e
   out=$( PATH="$FB:$PATH" FM_ORCA_LOG="$LOG" FM_ORCA_RESPONSES="$RESP" \
@@ -1119,7 +1136,8 @@ test_ship_teardown_refuses_orca_id_path_mismatch() {
   [ "$rc" -ne 0 ] || fail "Orca ship teardown should refuse when the id path differs from worktree="
   assert_contains "$out" "not inspected worktree" \
     "mismatched Orca worktree path refusal should name the mismatch"
-  assert_contains "$(cat "$LOG")" $'orca\x1f''worktree'$'\x1f''show'$'\x1f''--worktree'$'\x1f''id:wt-ship-mismatch'$'\x1f''--json' \
+  assert_contains "$(cat "$LOG")" \
+    $'orca\x1f''worktree'$'\x1f''show'$'\x1f''--worktree'$'\x1f''id:wt-ship-mismatch::'"$wt"$'\x1f''--json' \
     "teardown did not resolve the mismatched Orca worktree id"
   assert_not_contains "$(cat "$LOG")" $'orca\x1f''terminal'$'\x1f''close' \
     "refused mismatched Orca ship teardown should not close terminals"
@@ -1175,7 +1193,7 @@ test_teardown_refuses_orca_worktree_without_terminal_handle() {
   fm_write_meta "$state/$id.meta" \
     "window=fm-$id" "endpoint_task_id=$id" "worktree=$wt" "project=$proj" \
     "harness=claude" "kind=scout" "mode=no-mistakes" "yolo=off" \
-    "backend=orca" "orca_worktree_id=wt-no-terminal" \
+    "backend=orca" "orca_worktree_id=wt-no-terminal::$wt" \
     "decisions_reviewed=1" "decision_keys="
   orca_case no-terminal
   neutral=$(neutral_fm_root "$CASE_DIR/neutral")
@@ -1212,10 +1230,12 @@ test_secondmate_force_teardown_removes_orca_child_via_orca() {
     "window=fm-$child_id" "endpoint_task_id=$child_id" \
     "terminal=term-child-cleanup" "worktree=$childwt" "project=$childproj" \
     "harness=claude" "kind=ship" "mode=no-mistakes" "yolo=off" \
-    "backend=orca" "orca_worktree_id=wt-child-cleanup"
+    "backend=orca" "orca_worktree_id=wt-child-cleanup::$childwt"
   orca_case secondmate-child-cleanup
-  printf '{"ok":true,"result":{"worktree":{"id":"wt-child-cleanup","path":"%s"}}}\n' "$childwt" > "$RESP/1.out"
-  printf '{"ok":true,"result":{"worktree":{"id":"wt-child-cleanup","path":"%s"}}}\n' "$childwt" > "$RESP/2.out"
+  printf '{"ok":true,"result":{"worktree":{"id":"wt-child-cleanup::%s","path":"%s"}}}\n' \
+    "$childwt" "$childwt" > "$RESP/1.out"
+  printf '{"ok":true,"result":{"worktree":{"id":"wt-child-cleanup::%s","path":"%s"}}}\n' \
+    "$childwt" "$childwt" > "$RESP/2.out"
   printf '{"ok":true,"result":{}}\n' > "$RESP/3.out"
   printf '{"ok":true,"result":{}}\n' > "$RESP/4.out"
   add_tmux_fake "$FB"
@@ -1228,7 +1248,8 @@ test_secondmate_force_teardown_removes_orca_child_via_orca() {
   expect_code 0 "$rc" "forced secondmate teardown should remove Orca child work through Orca"$'\n'"$out"
   assert_contains "$(cat "$LOG")" $'orca\x1f''terminal'$'\x1f''close'$'\x1f''--terminal'$'\x1f''term-child-cleanup'$'\x1f''--json' \
     "child cleanup did not close the recorded Orca terminal"
-  assert_contains "$(cat "$LOG")" $'orca\x1f''worktree'$'\x1f''rm'$'\x1f''--worktree'$'\x1f''id:wt-child-cleanup'$'\x1f''--force'$'\x1f''--json' \
+  assert_contains "$(cat "$LOG")" \
+    $'orca\x1f''worktree'$'\x1f''rm'$'\x1f''--worktree'$'\x1f''id:wt-child-cleanup::'"$childwt"$'\x1f''--force'$'\x1f''--json' \
     "child cleanup did not remove the Orca worktree through orca worktree rm"
   assert_not_contains "$(cat "$LOG")" $'orca\x1f''terminal'$'\x1f''close'$'\x1f''--terminal'$'\x1f'"fm-$child_id" \
     "child cleanup closed the stable alias instead of the Orca terminal"
@@ -1258,9 +1279,10 @@ test_secondmate_force_teardown_refuses_orca_child_id_path_mismatch() {
     "window=fm-$child_id" "endpoint_task_id=$child_id" \
     "terminal=term-child-mismatch" "worktree=$childwt" "project=$childproj" \
     "harness=claude" "kind=ship" "mode=no-mistakes" "yolo=off" \
-    "backend=orca" "orca_worktree_id=wt-child-mismatch"
+    "backend=orca" "orca_worktree_id=wt-child-mismatch::$childwt"
   orca_case secondmate-child-mismatch
-  printf '{"ok":true,"result":{"worktree":{"id":"wt-child-mismatch","path":"%s"}}}\n' "$other_wt" > "$RESP/1.out"
+  printf '{"ok":true,"result":{"worktree":{"id":"wt-child-mismatch::%s","path":"%s"}}}\n' \
+    "$childwt" "$other_wt" > "$RESP/1.out"
   add_tmux_fake "$FB"
   neutral=$(neutral_fm_root "$CASE_DIR/neutral")
   set +e
@@ -1299,7 +1321,7 @@ test_secondmate_force_teardown_refuses_partial_orca_child() {
     "window=fm-$child_id" "endpoint_task_id=$child_id" \
     "worktree=$childwt" "project=$childproj" \
     "harness=claude" "kind=ship" "mode=no-mistakes" "yolo=off" \
-    "backend=orca" "orca_worktree_id=wt-partial-child"
+    "backend=orca" "orca_worktree_id=wt-partial-child::$childwt"
   orca_case secondmate-partial-child-cleanup
   add_tmux_fake "$FB"
   neutral=$(neutral_fm_root "$CASE_DIR/neutral")

--- a/tests/fm-backend-orca.test.sh
+++ b/tests/fm-backend-orca.test.sh
@@ -817,13 +817,14 @@ test_target_exists_rejects_orca_error_json() {
 }
 
 test_scout_teardown_removes_orca_worktree_via_helper() {
-  local proj wt data state config id out rc neutral
+  local proj wt data state config id out rc neutral worktree_id
   id="orcateardownz3"
   proj="$TMP_ROOT/teardown-project"
   wt="$TMP_ROOT/teardown-wt"
   data="$TMP_ROOT/teardown-data"
   state="$TMP_ROOT/teardown-state"
   config="$TMP_ROOT/teardown-config"
+  worktree_id="839d4e34-8224-4ef8-a1bd-056a615b57d7::$wt"
   fm_git_worktree "$proj" "$wt" "fm/$id"
   mkdir -p "$data/$id" "$state" "$config"
   printf 'report\n' > "$data/$id/report.md"
@@ -831,10 +832,11 @@ test_scout_teardown_removes_orca_worktree_via_helper() {
   fm_write_meta "$state/$id.meta" \
     "window=fm-$id" "endpoint_task_id=$id" "terminal=term-teardown" "worktree=$wt" "project=$proj" \
     "harness=claude" "kind=scout" "mode=no-mistakes" "yolo=off" \
-    "backend=orca" "orca_worktree_id=wt-teardown" \
+    "backend=orca" "orca_worktree_id=$worktree_id" \
     "decisions_reviewed=1" "decision_keys="
   orca_case teardown
-  printf '{"ok":true,"result":{"worktree":{"id":"wt-teardown","path":"%s"}}}\n' "$wt" > "$RESP/1.out"
+  printf '{"ok":true,"result":{"worktree":{"id":"%s","path":"%s"}}}\n' \
+    "$worktree_id" "$wt" > "$RESP/1.out"
   neutral=$(neutral_fm_root "$CASE_DIR/neutral")
   set +e
   out=$( PATH="$FB:$PATH" FM_ORCA_LOG="$LOG" FM_ORCA_RESPONSES="$RESP" \
@@ -845,10 +847,11 @@ test_scout_teardown_removes_orca_worktree_via_helper() {
   expect_code 0 "$rc" "Orca scout teardown should succeed once report exists"$'\n'"$out"
   assert_contains "$(cat "$LOG")" $'orca\x1f''terminal'$'\x1f''close'$'\x1f''--terminal'$'\x1f''term-teardown'$'\x1f''--json' \
     "teardown did not close the recorded Orca terminal"
-  assert_contains "$(cat "$LOG")" $'orca\x1f''worktree'$'\x1f''rm'$'\x1f''--worktree'$'\x1f''id:wt-teardown'$'\x1f''--force'$'\x1f''--json' \
+  assert_contains "$(cat "$LOG")" \
+    $'orca\x1f''worktree'$'\x1f''rm'$'\x1f''--worktree'$'\x1f'"id:$worktree_id"$'\x1f''--force'$'\x1f''--json' \
     "teardown did not remove the Orca worktree through orca worktree rm"
   assert_absent "$state/$id.meta" "teardown should remove task metadata"
-  pass "fm-teardown.sh backend=orca: scout report gate then helper-backed worktree removal"
+  pass "fm-teardown.sh backend=orca: composite worktree id passes the scout report gate and helper-backed removal"
 }
 
 test_scout_teardown_refuses_orca_id_path_mismatch() {

--- a/tests/fm-control.test.sh
+++ b/tests/fm-control.test.sh
@@ -148,6 +148,32 @@ SH
   printf '%s\n' "$fb"
 }
 
+make_orca_stub() {  # <dir>
+  local dir=$1
+  cat > "$dir/fakebin/orca" <<'SH'
+#!/usr/bin/env bash
+set -u
+printf 'orca' >> "$FM_FAKE_DIR/orca"
+printf ' <%s>' "$@" >> "$FM_FAKE_DIR/orca"
+printf '\n' >> "$FM_FAKE_DIR/orca"
+case "${1:-} ${2:-}" in
+  'status --json')
+    printf '%s\n' '{"ok":true,"result":{"runtime":{"reachable":true,"state":"ready"}}}'
+    ;;
+  'terminal send')
+    printf '%s\n' '{"ok":true,"result":{"accepted":true}}'
+    ;;
+  'terminal read')
+    printf '%s\n' '{"ok":true,"result":{"terminal":{"tail":["ready"]}}}'
+    ;;
+  *)
+    exit 1
+    ;;
+esac
+SH
+  chmod +x "$dir/fakebin/orca"
+}
+
 # new_case <name> -> echoes a case dir holding home/, fake/, and fakebin.
 new_case() {
   local dir="$TMP_ROOT/$1-$RANDOM"
@@ -399,6 +425,44 @@ test_orca_refuses_an_escape_harness_interrupt() {
   expect_code 1 "$rc" "an Escape harness on orca should refuse"
   assert_contains "$out" "cannot deliver" "refusal should name the undeliverable key"
   pass "fm-control interrupt: a backend that cannot deliver the harness's key refuses instead of sending another"
+}
+
+test_orca_composite_worktree_id_reaches_each_control_verb() {
+  local dir out rc verb id=t1 worktree_id
+  dir=$(new_case orca-composite-control)
+  add_task "$dir" "$id" grok ship orca term-composite
+  worktree_id="839d4e34-8224-4ef8-a1bd-056a615b57d7::$dir/wt-$id"
+  {
+    cat "$dir/home/state/$id.meta"
+    echo "terminal=term-composite"
+    echo "orca_worktree_id=$worktree_id"
+  } > "$dir/home/state/$id.meta.new"
+  sed "s|^window=.*|window=fm-$id|" \
+    "$dir/home/state/$id.meta.new" > "$dir/home/state/$id.meta"
+  make_orca_stub "$dir"
+  : > "$dir/fake/orca"
+
+  out=$(run_control "$dir" "$id" interrupt); rc=$?
+  expect_code 0 "$rc" "Orca interrupt should accept a composite worktree id"$'\n'"$out"
+  assert_contains "$out" "interrupt-delivered $id" \
+    "Orca interrupt did not reach its executable lifecycle path"
+  assert_contains "$(cat "$dir/fake/orca")" \
+    'orca <terminal> <send> <--terminal> <term-composite> <--interrupt> <--json>' \
+    "Orca interrupt did not target the recorded terminal"
+
+  for verb in exit relaunch; do
+    if [ "$verb" = relaunch ]; then
+      out=$(run_control "$dir" "$id" "$verb" --note preserve); rc=$?
+    else
+      out=$(run_control "$dir" "$id" "$verb"); rc=$?
+    fi
+    expect_code 1 "$rc" "Orca $verb should reach its independent state-proof refusal"$'\n'"$out"
+    assert_contains "$out" "no recovery-grade agent-state classifier" \
+      "Orca $verb did not pass composite endpoint validation"
+    assert_not_contains "$out" "malformed or inconsistent" \
+      "Orca $verb was still refused by composite endpoint validation"
+  done
+  pass "fm-control: Orca composite worktree ids reach interrupt, exit, and relaunch behavior"
 }
 
 test_unverified_state_backends_refuse_stop_verbs() {
@@ -882,6 +946,7 @@ test_prefixed_recorded_harness_reaches_each_control_verb
 test_backend_key_capability_matrix
 test_harness_kind_capability
 test_orca_refuses_an_escape_harness_interrupt
+test_orca_composite_worktree_id_reaches_each_control_verb
 test_unverified_state_backends_refuse_stop_verbs
 test_state_verified_backends_are_exactly_tmux_and_herdr
 test_window_label_is_refused_with_the_exact_id

--- a/tests/fm-control.test.sh
+++ b/tests/fm-control.test.sh
@@ -418,7 +418,7 @@ test_orca_refuses_an_escape_harness_interrupt() {
   {
     cat "$dir/home/state/t1.meta"
     echo "terminal=term-1"
-    echo "orca_worktree_id=wt-1"
+    echo "orca_worktree_id=wt-1::$dir/wt-t1"
   } > "$dir/home/state/t1.meta.new"
   sed 's|^window=.*|window=fm-t1|' "$dir/home/state/t1.meta.new" > "$dir/home/state/t1.meta"
   out=$(run_control "$dir" t1 interrupt); rc=$?
@@ -431,7 +431,7 @@ test_orca_composite_worktree_id_reaches_each_control_verb() {
   local dir out rc verb id=t1 worktree_id
   dir=$(new_case orca-composite-control)
   add_task "$dir" "$id" grok ship orca term-composite
-  worktree_id="839d4e34-8224-4ef8-a1bd-056a615b57d7::$dir/wt-$id"
+  worktree_id="worktree-10::$dir/wt $id"
   {
     cat "$dir/home/state/$id.meta"
     echo "terminal=term-composite"

--- a/tests/fm-teardown-endpoint-safety.test.sh
+++ b/tests/fm-teardown-endpoint-safety.test.sh
@@ -191,7 +191,7 @@ test_metadata_lock_serializes_destructive_cleanup() {
 }
 
 test_supported_backend_endpoint_records_validate() {
-  local dir id backend target
+  local dir id backend target worktree_id
   dir=$(make_case valid-backends)
   # shellcheck source=/dev/null
   . "$ROOT/bin/fm-backend.sh"
@@ -220,18 +220,12 @@ test_supported_backend_endpoint_records_validate() {
     "backend=zellij" "zellij_session=lab" "zellij_tab_id=3" "zellij_pane_id=7"
   fm_backend_validate_task_endpoint "$dir/home/state/$id.meta" "$id" || fail "valid Zellij endpoint refused"
 
-  id=orca-task
-  fm_write_meta "$dir/home/state/$id.meta" \
-    "window=fm-$id" "endpoint_task_id=$id" "terminal=term-7" \
-    "worktree=$dir/worktree" "project=$dir/project" "backend=orca" "orca_worktree_id=worktree-9"
-  fm_backend_validate_task_endpoint "$dir/home/state/$id.meta" "$id" || fail "valid Orca endpoint refused"
-  [ "$FM_BACKEND_VALIDATED_TARGET" = term-7 ] || fail "Orca validation did not select its terminal"
-
   id=orca-composite-task
+  worktree_id="worktree-10::$dir/work tree"
   fm_write_meta "$dir/home/state/$id.meta" \
     "window=fm-$id" "endpoint_task_id=$id" "terminal=term-8" \
-    "worktree=$dir/worktree" "project=$dir/project" "backend=orca" \
-    "orca_worktree_id=worktree-10::$dir/worktree"
+    "worktree=$dir/work tree" "project=$dir/project" "backend=orca" \
+    "orca_worktree_id=$worktree_id"
   fm_backend_validate_task_endpoint "$dir/home/state/$id.meta" "$id" \
     || fail "valid composite Orca endpoint refused"
   [ "$FM_BACKEND_VALIDATED_TARGET" = term-8 ] \
@@ -276,6 +270,7 @@ test_invalid_orca_composite_worktree_ids_refuse_before_mutation() {
   assert_invalid_orca_worktree_id_refused empty-path 'worktree-1::'
   assert_invalid_orca_worktree_id_refused relative-path \
     'worktree-1::relative/worktree'
+  assert_invalid_orca_worktree_id_refused bare-atom 'worktree-9'
   pass "fm-teardown: malformed and hostile Orca composite worktree ids refuse before mutation"
 }
 

--- a/tests/fm-teardown-endpoint-safety.test.sh
+++ b/tests/fm-teardown-endpoint-safety.test.sh
@@ -227,6 +227,16 @@ test_supported_backend_endpoint_records_validate() {
   fm_backend_validate_task_endpoint "$dir/home/state/$id.meta" "$id" || fail "valid Orca endpoint refused"
   [ "$FM_BACKEND_VALIDATED_TARGET" = term-7 ] || fail "Orca validation did not select its terminal"
 
+  id=orca-composite-task
+  fm_write_meta "$dir/home/state/$id.meta" \
+    "window=fm-$id" "endpoint_task_id=$id" "terminal=term-8" \
+    "worktree=$dir/worktree" "project=$dir/project" "backend=orca" \
+    "orca_worktree_id=worktree-10::$dir/worktree"
+  fm_backend_validate_task_endpoint "$dir/home/state/$id.meta" "$id" \
+    || fail "valid composite Orca endpoint refused"
+  [ "$FM_BACKEND_VALIDATED_TARGET" = term-8 ] \
+    || fail "composite Orca validation did not select its terminal"
+
   id=cmux-task
   fm_write_meta "$dir/home/state/$id.meta" \
     "window=workspace-1:surface-2" "endpoint_task_id=$id" "worktree=$dir/worktree" "project=$dir/project" \
@@ -241,6 +251,49 @@ test_supported_backend_endpoint_records_validate() {
     [ "$target" -ne 0 ] || fail "$backend generic kill accepted an empty target"
   done
   pass "cleanup identity: valid tmux, Herdr, Zellij, Orca, and cmux records validate while every empty backend target refuses"
+}
+
+assert_invalid_orca_worktree_id_refused() {  # <name> <worktree-id>
+  local name=$1 worktree_id=$2 dir id=orca-invalid
+  dir=$(make_case "orca-$name")
+  fm_write_meta "$dir/home/state/$id.meta" \
+    "window=fm-$id" "endpoint_task_id=$id" "terminal=term-invalid" \
+    "worktree=$dir/worktree" "project=$dir/project" "backend=orca" \
+    "orca_worktree_id=$worktree_id"
+  assert_refused_without_mutation "$dir" "$id" "invalid Orca worktree id $name"
+  assert_contains "$(cat "$dir/stderr")" "Orca endpoint metadata" \
+    "invalid Orca worktree id $name did not reach the endpoint-identity refusal"
+}
+
+test_invalid_orca_composite_worktree_ids_refuse_before_mutation() {
+  assert_invalid_orca_worktree_id_refused left-metachar \
+    'worktree;touch-bad::/safe/worktree'
+  assert_invalid_orca_worktree_id_refused path-metachar \
+    'worktree-1::/safe/worktree;touch-bad'
+  assert_invalid_orca_worktree_id_refused extra-separator \
+    'worktree-1::/safe/worktree::/extra'
+  assert_invalid_orca_worktree_id_refused empty-id '::/safe/worktree'
+  assert_invalid_orca_worktree_id_refused empty-path 'worktree-1::'
+  assert_invalid_orca_worktree_id_refused relative-path \
+    'worktree-1::relative/worktree'
+  pass "fm-teardown: malformed and hostile Orca composite worktree ids refuse before mutation"
+}
+
+test_endpoint_atom_safety_boundary_is_unchanged() {
+  local value
+  # shellcheck source=/dev/null
+  . "$ROOT/bin/fm-backend.sh"
+  for value in atom-1 atom_2 atom.3 'atom@4' 'atom%5' 'atom+6'; do
+    fm_backend_endpoint_atom_valid "$value" \
+      || fail "endpoint atom validator refused unchanged safe input '$value'"
+  done
+  for value in 'atom:value' '/absolute/path' 'two words' \
+      'atom&touch-bad' 'atom;touch-bad'; do
+    if fm_backend_endpoint_atom_valid "$value"; then
+      fail "endpoint atom validator accepted unchanged unsafe input '$value'"
+    fi
+  done
+  pass "fm_backend_endpoint_atom_valid: the single-atom shell-safety boundary is unchanged"
 }
 
 test_tmux_empty_target_refuses_without_invocation() {
@@ -369,6 +422,8 @@ test_invalid_endpoint_records_refuse_before_mutation
 test_control_lock_contention_refuses_before_mutation
 test_metadata_lock_serializes_destructive_cleanup
 test_supported_backend_endpoint_records_validate
+test_invalid_orca_composite_worktree_ids_refuse_before_mutation
+test_endpoint_atom_safety_boundary_is_unchanged
 test_tmux_empty_target_refuses_without_invocation
 test_recorded_process_identity_cleanup_is_exact
 test_isolated_tmux_invalid_and_valid_cleanup


### PR DESCRIPTION
## Intent

Fix the Orca endpoint-identity mismatch that makes Orca-backed tasks impossible to control or tear down. Existing metadata stores orca_worktree_id as exactly one composite value of the form safe-opaque-atom::absolute-worktree-path; validate that composite with its own strict grammar rather than widening fm_backend_endpoint_atom_valid, so all existing consumers continue receiving the form they expect and all already-recorded live composite values remain backward compatible. The left half is intentionally any value accepted by the existing shell-safe atom validator, not a UUID-only contract, because vendor identifier spelling is not stable. Accept the composite form only; there are 15 current records in this home, all composite and zero bare, so do not accept a speculative bare-atom fallback. ASCII space is intentionally allowed in the absolute path because valid macOS paths may contain spaces; safety depends on every consumer preserving the complete composite as one quoted argument. The consumer audit confirmed validation uses quoted values, spawn quotes the value into terminal create, removal, and metadata, teardown quotes it through worktree-path and removal dispatch, dispatch preserves boundaries with "$@", and the Orca adapter passes "id:$worktree_id" as one quoted argument. Control interrupt, exit, relaunch, and teardown endpoint validation must accept valid composite values, including a spaced absolute path. Reject shell command metacharacters other than valid path spaces, more than one :: separator, either empty half, a relative path, and a bare atom. Demonstrate that fm_backend_endpoint_atom_valid still rejects the same unsafe inputs for its other atom callers. Find and preserve every consumer. Extend existing colocated test runners and exercise executable behavior rather than asserting implementation source bytes. Run bin/fm-lint.sh. Confirm only through validator logic that the real occ-flow-next-master-planning recorded composite endpoint is accepted; do not interrupt, exit, relaunch, teardown, alter its metadata, or touch its worktree or uncommitted planning work. Do not touch any other task metadata, worktree, or process; the Orca CLI or configuration; abort-recovery survivor publication; or any OMP work. Update docs/verification/runtime-backends.md only if the Orca truth it owns changed, with dated versioned exact evidence. Follow firstmate coding guidelines, one-owner placement, one sentence per Markdown line, plain dashes, no agent co-author. Deliver through the full no-mistakes pipeline to an open PR with green checks as soon as gates honestly permit. Do not merge. Never use --yes. Escalate any ask-user finding to Firstmate without answering it.

## What Changed

- Add a strict Orca-specific validator for `<safe-atom>::<absolute-path>` worktree identities, including paths with ASCII spaces, without widening the shared endpoint-atom grammar.
- Reject bare IDs, empty halves, extra separators, relative paths, and unsafe metacharacters before control or teardown dispatch.
- Extend executable Orca regressions across spawn, cleanup, control, and teardown flows, and document the composite metadata contract and verification entry points.

## Risk Assessment

✅ Low: Captain, the change is narrowly bounded, satisfies the composite-only Orca identity contract, preserves quoted argument boundaries across all consumers, and introduces no substantiated source defect or unnecessary component.

## Testing

The configured changed-test baseline was already successful; all three changed behavior suites then passed independently, and sandboxed CLI evidence demonstrated control, teardown, quoted single-argument forwarding, fail-before-mutation rejection, the unchanged generic validator, and validator-only compatibility with the real planning record. The worktree remains clean, temporary fixtures were removed, and the reviewer-visible transcript was saved as evidence.

<details>
<summary>Evidence: Orca composite endpoint end-to-end CLI transcript</summary>

Source: [Orca composite endpoint end-to-end CLI transcript](https://github.com/Lakescape/firstmate/blob/b278e43db50a021d4cc386ffeb8889cec7bae7f9/.no-mistakes/evidence/fm/fm-orca-teardown-composite-worktree-id/orca-composite-endpoint-e2e.txt)

```text
=== End-user control path: composite ID with a spaced absolute path ===
recorded_worktree_id=<vendor+opaque::/private/var/folders/k7/pv977h6550z7pncjygnj7xn80000gn/T/orca-composite-evidence.Mukqmr/work tree>
$ bin/fm-control.sh orca-e2e interrupt
interrupt-delivered orca-e2e harness=grok backend=orca verified=endpoint cancel=unconfirmed
exit_code=0
Orca argv observed:
orca argc=6 argv[1]=<terminal> argv[2]=<send> argv[3]=<--terminal> argv[4]=<term-e2e> argv[5]=<--interrupt> argv[6]=<--json>
orca argc=7 argv[1]=<terminal> argv[2]=<read> argv[3]=<--terminal> argv[4]=<term-e2e> argv[5]=<--limit> argv[6]=<1> argv[7]=<--json>

=== End-user teardown path: same complete composite reaches Orca as one argument ===
$ bin/fm-teardown.sh orca-e2e
teardown orca-e2e complete (window term-e2e, worktree /private/var/folders/k7/pv977h6550z7pncjygnj7xn80000gn/T/orca-composite-evidence.Mukqmr/work tree)
Backlog: orca-e2e just finished (this home keeps no backlog at /private/var/folders/k7/pv977h6550z7pncjygnj7xn80000gn/T/orca-composite-evidence.Mukqmr/home/data/backlog.md). Update /private/var/folders/k7/pv977h6550z7pncjygnj7xn80000gn/T/orca-composite-evidence.Mukqmr/home/data/backlog.md - move orca-e2e to Done, keep Done to the 10 most recent, then re-scan Queued and dispatch only work whose blockers are gone and date is due.
exit_code=0
Orca argv observed:
orca argc=5 argv[1]=<worktree> argv[2]=<show> argv[3]=<--worktree> argv[4]=<id:vendor+opaque::/private/var/folders/k7/pv977h6550z7pncjygnj7xn80000gn/T/orca-composite-evidence.Mukqmr/work tree> argv[5]=<--json>
orca argc=5 argv[1]=<terminal> argv[2]=<close> argv[3]=<--terminal> argv[4]=<term-e2e> argv[5]=<--json>
orca argc=6 argv[1]=<worktree> argv[2]=<rm> argv[3]=<--worktree> argv[4]=<id:vendor+opaque::/private/var/folders/k7/pv977h6550z7pncjygnj7xn80000gn/T/orca-composite-evidence.Mukqmr/work tree> argv[5]=<--force> argv[6]=<--json>
metadata_after=removed

=== Hostile metadata: refusal happens before runtime or state mutation ===
$ bin/fm-teardown.sh orca-hostile
REFUSED: Orca endpoint metadata for task orca-hostile is malformed or inconsistent; preserving task state.
exit_code=1
metadata_after=present sentinel_after=present orca_calls=0

=== Composite grammar matrix through executable validator logic ===
valid-spaced-path      expected=ACCEPT actual=ACCEPT value=<vendor+opaque::/Volumes/Work Tree/task-1>
bare-atom              expected=REJECT actual=REJECT value=<vendor+opaque>
empty-left             expected=REJECT actual=REJECT value=<::/safe/worktree>
empty-right            expected=REJECT actual=REJECT value=<vendor+opaque::>
relative-path          expected=REJECT actual=REJECT value=<vendor+opaque::relative/worktree>
two-separators         expected=REJECT actual=REJECT value=<vendor+opaque::/safe::/extra>
left-semicolon         expected=REJECT actual=REJECT value=<vendor;bad::/safe/worktree>
path-semicolon         expected=REJECT actual=REJECT value=<vendor+opaque::/safe/worktree;bad>
path-ampersand         expected=REJECT actual=REJECT value=<vendor+opaque::/safe/worktree&bad>
path-pipe              expected=REJECT actual=REJECT value=<vendor+opaque::/safe/worktree|bad>
path-dollar            expected=REJECT actual=REJECT value=<vendor+opaque::/safe/$HOME>
path-backtick          expected=REJECT actual=REJECT value=<vendor+opaque::/safe/`id`>
path-newline           expected=REJECT actual=REJECT value=<vendor+opaque::/safe/worktree
next>

=== Generic atom validator remains narrow for non-Orca callers ===
atom-safe              expected=ACCEPT actual=ACCEPT value=<atom_2+ok@vendor%3>
atom-space             expected=REJECT actual=REJECT value=<two words>
atom-colon             expected=REJECT actual=REJECT value=<atom:value>
atom-path              expected=REJECT actual=REJECT value=</absolute/path>
atom-semicolon         expected=REJECT actual=REJECT value=<atom;bad>

=== Existing live record: validator-only compatibility check ===
real_record=accepted backend=orca runtime_actions=0
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"a59aebc6c26b7e20f196ba4b729bea7850dfe7ca","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `bin/fm-test-run.sh --changed --exclude-family real-herdr-gated`
- <code>Configured baseline supplied as successful: `bin/fm-test-run.sh --changed --exclude-family real-herdr-gated`</code>
- `tests/fm-teardown-endpoint-safety.test.sh`
- `tests/fm-control.test.sh`
- `tests/fm-backend-orca.test.sh`
- <code>Sandboxed end-user check: `bin/fm-control.sh orca-e2e interrupt` accepted composite metadata containing a spaced absolute path and reached the recorded Orca terminal</code>
- <code>Sandboxed end-user check: `bin/fm-teardown.sh orca-e2e` passed the complete composite to Orca as one `id:&lt;atom&gt;::&lt;path&gt;` argument and removed the fixture metadata</code>
- `Sandboxed hostile-metadata teardown preserved metadata and its sentinel while making zero Orca calls`
- `Executable validator matrix covered a valid spaced path, bare atom, empty halves, relative path, multiple separators, newline, and shell metacharacters; it also checked the unchanged generic atom boundary`
- <code>Validator-only check: `fm_backend_validate_task_endpoint ~/firstmate/state/occ-flow-next-master-planning.meta occ-flow-next-master-planning` accepted the real record as Orca without invoking a runtime action</code>
- <code>Verified evidence integrity and cleanup with `shasum -a 256`, clean `git status`, no surviving focused-test processes, and no surviving `orca-composite-evidence.*` temporary directory</code>
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
