### PR TITLE
fix: verify Treehouse slot ownership before teardown

### DIFF
--- a/.agents/skills/secondmate-provisioning/SKILL.md
+++ b/.agents/skills/secondmate-provisioning/SKILL.md
@@ -255,6 +255,7 @@ It refuses retirement while that cleanup is uncertain or unavailable, preserving
 Raw deletion is unsupported because a blocking process-event child can outlive its home.
 
 With `--force`, teardown is the explicit discard path.
+The worktree-slot ownership contract in `bin/fm-teardown.sh` still applies: `--force` never authorizes returning a descendant pool slot that another task may own.
 It kills child windows, discards child work and state inside the secondmate home, removes the route, releases the lease, and removes the retired secondmate home.
 If forced teardown contends with a fresh task publication in any affected home, one command refuses without publishing or removing task state; treat that refusal as terminal and inspect the other operation before retrying.
 Relaunch and non-forced teardown remain outside that serialization.

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -108,6 +108,11 @@
 #   even when they select different backends. A fresh spawn first takes the
 #   per-home task-set lock and refuses rather than waits when forced teardown owns
 #   it; relaunch is exempt because the existing task's control lock covers it.
+#   A fresh Treehouse-backed spawn also takes the shared lock in the project's
+#   git common directory before slot allocation and holds it through task metadata
+#   publication. Teardown holds that same lock while proving and returning a slot,
+#   so allocation cannot reuse a slot across an unpublished ownership record;
+#   contention refuses rather than waits.
 #   With no harness arg, a crewmate/scout spawn resolves the CREW harness only when
 #   config/crew-dispatch.json is absent. When that file exists, crewmate/scout
 #   spawns require an explicit harness so firstmate cannot silently skip dispatch
@@ -808,6 +813,8 @@ SPAWN_META_PUBLISH_STARTED=0
 SPAWN_FRESH_COMMIT_PENDING=0
 SPAWN_TASK_SET_LOCK=
 SPAWN_TASK_SET_LOCK_HELD=0
+SPAWN_TREEHOUSE_PROJECT_LOCK=
+SPAWN_TREEHOUSE_PROJECT_LOCK_HELD=0
 RELAUNCH_REPLACEMENT_PENDING=0
 RELAUNCH_REPLACEMENT_BUSY_GEN=
 RELAUNCH_REPLACEMENT_HARNESS=
@@ -938,6 +945,10 @@ spawn_abort_cleanup() {
   if [ "$SPAWN_META_LOCK_HELD" = 1 ]; then
     SPAWN_META_LOCK_HELD=0
     fm_lock_release "$SPAWN_META_LOCK" || true
+  fi
+  if [ "$SPAWN_TREEHOUSE_PROJECT_LOCK_HELD" = 1 ]; then
+    SPAWN_TREEHOUSE_PROJECT_LOCK_HELD=0
+    fm_lock_release "$SPAWN_TREEHOUSE_PROJECT_LOCK" || true
   fi
   if [ "$SPAWN_TASK_SET_LOCK_HELD" = 1 ]; then
     SPAWN_TASK_SET_LOCK_HELD=0
@@ -2019,6 +2030,17 @@ else
   PROJ_ABS="$(cd "$(resolve_project_dir_arg "$PROJ")" && pwd)"
   WT=""
   BRIEF="$DATA/$ID/brief.md"
+fi
+if [ "$RELAUNCH" -eq 0 ] && [ "$KIND" != secondmate ] && [ "$BACKEND" != orca ]; then
+  SPAWN_TREEHOUSE_PROJECT_LOCK=$(fm_treehouse_project_lock_path "$PROJ_ABS") || {
+    echo "error: could not resolve the shared Treehouse project lock for $PROJ_ABS" >&2
+    exit 1
+  }
+  if ! fm_lock_try_acquire "$SPAWN_TREEHOUSE_PROJECT_LOCK"; then
+    echo "error: another Treehouse slot allocation or return is in progress for $PROJ_ABS; refusing to race it" >&2
+    exit 1
+  fi
+  SPAWN_TREEHOUSE_PROJECT_LOCK_HELD=1
 fi
 [ -f "$BRIEF" ] || { echo "error: task $ID has no brief at inaccessible data path $BRIEF" >&2; exit 1; }
 if [ "$KIND" = ship ] || [ "$KIND" = scout ]; then
@@ -3392,6 +3414,10 @@ fi
 # still being delivered, cannot observe or complete a fresh provisional record
 # between its state check and `tasks-axi start`, and a delivery failure cannot
 # follow a committed In-flight transition.
+if [ "$SPAWN_TREEHOUSE_PROJECT_LOCK_HELD" = 1 ]; then
+  SPAWN_TREEHOUSE_PROJECT_LOCK_HELD=0
+  fm_lock_release "$SPAWN_TREEHOUSE_PROJECT_LOCK"
+fi
 if [ "$SPAWN_TASK_SET_LOCK_HELD" = 1 ]; then
   # The record is published, so this task is now part of the set a teardown
   # enumerates and locks per task. The set lock is only needed across that

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -108,10 +108,11 @@
 #   even when they select different backends. A fresh spawn first takes the
 #   per-home task-set lock and refuses rather than waits when forced teardown owns
 #   it; relaunch is exempt because the existing task's control lock covers it.
-#   A fresh Treehouse-backed spawn also takes the shared lock in the project's
-#   git common directory before slot allocation and holds it through task metadata
-#   publication. Teardown holds that same lock while proving and returning a slot,
-#   so allocation cannot reuse a slot across an unpublished ownership record;
+#   A fresh Treehouse-backed spawn also takes the project-identity lock in the root
+#   Firstmate home's state directory before slot allocation and holds it through
+#   task metadata publication. Teardown holds that same lock while proving and
+#   returning a slot, so allocation cannot reuse a slot before its owner record
+#   is published;
 #   contention refuses rather than waits.
 #   With no harness arg, a crewmate/scout spawn resolves the CREW harness only when
 #   config/crew-dispatch.json is absent. When that file exists, crewmate/scout

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -64,32 +64,24 @@
 # name a slot a DIFFERENT live task now holds. Cleanup kills every process under
 # that path and hard-resets it before returning it, so releasing a slot that is
 # not genuinely this task's destroys another worker's live work. Before the first
-# cleanup step, teardown evaluates two independent ownership sources and refuses
-# with both tasks and the slot untouched when either contradicts:
-#   1. Record exclusivity - no OTHER task record in this home or any locally
-#      registered Firstmate home may name the same live path in its worktree= or
-#      home=. One live path with two task
-#      records is the reuse collision itself, whichever record is stale.
-#   2. Endpoint agreement - when the recorded endpoint answers with a live
-#      working directory, it must resolve inside the recorded slot. A pane that
-#      has been rebound to another slot contradicts the record even when this
-#      home holds only one task record for the path.
+# cleanup step, teardown verifies record exclusivity: no OTHER task record in
+# this home or any locally registered Firstmate home may name the same live path
+# in its worktree= or home=. One live path with two task records is the reuse
+# collision itself, whichever record is stale. The recorded endpoint's exact
+# task identity and the record's spawn incarnation are validated separately
+# before cleanup. Its current working directory is only incidental process
+# state: the same worker remains the owner after changing directory, so cwd can
+# never veto teardown of that exact recorded endpoint.
 # The scan and destructive return hold a project-identity lock in the root
 # Firstmate home's state directory. Fresh Treehouse spawns for that project in
 # every local Firstmate home hold the same lock from before slot allocation
 # through metadata publication, closing the publication
 # gap; forced secondmate teardown takes it and runs the same checks for every
 # descendant Treehouse slot before touching any child.
-# Neither refusal is relaxed by --force: --force authorizes discarding THIS
+# This refusal is not relaxed by --force: --force authorizes discarding THIS
 # task's unlanded work, never another task's live work. Reconcile whichever
-# record is wrong and re-run; both refusals name the inspection command.
-# Only backends whose current-path read tracks the live process are consulted for
-# check 2 (tmux's pane_current_path, herdr's foreground_cwd). zellij and cmux
-# freeze a pane's cwd at creation, so their read cannot distinguish a rebound
-# pane from a normal one and is not evidence; Orca is not a pool slot and proves
-# its path through require_orca_worktree_path_match instead. An endpoint that
-# answers nothing readable is inconclusive, not a contradiction, so the ordinary
-# dead-endpoint teardown still proceeds on check 1 alone.
+# record is wrong and re-run. Orca is not a pool slot and proves its path through
+# require_orca_worktree_path_match instead.
 # Orca tasks use the same safety checks, then close the recorded terminal and
 # remove the recorded worktree through `orca worktree rm`; teardown never guesses
 # an Orca target from ambient CLI state.
@@ -2153,46 +2145,6 @@ require_exclusive_task_worktree_slot() {
   require_exclusive_worktree_slot_record "$META" "$ID" "$STATE" "$slot"
 }
 
-# The live working directory the recorded endpoint reports, for the backends
-# whose read tracks the running process. Empty output (including from every
-# other backend) means "no evidence", never "contradicts".
-teardown_endpoint_live_path() {
-  local backend=$1 target=$2
-  case "$backend" in
-    tmux)
-      fm_backend_source tmux >/dev/null 2>&1 || return 0
-      fm_backend_tmux_current_path "$target" 2>/dev/null || true
-      ;;
-    herdr)
-      fm_backend_source herdr >/dev/null 2>&1 || return 0
-      fm_backend_herdr_current_path "$target" 2>/dev/null || true
-      ;;
-  esac
-}
-
-# See "Worktree-slot ownership" in the header. Check 2: a readable endpoint
-# working directory must resolve inside the recorded slot.
-require_endpoint_slot_agreement() {
-  local task_id=$1 backend=$2 target=$3 worktree=$4 slot seen seen_path
-  slot=$(canonical_existing_dir "$worktree") || return 0
-  seen=$(teardown_endpoint_live_path "$backend" "$target")
-  [ -n "$seen" ] || return 0
-  seen_path=$(canonical_existing_dir "$seen") || return 0
-  case "$seen_path" in
-    "$slot"|"$slot"/*) return 0 ;;
-  esac
-  echo "REFUSED: task $task_id's endpoint $target is working in $seen_path, outside its recorded worktree $slot." >&2
-  echo "The recorded copy may already belong to another task, so nothing was changed - not even with --force." >&2
-  echo "Reconcile the endpoint against the record (bin/fm-crew-state.sh $task_id), then re-run teardown: either the record names the wrong copy, or that endpoint is no longer this task's." >&2
-  return 1
-}
-
-require_task_endpoint_slot_agreement() {
-  local slot
-  slot=$(teardown_live_slot_path) || return 0
-  require_endpoint_slot_agreement "$ID" "$BACKEND" "$T" "$slot"
-}
-
 firstmate_home_has_treehouse_slot() {
   local home=$1
   worktree_registered_for_project "$FM_ROOT" "$home"
@@ -2710,9 +2662,7 @@ preflight_descendant_treehouse_slots() {
       continue
     fi
     fm_backend_validate_task_endpoint "$meta" "$task_id" || return 1
-    target=$FM_BACKEND_VALIDATED_TARGET
     require_exclusive_worktree_slot_record "$meta" "$task_id" "$state" "$worktree" || return 1
-    require_endpoint_slot_agreement "$task_id" "$backend" "$target" "$worktree" || return 1
   done
 }
 
@@ -2994,7 +2944,6 @@ remove_secondmate_registry_entry() {
 }
 
 require_exclusive_task_worktree_slot || exit 1
-require_task_endpoint_slot_agreement || exit 1
 
 validate_pr_poll_cleanup "$STATE" "$ID" || exit 1
 

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -59,6 +59,36 @@
 # task state when that proof fails; otherwise it removes the task's check,
 # trust record, PR sidecar, and publication record with the rest of the
 # volatile state.
+# Worktree-slot ownership (teardown-slot-collision): a treehouse pool slot is
+# reused across tasks, so a stale, duplicated, or drifted worktree= record can
+# name a slot a DIFFERENT live task now holds. Cleanup kills every process under
+# that path and hard-resets it before returning it, so releasing a slot that is
+# not genuinely this task's destroys another worker's live work. Before the first
+# cleanup step, teardown evaluates two independent ownership sources and refuses
+# with both tasks and the slot untouched when either contradicts:
+#   1. Record exclusivity - no OTHER task record in this home or any Firstmate
+#      home discoverable as a linked worktree of the same project may name the
+#      same live path in its worktree= or home=. One live path with two task
+#      records is the reuse collision itself, whichever record is stale.
+#   2. Endpoint agreement - when the recorded endpoint answers with a live
+#      working directory, it must resolve inside the recorded slot. A pane that
+#      has been rebound to another slot contradicts the record even when this
+#      home holds only one task record for the path.
+# The scan and destructive return hold a lock in the project's git common
+# directory. Fresh Treehouse spawns for that project hold the same lock from
+# before slot allocation through metadata publication, closing the publication
+# gap; forced secondmate teardown takes it and runs the same checks for every
+# descendant Treehouse slot before touching any child.
+# Neither refusal is relaxed by --force: --force authorizes discarding THIS
+# task's unlanded work, never another task's live work. Reconcile whichever
+# record is wrong and re-run; both refusals name the inspection command.
+# Only backends whose current-path read tracks the live process are consulted for
+# check 2 (tmux's pane_current_path, herdr's foreground_cwd). zellij and cmux
+# freeze a pane's cwd at creation, so their read cannot distinguish a rebound
+# pane from a normal one and is not evidence; Orca is not a pool slot and proves
+# its path through require_orca_worktree_path_match instead. An endpoint that
+# answers nothing readable is inconclusive, not a contradiction, so the ordinary
+# dead-endpoint teardown still proceeds on check 1 alone.
 # Orca tasks use the same safety checks, then close the recorded terminal and
 # remove the recorded worktree through `orca worktree rm`; teardown never guesses
 # an Orca target from ambient CLI state.
@@ -258,6 +288,30 @@ if [ "$FORCE" = --force ] && [ "$(fm_lease_actor)" = branch ]; then
   exit "$FM_LEASE_REFUSE_EXIT"
 fi
 fm_lease_guard "$ID" "teardown (fm-teardown)"
+META="$STATE/$ID.meta"
+TREEHOUSE_PROJECT_LOCK=
+TREEHOUSE_PROJECT_LOCK_HELD=0
+if [ -f "$META" ] && [ ! -L "$META" ]; then
+  TEARDOWN_LOCK_KIND=$(fm_meta_get "$META" kind)
+  [ -n "$TEARDOWN_LOCK_KIND" ] || TEARDOWN_LOCK_KIND=ship
+  TEARDOWN_LOCK_BACKEND=$(fm_meta_get "$META" backend)
+  [ -n "$TEARDOWN_LOCK_BACKEND" ] || TEARDOWN_LOCK_BACKEND=tmux
+  TEARDOWN_LOCK_WT=$(fm_meta_get "$META" worktree)
+  TEARDOWN_LOCK_PROJECT=$(fm_meta_get "$META" project)
+  if [ "$TEARDOWN_LOCK_KIND" != secondmate ] \
+     && [ "$TEARDOWN_LOCK_BACKEND" != orca ] \
+     && [ -n "$TEARDOWN_LOCK_WT" ] && [ -d "$TEARDOWN_LOCK_WT" ]; then
+    TREEHOUSE_PROJECT_LOCK=$(fm_treehouse_project_lock_path "$TEARDOWN_LOCK_PROJECT") || {
+      echo "REFUSED: cannot resolve the shared Treehouse project lock for ${TEARDOWN_LOCK_PROJECT:-<missing>}; nothing was changed" >&2
+      exit 1
+    }
+    fm_lock_try_acquire "$TREEHOUSE_PROJECT_LOCK" || {
+      echo "REFUSED: another Treehouse slot allocation or return is in progress for $TEARDOWN_LOCK_PROJECT; nothing was changed" >&2
+      exit 1
+    }
+    TREEHOUSE_PROJECT_LOCK_HELD=1
+  fi
+fi
 CONTROL_LOCK="$STATE/.control-$ID.lock"
 CONTROL_LOCK_HELD=0
 META_LOCK=
@@ -267,6 +321,7 @@ DESCENDANT_TASK_STATES=()
 DESCENDANT_TASK_IDS=()
 DESCENDANT_TASK_KINDS=()
 DESCENDANT_TASK_HOMES=()
+DESCENDANT_TREEHOUSE_LOCK_PATHS=()
 teardown_release_locks() {
   local status=$? i
   if declare -F teardown_release_herdr_locks >/dev/null 2>&1; then
@@ -296,6 +351,10 @@ teardown_release_locks() {
     fm_lock_release "$CONTROL_LOCK" || true
     CONTROL_LOCK_HELD=0
   fi
+  if [ "$TREEHOUSE_PROJECT_LOCK_HELD" = 1 ]; then
+    fm_lock_release "$TREEHOUSE_PROJECT_LOCK" || true
+    TREEHOUSE_PROJECT_LOCK_HELD=0
+  fi
   fm_lease_guard_release || true
   return "$status"
 }
@@ -310,7 +369,6 @@ CONTROL_LOCK_HELD=1
 fm_refuse_if_gate_agent
 FM_LOCK_LOG_PREFIX=teardown
 
-META="$STATE/$ID.meta"
 fm_backlog_record_present "$META" "task record" "$STATE" || {
   echo "error: teardown refused: $FM_BACKLOG_TRANSITION_ERROR" >&2
   exit 1
@@ -838,6 +896,21 @@ ORCA_PATH_MATCH_VERIFIED=0
 CLEANUP_RECOVERY=$TEARDOWN_CLEANUP_RECOVERY
 
 KIND=$TEARDOWN_META_KIND
+EXPECTED_TREEHOUSE_PROJECT_LOCK=
+if [ "$KIND" != secondmate ] && [ "$BACKEND" != orca ] && [ -n "$WT" ] && [ -d "$WT" ]; then
+  EXPECTED_TREEHOUSE_PROJECT_LOCK=$(fm_treehouse_project_lock_path "$PROJ") || {
+    echo "REFUSED: cannot resolve the shared Treehouse project lock for ${PROJ:-<missing>}; nothing was changed" >&2
+    exit 1
+  }
+  if [ "$TREEHOUSE_PROJECT_LOCK_HELD" != 1 ] \
+     || [ "$TREEHOUSE_PROJECT_LOCK" != "$EXPECTED_TREEHOUSE_PROJECT_LOCK" ]; then
+    echo "REFUSED: task $ID's Treehouse project identity changed while teardown acquired its locks; nothing was changed" >&2
+    exit 1
+  fi
+elif [ "$TREEHOUSE_PROJECT_LOCK_HELD" = 1 ]; then
+  echo "REFUSED: task $ID stopped naming a live Treehouse slot while teardown acquired its locks; nothing was changed" >&2
+  exit 1
+fi
 MODE=$(grep '^mode=' "$META" | cut -d= -f2- || true)
 [ -n "$MODE" ] || MODE=no-mistakes
 
@@ -1972,6 +2045,105 @@ require_orca_worktree_path_match_if_present() {
   require_orca_worktree_path_match "$worktree_id" "$inspected"
 }
 
+# The task's own live slot, canonicalized, or empty when this record has no slot
+# to release (a secondmate home, a record with no worktree=, or a path that is
+# already gone). Every slot-ownership check below is scoped to that value, so a
+# record with nothing live to return skips them rather than refusing.
+teardown_live_slot_path() {
+  [ "$KIND" != secondmate ] || return 1
+  [ -n "$WT" ] || return 1
+  canonical_existing_dir "$WT"
+}
+
+# See "Worktree-slot ownership" in the header. Check 1: task records in every
+# home sharing this Treehouse project must not name the same live slot twice.
+require_exclusive_worktree_slot_record() {
+  local record_meta=$1 record_id=$2 record_state=$3 project=$4 worktree=$5
+  local slot listing line state_dir known other other_id field other_path other_slot
+  local -a states
+  slot=$(canonical_existing_dir "$worktree") || return 0
+  listing=$(git -C "$project" -c core.quotePath=false worktree list --porcelain 2>/dev/null) || {
+    echo "REFUSED: cannot enumerate the homes sharing Treehouse project $project; nothing was changed" >&2
+    return 1
+  }
+  states=("$record_state")
+  while IFS= read -r line; do
+    case "$line" in
+      worktree\ *)
+        state_dir="${line#worktree }/state"
+        known=0
+        for other in "${states[@]}"; do
+          [ "$other" != "$state_dir" ] || known=1
+        done
+        [ "$known" = 1 ] || states+=("$state_dir")
+        ;;
+    esac
+  done <<< "$listing"
+  for state_dir in "${states[@]}"; do
+    for other in "$state_dir"/*.meta; do
+      [ -f "$other" ] && [ ! -L "$other" ] || continue
+      [ "$other" != "$record_meta" ] || continue
+      other_id=$(basename "$other" .meta)
+      for field in worktree home; do
+        other_path=$(fm_meta_get "$other" "$field")
+        [ -n "$other_path" ] || continue
+        other_slot=$(canonical_existing_dir "$other_path") || continue
+        [ "$other_slot" = "$slot" ] || continue
+        echo "REFUSED: task $record_id's recorded worktree $slot is also task $other_id's recorded $field." >&2
+        echo "Returning that pool slot would kill $other_id's processes and reset its copy, so nothing was changed - not even with --force." >&2
+        echo "Reconcile whichever record is wrong (bin/fm-crew-state.sh $record_id; bin/fm-crew-state.sh $other_id), then re-run teardown." >&2
+        return 1
+      done
+    done
+  done
+}
+
+require_exclusive_task_worktree_slot() {
+  local slot
+  slot=$(teardown_live_slot_path) || return 0
+  require_exclusive_worktree_slot_record "$META" "$ID" "$STATE" "$PROJ" "$slot"
+}
+
+# The live working directory the recorded endpoint reports, for the backends
+# whose read tracks the running process. Empty output (including from every
+# other backend) means "no evidence", never "contradicts".
+teardown_endpoint_live_path() {
+  local backend=$1 target=$2
+  case "$backend" in
+    tmux)
+      fm_backend_source tmux >/dev/null 2>&1 || return 0
+      fm_backend_tmux_current_path "$target" 2>/dev/null || true
+      ;;
+    herdr)
+      fm_backend_source herdr >/dev/null 2>&1 || return 0
+      fm_backend_herdr_current_path "$target" 2>/dev/null || true
+      ;;
+  esac
+}
+
+# See "Worktree-slot ownership" in the header. Check 2: a readable endpoint
+# working directory must resolve inside the recorded slot.
+require_endpoint_slot_agreement() {
+  local task_id=$1 backend=$2 target=$3 worktree=$4 slot seen seen_path
+  slot=$(canonical_existing_dir "$worktree") || return 0
+  seen=$(teardown_endpoint_live_path "$backend" "$target")
+  [ -n "$seen" ] || return 0
+  seen_path=$(canonical_existing_dir "$seen") || return 0
+  case "$seen_path" in
+    "$slot"|"$slot"/*) return 0 ;;
+  esac
+  echo "REFUSED: task $task_id's endpoint $target is working in $seen_path, outside its recorded worktree $slot." >&2
+  echo "The recorded copy may already belong to another task, so nothing was changed - not even with --force." >&2
+  echo "Reconcile the endpoint against the record (bin/fm-crew-state.sh $task_id), then re-run teardown: either the record names the wrong copy, or that endpoint is no longer this task's." >&2
+  return 1
+}
+
+require_task_endpoint_slot_agreement() {
+  local slot
+  slot=$(teardown_live_slot_path) || return 0
+  require_endpoint_slot_agreement "$ID" "$BACKEND" "$T" "$slot"
+}
+
 firstmate_home_has_treehouse_slot() {
   local home=$1
   worktree_registered_for_project "$FM_ROOT" "$home"
@@ -2388,6 +2560,7 @@ preflight_descendant_task_locks() {
   DESCENDANT_TASK_IDS=()
   DESCENDANT_TASK_KINDS=()
   DESCENDANT_TASK_HOMES=()
+  DESCENDANT_TREEHOUSE_LOCK_PATHS=()
   collect_descendant_task_locks "$home" || return 1
   # Acquisition order, which every other holder of these locks must match so
   # they cannot cycle: each home's task-set lock first (parent home before child
@@ -2434,6 +2607,55 @@ preflight_descendant_task_locks() {
         return 1
       }
     fi
+  done
+}
+
+preflight_descendant_treehouse_slots() {
+  local i state task_id meta kind backend target worktree project lock_path held
+  for ((i=0; i < ${#DESCENDANT_TASK_IDS[@]}; i++)); do
+    state=${DESCENDANT_TASK_STATES[$i]}
+    task_id=${DESCENDANT_TASK_IDS[$i]}
+    meta="$state/$task_id.meta"
+    kind=$(meta_value "$meta" kind)
+    [ -n "$kind" ] || kind=ship
+    backend=$(fm_backend_of_meta "$meta")
+    worktree=$(meta_value "$meta" worktree)
+    [ "$kind" != secondmate ] && [ "$backend" != orca ] \
+      && [ -n "$worktree" ] && [ -d "$worktree" ] || continue
+    project=$(meta_value "$meta" project)
+    lock_path=$(fm_treehouse_project_lock_path "$project") || {
+      echo "REFUSED: cannot resolve the shared Treehouse project lock for child $task_id; forced teardown changed nothing" >&2
+      return 1
+    }
+    held=0
+    [ "$TREEHOUSE_PROJECT_LOCK_HELD" != 1 ] || [ "$TREEHOUSE_PROJECT_LOCK" != "$lock_path" ] || held=1
+    for target in "${DESCENDANT_TREEHOUSE_LOCK_PATHS[@]}"; do
+      [ "$target" != "$lock_path" ] || held=1
+    done
+    if [ "$held" = 0 ]; then
+      fm_lock_try_acquire "$lock_path" || {
+        echo "REFUSED: another Treehouse slot allocation or return is in progress for child $task_id; forced teardown changed nothing" >&2
+        return 1
+      }
+      DESCENDANT_TREEHOUSE_LOCK_PATHS+=("$lock_path")
+      DESCENDANT_LOCK_PATHS+=("$lock_path")
+    fi
+  done
+  for ((i=0; i < ${#DESCENDANT_TASK_IDS[@]}; i++)); do
+    state=${DESCENDANT_TASK_STATES[$i]}
+    task_id=${DESCENDANT_TASK_IDS[$i]}
+    meta="$state/$task_id.meta"
+    kind=$(meta_value "$meta" kind)
+    [ -n "$kind" ] || kind=ship
+    backend=$(fm_backend_of_meta "$meta")
+    worktree=$(meta_value "$meta" worktree)
+    [ "$kind" != secondmate ] && [ "$backend" != orca ] \
+      && [ -n "$worktree" ] && [ -d "$worktree" ] || continue
+    project=$(meta_value "$meta" project)
+    fm_backend_validate_task_endpoint "$meta" "$task_id" || return 1
+    target=$FM_BACKEND_VALIDATED_TARGET
+    require_exclusive_worktree_slot_record "$meta" "$task_id" "$state" "$project" "$worktree" || return 1
+    require_endpoint_slot_agreement "$task_id" "$backend" "$target" "$worktree" || return 1
   done
 }
 
@@ -2714,6 +2936,9 @@ remove_secondmate_registry_entry() {
   return "$rc"
 }
 
+require_exclusive_task_worktree_slot || exit 1
+require_task_endpoint_slot_agreement || exit 1
+
 validate_pr_poll_cleanup "$STATE" "$ID" || exit 1
 
 if [ "$KIND" = secondmate ]; then
@@ -2729,6 +2954,7 @@ if [ "$KIND" = secondmate ]; then
     validate_firstmate_home_children_removal "$HOME_PATH" || exit 1
     preflight_descendant_task_locks "$HOME_PATH" || exit 1
     validate_firstmate_home_children_removal "$HOME_PATH" || exit 1
+    preflight_descendant_treehouse_slots || exit 1
     if [ "$BACKEND" = herdr ]; then
       teardown_herdr_preflight_target "$T" "$ID" || exit 1
     fi

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -289,9 +289,28 @@ if [ "$FORCE" = --force ] && [ "$(fm_lease_actor)" = branch ]; then
   exit "$FM_LEASE_REFUSE_EXIT"
 fi
 fm_lease_guard "$ID" "teardown (fm-teardown)"
+
+# A Treehouse slot has the managed pool's fixed <pool>/<slot>/<repo> layout.
+# Require both its pool state and the same Git common directory as the recorded
+# project; an ordinary linked worktree is not evidence that Treehouse owns it.
+is_treehouse_pool_slot() {  # <project> <worktree>
+  local project=$1 worktree=$2 slot pool state project_common slot_common
+  [ -d "$project" ] && [ -d "$worktree" ] || return 1
+  slot=$(CDPATH='' cd -- "$worktree" 2>/dev/null && pwd -P) || return 1
+  pool=$(dirname "$(dirname "$slot")")
+  state="$pool/treehouse-state.json"
+  [ -f "$state" ] && [ ! -L "$state" ] || return 1
+  project_common=$(git -C "$project" rev-parse --path-format=absolute --git-common-dir 2>/dev/null) || return 1
+  slot_common=$(git -C "$slot" rev-parse --path-format=absolute --git-common-dir 2>/dev/null) || return 1
+  project_common=$(CDPATH='' cd -- "$project_common" 2>/dev/null && pwd -P) || return 1
+  slot_common=$(CDPATH='' cd -- "$slot_common" 2>/dev/null && pwd -P) || return 1
+  [ "$project_common" = "$slot_common" ]
+}
+
 META="$STATE/$ID.meta"
 TREEHOUSE_PROJECT_LOCK=
 TREEHOUSE_PROJECT_LOCK_HELD=0
+TREEHOUSE_SLOT_LOCK_REQUIRED=0
 if [ -f "$META" ] && [ ! -L "$META" ]; then
   TEARDOWN_LOCK_KIND=$(fm_meta_get "$META" kind)
   [ -n "$TEARDOWN_LOCK_KIND" ] || TEARDOWN_LOCK_KIND=ship
@@ -301,7 +320,8 @@ if [ -f "$META" ] && [ ! -L "$META" ]; then
   TEARDOWN_LOCK_PROJECT=$(fm_meta_get "$META" project)
   if [ "$TEARDOWN_LOCK_KIND" != secondmate ] \
      && [ "$TEARDOWN_LOCK_BACKEND" != orca ] \
-     && [ -n "$TEARDOWN_LOCK_WT" ] && [ -d "$TEARDOWN_LOCK_WT" ]; then
+     && is_treehouse_pool_slot "$TEARDOWN_LOCK_PROJECT" "$TEARDOWN_LOCK_WT"; then
+    TREEHOUSE_SLOT_LOCK_REQUIRED=1
     TREEHOUSE_PROJECT_LOCK=$(fm_treehouse_project_lock_path "$TEARDOWN_LOCK_PROJECT") || {
       echo "REFUSED: cannot resolve the shared Treehouse project lock for ${TEARDOWN_LOCK_PROJECT:-<missing>}; nothing was changed" >&2
       exit 1
@@ -898,7 +918,8 @@ CLEANUP_RECOVERY=$TEARDOWN_CLEANUP_RECOVERY
 
 KIND=$TEARDOWN_META_KIND
 EXPECTED_TREEHOUSE_PROJECT_LOCK=
-if [ "$KIND" != secondmate ] && [ "$BACKEND" != orca ] && [ -n "$WT" ] && [ -d "$WT" ]; then
+if [ "$KIND" != secondmate ] && [ "$BACKEND" != orca ] \
+   && is_treehouse_pool_slot "$PROJ" "$WT"; then
   EXPECTED_TREEHOUSE_PROJECT_LOCK=$(fm_treehouse_project_lock_path "$PROJ") || {
     echo "REFUSED: cannot resolve the shared Treehouse project lock for ${PROJ:-<missing>}; nothing was changed" >&2
     exit 1
@@ -908,7 +929,7 @@ if [ "$KIND" != secondmate ] && [ "$BACKEND" != orca ] && [ -n "$WT" ] && [ -d "
     echo "REFUSED: task $ID's Treehouse project identity changed while teardown acquired its locks; nothing was changed" >&2
     exit 1
   fi
-elif [ "$TREEHOUSE_PROJECT_LOCK_HELD" = 1 ]; then
+elif [ "$TREEHOUSE_SLOT_LOCK_REQUIRED" = 1 ]; then
   echo "REFUSED: task $ID stopped naming a live Treehouse slot while teardown acquired its locks; nothing was changed" >&2
   exit 1
 fi
@@ -2052,7 +2073,7 @@ require_orca_worktree_path_match_if_present() {
 # record with nothing live to return skips them rather than refusing.
 teardown_live_slot_path() {
   [ "$KIND" != secondmate ] || return 1
-  [ -n "$WT" ] || return 1
+  is_treehouse_pool_slot "$PROJ" "$WT" || return 1
   canonical_existing_dir "$WT"
 }
 
@@ -2648,9 +2669,9 @@ preflight_descendant_treehouse_slots() {
     [ -n "$kind" ] || kind=ship
     backend=$(fm_backend_of_meta "$meta")
     worktree=$(meta_value "$meta" worktree)
-    [ "$kind" != secondmate ] && [ "$backend" != orca ] \
-      && [ -n "$worktree" ] && [ -d "$worktree" ] || continue
     project=$(meta_value "$meta" project)
+    [ "$kind" != secondmate ] && [ "$backend" != orca ] \
+      && is_treehouse_pool_slot "$project" "$worktree" || continue
     lock_path=$(fm_treehouse_project_lock_path "$project") || {
       echo "REFUSED: cannot resolve the shared Treehouse project lock for child $task_id; forced teardown changed nothing" >&2
       return 1
@@ -2677,9 +2698,9 @@ preflight_descendant_treehouse_slots() {
     [ -n "$kind" ] || kind=ship
     backend=$(fm_backend_of_meta "$meta")
     worktree=$(meta_value "$meta" worktree)
-    [ "$kind" != secondmate ] && [ "$backend" != orca ] \
-      && [ -n "$worktree" ] && [ -d "$worktree" ] || continue
     project=$(meta_value "$meta" project)
+    [ "$kind" != secondmate ] && [ "$backend" != orca ] \
+      && is_treehouse_pool_slot "$project" "$worktree" || continue
     fm_backend_validate_task_endpoint "$meta" "$task_id" || return 1
     target=$FM_BACKEND_VALIDATED_TARGET
     require_exclusive_worktree_slot_record "$meta" "$task_id" "$state" "$worktree" || return 1

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -66,17 +66,18 @@
 # not genuinely this task's destroys another worker's live work. Before the first
 # cleanup step, teardown evaluates two independent ownership sources and refuses
 # with both tasks and the slot untouched when either contradicts:
-#   1. Record exclusivity - no OTHER task record in this home or any Firstmate
-#      home discoverable as a linked worktree of the same project may name the
-#      same live path in its worktree= or home=. One live path with two task
+#   1. Record exclusivity - no OTHER task record in this home or any locally
+#      registered Firstmate home may name the same live path in its worktree= or
+#      home=. One live path with two task
 #      records is the reuse collision itself, whichever record is stale.
 #   2. Endpoint agreement - when the recorded endpoint answers with a live
 #      working directory, it must resolve inside the recorded slot. A pane that
 #      has been rebound to another slot contradicts the record even when this
 #      home holds only one task record for the path.
-# The scan and destructive return hold a lock in the project's git common
-# directory. Fresh Treehouse spawns for that project hold the same lock from
-# before slot allocation through metadata publication, closing the publication
+# The scan and destructive return hold a project-identity lock in the root
+# Firstmate home's state directory. Fresh Treehouse spawns for that project in
+# every local Firstmate home hold the same lock from before slot allocation
+# through metadata publication, closing the publication
 # gap; forced secondmate teardown takes it and runs the same checks for every
 # descendant Treehouse slot before touching any child.
 # Neither refusal is relaxed by --force: --force authorizes discarding THIS
@@ -2055,31 +2056,58 @@ teardown_live_slot_path() {
   canonical_existing_dir "$WT"
 }
 
-# See "Worktree-slot ownership" in the header. Check 1: task records in every
-# home sharing this Treehouse project must not name the same live slot twice.
-require_exclusive_worktree_slot_record() {
-  local record_meta=$1 record_id=$2 record_state=$3 project=$4 worktree=$5
-  local slot listing line state_dir known other other_id field other_path other_slot
-  local -a states
-  slot=$(canonical_existing_dir "$worktree") || return 0
-  listing=$(git -C "$project" -c core.quotePath=false worktree list --porcelain 2>/dev/null) || {
-    echo "REFUSED: cannot enumerate the homes sharing Treehouse project $project; nothing was changed" >&2
+collect_local_firstmate_states() {
+  local record_state=$1 root home reg line child known existing i=0
+  local -a homes
+  TREEHOUSE_OWNER_STATES=("$record_state")
+  root=$(fm_firstmate_root_home "$FM_HOME") || {
+    echo "REFUSED: cannot resolve the root Firstmate home; nothing was changed" >&2
     return 1
   }
-  states=("$record_state")
-  while IFS= read -r line; do
-    case "$line" in
-      worktree\ *)
-        state_dir="${line#worktree }/state"
-        known=0
-        for other in "${states[@]}"; do
-          [ "$other" != "$state_dir" ] || known=1
-        done
-        [ "$known" = 1 ] || states+=("$state_dir")
-        ;;
-    esac
-  done <<< "$listing"
-  for state_dir in "${states[@]}"; do
+  homes=("$root")
+  while [ "$i" -lt "${#homes[@]}" ]; do
+    home=${homes[$i]}
+    i=$((i + 1))
+    known=0
+    for existing in "${TREEHOUSE_OWNER_STATES[@]}"; do
+      [ "$existing" != "$home/state" ] || known=1
+    done
+    [ "$known" = 1 ] || TREEHOUSE_OWNER_STATES+=("$home/state")
+    reg="$home/data/secondmates.md"
+    [ ! -e "$reg" ] && [ ! -L "$reg" ] && continue
+    [ -f "$reg" ] && [ ! -L "$reg" ] || {
+      echo "REFUSED: local Firstmate registry is unsafe at $reg; nothing was changed" >&2
+      return 1
+    }
+    while IFS= read -r line || [ -n "$line" ]; do
+      case "$line" in
+        "- "*)
+          secondmate_registry_parse_line "$line" || {
+            echo "REFUSED: malformed local Firstmate registry entry in $reg; nothing was changed" >&2
+            return 1
+          }
+          [ "$SECONDMATE_REGISTRY_REMOTE" -eq 0 ] || continue
+          child=$(canonical_existing_dir "$SECONDMATE_REGISTRY_HOME") || {
+            echo "REFUSED: registered local Firstmate home is unavailable: $SECONDMATE_REGISTRY_HOME; nothing was changed" >&2
+            return 1
+          }
+          known=0
+          for existing in "${homes[@]}"; do
+            [ "$existing" != "$child" ] || known=1
+          done
+          [ "$known" = 1 ] || homes+=("$child")
+          ;;
+      esac
+    done < "$reg"
+  done
+}
+
+require_exclusive_worktree_slot_record() {
+  local record_meta=$1 record_id=$2 record_state=$3 worktree=$4
+  local slot state_dir other other_id field other_path other_slot
+  slot=$(canonical_existing_dir "$worktree") || return 0
+  collect_local_firstmate_states "$record_state" || return 1
+  for state_dir in "${TREEHOUSE_OWNER_STATES[@]}"; do
     for other in "$state_dir"/*.meta; do
       [ -f "$other" ] && [ ! -L "$other" ] || continue
       [ "$other" != "$record_meta" ] || continue
@@ -2101,7 +2129,7 @@ require_exclusive_worktree_slot_record() {
 require_exclusive_task_worktree_slot() {
   local slot
   slot=$(teardown_live_slot_path) || return 0
-  require_exclusive_worktree_slot_record "$META" "$ID" "$STATE" "$PROJ" "$slot"
+  require_exclusive_worktree_slot_record "$META" "$ID" "$STATE" "$slot"
 }
 
 # The live working directory the recorded endpoint reports, for the backends
@@ -2654,7 +2682,7 @@ preflight_descendant_treehouse_slots() {
     project=$(meta_value "$meta" project)
     fm_backend_validate_task_endpoint "$meta" "$task_id" || return 1
     target=$FM_BACKEND_VALIDATED_TARGET
-    require_exclusive_worktree_slot_record "$meta" "$task_id" "$state" "$project" "$worktree" || return 1
+    require_exclusive_worktree_slot_record "$meta" "$task_id" "$state" "$worktree" || return 1
     require_endpoint_slot_agreement "$task_id" "$backend" "$target" "$worktree" || return 1
   done
 }

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -2670,8 +2670,12 @@ preflight_descendant_treehouse_slots() {
     backend=$(fm_backend_of_meta "$meta")
     worktree=$(meta_value "$meta" worktree)
     project=$(meta_value "$meta" project)
-    [ "$kind" != secondmate ] && [ "$backend" != orca ] \
-      && is_treehouse_pool_slot "$project" "$worktree" || continue
+    if [ "$kind" = secondmate ] || [ "$backend" = orca ]; then
+      continue
+    fi
+    if ! is_treehouse_pool_slot "$project" "$worktree"; then
+      continue
+    fi
     lock_path=$(fm_treehouse_project_lock_path "$project") || {
       echo "REFUSED: cannot resolve the shared Treehouse project lock for child $task_id; forced teardown changed nothing" >&2
       return 1
@@ -2699,8 +2703,12 @@ preflight_descendant_treehouse_slots() {
     backend=$(fm_backend_of_meta "$meta")
     worktree=$(meta_value "$meta" worktree)
     project=$(meta_value "$meta" project)
-    [ "$kind" != secondmate ] && [ "$backend" != orca ] \
-      && is_treehouse_pool_slot "$project" "$worktree" || continue
+    if [ "$kind" = secondmate ] || [ "$backend" = orca ]; then
+      continue
+    fi
+    if ! is_treehouse_pool_slot "$project" "$worktree"; then
+      continue
+    fi
     fm_backend_validate_task_endpoint "$meta" "$task_id" || return 1
     target=$FM_BACKEND_VALIDATED_TARGET
     require_exclusive_worktree_slot_record "$meta" "$task_id" "$state" "$worktree" || return 1

--- a/bin/fm-wake-lib.sh
+++ b/bin/fm-wake-lib.sh
@@ -1093,8 +1093,10 @@ fm_firstmate_root_home() {
   home=$(CDPATH='' cd -- "$home" 2>/dev/null && pwd -P) || return 1
   while [ -e "$home/.fm-secondmate-parent" ] || [ -L "$home/.fm-secondmate-parent" ]; do
     marker="$home/.fm-secondmate-parent"
-    command -v fm_secondmate_parent_record_parse >/dev/null 2>&1 \
-      || . "$FM_WAKE_LIB_DIR/fm-secondmate-parent-lib.sh"
+    if ! command -v fm_secondmate_parent_record_parse >/dev/null 2>&1; then
+      # shellcheck source=bin/fm-secondmate-parent-lib.sh
+      . "$FM_WAKE_LIB_DIR/fm-secondmate-parent-lib.sh"
+    fi
     fm_secondmate_parent_record_parse "$marker" || return 1
     [ "$FM_SECONDMATE_PARENT_ROUTE" = local ] || return 1
     parent=$(CDPATH='' cd -- "$FM_SECONDMATE_PARENT_HOME" 2>/dev/null && pwd -P) || return 1
@@ -1116,6 +1118,8 @@ fm_treehouse_project_lock_path() {  # <project-dir>
     case "$origin" in
       /*) [ ! -d "$origin" ] || origin=$(CDPATH='' cd -- "$origin" 2>/dev/null && pwd -P) || return 1 ;;
       ./*|../*) [ ! -d "$project/$origin" ] || origin=$(CDPATH='' cd -- "$project/$origin" 2>/dev/null && pwd -P) || return 1 ;;
+      *://*|*:* ) ;;
+      *) [ ! -d "$(dirname "$project")/$origin" ] || origin=$(CDPATH='' cd -- "$(dirname "$project")/$origin" 2>/dev/null && pwd -P) || return 1 ;;
     esac
     identity=$origin
   else

--- a/bin/fm-wake-lib.sh
+++ b/bin/fm-wake-lib.sh
@@ -1088,15 +1088,44 @@ fm_task_set_lock_path() {  # <state-dir>
   printf '%s/.task-set.lock\n' "$state"
 }
 
+fm_firstmate_root_home() {
+  local home=${1:-$FM_HOME} marker parent seen="|" depth=0
+  home=$(CDPATH='' cd -- "$home" 2>/dev/null && pwd -P) || return 1
+  while [ -e "$home/.fm-secondmate-parent" ] || [ -L "$home/.fm-secondmate-parent" ]; do
+    marker="$home/.fm-secondmate-parent"
+    command -v fm_secondmate_parent_record_parse >/dev/null 2>&1 \
+      || . "$FM_WAKE_LIB_DIR/fm-secondmate-parent-lib.sh"
+    fm_secondmate_parent_record_parse "$marker" || return 1
+    [ "$FM_SECONDMATE_PARENT_ROUTE" = local ] || return 1
+    parent=$(CDPATH='' cd -- "$FM_SECONDMATE_PARENT_HOME" 2>/dev/null && pwd -P) || return 1
+    case "$seen" in *"|$parent|"*) return 1 ;; esac
+    seen="$seen$home|"
+    home=$parent
+    depth=$((depth + 1))
+    [ "$depth" -le 64 ] || return 1
+  done
+  printf '%s\n' "$home"
+}
+
 fm_treehouse_project_lock_path() {  # <project-dir>
-  local project=$1 common
+  local project=$1 root origin identity hash top
   [ -d "$project" ] || return 1
-  common=$(git -C "$project" rev-parse --git-common-dir 2>/dev/null) || return 1
-  case "$common" in
-    /*) common=$(CDPATH='' cd -- "$common" 2>/dev/null && pwd -P) || return 1 ;;
-    *) common=$(CDPATH='' cd -- "$project/$common" 2>/dev/null && pwd -P) || return 1 ;;
-  esac
-  printf '%s/.fm-treehouse-project.lock\n' "$common"
+  root=$(fm_firstmate_root_home "$FM_HOME") || return 1
+  origin=$(git -C "$project" remote get-url origin 2>/dev/null || true)
+  if [ -n "$origin" ]; then
+    case "$origin" in
+      /*) [ ! -d "$origin" ] || origin=$(CDPATH='' cd -- "$origin" 2>/dev/null && pwd -P) || return 1 ;;
+      ./*|../*) [ ! -d "$project/$origin" ] || origin=$(CDPATH='' cd -- "$project/$origin" 2>/dev/null && pwd -P) || return 1 ;;
+    esac
+    identity=$origin
+  else
+    top=$(git -C "$project" rev-parse --show-toplevel 2>/dev/null) || return 1
+    top=$(CDPATH='' cd -- "$top" 2>/dev/null && pwd -P) || return 1
+    identity=$top
+  fi
+  hash=$(printf '%s' "$identity" | git hash-object --stdin 2>/dev/null) || return 1
+  [ -d "$root/state" ] || return 1
+  printf '%s/.treehouse-project-%s.lock\n' "$root/state" "$hash"
 }
 
 fm_failure_episode_reset() {

--- a/bin/fm-wake-lib.sh
+++ b/bin/fm-wake-lib.sh
@@ -1088,6 +1088,17 @@ fm_task_set_lock_path() {  # <state-dir>
   printf '%s/.task-set.lock\n' "$state"
 }
 
+fm_treehouse_project_lock_path() {  # <project-dir>
+  local project=$1 common
+  [ -d "$project" ] || return 1
+  common=$(git -C "$project" rev-parse --git-common-dir 2>/dev/null) || return 1
+  case "$common" in
+    /*) common=$(CDPATH='' cd -- "$common" 2>/dev/null && pwd -P) || return 1 ;;
+    *) common=$(CDPATH='' cd -- "$project/$common" 2>/dev/null && pwd -P) || return 1 ;;
+  esac
+  printf '%s/.fm-treehouse-project.lock\n' "$common"
+}
+
 fm_failure_episode_reset() {
   local state=$1 mode=${2:-acquire} lock current pid acquired=0 path
   lock="$state/.turnend-claude-blocks.lock"

--- a/bin/fm-wake-lib.sh
+++ b/bin/fm-wake-lib.sh
@@ -1117,9 +1117,8 @@ fm_treehouse_project_lock_path() {  # <project-dir>
   if [ -n "$origin" ]; then
     case "$origin" in
       /*) [ ! -d "$origin" ] || origin=$(CDPATH='' cd -- "$origin" 2>/dev/null && pwd -P) || return 1 ;;
-      ./*|../*) [ ! -d "$project/$origin" ] || origin=$(CDPATH='' cd -- "$project/$origin" 2>/dev/null && pwd -P) || return 1 ;;
       *://*|*:* ) ;;
-      *) [ ! -d "$(dirname "$project")/$origin" ] || origin=$(CDPATH='' cd -- "$(dirname "$project")/$origin" 2>/dev/null && pwd -P) || return 1 ;;
+      *) [ ! -d "$project/$origin" ] || origin=$(CDPATH='' cd -- "$project/$origin" 2>/dev/null && pwd -P) || return 1 ;;
     esac
     identity=$origin
   else

--- a/bin/fm-watch-checkpoint.sh
+++ b/bin/fm-watch-checkpoint.sh
@@ -63,12 +63,19 @@ run_with_perl_timeout() {
     }
     local $SIG{ALRM} = sub {
       kill "TERM", -$pid;
-      select undef, undef, undef, 0.2;
-      kill "KILL", -$pid;
+      my $grace = $ENV{FM_SIGNAL_GRACE} || 5;
+      local $SIG{ALRM} = sub {
+        kill "KILL", -$pid;
+        waitpid $pid, 0;
+        exit 124;
+      };
+      alarm $grace;
+      waitpid $pid, 0;
       exit 124;
     };
     alarm $seconds;
     waitpid $pid, 0;
+    alarm 0;
     exit($? >> 8);
   ' "$SECONDS_ARG" "$SCRIPT_DIR/fm-watch.sh"
 }

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -307,8 +307,9 @@ Every GitHub refusal states what it could not observe as plainly as what it did,
 A confirmed merge leaves a durable role-routed outcome instead of living only in the merging agent's memory, and [`bin/fm-merge-outcome-lib.sh`](../bin/fm-merge-outcome-lib.sh)'s header owns its destination, shape, identity, normal-case deduplication, and at-least-once recovery.
 The same emitter handles a merge firstmate performed and one its poll detected, while the watcher immediately delivers the emitter's local actionable poll row.
 Teardown is fail-closed for ship worktrees: dirty worktrees refuse, and committed work must be landed before the worktree is returned.
+A pool worktree is only returned after teardown passes the slot-ownership proof: a contradictory task record or supported live endpoint refuses without touching either task, and no discard authority relaxes that.
 Before the worktree is returned, teardown concludes the task's own no-mistakes run when it is parked at a gate, including a run whose head the task copy cannot resolve - the shared runs-ledger continuation proof is the only recognition for that case, so cleanup never orphans a parked run the pipeline advanced past the submitted head.
-[`bin/fm-teardown.sh`](../bin/fm-teardown.sh)'s header owns the landed-work proofs, PR-discovery fallback, pre-teardown run conclusion, and stale-lock recovery procedure.
+[`bin/fm-teardown.sh`](../bin/fm-teardown.sh)'s header owns the landed-work proofs, slot-ownership proof, PR-discovery fallback, pre-teardown run conclusion, and stale-lock recovery procedure; [`tests/fm-teardown-endpoint-safety.test.sh`](../tests/fm-teardown-endpoint-safety.test.sh) and [`tests/fm-secondmate-safety.test.sh`](../tests/fm-secondmate-safety.test.sh) pin the slot-collision boundary.
 
 ## Optional Relay
 

--- a/tests/fm-backend-herdr-presentation-e2e.test.sh
+++ b/tests/fm-backend-herdr-presentation-e2e.test.sh
@@ -437,8 +437,10 @@ teardown_task() {  # <id> <home>
 finish_concurrent_teardown() {  # <id> <status> <stdout> <stderr>
   local id=$1 status=$2 out=$3 err=$4
   [ "$status" -ne 0 ] || return 0
-  grep -F "session presentation lock is contended" "$err" >/dev/null 2>&1 \
-    || fail "projected teardown $id failed unexpectedly: $(cat "$err")"
+  if ! grep -F "session presentation lock is contended" "$err" >/dev/null 2>&1 \
+     && ! grep -F "another Treehouse slot allocation or return is in progress" "$err" >/dev/null 2>&1; then
+    fail "projected teardown $id failed unexpectedly: $(cat "$err")"
+  fi
   teardown_task "$id" "$HOME_DIR" > "$out" 2> "$err" \
     || fail "projected teardown $id retry failed after presentation cleanup completed: $(cat "$err")"
 }

--- a/tests/fm-backend-herdr-presentation-e2e.test.sh
+++ b/tests/fm-backend-herdr-presentation-e2e.test.sh
@@ -398,7 +398,7 @@ EOF
 spawn_task() {  # <id> <home> <project>
   local id=$1 home=$2 project=$3
   FM_GATE_REFUSE_BYPASS=1 FM_SPAWN_NO_GUARD=1 FM_HOME="$home" FM_ROOT_OVERRIDE="$ROOT" \
-    "$ROOT/bin/fm-spawn.sh" "$id" "$project" "sh -c 'sleep 120'" --mode no-mistakes --yolo off --backend herdr
+    "$ROOT/bin/fm-spawn.sh" "$id" "$project" "sh -c 'while :; do sleep 60; done'" --mode no-mistakes --yolo off --backend herdr
 }
 
 finish_concurrent_spawn() {  # <id> <status> <stdout> <stderr>
@@ -423,7 +423,7 @@ finish_concurrent_expected_abort() {  # <id> <status> <stdout> <stderr>
 spawn_secondmate_task() {
   local id=$1 home=$2
   FM_GATE_REFUSE_BYPASS=1 FM_SPAWN_NO_GUARD=1 FM_HOME="$HOME_DIR" FM_ROOT_OVERRIDE="$ROOT" \
-    "$ROOT/bin/fm-spawn.sh" "$id" "$home" "sh -c 'sleep 120'" --secondmate --backend herdr
+    "$ROOT/bin/fm-spawn.sh" "$id" "$home" "sh -c 'while :; do sleep 60; done'" --secondmate --backend herdr
 }
 
 teardown_task() {  # <id> <home>
@@ -1199,6 +1199,10 @@ for RESTART_ID in fm-hibit-resume-r1 wheelhouse-healing-r1; do
   PATH="$HERDR_ORIGINAL_PATH" \
     "$HERDR_LAB_HELPER" provision "$HERDR_LAB_SESSION" \
     || fail "could not reprovision the isolated session for $RESTART_ID validation"
+  # Stopping the whole Herdr session also ends the anchor's agent. Its restored
+  # shell remains useful as the durable layout anchor, but its task record no
+  # longer represents a live slot owner and must not poison later slot reuse.
+  rm -f "$ANCHOR_META"
   lab pane get "$OLD_RESTART_PANE" >/dev/null 2>&1 \
     || fail "$RESTART_ID restart did not preserve the projected pane structurally"
   if lab agent get "$OLD_RESTART_PANE" >/dev/null 2>&1; then
@@ -1239,7 +1243,9 @@ for RESTART_ID in fm-hibit-resume-r1 wheelhouse-healing-r1; do
       || fail "$RESTART_ID repeated reclaim changed workspace identity"
     [ "$NEW_RESTART_PANE" != "$PRIOR_RESTART_PANE" ] \
       || fail "$RESTART_ID repeated reclaim reused the prior husk pane"
-    "$REAL_TREEHOUSE" return --force "$PRIOR_RESTART_WT" >/dev/null 2>&1 || true
+    if [ "$PRIOR_RESTART_WT" != "$NEW_RESTART_WT" ]; then
+      "$REAL_TREEHOUSE" return --force "$PRIOR_RESTART_WT" >/dev/null 2>&1 || true
+    fi
   fi
 
   teardown_task "$RESTART_ID" "$HOME_DIR" > "$TMP_ROOT/$RESTART_ID-teardown.out" 2> "$TMP_ROOT/$RESTART_ID-teardown.err" \
@@ -1332,9 +1338,9 @@ if lab pane get "$PRIMARY_WAVE_OLD_PANE" >/dev/null 2>&1 \
 fi
 assert_focus_is "$CONCURRENT_RECOVERY_FOCUS" "concurrent cross-home recovery"
 teardown_task "$PRIMARY_WAVE_ID" "$HOME_DIR" > "$TMP_ROOT/primary-wave-teardown.out" 2> "$TMP_ROOT/primary-wave-teardown.err" \
-  || fail "concurrent primary recovery teardown failed"
+  || fail "concurrent primary recovery teardown failed: $(cat "$TMP_ROOT/primary-wave-teardown.err")"
 teardown_task "$BRAVO_WAVE_ID" "$SECOND_HOME_B" > "$TMP_ROOT/bravo-wave-teardown.out" 2> "$TMP_ROOT/bravo-wave-teardown.err" \
-  || fail "concurrent secondmate recovery teardown failed"
+  || fail "concurrent secondmate recovery teardown failed: $(cat "$TMP_ROOT/bravo-wave-teardown.err")"
 "$REAL_TREEHOUSE" return --force "$PRIMARY_WAVE_OLD_WT" >/dev/null 2>&1 || true
 "$REAL_TREEHOUSE" return --force "$BRAVO_WAVE_OLD_WT" >/dev/null 2>&1 || true
 "$REAL_TREEHOUSE" return --force "$PRIMARY_WAVE_NEW_WT" >/dev/null 2>&1 || true

--- a/tests/fm-captain-hold-lifecycle.test.sh
+++ b/tests/fm-captain-hold-lifecycle.test.sh
@@ -1960,6 +1960,7 @@ test_interrupted_cleanup_keeps_the_captain_call_recoverable() {
   id=sample-held-cleanup-failure
   wt="$home/projects/$id"
   mkdir -p "$home/data/$id" "$wt" "$home/projects/sample"
+  git -C "$home/projects/sample" init -q || fail "could not initialize cleanup-failure project fixture"
   tasks_in "$home" add "$id" "Investigate failed sample cleanup" --kind scout \
     --repo sample --start >/dev/null || fail "could not create the cleanup-failure fixture"
   fm_write_meta "$home/state/$id.meta" \

--- a/tests/fm-secondmate-safety.test.sh
+++ b/tests/fm-secondmate-safety.test.sh
@@ -1941,10 +1941,12 @@ test_secondmate_force_teardown_refuses_duplicated_child_slot() {
   home="$TMP_ROOT/force-duplicate-slot-home"
   subhome="$TMP_ROOT/force-duplicate-slot-subhome"
   childproj="$subhome/projects/alpha"
-  childwt="$TMP_ROOT/force-duplicate-slot-worktree"
+  childwt="$TMP_ROOT/force-duplicate-slot-pool/1/alpha"
   err="$TMP_ROOT/force-duplicate-slot.err"
-  mkdir -p "$home/state" "$home/data" "$subhome/state"
+  mkdir -p "$home/state" "$home/data" "$subhome/state" "$(dirname "$childwt")"
   fm_git_worktree "$childproj" "$childwt" duplicate-child
+  printf '{"worktrees":[{"name":"1","path":"%s"}]}\n' "$childwt" \
+    > "$TMP_ROOT/force-duplicate-slot-pool/treehouse-state.json"
   printf 'domain\n' > "$subhome/.fm-secondmate-home"
   cat > "$home/state/domain.meta" <<EOF
 window=firstmate:fm-domain
@@ -1993,10 +1995,12 @@ test_secondmate_force_teardown_preserves_child_on_unproven_lock() {
   home="$TMP_ROOT/force-lock-home"
   subhome="$TMP_ROOT/force-lock-subhome"
   childproj="$subhome/projects/alpha"
-  childwt="$TMP_ROOT/force-lock-child-worktree"
+  childwt="$TMP_ROOT/force-lock-child-pool/1/alpha"
   err="$TMP_ROOT/force-lock-child.err"
-  mkdir -p "$home/state" "$home/data" "$subhome/state"
+  mkdir -p "$home/state" "$home/data" "$subhome/state" "$(dirname "$childwt")"
   fm_git_worktree "$childproj" "$childwt" force-child-lock
+  printf '{"worktrees":[{"name":"1","path":"%s"}]}\n' "$childwt" \
+    > "$TMP_ROOT/force-lock-child-pool/treehouse-state.json"
   printf 'domain\n' > "$subhome/.fm-secondmate-home"
   cat > "$home/state/domain.meta" <<EOF
 window=firstmate:fm-domain

--- a/tests/fm-secondmate-safety.test.sh
+++ b/tests/fm-secondmate-safety.test.sh
@@ -1936,6 +1936,58 @@ EOF
   pass "secondmate force teardown discards child work"
 }
 
+test_secondmate_force_teardown_refuses_duplicated_child_slot() {
+  local home subhome childproj childwt fakebin log err rc
+  home="$TMP_ROOT/force-duplicate-slot-home"
+  subhome="$TMP_ROOT/force-duplicate-slot-subhome"
+  childproj="$subhome/projects/alpha"
+  childwt="$TMP_ROOT/force-duplicate-slot-worktree"
+  err="$TMP_ROOT/force-duplicate-slot.err"
+  mkdir -p "$home/state" "$home/data" "$subhome/state"
+  fm_git_worktree "$childproj" "$childwt" duplicate-child
+  printf 'domain\n' > "$subhome/.fm-secondmate-home"
+  cat > "$home/state/domain.meta" <<EOF
+window=firstmate:fm-domain
+worktree=$subhome
+project=$subhome
+harness=echo
+kind=secondmate
+mode=secondmate
+yolo=off
+home=$subhome
+projects=alpha
+EOF
+  printf '%s\n' '- domain - design domain (home: '"$subhome"'; scope: design domain; projects: alpha; added 2026-06-22)' > "$home/data/secondmates.md"
+  for child in stale-child live-child; do
+    cat > "$subhome/state/$child.meta" <<EOF
+window=firstmate:fm-$child
+worktree=$childwt
+project=$childproj
+harness=echo
+kind=ship
+mode=no-mistakes
+yolo=off
+EOF
+  done
+  fakebin=$(make_fake_tmux "$TMP_ROOT/force-duplicate-slot-fake")
+  log="$TMP_ROOT/force-duplicate-slot-fake/tmux.log"
+
+  set +e
+  PATH="$fakebin:$PATH" FM_HOME="$home" FM_FAKE_TMUX_LOG="$log" \
+    FM_FAKE_TMUX_CAPTURE="$TMP_ROOT/force-duplicate-slot-fake/pane.txt" \
+    "$ROOT/bin/fm-teardown.sh" domain --force >/dev/null 2>"$err"
+  rc=$?
+  set -e
+  [ "$rc" -ne 0 ] || fail "forced secondmate teardown returned a duplicated child slot"
+  [ -d "$childwt" ] || fail "forced secondmate teardown removed the duplicated child slot"
+  [ -e "$subhome/state/stale-child.meta" ] || fail "forced secondmate teardown removed the stale child record"
+  [ -e "$subhome/state/live-child.meta" ] || fail "forced secondmate teardown removed the live child record"
+  grep -F 'kill-window' "$log" >/dev/null && fail "forced secondmate teardown killed a child before detecting its slot collision"
+  grep -F 'live-child' "$err" >/dev/null || grep -F 'stale-child' "$err" >/dev/null \
+    || fail "forced secondmate teardown did not identify the duplicated child slot"
+  pass "forced secondmate teardown refuses duplicated descendant pool slots"
+}
+
 test_secondmate_force_teardown_preserves_child_on_unproven_lock() {
   local home subhome childproj childwt fakebin log err rc lock
   home="$TMP_ROOT/force-lock-home"
@@ -2954,6 +3006,7 @@ test_secondmate_force_teardown_preserves_nested_restore_status
 test_secondmate_teardown_refuses_failed_leased_home_return
 test_secondmate_teardown_removes_plain_clone_home_without_treehouse_return
 test_secondmate_force_teardown_discards_child_work
+test_secondmate_force_teardown_refuses_duplicated_child_slot
 test_secondmate_force_teardown_preserves_child_on_unproven_lock
 test_secondmate_force_teardown_allows_non_state_operational_dir_symlinks_inside_home
 test_secondmate_force_teardown_refuses_operational_dir_symlink_outside_home

--- a/tests/fm-spawn-batch.test.sh
+++ b/tests/fm-spawn-batch.test.sh
@@ -84,12 +84,14 @@ test_projects_path_scoping() {
     home="$TMP_ROOT/$id home"
     projects="$TMP_ROOT/$id projects"
     mkdir -p "$home/data" "$projects/alpha"
+    git -C "$projects/alpha" init -q || fail "$label: could not initialize project fixture"
     if [ "$use_override" = yes ]; then
       out=$(FM_ROOT_OVERRIDE='' FM_STATE_OVERRIDE='' FM_DATA_OVERRIDE='' FM_CONFIG_OVERRIDE='' \
         FM_HOME="$home" FM_PROJECTS_OVERRIDE="$projects" FM_SPAWN_NO_GUARD=1 \
         "$SPAWN" "$id" projects/alpha codex --mode no-mistakes --yolo off 2>&1)
     else
       mkdir -p "$home/projects/alpha"
+      git -C "$home/projects/alpha" init -q || fail "$label: could not initialize home project fixture"
       out=$(FM_ROOT_OVERRIDE='' FM_STATE_OVERRIDE='' FM_DATA_OVERRIDE='' FM_PROJECTS_OVERRIDE='' FM_CONFIG_OVERRIDE='' \
         FM_HOME="$home" FM_SPAWN_NO_GUARD=1 \
         "$SPAWN" "$id" projects/alpha codex --mode no-mistakes --yolo off 2>&1)

--- a/tests/fm-task-delivery.test.sh
+++ b/tests/fm-task-delivery.test.sh
@@ -33,6 +33,7 @@ make_home() {  # <name> [<registry-line>...]
   projects="$TMP_ROOT/$name/projects"
   fakebin="$TMP_ROOT/$name/bin"
   mkdir -p "$home/data" "$home/state" "$home/config" "$projects/proj" "$fakebin"
+  git -C "$projects/proj" init -q || fail "could not initialize project fixture"
   printf '#!/bin/sh\nexit 1\n' > "$fakebin/tmux"
   chmod +x "$fakebin/tmux"
   if [ "$#" -gt 0 ]; then

--- a/tests/fm-teardown-endpoint-safety.test.sh
+++ b/tests/fm-teardown-endpoint-safety.test.sh
@@ -415,6 +415,29 @@ SH
   pass "fm-teardown: exact tmux cleanup preserves invalid and prefix-matched neighbors while removing only the recorded target"
 }
 
+test_bare_relative_origin_shares_project_lock_with_clone() {
+  local dir second_project primary_lock clone_lock
+  dir=$(make_case bare-relative-origin-lock)
+  git -C "$dir/project" -c user.name=test -c user.email=test@example.invalid \
+    commit --allow-empty -qm lock-fixture
+  git -C "$dir/project" remote add origin project
+  second_project="$dir/second-project"
+  git clone -q "$dir/project" "$second_project"
+
+  primary_lock=$(FM_HOME="$dir/home" bash -c \
+    '. "$1"; fm_treehouse_project_lock_path "$2"' _ \
+    "$ROOT/bin/fm-wake-lib.sh" "$dir/project") \
+    || fail "could not resolve the primary project's bare-origin lock"
+  clone_lock=$(FM_HOME="$dir/home" bash -c \
+    '. "$1"; fm_treehouse_project_lock_path "$2"' _ \
+    "$ROOT/bin/fm-wake-lib.sh" "$second_project") \
+    || fail "could not resolve the clone project's absolute-origin lock"
+  [ "$primary_lock" = "$clone_lock" ] \
+    || fail "bare and absolute forms of the same local origin resolved different project locks"
+
+  pass "Treehouse locking gives a bare local origin and its absolute clone one project identity"
+}
+
 test_reused_pool_slot_refuses_before_touching_the_other_task() {
   local dir id=stale-task other=live-task worker rc
 
@@ -606,6 +629,7 @@ test_supported_backend_endpoint_records_validate
 test_tmux_empty_target_refuses_without_invocation
 test_recorded_process_identity_cleanup_is_exact
 test_isolated_tmux_invalid_and_valid_cleanup
+test_bare_relative_origin_shares_project_lock_with_clone
 test_reused_pool_slot_refuses_before_touching_the_other_task
 test_cross_home_pool_slot_collision_refuses
 test_sole_slot_record_still_tears_down

--- a/tests/fm-teardown-endpoint-safety.test.sh
+++ b/tests/fm-teardown-endpoint-safety.test.sh
@@ -35,6 +35,19 @@ SH
   printf '%s\n' "$TMP_ROOT/$dir"
 }
 
+mark_case_as_treehouse_pool() {  # <case>
+  local dir=$1
+  rm -rf "$dir/worktree"
+  mkdir -p "$dir/pool/1"
+  git -C "$dir/project" -c user.name=test -c user.email=test@example.invalid \
+    commit --allow-empty -qm pool-fixture
+  git -C "$dir/project" worktree add -q --detach "$dir/pool/1/project"
+  ln -s "pool/1/project" "$dir/worktree"
+  printf '{"worktrees":[{"name":"1","path":"%s"}]}\n' \
+    "$dir/pool/1/project" > "$dir/pool/treehouse-state.json"
+  : > "$dir/worktree/sentinel"
+}
+
 run_case() {  # <case> <id>
   local dir=$1 id=$2
   FM_HOME="$dir/home" FM_ROOT_OVERRIDE="$ROOT" \
@@ -406,6 +419,7 @@ test_reused_pool_slot_refuses_before_touching_the_other_task() {
   local dir id=stale-task other=live-task worker rc
 
   dir=$(make_case slot-reuse)
+  mark_case_as_treehouse_pool "$dir"
   # The reuse collision: the pool slot recorded for a finished task has already
   # been handed to another task, whose worker is live in it right now.
   fm_write_meta "$dir/home/state/$id.meta" \
@@ -440,6 +454,7 @@ test_reused_pool_slot_refuses_before_touching_the_other_task() {
   # The same collision recorded on a secondmate home field rather than a task
   # worktree is the same slot, and refuses the same way.
   dir=$(make_case slot-reuse-home)
+  mark_case_as_treehouse_pool "$dir"
   fm_write_meta "$dir/home/state/$id.meta" \
     "window=firstmate:fm-$id" "endpoint_task_id=$id" \
     "worktree=$dir/worktree" "project=$dir/project" "kind=scout"
@@ -463,6 +478,7 @@ test_reused_pool_slot_refuses_before_touching_the_other_task() {
 test_cross_home_pool_slot_collision_refuses() {
   local dir id=stale-task other=secondmate-task second_home second_project rc
   dir=$(make_case slot-reuse-cross-home)
+  mark_case_as_treehouse_pool "$dir"
   printf 'fixture\n' > "$dir/project/tracked"
   git -C "$dir/project" add tracked
   git -C "$dir/project" -c user.name=test -c user.email=test@example.invalid commit -qm fixture
@@ -498,6 +514,7 @@ test_sole_slot_record_still_tears_down() {
   local dir id=sole-task worker
 
   dir=$(make_case slot-sole)
+  mark_case_as_treehouse_pool "$dir"
   fm_write_meta "$dir/home/state/$id.meta" \
     "window=firstmate:fm-$id" "endpoint_task_id=$id" \
     "worktree=$dir/worktree" "project=$dir/project" "kind=scout"
@@ -525,6 +542,7 @@ test_endpoint_outside_recorded_slot_refuses_before_mutation() {
   local dir id=drifted-task rc
 
   dir=$(make_case slot-endpoint-drift)
+  mark_case_as_treehouse_pool "$dir"
   mkdir -p "$dir/other-worktree"
   # The recorded pane answers from a DIFFERENT copy: the record no longer proves
   # this task owns the slot it names.

--- a/tests/fm-teardown-endpoint-safety.test.sh
+++ b/tests/fm-teardown-endpoint-safety.test.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Regression tests for cleanup endpoint identity validation.
+# Regression tests for cleanup endpoint and worktree-slot identity validation.
 set -u
 
 # shellcheck source=tests/lib.sh
@@ -14,6 +14,7 @@ make_case() {  # <name>
   mkdir -p "$TMP_ROOT/$dir/home/state" "$TMP_ROOT/$dir/home/data" \
     "$TMP_ROOT/$dir/home/config" "$TMP_ROOT/$dir/fakebin" \
     "$TMP_ROOT/$dir/worktree" "$TMP_ROOT/$dir/project"
+  git init -q "$TMP_ROOT/$dir/project"
   : > "$TMP_ROOT/$dir/worktree/sentinel"
   : > "$TMP_ROOT/$dir/runtime.log"
   cat > "$TMP_ROOT/$dir/fakebin/tmux" <<'SH'
@@ -135,6 +136,42 @@ test_control_lock_contention_refuses_before_mutation() {
   kill "$holder" 2>/dev/null || true
   wait "$holder" 2>/dev/null || true
   pass "fm-teardown: a concurrent lifecycle action refuses before mutation"
+}
+
+test_non_pool_teardown_ignores_task_set_lock() {
+  local dir id=non-pool-task lock ready holder i=0
+  dir=$(make_case non-pool-task-set-lock)
+  fm_write_meta "$dir/home/state/$id.meta" \
+    "window=isolated:fm-$id" "endpoint_task_id=$id" \
+    "worktree=$dir/missing-worktree" "project=$dir/project" "kind=scout"
+  lock="$dir/home/state/.task-set.lock"
+  ready="$dir/task-set-lock-ready"
+  (
+    # shellcheck source=/dev/null
+    . "$ROOT/bin/fm-wake-lib.sh"
+    fm_lock_try_acquire "$lock" || exit 1
+    trap 'fm_lock_release "$lock"' EXIT
+    : > "$ready"
+    sleep 30
+  ) &
+  holder=$!
+  while [ ! -e "$ready" ] && [ "$i" -lt 100 ]; do
+    sleep 0.1
+    i=$((i + 1))
+  done
+  [ -e "$ready" ] || {
+    kill "$holder" 2>/dev/null || true
+    wait "$holder" 2>/dev/null || true
+    fail "could not stage an in-progress task publication"
+  }
+
+  run_case "$dir" "$id" > "$dir/stdout" 2> "$dir/stderr" \
+    || fail "non-pool teardown was blocked by an unrelated task publication: $(cat "$dir/stderr")"
+  assert_absent "$dir/home/state/$id.meta" "non-pool teardown left task metadata"
+  assert_present "$lock" "non-pool teardown removed the publisher's lock"
+  kill "$holder" 2>/dev/null || true
+  wait "$holder" 2>/dev/null || true
+  pass "fm-teardown: non-pool cleanup ignores unrelated task publication locks"
 }
 
 test_metadata_lock_serializes_destructive_cleanup() {
@@ -365,10 +402,190 @@ SH
   pass "fm-teardown: exact tmux cleanup preserves invalid and prefix-matched neighbors while removing only the recorded target"
 }
 
+test_reused_pool_slot_refuses_before_touching_the_other_task() {
+  local dir id=stale-task other=live-task worker rc
+
+  dir=$(make_case slot-reuse)
+  # The reuse collision: the pool slot recorded for a finished task has already
+  # been handed to another task, whose worker is live in it right now.
+  fm_write_meta "$dir/home/state/$id.meta" \
+    "window=firstmate:fm-$id" "endpoint_task_id=$id" \
+    "worktree=$dir/worktree" "project=$dir/project" "kind=scout"
+  fm_write_meta "$dir/home/state/$other.meta" \
+    "window=firstmate:fm-$other" "endpoint_task_id=$other" \
+    "worktree=$dir/worktree" "project=$dir/project" "kind=scout"
+  # Staged in this shell, not a command substitution: a background child of a
+  # $(...) subshell does not outlive it, and the point of this worker is to be
+  # alive in the slot while teardown runs.
+  ( cd "$dir/worktree" && exec sleep 30 ) &
+  worker=$!
+
+  set +e
+  run_case "$dir" "$id" > "$dir/stdout" 2> "$dir/stderr"
+  rc=$?
+  set -e
+
+  [ "$rc" -ne 0 ] || fail "teardown returned a pool slot a second task record still holds"
+  kill -0 "$worker" 2>/dev/null || fail "teardown killed the worker holding the reused pool slot"
+  assert_present "$dir/worktree/sentinel" "teardown reset a pool slot a second task record still holds"
+  assert_present "$dir/home/state/$other.meta" "teardown removed the live task's record"
+  assert_present "$dir/home/state/$id.meta" "teardown removed the stale task's record before refusing"
+  [ ! -s "$dir/runtime.log" ] \
+    || fail "teardown reached the runtime on a contested pool slot: $(cat "$dir/runtime.log")"
+  assert_contains "$(cat "$dir/stderr")" "$other" \
+    "refusal should name the other task holding the slot"
+  kill "$worker" 2>/dev/null || true
+  wait "$worker" 2>/dev/null || true
+
+  # The same collision recorded on a secondmate home field rather than a task
+  # worktree is the same slot, and refuses the same way.
+  dir=$(make_case slot-reuse-home)
+  fm_write_meta "$dir/home/state/$id.meta" \
+    "window=firstmate:fm-$id" "endpoint_task_id=$id" \
+    "worktree=$dir/worktree" "project=$dir/project" "kind=scout"
+  fm_write_meta "$dir/home/state/$other.meta" \
+    "window=firstmate:fm-$other" "endpoint_task_id=$other" \
+    "worktree=$dir/worktree" "home=$dir/worktree" \
+    "project=$dir/project" "kind=secondmate"
+  set +e
+  run_case "$dir" "$id" > "$dir/stdout" 2> "$dir/stderr"
+  rc=$?
+  set -e
+  [ "$rc" -ne 0 ] || fail "teardown returned a pool slot a secondmate home record still holds"
+  assert_present "$dir/worktree/sentinel" "teardown reset a pool slot a secondmate home record still holds"
+  assert_present "$dir/home/state/$other.meta" "teardown removed the secondmate record"
+  [ ! -s "$dir/runtime.log" ] \
+    || fail "teardown reached the runtime on a slot held by a secondmate home: $(cat "$dir/runtime.log")"
+
+  pass "fm-teardown: a pool slot named by a second task record is never returned, killed, or reset"
+}
+
+test_cross_home_pool_slot_collision_refuses() {
+  local dir id=stale-task other=secondmate-task second_home rc
+  dir=$(make_case slot-reuse-cross-home)
+  printf 'fixture\n' > "$dir/project/tracked"
+  git -C "$dir/project" add tracked
+  git -C "$dir/project" -c user.name=test -c user.email=test@example.invalid commit -qm fixture
+  second_home="$dir/secondmate-home"
+  git -C "$dir/project" worktree add -q -b secondmate-fixture "$second_home"
+  mkdir -p "$second_home/state"
+  fm_write_meta "$dir/home/state/$id.meta" \
+    "window=firstmate:fm-$id" "endpoint_task_id=$id" \
+    "worktree=$dir/worktree" "project=$dir/project" "kind=scout"
+  fm_write_meta "$second_home/state/$other.meta" \
+    "window=firstmate:fm-$other" "endpoint_task_id=$other" \
+    "worktree=$dir/worktree" "project=$second_home" "kind=scout"
+
+  set +e
+  run_case "$dir" "$id" > "$dir/stdout" 2> "$dir/stderr"
+  rc=$?
+  set -e
+  [ "$rc" -ne 0 ] || fail "teardown returned a pool slot held by another firstmate home"
+  assert_present "$dir/home/state/$id.meta" "cross-home collision removed stale metadata"
+  assert_present "$second_home/state/$other.meta" "cross-home collision removed live metadata"
+  assert_present "$dir/worktree/sentinel" "cross-home collision reset the shared slot"
+  [ ! -s "$dir/runtime.log" ] \
+    || fail "cross-home collision reached the runtime: $(cat "$dir/runtime.log")"
+  assert_contains "$(cat "$dir/stderr")" "$other" \
+    "cross-home refusal should name the task holding the slot"
+  pass "fm-teardown: a pool slot held by another firstmate home is never returned"
+}
+
+test_sole_slot_record_still_tears_down() {
+  local dir id=sole-task worker
+
+  dir=$(make_case slot-sole)
+  fm_write_meta "$dir/home/state/$id.meta" \
+    "window=firstmate:fm-$id" "endpoint_task_id=$id" \
+    "worktree=$dir/worktree" "project=$dir/project" "kind=scout"
+  # A neighbouring task on its OWN slot must not look like a collision.
+  mkdir -p "$dir/other-worktree"
+  fm_write_meta "$dir/home/state/neighbour.meta" \
+    "window=firstmate:fm-neighbour" "endpoint_task_id=neighbour" \
+    "worktree=$dir/other-worktree" "project=$dir/project" "kind=scout"
+  ( cd "$dir/other-worktree" && exec sleep 30 ) &
+  worker=$!
+
+  run_case "$dir" "$id" > "$dir/stdout" 2> "$dir/stderr" \
+    || fail "teardown of a task that solely holds its slot failed: $(cat "$dir/stderr")"
+  assert_absent "$dir/home/state/$id.meta" "uncontested teardown left the task record"
+  assert_present "$dir/home/state/neighbour.meta" "uncontested teardown removed the neighbour's record"
+  kill -0 "$worker" 2>/dev/null || fail "uncontested teardown killed a worker in a different slot"
+  grep -Fq "treehouse <return>" "$dir/runtime.log" \
+    || fail "uncontested teardown did not return its own pool slot: $(cat "$dir/runtime.log")"
+  kill "$worker" 2>/dev/null || true
+  wait "$worker" 2>/dev/null || true
+  pass "fm-teardown: a task that solely holds its slot still returns it"
+}
+
+test_endpoint_outside_recorded_slot_refuses_before_mutation() {
+  local dir id=drifted-task rc
+
+  dir=$(make_case slot-endpoint-drift)
+  mkdir -p "$dir/other-worktree"
+  # The recorded pane answers from a DIFFERENT copy: the record no longer proves
+  # this task owns the slot it names.
+  cat > "$dir/fakebin/tmux" <<SH
+#!/usr/bin/env bash
+if [ "\${1:-}" = display-message ]; then
+  printf '%s\n' '$dir/other-worktree'
+  exit 0
+fi
+printf 'tmux' >> "\${FM_RUNTIME_LOG:?}"
+printf ' <%s>' "\$@" >> "\${FM_RUNTIME_LOG:?}"
+printf '\n' >> "\${FM_RUNTIME_LOG:?}"
+exit 0
+SH
+  chmod +x "$dir/fakebin/tmux"
+  fm_write_meta "$dir/home/state/$id.meta" \
+    "window=firstmate:fm-$id" "endpoint_task_id=$id" \
+    "worktree=$dir/worktree" "project=$dir/project" "kind=scout"
+
+  set +e
+  run_case "$dir" "$id" > "$dir/stdout" 2> "$dir/stderr"
+  rc=$?
+  set -e
+  [ "$rc" -ne 0 ] || fail "teardown returned a slot its own endpoint contradicts"
+  assert_present "$dir/worktree/sentinel" "contradicted teardown reset the recorded slot"
+  assert_present "$dir/home/state/$id.meta" "contradicted teardown removed the task record"
+  [ ! -s "$dir/runtime.log" ] \
+    || fail "contradicted teardown reached a mutating runtime call: $(cat "$dir/runtime.log")"
+
+  # A pane sitting in a subdirectory of its own slot is ordinary drift, not a
+  # contradiction, and must still tear down.
+  dir=$(make_case slot-endpoint-subdir)
+  mkdir -p "$dir/worktree/sub"
+  cat > "$dir/fakebin/tmux" <<SH
+#!/usr/bin/env bash
+if [ "\${1:-}" = display-message ]; then
+  printf '%s\n' '$dir/worktree/sub'
+  exit 0
+fi
+printf 'tmux' >> "\${FM_RUNTIME_LOG:?}"
+printf ' <%s>' "\$@" >> "\${FM_RUNTIME_LOG:?}"
+printf '\n' >> "\${FM_RUNTIME_LOG:?}"
+exit 0
+SH
+  chmod +x "$dir/fakebin/tmux"
+  fm_write_meta "$dir/home/state/$id.meta" \
+    "window=firstmate:fm-$id" "endpoint_task_id=$id" \
+    "worktree=$dir/worktree" "project=$dir/project" "kind=scout"
+  run_case "$dir" "$id" > "$dir/stdout" 2> "$dir/stderr" \
+    || fail "teardown refused an endpoint inside its own slot: $(cat "$dir/stderr")"
+  assert_absent "$dir/home/state/$id.meta" "in-slot endpoint teardown left the task record"
+
+  pass "fm-teardown: an endpoint outside the recorded slot refuses, while in-slot drift still tears down"
+}
+
 test_invalid_endpoint_records_refuse_before_mutation
 test_control_lock_contention_refuses_before_mutation
+test_non_pool_teardown_ignores_task_set_lock
 test_metadata_lock_serializes_destructive_cleanup
 test_supported_backend_endpoint_records_validate
 test_tmux_empty_target_refuses_without_invocation
 test_recorded_process_identity_cleanup_is_exact
 test_isolated_tmux_invalid_and_valid_cleanup
+test_reused_pool_slot_refuses_before_touching_the_other_task
+test_cross_home_pool_slot_collision_refuses
+test_sole_slot_record_still_tears_down
+test_endpoint_outside_recorded_slot_refuses_before_mutation

--- a/tests/fm-teardown-endpoint-safety.test.sh
+++ b/tests/fm-teardown-endpoint-safety.test.sh
@@ -563,18 +563,18 @@ test_sole_slot_record_still_tears_down() {
   pass "fm-teardown: a task that solely holds its slot still returns it"
 }
 
-test_endpoint_outside_recorded_slot_refuses_before_mutation() {
-  local dir id=drifted-task rc
+test_recorded_endpoint_that_changed_directory_still_tears_down() {
+  local dir id=moved-task
 
-  dir=$(make_case slot-endpoint-drift)
+  dir=$(make_case slot-endpoint-moved)
   mark_case_as_treehouse_pool "$dir"
-  mkdir -p "$dir/other-worktree"
-  # The recorded pane answers from a DIFFERENT copy: the record no longer proves
-  # this task owns the slot it names.
+  mkdir -p "$dir/other-directory"
+  # The exact recorded worker may legitimately cd outside its worktree. Its
+  # endpoint identity still owns the lifecycle; cwd alone must not brick it.
   cat > "$dir/fakebin/tmux" <<SH
 #!/usr/bin/env bash
 if [ "\${1:-}" = display-message ]; then
-  printf '%s\n' '$dir/other-worktree'
+  printf '%s\n' '$dir/other-directory'
   exit 0
 fi
 printf 'tmux' >> "\${FM_RUNTIME_LOG:?}"
@@ -587,40 +587,15 @@ SH
     "window=firstmate:fm-$id" "endpoint_task_id=$id" \
     "worktree=$dir/worktree" "project=$dir/project" "kind=scout"
 
-  set +e
-  run_case "$dir" "$id" > "$dir/stdout" 2> "$dir/stderr"
-  rc=$?
-  set -e
-  [ "$rc" -ne 0 ] || fail "teardown returned a slot its own endpoint contradicts"
-  assert_present "$dir/worktree/sentinel" "contradicted teardown reset the recorded slot"
-  assert_present "$dir/home/state/$id.meta" "contradicted teardown removed the task record"
-  [ ! -s "$dir/runtime.log" ] \
-    || fail "contradicted teardown reached a mutating runtime call: $(cat "$dir/runtime.log")"
-
-  # A pane sitting in a subdirectory of its own slot is ordinary drift, not a
-  # contradiction, and must still tear down.
-  dir=$(make_case slot-endpoint-subdir)
-  mkdir -p "$dir/worktree/sub"
-  cat > "$dir/fakebin/tmux" <<SH
-#!/usr/bin/env bash
-if [ "\${1:-}" = display-message ]; then
-  printf '%s\n' '$dir/worktree/sub'
-  exit 0
-fi
-printf 'tmux' >> "\${FM_RUNTIME_LOG:?}"
-printf ' <%s>' "\$@" >> "\${FM_RUNTIME_LOG:?}"
-printf '\n' >> "\${FM_RUNTIME_LOG:?}"
-exit 0
-SH
-  chmod +x "$dir/fakebin/tmux"
-  fm_write_meta "$dir/home/state/$id.meta" \
-    "window=firstmate:fm-$id" "endpoint_task_id=$id" \
-    "worktree=$dir/worktree" "project=$dir/project" "kind=scout"
   run_case "$dir" "$id" > "$dir/stdout" 2> "$dir/stderr" \
-    || fail "teardown refused an endpoint inside its own slot: $(cat "$dir/stderr")"
-  assert_absent "$dir/home/state/$id.meta" "in-slot endpoint teardown left the task record"
+    || fail "teardown refused its recorded endpoint after it changed directory: $(cat "$dir/stderr")"
+  assert_absent "$dir/home/state/$id.meta" "moved-endpoint teardown left the task record"
+  grep -Fq "tmux <kill-window> <-t> <=firstmate:=fm-$id>" "$dir/runtime.log" \
+    || fail "moved-endpoint teardown did not stop the exact recorded worker: $(cat "$dir/runtime.log")"
+  grep -Fq "treehouse <return>" "$dir/runtime.log" \
+    || fail "moved-endpoint teardown did not return its uncontested pool slot: $(cat "$dir/runtime.log")"
 
-  pass "fm-teardown: an endpoint outside the recorded slot refuses, while in-slot drift still tears down"
+  pass "fm-teardown: an exact recorded endpoint still tears down after changing cwd outside its worktree"
 }
 
 test_invalid_endpoint_records_refuse_before_mutation
@@ -635,4 +610,4 @@ test_bare_relative_origin_shares_project_lock_with_clone
 test_reused_pool_slot_refuses_before_touching_the_other_task
 test_cross_home_pool_slot_collision_refuses
 test_sole_slot_record_still_tears_down
-test_endpoint_outside_recorded_slot_refuses_before_mutation
+test_recorded_endpoint_that_changed_directory_still_tears_down

--- a/tests/fm-teardown-endpoint-safety.test.sh
+++ b/tests/fm-teardown-endpoint-safety.test.sh
@@ -420,9 +420,11 @@ test_bare_relative_origin_shares_project_lock_with_clone() {
   dir=$(make_case bare-relative-origin-lock)
   git -C "$dir/project" -c user.name=test -c user.email=test@example.invalid \
     commit --allow-empty -qm lock-fixture
-  git -C "$dir/project" remote add origin project
+  mkdir -p "$dir/project/remotes"
+  git clone -q --bare "$dir/project" "$dir/project/remotes/origin.git"
+  git -C "$dir/project" remote add origin remotes/origin.git
   second_project="$dir/second-project"
-  git clone -q "$dir/project" "$second_project"
+  git clone -q "$dir/project/remotes/origin.git" "$second_project"
 
   primary_lock=$(FM_HOME="$dir/home" bash -c \
     '. "$1"; fm_treehouse_project_lock_path "$2"' _ \
@@ -435,7 +437,7 @@ test_bare_relative_origin_shares_project_lock_with_clone() {
   [ "$primary_lock" = "$clone_lock" ] \
     || fail "bare and absolute forms of the same local origin resolved different project locks"
 
-  pass "Treehouse locking gives a bare local origin and its absolute clone one project identity"
+  pass "Treehouse locking resolves a bare local origin against its source project, matching the provisioned clone"
 }
 
 test_reused_pool_slot_refuses_before_touching_the_other_task() {

--- a/tests/fm-teardown-endpoint-safety.test.sh
+++ b/tests/fm-teardown-endpoint-safety.test.sh
@@ -461,20 +461,23 @@ test_reused_pool_slot_refuses_before_touching_the_other_task() {
 }
 
 test_cross_home_pool_slot_collision_refuses() {
-  local dir id=stale-task other=secondmate-task second_home rc
+  local dir id=stale-task other=secondmate-task second_home second_project rc
   dir=$(make_case slot-reuse-cross-home)
   printf 'fixture\n' > "$dir/project/tracked"
   git -C "$dir/project" add tracked
   git -C "$dir/project" -c user.name=test -c user.email=test@example.invalid commit -qm fixture
   second_home="$dir/secondmate-home"
-  git -C "$dir/project" worktree add -q -b secondmate-fixture "$second_home"
-  mkdir -p "$second_home/state"
+  second_project="$second_home/projects/project"
+  mkdir -p "$second_home/projects" "$second_home/state" "$second_home/data"
+  git clone -q "$dir/project" "$second_project"
+  printf '%s\n' "- mate - fixture (home: $second_home; scope: test; projects: project; added 2026-01-01)" \
+    > "$dir/home/data/secondmates.md"
   fm_write_meta "$dir/home/state/$id.meta" \
     "window=firstmate:fm-$id" "endpoint_task_id=$id" \
     "worktree=$dir/worktree" "project=$dir/project" "kind=scout"
   fm_write_meta "$second_home/state/$other.meta" \
     "window=firstmate:fm-$other" "endpoint_task_id=$other" \
-    "worktree=$dir/worktree" "project=$second_home" "kind=scout"
+    "worktree=$dir/worktree" "project=$second_project" "kind=scout"
 
   set +e
   run_case "$dir" "$id" > "$dir/stdout" 2> "$dir/stderr"

--- a/tests/fm-watch-arm.test.sh
+++ b/tests/fm-watch-arm.test.sh
@@ -288,16 +288,10 @@ test_rearm_resurfaces_durable_queue_and_remote_open_decision() {
   append_wake "$state" check startup-network 'check: startup-network'
 
   start_rearm_arm "$home" "$state" "$fakebin" "$armout"
-  sleep 0.25
-  if is_live_non_zombie "$ARM_PID"; then
-    # End the fixture through an ordinary actionable status transition so this
-    # failing pre-fix path leaves no child behind.
-    printf 'done: fixture cleanup\n' > "$state/cleanup.status"
-    wait_for_exit "$ARM_PID" 80 || true
-    fail "re-arm stayed live instead of surfacing durable wakes and the still-open remote decision"
-  fi
-  wait "$ARM_PID"
+  wait_for_exit "$ARM_PID" 80
   status=$?
+  [ "$status" -ne 124 ] \
+    || fail "re-arm stayed live instead of surfacing durable wakes and the still-open remote decision"
   expect_code 0 "$status" "re-arm re-surface wake must close successfully"
   grep -F 'check: rearm-resurface' "$armout" >/dev/null \
     || fail "re-arm did not report the durable recovery wake: $(cat "$armout")"


### PR DESCRIPTION
## Intent

The captain's order in substance: workers were killed by a pool-slot collision during cleanup - never let that happen again. Make worktree-slot return verify the slot is genuinely the task's before releasing it.

## What Changed
- Refuse Treehouse slot cleanup when another local task record claims the slot or a supported live endpoint reports a different working copy, including forced secondmate descendant teardown.
- Serialize Treehouse slot allocation, metadata publication, ownership verification, and return with a shared project-identity lock.
- Give checkpoint watcher subprocesses a configurable termination grace period before forcing them to exit.

## Risk Assessment

✅ Low: The change now scans registered local Firstmate homes and serializes slot allocation, publication, verification, and return using a shared project identity lock, closing the previously identified collision path without introducing a substantiated material defect.

## Testing

The successful changed-test baseline was supplemented with focused teardown, secondmate, and watcher lifecycle tests plus an end-to-end cross-home collision fixture; teardown refused even with `--force` while preserving the live worker, slot contents, and both task records, with no regressions observed.

<details>
<summary>Evidence: Cross-home Treehouse slot-collision teardown transcript</summary>

Source: [Cross-home Treehouse slot-collision teardown transcript](https://github.com/kunchenguid/firstmate/blob/d4fd90ef9e9eda8f7b1b52c0964cc9bb44217578/.no-mistakes/evidence/fm/fm-teardown-slot-collision-fix-r2/cross-home-slot-collision-transcript.txt)

```text
$ bin/fm-teardown.sh stale-task --force
exit_code=1
--- stderr ---
●━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
●  WATCHER DOWN - SUPERVISION IS OFF
●  1 task(s) in flight, but no watcher has a fresh beacon (last beat: never, grace 300s).
●  Trust the emitted supervision protocol for this harness; do not use shell & for watcher repair.
●  This is a supervision warning only; the guarded operation WILL still run.
●  repair a missing or failed watcher cycle with the Pi tool fm_watch_arm_pi, or restart Pi with -e ~/.no-mistakes/worktrees/016d88035d58/01M1TJBY608T137DYWBW3YGY44/.pi/extensions/fm-primary-turnend-guard.ts -e ~/.no-mistakes/worktrees/016d88035d58/01M1TJBY608T137DYWBW3YGY44/.pi/extensions/fm-primary-pi-watch.ts if the extensions are not loaded.
●━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
REFUSED: task stale-task's recorded worktree ~/.no-mistakes/worktrees/016d88035d58/01M1TJBY608T137DYWBW3YGY44/.slot-collision-e2e.6IymFN/pool/1/project is also task live-task's recorded worktree.
Returning that pool slot would kill live-task's processes and reset its copy, so nothing was changed - not even with --force.
Reconcile whichever record is wrong (bin/fm-crew-state.sh stale-task; bin/fm-crew-state.sh live-task), then re-run teardown.
--- postconditions ---
live_worker=alive
slot_payload=worker-data-must-survive
stale_record=preserved
cross_home_live_record=preserved
mutating_runtime_calls=none
```
</details>
- Outcome: 🔧 1 issue found → auto-fixed (4) ✅ across 5 runs (3h45m2s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"6f8d99b468c1a88ef19ad0cfaca4b2eabff9623d","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed ✅</summary>

- 🚨 `bin/fm-teardown.sh:2065` - Cross-home ownership verification enumerates the recorded project’s Git worktrees, not Firstmate homes. Real secondmate homes contain separately cloned projects (`fm-home-seed.sh` uses `git clone`), so their `state/*.meta` files are absent from this listing; the project-common-directory locks are likewise different across clones. Concrete sequence: a stale primary record names slot S, Treehouse reuses S for a task in a secondmate clone, and that live task publishes in the secondmate home. Teardown of the stale record scans only the primary state/project worktrees, a dead endpoint supplies no contradictory cwd, and S is still returned, killing the live worker. The new cross-home test does not reproduce the production layout because it places the second home directly in the project’s worktree list. Enumerate actual registered/local Firstmate homes and serialize allocation/publication/return at an identity shared across their project clones.

🔧 Fix: Protect slots across cloned Firstmate homes
✅ Re-checked - no issues remain.
</details>

<details>
<summary>🔧 **Test** - 1 issue found → auto-fixed (4) ✅</summary>

- 🚨 tests failed with exit code 1
- `bin/fm-test-run.sh --changed --exclude-family real-herdr-gated`

🔧 Fix: Gate teardown locking on genuine Treehouse slots
1 error still open:

- 🚨 tests failed with exit code 1
- `bin/fm-test-run.sh --changed --exclude-family real-herdr-gated`

🔧 Fix: Clarify pooled descendant slot gating
1 error still open:

- 🚨 tests failed with exit code 1
- `bin/fm-test-run.sh --changed --exclude-family real-herdr-gated`

🔧 Fix: Synchronize watcher re-arm test on process exit
1 error still open:

- 🚨 tests failed with exit code 1
- `bin/fm-test-run.sh --changed --exclude-family real-herdr-gated`

🔧 Fix: Wait for watcher cleanup before timeout escalation
✅ Re-checked - no issues remain.
- `bin/fm-test-run.sh --changed --exclude-family real-herdr-gated`
- <code>Baseline: `bin/fm-test-run.sh --changed --exclude-family real-herdr-gated`</code>
- `tests/fm-teardown-endpoint-safety.test.sh`
- `tests/fm-secondmate-safety.test.sh`
- `tests/fm-watch-checkpoint.test.sh`
- `tests/fm-watch-arm.test.sh`
- <code>Manual cross-home pool-slot collision: ran `bin/fm-teardown.sh stale-task --force` against a stale primary record and a live secondmate-clone record sharing one Treehouse slot; verified refusal, live worker survival, payload and metadata preservation, and zero mutating runtime calls</code>
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
