### PR TITLE
fix(bin): wait out transient primary-checkout reads in the spawn worktree poll

### DIFF
--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -2132,7 +2132,8 @@ real_path_or_raw() {  # <path>
 # True when <path> is an isolated worktree of the spawning project: a real
 # directory that is its own worktree root, is not the spawning project itself,
 # and does not share the project repository's common git dir. SPAWN_WT_TOP is
-# left holding the worktree root the check read, for the refusal message.
+# left holding the worktree root the check read, and SPAWN_WT_REASON a short
+# phrase naming why a rejected path failed, both for the refusal messages.
 #
 # The worktree-discovery poll below reads this same predicate, so it can never
 # adopt a path the guard would then refuse. That matters because a pane's cwd
@@ -2143,17 +2144,35 @@ real_path_or_raw() {  # <path>
 # guard then refused a launch whose slot treehouse went on to create normally.
 # A read like that is a transient, not a destination: the poll keeps waiting.
 SPAWN_WT_TOP=
+SPAWN_WT_REASON=
 spawn_worktree_isolated() {  # <path>
   local path=$1 wt_real wt_top_real wt_git_dir proj_common
   SPAWN_WT_TOP=
+  SPAWN_WT_REASON=
   wt_real=
   if ! wt_real=$(cd "$path" 2>/dev/null && pwd -P); then
     wt_real=
+  fi
+  if [ -z "$wt_real" ]; then
+    SPAWN_WT_REASON="it is not a readable directory"
+    return 1
   fi
   SPAWN_WT_TOP=$(git -C "$path" rev-parse --show-toplevel 2>/dev/null || true)
   wt_top_real=
   if ! wt_top_real=$(cd "$SPAWN_WT_TOP" 2>/dev/null && pwd -P); then
     wt_top_real=
+  fi
+  if [ -z "$wt_top_real" ]; then
+    SPAWN_WT_REASON="it is not inside a git worktree"
+    return 1
+  fi
+  if [ "$wt_real" != "$wt_top_real" ]; then
+    SPAWN_WT_REASON="it is a subdirectory of worktree root '$wt_top_real', not a worktree root"
+    return 1
+  fi
+  if [ "$wt_real" = "$PROJ_ABS_REAL" ]; then
+    SPAWN_WT_REASON="it is the spawning project itself"
+    return 1
   fi
   # The primary checkout uses the repository's common git dir as its own git
   # dir. A linked spawning home has a different top-level, but the same common
@@ -2162,9 +2181,15 @@ spawn_worktree_isolated() {  # <path>
     && wt_git_dir=$(cd "$wt_git_dir" 2>/dev/null && pwd -P) || wt_git_dir=
   proj_common=$(git -C "$PROJ_ABS" rev-parse --path-format=absolute --git-common-dir 2>/dev/null) \
     && proj_common=$(cd "$proj_common" 2>/dev/null && pwd -P) || proj_common=
-  [ -n "$wt_real" ] && [ -n "$wt_top_real" ] && [ "$wt_real" = "$wt_top_real" ] \
-    && [ "$wt_real" != "$PROJ_ABS_REAL" ] && [ -n "$wt_git_dir" ] && [ -n "$proj_common" ] \
-    && [ "$wt_git_dir" != "$proj_common" ]
+  if [ -z "$wt_git_dir" ] || [ -z "$proj_common" ]; then
+    SPAWN_WT_REASON="its git directory could not be resolved"
+    return 1
+  fi
+  if [ "$wt_git_dir" = "$proj_common" ]; then
+    SPAWN_WT_REASON="it is the repository's primary checkout (its git dir is the spawning project's common git dir)"
+    return 1
+  fi
+  return 0
 }
 
 validate_spawn_worktree() {  # <source> <inspect-target>
@@ -2854,13 +2879,21 @@ elif [ "$KIND" != secondmate ] && [ "$BACKEND" != orca ]; then
   # read of the project itself or of the repository primary checkout is treated
   # as the transient it is and the wait continues, instead of being adopted and
   # then refused by the guard.
+  # A candidate the screen rejects is never adopted, so a host where the pane
+  # never reaches an isolated worktree spends the whole window before refusing.
+  # That wait is deliberate - telling a transient apart from a terminal
+  # misconfiguration would need machinery this path does not want - so the
+  # refusal has to be self-explaining instead: carry the last path seen and the
+  # reason it was rejected, and report both at the deadline.
   candidate=""
   last_seen=""
+  last_reason="the pane reported no path"
   for _ in $(seq 1 60); do
     p=$(spawn_current_path "$WT_TARGET" || true)
     [ -z "$p" ] || last_seen="$p"
     if [ -n "$p" ] && spawn_worktree_isolated "$p"; then
       p_real=$(real_path_or_raw "$p")
+      last_reason="it is an isolated worktree, but no second read agreed with it"
       if [ -n "$candidate" ] && [ "$p_real" = "$candidate" ]; then
         WT="$p"
         break
@@ -2868,11 +2901,12 @@ elif [ "$KIND" != secondmate ] && [ "$BACKEND" != orca ]; then
       candidate="$p_real"
     else
       candidate=""
+      [ -z "$p" ] || last_reason=$SPAWN_WT_REASON
     fi
     sleep 1
   done
   if [ -z "$WT" ]; then
-    echo "error: treehouse get did not enter an isolated worktree within 60s (last seen '${last_seen:-unknown}'; spawning project '$PROJ_ABS'); inspect window $T" >&2
+    echo "error: treehouse get did not enter an isolated worktree within 60s (last seen '${last_seen:-none}': $last_reason; spawning project '$PROJ_ABS'); inspect window $T" >&2
     exit 1
   fi
 

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -2128,30 +2128,49 @@ real_path_or_raw() {  # <path>
 # herdr-sm-spaces-k4). Both branches converge on the same $T ("target") string
 # that every downstream operation (send/capture/kill) already treats as opaque
 # per-backend routing (fm_backend_resolve_selector).
-validate_spawn_worktree() {  # <source> <inspect-target>
-  local source=$1 inspect_target=$2 wt_real proj_real wt_top wt_top_real
-  local wt_git_dir proj_common
+
+# True when <path> is an isolated worktree of the spawning project: a real
+# directory that is its own worktree root, is not the spawning project itself,
+# and does not share the project repository's common git dir. SPAWN_WT_TOP is
+# left holding the worktree root the check read, for the refusal message.
+#
+# The worktree-discovery poll below reads this same predicate, so it can never
+# adopt a path the guard would then refuse. That matters because a pane's cwd
+# read is a snapshot of whatever process is in the foreground: while `treehouse
+# get` is still fetching and checking a slot out, it reports the REPOSITORY's
+# primary checkout as its own cwd. That path differs from a linked spawning
+# project, so a poll comparing only against the project accepted it, and the
+# guard then refused a launch whose slot treehouse went on to create normally.
+# A read like that is a transient, not a destination: the poll keeps waiting.
+SPAWN_WT_TOP=
+spawn_worktree_isolated() {  # <path>
+  local path=$1 wt_real wt_top_real wt_git_dir proj_common
+  SPAWN_WT_TOP=
   wt_real=
-  if ! wt_real=$(cd "$WT" 2>/dev/null && pwd -P); then
+  if ! wt_real=$(cd "$path" 2>/dev/null && pwd -P); then
     wt_real=
   fi
-  proj_real=$PROJ_ABS_REAL
-  wt_top=$(git -C "$WT" rev-parse --show-toplevel 2>/dev/null || true)
+  SPAWN_WT_TOP=$(git -C "$path" rev-parse --show-toplevel 2>/dev/null || true)
   wt_top_real=
-  if ! wt_top_real=$(cd "$wt_top" 2>/dev/null && pwd -P); then
+  if ! wt_top_real=$(cd "$SPAWN_WT_TOP" 2>/dev/null && pwd -P); then
     wt_top_real=
   fi
   # The primary checkout uses the repository's common git dir as its own git
   # dir. A linked spawning home has a different top-level, but the same common
   # dir, so comparing only the two working directories cannot protect primary.
-  wt_git_dir=$(git -C "$WT" rev-parse --absolute-git-dir 2>/dev/null) \
+  wt_git_dir=$(git -C "$path" rev-parse --absolute-git-dir 2>/dev/null) \
     && wt_git_dir=$(cd "$wt_git_dir" 2>/dev/null && pwd -P) || wt_git_dir=
   proj_common=$(git -C "$PROJ_ABS" rev-parse --path-format=absolute --git-common-dir 2>/dev/null) \
     && proj_common=$(cd "$proj_common" 2>/dev/null && pwd -P) || proj_common=
-  if [ -z "$wt_real" ] || [ -z "$wt_top_real" ] || [ "$wt_real" != "$wt_top_real" ] \
-     || [ "$wt_real" = "$proj_real" ] || [ -z "$wt_git_dir" ] || [ -z "$proj_common" ] \
-     || [ "$wt_git_dir" = "$proj_common" ]; then
-    echo "error: $source did not yield an isolated worktree (resolved '$WT'; worktree root '${wt_top:-none}'; spawning project '$PROJ_ABS'); refusing to launch to avoid tangling the primary checkout. Inspect target $inspect_target" >&2
+  [ -n "$wt_real" ] && [ -n "$wt_top_real" ] && [ "$wt_real" = "$wt_top_real" ] \
+    && [ "$wt_real" != "$PROJ_ABS_REAL" ] && [ -n "$wt_git_dir" ] && [ -n "$proj_common" ] \
+    && [ "$wt_git_dir" != "$proj_common" ]
+}
+
+validate_spawn_worktree() {  # <source> <inspect-target>
+  local source=$1 inspect_target=$2
+  if ! spawn_worktree_isolated "$WT"; then
+    echo "error: $source did not yield an isolated worktree (resolved '$WT'; worktree root '${SPAWN_WT_TOP:-none}'; spawning project '$PROJ_ABS'); refusing to launch to avoid tangling the primary checkout. Inspect target $inspect_target" >&2
     exit 1
   fi
 }
@@ -2819,38 +2838,41 @@ elif [ "$KIND" != secondmate ] && [ "$BACKEND" != orca ]; then
   # prefix would otherwise make the pane's OS-level cwd read differ from
   # PROJ_ABS on the very first poll, before the pane has actually moved.
   #
-  # A single read that already differs from PROJ_ABS_REAL is not proof the pane
-  # settled there: on some tmux/WSL setups a brand-new window's pane_current_path
+  # A single read that already looks isolated is not proof the pane settled
+  # there: on some tmux/WSL setups a brand-new window's pane_current_path
   # transiently reports an unrelated stale path (seen live as another real git
   # checkout entirely) before the shell catches up with treehouse get's cd. That
-  # stale path still passes the PROJ_ABS_REAL comparison and validate_spawn_worktree
-  # below (it resolves to a real, distinct worktree top-level too), so accepting it
-  # on one read alone silently records the wrong worktree= in state/<id>.meta. Require
-  # two consecutive reads to agree on the same non-project path before accepting it;
-  # a mismatch just becomes the new candidate rather than resetting the wait, so a
-  # pane that is already settled by the first real read only costs the one existing
+  # stale path passes spawn_worktree_isolated too (it resolves to a real,
+  # distinct worktree top-level), so accepting it on one read alone silently
+  # records the wrong worktree= in state/<id>.meta. Require two consecutive
+  # reads to agree on the same isolated path before accepting it; a mismatch
+  # just becomes the new candidate rather than resetting the wait, so a pane
+  # that is already settled by the first real read only costs the one existing
   # inter-poll sleep as confirmation, not a whole extra cycle on top.
+  #
+  # Every candidate is screened with the isolation guard's own predicate, so a
+  # read of the project itself or of the repository primary checkout is treated
+  # as the transient it is and the wait continues, instead of being adopted and
+  # then refused by the guard.
   candidate=""
+  last_seen=""
   for _ in $(seq 1 60); do
     p=$(spawn_current_path "$WT_TARGET" || true)
-    if [ -n "$p" ]; then
+    [ -z "$p" ] || last_seen="$p"
+    if [ -n "$p" ] && spawn_worktree_isolated "$p"; then
       p_real=$(real_path_or_raw "$p")
-      if [ "$p_real" != "$PROJ_ABS_REAL" ]; then
-        if [ -n "$candidate" ] && [ "$p_real" = "$candidate" ]; then
-          WT="$p"
-          break
-        fi
-        candidate="$p_real"
-      else
-        candidate=""
+      if [ -n "$candidate" ] && [ "$p_real" = "$candidate" ]; then
+        WT="$p"
+        break
       fi
+      candidate="$p_real"
     else
       candidate=""
     fi
     sleep 1
   done
   if [ -z "$WT" ]; then
-    echo "error: treehouse get did not enter a worktree within 60s; inspect window $T" >&2
+    echo "error: treehouse get did not enter an isolated worktree within 60s (last seen '${last_seen:-unknown}'; spawning project '$PROJ_ABS'); inspect window $T" >&2
     exit 1
   fi
 

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -146,6 +146,13 @@
 #   Ship/scout spawns refuse to launch unless the resolved task path is a real
 #   git worktree root distinct from both the spawning project and its repository's
 #   primary checkout, including when the spawning project is a linked worktree.
+#   On the backends that discover that path by reading the task pane's own cwd,
+#   the same isolation test screens every read: a pane still showing the project
+#   or the repository primary while `treehouse get` prepares the slot is waited
+#   out as a transient rather than adopted and then refused, so a home that is
+#   itself a linked worktree of the project repository still launches. A pane
+#   that never reaches an isolated worktree refuses at the end of that wait,
+#   naming the last path seen and why it was rejected.
 #   Only after this isolation check, a fresh ship or scout's clean task worktree
 #   fetches origin, resolves the current remote default branch, and resets to its tip.
 #   Relaunch reuses the recorded worktree without fetching or resetting its base.

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -2866,9 +2866,10 @@ elif [ "$KIND" != secondmate ] && [ "$BACKEND" != orca ]; then
   # automatic-rename slips through), display-message -t <bad-name> falls back to the
   # active client's window, which would misread firstmate's OWN pane path as the
   # worktree and tangle a hook into the primary checkout. The window id never lies.
-  # Compare against PROJ_ABS_REAL (physical), not PROJ_ABS: a symlinked project
-  # prefix would otherwise make the pane's OS-level cwd read differ from
-  # PROJ_ABS on the very first poll, before the pane has actually moved.
+  # The project comparison is physical: spawn_worktree_isolated screens each
+  # read against PROJ_ABS_REAL, not PROJ_ABS, because a symlinked project prefix
+  # would otherwise make the pane's OS-level cwd read differ from PROJ_ABS on
+  # the very first poll, before the pane has actually moved.
   #
   # A single read that already looks isolated is not proof the pane settled
   # there: on some tmux/WSL setups a brand-new window's pane_current_path

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -2165,8 +2165,12 @@ spawn_worktree_isolated() {  # <path>
     return 1
   fi
   SPAWN_WT_TOP=$(git -C "$path" rev-parse --show-toplevel 2>/dev/null || true)
+  # A path in no repository leaves the toplevel empty, and that empty value must
+  # never reach `cd`: bash before 5.3 accepts `cd ""` as a successful no-op, so
+  # it would resolve to fm-spawn's OWN cwd and report the path as a subdirectory
+  # of whatever checkout firstmate happens to be running from.
   wt_top_real=
-  if ! wt_top_real=$(cd "$SPAWN_WT_TOP" 2>/dev/null && pwd -P); then
+  if [ -n "$SPAWN_WT_TOP" ] && ! wt_top_real=$(cd "$SPAWN_WT_TOP" 2>/dev/null && pwd -P); then
     wt_top_real=
   fi
   if [ -z "$wt_top_real" ]; then

--- a/tests/fm-backend-herdr-presentation-e2e.test.sh
+++ b/tests/fm-backend-herdr-presentation-e2e.test.sh
@@ -854,9 +854,12 @@ if wait "$ABORT_A_PID"; then ABORT_A_STATUS=0; else ABORT_A_STATUS=$?; fi
 if wait "$ABORT_B_PID"; then ABORT_B_STATUS=0; else ABORT_B_STATUS=$?; fi
 finish_concurrent_expected_abort abort-a "$ABORT_A_STATUS" "$TMP_ROOT/abort-a.out" "$TMP_ROOT/abort-a.err"
 finish_concurrent_expected_abort abort-b "$ABORT_B_STATUS" "$TMP_ROOT/abort-b.out" "$TMP_ROOT/abort-b.err"
-grep -F "did not yield an isolated worktree" "$TMP_ROOT/abort-a.err" >/dev/null 2>&1 \
+# The forced foreground_cwd is a plain non-git directory, which the discovery
+# poll now screens out on every read rather than adopting, so the armed failure
+# arrives as the poll's own deadline refusal naming that path.
+grep -F "did not enter an isolated worktree" "$TMP_ROOT/abort-a.err" >/dev/null 2>&1 \
   || fail "post-create abort fixture A did not reach the armed validation failure"
-grep -F "did not yield an isolated worktree" "$TMP_ROOT/abort-b.err" >/dev/null 2>&1 \
+grep -F "did not enter an isolated worktree" "$TMP_ROOT/abort-b.err" >/dev/null 2>&1 \
   || fail "post-create abort fixture B did not reach the armed validation failure"
 ABORT_A_PANE=$(cat "$POST_CREATE_ABORT_CONTROL/abort-a/task-pane")
 ABORT_B_PANE=$(cat "$POST_CREATE_ABORT_CONTROL/abort-b/task-pane")

--- a/tests/fm-spawn-pool-base-freshen.test.sh
+++ b/tests/fm-spawn-pool-base-freshen.test.sh
@@ -109,11 +109,14 @@ test_linked_spawning_home_rejects_primary_before_refresh() {
         || fail "spawn did not refresh the genuine scout copy"
     else
       [ "$status" -ne 0 ] || fail "linked spawning home accepted $returned as a disposable copy"
-      if [ "$returned" = spawning ]; then
-        assert_contains "$out" "did not enter a worktree" "spawn accepted its own spawning directory"
-      else
-        assert_contains "$out" "did not yield an isolated worktree" "spawn did not explain its isolation refusal"
-      fi
+      # None of these is an isolated copy, so the worktree poll never adopts one
+      # and the wait runs out instead: the spawning directory fails the poll's
+      # own project comparison, and the repository primary (named directly or
+      # through a symlink) fails the isolation screen the poll shares with the
+      # guard. The refusal names the last path the pane reported.
+      assert_contains "$out" "did not enter an isolated worktree" \
+        "spawn did not explain its isolation refusal"
+      assert_contains "$out" "last seen" "refusal did not name the path the pane reported"
       [ ! -e "$HOME_DIR/state/$id.meta" ] || fail "refused spawn published task metadata"
       [ ! -e "$primary/.git/FETCH_HEAD" ] || fail "refused spawn fetched before proving isolation"
     fi

--- a/tests/fm-spawn-worktree-settle.test.sh
+++ b/tests/fm-spawn-worktree-settle.test.sh
@@ -213,6 +213,10 @@ test_primary_checkout_that_never_settles_fails_at_the_deadline() {
   [ "$status" -ne 0 ] || fail "spawn accepted a pane that never left the primary checkout"$'\n'"$out"
   assert_contains "$out" "did not enter an isolated worktree" \
     "spawn did not explain that the pane never reached an isolated worktree"
+  assert_contains "$out" "$STALE_DIR" \
+    "the refusal did not name the path the pane kept reporting"
+  assert_contains "$out" "it is the repository's primary checkout" \
+    "the refusal did not say why that path was rejected"
   [ ! -e "$HOME_DIR/state/$id.meta" ] || fail "refused spawn published task metadata"
   pass "a pane stuck on the primary checkout fails loudly at the deadline"
 }

--- a/tests/fm-spawn-worktree-settle.test.sh
+++ b/tests/fm-spawn-worktree-settle.test.sh
@@ -12,10 +12,17 @@
 # transient-then-settled pane_current_path sequence with a fake tmux and
 # asserts the recorded worktree resolves to the real, settled worktree, never
 # the stale first read.
+#
+# The same loop has a second transient to survive: `treehouse get` reports the
+# REPOSITORY's primary checkout as its own cwd while it is still preparing a
+# slot. From a linked spawning home that path is not the project, so a poll
+# comparing only against the project adopted it and the isolation guard then
+# refused the launch. The cases below cover both the transient and the pane
+# that never leaves the primary at all.
 set -u
 
-# shellcheck source=tests/lib.sh
-. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+# shellcheck source=tests/fixtures.sh
+. "$(dirname "${BASH_SOURCE[0]}")/fixtures.sh"
 
 SPAWN="$ROOT/bin/fm-spawn.sh"
 TMP_ROOT=$(fm_test_tmproot fm-spawn-worktree-settle)
@@ -127,27 +134,92 @@ test_single_stale_first_read_is_not_accepted() {
   pass "a single transient stale pane_current_path read is not accepted as the worktree"
 }
 
-# A pane that reports the real worktree from the very first read still only
-# costs the loop's existing one-second inter-poll sleep to confirm - not an
-# extra full cycle on top of that.
-test_already_settled_pane_costs_one_confirm_sleep() {
-  local rec id out status pane_reads expected_reads
+# A pane that reports the real worktree from the very first read costs exactly
+# one confirming read - not a whole extra polling cycle on top of it. Counting
+# the pane reads measures the loop itself; wall-clock time would fold in every
+# other cost of a spawn (fetch, trust registration) and drift with the machine.
+test_already_settled_pane_costs_one_confirm_read() {
+  local rec id out status reads
   id=settle-already-settled-z2
   rec=$(make_settle_case settle-already-settled "$id" 0)
   read_settle_record "$rec"
 
   out=$(run_settle_spawn "$id")
   status=$?
-  pane_reads=$(cat "$COUNTFILE")
-  expected_reads=2
-  expect_code 0 "$status" "spawn should succeed when the pane is already settled"
+  expect_code 0 "$status" "spawn should succeed when the pane is already settled"$'\n'"$out"
   assert_grep "worktree=$WT_DIR" "$HOME_DIR/state/$id.meta" \
     "meta did not record the already-settled worktree"
-  [ "$pane_reads" -eq "$expected_reads" ] || fail "already-settled pane used $pane_reads pane reads; expected $expected_reads (initial read plus one confirmation)"
-  pass "an already-settled pane confirms via the existing inter-poll sleep, not an extra full cycle"
+  reads=$(cat "$COUNTFILE")
+  [ "$reads" -eq 2 ] || fail "already-settled pane took $reads reads to confirm - expected the first read plus one confirmation"
+  pass "an already-settled pane confirms on the next read, not a whole extra cycle"
+}
+
+# make_primary_case <name> <id> <stale_reads> builds the linked-home shape: the
+# spawning project is itself a LINKED worktree of the repository, and the path
+# the pane transiently reports is that repository's PRIMARY checkout. `treehouse
+# get` reports the repository it is preparing a slot from as its own cwd while
+# it is still fetching and checking out, so the pane reads the primary for the
+# first seconds. The primary is not the spawning project, so a poll that only
+# compares against the project accepts it as the worktree, and the isolation
+# guard then refuses the launch even though treehouse went on to enter a real
+# slot. The settled path is a second linked worktree of the same repository.
+make_primary_case() {
+  local name=$1 id=$2 stale_reads=$3 case_dir home primary proj wt fakebin countfile
+  case_dir="$TMP_ROOT/$name"
+  home="$case_dir/home"
+  primary="$case_dir/primary"
+  proj="$case_dir/mate"
+  wt="$case_dir/slot"
+  countfile="$case_dir/pane-call-count"
+  fakebin=$(make_settle_fakebin "$case_dir/fake")
+  fm_test_spawn_home "$home" codex
+  fm_git_worktree "$primary" "$proj" "mate-$name"
+  git -C "$primary" worktree add --quiet -b "slot-$name" "$wt"
+  fm_test_spawn_brief "$home" "$id" "Exercise primary-checkout transient detection for $id."
+  printf '%s\n' "$case_dir|$home|$proj|$wt|$primary|$fakebin|$countfile|$stale_reads"
+}
+
+# The exact incident: the pane reports the repository primary for the first
+# reads, then settles into the slot treehouse actually created. The primary must
+# never be adopted as the worktree, so the spawn lands on the settled slot.
+test_transient_primary_checkout_is_not_accepted() {
+  local rec id out status
+  id=settle-primary-transient-z3
+  rec=$(make_primary_case settle-primary-transient "$id" 3)
+  read_settle_record "$rec"
+  fm_test_fake_sleep_noop "$FAKEBIN_DIR"
+
+  out=$(run_settle_spawn "$id")
+  status=$?
+  expect_code 0 "$status" "spawn should succeed once the pane leaves the primary checkout"$'\n'"$out"
+  assert_grep "worktree=$WT_DIR" "$HOME_DIR/state/$id.meta" \
+    "meta did not record the settled worktree"
+  assert_no_grep "worktree=$STALE_DIR" "$HOME_DIR/state/$id.meta" \
+    "meta wrongly recorded the repository primary checkout as the worktree"
+  pass "a transient primary-checkout pane read is not accepted as the worktree"
+}
+
+# A pane that never leaves the primary checkout must still fail at the deadline
+# rather than waiting forever or recording the primary.
+test_primary_checkout_that_never_settles_fails_at_the_deadline() {
+  local rec id out status
+  id=settle-primary-stuck-z4
+  rec=$(make_primary_case settle-primary-stuck "$id" 100000)
+  read_settle_record "$rec"
+  fm_test_fake_sleep_noop "$FAKEBIN_DIR"
+
+  out=$(run_settle_spawn "$id")
+  status=$?
+  [ "$status" -ne 0 ] || fail "spawn accepted a pane that never left the primary checkout"$'\n'"$out"
+  assert_contains "$out" "did not enter an isolated worktree" \
+    "spawn did not explain that the pane never reached an isolated worktree"
+  [ ! -e "$HOME_DIR/state/$id.meta" ] || fail "refused spawn published task metadata"
+  pass "a pane stuck on the primary checkout fails loudly at the deadline"
 }
 
 test_single_stale_first_read_is_not_accepted
-test_already_settled_pane_costs_one_confirm_sleep
+test_already_settled_pane_costs_one_confirm_read
+test_transient_primary_checkout_is_not_accepted
+test_primary_checkout_that_never_settles_fails_at_the_deadline
 
 echo "# all fm-spawn-worktree-settle tests passed"

--- a/tests/fm-spawn-worktree-settle.test.sh
+++ b/tests/fm-spawn-worktree-settle.test.sh
@@ -215,7 +215,7 @@ test_primary_checkout_that_never_settles_fails_at_the_deadline() {
     "spawn did not explain that the pane never reached an isolated worktree"
   assert_contains "$out" "$STALE_DIR" \
     "the refusal did not name the path the pane kept reporting"
-  assert_contains "$out" "it is the repository's primary checkout" \
+  assert_contains "$out" "repository's primary checkout" \
     "the refusal did not say why that path was rejected"
   [ ! -e "$HOME_DIR/state/$id.meta" ] || fail "refused spawn published task metadata"
   pass "a pane stuck on the primary checkout fails loudly at the deadline"

--- a/tests/fm-tangle-guard.test.sh
+++ b/tests/fm-tangle-guard.test.sh
@@ -169,21 +169,27 @@ test_spawn_isolation_abort() {
   mkdir -p "$TMP_ROOT/spawn-notgit" "$proj/sub"
 
   # Abort: the pane resolves to a plain non-git directory (not a worktree at all).
+  # The discovery poll screens every candidate with the isolation conditions, so
+  # a path like this is never adopted and the refusal comes from the poll's own
+  # deadline, naming the path and why it was rejected.
   out=$(run_spawn "$home" abort-notgit-dd4 "$proj" "$TMP_ROOT/spawn-notgit" "$fakebin"); status=$?
   expect_code 1 "$status" "spawn into a non-worktree dir should abort"
-  assert_contains "$out" "did not yield an isolated worktree" "non-worktree spawn lacked the isolation error"
+  assert_contains "$out" "did not enter an isolated worktree" "non-worktree spawn lacked the isolation error"
+  assert_contains "$out" "it is not inside a git worktree" "non-worktree spawn did not say why the path was rejected"
   assert_absent "$home/state/abort-notgit-dd4.meta" "aborted spawn must not record meta"
 
   # Abort: the pane resolves INTO the primary checkout (a subdir of PROJ_ABS).
   out=$(run_spawn "$home" abort-primary-ee5 "$proj" "$proj/sub" "$fakebin"); status=$?
   expect_code 1 "$status" "spawn landing inside the primary checkout should abort"
-  assert_contains "$out" "did not yield an isolated worktree" "primary-checkout spawn lacked the isolation error"
+  assert_contains "$out" "did not enter an isolated worktree" "primary-checkout spawn lacked the isolation error"
+  assert_contains "$out" "not a worktree root" "primary-checkout spawn did not say why the path was rejected"
+  assert_absent "$home/state/abort-primary-ee5.meta" "aborted spawn must not record meta"
 
   # Proceed: the pane resolves to a genuine, isolated worktree.
   out=$(run_spawn "$home" ok-isolated-ff6 "$proj" "$TMP_ROOT/spawn-wt" "$fakebin"); status=$?
   expect_code 0 "$status" "spawn into a genuine isolated worktree should succeed"
   assert_contains "$out" "spawned ok-isolated-ff6" "isolated spawn did not report success"
-  assert_not_contains "$out" "did not yield an isolated worktree" "isolated spawn wrongly tripped the guard"
+  assert_not_contains "$out" "isolated worktree" "isolated spawn wrongly tripped the guard"
   pass "fm-spawn: aborts unless the resolved worktree is a genuine, isolated worktree"
 }
 

--- a/tests/fm-tangle-guard.test.sh
+++ b/tests/fm-tangle-guard.test.sh
@@ -164,6 +164,8 @@ test_spawn_isolation_abort() {
   mkdir -p "$home/data"
   proj=$(make_repo "$TMP_ROOT/spawn-proj")
   fakebin=$(make_spawn_fakebin "$TMP_ROOT/spawn-fake")
+  # The assertions concern identity, not how long an unchanged cwd is polled.
+  fm_test_fake_sleep_noop "$fakebin"
   # A genuine isolated linked worktree of the project, detached on the default.
   git -C "$proj" worktree add -q --detach "$TMP_ROOT/spawn-wt" >/dev/null 2>&1
   mkdir -p "$TMP_ROOT/spawn-notgit" "$proj/sub"

--- a/tests/fm-tangle-guard.test.sh
+++ b/tests/fm-tangle-guard.test.sh
@@ -168,16 +168,25 @@ test_spawn_isolation_abort() {
   fm_test_fake_sleep_noop "$fakebin"
   # A genuine isolated linked worktree of the project, detached on the default.
   git -C "$proj" worktree add -q --detach "$TMP_ROOT/spawn-wt" >/dev/null 2>&1
-  mkdir -p "$TMP_ROOT/spawn-notgit" "$proj/sub"
+  # The non-git case must BE non-git wherever this suite runs. A directory under
+  # TMPDIR is not one when TMPDIR itself sits inside a git repository - git walks
+  # up and finds that repo, and the spawn reports the subdirectory cause instead.
+  # GIT_CEILING_DIRECTORIES stops that upward walk: git does not chdir up into a
+  # listed directory, though it never excludes the directory being searched, so
+  # the ceiling is the PARENT of the path handed to the spawn (git(1),
+  # "GIT_CEILING_DIRECTORIES").
+  mkdir -p "$TMP_ROOT/spawn-notgit-root/plain" "$proj/sub"
 
   # Abort: the pane resolves to a plain non-git directory (not a worktree at all).
   # The discovery poll screens every candidate with the isolation conditions, so
   # a path like this is never adopted and the refusal comes from the poll's own
-  # deadline, naming the path and why it was rejected.
-  out=$(run_spawn "$home" abort-notgit-dd4 "$proj" "$TMP_ROOT/spawn-notgit" "$fakebin"); status=$?
+  # deadline, naming the path and why it was rejected. The assertions pin which
+  # cause fired, not the operator wording that explains it.
+  out=$(GIT_CEILING_DIRECTORIES="$TMP_ROOT/spawn-notgit-root" \
+    run_spawn "$home" abort-notgit-dd4 "$proj" "$TMP_ROOT/spawn-notgit-root/plain" "$fakebin"); status=$?
   expect_code 1 "$status" "spawn into a non-worktree dir should abort"
   assert_contains "$out" "did not enter an isolated worktree" "non-worktree spawn lacked the isolation error"
-  assert_contains "$out" "it is not inside a git worktree" "non-worktree spawn did not say why the path was rejected"
+  assert_contains "$out" "not inside a git worktree" "non-worktree spawn did not say why the path was rejected"
   assert_absent "$home/state/abort-notgit-dd4.meta" "aborted spawn must not record meta"
 
   # Abort: the pane resolves INTO the primary checkout (a subdir of PROJ_ABS).


### PR DESCRIPTION
## Intent

Restore crewmate and scout launches from a Firstmate home whose project is itself a linked worktree of a repository (a home whose workers take pooled worktrees of that same repo). Every launch from such a home currently exits with:

error: treehouse get did not yield an isolated worktree (resolved '<repository primary checkout>'; worktree root '<repository primary checkout>'; spawning project '<linked worktree>'); refusing to launch to avoid tangling the primary checkout

treehouse does create a correct isolated worktree for the task, so this is a defect in bin/fm-spawn.sh's worktree discovery rather than a local configuration problem: the spawn settles on the repository primary checkout it observes before treehouse has finished preparing the slot, and the isolation guard then refuses the launch. A spawn should land on the isolated worktree treehouse creates, and should still refuse loudly when no isolated worktree is ever reached. Reported and confirmed on main as kunchenguid/firstmate#3808.

## What Changed

- Extracted the spawn isolation conditions into a shared `spawn_worktree_isolated` predicate in `bin/fm-spawn.sh` and made the pane-cwd discovery poll screen every read through it, so a pane reporting the spawning project or the repository's primary checkout while `treehouse get` prepares the slot is treated as a transient and waited out instead of adopted and then refused by the isolation guard.
- Reworked the poll's deadline failure to refuse loudly with detail: it now reports "did not enter an isolated worktree", naming the last path the pane reported and the specific reason it was rejected (not a readable directory, not inside a git worktree, a subdirectory rather than a worktree root, the spawning project itself, unresolvable git dir, or the repository's primary checkout); `validate_spawn_worktree` reuses the same predicate and reason for its own message.
- Added linked-spawning-home cases to `tests/fm-spawn-worktree-settle.test.sh` for a transient primary-checkout read that later settles into the real slot and for a pane that never leaves the primary, and updated the expected refusal strings and causes in the tangle-guard, pool-base-freshen, and herdr presentation e2e suites; the tangle-guard non-git case now pins `GIT_CEILING_DIRECTORIES` so the fixture directory is non-git wherever the suite runs, and stubs the poll's sleep.

## Risk Assessment

✅ Low: The change makes an existing guard strictly more conservative on one code path (the screen can only reject more candidates than the old poll, never accept more), preserves the guard predicate condition-for-condition for the relaunch and orca callers, and lands a regression test that provably fails against the base commit; the only cost is refusal latency the user has already accepted.

## Testing

Beyond the already-green baseline run, I exercised the three touched suites directly and then demonstrated the intent as an end user would: real `bin/fm-spawn.sh` launches from a Firstmate home whose project is a linked worktree of a repository, with the task pane transiently reporting the repository primary checkout. On the base commit both the crewmate and scout launches exit 1 with the verbatim error from the report and write no task metadata; on the change both succeed and record the isolated slot `treehouse get` created. A pane that never reaches an isolated worktree still refuses loudly at the real 60s deadline, naming the last path seen and the reason it was rejected. The new regression case also fails against the base spawn script and passes against the change, and the worktree was restored clean after the swap. No UI surface is involved — this is a CLI launch path, so the evidence is command transcripts rather than screenshots.

<details>
<summary>Evidence: End-to-end launch transcripts (before/after, crewmate + scout, and the loud refusal)</summary>

Source: [End-to-end launch transcripts (before/after, crewmate + scout, and the loud refusal)](https://github.com/tiago-peixoto/firstmate/blob/3b5f5c22fe738210993eafba51eb7169009dd907/.no-mistakes/evidence/fm/firstmate-spawn-poll-accepts-primary-transient-2/launch-transcripts.md)

```text
# firstmate#3808 — end-to-end launch transcripts

A Firstmate home whose **project is itself a linked worktree** of a repository.
`treehouse get` reports the repository's **primary checkout** as its own cwd
while it is still fetching and checking out the pooled slot, so the task pane
reads the primary for the first seconds before settling into the isolated slot.

Fixture shape (`$R` = a temp root):

| path | role |
|---|---|
| `$R/acme` | repository primary checkout |
| `$R/acme-mate` | the Firstmate home's project — a **linked worktree** of `acme` |
| `$R/acme-slot-7` | the isolated worktree `treehouse get` creates for the task |

The task pane reports `$R/acme` for its first 3 reads, then `$R/acme-slot-7`.
Real `bin/fm-spawn.sh`, real git worktrees; `tmux`/`treehouse` are stubs
standing in for the terminal backend.

---

## BEFORE — base commit c499f84

`` `
\### BEFORE (base c499f84) — crewmate launch, pane transiently on the repository primary

repository primary checkout  : $R/acme
firstmate home's project     : $R/acme-mate     (linked worktree of acme)
isolated slot treehouse gets : $R/acme-slot-7   (linked worktree of acme)
pane reads reporting primary : 3

$ bin/fm-spawn.sh demo-ship-a1 $R/acme-mate --mode no-mistakes --yolo off
error: treehouse get did not yield an isolated worktree (resolved '$R/acme'; worktree root '$R/acme'; spawning project '$R/acme-mate'); refusing to launch to avoid tangling the primary checkout. Inspect target firstmate:fm-demo-ship-a1

exit status: 1

$ cat $FM_HOME/state/demo-ship-a1.meta   # recorded task worktree
(no metadata written - launch refused)

\### BEFORE (base c499f84) — scout launch, same transient

repository primary checkout  : $R/acme
firstmate home's project     : $R/acme-mate     (linked worktree of acme)
isolated slot treehouse gets : $R/acme-slot-7   (linked worktree of acme)
pane reads reporting primary : 3

$ bin/fm-spawn.sh demo-scout-a1 $R/acme-mate --scout
error: treehouse get did not yield an isolated worktree (resolved '$R/acme'; worktree root '$R/acme'; spawning project '$R/acme-mate'); refusing to launch to avoid tangling the primary checkout. Inspect target firstmate:fm-demo-scout-a1

exit status: 1

$ cat $FM_HOME/state/demo-scout-a1.meta   # recorded task worktree
(no metadata written - launch refused)

`` `

Both launches exit 1 with the exact error from the report, and no task
metadata is written.

---

## AFTER — the change under test (93b2fce)

`` `
\### AFTER (fix) — crewmate launch, pane transiently on the repository primary

repository primary checkout  : $R/acme
firstmate home's project     : $R/acme-mate     (linked worktree of acme)
isolated slot treehouse gets : $R/acme-slot-7   (linked worktree of acme)
pane reads reporting primary : 3

$ bin/fm-spawn.sh demo-ship-a1 $R/acme-mate --mode no-mistakes --yolo off
spawned demo-ship-a1 harness=codex kind=ship mode=no-mistakes yolo=off window=firstmate:fm-demo-ship-a1 worktree=$R/acme-slot-7

exit status: 0

$ cat $FM_HOME/state/demo-ship-a1.meta   # recorded task worktree
worktree=$R/acme-slot-7
project=$R/acme-mate
kind=ship

\### AFTER (fix) — scout launch, same transient

repository primary checkout  : $R/acme
firstmate home's project     : $R/acme-mate     (linked worktree of acme)
isolated slot treehouse gets : $R/acme-slot-7   (linked worktree of acme)
pane reads reporting primary : 3

$ bin/fm-spawn.sh demo-scout-a1 $R/acme-mate --scout
spawned demo-scout-a1 harness=codex kind=scout window=firstmate:fm-demo-scout-a1 worktree=$R/acme-slot-7

exit status: 0

$ cat $FM_HOME/state/demo-scout-a1.meta   # recorded task worktree
worktree=$R/acme-slot-7
project=$R/acme-mate
kind=scout

`` `

Both launches now land on the isolated slot `treehouse` created, and
`state/<id>.meta` records that slot — never the repository primary.

---

## AFTER — a pane that never reaches an isolated worktree still refuses loudly

The same fixture, but the pane reports the repository primary forever
(`treehouse get` never enters a slot). Real 60s deadline, real `sleep`:

`` `
\### AFTER (fix) — pane NEVER reaches an isolated worktree, so the launch still refuses loudly

repository primary checkout  : $R/acme
firstmate home's project     : $R/acme-mate     (linked worktree of acme)
isolated slot treehouse gets : $R/acme-slot-7   (linked worktree of acme)
pane reads reporting primary : 999

$ bin/fm-spawn.sh demo-ship-a1 $R/acme-mate --mode no-mistakes --yolo off
error: treehouse get did not enter an isolated worktree within 60s (last seen '$R/acme': it is the repository's primary checkout (its git dir is the spawning project's common git dir); spawning project '$R/acme-mate'); inspect window firstmate:fm-demo-ship-a1

exit status: 1

$ cat $FM_HOME/state/demo-ship-a1.meta   # recorded task worktree
(no metadata written - launch refused)

`` `

The launch still refuses, exits 1, writes no metadata, and the refusal now
names the last path the pane reported and why it was rejected.
```
</details>
<details>
<summary>Evidence: Regression proof: new settle cases fail on base c499f84, pass on the change</summary>

Source: [Regression proof: new settle cases fail on base c499f84, pass on the change](https://github.com/tiago-peixoto/firstmate/blob/3b5f5c22fe738210993eafba51eb7169009dd907/.no-mistakes/evidence/fm/firstmate-spawn-poll-accepts-primary-transient-2/regression-before-after.md)

```text
# Regression proof: tests/fm-spawn-worktree-settle.test.sh

## Against BASE bin/fm-spawn.sh (c499f84) - the new cases fail with the reported error
`` `
ok - a single transient stale pane_current_path read is not accepted as the worktree
ok - an already-settled pane confirms on the next read, not a whole extra cycle
not ok - spawn should succeed once the pane leaves the primary checkout
error: treehouse get did not yield an isolated worktree (resolved '/private/var/folders/r8/cylyt7xd7t50y9x5wc05my380000gn/T/fm-spawn-worktree-settle.ZSrJSo/settle-primary-transient/primary'; worktree root '/private/var/folders/r8/cylyt7xd7t50y9x5wc05my380000gn/T/fm-spawn-worktree-settle.ZSrJSo/settle-primary-transient/primary'; spawning project '/private/var/folders/r8/cylyt7xd7t50y9x5wc05my380000gn/T/fm-spawn-worktree-settle.ZSrJSo/settle-primary-transient/mate'); refusing to launch to avoid tangling the primary checkout. Inspect target firstmate:fm-settle-primary-transient-z3: expected exit 0, got 1
`` `

## Against the change under test (93b2fce) - all four cases pass
`` `
ok - a single transient stale pane_current_path read is not accepted as the worktree
ok - an already-settled pane confirms on the next read, not a whole extra cycle
ok - a transient primary-checkout pane read is not accepted as the worktree
ok - a pane stuck on the primary checkout fails loudly at the deadline
# all fm-spawn-worktree-settle tests passed
`` `
```
</details>
<details>
<summary>Evidence: Repro script used for the manual launches (rerunnable: fm3808-repro.sh &lt;label&gt; &lt;worktree&gt; &lt;ship|scout&gt; &lt;stale-reads&gt;)</summary>

Source: [Repro script used for the manual launches (rerunnable: fm3808-repro.sh &lt;label&gt; &lt;worktree&gt; &lt;ship|scout&gt; &lt;stale-reads&gt;)](https://github.com/tiago-peixoto/firstmate/blob/3b5f5c22fe738210993eafba51eb7169009dd907/.no-mistakes/evidence/fm/firstmate-spawn-poll-accepts-primary-transient-2/fm3808-repro.sh)

```text
#!/usr/bin/env bash
# Manual end-to-end repro of kunchenguid/firstmate#3808: a launch from a
# Firstmate home whose project is itself a LINKED worktree of a repository.
# `treehouse get` reports the repository PRIMARY checkout as its own cwd while
# it is still preparing the pooled slot, so the task pane reads the primary for
# the first seconds before settling into the isolated slot treehouse created.
set -u
LABEL=${1:?label}
WORKTREE=${2:?worktree root}
KIND=${3:-ship}          # ship (crewmate) | scout
STALE=${4:-3}            # pane reads that still report the primary checkout
. "$WORKTREE/tests/fixtures.sh"

root=$(fm_test_tmproot fm3808-"$LABEL")
home="$root/firstmate-home"
primary="$root/acme"          # repository primary checkout
mate="$root/acme-mate"        # the home's project: a LINKED worktree of acme
slot="$root/acme-slot-7"      # the isolated worktree treehouse get creates
id=demo-$KIND-a1

fm_test_spawn_home "$home" codex
fm_git_worktree "$primary" "$mate" mate >/dev/null 2>&1
git -C "$primary" worktree add --quiet -b slot-7 "$slot"
fm_test_spawn_brief "$home" "$id" "Demonstrate launching from a linked-worktree home."

fake=$(fm_fakebin "$root/fake")
fm_fake_exit0 "$fake" treehouse
cat > "$fake/tmux" <<'SH'
#!/usr/bin/env bash
set -u
case "$*" in
  *"#{pane_current_path}"*)
    n=0; [ -f "$FM_FAKE_PANE_COUNTFILE" ] && n=$(cat "$FM_FAKE_PANE_COUNTFILE")
    n=$((n + 1)); printf '%s\n' "$n" > "$FM_FAKE_PANE_COUNTFILE"
    # treehouse get is still fetching/checking the slot out for these reads.
    if [ "$n" -le "$FM_FAKE_PANE_STALE_READS" ]; then printf '%s\n' "$FM_FAKE_PANE_STALE"
    else printf '%s\n' "$FM_FAKE_PANE_PATH"; fi
    exit 0 ;;
esac
case "${1:-}" in display-message) printf 'firstmate\n'; exit 0 ;; esac
exit 0
SH
chmod +x "$fake/tmux"

args=("$id" "$mate")
if [ "$KIND" = scout ]; then args+=(--scout); else args+=(--mode no-mistakes --yolo off); fi

echo "### $LABEL"
echo
echo "repository primary checkout  : \$R/acme"
echo "firstmate home's project     : \$R/acme-mate     (linked worktree of acme)"
echo "isolated slot treehouse gets : \$R/acme-slot-7   (linked worktree of acme)"
echo "pane reads reporting primary : $STALE"
echo
echo "\$ bin/fm-spawn.sh ${args[*]//$root/\$R}"
set +e
FM_ROOT_OVERRIDE='' FM_HOME="$home" \
  FM_STATE_OVERRIDE="$home/state" FM_DATA_OVERRIDE="$home/data" \
  FM_PROJECTS_OVERRIDE="$home/projects" FM_CONFIG_OVERRIDE="$home/config" \
  FM_SPAWN_NO_GUARD=1 TMUX="fake,1,0" \
  FM_FAKE_PANE_PATH="$slot" FM_FAKE_PANE_STALE="$primary" \
  FM_FAKE_PANE_STALE_READS="$STALE" \
  FM_FAKE_PANE_COUNTFILE="$root/pane-reads" \
  PATH="$fake:$PATH" \
  "$WORKTREE/bin/fm-spawn.sh" "${args[@]}" 2>&1 \
  | grep -v '^warning: .*records no delivery contract line' | sed "s#$root#\$R#g"
rc=${PIPESTATUS[0]}
set -e
echo
echo "exit status: $rc"
echo
echo "\$ cat \$FM_HOME/state/$id.meta   # recorded task worktree"
if [ -e "$home/state/$id.meta" ]; then
  grep -E '^(worktree|project|kind)=' "$home/state/$id.meta" | sed "s#$root#\$R#g"
else
  echo "(no metadata written - launch refused)"
fi
echo
```
</details>
<details>
<summary>Evidence: Crewmate launch, before vs after</summary>

```text
BEFORE (base c499f84)
$ bin/fm-spawn.sh demo-ship-a1 $R/acme-mate --mode no-mistakes --yolo off
error: treehouse get did not yield an isolated worktree (resolved '$R/acme'; worktree root '$R/acme'; spawning project '$R/acme-mate'); refusing to launch to avoid tangling the primary checkout. Inspect target firstmate:fm-demo-ship-a1
exit status: 1
$ cat $FM_HOME/state/demo-ship-a1.meta
(no metadata written - launch refused)

AFTER (change under test)
$ bin/fm-spawn.sh demo-ship-a1 $R/acme-mate --mode no-mistakes --yolo off
spawned demo-ship-a1 harness=codex kind=ship mode=no-mistakes yolo=off window=firstmate:fm-demo-ship-a1 worktree=$R/acme-slot-7
exit status: 0
$ cat $FM_HOME/state/demo-ship-a1.meta
worktree=$R/acme-slot-7
project=$R/acme-mate
kind=ship
```
</details>
<details>
<summary>Evidence: Pane that never reaches an isolated worktree still refuses loudly (real 60s deadline)</summary>

```text
$ bin/fm-spawn.sh demo-ship-a1 $R/acme-mate --mode no-mistakes --yolo off
error: treehouse get did not enter an isolated worktree within 60s (last seen '$R/acme': it is the repository's primary checkout (its git dir is the spawning project's common git dir); spawning project '$R/acme-mate'); inspect window firstmate:fm-demo-ship-a1
exit status: 1
$ cat $FM_HOME/state/demo-ship-a1.meta
(no metadata written - launch refused)
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"ba6d5c09f7c610ccf5393a552fdbf3185bc34de4","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>⚠️ **Review** - 1 info</summary>

- ℹ️ `bin/fm-spawn.sh:2898` - Durability bound, not a regression: the fix converts the linked-home failure from &#34;adopt the primary at ~2s and refuse&#34; into &#34;wait for the pane to reach an isolated worktree&#34;, but that wait is still capped by the pre-existing 60-iteration/60s deadline. If `treehouse get` on the reporter&#39;s host needs longer than 60s to fetch and check out the slot, the launch still ends in the same refusal class the intent asks to eliminate (now worded `did not enter an isolated worktree within 60s (last seen &#39;&lt;primary&gt;&#39;: it is the repository&#39;s primary checkout ...)`). The change does not shrink that budget - it strictly enlarges the window in which a slow slot can still be adopted - so there is nothing to correct here; noting it because the fix&#39;s success on any given host depends on a timeout the change deliberately left alone. Any remedy (configurable or adaptive deadline) would extend the change beyond its stated scope.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `bin/fm-test-run.sh --changed --exclude-family real-herdr-gated`
- <code>`./tests/fm-spawn-worktree-settle.test.sh` — 4/4 pass on the change (includes the two new primary-checkout cases)</code>
- <code>Regression proof: same suite re-run with `bin/fm-spawn.sh` swapped to base `c499f84`, then restored — `test_transient_primary_checkout_is_not_accepted` fails there with `did not yield an isolated worktree (resolved &#39;&lt;primary&gt;&#39; ...)`</code>
- <code>`./tests/fm-tangle-guard.test.sh` — 6/6 pass, ~18s wall (the stubbed poll sleep from review round 1 holds)</code>
- <code>`./tests/fm-spawn-pool-base-freshen.test.sh` — all pass, including the four `linked spawning home: ...` cases</code>
- <code>Manual end-to-end launch, crewmate: `bin/fm-spawn.sh demo-ship-a1 $R/acme-mate --mode no-mistakes --yolo off` from a linked-worktree home, pane on the repository primary for 3 reads then the slot — base exits 1 with the reported error, change exits 0 and records `worktree=$R/acme-slot-7`</code>
- <code>Manual end-to-end launch, scout: same fixture with `--scout` — base exits 1 with the reported error, change exits 0 and records `worktree=$R/acme-slot-7` with `kind=scout`</code>
- <code>Manual loud-refusal check: same fixture with the pane never leaving the primary, real 60s deadline and real `sleep` — exits 1, writes no `state/&lt;id&gt;.meta`, and reports `did not enter an isolated worktree within 60s (last seen &#39;$R/acme&#39;: it is the repository&#39;s primary checkout ...)`</code>
</details>

<details>
<summary>⚠️ **Document** - 1 info</summary>

- ℹ️ `docs/architecture.md:204` - Judgment call, left unchanged: the spawn-isolation regression pointer names tests/fm-spawn-pool-base-freshen.test.sh and tests/fm-control-relaunch.test.sh, but the definitive regression for this change&#39;s invariant (the discovery poll screening a transient primary-checkout read instead of adopting it) is tests/fm-spawn-worktree-settle.test.sh. That suite pre-dates this change and the line never listed it, so the omission is not staleness this change introduced, and adding a third pointer would be opportunistic expansion of an unrelated line. Worth a follow-up only if the pointer list is meant to be exhaustive.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
