### PR TITLE
fix(bin): verify pool-slot ownership before teardown

### DIFF
--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -805,6 +805,8 @@ SPAWN_META_PUBLISH_STARTED=0
 SPAWN_FRESH_COMMIT_PENDING=0
 SPAWN_TASK_SET_LOCK=
 SPAWN_TASK_SET_LOCK_HELD=0
+SPAWN_TREEHOUSE_PROJECT_LOCK=
+SPAWN_TREEHOUSE_PROJECT_LOCK_HELD=0
 RELAUNCH_REPLACEMENT_PENDING=0
 RELAUNCH_REPLACEMENT_BUSY_GEN=
 RELAUNCH_REPLACEMENT_HARNESS=
@@ -935,6 +937,10 @@ spawn_abort_cleanup() {
   if [ "$SPAWN_META_LOCK_HELD" = 1 ]; then
     SPAWN_META_LOCK_HELD=0
     fm_lock_release "$SPAWN_META_LOCK" || true
+  fi
+  if [ "$SPAWN_TREEHOUSE_PROJECT_LOCK_HELD" = 1 ]; then
+    SPAWN_TREEHOUSE_PROJECT_LOCK_HELD=0
+    fm_lock_release "$SPAWN_TREEHOUSE_PROJECT_LOCK" || true
   fi
   if [ "$SPAWN_TASK_SET_LOCK_HELD" = 1 ]; then
     SPAWN_TASK_SET_LOCK_HELD=0
@@ -2016,6 +2022,17 @@ else
   PROJ_ABS="$(cd "$(resolve_project_dir_arg "$PROJ")" && pwd)"
   WT=""
   BRIEF="$DATA/$ID/brief.md"
+fi
+if [ "$RELAUNCH" -eq 0 ] && [ "$KIND" != secondmate ] && [ "$BACKEND" != orca ]; then
+  SPAWN_TREEHOUSE_PROJECT_LOCK=$(fm_treehouse_project_lock_path "$PROJ_ABS") || {
+    echo "error: could not resolve the shared Treehouse project lock for $PROJ_ABS" >&2
+    exit 1
+  }
+  if ! fm_lock_try_acquire "$SPAWN_TREEHOUSE_PROJECT_LOCK"; then
+    echo "error: another Treehouse slot allocation or return is in progress for $PROJ_ABS; refusing to race it" >&2
+    exit 1
+  fi
+  SPAWN_TREEHOUSE_PROJECT_LOCK_HELD=1
 fi
 [ -f "$BRIEF" ] || { echo "error: task $ID has no brief at inaccessible data path $BRIEF" >&2; exit 1; }
 if [ "$KIND" = ship ] || [ "$KIND" = scout ]; then
@@ -3383,6 +3400,10 @@ fi
 # still being delivered, cannot observe or complete a fresh provisional record
 # between its state check and `tasks-axi start`, and a delivery failure cannot
 # follow a committed In-flight transition.
+if [ "$SPAWN_TREEHOUSE_PROJECT_LOCK_HELD" = 1 ]; then
+  SPAWN_TREEHOUSE_PROJECT_LOCK_HELD=0
+  fm_lock_release "$SPAWN_TREEHOUSE_PROJECT_LOCK"
+fi
 if [ "$SPAWN_TASK_SET_LOCK_HELD" = 1 ]; then
   # The record is published, so this task is now part of the set a teardown
   # enumerates and locks per task. The set lock is only needed across that

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -105,6 +105,11 @@
 #   even when they select different backends. A fresh spawn first takes the
 #   per-home task-set lock and refuses rather than waits when forced teardown owns
 #   it; relaunch is exempt because the existing task's control lock covers it.
+#   A fresh Treehouse-backed spawn also takes the shared lock in the project's
+#   git common directory before slot allocation and holds it through task metadata
+#   publication. Teardown holds that same lock while proving and returning a slot,
+#   so allocation cannot reuse a slot across an unpublished ownership record;
+#   contention refuses rather than waits.
 #   With no harness arg, a crewmate/scout spawn resolves the CREW harness only when
 #   config/crew-dispatch.json is absent. When that file exists, crewmate/scout
 #   spawns require an explicit harness so firstmate cannot silently skip dispatch

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -64,16 +64,21 @@
 # name a slot a DIFFERENT live task now holds. Cleanup kills every process under
 # that path and hard-resets it before returning it, so releasing a slot that is
 # not genuinely this task's destroys another worker's live work. Before the first
-# cleanup step, teardown proves the slot is this task's on two independent
-# records, and refuses with both tasks and the slot untouched when either
-# contradicts:
-#   1. Record exclusivity - no OTHER task record in this home may name the same
-#      live path in its worktree= or home=. One live path with two task records
-#      is the reuse collision itself, whichever record is stale.
+# cleanup step, teardown evaluates two independent ownership sources and refuses
+# with both tasks and the slot untouched when either contradicts:
+#   1. Record exclusivity - no OTHER task record in this home or any Firstmate
+#      home discoverable as a linked worktree of the same project may name the
+#      same live path in its worktree= or home=. One live path with two task
+#      records is the reuse collision itself, whichever record is stale.
 #   2. Endpoint agreement - when the recorded endpoint answers with a live
 #      working directory, it must resolve inside the recorded slot. A pane that
 #      has been rebound to another slot contradicts the record even when this
 #      home holds only one task record for the path.
+# The scan and destructive return hold a lock in the project's git common
+# directory. Fresh Treehouse spawns for that project hold the same lock from
+# before slot allocation through metadata publication, closing the publication
+# gap; forced secondmate teardown takes it and runs the same checks for every
+# descendant Treehouse slot before touching any child.
 # Neither refusal is relaxed by --force: --force authorizes discarding THIS
 # task's unlanded work, never another task's live work. Reconcile whichever
 # record is wrong and re-run; both refusals name the inspection command.

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -283,6 +283,11 @@ if [ "$FORCE" = --force ] && [ "$(fm_lease_actor)" = branch ]; then
   exit "$FM_LEASE_REFUSE_EXIT"
 fi
 fm_lease_guard "$ID" "teardown (fm-teardown)"
+TASK_SET_LOCK=$(fm_task_set_lock_path "$STATE") || {
+  echo "error: could not resolve the task-set lock for $STATE" >&2
+  exit 1
+}
+TASK_SET_LOCK_HELD=0
 CONTROL_LOCK="$STATE/.control-$ID.lock"
 CONTROL_LOCK_HELD=0
 META_LOCK=
@@ -321,10 +326,19 @@ teardown_release_locks() {
     fm_lock_release "$CONTROL_LOCK" || true
     CONTROL_LOCK_HELD=0
   fi
+  if [ "$TASK_SET_LOCK_HELD" = 1 ]; then
+    fm_lock_release "$TASK_SET_LOCK" || true
+    TASK_SET_LOCK_HELD=0
+  fi
   fm_lease_guard_release || true
   return "$status"
 }
 trap teardown_release_locks EXIT
+fm_lock_try_acquire "$TASK_SET_LOCK" || {
+  echo "error: this home's task set is locked by another operation; nothing was changed" >&2
+  exit 1
+}
+TASK_SET_LOCK_HELD=1
 fm_lock_try_acquire "$CONTROL_LOCK" || {
   echo "error: another lifecycle action is already running for task $ID; nothing was changed" >&2
   exit 1

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -316,6 +316,7 @@ DESCENDANT_TASK_STATES=()
 DESCENDANT_TASK_IDS=()
 DESCENDANT_TASK_KINDS=()
 DESCENDANT_TASK_HOMES=()
+DESCENDANT_TREEHOUSE_LOCK_PATHS=()
 teardown_release_locks() {
   local status=$? i
   if declare -F teardown_release_herdr_locks >/dev/null 2>&1; then
@@ -2051,15 +2052,16 @@ teardown_live_slot_path() {
 
 # See "Worktree-slot ownership" in the header. Check 1: task records in every
 # home sharing this Treehouse project must not name the same live slot twice.
-require_exclusive_task_worktree_slot() {
+require_exclusive_worktree_slot_record() {
+  local record_meta=$1 record_id=$2 record_state=$3 project=$4 worktree=$5
   local slot listing line state_dir known other other_id field other_path other_slot
   local -a states
-  slot=$(teardown_live_slot_path) || return 0
-  listing=$(git -C "$PROJ" -c core.quotePath=false worktree list --porcelain 2>/dev/null) || {
-    echo "REFUSED: cannot enumerate the homes sharing Treehouse project $PROJ; nothing was changed" >&2
+  slot=$(canonical_existing_dir "$worktree") || return 0
+  listing=$(git -C "$project" -c core.quotePath=false worktree list --porcelain 2>/dev/null) || {
+    echo "REFUSED: cannot enumerate the homes sharing Treehouse project $project; nothing was changed" >&2
     return 1
   }
-  states=("$STATE")
+  states=("$record_state")
   while IFS= read -r line; do
     case "$line" in
       worktree\ *)
@@ -2075,53 +2077,66 @@ require_exclusive_task_worktree_slot() {
   for state_dir in "${states[@]}"; do
     for other in "$state_dir"/*.meta; do
       [ -f "$other" ] && [ ! -L "$other" ] || continue
-      [ "$other" != "$META" ] || continue
+      [ "$other" != "$record_meta" ] || continue
       other_id=$(basename "$other" .meta)
       for field in worktree home; do
         other_path=$(fm_meta_get "$other" "$field")
         [ -n "$other_path" ] || continue
         other_slot=$(canonical_existing_dir "$other_path") || continue
         [ "$other_slot" = "$slot" ] || continue
-        echo "REFUSED: task $ID's recorded worktree $slot is also task $other_id's recorded $field." >&2
+        echo "REFUSED: task $record_id's recorded worktree $slot is also task $other_id's recorded $field." >&2
         echo "Returning that pool slot would kill $other_id's processes and reset its copy, so nothing was changed - not even with --force." >&2
-        echo "Reconcile whichever record is wrong (bin/fm-crew-state.sh $ID; bin/fm-crew-state.sh $other_id), then re-run teardown." >&2
+        echo "Reconcile whichever record is wrong (bin/fm-crew-state.sh $record_id; bin/fm-crew-state.sh $other_id), then re-run teardown." >&2
         return 1
       done
     done
   done
 }
 
+require_exclusive_task_worktree_slot() {
+  local slot
+  slot=$(teardown_live_slot_path) || return 0
+  require_exclusive_worktree_slot_record "$META" "$ID" "$STATE" "$PROJ" "$slot"
+}
+
 # The live working directory the recorded endpoint reports, for the backends
 # whose read tracks the running process. Empty output (including from every
 # other backend) means "no evidence", never "contradicts".
 teardown_endpoint_live_path() {
-  case "$BACKEND" in
+  local backend=$1 target=$2
+  case "$backend" in
     tmux)
       fm_backend_source tmux >/dev/null 2>&1 || return 0
-      fm_backend_tmux_current_path "$T" 2>/dev/null || true
+      fm_backend_tmux_current_path "$target" 2>/dev/null || true
       ;;
     herdr)
       fm_backend_source herdr >/dev/null 2>&1 || return 0
-      fm_backend_herdr_current_path "$T" 2>/dev/null || true
+      fm_backend_herdr_current_path "$target" 2>/dev/null || true
       ;;
   esac
 }
 
 # See "Worktree-slot ownership" in the header. Check 2: a readable endpoint
 # working directory must resolve inside the recorded slot.
-require_task_endpoint_slot_agreement() {
-  local slot seen seen_path
-  slot=$(teardown_live_slot_path) || return 0
-  seen=$(teardown_endpoint_live_path)
+require_endpoint_slot_agreement() {
+  local task_id=$1 backend=$2 target=$3 worktree=$4 slot seen seen_path
+  slot=$(canonical_existing_dir "$worktree") || return 0
+  seen=$(teardown_endpoint_live_path "$backend" "$target")
   [ -n "$seen" ] || return 0
   seen_path=$(canonical_existing_dir "$seen") || return 0
   case "$seen_path" in
     "$slot"|"$slot"/*) return 0 ;;
   esac
-  echo "REFUSED: task $ID's endpoint $T is working in $seen_path, outside its recorded worktree $slot." >&2
+  echo "REFUSED: task $task_id's endpoint $target is working in $seen_path, outside its recorded worktree $slot." >&2
   echo "The recorded copy may already belong to another task, so nothing was changed - not even with --force." >&2
-  echo "Reconcile the endpoint against the record (bin/fm-crew-state.sh $ID), then re-run teardown: either the record names the wrong copy, or that endpoint is no longer this task's." >&2
+  echo "Reconcile the endpoint against the record (bin/fm-crew-state.sh $task_id), then re-run teardown: either the record names the wrong copy, or that endpoint is no longer this task's." >&2
   return 1
+}
+
+require_task_endpoint_slot_agreement() {
+  local slot
+  slot=$(teardown_live_slot_path) || return 0
+  require_endpoint_slot_agreement "$ID" "$BACKEND" "$T" "$slot"
 }
 
 firstmate_home_has_treehouse_slot() {
@@ -2540,6 +2555,7 @@ preflight_descendant_task_locks() {
   DESCENDANT_TASK_IDS=()
   DESCENDANT_TASK_KINDS=()
   DESCENDANT_TASK_HOMES=()
+  DESCENDANT_TREEHOUSE_LOCK_PATHS=()
   collect_descendant_task_locks "$home" || return 1
   # Acquisition order, which every other holder of these locks must match so
   # they cannot cycle: each home's task-set lock first (parent home before child
@@ -2586,6 +2602,55 @@ preflight_descendant_task_locks() {
         return 1
       }
     fi
+  done
+}
+
+preflight_descendant_treehouse_slots() {
+  local i state task_id meta kind backend target worktree project lock_path held
+  for ((i=0; i < ${#DESCENDANT_TASK_IDS[@]}; i++)); do
+    state=${DESCENDANT_TASK_STATES[$i]}
+    task_id=${DESCENDANT_TASK_IDS[$i]}
+    meta="$state/$task_id.meta"
+    kind=$(meta_value "$meta" kind)
+    [ -n "$kind" ] || kind=ship
+    backend=$(fm_backend_of_meta "$meta")
+    worktree=$(meta_value "$meta" worktree)
+    [ "$kind" != secondmate ] && [ "$backend" != orca ] \
+      && [ -n "$worktree" ] && [ -d "$worktree" ] || continue
+    project=$(meta_value "$meta" project)
+    lock_path=$(fm_treehouse_project_lock_path "$project") || {
+      echo "REFUSED: cannot resolve the shared Treehouse project lock for child $task_id; forced teardown changed nothing" >&2
+      return 1
+    }
+    held=0
+    [ "$TREEHOUSE_PROJECT_LOCK_HELD" != 1 ] || [ "$TREEHOUSE_PROJECT_LOCK" != "$lock_path" ] || held=1
+    for target in "${DESCENDANT_TREEHOUSE_LOCK_PATHS[@]}"; do
+      [ "$target" != "$lock_path" ] || held=1
+    done
+    if [ "$held" = 0 ]; then
+      fm_lock_try_acquire "$lock_path" || {
+        echo "REFUSED: another Treehouse slot allocation or return is in progress for child $task_id; forced teardown changed nothing" >&2
+        return 1
+      }
+      DESCENDANT_TREEHOUSE_LOCK_PATHS+=("$lock_path")
+      DESCENDANT_LOCK_PATHS+=("$lock_path")
+    fi
+  done
+  for ((i=0; i < ${#DESCENDANT_TASK_IDS[@]}; i++)); do
+    state=${DESCENDANT_TASK_STATES[$i]}
+    task_id=${DESCENDANT_TASK_IDS[$i]}
+    meta="$state/$task_id.meta"
+    kind=$(meta_value "$meta" kind)
+    [ -n "$kind" ] || kind=ship
+    backend=$(fm_backend_of_meta "$meta")
+    worktree=$(meta_value "$meta" worktree)
+    [ "$kind" != secondmate ] && [ "$backend" != orca ] \
+      && [ -n "$worktree" ] && [ -d "$worktree" ] || continue
+    project=$(meta_value "$meta" project)
+    fm_backend_validate_task_endpoint "$meta" "$task_id" || return 1
+    target=$FM_BACKEND_VALIDATED_TARGET
+    require_exclusive_worktree_slot_record "$meta" "$task_id" "$state" "$project" "$worktree" || return 1
+    require_endpoint_slot_agreement "$task_id" "$backend" "$target" "$worktree" || return 1
   done
 }
 
@@ -2884,6 +2949,7 @@ if [ "$KIND" = secondmate ]; then
     validate_firstmate_home_children_removal "$HOME_PATH" || exit 1
     preflight_descendant_task_locks "$HOME_PATH" || exit 1
     validate_firstmate_home_children_removal "$HOME_PATH" || exit 1
+    preflight_descendant_treehouse_slots || exit 1
     if [ "$BACKEND" = herdr ]; then
       teardown_herdr_preflight_target "$T" "$ID" || exit 1
     fi

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -283,11 +283,30 @@ if [ "$FORCE" = --force ] && [ "$(fm_lease_actor)" = branch ]; then
   exit "$FM_LEASE_REFUSE_EXIT"
 fi
 fm_lease_guard "$ID" "teardown (fm-teardown)"
-TASK_SET_LOCK=$(fm_task_set_lock_path "$STATE") || {
-  echo "error: could not resolve the task-set lock for $STATE" >&2
-  exit 1
-}
-TASK_SET_LOCK_HELD=0
+META="$STATE/$ID.meta"
+TREEHOUSE_PROJECT_LOCK=
+TREEHOUSE_PROJECT_LOCK_HELD=0
+if [ -f "$META" ] && [ ! -L "$META" ]; then
+  TEARDOWN_LOCK_KIND=$(fm_meta_get "$META" kind)
+  [ -n "$TEARDOWN_LOCK_KIND" ] || TEARDOWN_LOCK_KIND=ship
+  TEARDOWN_LOCK_BACKEND=$(fm_meta_get "$META" backend)
+  [ -n "$TEARDOWN_LOCK_BACKEND" ] || TEARDOWN_LOCK_BACKEND=tmux
+  TEARDOWN_LOCK_WT=$(fm_meta_get "$META" worktree)
+  TEARDOWN_LOCK_PROJECT=$(fm_meta_get "$META" project)
+  if [ "$TEARDOWN_LOCK_KIND" != secondmate ] \
+     && [ "$TEARDOWN_LOCK_BACKEND" != orca ] \
+     && [ -n "$TEARDOWN_LOCK_WT" ] && [ -d "$TEARDOWN_LOCK_WT" ]; then
+    TREEHOUSE_PROJECT_LOCK=$(fm_treehouse_project_lock_path "$TEARDOWN_LOCK_PROJECT") || {
+      echo "REFUSED: cannot resolve the shared Treehouse project lock for ${TEARDOWN_LOCK_PROJECT:-<missing>}; nothing was changed" >&2
+      exit 1
+    }
+    fm_lock_try_acquire "$TREEHOUSE_PROJECT_LOCK" || {
+      echo "REFUSED: another Treehouse slot allocation or return is in progress for $TEARDOWN_LOCK_PROJECT; nothing was changed" >&2
+      exit 1
+    }
+    TREEHOUSE_PROJECT_LOCK_HELD=1
+  fi
+fi
 CONTROL_LOCK="$STATE/.control-$ID.lock"
 CONTROL_LOCK_HELD=0
 META_LOCK=
@@ -326,19 +345,14 @@ teardown_release_locks() {
     fm_lock_release "$CONTROL_LOCK" || true
     CONTROL_LOCK_HELD=0
   fi
-  if [ "$TASK_SET_LOCK_HELD" = 1 ]; then
-    fm_lock_release "$TASK_SET_LOCK" || true
-    TASK_SET_LOCK_HELD=0
+  if [ "$TREEHOUSE_PROJECT_LOCK_HELD" = 1 ]; then
+    fm_lock_release "$TREEHOUSE_PROJECT_LOCK" || true
+    TREEHOUSE_PROJECT_LOCK_HELD=0
   fi
   fm_lease_guard_release || true
   return "$status"
 }
 trap teardown_release_locks EXIT
-fm_lock_try_acquire "$TASK_SET_LOCK" || {
-  echo "error: this home's task set is locked by another operation; nothing was changed" >&2
-  exit 1
-}
-TASK_SET_LOCK_HELD=1
 fm_lock_try_acquire "$CONTROL_LOCK" || {
   echo "error: another lifecycle action is already running for task $ID; nothing was changed" >&2
   exit 1
@@ -349,7 +363,6 @@ CONTROL_LOCK_HELD=1
 fm_refuse_if_gate_agent
 FM_LOCK_LOG_PREFIX=teardown
 
-META="$STATE/$ID.meta"
 fm_backlog_record_present "$META" "task record" "$STATE" || {
   echo "error: teardown refused: $FM_BACKLOG_TRANSITION_ERROR" >&2
   exit 1
@@ -877,6 +890,21 @@ ORCA_PATH_MATCH_VERIFIED=0
 CLEANUP_RECOVERY=$TEARDOWN_CLEANUP_RECOVERY
 
 KIND=$TEARDOWN_META_KIND
+EXPECTED_TREEHOUSE_PROJECT_LOCK=
+if [ "$KIND" != secondmate ] && [ "$BACKEND" != orca ] && [ -n "$WT" ] && [ -d "$WT" ]; then
+  EXPECTED_TREEHOUSE_PROJECT_LOCK=$(fm_treehouse_project_lock_path "$PROJ") || {
+    echo "REFUSED: cannot resolve the shared Treehouse project lock for ${PROJ:-<missing>}; nothing was changed" >&2
+    exit 1
+  }
+  if [ "$TREEHOUSE_PROJECT_LOCK_HELD" != 1 ] \
+     || [ "$TREEHOUSE_PROJECT_LOCK" != "$EXPECTED_TREEHOUSE_PROJECT_LOCK" ]; then
+    echo "REFUSED: task $ID's Treehouse project identity changed while teardown acquired its locks; nothing was changed" >&2
+    exit 1
+  fi
+elif [ "$TREEHOUSE_PROJECT_LOCK_HELD" = 1 ]; then
+  echo "REFUSED: task $ID stopped naming a live Treehouse slot while teardown acquired its locks; nothing was changed" >&2
+  exit 1
+fi
 MODE=$(grep '^mode=' "$META" | cut -d= -f2- || true)
 [ -n "$MODE" ] || MODE=no-mistakes
 
@@ -2021,24 +2049,44 @@ teardown_live_slot_path() {
   canonical_existing_dir "$WT"
 }
 
-# See "Worktree-slot ownership" in the header. Check 1: this home's task records
-# must not name the same live slot twice.
+# See "Worktree-slot ownership" in the header. Check 1: task records in every
+# home sharing this Treehouse project must not name the same live slot twice.
 require_exclusive_task_worktree_slot() {
-  local slot other other_id field other_path other_slot
+  local slot listing line state_dir known other other_id field other_path other_slot
+  local -a states
   slot=$(teardown_live_slot_path) || return 0
-  for other in "$STATE"/*.meta; do
-    [ -f "$other" ] && [ ! -L "$other" ] || continue
-    other_id=$(basename "$other" .meta)
-    [ "$other_id" != "$ID" ] || continue
-    for field in worktree home; do
-      other_path=$(fm_meta_get "$other" "$field")
-      [ -n "$other_path" ] || continue
-      other_slot=$(canonical_existing_dir "$other_path") || continue
-      [ "$other_slot" = "$slot" ] || continue
-      echo "REFUSED: task $ID's recorded worktree $slot is also task $other_id's recorded $field." >&2
-      echo "Returning that pool slot would kill $other_id's processes and reset its copy, so nothing was changed - not even with --force." >&2
-      echo "Reconcile whichever record is wrong (bin/fm-crew-state.sh $ID; bin/fm-crew-state.sh $other_id), then re-run teardown." >&2
-      return 1
+  listing=$(git -C "$PROJ" -c core.quotePath=false worktree list --porcelain 2>/dev/null) || {
+    echo "REFUSED: cannot enumerate the homes sharing Treehouse project $PROJ; nothing was changed" >&2
+    return 1
+  }
+  states=("$STATE")
+  while IFS= read -r line; do
+    case "$line" in
+      worktree\ *)
+        state_dir="${line#worktree }/state"
+        known=0
+        for other in "${states[@]}"; do
+          [ "$other" != "$state_dir" ] || known=1
+        done
+        [ "$known" = 1 ] || states+=("$state_dir")
+        ;;
+    esac
+  done <<< "$listing"
+  for state_dir in "${states[@]}"; do
+    for other in "$state_dir"/*.meta; do
+      [ -f "$other" ] && [ ! -L "$other" ] || continue
+      [ "$other" != "$META" ] || continue
+      other_id=$(basename "$other" .meta)
+      for field in worktree home; do
+        other_path=$(fm_meta_get "$other" "$field")
+        [ -n "$other_path" ] || continue
+        other_slot=$(canonical_existing_dir "$other_path") || continue
+        [ "$other_slot" = "$slot" ] || continue
+        echo "REFUSED: task $ID's recorded worktree $slot is also task $other_id's recorded $field." >&2
+        echo "Returning that pool slot would kill $other_id's processes and reset its copy, so nothing was changed - not even with --force." >&2
+        echo "Reconcile whichever record is wrong (bin/fm-crew-state.sh $ID; bin/fm-crew-state.sh $other_id), then re-run teardown." >&2
+        return 1
+      done
     done
   done
 }

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -59,6 +59,31 @@
 # task state when that proof fails; otherwise it removes the task's check,
 # trust record, PR sidecar, and publication record with the rest of the
 # volatile state.
+# Worktree-slot ownership (teardown-slot-collision): a treehouse pool slot is
+# reused across tasks, so a stale, duplicated, or drifted worktree= record can
+# name a slot a DIFFERENT live task now holds. Cleanup kills every process under
+# that path and hard-resets it before returning it, so releasing a slot that is
+# not genuinely this task's destroys another worker's live work. Before the first
+# cleanup step, teardown proves the slot is this task's on two independent
+# records, and refuses with both tasks and the slot untouched when either
+# contradicts:
+#   1. Record exclusivity - no OTHER task record in this home may name the same
+#      live path in its worktree= or home=. One live path with two task records
+#      is the reuse collision itself, whichever record is stale.
+#   2. Endpoint agreement - when the recorded endpoint answers with a live
+#      working directory, it must resolve inside the recorded slot. A pane that
+#      has been rebound to another slot contradicts the record even when this
+#      home holds only one task record for the path.
+# Neither refusal is relaxed by --force: --force authorizes discarding THIS
+# task's unlanded work, never another task's live work. Reconcile whichever
+# record is wrong and re-run; both refusals name the inspection command.
+# Only backends whose current-path read tracks the live process are consulted for
+# check 2 (tmux's pane_current_path, herdr's foreground_cwd). zellij and cmux
+# freeze a pane's cwd at creation, so their read cannot distinguish a rebound
+# pane from a normal one and is not evidence; Orca is not a pool slot and proves
+# its path through require_orca_worktree_path_match instead. An endpoint that
+# answers nothing readable is inconclusive, not a contradiction, so the ordinary
+# dead-endpoint teardown still proceeds on check 1 alone.
 # Orca tasks use the same safety checks, then close the recorded terminal and
 # remove the recorded worktree through `orca worktree rm`; teardown never guesses
 # an Orca target from ambient CLI state.
@@ -1972,6 +1997,71 @@ require_orca_worktree_path_match_if_present() {
   require_orca_worktree_path_match "$worktree_id" "$inspected"
 }
 
+# The task's own live slot, canonicalized, or empty when this record has no slot
+# to release (a secondmate home, a record with no worktree=, or a path that is
+# already gone). Every slot-ownership check below is scoped to that value, so a
+# record with nothing live to return skips them rather than refusing.
+teardown_live_slot_path() {
+  [ "$KIND" != secondmate ] || return 1
+  [ -n "$WT" ] || return 1
+  canonical_existing_dir "$WT"
+}
+
+# See "Worktree-slot ownership" in the header. Check 1: this home's task records
+# must not name the same live slot twice.
+require_exclusive_task_worktree_slot() {
+  local slot other other_id field other_path other_slot
+  slot=$(teardown_live_slot_path) || return 0
+  for other in "$STATE"/*.meta; do
+    [ -f "$other" ] && [ ! -L "$other" ] || continue
+    other_id=$(basename "$other" .meta)
+    [ "$other_id" != "$ID" ] || continue
+    for field in worktree home; do
+      other_path=$(fm_meta_get "$other" "$field")
+      [ -n "$other_path" ] || continue
+      other_slot=$(canonical_existing_dir "$other_path") || continue
+      [ "$other_slot" = "$slot" ] || continue
+      echo "REFUSED: task $ID's recorded worktree $slot is also task $other_id's recorded $field." >&2
+      echo "Returning that pool slot would kill $other_id's processes and reset its copy, so nothing was changed - not even with --force." >&2
+      echo "Reconcile whichever record is wrong (bin/fm-crew-state.sh $ID; bin/fm-crew-state.sh $other_id), then re-run teardown." >&2
+      return 1
+    done
+  done
+}
+
+# The live working directory the recorded endpoint reports, for the backends
+# whose read tracks the running process. Empty output (including from every
+# other backend) means "no evidence", never "contradicts".
+teardown_endpoint_live_path() {
+  case "$BACKEND" in
+    tmux)
+      fm_backend_source tmux >/dev/null 2>&1 || return 0
+      fm_backend_tmux_current_path "$T" 2>/dev/null || true
+      ;;
+    herdr)
+      fm_backend_source herdr >/dev/null 2>&1 || return 0
+      fm_backend_herdr_current_path "$T" 2>/dev/null || true
+      ;;
+  esac
+}
+
+# See "Worktree-slot ownership" in the header. Check 2: a readable endpoint
+# working directory must resolve inside the recorded slot.
+require_task_endpoint_slot_agreement() {
+  local slot seen seen_path
+  slot=$(teardown_live_slot_path) || return 0
+  seen=$(teardown_endpoint_live_path)
+  [ -n "$seen" ] || return 0
+  seen_path=$(canonical_existing_dir "$seen") || return 0
+  case "$seen_path" in
+    "$slot"|"$slot"/*) return 0 ;;
+  esac
+  echo "REFUSED: task $ID's endpoint $T is working in $seen_path, outside its recorded worktree $slot." >&2
+  echo "The recorded copy may already belong to another task, so nothing was changed - not even with --force." >&2
+  echo "Reconcile the endpoint against the record (bin/fm-crew-state.sh $ID), then re-run teardown: either the record names the wrong copy, or that endpoint is no longer this task's." >&2
+  return 1
+}
+
 firstmate_home_has_treehouse_slot() {
   local home=$1
   worktree_registered_for_project "$FM_ROOT" "$home"
@@ -2713,6 +2803,9 @@ remove_secondmate_registry_entry() {
   [ "$acquired" -eq 0 ] || fm_lock_release "$lock"
   return "$rc"
 }
+
+require_exclusive_task_worktree_slot || exit 1
+require_task_endpoint_slot_agreement || exit 1
 
 validate_pr_poll_cleanup "$STATE" "$ID" || exit 1
 

--- a/bin/fm-wake-lib.sh
+++ b/bin/fm-wake-lib.sh
@@ -1088,6 +1088,17 @@ fm_task_set_lock_path() {  # <state-dir>
   printf '%s/.task-set.lock\n' "$state"
 }
 
+fm_treehouse_project_lock_path() {  # <project-dir>
+  local project=$1 common
+  [ -d "$project" ] || return 1
+  common=$(git -C "$project" rev-parse --git-common-dir 2>/dev/null) || return 1
+  case "$common" in
+    /*) common=$(CDPATH='' cd -- "$common" 2>/dev/null && pwd -P) || return 1 ;;
+    *) common=$(CDPATH='' cd -- "$project/$common" 2>/dev/null && pwd -P) || return 1 ;;
+  esac
+  printf '%s/.fm-treehouse-project.lock\n' "$common"
+}
+
 fm_failure_episode_reset() {
   local state=$1 mode=${2:-acquire} lock current pid acquired=0 path
   lock="$state/.turnend-claude-blocks.lock"

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -305,9 +305,9 @@ Every GitHub refusal states what it could not observe as plainly as what it did,
 A confirmed merge leaves a durable role-routed outcome instead of living only in the merging agent's memory, and [`bin/fm-merge-outcome-lib.sh`](../bin/fm-merge-outcome-lib.sh)'s header owns its destination, shape, identity, normal-case deduplication, and at-least-once recovery.
 The same emitter handles a merge firstmate performed and one its poll detected, while the watcher immediately delivers the emitter's local actionable poll row.
 Teardown is fail-closed for ship worktrees: dirty worktrees refuse, and committed work must be landed before the worktree is returned.
-A pool worktree is only returned once teardown has proved the slot is genuinely that task's: another task record naming the same live path, or the task's own endpoint working outside it, refuses without touching either task, and no discard authority relaxes that.
+A pool worktree is only returned after teardown passes the slot-ownership proof: a contradictory task record or supported live endpoint refuses without touching either task, and no discard authority relaxes that.
 Before the worktree is returned, teardown concludes the task's own no-mistakes run when it is parked at a gate, including a run whose head the task copy cannot resolve - the shared runs-ledger continuation proof is the only recognition for that case, so cleanup never orphans a parked run the pipeline advanced past the submitted head.
-[`bin/fm-teardown.sh`](../bin/fm-teardown.sh)'s header owns the landed-work proofs, slot-ownership proof, PR-discovery fallback, pre-teardown run conclusion, and stale-lock recovery procedure.
+[`bin/fm-teardown.sh`](../bin/fm-teardown.sh)'s header owns the landed-work proofs, slot-ownership proof, PR-discovery fallback, pre-teardown run conclusion, and stale-lock recovery procedure; [`tests/fm-teardown-endpoint-safety.test.sh`](../tests/fm-teardown-endpoint-safety.test.sh) and [`tests/fm-secondmate-safety.test.sh`](../tests/fm-secondmate-safety.test.sh) pin the slot-collision boundary.
 
 ## Optional Relay
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -305,8 +305,9 @@ Every GitHub refusal states what it could not observe as plainly as what it did,
 A confirmed merge leaves a durable role-routed outcome instead of living only in the merging agent's memory, and [`bin/fm-merge-outcome-lib.sh`](../bin/fm-merge-outcome-lib.sh)'s header owns its destination, shape, identity, normal-case deduplication, and at-least-once recovery.
 The same emitter handles a merge firstmate performed and one its poll detected, while the watcher immediately delivers the emitter's local actionable poll row.
 Teardown is fail-closed for ship worktrees: dirty worktrees refuse, and committed work must be landed before the worktree is returned.
+A pool worktree is only returned once teardown has proved the slot is genuinely that task's: another task record naming the same live path, or the task's own endpoint working outside it, refuses without touching either task, and no discard authority relaxes that.
 Before the worktree is returned, teardown concludes the task's own no-mistakes run when it is parked at a gate, including a run whose head the task copy cannot resolve - the shared runs-ledger continuation proof is the only recognition for that case, so cleanup never orphans a parked run the pipeline advanced past the submitted head.
-[`bin/fm-teardown.sh`](../bin/fm-teardown.sh)'s header owns the landed-work proofs, PR-discovery fallback, pre-teardown run conclusion, and stale-lock recovery procedure.
+[`bin/fm-teardown.sh`](../bin/fm-teardown.sh)'s header owns the landed-work proofs, slot-ownership proof, PR-discovery fallback, pre-teardown run conclusion, and stale-lock recovery procedure.
 
 ## Optional Relay
 

--- a/tests/fm-captain-hold-lifecycle.test.sh
+++ b/tests/fm-captain-hold-lifecycle.test.sh
@@ -1960,6 +1960,7 @@ test_interrupted_cleanup_keeps_the_captain_call_recoverable() {
   id=sample-held-cleanup-failure
   wt="$home/projects/$id"
   mkdir -p "$home/data/$id" "$wt" "$home/projects/sample"
+  git -C "$home/projects/sample" init -q || fail "could not initialize cleanup-failure project fixture"
   tasks_in "$home" add "$id" "Investigate failed sample cleanup" --kind scout \
     --repo sample --start >/dev/null || fail "could not create the cleanup-failure fixture"
   fm_write_meta "$home/state/$id.meta" \

--- a/tests/fm-secondmate-safety.test.sh
+++ b/tests/fm-secondmate-safety.test.sh
@@ -1936,6 +1936,58 @@ EOF
   pass "secondmate force teardown discards child work"
 }
 
+test_secondmate_force_teardown_refuses_duplicated_child_slot() {
+  local home subhome childproj childwt fakebin log err rc
+  home="$TMP_ROOT/force-duplicate-slot-home"
+  subhome="$TMP_ROOT/force-duplicate-slot-subhome"
+  childproj="$subhome/projects/alpha"
+  childwt="$TMP_ROOT/force-duplicate-slot-worktree"
+  err="$TMP_ROOT/force-duplicate-slot.err"
+  mkdir -p "$home/state" "$home/data" "$subhome/state"
+  fm_git_worktree "$childproj" "$childwt" duplicate-child
+  printf 'domain\n' > "$subhome/.fm-secondmate-home"
+  cat > "$home/state/domain.meta" <<EOF
+window=firstmate:fm-domain
+worktree=$subhome
+project=$subhome
+harness=echo
+kind=secondmate
+mode=secondmate
+yolo=off
+home=$subhome
+projects=alpha
+EOF
+  printf '%s\n' '- domain - design domain (home: '"$subhome"'; scope: design domain; projects: alpha; added 2026-06-22)' > "$home/data/secondmates.md"
+  for child in stale-child live-child; do
+    cat > "$subhome/state/$child.meta" <<EOF
+window=firstmate:fm-$child
+worktree=$childwt
+project=$childproj
+harness=echo
+kind=ship
+mode=no-mistakes
+yolo=off
+EOF
+  done
+  fakebin=$(make_fake_tmux "$TMP_ROOT/force-duplicate-slot-fake")
+  log="$TMP_ROOT/force-duplicate-slot-fake/tmux.log"
+
+  set +e
+  PATH="$fakebin:$PATH" FM_HOME="$home" FM_FAKE_TMUX_LOG="$log" \
+    FM_FAKE_TMUX_CAPTURE="$TMP_ROOT/force-duplicate-slot-fake/pane.txt" \
+    "$ROOT/bin/fm-teardown.sh" domain --force >/dev/null 2>"$err"
+  rc=$?
+  set -e
+  [ "$rc" -ne 0 ] || fail "forced secondmate teardown returned a duplicated child slot"
+  [ -d "$childwt" ] || fail "forced secondmate teardown removed the duplicated child slot"
+  [ -e "$subhome/state/stale-child.meta" ] || fail "forced secondmate teardown removed the stale child record"
+  [ -e "$subhome/state/live-child.meta" ] || fail "forced secondmate teardown removed the live child record"
+  grep -F 'kill-window' "$log" >/dev/null && fail "forced secondmate teardown killed a child before detecting its slot collision"
+  grep -F 'live-child' "$err" >/dev/null || grep -F 'stale-child' "$err" >/dev/null \
+    || fail "forced secondmate teardown did not identify the duplicated child slot"
+  pass "forced secondmate teardown refuses duplicated descendant pool slots"
+}
+
 test_secondmate_force_teardown_preserves_child_on_unproven_lock() {
   local home subhome childproj childwt fakebin log err rc lock
   home="$TMP_ROOT/force-lock-home"
@@ -2954,6 +3006,7 @@ test_secondmate_force_teardown_preserves_nested_restore_status
 test_secondmate_teardown_refuses_failed_leased_home_return
 test_secondmate_teardown_removes_plain_clone_home_without_treehouse_return
 test_secondmate_force_teardown_discards_child_work
+test_secondmate_force_teardown_refuses_duplicated_child_slot
 test_secondmate_force_teardown_preserves_child_on_unproven_lock
 test_secondmate_force_teardown_allows_non_state_operational_dir_symlinks_inside_home
 test_secondmate_force_teardown_refuses_operational_dir_symlink_outside_home

--- a/tests/fm-spawn-batch.test.sh
+++ b/tests/fm-spawn-batch.test.sh
@@ -84,12 +84,14 @@ test_projects_path_scoping() {
     home="$TMP_ROOT/$id home"
     projects="$TMP_ROOT/$id projects"
     mkdir -p "$home/data" "$projects/alpha"
+    git -C "$projects/alpha" init -q || fail "$label: could not initialize project fixture"
     if [ "$use_override" = yes ]; then
       out=$(FM_ROOT_OVERRIDE='' FM_STATE_OVERRIDE='' FM_DATA_OVERRIDE='' FM_CONFIG_OVERRIDE='' \
         FM_HOME="$home" FM_PROJECTS_OVERRIDE="$projects" FM_SPAWN_NO_GUARD=1 \
         "$SPAWN" "$id" projects/alpha codex --mode no-mistakes --yolo off 2>&1)
     else
       mkdir -p "$home/projects/alpha"
+      git -C "$home/projects/alpha" init -q || fail "$label: could not initialize home project fixture"
       out=$(FM_ROOT_OVERRIDE='' FM_STATE_OVERRIDE='' FM_DATA_OVERRIDE='' FM_PROJECTS_OVERRIDE='' FM_CONFIG_OVERRIDE='' \
         FM_HOME="$home" FM_SPAWN_NO_GUARD=1 \
         "$SPAWN" "$id" projects/alpha codex --mode no-mistakes --yolo off 2>&1)

--- a/tests/fm-spawn-dispatch-profile.test.sh
+++ b/tests/fm-spawn-dispatch-profile.test.sh
@@ -825,6 +825,7 @@ SH
     launch=$(cat "$LAUNCH_LOG")
     for pane_shell in /bin/sh /bin/bash /bin/zsh; do
       [ -x "$pane_shell" ] || continue
+      # shellcheck disable=SC2016 # Expand PATH inside the spawned shell.
       pane_path=$(env -i HOME="$HOME_DIR/user-home" PATH=/usr/bin:/bin TERM=xterm \
         "$pane_shell" -c 'printf %s "$PATH"') \
         || fail "could not observe the $pane_shell startup environment"

--- a/tests/fm-spawn-dispatch-profile.test.sh
+++ b/tests/fm-spawn-dispatch-profile.test.sh
@@ -799,7 +799,7 @@ test_active_dispatch_profile_does_not_block_secondmate_launch() {
 # fake backend records delivery, while real shells exercise the env boundary.
 # No developer environment or credential values are inspected by these probes.
 test_launch_environment_allowlist() {
-  local setting rec id out status probe result expected launch value pane_shell
+  local setting rec id out status probe result expected launch value pane_shell pane_path
   # shellcheck disable=SC2016
   value='synthetic value; $(touch SHOULD_NOT_EXIST) `false` "quoted"'
   for setting in absent missing-config enabled empty; do
@@ -825,6 +825,9 @@ SH
     launch=$(cat "$LAUNCH_LOG")
     for pane_shell in /bin/sh /bin/bash /bin/zsh; do
       [ -x "$pane_shell" ] || continue
+      pane_path=$(env -i HOME="$HOME_DIR/user-home" PATH=/usr/bin:/bin TERM=xterm \
+        "$pane_shell" -c 'printf %s "$PATH"') \
+        || fail "could not observe the $pane_shell startup environment"
       result=$(env -i HOME="$HOME_DIR/user-home" PATH=/usr/bin:/bin TERM=xterm \
       TMUX=synthetic-pane GOTMPDIR=/synthetic/gotmp \
       FM_TEST_AMBIENT_SENTINEL=synthetic-unrelated FM_TEST_ALLOWED="$value" FM_TEST_EMPTY='' \
@@ -834,7 +837,7 @@ SH
         enabled) expected=$(printf '%s\n' unset "$value" '' unset) ;;
         empty) expected=$(printf '%s\n' unset unset unset unset) ;;
       esac
-      expected="$expected"$'\n'"$HOME_DIR/user-home"$'\n/usr/bin:/bin\nxterm\nsynthetic-pane\n/synthetic/gotmp'
+      expected="$expected"$'\n'"$HOME_DIR/user-home"$'\n'"$pane_path"$'\nxterm\nsynthetic-pane\n/synthetic/gotmp'
       [ "$result" = "$expected" ] || fail "allowlist=$setting worker environment mismatch: $result"
     done
     pass "allowlist=$setting preserves the operational floor and filters only when opted in"

--- a/tests/fm-task-delivery.test.sh
+++ b/tests/fm-task-delivery.test.sh
@@ -33,6 +33,7 @@ make_home() {  # <name> [<registry-line>...]
   projects="$TMP_ROOT/$name/projects"
   fakebin="$TMP_ROOT/$name/bin"
   mkdir -p "$home/data" "$home/state" "$home/config" "$projects/proj" "$fakebin"
+  git -C "$projects/proj" init -q || fail "could not initialize project fixture"
   printf '#!/bin/sh\nexit 1\n' > "$fakebin/tmux"
   chmod +x "$fakebin/tmux"
   if [ "$#" -gt 0 ]; then

--- a/tests/fm-teardown-endpoint-safety.test.sh
+++ b/tests/fm-teardown-endpoint-safety.test.sh
@@ -137,6 +137,48 @@ test_control_lock_contention_refuses_before_mutation() {
   pass "fm-teardown: a concurrent lifecycle action refuses before mutation"
 }
 
+test_task_set_lock_contention_refuses_before_mutation() {
+  local dir id=publishing-task lock ready holder i=0 rc
+  dir=$(make_case task-set-lock)
+  fm_write_meta "$dir/home/state/$id.meta" \
+    "window=isolated:fm-$id" "endpoint_task_id=$id" \
+    "worktree=$dir/worktree" "project=$dir/project" "kind=scout"
+  lock="$dir/home/state/.task-set.lock"
+  ready="$dir/task-set-lock-ready"
+  (
+    # shellcheck source=/dev/null
+    . "$ROOT/bin/fm-wake-lib.sh"
+    fm_lock_try_acquire "$lock" || exit 1
+    trap 'fm_lock_release "$lock"' EXIT
+    : > "$ready"
+    sleep 30
+  ) &
+  holder=$!
+  while [ ! -e "$ready" ] && [ "$i" -lt 100 ]; do
+    sleep 0.1
+    i=$((i + 1))
+  done
+  [ -e "$ready" ] || {
+    kill "$holder" 2>/dev/null || true
+    wait "$holder" 2>/dev/null || true
+    fail "could not stage an in-progress task publication"
+  }
+
+  set +e
+  run_case "$dir" "$id" > "$dir/stdout" 2> "$dir/stderr"
+  rc=$?
+  set -e
+  [ "$rc" -ne 0 ] || fail "teardown raced an in-progress task publication"
+  assert_present "$dir/home/state/$id.meta" "task-set contention removed task metadata"
+  assert_present "$dir/worktree/sentinel" "task-set contention changed the worktree"
+  assert_present "$lock" "task-set contention removed the publisher's lock"
+  [ ! -s "$dir/runtime.log" ] \
+    || fail "task-set contention reached the runtime: $(cat "$dir/runtime.log")"
+  kill "$holder" 2>/dev/null || true
+  wait "$holder" 2>/dev/null || true
+  pass "fm-teardown: an in-progress task publication refuses before mutation"
+}
+
 test_metadata_lock_serializes_destructive_cleanup() {
   local dir id=metadata-locked-task lock ready release holder teardown_pid i=0 rc
   dir=$(make_case metadata-lock)
@@ -511,6 +553,7 @@ SH
 
 test_invalid_endpoint_records_refuse_before_mutation
 test_control_lock_contention_refuses_before_mutation
+test_task_set_lock_contention_refuses_before_mutation
 test_metadata_lock_serializes_destructive_cleanup
 test_supported_backend_endpoint_records_validate
 test_tmux_empty_target_refuses_without_invocation

--- a/tests/fm-teardown-endpoint-safety.test.sh
+++ b/tests/fm-teardown-endpoint-safety.test.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Regression tests for cleanup endpoint identity validation.
+# Regression tests for cleanup endpoint and worktree-slot identity validation.
 set -u
 
 # shellcheck source=tests/lib.sh
@@ -365,6 +365,150 @@ SH
   pass "fm-teardown: exact tmux cleanup preserves invalid and prefix-matched neighbors while removing only the recorded target"
 }
 
+test_reused_pool_slot_refuses_before_touching_the_other_task() {
+  local dir id=stale-task other=live-task worker rc
+
+  dir=$(make_case slot-reuse)
+  # The reuse collision: the pool slot recorded for a finished task has already
+  # been handed to another task, whose worker is live in it right now.
+  fm_write_meta "$dir/home/state/$id.meta" \
+    "window=firstmate:fm-$id" "endpoint_task_id=$id" \
+    "worktree=$dir/worktree" "project=$dir/project" "kind=scout"
+  fm_write_meta "$dir/home/state/$other.meta" \
+    "window=firstmate:fm-$other" "endpoint_task_id=$other" \
+    "worktree=$dir/worktree" "project=$dir/project" "kind=scout"
+  # Staged in this shell, not a command substitution: a background child of a
+  # $(...) subshell does not outlive it, and the point of this worker is to be
+  # alive in the slot while teardown runs.
+  ( cd "$dir/worktree" && exec sleep 30 ) &
+  worker=$!
+
+  set +e
+  run_case "$dir" "$id" > "$dir/stdout" 2> "$dir/stderr"
+  rc=$?
+  set -e
+
+  [ "$rc" -ne 0 ] || fail "teardown returned a pool slot a second task record still holds"
+  kill -0 "$worker" 2>/dev/null || fail "teardown killed the worker holding the reused pool slot"
+  assert_present "$dir/worktree/sentinel" "teardown reset a pool slot a second task record still holds"
+  assert_present "$dir/home/state/$other.meta" "teardown removed the live task's record"
+  assert_present "$dir/home/state/$id.meta" "teardown removed the stale task's record before refusing"
+  [ ! -s "$dir/runtime.log" ] \
+    || fail "teardown reached the runtime on a contested pool slot: $(cat "$dir/runtime.log")"
+  assert_contains "$(cat "$dir/stderr")" "$other" \
+    "refusal should name the other task holding the slot"
+  kill "$worker" 2>/dev/null || true
+  wait "$worker" 2>/dev/null || true
+
+  # The same collision recorded on a secondmate home field rather than a task
+  # worktree is the same slot, and refuses the same way.
+  dir=$(make_case slot-reuse-home)
+  fm_write_meta "$dir/home/state/$id.meta" \
+    "window=firstmate:fm-$id" "endpoint_task_id=$id" \
+    "worktree=$dir/worktree" "project=$dir/project" "kind=scout"
+  fm_write_meta "$dir/home/state/$other.meta" \
+    "window=firstmate:fm-$other" "endpoint_task_id=$other" \
+    "worktree=$dir/worktree" "home=$dir/worktree" \
+    "project=$dir/project" "kind=secondmate"
+  set +e
+  run_case "$dir" "$id" > "$dir/stdout" 2> "$dir/stderr"
+  rc=$?
+  set -e
+  [ "$rc" -ne 0 ] || fail "teardown returned a pool slot a secondmate home record still holds"
+  assert_present "$dir/worktree/sentinel" "teardown reset a pool slot a secondmate home record still holds"
+  assert_present "$dir/home/state/$other.meta" "teardown removed the secondmate record"
+  [ ! -s "$dir/runtime.log" ] \
+    || fail "teardown reached the runtime on a slot held by a secondmate home: $(cat "$dir/runtime.log")"
+
+  pass "fm-teardown: a pool slot named by a second task record is never returned, killed, or reset"
+}
+
+test_sole_slot_record_still_tears_down() {
+  local dir id=sole-task worker
+
+  dir=$(make_case slot-sole)
+  fm_write_meta "$dir/home/state/$id.meta" \
+    "window=firstmate:fm-$id" "endpoint_task_id=$id" \
+    "worktree=$dir/worktree" "project=$dir/project" "kind=scout"
+  # A neighbouring task on its OWN slot must not look like a collision.
+  mkdir -p "$dir/other-worktree"
+  fm_write_meta "$dir/home/state/neighbour.meta" \
+    "window=firstmate:fm-neighbour" "endpoint_task_id=neighbour" \
+    "worktree=$dir/other-worktree" "project=$dir/project" "kind=scout"
+  ( cd "$dir/other-worktree" && exec sleep 30 ) &
+  worker=$!
+
+  run_case "$dir" "$id" > "$dir/stdout" 2> "$dir/stderr" \
+    || fail "teardown of a task that solely holds its slot failed: $(cat "$dir/stderr")"
+  assert_absent "$dir/home/state/$id.meta" "uncontested teardown left the task record"
+  assert_present "$dir/home/state/neighbour.meta" "uncontested teardown removed the neighbour's record"
+  kill -0 "$worker" 2>/dev/null || fail "uncontested teardown killed a worker in a different slot"
+  grep -Fq "treehouse <return>" "$dir/runtime.log" \
+    || fail "uncontested teardown did not return its own pool slot: $(cat "$dir/runtime.log")"
+  kill "$worker" 2>/dev/null || true
+  wait "$worker" 2>/dev/null || true
+  pass "fm-teardown: a task that solely holds its slot still returns it"
+}
+
+test_endpoint_outside_recorded_slot_refuses_before_mutation() {
+  local dir id=drifted-task rc
+
+  dir=$(make_case slot-endpoint-drift)
+  mkdir -p "$dir/other-worktree"
+  # The recorded pane answers from a DIFFERENT copy: the record no longer proves
+  # this task owns the slot it names.
+  cat > "$dir/fakebin/tmux" <<SH
+#!/usr/bin/env bash
+if [ "\${1:-}" = display-message ]; then
+  printf '%s\n' '$dir/other-worktree'
+  exit 0
+fi
+printf 'tmux' >> "\${FM_RUNTIME_LOG:?}"
+printf ' <%s>' "\$@" >> "\${FM_RUNTIME_LOG:?}"
+printf '\n' >> "\${FM_RUNTIME_LOG:?}"
+exit 0
+SH
+  chmod +x "$dir/fakebin/tmux"
+  fm_write_meta "$dir/home/state/$id.meta" \
+    "window=firstmate:fm-$id" "endpoint_task_id=$id" \
+    "worktree=$dir/worktree" "project=$dir/project" "kind=scout"
+
+  set +e
+  run_case "$dir" "$id" > "$dir/stdout" 2> "$dir/stderr"
+  rc=$?
+  set -e
+  [ "$rc" -ne 0 ] || fail "teardown returned a slot its own endpoint contradicts"
+  assert_present "$dir/worktree/sentinel" "contradicted teardown reset the recorded slot"
+  assert_present "$dir/home/state/$id.meta" "contradicted teardown removed the task record"
+  [ ! -s "$dir/runtime.log" ] \
+    || fail "contradicted teardown reached a mutating runtime call: $(cat "$dir/runtime.log")"
+
+  # A pane sitting in a subdirectory of its own slot is ordinary drift, not a
+  # contradiction, and must still tear down.
+  dir=$(make_case slot-endpoint-subdir)
+  mkdir -p "$dir/worktree/sub"
+  cat > "$dir/fakebin/tmux" <<SH
+#!/usr/bin/env bash
+if [ "\${1:-}" = display-message ]; then
+  printf '%s\n' '$dir/worktree/sub'
+  exit 0
+fi
+printf 'tmux' >> "\${FM_RUNTIME_LOG:?}"
+printf ' <%s>' "\$@" >> "\${FM_RUNTIME_LOG:?}"
+printf '\n' >> "\${FM_RUNTIME_LOG:?}"
+exit 0
+SH
+  chmod +x "$dir/fakebin/tmux"
+  fm_write_meta "$dir/home/state/$id.meta" \
+    "window=firstmate:fm-$id" "endpoint_task_id=$id" \
+    "worktree=$dir/worktree" "project=$dir/project" "kind=scout"
+  run_case "$dir" "$id" > "$dir/stdout" 2> "$dir/stderr" \
+    || fail "teardown refused an endpoint inside its own slot: $(cat "$dir/stderr")"
+  assert_absent "$dir/home/state/$id.meta" "in-slot endpoint teardown left the task record"
+
+  pass "fm-teardown: an endpoint outside the recorded slot refuses, while in-slot drift still tears down"
+}
+
 test_invalid_endpoint_records_refuse_before_mutation
 test_control_lock_contention_refuses_before_mutation
 test_metadata_lock_serializes_destructive_cleanup
@@ -372,3 +516,6 @@ test_supported_backend_endpoint_records_validate
 test_tmux_empty_target_refuses_without_invocation
 test_recorded_process_identity_cleanup_is_exact
 test_isolated_tmux_invalid_and_valid_cleanup
+test_reused_pool_slot_refuses_before_touching_the_other_task
+test_sole_slot_record_still_tears_down
+test_endpoint_outside_recorded_slot_refuses_before_mutation

--- a/tests/fm-teardown-endpoint-safety.test.sh
+++ b/tests/fm-teardown-endpoint-safety.test.sh
@@ -14,6 +14,7 @@ make_case() {  # <name>
   mkdir -p "$TMP_ROOT/$dir/home/state" "$TMP_ROOT/$dir/home/data" \
     "$TMP_ROOT/$dir/home/config" "$TMP_ROOT/$dir/fakebin" \
     "$TMP_ROOT/$dir/worktree" "$TMP_ROOT/$dir/project"
+  git init -q "$TMP_ROOT/$dir/project"
   : > "$TMP_ROOT/$dir/worktree/sentinel"
   : > "$TMP_ROOT/$dir/runtime.log"
   cat > "$TMP_ROOT/$dir/fakebin/tmux" <<'SH'
@@ -137,12 +138,12 @@ test_control_lock_contention_refuses_before_mutation() {
   pass "fm-teardown: a concurrent lifecycle action refuses before mutation"
 }
 
-test_task_set_lock_contention_refuses_before_mutation() {
-  local dir id=publishing-task lock ready holder i=0 rc
-  dir=$(make_case task-set-lock)
+test_non_pool_teardown_ignores_task_set_lock() {
+  local dir id=non-pool-task lock ready holder i=0
+  dir=$(make_case non-pool-task-set-lock)
   fm_write_meta "$dir/home/state/$id.meta" \
     "window=isolated:fm-$id" "endpoint_task_id=$id" \
-    "worktree=$dir/worktree" "project=$dir/project" "kind=scout"
+    "worktree=$dir/missing-worktree" "project=$dir/project" "kind=scout"
   lock="$dir/home/state/.task-set.lock"
   ready="$dir/task-set-lock-ready"
   (
@@ -164,19 +165,13 @@ test_task_set_lock_contention_refuses_before_mutation() {
     fail "could not stage an in-progress task publication"
   }
 
-  set +e
-  run_case "$dir" "$id" > "$dir/stdout" 2> "$dir/stderr"
-  rc=$?
-  set -e
-  [ "$rc" -ne 0 ] || fail "teardown raced an in-progress task publication"
-  assert_present "$dir/home/state/$id.meta" "task-set contention removed task metadata"
-  assert_present "$dir/worktree/sentinel" "task-set contention changed the worktree"
-  assert_present "$lock" "task-set contention removed the publisher's lock"
-  [ ! -s "$dir/runtime.log" ] \
-    || fail "task-set contention reached the runtime: $(cat "$dir/runtime.log")"
+  run_case "$dir" "$id" > "$dir/stdout" 2> "$dir/stderr" \
+    || fail "non-pool teardown was blocked by an unrelated task publication: $(cat "$dir/stderr")"
+  assert_absent "$dir/home/state/$id.meta" "non-pool teardown left task metadata"
+  assert_present "$lock" "non-pool teardown removed the publisher's lock"
   kill "$holder" 2>/dev/null || true
   wait "$holder" 2>/dev/null || true
-  pass "fm-teardown: an in-progress task publication refuses before mutation"
+  pass "fm-teardown: non-pool cleanup ignores unrelated task publication locks"
 }
 
 test_metadata_lock_serializes_destructive_cleanup() {
@@ -465,6 +460,37 @@ test_reused_pool_slot_refuses_before_touching_the_other_task() {
   pass "fm-teardown: a pool slot named by a second task record is never returned, killed, or reset"
 }
 
+test_cross_home_pool_slot_collision_refuses() {
+  local dir id=stale-task other=secondmate-task second_home rc
+  dir=$(make_case slot-reuse-cross-home)
+  printf 'fixture\n' > "$dir/project/tracked"
+  git -C "$dir/project" add tracked
+  git -C "$dir/project" -c user.name=test -c user.email=test@example.invalid commit -qm fixture
+  second_home="$dir/secondmate-home"
+  git -C "$dir/project" worktree add -q -b secondmate-fixture "$second_home"
+  mkdir -p "$second_home/state"
+  fm_write_meta "$dir/home/state/$id.meta" \
+    "window=firstmate:fm-$id" "endpoint_task_id=$id" \
+    "worktree=$dir/worktree" "project=$dir/project" "kind=scout"
+  fm_write_meta "$second_home/state/$other.meta" \
+    "window=firstmate:fm-$other" "endpoint_task_id=$other" \
+    "worktree=$dir/worktree" "project=$second_home" "kind=scout"
+
+  set +e
+  run_case "$dir" "$id" > "$dir/stdout" 2> "$dir/stderr"
+  rc=$?
+  set -e
+  [ "$rc" -ne 0 ] || fail "teardown returned a pool slot held by another firstmate home"
+  assert_present "$dir/home/state/$id.meta" "cross-home collision removed stale metadata"
+  assert_present "$second_home/state/$other.meta" "cross-home collision removed live metadata"
+  assert_present "$dir/worktree/sentinel" "cross-home collision reset the shared slot"
+  [ ! -s "$dir/runtime.log" ] \
+    || fail "cross-home collision reached the runtime: $(cat "$dir/runtime.log")"
+  assert_contains "$(cat "$dir/stderr")" "$other" \
+    "cross-home refusal should name the task holding the slot"
+  pass "fm-teardown: a pool slot held by another firstmate home is never returned"
+}
+
 test_sole_slot_record_still_tears_down() {
   local dir id=sole-task worker
 
@@ -553,12 +579,13 @@ SH
 
 test_invalid_endpoint_records_refuse_before_mutation
 test_control_lock_contention_refuses_before_mutation
-test_task_set_lock_contention_refuses_before_mutation
+test_non_pool_teardown_ignores_task_set_lock
 test_metadata_lock_serializes_destructive_cleanup
 test_supported_backend_endpoint_records_validate
 test_tmux_empty_target_refuses_without_invocation
 test_recorded_process_identity_cleanup_is_exact
 test_isolated_tmux_invalid_and_valid_cleanup
 test_reused_pool_slot_refuses_before_touching_the_other_task
+test_cross_home_pool_slot_collision_refuses
 test_sole_slot_record_still_tears_down
 test_endpoint_outside_recorded_slot_refuses_before_mutation


### PR DESCRIPTION
## Intent

The captain's order in substance: workers were killed by a pool-slot collision during cleanup - never let that happen again. Make worktree-slot return verify the slot is genuinely the task's before releasing it.

## What Changed
- Refuse pool-slot teardown when another task record claims the slot or the live endpoint is outside its recorded worktree, even with `--force`.
- Serialize Treehouse slot allocation, metadata publication, ownership verification, and return across linked Firstmate homes.
- Apply the same ownership checks to forced secondmate descendant cleanup and document the safety boundary.

## Risk Assessment

✅ Low: The ownership checks and project-wide locking consistently cover normal and forced descendant Treehouse returns, with no concrete remaining collision path found.

## Testing

Completed 1 recorded test check.

- Outcome: ⚠️ 1 error across 4 runs (3h3m50s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"eeae1f4c96235a863d80ada1ccb6a1d9b9132859","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed (3) ✅</summary>

- 🚨 `bin/fm-teardown.sh:2015` - The ownership proof enumerates task records without acquiring the per-home task-set lock. A fresh spawn holds that lock while acquiring a treehouse slot and until publishing its metadata. Therefore, a new task can acquire the stale record&#39;s slot before its .meta exists—or publish immediately after this scan—so teardown sees no conflict, treats the dead endpoint as inconclusive, then reaps the new worker and returns its slot. Acquire the shared task-set lock before this scan, following the established task-set-before-meta lock order, and retain it through the destructive slot return.

🔧 Fix: Serialize teardown with task publication
2 issues (1 error, 1 warning) still open:

- 🚨 `bin/fm-teardown.sh:2029` - The ownership proof scans and locks only the current home&#39;s state directory. A documented project-less secondmate can take pooled worktrees of the same repository: if a stale primary-home record names slot S while a secondmate-home task acquires S and publishes under its own state directory, primary teardown sees no competing record; with the stale endpoint unreadable, it proceeds to reap and return S, killing the live worker. This contradicts the required “never let that happen again” invariant. Ownership must be enforced at a project-wide boundary shared by every home that can acquire or return the pool slot; author approval is needed because the durable remedy may require broader shared state or locking.
- ⚠️ `bin/fm-teardown.sh:337` - The new task-set lock is acquired unconditionally, including secondmate, Orca, missing-worktree, and other paths that do not return a Treehouse task slot. Those teardowns can now make unrelated fresh spawns fail immediately for the entire teardown duration, although the stated intent requires serialization only around pool-slot ownership and return. Narrow the lock to teardown paths that can actually return a pooled task worktree.

🔧 Fix: Serialize Treehouse ownership across firstmate homes
2 issues (1 error, 1 warning) still open:

- 🚨 `bin/fm-teardown.sh:2869` - The required “Make worktree-slot return verify the slot is genuinely the task&#39;s before releasing it” invariant is still bypassed by forced secondmate teardown. These checks deliberately no-op for kind=secondmate, but cleanup_firstmate_home_children later returns every descendant&#39;s Treehouse worktree at line 2822 without checking descendant records. If stale child A and live child B name the same slot, cleaning A returns and resets B&#39;s slot despite both records being lifecycle-locked. Extend the shared project lock and ownership proof to every descendant Treehouse return before any child endpoint or worktree is touched.
- ⚠️ `bin/fm-spawn.sh:2026` - A fresh pooled spawn acquires the project-wide nonblocking lock here, hundreds of lines before `treehouse get`, and retains it through backend creation, readiness checks, allocation, and metadata publication. Consequently, while one spawn is still performing unrelated setup, any concurrent spawn for another task in the same project fails immediately even though no slot allocation or return is in progress. Acquire the lock immediately before `treehouse get` and retain it through metadata publication, which preserves the ownership invariant without unnecessarily rejecting concurrent setup.

🔧 Fix: Verify descendant slot ownership before forced cleanup
✅ Re-checked - no issues remain.
</details>

<details>
<summary>⚠️ **Test** - 1 error</summary>

- 🚨 tests failed with exit code 1
- `bin/fm-test-run.sh --changed --exclude-family real-herdr-gated`

🔧 Fix: Respect shell startup PATH in environment test
1 error still open:

- 🚨 tests failed with exit code 1
- `bin/fm-test-run.sh --changed --exclude-family real-herdr-gated`

🔧 Fix: Initialize Git repositories in Treehouse test fixtures
1 error still open:

- 🚨 tests failed with exit code 1
- `bin/fm-test-run.sh --changed --exclude-family real-herdr-gated`

🔧 Fix: Targeted reruns could not reproduce reported failures
1 error still open:

- 🚨 tests failed with exit code 1
- `bin/fm-test-run.sh --changed --exclude-family real-herdr-gated`
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>🔧 **Lint** - 1 issue found → auto-fixed ✅</summary>

- ⚠️ linter found issues (exit code 1)

🔧 Fix: Suppress intentional deferred PATH expansion warning
✅ Re-checked - no issues remain.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
