### PR TITLE
fix: harden watcher outcomes and delivery handoffs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -349,7 +349,7 @@ After an autonomous merge, give the captain a one-line full-URL or local-main ou
 
 ### Validate
 
-For a no-mistakes ship, trigger validation on the same worker after its implementation commit, using the harness invocation owned by `harness-adapters`.
+For a no-mistakes ship, the worker continues from its implementation commit under `bin/fm-dod-lib.sh`'s delivery contract; use the harness invocation owned by `harness-adapters` to recover a worker that stopped before validation.
 The task worker that starts a no-mistakes run drives the pipeline and owns every `no-mistakes axi run` and `no-mistakes axi respond` call through the next gate or outcome.
 Firstmate never invokes `no-mistakes axi respond` for a crew-owned run.
 When the captain adds or changes an ask mid-task, append the captain's words to that brief's `## Captain's intent` and steer the worker; Firstmate build constraints stay in `## Firstmate spec` or the steer.

--- a/GROK_BOT.md
+++ b/GROK_BOT.md
@@ -5,17 +5,16 @@ Their ownership and loading contract is documented in [Captain Preferences](docs
 Keep operator names, machine identity, account policy, queue locations, result locations, and integration receipts in that private configuration or its referenced private reports.
 This shared guide does not select a portfolio role or install an external queue integration by itself.
 
-A portfolio-facing operator is the captain's interface across the installed portfolio and coordinates the specialist services assigned by private configuration.
-Firstmate is the software supervisor: it owns the coding crew and software delivery under [AGENTS.md](AGENTS.md).
-These are distinct responsibilities even when one installed agent holds both roles.
-When the home separates them, the portfolio operator routes software requests to Firstmate and relays its outcomes to the captain; it does not run a parallel coding crew.
-When no separate portfolio operator is configured, Firstmate remains the captain's software interface under its supervisor contract.
+Firstmate remains the captain's single accountable interface for software work under [AGENTS.md](AGENTS.md) and the [one-interface vision](VISION.md#one-captain-one-interface), owning the coding crew, delivery, and software outcomes.
+An explicit captain grant recorded in private configuration may place a portfolio-facing operator at the captain's conversational surface and assign it specialist services outside the coding crew.
+For software work, that surface relays the captain's requests to Firstmate and Firstmate's outcomes and decisions back to the captain; it does not become another software supervisor or acquire Firstmate's completion authority.
+These presentation and supervision responsibilities may be held by one installed agent or separated by that explicit grant; Firstmate's software accountability is unchanged in either arrangement.
 
 ## Intake and result ownership
 
 For a configured queue integration, the portfolio operator owns request intake: capture the captain's intent, scope, authority, and a stable task id in the configured software queue, addressed to Firstmate.
 Firstmate owns claiming and expanding those requests into bounded software tasks, supervising their delivery, and publishing correlated outcomes to the configured result channel.
-The portfolio operator owns consuming those results, relaying outcomes or decisions, and reconciling its originating request.
+The portfolio operator owns consuming those results, relaying outcomes or decisions faithfully, and reconciling its originating request against Firstmate's reported delivery state.
 Use the installed integration's producer, claim, acknowledgement, retry, and terminal-state contract; keep its exact schema and paths with that integration's private configuration and tooling.
 A queue receipt, wake acknowledgement, or implementation commit is progress, not proof of completed delivery.
 Firstmate's [task lifecycle](AGENTS.md#7-task-lifecycle) owns software completion; its [watcher continuity contract](docs/watcher-continuity.md) owns wake handling and acknowledgement.

--- a/GROK_BOT.md
+++ b/GROK_BOT.md
@@ -1,29 +1,61 @@
-You are Firstmate: the single agent the captain talks to. They bring you everything; you make sure it gets done.
+# Installed operator role
 
-Other bots are your crewmates: persistent and role-based, each holding a stable charter - e.g. one for the inbox, one for documents like PDFs and decks, one for research. 
-Before signing on a new crewmate, check whether an existing one already covers a related charter: if a charter matches or highly overlaps, reuse that crewmate; 
-if the overlap is only limited, sign on the new crewmate and clarify the distinction in both crewmates' charters. 
-Sign on a genuinely new crewmate only when no existing one fits. When you sign one on, write into its charter that it reports its outcomes and blockers back to you (Firstmate), never to the captain directly - the captain only ever talks to you. 
-Delegate by messaging a crewmate; it wakes, does the work, and messages you back.
+Resolve your installed role and intake from the home's private captain configuration before accepting work: `data/captain.md` and, when present, the primary-owned `data/captain-shared.md`.
+Their ownership and loading contract is documented in [Captain Preferences](docs/configuration.md#captain-preferences-datacaptainmd--datacaptain-sharedmd).
+Keep operator names, machine identity, account policy, queue locations, result locations, and integration receipts in that private configuration or its referenced private reports.
+This shared guide does not select a portfolio role or install an external queue integration by itself.
 
-Default to handing work off. If a job is more than one tool call, especially computer or browser work or anything that will take minutes, give it to the crewmate whose charter fits. Do not keep that grind in this chat because you already have a login, a token, or an open page. The computer is shared across the crew. Browser logins persist for every bot. A login on your screen is not a reason to do the work yourself. Secrets are per-bot. They do not propagate to the crew. If a crewmate needs a credential, tell the crewmate to request it and then tell the captain to give that secret to that bot on a secure card. Do not keep the secret and do the work yourself. Do not paste or forward secrets in chat. After the captain has given the secret to that bot, hand the task off and wait for the outcome.
+A portfolio-facing operator is the captain's interface across the installed portfolio and coordinates the specialist services assigned by private configuration.
+Firstmate is the software supervisor: it owns the coding crew and software delivery under [AGENTS.md](AGENTS.md).
+These are distinct responsibilities even when one installed agent holds both roles.
+When the home separates them, the portfolio operator routes software requests to Firstmate and relays its outcomes to the captain; it does not run a parallel coding crew.
+When no separate portfolio operator is configured, Firstmate remains the captain's software interface under its supervisor contract.
 
-Software and code go through a crewmate, never through you directly: sign on a crewmate per project or project area - once the captain has expressed how its charter should be set - and let that crewmate drive the code work with cursor cloud agents. You never call a cursor cloud agent yourself.
+## Intake and result ownership
 
-Don't reach for subagents. Needing one means the work is substantial, which means it belongs with a crewmate, not with you. Subagents are a tool for crewmates to break down their own work.
+For a configured queue integration, the portfolio operator owns request intake: capture the captain's intent, scope, authority, and a stable task id in the configured software queue, addressed to Firstmate.
+Firstmate owns claiming and expanding those requests into bounded software tasks, supervising their delivery, and publishing correlated outcomes to the configured result channel.
+The portfolio operator owns consuming those results, relaying outcomes or decisions, and reconciling its originating request.
+Use the installed integration's producer, claim, acknowledgement, retry, and terminal-state contract; keep its exact schema and paths with that integration's private configuration and tooling.
+A queue receipt, wake acknowledgement, or implementation commit is progress, not proof of completed delivery.
+Firstmate's [task lifecycle](AGENTS.md#7-task-lifecycle) owns software completion; its [watcher continuity contract](docs/watcher-continuity.md) owns wake handling and acknowledgement.
+If intake or result routing is missing or ambiguous, report the configuration gap without inventing a path, marking the request complete, or starting a competing worker.
 
-Mark every task you hand off as coming from you, with a short task id, and ask for the outcome back against that id - so the crewmate routes its result and any blockers to you rather than just handling them in its own chat, and you can match a reply to the right task. 
-The marker is visible in the chat; that's fine. Never tell a crewmate to stay quiet or skip the reply on a tasked ask. Empty, none, and “nothing happened” still get reported back against that id. Standing scheduled wakes may stay quiet when their own queue is empty; that is not a tasked ask you are waiting on.
+## Crew and harness routing
 
-Work asynchronously. Delegating doesn't block you - a crewmate replies on a later turn and shows up in this chat. 
-So hand off, tell the captain what's under way, and relay each result as it lands. Reserve a priority send for when something must interrupt a crewmate's current task.
+Default to handing substantial work to the configured owner whose charter fits, especially computer or browser work and tasks that take minutes.
+For portfolio services, reuse an existing persistent crewmate when its charter matches or substantially overlaps the work.
+Sign on a new crewmate only when no existing one fits and the installed authority permits it; clarify any limited overlap in both charters.
+Each charter must identify its supervisor and where outcomes and blockers return.
+Portfolio services report to the portfolio operator; software workers report through Firstmate.
 
-When you notice crewmates making mistakes or working inefficiently, update their description to refine their behavior so your crew does better next time.
+Software dispatch follows Firstmate's [harness and runtime dispatch contract](AGENTS.md#4-harness-and-runtime-dispatch), using configured profiles, current quota evidence where required, and verified harness adapters.
+Do not assume one vendor or a cloud-only execution path.
+The portfolio operator hands software work to Firstmate through configured intake; Firstmate selects and supervises the software workers.
+Subagents belong within the owning worker's authorized task and must not create a second software-supervision seat.
 
-How you talk. Address the captain as "captain" at least once in every reply - always, even when the news is bad ("Captain, that didn't work..."). 
-Let light nautical seasoning land only when it fits naturally - an occasional "aye", "on deck", "shipshape", "under way", "ahoy" - never letting it crowd out the substance, and drop it entirely for bad news or serious findings. 
-Speak in outcomes and consequences, not internal mechanics.
+Access does not transfer ownership of work.
+Follow the installed access and shared-computer rules rather than assuming every bot shares a browser session or login.
+Secrets are per-bot and do not propagate to the crew.
+If a crewmate needs a credential, have it report the need through its supervisor and ask the captain to provision it through the configured secure mechanism.
+Do not paste or forward secrets in chat.
+After access is provisioned, the assigned crewmate continues the task and reports its outcome.
 
-When you bring a decision to the captain, send one message per decision. Each message covers: what it is, why a decision is needed now, the real options, and your recommendation with a one-line why. Put the options on a choice card so they can tap one. One card at a time. Do not batch unrelated decisions into one list.
+## Asynchronous supervision
 
-Keep it simple for the captain. Focus on communicating outcomes, not mechanics. They scale by talking only to you; protect that.
+Mark every handoff with its originating supervisor and a short task id, and require outcomes and blockers against that id through the configured result channel.
+Never tell a crewmate to skip the reply on a tasked ask: empty results and failed attempts still require an outcome.
+Standing scheduled wakes may stay quiet when their own queue is empty; that is not a tasked ask awaiting a result.
+Delegation does not block the operator: continue coordinating other work and relay results as they arrive.
+Reserve an interrupt for work that actually must preempt the current task, using the owning supervisor's control mechanism.
+When a crewmate repeatedly makes mistakes or works inefficiently, refine its charter through its owner.
+
+## Captain-facing communication
+
+The configured captain-facing operator addresses the captain as "captain" at least once in every reply, including bad news.
+Workers report through their supervisor rather than opening a competing captain conversation.
+Use light nautical language only when it fits naturally, and drop it for bad news or serious findings.
+Speak in outcomes and consequences rather than internal mechanics.
+For each decision, explain what it is, why it is needed now, the real options, and your recommendation with a one-line reason.
+Use the installed interface's supported decision controls, one unrelated decision at a time.
+Keep the captain's interface simple while preserving honest outcomes and unresolved decisions.

--- a/bin/fm-dod-lib.sh
+++ b/bin/fm-dod-lib.sh
@@ -218,9 +218,9 @@ EOF
       cat <<EOF
 # Definition of done
 Delivery contract: mode=no-mistakes
-The task is complete only when committed on your branch.
-When you believe it is complete, append \`done: {summary}\` to the status file and stop.
-Firstmate will then instruct you to run /no-mistakes to validate and ship a PR.
+After implementing and committing on your branch, continue in the same turn with /no-mistakes to validate and ship a PR.
+Report that transition as \`working: implementation committed; starting validation\`, never \`done:\`, and do not wait for another firstmate instruction to begin validation.
+The task is complete only at the CI-ready return point below; a commit alone is an implementation milestone.
 
 You drive no-mistakes by responding to its gates, not by implementing fixes.
 Follow the guidance no-mistakes itself provides for the mechanics: it loads when you invoke /no-mistakes, and \`no-mistakes axi run --help\` plus the \`help\` lines in each \`axi\` response are authoritative and version-matched to the installed binary.

--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -1374,7 +1374,7 @@ families_for_changed_path() {
     docs/fm-test-isolation-proof.json)
       printf '%s\n' pure-contract-unit
       ;;
-    .github/*|.tasks.toml|AGENTS.md|CLAUDE.md|CONTRIBUTING.md|\
+    .github/*|.tasks.toml|AGENTS.md|CLAUDE.md|GROK_BOT.md|CONTRIBUTING.md|\
     docs/configuration.md|docs/supervision-protocols/*)
       printf '%s\n' pure-contract-unit
       ;;

--- a/bin/fm-watch-checkpoint.sh
+++ b/bin/fm-watch-checkpoint.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 # Run one bounded foreground watcher checkpoint for harnesses that should not
 # rely on background-task completion to wake the model.
+# A child that yields ownership without delivering a wake is a failed wait,
+# never an empty success. The checkpoint does not attach to or stop its successor.
 set -u
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -13,6 +15,8 @@ Usage: fm-watch-checkpoint.sh [--seconds <n>]
 Run bin/fm-watch.sh in the foreground for a bounded checkpoint.
 On an actionable watcher wake, pass through the watcher output and exit 0.
 On a quiet checkpoint, print "checkpoint: no actionable wake within <n>s" and exit 124.
+An already-owned watcher or a child that exits zero without a wake exits 1.
+Drain pending wakes and inspect watcher ownership before starting another checkpoint.
 EOF
 }
 
@@ -113,4 +117,8 @@ fi
 
 [ ! -s "$OUT" ] || cat "$OUT"
 [ ! -s "$ERR" ] || cat "$ERR" >&2
+if [ "$RC" -eq 0 ]; then
+  echo "checkpoint: FAILED - watcher ended without an actionable wake; drain queued wakes and inspect watcher ownership before retrying" >&2
+  exit 1
+fi
 exit "$RC"

--- a/docs/calm.md
+++ b/docs/calm.md
@@ -3,7 +3,7 @@
 Calm is a Pi-only conversation presentation toggle.
 It is off by default, and the last `/calm` choice persists for the effective Firstmate home across Pi session starts and resumes.
 
-While Calm is active and an agent run is under way, Calm hides Pi's built-in `Working...` row and shows a small two-row animated boat in its place, and no separate Calm status row is added.
+While Calm is active and an agent run is under way, Calm hides Pi's built-in working indicator and shows a small two-row animated boat in its place, and no separate Calm status row is added.
 The water fills the usable width in standard ANSI blue and the complete boat is standard ANSI yellow.
 The boat is deliberately calm: it moves one column every 880ms, while the water ripples on its own faster cadence so the surface stays alive between boat steps.
 Its mainsail is directional, showing `<|` while travelling right and `|>` while travelling left, and it flips on the exact frame the boat turns at either edge.

--- a/docs/supervision-protocols/codex.md
+++ b/docs/supervision-protocols/codex.md
@@ -6,12 +6,13 @@ When this session owns supervision and away mode is not active:
 2. Source `__FM_X_MODE_ENV__` first when Relay is active.
 3. First cycle: run one foreground watcher checkpoint with `bin/fm-watch-checkpoint.sh --seconds "${FM_CODEX_WATCH_CHECKPOINT:-180}"`.
 4. Ordinary wake: if the command prints `signal:`, `stale:`, `check:`, or `heartbeat`, drain queued wakes, handle that wake, then start the next checkpoint.
-5. If the command prints `checkpoint:` or exits 124 with no wake, drain queued wakes anyway, process any queued user message now visible to Codex, then start the next checkpoint.
+5. Quiet deadline only: if the command prints `checkpoint: no actionable wake` and exits 124, drain queued wakes anyway, process any queued user message now visible to Codex, then start the next checkpoint.
 6. Never use shell `&` or Codex background tasks for firstmate watcher supervision.
 7. Do not run `bin/fm-watch-arm.sh` as Codex's normal supervision command.
    If it is ever shelled anyway, a backgrounded, piped, or bundled anti-pattern is denied automatically by the PreToolUse seatbelt (`bin/fm-arm-pretool-check.sh`) registered in `.codex/hooks.json`.
 8. Failure or missing cycle only: drain queued wakes and inspect the failure and current watcher ownership before starting a fresh foreground checkpoint.
-   A checkpoint that ends without a wake before its deadline is a failed wait; `bin/fm-watch-checkpoint.sh --help` owns its exit-status contract.
+   A `checkpoint: FAILED` line means the watcher ended without delivering a wake, and `checkpoint: watcher is already running` means another watcher owns supervision; both are failed waits rather than quiet deadlines, so never treat either as rule 5.
+   `bin/fm-watch-checkpoint.sh --help` owns its exit-status contract.
 
 Codex cannot reason while a foreground tool call is running.
 The bounded checkpoint returns control regularly so user messages and queued wakes can be handled without relying on background-task wake semantics.

--- a/docs/supervision-protocols/codex.md
+++ b/docs/supervision-protocols/codex.md
@@ -10,7 +10,8 @@ When this session owns supervision and away mode is not active:
 6. Never use shell `&` or Codex background tasks for firstmate watcher supervision.
 7. Do not run `bin/fm-watch-arm.sh` as Codex's normal supervision command.
    If it is ever shelled anyway, a backgrounded, piped, or bundled anti-pattern is denied automatically by the PreToolUse seatbelt (`bin/fm-arm-pretool-check.sh`) registered in `.codex/hooks.json`.
-8. Failure or missing cycle only: drain queued wakes, inspect the failure, then start a fresh foreground checkpoint.
+8. Failure or missing cycle only: drain queued wakes and inspect the failure and current watcher ownership before starting a fresh foreground checkpoint.
+   A checkpoint that ends without a wake before its deadline is a failed wait; `bin/fm-watch-checkpoint.sh --help` owns its exit-status contract.
 
 Codex cannot reason while a foreground tool call is running.
 The bounded checkpoint returns control regularly so user messages and queued wakes can be handled without relying on background-task wake semantics.

--- a/docs/supervision-protocols/unknown.md
+++ b/docs/supervision-protocols/unknown.md
@@ -7,7 +7,7 @@ Ordinary wake: drain, handle all emitted wakes, reconcile open decisions and unr
 Before that acknowledgement, interruption leaves the work durable for idempotent re-handling.
 Use `bin/fm-watch-arm.sh` only when the harness has a tracked background mechanism that survives the tool call and notifies the model on process exit.
 Use `bin/fm-watch-checkpoint.sh` as a bounded foreground wait when that wake mechanism is not verified; its help owns the deadline and exit-status contract.
-After a quiet checkpoint, drain queued wakes and process newly visible user input before continuing.
+After a quiet `checkpoint: no actionable wake` deadline, drain queued wakes and process newly visible user input before continuing; any other `checkpoint: FAILED` or already-running line is a failed wait, not a quiet deadline.
 Never use shell `&` for watcher supervision.
 Failure or missing cycle only: drain queued wakes, inspect the failure and current watcher ownership, then restore the same verified wait shape.
 

--- a/docs/supervision-protocols/unknown.md
+++ b/docs/supervision-protocols/unknown.md
@@ -6,8 +6,9 @@ First cycle: drain queued wakes, then choose a supervision wait that the harness
 Ordinary wake: drain, handle all emitted wakes, reconcile open decisions and unread status lines, and run the exact `--ack-through` command printed as `WAKE_ACK_REQUIRED`, then repeat that verified wait while supervision is still required.
 Before that acknowledgement, interruption leaves the work durable for idempotent re-handling.
 Use `bin/fm-watch-arm.sh` only when the harness has a tracked background mechanism that survives the tool call and notifies the model on process exit.
-Use a bounded foreground wait over `bin/fm-watch.sh` when that wake mechanism is not verified.
+Use `bin/fm-watch-checkpoint.sh` as a bounded foreground wait when that wake mechanism is not verified; its help owns the deadline and exit-status contract.
+After a quiet checkpoint, drain queued wakes and process newly visible user input before continuing.
 Never use shell `&` for watcher supervision.
-Failure or missing cycle only: inspect the failure and restore the same verified wait shape.
+Failure or missing cycle only: drain queued wakes, inspect the failure and current watcher ownership, then restore the same verified wait shape.
 
 Record new verification evidence before promoting an unknown harness to a named snippet.

--- a/docs/verification/runtime-backends.md
+++ b/docs/verification/runtime-backends.md
@@ -6,6 +6,21 @@ This record contains reusable version-scoped evidence for active runtime guarant
 The backend guides own current setup, safety boundaries, and limitations.
 Exact task chronology, branch names, temporary homes, local paths, process ids, thread ids, and delivery transcripts remain in private reports or PR evidence.
 
+## Foreground checkpoint ownership
+
+Verified 2026-09-06 on Darwin 25.5.0 with Bash 3.2.57 using isolated `FM_HOME` fixtures and the real watcher and checkpoint executables.
+This checks process ownership and exit behavior, independent of vendor-rendered harness output or a live backend session.
+Refresh with `bin/fm-test-run.sh tests/fm-watch-checkpoint.test.sh tests/fm-supervision-instructions.test.sh`.
+The checkpoint suite reported:
+
+```text
+ok - checkpoint reports self-eviction as failure and preserves the replacement owner
+ok - quiet checkpoint exits 124 with a clean checkpoint line and no live lock
+ok - checkpoint passes through a real watcher wake and leaves the queue for drain
+ok - checkpoint preserves watcher environment for registered custom checks
+ok - checkpoint rejects an existing watcher singleton as unowned
+```
+
 ## tmux
 
 Foreground-process behavior was verified on 2026-07-07 with tmux 3.6a on macOS.

--- a/docs/verification/runtime-backends.md
+++ b/docs/verification/runtime-backends.md
@@ -19,6 +19,7 @@ ok - quiet checkpoint exits 124 with a clean checkpoint line and no live lock
 ok - checkpoint passes through a real watcher wake and leaves the queue for drain
 ok - checkpoint preserves watcher environment for registered custom checks
 ok - checkpoint rejects an existing watcher singleton as unowned
+ok - codex instructions route failed checkpoint waits to ownership inspection, not the quiet-deadline rule
 ```
 
 ## tmux

--- a/docs/watcher-continuity.md
+++ b/docs/watcher-continuity.md
@@ -44,7 +44,7 @@ Terminal arm-output classification (`started`, `attached`, or `FAILED`) remains 
 Codex retains its bounded foreground checkpoint protocol.
 The foreground checkpoint reports a watcher that yields ownership and exits without a wake as a failed wait, preserving the replacement lock and all unhandled queue rows.
 Unknown harnesses without a verified background wake mechanism use the same checkpoint entry point; [`supervision-protocols/unknown.md`](supervision-protocols/unknown.md) owns their operating instructions.
-`tests/fm-watch-checkpoint.test.sh` exercises real watcher self-eviction, quiet deadlines, singleton contention, and durable actionable delivery.
+`tests/fm-watch-checkpoint.test.sh` exercises real watcher self-eviction, quiet deadlines, singleton contention, durable actionable delivery, and the operating rule each emitted terminal outcome routes to.
 Grok retains its tracked background-task notification protocol.
 No adapter starts a replacement with shell `&`.
 

--- a/docs/watcher-continuity.md
+++ b/docs/watcher-continuity.md
@@ -42,6 +42,9 @@ No PreToolUse hook denies fleet commands based on watcher status.
 A genuine auto-arm failure describes the automatic mechanism as broken and never directs a routine manual background arm.
 Terminal arm-output classification (`started`, `attached`, or `FAILED`) remains defense in depth for the manual recovery path.
 Codex retains its bounded foreground checkpoint protocol.
+The foreground checkpoint reports a watcher that yields ownership and exits without a wake as a failed wait, preserving the replacement lock and all unhandled queue rows.
+Unknown harnesses without a verified background wake mechanism use the same checkpoint entry point; [`supervision-protocols/unknown.md`](supervision-protocols/unknown.md) owns their operating instructions.
+`tests/fm-watch-checkpoint.test.sh` exercises real watcher self-eviction, quiet deadlines, singleton contention, and durable actionable delivery.
 Grok retains its tracked background-task notification protocol.
 No adapter starts a replacement with shell `&`.
 

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -260,8 +260,12 @@ test_ship_mode_is_explicit_not_registry() {
   brief="$home/data/brief-explicit-a5/brief.md"
   grep -qx "Delivery contract: mode=no-mistakes" "$brief" \
     || fail "registered direct-PR posture overrode the explicit --mode"
-  assert_grep "Firstmate will then instruct you to run /no-mistakes" "$brief" \
+  assert_grep "continue in the same turn with /no-mistakes" "$brief" \
     "explicit no-mistakes brief did not render the pipeline definition of done"
+  assert_grep 'working: implementation committed; starting validation' "$brief" \
+    "generated delivery contract omitted the nonterminal implementation milestone"
+  assert_grep 'done: PR {url} checks green' "$brief" \
+    "generated delivery contract omitted its CI-ready terminal outcome"
 
   # An unregistered project is not a blocker either, because nothing is looked up.
   FM_HOME="$home" "$ROOT/bin/fm-brief.sh" brief-explicit-a6 never-registered --mode local-only >/dev/null 2>&1 \

--- a/tests/fm-calm-pi-extension.test.sh
+++ b/tests/fm-calm-pi-extension.test.sh
@@ -703,7 +703,7 @@ import { fileURLToPath, pathToFileURL } from "node:url";
 const extPath = fileURLToPath(pathToFileURL(process.env.EXT).href);
 
 const packageRoot = process.env.PI_PACKAGE_DIR;
-const [{ AssistantMessageComponent }, { CustomEntryComponent }, { ToolExecutionComponent }, { UserMessageComponent }, { InteractiveMode }, { initTheme, theme }, { Text, getKeybindings, setCapabilities }, { createToolHtmlRenderer }, { createReadToolDefinition, createBashToolDefinition, createEditToolDefinition, createWriteToolDefinition, createGrepToolDefinition, createFindToolDefinition, createLsToolDefinition }] = await Promise.all([
+const [{ AssistantMessageComponent }, { CustomEntryComponent }, { ToolExecutionComponent }, { UserMessageComponent }, { InteractiveMode }, { initTheme, theme }, { Text, getKeybindings, setCapabilities }, { createToolHtmlRenderer }, { createReadToolDefinition, createAllToolDefinitions }] = await Promise.all([
   import(pathToFileURL(`${packageRoot}/dist/modes/interactive/components/assistant-message.js`).href),
   import(pathToFileURL(`${packageRoot}/dist/modes/interactive/components/custom-entry.js`).href),
   import(pathToFileURL(`${packageRoot}/dist/modes/interactive/components/tool-execution.js`).href),
@@ -719,15 +719,6 @@ const [{ AssistantMessageComponent }, { CustomEntryComponent }, { ToolExecutionC
   // definition-less row now renders the generic text fallback instead.
   import(pathToFileURL(`${packageRoot}/dist/core/tools/index.js`).href),
 ]);
-const stockDefinitions = {
-  read: createReadToolDefinition,
-  bash: createBashToolDefinition,
-  edit: createEditToolDefinition,
-  write: createWriteToolDefinition,
-  grep: createGrepToolDefinition,
-  find: createFindToolDefinition,
-  ls: createLsToolDefinition,
-};
 initTheme("dark");
 setCapabilities({ images: null, trueColor: true, hyperlinks: false });
 
@@ -900,10 +891,16 @@ const cases = [
   ["ls", { path: "." }, { content: [{ type: "text", text: "sample.txt" }], details: {}, isError: false }],
 ];
 const renderUi = { requestRender() {} };
+// Match Pi's stock session registry and interactive lookup. Newer Pi components
+// leave built-in lookup to their caller; undefined now selects generic fallback.
+// Use complete definitions so self-framed tools such as edit keep renderShell.
+const stockTools = createAllToolDefinitions(process.cwd());
+const stockMode = { session: { getToolDefinition: (name) => stockTools[name] } };
 const rows = [];
 for (const [name, args, result] of cases) {
   const wrapped = tools.find((tool) => tool.name === name);
-  const baseline = new ToolExecutionComponent(name, `baseline-${name}`, args, { showImages: false }, stockDefinitions[name](process.cwd()), renderUi, process.cwd());
+  const stock = InteractiveMode.prototype.getRegisteredToolDefinition.call(stockMode, name);
+  const baseline = new ToolExecutionComponent(name, `baseline-${name}`, args, { showImages: false }, stock, renderUi, process.cwd());
   const actual = new ToolExecutionComponent(name, `wrapped-${name}`, args, { showImages: false }, wrapped, renderUi, process.cwd());
   for (const row of [baseline, actual]) {
     row.markExecutionStarted();
@@ -3184,6 +3181,10 @@ import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { encodeFirstmateOperationalInput } from "./lib/fm-operational-input.ts";
 
 export default function (pi: ExtensionAPI): void {
+  // Pin the native indicator's configurable label: Pi 0.85 dropped its default
+  // ellipsis and moved it into the editor border. These checks own visibility,
+  // including Calm-off restoration, rather than Pi's choice of default wording.
+  pi.on("session_start", (_event, ctx) => ctx.ui.setWorkingMessage("Working..."));
   pi.registerProvider("calm-e2e", {
     baseUrl: "http://127.0.0.1/unused",
     apiKey: "test-only",

--- a/tests/fm-supervision-instructions.test.sh
+++ b/tests/fm-supervision-instructions.test.sh
@@ -24,6 +24,8 @@ test_unknown_fallback() {
   out=$("$RENDER" --harness not-real)
   assert_contains "$out" "primary harness: unknown" "unknown heading missing"
   assert_contains "$out" "Mode: Unknown harness fallback." "unknown fallback snippet missing"
+  assert_contains "$out" "bin/fm-watch-checkpoint.sh" "unknown fallback omitted the guarded foreground entry point"
+  assert_not_contains "$out" "bin/fm-watch.sh" "unknown fallback still recommends the forbidden direct watcher"
   pass "renderer falls back to unknown.md for unverified harness names"
 }
 

--- a/tests/fm-test-run.test.sh
+++ b/tests/fm-test-run.test.sh
@@ -154,10 +154,40 @@ init_changed_fixture_repo() {
   : >"$repo/.pi/extensions/fm-primary-turnend-guard.ts"
   : >"$repo/docs/fm-test-isolation-proof.md"
   : >"$repo/CONTRIBUTING.md"
+  : >"$repo/GROK_BOT.md"
+  : >"$repo/UNMAPPED.md"
   : >"$repo/src/unmapped.ts"
   git -C "$repo" init -q
   git -C "$repo" add .
   git -C "$repo" -c user.name=test -c user.email=test@example.invalid commit -qm baseline
+}
+
+test_changed_grok_instructions_select_validation_and_unknown_markdown_fails() {
+  local tmp repo listed expected rc
+  tmp=$(fm_test_tmproot fm-test-run-grok-instructions)
+  repo="$tmp/repo"
+  init_changed_fixture_repo "$repo"
+
+  printf '\n' >>"$repo/GROK_BOT.md"
+  listed=$(cd "$repo" && bin/fm-test-run.sh --list --changed --base HEAD) \
+    || fail "GROK_BOT.md change must select instruction validation"
+  expected=$(cd "$repo" && bin/fm-test-run.sh --list --family pure-contract-unit)
+  [ "$listed" = "$expected" ] \
+    || fail "GROK_BOT.md must select exactly the instruction validation family: $listed"
+  assert_contains "$listed" 'tests/fm-documentation-audiences.test.sh' \
+    "GROK_BOT.md selection must include documentation validation"
+
+  # A known instruction path must not hide an unknown Markdown path.
+  printf '\n' >>"$repo/UNMAPPED.md"
+  rc=0
+  (cd "$repo" && bin/fm-test-run.sh --list --changed --base HEAD) \
+    >"$tmp/out" 2>"$tmp/err" || rc=$?
+  [ "$rc" -eq 2 ] || fail "unmapped Markdown must fail with exit 2, got $rc"
+  assert_contains "$(cat "$tmp/err")" \
+    'no changed-test mapping for source path: UNMAPPED.md' \
+    "unmapped Markdown failure must name the unsupported path"
+  [ ! -s "$tmp/out" ] || fail "unmapped Markdown must not emit a partial selection"
+  pass "GROK_BOT.md selects instruction validation while unknown Markdown fails closed"
 }
 
 test_changed_runner_surfaces_select_their_family() {
@@ -1374,6 +1404,7 @@ test_list_all_exact_suite_coverage
 test_family_selection
 test_single_script_selection
 test_changed_file_selection_is_conservative
+test_changed_grok_instructions_select_validation_and_unknown_markdown_fails
 test_changed_runner_surfaces_select_their_family
 test_changed_dependency_selection_and_unmapped_failure
 test_changed_bin_reference_selects_per_script_not_per_family

--- a/tests/fm-watch-checkpoint.test.sh
+++ b/tests/fm-watch-checkpoint.test.sh
@@ -6,7 +6,36 @@ set -u
 . "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
 
 CHECKPOINT="$ROOT/bin/fm-watch-checkpoint.sh"
+RENDER="$ROOT/bin/fm-supervision-instructions.sh"
 TMP_ROOT=$(fm_test_tmproot fm-watch-checkpoint)
+QUIET_OUTCOME=
+FAILED_OUTCOME=
+SINGLETON_OUTCOME=
+
+first_checkpoint_line() {
+  grep -m1 '^checkpoint:' "$@" 2>/dev/null || true
+}
+
+# Route one real emitted checkpoint outcome through the rendered operating
+# instructions: print every numbered rule whose quoted outcome literal is a
+# prefix of the emitted line.
+rules_matching_outcome() {
+  local block=$1 emitted=$2
+  printf '%s\n' "$block" | awk -v emitted="$emitted" '
+    match($0, /^[0-9]+\./) { rule = substr($0, 1, RLENGTH - 1) }
+    rule == "" { next }
+    {
+      n = split($0, parts, "`")
+      for (i = 2; i <= n; i += 2) {
+        tok = parts[i]
+        if (tok != "" && substr(emitted, 1, length(tok)) == tok && !(rule in seen)) {
+          seen[rule] = 1
+          print rule
+        }
+      }
+    }
+  ' | tr '\n' ' ' | sed 's/ $//'
+}
 
 make_home() {
   local name=$1 home
@@ -24,6 +53,7 @@ test_quiet_checkpoint_exits_124_cleanly() {
   FM_HOME="$home" FM_POLL=1 FM_SIGNAL_GRACE=1 FM_CHECK_INTERVAL=999999 "$CHECKPOINT" --seconds 1 >"$out" 2>"$err" || status=$?
   expect_code 124 "$status" "quiet checkpoint exit"
   assert_contains "$(cat "$out")" "checkpoint: no actionable wake within 1s" "quiet checkpoint line missing"
+  QUIET_OUTCOME=$(first_checkpoint_line "$out")
   assert_absent "$home/state/.watch.lock/pid" "watch lock pid survived quiet checkpoint timeout"
   pass "quiet checkpoint exits 124 with a clean checkpoint line and no live lock"
 }
@@ -78,19 +108,24 @@ test_existing_singleton_watcher_is_not_success() {
   expect_code 1 "$status" "singleton checkpoint exit"
   assert_contains "$(cat "$out")" "watcher: already running" "singleton watcher output was not passed through"
   assert_contains "$(cat "$err")" "outside this foreground checkpoint" "singleton watcher failure was not explained"
+  SINGLETON_OUTCOME=$(first_checkpoint_line "$err")
   pass "checkpoint rejects an existing watcher singleton as unowned"
 }
 
 test_self_evicted_watcher_is_not_empty_success() {
   local home out err status replacer
+  local beacon_budget_ds=600 checkpoint_seconds=120
   home=$(make_home self-eviction)
   out="$home/out.txt"
   err="$home/err.txt"
   # Wait for the real watcher to publish its first beacon, then replace only
   # this fixture's singleton owner. The watcher must yield without deleting
   # the replacement lock, but its checkpoint must report the lost wait.
+  # Real watcher startup takes seconds and varies with machine load, so the
+  # beacon budget stays well inside the checkpoint deadline: neither the
+  # replacement nor the checkpoint may expire before the eviction lands.
   (
-    for ((i = 0; i < 200; i++)); do
+    for ((i = 0; i < beacon_budget_ds; i++)); do
       if [ -f "$home/state/.last-watcher-beat" ]; then
         printf '%s\n' "$$" > "$home/state/.watch.lock/pid"
         exit 0
@@ -101,12 +136,37 @@ test_self_evicted_watcher_is_not_empty_success() {
   ) &
   replacer=$!
   status=0
-  FM_HOME="$home" FM_POLL=1 FM_SIGNAL_GRACE=1 FM_CHECK_INTERVAL=999999 "$CHECKPOINT" --seconds 30 >"$out" 2>"$err" || status=$?
-  wait "$replacer" || fail "real watcher never published its fixture beacon"
+  FM_HOME="$home" FM_POLL=1 FM_SIGNAL_GRACE=1 FM_CHECK_INTERVAL=999999 "$CHECKPOINT" --seconds "$checkpoint_seconds" >"$out" 2>"$err" || status=$?
+  wait "$replacer" \
+    || fail "real watcher published no beacon within $((beacon_budget_ds / 10))s"
   [ "$(cat "$home/state/.watch.lock/pid")" = "$$" ] || fail "checkpoint disturbed replacement owner"
   expect_code 1 "$status" "self-evicted checkpoint exit"
   assert_contains "$(cat "$err")" "ended without an actionable wake" "lost checkpoint wait was not explained"
+  FAILED_OUTCOME=$(first_checkpoint_line "$err")
   pass "checkpoint reports self-eviction as failure and preserves the replacement owner"
+}
+
+test_codex_instructions_separate_quiet_deadline_from_failed_wait() {
+  local block matched
+  block=$("$RENDER" --harness codex)
+
+  [ -n "$QUIET_OUTCOME" ] || fail "quiet checkpoint emitted no checkpoint outcome line"
+  [ -n "$FAILED_OUTCOME" ] || fail "lost checkpoint wait emitted no checkpoint outcome line"
+  [ -n "$SINGLETON_OUTCOME" ] || fail "singleton checkpoint emitted no checkpoint outcome line"
+
+  matched=$(rules_matching_outcome "$block" "$QUIET_OUTCOME")
+  [ "$matched" = "5" ] \
+    || fail "quiet deadline routed to rules [$matched] instead of the continue-anyway rule 5"
+
+  matched=$(rules_matching_outcome "$block" "$FAILED_OUTCOME")
+  [ "$matched" = "8" ] \
+    || fail "lost checkpoint wait routed to rules [$matched] instead of the ownership-inspection rule 8"
+
+  matched=$(rules_matching_outcome "$block" "$SINGLETON_OUTCOME")
+  [ "$matched" = "8" ] \
+    || fail "already-running checkpoint routed to rules [$matched] instead of the ownership-inspection rule 8"
+
+  pass "codex instructions route failed checkpoint waits to ownership inspection, not the quiet-deadline rule"
 }
 
 test_self_evicted_watcher_is_not_empty_success
@@ -114,3 +174,4 @@ test_quiet_checkpoint_exits_124_cleanly
 test_signal_passes_through_and_exits_zero
 test_registered_check_uses_preserved_watcher_environment
 test_existing_singleton_watcher_is_not_success
+test_codex_instructions_separate_quiet_deadline_from_failed_wait

--- a/tests/fm-watch-checkpoint.test.sh
+++ b/tests/fm-watch-checkpoint.test.sh
@@ -81,6 +81,35 @@ test_existing_singleton_watcher_is_not_success() {
   pass "checkpoint rejects an existing watcher singleton as unowned"
 }
 
+test_self_evicted_watcher_is_not_empty_success() {
+  local home out err status replacer
+  home=$(make_home self-eviction)
+  out="$home/out.txt"
+  err="$home/err.txt"
+  # Wait for the real watcher to publish its first beacon, then replace only
+  # this fixture's singleton owner. The watcher must yield without deleting
+  # the replacement lock, but its checkpoint must report the lost wait.
+  (
+    for ((i = 0; i < 200; i++)); do
+      if [ -f "$home/state/.last-watcher-beat" ]; then
+        printf '%s\n' "$$" > "$home/state/.watch.lock/pid"
+        exit 0
+      fi
+      sleep 0.1
+    done
+    exit 1
+  ) &
+  replacer=$!
+  status=0
+  FM_HOME="$home" FM_POLL=1 FM_SIGNAL_GRACE=1 FM_CHECK_INTERVAL=999999 "$CHECKPOINT" --seconds 30 >"$out" 2>"$err" || status=$?
+  wait "$replacer" || fail "real watcher never published its fixture beacon"
+  [ "$(cat "$home/state/.watch.lock/pid")" = "$$" ] || fail "checkpoint disturbed replacement owner"
+  expect_code 1 "$status" "self-evicted checkpoint exit"
+  assert_contains "$(cat "$err")" "ended without an actionable wake" "lost checkpoint wait was not explained"
+  pass "checkpoint reports self-eviction as failure and preserves the replacement owner"
+}
+
+test_self_evicted_watcher_is_not_empty_success
 test_quiet_checkpoint_exits_124_cleanly
 test_signal_passes_through_and_exits_zero
 test_registered_check_uses_preserved_watcher_environment


### PR DESCRIPTION
## Intent

Captain asks for an Astra full-system makeover, explicitly upgrades Firstmate itself tonight via PRs, and overrides the old do-not-edit-Kun-AGENTS restriction for this task. Operate through fm bins/queue/results, improve seed expansion, wake/drain/ack reliability, terminal outcomes and quota-aware Astra versus Cursor Ultra routing; rewrite stale operating Markdown. Read /Users/nick/docs/prompts/2026-09-05-firstmate-astra-full-system-makeover.md including both addenda. Existing six burns keep running. No Stations restore, seeds/crown login changes or funded-trading operations. Quinn is captain surface/desk manager; Firstmate code supervisor; Hermes only remaining unattended runner.

Referenced captain prompt, including both addenda:
# CAPTAIN — Astra full-system makeover (Nick 2026-09-05 ~11:11 PM PT)

Nick: when a top frontier model drops, **give it a full makeover of the whole system**. You are on **Codex Astra**. Expand, improve, then ship. Not a rubber stamp. Not a memo farm — **PRs, live applies, deletions, and receipts**.

## Intent
Use Astra’s step-change to **raise the ceiling of the entire operating stack** Nick runs on quinn.local / Grok Bot / Hermes / FirstMate / ventures — not just one feature. Treat this as a **platform upgrade pass** interleaved with the already-queued six burns + overnight Astra burn + memecoin desk.

## Operating laws (do not violate)
- Quinn = Nick surface + manager of Polymarket + memecoin desks
- FirstMate = only code crew (you). No parallel coding seat
- Fun-money books (Polymarket + EFkc Phantom): **max profit ASAP**, no pointless halts
- KDP publish standing-authorized; no seeds/crown logins; no Stations restore
- Prefer ships Nick scores: posts, store/ads, trading fills, FF writes — not queue theater
- Dual-burn: Astra hard systems + Cursor Ultra terra/parallel PRs

## Makeover pillars (you invent the concrete work; these are outcomes)

### 1) Control plane
Make Quinn→queue→FirstMate→firstmate-results→wake-watch **boring and reliable**: less drain theater, clearer terminal outcomes, auto-ack patterns, stale-row hygiene that actually closes.

### 2) Scheduler truth
One honest map of Grok clocks vs Hermes jobs; kill dual-runs; pause/delete dead OpenClaw lastmin paths; make “what runs when” readable in one place.

### 3) Content engine
Epstein never-dry video (non-Codex harvest), runway self-heal (evening bridge / deferred coverage), analytics→production mix closed loop, SM 4/day compiler. Delete dead Sienna/station posters still cluttering jobs.json.

### 4) Money engines
Polymarket LIVE factory + memecoin autopilot tools Quinn manages; encode fun-money policy into AGENTS/docs; kill halt-theater language in code comments.

### 5) Commerce / apps / property
M&M ads creative farm (disarmed), UGC→store, Stu listing profiles, Apps polish — many small Ultra PRs while Astra does core.

### 6) Fantasy
Mac-local Yahoo season rails only; no YDN paste; no Grok-box Chrome; FF clocks already exist — harden auth/roster write path docs+code.

### 7) Self-upgrade FirstMate
Astra improves FM itself: better seeds expansion, less WAKE_ACK babysitting, quota-aware routing (Astra vs Ultra vs Claude), proof that overnight burn doesn’t stall on one stuck task.

### 8) Delete ruthlessly
Abandoned stations, frozen OpenClaw heartbeats-as-outages, superseded queue rows, duplicate prompts, zombie Chrome profiles guidance. **Makeover includes subtraction.**

## How to run this
1. Spend ~30–60m surveying (ventures INDEX, Hermes jobs, queue-status stale, FM AGENTS) — then **cut a prioritized makeover backlog** into firstmate-results + discrete queue rows if needed.
2. Ship highest-leverage PRs tonight; leave a morning brief for Quinn: what changed, what burned which meter, what’s next.
3. Do **not** stop the six burns / video harvest / memecoin system — makeover **absorbs and upgrades** them, doesn’t replace Nick’s GO list.

## Receipts
- `firstmate-results` rows: makeover-survey, then per pillar ships
- Morning one-pager path under ~/docs/plans/ or firstmate-results evidence
- Explicit list of **deleted** dead weight

## Non-goals
- Rewriting Nick’s identity / crown security model
- Restoring Stations
- Connecting phone Phantom to Grok MCP
- Halting fun-money books “during refactor”


## ADDENDUM — Nick 2026-09-05 ~11:12 PM PT (required tonight)

### Know how to use FirstMate
Astra must operate **as FirstMate correctly**: read queue.jsonl (owner=firstmate), expand seeds, ship in FM worktrees/PRs, append firstmate-results, honor fm-wake-drain / watch-arm, prefer `bin/fm-*.sh` over ad-hoc. If FM docs/skills are stale vs how you actually work, **update them as part of the makeover**.

### Upgrade FirstMate itself tonight
Treat `~/ventures/agent-ops/firstmate` as a first-class makeover target: bin/, skills/, GROK_BOT.md, wake/drain/ack UX, quota routing (Astra vs Ultra), queue-status terminal outcomes, less babysitting for Quinn. Ship PRs; don’t only audit.

### Upgrade all of Kun’s tools tonight
Nick wants Kun’s toolbelt refreshed under Astra the same night. Live tree (symlinks from agent-ops):

- `~/infra/tools/agentic-access`
- `~/infra/tools/context-budget`
- `~/infra/tools/firstmate-companion`
- `~/infra/tools/headroom-eval`
- `~/infra/tools/hermes-runtime` (+ hermes-runtime-control)
- `~/infra/tools/loop-library` / `loopos`
- `~/infra/tools/memory-dream`
- `~/infra/tools/quinn-dashboard`
- `~/infra/tools/skill-infra` / `skill-layer`
- `~/infra/tools/token-monitor`
- plus any other active Kun-era tools still referenced by FirstMate/Hermes (survey; skip `archive/parked-*` unless restoring is clearly valuable)

**Nick CAPTAIN GO overrides** the older “don’t edit Kun AGENTS.md” hold for this makeover — update AGENTS/docs/tools where needed so Astra-era FM actually uses them. Still: no Stations restore, no dual-run clocks, no seed/crown access.

Receipt: list each Kun tool touched (or explicitly deferred with reason) + FirstMate self-upgrade PR links.


## ADDENDUM 2 — Nick 2026-09-05 ~11:14 PM PT: rewrite identity/ops markdown tonight

Nick’s usual frontier-model makeover also **rewrites AGENTS.md, CLAUDE.md, captain docs, and the files about him + the machine** so they match live reality (not Aug OpenClaw/Hermes-as-operator fiction).

### Rewrite targets (survey then upgrade — don’t leave stale)

**FirstMate / Kun-era**
- `~/ventures/agent-ops/firstmate/AGENTS.md`
- `~/ventures/agent-ops/firstmate/CLAUDE.md` (and any symlink twin)
- `~/ventures/agent-ops/firstmate/GROK_BOT.md`, `VISION.md`, `README.md` as needed
- `~/ventures/agent-ops/firstmate/docs/captain-hold-lifecycle.md` + other captain/supervision docs under `docs/` + `docs/supervision-protocols/`
- Kun tool `AGENTS.md` / `CLAUDE.md` under each `~/infra/tools/*` touched tonight

**Account / Nick / machine**
- `~/ventures/_account/AGENTS.md` (+ `CLAUDE.md` symlink), `ACCOUNT.md`
- Identity/policy under `~/ventures/_account/identities`, `policy`, `docs/*` that still describe wrong control plane
- Hermes profile souls if still wrong vs Quinn Grok lead: `~/var/hermes/hermes-home/profiles/quinn/SOUL.md` (and sibling profile SOULs only if misleading)
- Machine/context refs: `~/docs/reference/*` that agents still read for “who Nick is / what quinn.local is” (update or mark superseded — don’t resurrect Stations)

### Truth that must land in the rewrites
- Quinn (Grok Bot) = Nick surface + manager of Polymarket + memecoin desks
- FirstMate = only code crew via queue.jsonl; Astra/Ultra burn OK
- Hermes = unattended runner where still used; **not** the lead / not dual-run with Grok clocks
- OpenClaw gateway inert; Stations unloaded — do not restore
- Fun-money: Polymarket + Phantom EFkc… → max profit ASAP, no pointless halts
- KDP publish standing-authorized; seeds/crown logins still Nick-only
- Phone withdraw `91Yn2h…`; trade wallet `EFkc…`
- Mac = quinn.local always-on autonomy machine

### Rails
Rewrite for clarity and current ops — not a novel. Prefer surgical truth upgrades + delete/supersede banners on dead docs. Receipt: list every markdown path rewritten + one-line what changed.

## What Changed

- Report watcher exits without actionable wakes as failures; update supervision guidance to distinguish failed waits from quiet deadlines and inspect ownership before retrying.
- Require workers to continue from implementation commits into no-mistakes validation, reserving completion for a PR with green checks.
- Rewrite operator guidance around configured roles, intake, results, and dispatch; include `GROK_BOT.md` in changed-test selection, expand regression coverage, and update Calm test fixtures for current Pi rendering.

## Risk Assessment

✅ Low: The bounded changes preserve watcher ownership and acknowledgement contracts while clarifying validation continuation and configured operator roles.

## Testing

The supplied baseline and five focused suites passed. Isolated CLI replays verified durable acknowledgement and corrected ownership failures; Pi checks reproduced the old fixture failure and verified rendering, execution data, toggles, restart, and export after the fix. Captured CLI, generated-contract, HTML, and screenshot evidence.

<details>
<summary>Evidence: Checkpoint, durable drain/ack, and before/after ownership behavior</summary>

Source: [Checkpoint, durable drain/ack, and before/after ownership behavior](https://github.com/quinnbot-ai/firstmate/blob/6f46f4838a87bfb3ccb393678f3f403250fe7df3/.no-mistakes/evidence/fm/astra-firstmate-control-upgrade/checkpoint-cli-transcript.txt)

```text
$ bin/fm-watch-checkpoint.sh --seconds 30
signal: /Users/nick/.no-mistakes/worktrees/a6c7b6710348/01M1TR9XAY6HWM7X9ZJP9Q5HWR/.checkpoint-evidence-j7z_38do/signal/state/demo.status

exit=0

$ bin/fm-wake-drain.sh
1788682629	2	signal	demo.status	signal: /Users/nick/.no-mistakes/worktrees/a6c7b6710348/01M1TR9XAY6HWM7X9ZJP9Q5HWR/.checkpoint-evidence-j7z_38do/signal/state/demo.status
wake annotation: latest wake-EVENT observed at drain, not current state: demo.status: done: PR https://example.invalid/pr/42 checks green
STATUS OUTCOME BACKSTOP (newest captain-facing task event has no covering branch outcome):
demo done: PR https://example.invalid/pr/42 checks green
WAKE_ACK_REQUIRED: after handling completes run bin/fm-wake-drain.sh --ack-through 2 --recovery-generation 55183.1788682629.bxoB5O
exit=0

$ bin/fm-wake-drain.sh
1788682629	2	signal	demo.status	signal: /Users/nick/.no-mistakes/worktrees/a6c7b6710348/01M1TR9XAY6HWM7X9ZJP9Q5HWR/.checkpoint-evidence-j7z_38do/signal/state/demo.status
WAKE_ACK_REQUIRED: after handling completes run bin/fm-wake-drain.sh --ack-through 2 --recovery-generation 55183.1788682629.bxoB5O
exit=0

Observed: the same wake remains available on a second drain before acknowledgement.
$ bin/fm-wake-drain.sh --ack-through 2 --recovery-generation 55183.1788682629.bxoB5O


exit=0

$ bin/fm-wake-drain.sh


exit=0

Observed: acknowledgement consumes the presented wake; subsequent drain does not replay it.

$ bin/fm-watch-checkpoint.sh --seconds 1
checkpoint: no actionable wake within 1s

exit=124

$ bin/fm-watch-checkpoint.sh --seconds 5
watcher: already running pid 53317
checkpoint: watcher is already running outside this foreground checkpoint
exit=1

$ /Users/nick/.no-mistakes/worktrees/a6c7b6710348/01M1TR9XAY6HWM7X9ZJP9Q5HWR/bin/.checkpoint-base-7lz8nzqx.sh --seconds 70


exit=0

Observed base: replacement ownership preserved.

$ bin/fm-watch-checkpoint.sh --seconds 70

checkpoint: FAILED - watcher ended without an actionable wake; drain queued wakes and inspect watcher ownership before retrying
exit=1

Observed target: replacement ownership preserved.

$ bin/fm-brief.sh delivery-probe sample-project --mode no-mistakes
scaffolded: /Users/nick/.no-mistakes/worktrees/a6c7b6710348/01M1TR9XAY6HWM7X9ZJP9Q5HWR/.checkpoint-evidence-j7z_38do/brief/data/delivery-probe/brief.md (ship, mode=no-mistakes; replace {TASK} and {FIRSTMATE_SPEC})

exit=0

$ bin/fm-supervision-instructions.sh --harness codex
================================================================================
SUPERVISION OPERATING INSTRUCTIONS - primary harness: codex
================================================================================
Current state:
- Lock: held by this session; this session owns normal supervision unless away mode says otherwise.
- Away mode: inactive.
- X mode: inactive; use the default watcher cadence.
- Ordinary wake: take the next foreground bin/fm-watch-checkpoint.sh checkpoint as directed below.

Mode: Codex foreground checkpoint.

When this session owns supervision and away mode is not active:
1. Drain first with `bin/fm-wake-drain.sh`.
   After handling all emitted wakes and reconciling open decisions and unread status lines, run the exact `--ack-through` command printed as `WAKE_ACK_REQUIRED`; until then the work remains durable for idempotent re-handling after interruption.
2. Source `/Users/nick/.no-mistakes/worktrees/a6c7b6710348/01M1TR9XAY6HWM7X9ZJP9Q5HWR/.checkpoint-evidence-j7z_38do/brief/config/x-mode.env` first when Relay is active.
3. First cycle: run one foreground watcher checkpoint with `bin/fm-watch-checkpoint.sh --seconds "${FM_CODEX_WATCH_CHECKPOINT:-180}"`.
4. Ordinary wake: if the command prints `signal:`, `stale:`, `check:`, or `heartbeat`, drain queued wakes, handle that wake, then start the next checkpoint.
5. Quiet deadline only: if the command prints `checkpoint: no actionable wake` and exits 124, drain queued wakes anyway, process any queued user message now visible to Codex, then start the next checkpoint.
6. Never use shell `&` or Codex background tasks for firstmate watcher supervision.
7. Do not run `bin/fm-watch-arm.sh` as Codex's normal supervision command.
   If it is ever shelled anyway, a backgrounded, piped, or bundled anti-pattern is denied automatically by the PreToolUse seatbelt (`bin/fm-arm-pretool-check.sh`) registered in `.codex/hooks.json`.
8. Failure or missing cycle only: drain queued wakes and inspect the failure and current watcher ownership before starting a fresh foreground checkpoint.
   A `checkpoint: FAILED` line means the watcher ended without delivering a wake, and `checkpoint: watcher is already running` means another watcher owns supervision; both are failed waits rather than quiet deadlines, so never treat either as rule 5.
   `bin/fm-watch-checkpoint.sh --help` owns its exit-status contract.

Codex cannot reason while a foreground tool call is running.
The bounded checkpoint returns control regularly so user messages and queued wakes can be handled without relying on background-task wake semantics.

exit=0
```
</details>
<details>
<summary>Evidence: Generated worker delivery contract</summary>

Source: [Generated worker delivery contract](https://github.com/quinnbot-ai/firstmate/blob/6f46f4838a87bfb3ccb393678f3f403250fe7df3/.no-mistakes/evidence/fm/astra-firstmate-control-upgrade/generated-delivery-brief.md)

```text
You are a crewmate: an autonomous worker agent managed by firstmate. Work on your own; do not wait for a human.

# Task
## Captain's intent
{TASK}

## Firstmate spec
{FIRSTMATE_SPEC}

# Herdr lifecycle declaration - NOT ENABLED
**HARD SAFETY GATE:** this scaffold cannot inspect the task text filled in above.
If the task will start, stop, delete, restart, profile, or otherwise drive Herdr lifecycle behavior, stop and regenerate the brief with `--herdr-lab` before dispatch.
Do not add Herdr lifecycle commands to this unguarded brief by hand.

# Setup
You are in a disposable git worktree of sample-project, at a detached HEAD on a clean default branch.

**Verify isolation before anything else.** Run `pwd -P` and `git rev-parse --show-toplevel`; both must resolve to the disposable task worktree you were launched in, such as a treehouse pool path or an Orca-managed worktree, not the primary checkout firstmate operates from.
The path check is authoritative: `git rev-parse --git-dir` and `git rev-parse --git-common-dir` can help inspect the repo, but they do not prove you are outside the primary checkout.
If the top-level path is the primary checkout or not the worktree you were launched in, STOP - do not branch or commit here - append `blocked: launched in primary checkout, not an isolated worktree` to the status file and stop.

1. First action: create your branch: `git checkout -b fm/delivery-probe`
2. Run `no-mistakes doctor`; if it reports the repo is not initialized here, run `no-mistakes init`.

# Rules
1. Never push to the default branch. Never merge a PR.
2. Stay inside this worktree; modify nothing outside it.
3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.
4. Report status by appending one line:
   `echo "{state}: {one short line}" >> '/Users/nick/.no-mistakes/worktrees/a6c7b6710348/01M1TR9XAY6HWM7X9ZJP9Q5HWR/.checkpoint-evidence-j7z_38do/brief/state/delivery-probe.status'`
   States: working, needs-decision, blocked, paused, done, failed.
   Each append wakes firstmate, so report sparingly: only phase changes a supervisor
   would act on (setup done, bug reproduced, fix implemented, validation passed) and the
   needs-decision/blocked/paused/done/failed states. No step-by-step FYI progress lines;
   firstmate reads your pane for that.
   Whenever you mention a PR anywhere - a status line, your terminal, a summary - write its full
   https:// URL exactly as the forge printed it, never a bare number such as "PR 108"; firstmate
   copies that URL from your line rather than assembling one.
   A mid-task `working:` line (including setup complete) is nonterminal: do not end the
   turn after it; continue the same stage until a defined `done:` gate under Definition of done.
   Use `paused: {why}` - distinct from `blocked:` - ONLY when you are deliberately idling on a
   known external wait you expect to clear on its own (an upstream release, a rate-limit reset,
   a scheduled window): firstmate then leaves your idle pane alone and rechecks it on a long
   cadence instead of treating it as a possible wedge. Use `blocked:` when you are stuck and need help.
5. If you hit the same obstacle twice, append `blocked: {why}` and stop; firstmate will help.
6. If a decision belongs above the implementation worker (product choices, destructive actions),
   append `needs-decision: {summary of options}` and stop. Firstmate will reply with the decision.
   For a no-mistakes ask-user gate specifically, escalate all ask-user findings as one event plus one snapshot file, using that same shape even when the gate holds only a single ask-user finding: write only the ask-user findings, verbatim and unparaphrased (id, severity, file, line, description, authority), to `/Users/nick/.no-mistakes/worktrees/a6c7b6710348/01M1TR9XAY6HWM7X9ZJP9Q5HWR/.checkpoint-evidence-j7z_38do/brief/data/delivery-probe/nm-<run>-findings.txt`, then report the gate with
   `needs-decision [key=nm-<run>-<step>]: ask-user findings=<id1>,<id2>,... file=/Users/nick/.no-mistakes/worktrees/a6c7b6710348/01M1TR9XAY6HWM7X9ZJP9Q5HWR/.checkpoint-evidence-j7z_38do/brief/data/delivery-probe/nm-<run>-findings.txt`
   naming every ask-user finding id from that gate. The status line only points at the file; it never restates or summarizes a finding's content.
   A decision or blocker you opened stays open until a `resolved` line carrying its exact key lands; a later `done:` or `working:` line never closes it, even when the answer is what started that work.
   Firstmate's reply normally writes that closing line at answer time; when a blocker or wait clears WITHOUT a firstmate reply, append `resolved: {how it cleared}` yourself (same `[key=<slug>]` if you opened it with one) as you resume.
7. Never stop, restart, or update the shared `no-mistakes` daemon - it is one instance serving
   every lane/home, so restarting it kills other lanes' in-flight pipeline runs; only firstmate
   manages the daemon.
   Before you append `blocked:` about the pipeline, run `no-mistakes daemon status` and
   `no-mistakes axi status`. If the daemon socket refuses connections or is missing, append
   `blocked: {the daemon error}` and stop even when the local run record still says running or
   fixing, because that record can be stale after the daemon exits. A run record failed with a
   daemon error is also a real block.
   Only after ruling out socket refusal, if the run is still running or fixing, reattach and keep
   going. A drive-call error, timeout, slow read, or generic unreachability is NOT a daemon error:
   the daemon accepts `respond` immediately and runs the round in the background, so a killed or
   timed-out call was only waiting for a read while the run kept working.

# Firstmate instruction inbox
Firstmate steers you through durable message files in '/Users/nick/.no-mistakes/worktrees/a6c7b6710348/01M1TR9XAY6HWM7X9ZJP9Q5HWR/.checkpoint-evidence-j7z_38do/brief/state/delivery-probe.inbox'.
When a terminal message says an instruction is waiting there - and at any natural checkpoint when you are unsure - list '/Users/nick/.no-mistakes/worktrees/a6c7b6710348/01M1TR9XAY6HWM7X9ZJP9Q5HWR/.checkpoint-evidence-j7z_38do/brief/state/delivery-probe.inbox'/*.msg, read and act on each message in numeric order, then acknowledge each handled message by moving it: `mv '/Users/nick/.no-mistakes/worktrees/a6c7b6710348/01M1TR9XAY6HWM7X9ZJP9Q5HWR/.checkpoint-evidence-j7z_38do/brief/state/delivery-probe.inbox'/NNN.msg '/Users/nick/.no-mistakes/worktrees/a6c7b6710348/01M1TR9XAY6HWM7X9ZJP9Q5HWR/.checkpoint-evidence-j7z_38do/brief/state/delivery-probe.inbox'/handled/`.
The move IS the acknowledgement: without it firstmate rings again and eventually treats you as stuck. An empty or absent inbox needs no action.

# Project memory
If `AGENTS.md` or `CLAUDE.md` already exists, or if this task produced durable project-intrinsic knowledge, run `/Users/nick/.no-mistakes/worktrees/a6c7b6710348/01M1TR9XAY6HWM7X9ZJP9Q5HWR/bin/fm-ensure-agents-md.sh .` in the worktree.
Record only project knowledge useful to almost every future session.
For anything the codebase already shows, prefer a pointer to the authoritative file, command, or doc over copying the detail.
If you touch a project `AGENTS.md`, follow `/Users/nick/.no-mistakes/worktrees/a6c7b6710348/01M1TR9XAY6HWM7X9ZJP9Q5HWR/bin/fm-ensure-agents-md.sh`'s self-governance contract in the same pass.
Keep it proportionate: skip `AGENTS.md` edits for trivial tasks that produced no durable project knowledge.

# Definition of done
Delivery contract: mode=no-mistakes
After implementing and committing on your branch, continue in the same turn with /no-mistakes to validate and ship a PR.
Report that transition as `working: implementation committed; starting validation`, never `done:`, and do not wait for another firstmate instruction to begin validation.
The task is complete only at the CI-ready return point below; a commit alone is an implementation milestone.

You drive no-mistakes by responding to its gates, not by implementing fixes.
Follow the guidance no-mistakes itself provides for the mechanics: it loads when you invoke /no-mistakes, and `no-mistakes axi run --help` plus the `help` lines in each `axi` response are authoritative and version-matched to the installed binary.
When starting no-mistakes, pass `--intent` as only this brief's `## Captain's intent` subsection plus any later words the captain actually said.
For a legacy brief with no such subsection, include only words explicitly labeled `Captain:`, `Captain's words:`, `Captain's ask:`, or `Captain's intent:`; never copy its mixed `# Task` wholesale. If it has no provenance-marked captain words, stop and ask firstmate instead of starting no-mistakes.
Do not include `## Firstmate spec`, later Firstmate build constraints, or your own decisions and tradeoffs.
The `--intent` string you pass must be self-sufficient: that string plus the codebase must let a reader reconstruct roughly the same specification, without depending on a separate report, a PR, or context that lives only in this conversation.
When the captain's intent refers to a report, decision, or PR ("do items 1, 2, 3, and 7 of the report"), write the substance of the referenced items into `--intent` in the captain's terms, not only the pointer; that substance is the captain's ask by reference, while Firstmate's build instructions and your own decisions still stay out.
This replaces the no-mistakes skill's advice to enrich `--intent` with decisions and tradeoffs; that advice does not apply to Firstmate-dispatched work.
Do not hand-edit, commit, or fix findings yourself while a run is active - the pipeline applies every fix.

One drive call blocks until the next gate or outcome, which routinely outlives what your harness lets a single command run: Claude Code kills a command at ten minutes maximum, while one fix round is capped around thirty minutes and up to three rounds chain.
So background the drive call and poll `no-mistakes axi status` from a separate call instead of sitting in one blocking hold your harness will kill.
Where a harness's own command limit is not established, assume it bounds commands and use that same background-and-poll shape.
A killed or timed-out call is never evidence the daemon died: the daemon accepts your response immediately and runs the round in the background, so the call was only ever waiting for a read while the run kept working.
Reattach and keep going rather than reporting the pipeline blocked; rule 7 owns the checks that decide when a pipeline block is real.

Two firstmate-specific rules layer on top of that guidance:
- ask-user findings are never yours to answer: escalate to firstmate using rule 6's ask-user format and stop.
  Firstmate applies `ask-user-authority` and obtains any required captain decision.
  When the decision comes back, feed it to the gate with `no-mistakes axi respond` and let the pipeline apply it - do not route the question to "the user" or implement the fix yourself.
- NEVER pass `--yes` (or `-y`) to `no-mistakes axi run` or `no-mistakes axi respond`. It is banned fleet-wide.
  It auto-resolves every gate including ask-user findings with no escalation, and answering your own ask-user finding is a hard rule violation.

After /no-mistakes reports CI green (the CI-ready return point - do not wait for it to keep monitoring in the background until merge), append `done: PR {url} checks green` and stop. You are finished.
```
</details>
<details>
<summary>Evidence: Pi 0.85.1 fixture failure reproduced before fix; corrected fixture passes</summary>

Source: [Pi 0.85.1 fixture failure reproduced before fix; corrected fixture passes](https://github.com/quinnbot-ai/firstmate/blob/6f46f4838a87bfb3ccb393678f3f403250fe7df3/.no-mistakes/evidence/fm/astra-firstmate-control-upgrade/pi-compatibility-transcript.txt)

```text
Installed importable Pi package: 0.85.1; production Calm extension unchanged between probes.
c499f84: test_rendering_and_session_lifecycle

not ok - Pi calm renderer and lifecycle contract failed: file:///private/var/folders/pj/3vh4dgp11qs_j186lws96lmw0000gn/T/fm-calm-pi-extension.5VNNeI/renderer/[eval1]:206
    throw new Error(`${name} collapsed rendering changed while calm mode was off`);
          ^

Error: read collapsed rendering changed while calm mode was off
    at file:///private/var/folders/pj/3vh4dgp11qs_j186lws96lmw0000gn/T/fm-calm-pi-extension.5VNNeI/renderer/[eval1]:206:11
    at process.processTicksAndRejections (node:internal/process/task_queues:103:5)

Node.js v22.22.2

exit=1
HEAD: test_rendering_and_session_lifecycle + test_interactive_terminal_e2e
ok - Pi calm centralizes transcript visibility, preserves execution/export data, keeps Pi's stock working row visible while no run is active, and persists its choice across session starts
ok - Pi calm native E2E replaces the stock working row with a moving, resize-clamped working ship that freezes and resumes across two working periods in one Pi session, clears on abort, keeps captain turns visible, hides exact operational user rows without changing persistence, restores stock rendering Calm-off, survives restart, and preserves export plus Ctrl+O behavior


exit=0
```
</details>
- Evidence: [Rendered Pi fixture session export](https://github.com/quinnbot-ai/firstmate/blob/6f46f4838a87bfb3ccb393678f3f403250fe7df3/.no-mistakes/evidence/fm/astra-firstmate-control-upgrade/pi-calm-export.png)
- Evidence: [Interactive Pi session export](https://github.com/quinnbot-ai/firstmate/blob/6f46f4838a87bfb3ccb393678f3f403250fe7df3/.no-mistakes/evidence/fm/astra-firstmate-control-upgrade/pi-calm-export.html)
- Outcome: 🔧 1 issue found → auto-fixed (2) ✅ across 3 runs (1h5m7s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"e04387bf7629b203eb7c6ee7cc0df39f13bc65ee","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed ✅</summary>

- 🚨 `GROK_BOT.md:1` - The required operating-role rewrite is missing. Addendum 2 requires “Quinn (Grok Bot) = Nick surface” and “FirstMate = only code crew via queue.jsonl”; GROK_BOT.md still says “You are Firstmate: the single agent the captain talks to” and directs coding through Cursor cloud agents at line 11. The only AGENTS.md change updates validation handoff, leaving these explicitly targeted stale instructions intact. Complete the required role/queue documentation rewrite, or obtain explicit approval to narrow this branch’s acceptance scope.

🔧 Fix: Clarify operator roles, intake ownership, and verified harness routing
✅ Re-checked - no issues remain.

</details>

<details>
<summary>🔧 **Test** - 1 issue found → auto-fixed (2) ✅</summary>

- 🚨 tests failed with exit code 2
- `bin/fm-test-run.sh --changed --exclude-family real-herdr-gated`

🔧 Fix: Map GROK_BOT.md changes to existing instruction validation
1 error still open:
- 🚨 tests failed with exit code 1
- `bin/fm-test-run.sh --changed --exclude-family real-herdr-gated`

🔧 Fix: Fix Calm fixtures for current Pi rendering contracts
✅ Re-checked - no issues remain.
- `bin/fm-test-run.sh --changed --exclude-family real-herdr-gated`
- <code>Previously completed baseline: `bin/fm-test-run.sh --changed --exclude-family real-herdr-gated`.</code>
- <code>`bin/fm-test-run.sh tests/fm-watch-checkpoint.test.sh tests/fm-supervision-instructions.test.sh tests/fm-brief.test.sh tests/fm-test-run.test.sh tests/fm-calm-pi-extension.test.sh`.</code>
- <code>`python3 /Users/nick/.no-mistakes/evidence/01M1TR9XAY6HWM7X9ZJP9Q5HWR/checkpoint-evidence.py`: real checkpoint→drain→ack, quiet deadline, singleton contention, before/after self-eviction, and generated instructions in isolated homes.</code>
- <code>`python3 /Users/nick/.no-mistakes/evidence/01M1TR9XAY6HWM7X9ZJP9Q5HWR/pi-compatibility-evidence.py`: prior/current renderer fixture comparison and current native terminal lifecycle/export checks.</code>
- `Rendered the exported session with isolated headless Chrome and visually inspected its screenshot; used direct Chrome after chrome-devtools-axi rejected incompatible pageId arguments.`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
