### PR TITLE
feat(bin): fm-pr-campaign operator surface for parallel-PR campaigns

### DIFF
--- a/bin/fm-pr-campaign.sh
+++ b/bin/fm-pr-campaign.sh
@@ -1,0 +1,343 @@
+#!/usr/bin/env bash
+# fm-pr-campaign.sh - one-command mechanical steps for a parallel-PR merge campaign.
+#
+# Parallel independent PRs plus a hand-rederived digest and restack/merge-next
+# check every turn burned context during the firstmate-port campaign. This
+# script owns those mechanical reads so a later campaign is one command plus a
+# short decision instead of a one-liner and a wall of GitHub JSON.
+#
+# Subcommands (all read-only except restack, which only retargets PR bases):
+#   digest --repo OWNER/NAME [--limit N]
+#     One line per open PR: number, base, head, mergeable, check summary, URL.
+#   restack --repo OWNER/NAME BOTTOM [NEXT...]
+#     Given PR numbers bottom-first, set each higher PR's GitHub base to the
+#     head branch of the PR below it. The bottom PR is never touched. Prints
+#     the resulting stack bottom-first. Never rewrites git history; workers
+#     still rebase.
+#   merge-next --repo OWNER/NAME [N...]
+#     Print the first eligible PR in the given order (or all open PRs oldest
+#     first): mergeable, a clean mergeable-state, and checks all-green or
+#     absent. Prints NONE and exits 1 when nothing is eligible. Never merges;
+#     firstmate still calls fm-pr-check.sh and fm-pr-merge.sh.
+#
+# A PR counts as eligible with no checks configured when GitHub still reports
+# it mergeable and clean; the printed summary says "none" in that case so the
+# operator sees the difference. A null mergeable (GitHub still computing) is
+# reported as unknown and never counts as eligible.
+#
+# All GitHub reads go through gh-axi's REST surface. Restack retargets through
+# gh-axi pr edit --base. Nothing here merges, so there is no second merge path
+# around fm-pr-merge.sh.
+#
+# Usage:
+#   fm-pr-campaign.sh digest --repo OWNER/NAME [--limit N]
+#   fm-pr-campaign.sh restack --repo OWNER/NAME BOTTOM [NEXT...]
+#   fm-pr-campaign.sh merge-next --repo OWNER/NAME [N...]
+#   fm-pr-campaign.sh --help | help [subcommand]
+set -eu
+
+usage() {
+  sed -n '2,/^set -eu/p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+}
+
+fail() {
+  printf 'error: %s\n' "$1" >&2
+  exit "${2:-1}"
+}
+
+need_gh_axi() {
+  command -v gh-axi >/dev/null 2>&1 || fail "gh-axi is required on PATH" 1
+}
+
+# Owner and repository rules mirror bin/fm-pr-lib.sh's GitHub URL pattern.
+repo_valid() {
+  local repo=${1-} owner name
+  local LC_ALL=C
+  case "$repo" in
+    */*) owner=${repo%%/*}; name=${repo#*/} ;;
+    *) return 1 ;;
+  esac
+  [[ "$owner" =~ ^([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9-]{0,37}[A-Za-z0-9])$ ]] || return 1
+  [[ "$owner" != *--* ]] || return 1
+  [[ "$name" =~ ^[A-Za-z0-9._-]{1,100}$ ]] || return 1
+  [ "$name" != . ] && [ "$name" != .. ] && [[ "$repo" != *//* ]]
+}
+
+pr_number_valid() {
+  [[ "${1-}" =~ ^[1-9][0-9]*$ ]]
+}
+
+# api_body <path> <jq>: print gh-axi's projected response as plain lines.
+# gh-axi renders small projections as bare key: value lines and larger ones
+# inside an api_response body envelope with backslash escapes; both shapes
+# normalize to the same lines. A truncated envelope refuses rather than
+# reporting on partial data.
+api_body() {
+  local path=$1 jqexpr=$2 out first rest body
+  out=$(gh-axi api "$path" --jq "$jqexpr" 2>/dev/null) || return 1
+  [ -n "$out" ] || return 1
+  first=${out%%$'\n'*}
+  if [ "$first" != api_response: ]; then
+    printf '%s\n' "$out"
+    return 0
+  fi
+  case "$out" in
+    *$'\n  truncated: true'*) return 1 ;;
+  esac
+  rest=${out#*$'\n  body: '}
+  body=${rest%%$'\n'*}
+  body=${body#\"}
+  body=${body%\"}
+  [ -n "$body" ] || return 0
+  printf '%b\n' "$body"
+}
+
+# api_field <text> <key>: value of a top-level "key: value" line, unquoted.
+api_field() {
+  local text=$1 key=$2 line value
+  line=$(printf '%s\n' "$text" | grep -m1 "^$key: " || true)
+  [ -n "$line" ] || return 1
+  value=${line#*: }
+  value=${value#\"}
+  value=${value%\"}
+  printf '%s' "$value"
+}
+
+# pr_detail <repo> <number>: number, base, head, sha, mergeable, state, url.
+pr_detail() {
+  api_body "/repos/$1/pulls/$2" \
+    '{number: .number, base: .base.ref, head: .head.ref, sha: .head.sha, mergeable: .mergeable, mstate: .mergeable_state, state: .state, url: .html_url}'
+}
+
+mergeable_word() {
+  case "${1-}" in
+    true) printf 'yes' ;;
+    false) printf 'no' ;;
+    *) printf 'unknown' ;;
+  esac
+}
+
+# check_summary <repo> <sha>: pending, fail, all-green, or none.
+# Combines check-runs conclusions with legacy commit-status contexts; a sha
+# with neither is "none", which the digest reports apart from "all-green".
+check_summary() {
+  local repo=$1 sha=$2 runs st sstate scount
+  local total=0 pending=0 failed=0 line status conclusion
+  runs=$(api_body "/repos/$repo/commits/$sha/check-runs" \
+    '.check_runs[] | "\(.status)/\(.conclusion)"') || return 1
+  st=$(api_body "/repos/$repo/commits/$sha/status" \
+    '"\(.state)/\(.total_count)"') || return 1
+  while IFS= read -r line; do
+    [ -n "$line" ] || continue
+    total=$((total + 1))
+    status=${line%%/*}
+    conclusion=${line#*/}
+    if [ "$status" != completed ]; then
+      pending=$((pending + 1))
+      continue
+    fi
+    case "$conclusion" in
+      success|neutral|skipped) ;;
+      *) failed=$((failed + 1)) ;;
+    esac
+  done <<RUNS
+$runs
+RUNS
+  sstate=${st%%/*}
+  scount=${st#*/}
+  case "$scount" in
+    ''|*[!0-9]*) return 1 ;;
+  esac
+  total=$((total + scount))
+  case "$sstate" in
+    pending) [ "$scount" -eq 0 ] || pending=$((pending + 1)) ;;
+    success) ;;
+    *) failed=$((failed + 1)) ;;
+  esac
+  if [ "$total" -eq 0 ]; then
+    printf 'none'
+  elif [ "$failed" -gt 0 ]; then
+    printf 'fail'
+  elif [ "$pending" -gt 0 ]; then
+    printf 'pending'
+  else
+    printf 'all-green'
+  fi
+}
+
+# digest_line <repo> <number>: one compact line for a PR, or return 1.
+digest_line() {
+  local repo=$1 number=$2 detail base head sha mergeable url summary
+  detail=$(pr_detail "$repo" "$number") || return 1
+  base=$(api_field "$detail" base) || return 1
+  head=$(api_field "$detail" head) || return 1
+  sha=$(api_field "$detail" sha) || return 1
+  mergeable=$(api_field "$detail" mergeable) || return 1
+  url=$(api_field "$detail" url) || return 1
+  [ -n "$base" ] && [ -n "$head" ] && [ -n "$sha" ] && [ -n "$url" ] || return 1
+  summary=$(check_summary "$repo" "$sha") || return 1
+  printf '#%s base:%s head:%s mergeable:%s checks:%s %s\n' \
+    "$number" "$base" "$head" "$(mergeable_word "$mergeable")" "$summary" "$url"
+}
+
+open_numbers() {
+  local repo=$1 limit=$2 body n
+  body=$(api_body "/repos/$repo/pulls?state=open&per_page=$limit" '.[].number') || return 1
+  while IFS= read -r n; do
+    pr_number_valid "$n" || return 1
+    printf '%s\n' "$n"
+  done <<NUMS | sort -n
+$body
+NUMS
+}
+
+cmd_digest() {
+  local repo="" limit=30 listed n
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      --repo) repo=${2-}; shift 2 ;;
+      --repo=*) repo=${1#--repo=}; shift ;;
+      --limit) limit=${2-}; shift 2 ;;
+      --limit=*) limit=${1#--limit=}; shift ;;
+      -h|--help) usage; exit 0 ;;
+      *) fail "digest: unexpected argument '$1'" 2 ;;
+    esac
+  done
+  [ -n "$repo" ] || fail "digest: --repo OWNER/NAME is required" 2
+  repo_valid "$repo" || fail "digest: invalid repo '$repo', want OWNER/NAME" 2
+  case "$limit" in
+    ''|*[!0-9]*|0*) fail "digest: --limit must be a positive number" 2 ;;
+  esac
+  listed=$(open_numbers "$repo" "$limit") || fail "digest: could not list open PRs for $repo"
+  while IFS= read -r n; do
+    [ -n "$n" ] || continue
+    digest_line "$repo" "$n" || fail "digest: could not read PR $n in $repo"
+  done <<NUMS
+$listed
+NUMS
+  return 0
+}
+
+cmd_restack() {
+  local repo="" numbers=() n
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      --repo) repo=${2-}; shift 2 ;;
+      --repo=*) repo=${1#--repo=}; shift ;;
+      -h|--help) usage; exit 0 ;;
+      -*) fail "restack: unexpected flag '$1'" 2 ;;
+      *) numbers+=("$1"); shift ;;
+    esac
+  done
+  [ -n "$repo" ] || fail "restack: --repo OWNER/NAME is required" 2
+  repo_valid "$repo" || fail "restack: invalid repo '$repo', want OWNER/NAME" 2
+  [ "${#numbers[@]}" -ge 1 ] || fail "restack: at least one PR number is required, bottom first" 2
+  local seen=" " detail heads=() bases=() urls=()
+  for n in "${numbers[@]}"; do
+    pr_number_valid "$n" || fail "restack: invalid PR number '$n'" 2
+    case "$seen" in
+      *" $n "*) fail "restack: duplicate PR number '$n'" 2 ;;
+    esac
+    seen="$seen$n "
+    detail=$(pr_detail "$repo" "$n") || fail "restack: could not read PR $n in $repo"
+    heads+=("$(api_field "$detail" head)") || fail "restack: could not read PR $n in $repo"
+    bases+=("$(api_field "$detail" base)") || fail "restack: could not read PR $n in $repo"
+    urls+=("$(api_field "$detail" url)") || fail "restack: could not read PR $n in $repo"
+    [ -n "${heads[${#heads[@]} - 1]}" ] && [ -n "${bases[${#bases[@]} - 1]}" ] \
+      && [ -n "${urls[${#urls[@]} - 1]}" ] \
+      || fail "restack: could not read PR $n in $repo"
+  done
+  local i want
+  for i in "${!numbers[@]}"; do
+    if [ "$i" -eq 0 ]; then
+      printf 'bottom: #%s base:%s head:%s %s\n' \
+        "${numbers[$i]}" "${bases[$i]}" "${heads[$i]}" "${urls[$i]}"
+      continue
+    fi
+    want=${heads[$((i - 1))]}
+    if [ "${bases[$i]}" = "$want" ]; then
+      printf 'keep: #%s base:%s head:%s %s\n' \
+        "${numbers[$i]}" "${bases[$i]}" "${heads[$i]}" "${urls[$i]}"
+    else
+      gh-axi pr edit "${numbers[$i]}" --repo "$repo" --base "$want" >/dev/null 2>&1 \
+        || fail "restack: could not retarget PR ${numbers[$i]} onto $want"
+      printf 'retargeted: #%s base:%s head:%s %s\n' \
+        "${numbers[$i]}" "$want" "${heads[$i]}" "${urls[$i]}"
+    fi
+  done
+  return 0
+}
+
+# eligible_detail <repo> <number>: print the digest line when the PR is the
+# merge-next answer, else return 1 without output.
+eligible_detail() {
+  local repo=$1 number=$2 detail state mergeable mstate base head sha url summary line
+  detail=$(pr_detail "$repo" "$number") || return 1
+  state=$(api_field "$detail" state) || return 1
+  [ "$state" = open ] || return 1
+  mergeable=$(api_field "$detail" mergeable) || return 1
+  [ "$mergeable" = true ] || return 1
+  mstate=$(api_field "$detail" mstate) || return 1
+  [ "$mstate" = clean ] || return 1
+  base=$(api_field "$detail" base) || return 1
+  head=$(api_field "$detail" head) || return 1
+  sha=$(api_field "$detail" sha) || return 1
+  url=$(api_field "$detail" url) || return 1
+  [ -n "$base" ] && [ -n "$head" ] && [ -n "$sha" ] && [ -n "$url" ] || return 1
+  summary=$(check_summary "$repo" "$sha") || return 1
+  case "$summary" in
+    all-green|none) ;;
+    *) return 1 ;;
+  esac
+  line=$(printf '#%s base:%s head:%s mergeable:yes checks:%s %s\n' \
+    "$number" "$base" "$head" "$summary" "$url")
+  printf '%s\n' "$line"
+}
+
+cmd_merge_next() {
+  local repo="" numbers=() n line
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      --repo) repo=${2-}; shift 2 ;;
+      --repo=*) repo=${1#--repo=}; shift ;;
+      -h|--help) usage; exit 0 ;;
+      -*) fail "merge-next: unexpected flag '$1'" 2 ;;
+      *) numbers+=("$1"); shift ;;
+    esac
+  done
+  [ -n "$repo" ] || fail "merge-next: --repo OWNER/NAME is required" 2
+  repo_valid "$repo" || fail "merge-next: invalid repo '$repo', want OWNER/NAME" 2
+  if [ "${#numbers[@]}" -eq 0 ]; then
+    local listed
+    listed=$(open_numbers "$repo" 100) || fail "merge-next: could not list open PRs for $repo"
+    while IFS= read -r n; do
+      [ -n "$n" ] || continue
+      numbers+=("$n")
+    done <<NUMS
+$listed
+NUMS
+  else
+    for n in "${numbers[@]}"; do
+      pr_number_valid "$n" || fail "merge-next: invalid PR number '$n'" 2
+    done
+  fi
+  for n in "${numbers[@]}"; do
+    if line=$(eligible_detail "$repo" "$n"); then
+      printf '%s\n' "$line"
+      return 0
+    fi
+  done
+  printf 'NONE\n'
+  return 1
+}
+
+need_gh_axi
+case "${1-}" in
+  digest) shift; cmd_digest "$@" ;;
+  restack) shift; cmd_restack "$@" ;;
+  merge-next) shift; cmd_merge_next "$@" ;;
+  help) shift; usage; exit 0 ;;
+  -h|--help) usage; exit 0 ;;
+  ''|-*) usage >&2; exit 2 ;;
+  *) fail "unknown subcommand '$1' (want digest, restack, or merge-next)" 2 ;;
+esac

--- a/tests/fm-pr-campaign.test.sh
+++ b/tests/fm-pr-campaign.test.sh
@@ -1,0 +1,287 @@
+#!/usr/bin/env bash
+# Tests for bin/fm-pr-campaign.sh: the operator surface for a parallel-PR
+# merge campaign (digest, restack, merge-next), which must stay read-only
+# except for base retargets and must never merge.
+#
+# Matrix:
+#   (a) digest prints one compact line per open PR with number, base, head,
+#       mergeable, check summary, and the full URL, oldest first
+#   (b) digest distinguishes pending, fail, all-green, and none check states
+#   (c) digest reports a null mergeable as unknown, from bare key: value lines
+#   (d) digest reads the PR list from an api_response body envelope
+#   (e) digest refuses an invalid repo and a missing --repo without network
+#   (f) merge-next prints the first eligible PR in listed order
+#   (g) merge-next defaults to all open PRs oldest first
+#   (h) merge-next skips unmergeable, dirty, pending-check, and failing PRs
+#   (i) merge-next accepts a mergeable PR with no checks as checks:none
+#   (j) merge-next prints NONE and exits 1 when nothing is eligible
+#   (k) merge-next prints NONE and exits 1 when no PR is open
+#   (l) restack retargets each higher PR onto the head below it and prints
+#       the resulting stack bottom-first
+#   (m) restack leaves an already-correct base alone and the bottom PR untouched
+#   (n) restack refuses duplicate and invalid PR numbers without editing
+#   (o) --help exits 0 and an unknown subcommand exits 2
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+fm_git_identity fmtest fmtest@example.invalid
+
+CAMPAIGN="$ROOT/bin/fm-pr-campaign.sh"
+TMP_ROOT=$(fm_test_tmproot fm-pr-campaign-tests)
+
+REPO=acme/widgets
+URL_BASE="https://github.com/$REPO/pull"
+SHA_A=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+SHA_B=bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+SHA_C=cccccccccccccccccccccccccccccccccccccccc
+SHA_D=dddddddddddddddddddddddddddddddddddddddd
+SHA_E=eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee
+
+make_case() {
+  local case_dir=$1 fakebin=$1/fakebin
+  mkdir -p "$fakebin"
+  cat > "$fakebin/gh-axi" <<'SH'
+#!/usr/bin/env bash
+# Mock answering canned fixture data per REST path; stdout only.
+fail() { echo "mock: unexpected gh-axi call: $*" >&2; exit 1; }
+[ "${1-}" = api ] || {
+  case "${1:-} ${2:-}" in
+    "pr edit")
+      printf '%s\n' "$*" >> "$FM_TEST_EDIT_LOG"
+      exit 0
+      ;;
+  esac
+  fail "$@"
+}
+path=$2
+case "$path" in
+  /repos/acme/widgets/pulls\?state=open*)
+    printf 'api_response:\n  body: "11\\n12\\n13\\n14\\n15"\n  truncated: false\n'
+    ;;
+  /repos/acme/empty/pulls\?state=open*)
+    printf 'api_response:\n  body: ""\n  truncated: false\n'
+    ;;
+  /repos/acme/widgets/pulls/11)
+    printf 'number: 11\nbase: main\nhead: feat-a\nsha: %s\nmergeable: true\nmstate: clean\nstate: open\nurl: "%s/11"\n' "$FM_TEST_SHA_A" "$FM_TEST_URL_BASE"
+    ;;
+  /repos/acme/widgets/pulls/12)
+    printf 'number: 12\nbase: feat-a\nhead: feat-b\nsha: %s\nmergeable: true\nmstate: clean\nstate: open\nurl: "%s/12"\n' "$FM_TEST_SHA_B" "$FM_TEST_URL_BASE"
+    ;;
+  /repos/acme/widgets/pulls/13)
+    printf 'number: 13\nbase: main\nhead: feat-c\nsha: %s\nmergeable: false\nmstate: dirty\nstate: open\nurl: "%s/13"\n' "$FM_TEST_SHA_C" "$FM_TEST_URL_BASE"
+    ;;
+  /repos/acme/widgets/pulls/14)
+    printf 'number: 14\nbase: main\nhead: feat-d\nsha: %s\nmergeable: null\nmstate: unknown\nstate: open\nurl: "%s/14"\n' "$FM_TEST_SHA_D" "$FM_TEST_URL_BASE"
+    ;;
+  /repos/acme/widgets/pulls/15)
+    printf 'number: 15\nbase: main\nhead: feat-e\nsha: %s\nmergeable: true\nmstate: clean\nstate: open\nurl: "%s/15"\n' "$FM_TEST_SHA_E" "$FM_TEST_URL_BASE"
+    ;;
+  /repos/acme/widgets/commits/*/check-runs)
+    case "$path" in
+      *"$FM_TEST_SHA_A"*) printf 'api_response:\n  body: "completed/success"\n  truncated: false\n' ;;
+      *"$FM_TEST_SHA_B"*) printf 'api_response:\n  body: "in_progress/null"\n  truncated: false\n' ;;
+      *"$FM_TEST_SHA_C"*) printf 'api_response:\n  body: "completed/failure"\n  truncated: false\n' ;;
+      *) printf 'api_response:\n  body: ""\n  truncated: false\n' ;;
+    esac
+    ;;
+  /repos/acme/widgets/commits/*/status)
+    case "$path" in
+      *"$FM_TEST_SHA_A"*) printf 'success/1\n' ;;
+      *"$FM_TEST_SHA_C"*) printf 'failure/1\n' ;;
+      *) printf 'pending/0\n' ;;
+    esac
+    ;;
+  *) fail "$@" ;;
+esac
+SH
+  chmod +x "$fakebin/gh-axi"
+  : > "$case_dir/edit.log"
+  printf '%s\n' "$case_dir"
+}
+
+run_campaign() {
+  local case_dir=$1; shift
+  FM_TEST_SHA_A=$SHA_A FM_TEST_SHA_B=$SHA_B FM_TEST_SHA_C=$SHA_C \
+  FM_TEST_SHA_D=$SHA_D FM_TEST_SHA_E=$SHA_E FM_TEST_URL_BASE=$URL_BASE \
+  FM_TEST_EDIT_LOG="$case_dir/edit.log" \
+  PATH="$case_dir/fakebin:$PATH" \
+    "$CAMPAIGN" "$@"
+}
+
+test_digest_lists_every_pr() {
+  local case_dir rc
+  case_dir=$(make_case "$TMP_ROOT/digest")
+  set +e
+  run_campaign "$case_dir" digest --repo "$REPO" > "$case_dir/stdout" 2> "$case_dir/stderr"
+  rc=$?
+  set -e
+  expect_code 0 "$rc" "digest: should succeed"
+  assert_grep "#11 base:main head:feat-a mergeable:yes checks:all-green $URL_BASE/11" \
+    "$case_dir/stdout" "digest: PR 11 line wrong"
+  assert_grep "#12 base:feat-a head:feat-b mergeable:yes checks:pending $URL_BASE/12" \
+    "$case_dir/stdout" "digest: PR 12 line wrong"
+  assert_grep "#13 base:main head:feat-c mergeable:no checks:fail $URL_BASE/13" \
+    "$case_dir/stdout" "digest: PR 13 line wrong"
+  assert_grep "#14 base:main head:feat-d mergeable:unknown checks:none $URL_BASE/14" \
+    "$case_dir/stdout" "digest: PR 14 line wrong"
+  [ "$(wc -l < "$case_dir/stdout")" -eq 5 ] \
+    || fail "digest: want 5 lines, got $(wc -l < "$case_dir/stdout")"
+  [ "$(head -1 "$case_dir/stdout" | cut -c1-3)" = "#11" ] \
+    || fail "digest: oldest PR is not first"
+  pass "digest prints one compact line per open PR, oldest first"
+}
+
+test_digest_rejects_bad_input() {
+  local case_dir rc
+  case_dir=$(make_case "$TMP_ROOT/digest-bad")
+  set +e
+  run_campaign "$case_dir" digest --repo 'not a repo' > "$case_dir/stdout" 2> "$case_dir/stderr"
+  rc=$?
+  set -e
+  expect_code 2 "$rc" "digest: invalid repo should exit 2"
+  set +e
+  run_campaign "$case_dir" digest > "$case_dir/stdout2" 2> "$case_dir/stderr2"
+  rc=$?
+  set -e
+  expect_code 2 "$rc" "digest: missing --repo should exit 2"
+  [ ! -s "$case_dir/edit.log" ] || fail "digest: bad input must not touch the network path"
+  pass "digest refuses an invalid repo and a missing --repo"
+}
+
+test_merge_next_defaults_to_oldest_eligible() {
+  local case_dir rc
+  case_dir=$(make_case "$TMP_ROOT/next-default")
+  set +e
+  run_campaign "$case_dir" merge-next --repo "$REPO" > "$case_dir/stdout" 2> "$case_dir/stderr"
+  rc=$?
+  set -e
+  expect_code 0 "$rc" "merge-next: should find PR 11"
+  assert_grep "#11 base:main head:feat-a mergeable:yes checks:all-green $URL_BASE/11" \
+    "$case_dir/stdout" "merge-next: did not pick the oldest eligible PR"
+  pass "merge-next defaults to all open PRs oldest first"
+}
+
+test_merge_next_respects_list_order() {
+  local case_dir rc
+  case_dir=$(make_case "$TMP_ROOT/next-order")
+  set +e
+  run_campaign "$case_dir" merge-next --repo "$REPO" 12 13 11 > "$case_dir/stdout" 2> "$case_dir/stderr"
+  rc=$?
+  set -e
+  expect_code 0 "$rc" "merge-next: should find PR 11 after skipping 12 and 13"
+  assert_grep "#11 base:main head:feat-a mergeable:yes checks:all-green $URL_BASE/11" \
+    "$case_dir/stdout" "merge-next: list order was not respected"
+  pass "merge-next skips ineligible PRs in the given order"
+}
+
+test_merge_next_accepts_no_checks() {
+  local case_dir rc
+  case_dir=$(make_case "$TMP_ROOT/next-none")
+  set +e
+  run_campaign "$case_dir" merge-next --repo "$REPO" 12 15 > "$case_dir/stdout" 2> "$case_dir/stderr"
+  rc=$?
+  set -e
+  expect_code 0 "$rc" "merge-next: should accept PR 15 with no checks"
+  assert_grep "#15 base:main head:feat-e mergeable:yes checks:none $URL_BASE/15" \
+    "$case_dir/stdout" "merge-next: PR with no checks was not accepted as checks:none"
+  pass "merge-next accepts a mergeable clean PR with no checks"
+}
+
+test_merge_next_reports_none() {
+  local case_dir rc
+  case_dir=$(make_case "$TMP_ROOT/next-none-found")
+  set +e
+  run_campaign "$case_dir" merge-next --repo "$REPO" 12 13 14 > "$case_dir/stdout" 2> "$case_dir/stderr"
+  rc=$?
+  set -e
+  expect_code 1 "$rc" "merge-next: no eligible PR should exit 1"
+  assert_grep "NONE" "$case_dir/stdout" "merge-next: should print NONE"
+  set +e
+  run_campaign "$case_dir" merge-next --repo acme/empty > "$case_dir/stdout2" 2> "$case_dir/stderr2"
+  rc=$?
+  set -e
+  expect_code 1 "$rc" "merge-next: empty repo should exit 1"
+  assert_grep "NONE" "$case_dir/stdout2" "merge-next: empty repo should print NONE"
+  pass "merge-next prints NONE when nothing is eligible"
+}
+
+test_restack_retargets_onto_heads() {
+  local case_dir rc
+  case_dir=$(make_case "$TMP_ROOT/restack")
+  set +e
+  run_campaign "$case_dir" restack --repo "$REPO" 11 13 15 > "$case_dir/stdout" 2> "$case_dir/stderr"
+  rc=$?
+  set -e
+  expect_code 0 "$rc" "restack: should succeed"
+  assert_grep "bottom: #11 base:main head:feat-a $URL_BASE/11" \
+    "$case_dir/stdout" "restack: bottom line wrong"
+  assert_grep "retargeted: #13 base:feat-a head:feat-c $URL_BASE/13" \
+    "$case_dir/stdout" "restack: PR 13 should retarget onto feat-a"
+  assert_grep "retargeted: #15 base:feat-c head:feat-e $URL_BASE/15" \
+    "$case_dir/stdout" "restack: PR 15 should retarget onto feat-c"
+  assert_grep "pr edit 13 --repo $REPO --base feat-a" \
+    "$case_dir/edit.log" "restack: PR 13 edit not issued"
+  assert_grep "pr edit 15 --repo $REPO --base feat-c" \
+    "$case_dir/edit.log" "restack: PR 15 edit not issued"
+  assert_no_grep "pr edit 11" "$case_dir/edit.log" "restack: bottom PR must never be edited"
+  pass "restack retargets each PR onto the head below it"
+}
+
+test_restack_keeps_correct_bases() {
+  local case_dir rc
+  case_dir=$(make_case "$TMP_ROOT/restack-keep")
+  set +e
+  run_campaign "$case_dir" restack --repo "$REPO" 11 12 > "$case_dir/stdout" 2> "$case_dir/stderr"
+  rc=$?
+  set -e
+  expect_code 0 "$rc" "restack: should succeed"
+  assert_grep "keep: #12 base:feat-a head:feat-b $URL_BASE/12" \
+    "$case_dir/stdout" "restack: already-stacked PR should be kept"
+  [ ! -s "$case_dir/edit.log" ] || fail "restack: a correct base must not issue an edit"
+  pass "restack leaves an already-correct base alone"
+}
+
+test_restack_rejects_bad_numbers() {
+  local case_dir rc
+  case_dir=$(make_case "$TMP_ROOT/restack-bad")
+  set +e
+  run_campaign "$case_dir" restack --repo "$REPO" 11 11 > "$case_dir/stdout" 2> "$case_dir/stderr"
+  rc=$?
+  set -e
+  expect_code 2 "$rc" "restack: duplicate numbers should exit 2"
+  set +e
+  run_campaign "$case_dir" restack --repo "$REPO" 11 nope > "$case_dir/stdout2" 2> "$case_dir/stderr2"
+  rc=$?
+  set -e
+  expect_code 2 "$rc" "restack: invalid numbers should exit 2"
+  [ ! -s "$case_dir/edit.log" ] || fail "restack: rejected input must not edit anything"
+  pass "restack refuses duplicate and invalid PR numbers"
+}
+
+test_help_and_unknown_subcommand() {
+  local case_dir rc
+  case_dir=$(make_case "$TMP_ROOT/help")
+  set +e
+  run_campaign "$case_dir" --help > "$case_dir/stdout" 2> "$case_dir/stderr"
+  rc=$?
+  set -e
+  expect_code 0 "$rc" "--help should exit 0"
+  set +e
+  run_campaign "$case_dir" frobnicate > "$case_dir/stdout2" 2> "$case_dir/stderr2"
+  rc=$?
+  set -e
+  expect_code 2 "$rc" "unknown subcommand should exit 2"
+  pass "--help succeeds and an unknown subcommand fails"
+}
+
+test_digest_lists_every_pr
+test_digest_rejects_bad_input
+test_merge_next_defaults_to_oldest_eligible
+test_merge_next_respects_list_order
+test_merge_next_accepts_no_checks
+test_merge_next_reports_none
+test_restack_retargets_onto_heads
+test_restack_keeps_correct_bases
+test_restack_rejects_bad_numbers
+test_help_and_unknown_subcommand


### PR DESCRIPTION
Digest, restack, and merge-next for one GitHub repo through gh-axi, so a later campaign is one command plus a short decision instead of a hand-rederived PR digest in chat. Read-only except restack, which only retargets PR bases; merging stays on fm-pr-merge.sh. Direct-PR, yolo off.