### PR TITLE
feat(skills): add public scroll-story scrollytelling skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,8 +194,10 @@ Firstmate's skills live in two separate places with different audiences:
 - `.agents/skills/` - agent-loaded skills (this section's table, plus firstmate's agent-only reference skills). Every one of these assumes a live firstmate home and is meaningless, or actively misleading, installed anywhere else, so each carries `metadata.internal: true` in its frontmatter. That flag hides them from installer discovery (tools like the [skills.sh](https://skills.sh) `npx skills add` installer) without affecting how firstmate itself loads them - frontmatter metadata is inert to the agent's own skill loader.
 - `skills/` - public, installer-facing skills meant to be installed standalone into any project, independent of firstmate.
   Each one is a self-contained skill with no dependency on firstmate's paths, tools, or vocabulary.
-  Today that is `skills/stow`, a generic session-knowledge-sweep skill that routes findings by explicit instruction first, then existing local conventions, then a private `.stow-notes.md` fallback, and curates tiered entries through decay, local archival, and user-approved on-demand offload proposals.
+  Today those are `skills/stow` and `skills/scroll-story`.
+  `skills/stow` is a generic session-knowledge-sweep skill that routes findings by explicit instruction first, then existing local conventions, then a private `.stow-notes.md` fallback, and curates tiered entries through decay, local archival, and user-approved on-demand offload proposals.
   It intentionally shares no code with the firstmate-internal `.agents/skills/stow` it is named after, so the two can evolve independently.
+  `skills/scroll-story` builds a self-contained scroll-driven explainer page for a technical change, pinning a diagram, code panel, or schema stage beside a scrolling column of narrative steps, and ships a runnable `template.html` to copy and adapt.
 
 ## Documentation
 

--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -1366,6 +1366,9 @@ families_for_changed_path() {
     .agents/skills/*/SKILL.md)
       printf '%s\n' pure-contract-unit
       ;;
+    skills/*)
+      printf '%s\n' pure-contract-unit
+      ;;
     .github/workflows/ci.yml|.no-mistakes.yaml)
       printf '%s\n' pure-contract-unit
       printf '%s\n' real-herdr-gated

--- a/docs/documentation-audiences.json
+++ b/docs/documentation-audiences.json
@@ -485,6 +485,10 @@
       "audience": "operator-current"
     },
     {
+      "path": "skills/scroll-story/SKILL.md",
+      "audience": "public-product"
+    },
+    {
       "path": "skills/stow/SKILL.md",
       "audience": "public-product"
     }

--- a/skills/scroll-story/SKILL.md
+++ b/skills/scroll-story/SKILL.md
@@ -1,0 +1,368 @@
+---
+name: scroll-story
+description: Create self-contained scroll-driven technical explainers with a pinned diagram, code panel, or schema beside narrative steps. Use for visual code reviews, PR walkthroughs, architecture or data-flow narratives, and requests for scrollytelling, sticky-scroll, pinned-diagram, or scroll-driven explainer pages.
+user-invocable: true
+---
+
+<!-- maintainers: this is a public, installer-facing skill. Keep it standalone, with no private project paths, environment branching, or assumptions about fleet-only tools. -->
+
+# scroll-story
+
+Turn a technical change into one self-contained HTML page where the narrative scrolls and a bounded stage stays pinned while its focus changes.
+Start by copying [`template.html`](template.html), then replace its example story, stage artwork, state map, and colors with evidence from the user's diff or system.
+
+## Build the story first
+
+Inspect the change, trace the real call and data paths, and choose only the beats needed to explain it.
+Use this sequence as a starting template, not a fixed six-step form:
+
+1. Show the trigger or entry point, such as the call site, route, or endpoint.
+2. Trace the call flow or stack, such as controller to service to repository.
+3. Reveal the new code in a code panel, with added lines highlighted like a diff.
+4. Show systems talking to each other by drawing each service-to-service edge when its beat is reached.
+5. Move into the data layer and light the affected tables and specific changed columns.
+6. End on the result and side effects, including emitted events, invalidated caches, and downstream consumers.
+
+Split or omit beats to match the actual change.
+Make every claim traceable to the supplied code, diff, schema, or architecture.
+
+Apply two hard design rules throughout:
+
+- Put one idea in each scroll step.
+- Change exactly one thing on the stage per step so the reader always knows what moved.
+
+A single focal path or schema delta may involve several related SVG elements, but it must read as one semantic change rather than several simultaneous revelations.
+
+## Use the bounded sticky layout
+
+Put the sticky stage and scrolling steps in the same `.scrolly` container.
+The container's height is established by the steps column, so it bounds the sticky element and releases it when the story ends.
+Use two columns on wide screens, vertically center the stage with `top: 50vh` plus a transform, and give the steps generous vertical spacing.
+
+```css
+:root {
+  --stage-height: min(68vh, 42rem);
+}
+
+.scrolly {
+  display: grid;
+  grid-template-columns: minmax(0, 1.25fr) minmax(18rem, 0.75fr);
+  gap: clamp(2rem, 6vw, 6rem);
+  align-items: stretch;
+  position: relative;
+}
+
+.stage-column {
+  min-width: 0;
+  align-self: stretch;
+}
+
+.stage {
+  position: sticky;
+  top: 50vh;
+  transform: translateY(-50%);
+  height: var(--stage-height);
+  overflow: hidden;
+}
+
+.steps {
+  min-width: 0;
+  display: grid;
+  gap: 38vh;
+  padding-block: 34vh 54vh;
+}
+
+.step {
+  min-height: 32vh;
+}
+
+@media (max-width: 50rem) {
+  .scrolly {
+    display: block;
+  }
+
+  .stage {
+    position: relative;
+    top: auto;
+    transform: none;
+    height: min(70vh, 32rem);
+  }
+
+  .steps {
+    gap: 1rem;
+    padding-block: 2rem;
+  }
+
+  .step {
+    min-height: auto;
+  }
+}
+```
+
+Do not place `overflow: hidden`, `auto`, or `scroll` on an ancestor of the sticky stage unless that ancestor is intentionally the scroll container.
+Reserve enough top and bottom padding in `.steps` for the first and last beats to cross the reading line while the stage is still visible.
+
+## Build stage types
+
+Choose the stage type that gives each beat a concrete visual target.
+Keep stable geometry within a stage so attention moves without the page jumping.
+
+### Inline SVG architecture diagram
+
+Draw architecture artwork as inline SVG so CSS and JavaScript can address it directly.
+Give every focusable node and edge a stable id, add `data-focusable` to nodes, and set `pathLength="1"` on animated edges.
+
+```html
+<svg viewBox="0 0 800 500" role="img" aria-labelledby="diagram-title diagram-desc">
+  <title id="diagram-title">Request processing architecture</title>
+  <desc id="diagram-desc">The endpoint calls the service, which writes the database and publishes an event.</desc>
+  <path id="edge-service-db" class="edge" pathLength="1" d="M 390 220 C 470 220 500 320 590 320" />
+  <g id="service" data-focusable class="node">...</g>
+</svg>
+```
+
+```css
+.node {
+  opacity: 0.22;
+  transition: opacity 280ms ease, filter 280ms ease;
+}
+
+.node.is-active {
+  opacity: 1;
+  filter: drop-shadow(0 0 10px var(--accent));
+}
+
+.edge {
+  fill: none;
+  stroke: var(--accent);
+  stroke-dasharray: 1;
+  stroke-dashoffset: 1;
+  opacity: 0.16;
+  transition: stroke-dashoffset 650ms ease, opacity 220ms ease;
+}
+
+.edge.is-drawn {
+  stroke-dashoffset: 0;
+  opacity: 1;
+}
+```
+
+Focus a node by adding `.is-active`, dim the remaining nodes with their base opacity, and draw only the edge named by the active state.
+Use SVG markers for arrowheads and keep labels inside the SVG so they stay aligned while scaling.
+
+### Code and diff panels
+
+Render code as a `<pre><code>` block containing one span per line.
+Give each line a stable `data-line` value, mark additions with `.added`, and let the active state name a line or inclusive range.
+
+```html
+<pre class="code-panel"><code>
+<span class="code-line" data-line="1">async function createOrder(input) {</span>
+<span class="code-line added" data-line="2">  const event = await outbox.insert(input);</span>
+<span class="code-line" data-line="3">}</span>
+</code></pre>
+```
+
+```css
+.code-line {
+  display: block;
+  border-left: 3px solid transparent;
+  opacity: 0.42;
+}
+
+.code-line.added::before {
+  content: "+";
+  color: var(--success);
+  margin-right: 0.75rem;
+}
+
+.code-line.is-active {
+  opacity: 1;
+  border-left-color: var(--accent);
+  background: var(--code-highlight);
+}
+
+.code-line.added.is-active {
+  box-shadow: inset 0 0 1.5rem var(--added-glow);
+}
+```
+
+Keep line numbers and the diff marker outside the copied code text when practical.
+Highlight only the line range discussed by the current step.
+
+### Table and schema stages
+
+Model each table as a card with a stable id and each row as a stable `data-column` target.
+Dim unaffected tables, light the affected table, and apply a stronger treatment only to the columns the prose names.
+
+```html
+<section id="orders" class="schema-table" aria-label="orders table">
+  <h3>orders</h3>
+  <div class="schema-column" data-column="orders.status"><code>status</code><span>text</span></div>
+</section>
+```
+
+```css
+.schema-table {
+  opacity: 0.28;
+  transition: opacity 280ms ease, border-color 280ms ease;
+}
+
+.schema-table.is-active {
+  opacity: 1;
+  border-color: var(--accent);
+}
+
+.schema-column.is-active {
+  color: var(--text);
+  background: var(--schema-highlight);
+}
+```
+
+Keep keys, types, and relationships visible in neutral form so the highlighted delta still has context.
+
+### Swap stage types without jumping
+
+Use one fixed-height stage and absolutely position every stage layer in the same inset box.
+Cross-fade opacity and visibility instead of inserting, removing, or resizing content.
+
+```css
+.stage-body {
+  position: relative;
+  height: 100%;
+}
+
+.stage-layer {
+  position: absolute;
+  inset: 0;
+  min-width: 0;
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
+  transition: opacity 240ms ease, visibility 0s linear 240ms;
+}
+
+.stage-layer.is-active {
+  opacity: 1;
+  visibility: visible;
+  pointer-events: auto;
+  transition-delay: 0s;
+}
+```
+
+## Activate steps declaratively
+
+Give every step a unique `data-step` id.
+Define one state object per id, observe the steps at a reading line near the middle of the viewport, and pass the selected id to one render function.
+
+```js
+const steps = [...document.querySelectorAll("[data-step]")];
+const states = {
+  entry: { layer: "architecture", nodes: ["endpoint"] },
+  code: { layer: "code", lines: [2, 3] },
+  data: { layer: "schema", tables: ["orders"], columns: ["orders.status"] }
+};
+
+function render(stepId) {
+  const state = states[stepId];
+  if (!state) return;
+
+  document.documentElement.dataset.activeStep = stepId;
+  steps.forEach((step) => step.classList.toggle("is-active", step.dataset.step === stepId));
+  document.querySelectorAll("[data-layer]").forEach((layer) => {
+    layer.classList.toggle("is-active", layer.dataset.layer === state.layer);
+  });
+
+  // Reset every focus class, then apply only state.nodes, state.edges,
+  // state.lines, state.tables, and state.columns here.
+}
+
+const observer = new IntersectionObserver((entries) => {
+  const crossing = entries
+    .filter((entry) => entry.isIntersecting)
+    .sort((a, b) => Math.abs(a.boundingClientRect.top - innerHeight * 0.5)
+      - Math.abs(b.boundingClientRect.top - innerHeight * 0.5));
+
+  if (crossing[0]) render(crossing[0].target.dataset.step);
+}, { rootMargin: "-46% 0px -46% 0px", threshold: 0 });
+
+steps.forEach((step) => observer.observe(step));
+render(steps[0].dataset.step);
+```
+
+Keep `states` as the declarative source of truth and make `render` idempotent so fast scrolling and reverse scrolling always reconstruct the complete stage state.
+Do not use a scroll listener that repeatedly calls `getBoundingClientRect()` across all steps.
+Do not scatter ad hoc DOM mutations through per-step callbacks.
+
+## Meet responsive and accessibility requirements
+
+Treat these as release requirements:
+
+- Collapse the sticky two-column layout on narrow screens into a stage-above-story or another non-sticky stacked flow.
+- Make every step complete, understandable prose when the stage is absent.
+- Mark a redundant visual stage `aria-hidden="true"`, or give an informative stage a concise accessible name and description.
+- Never put a fact only in a color, glow, arrow, animation, or highlighted line.
+- Preserve visible keyboard focus for any interactive controls.
+- Honor reduced motion by removing transitions and showing every shape in its final geometric position.
+
+```css
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after {
+    scroll-behavior: auto !important;
+    transition-duration: 0.01ms !important;
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+  }
+
+  .edge {
+    stroke-dashoffset: 0;
+  }
+}
+```
+
+## Keep the output self-contained
+
+Deliver one HTML file with inline CSS, inline JavaScript, inline SVG, and no CDN or external dependency.
+Define theme-aware colors as custom properties on `:root` and override them with `prefers-color-scheme: dark`.
+
+```css
+:root {
+  color-scheme: light dark;
+  --page: #f4f1e8;
+  --panel: #ffffff;
+  --text: #18201f;
+  --muted: #5c6966;
+  --accent: #176b87;
+  --success: #18794e;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --page: #0d1415;
+    --panel: #152022;
+    --text: #eef5f3;
+    --muted: #a6b6b2;
+    --accent: #68d7ff;
+    --success: #71e0a5;
+  }
+}
+```
+
+The result must work when opened directly as a plain file and when hosted as a published artifact.
+
+## Ship checklist
+
+Before handing over the page, verify every item in a real browser:
+
+- [ ] Every step maps to exactly one stage state, and every stage state has one step.
+- [ ] Every scroll step contains one idea.
+- [ ] The stage changes exactly one thing per step.
+- [ ] The first and last steps have enough scroll room to activate.
+- [ ] The stage remains pinned inside the story and releases at the story's end.
+- [ ] Fast forward scrolling and reverse scrolling reconstruct the correct state.
+- [ ] The layout collapses into a non-sticky flow at phone width.
+- [ ] Reduced motion removes transitions and leaves arrows and shapes in their final geometric positions.
+- [ ] Every step remains understandable without the stage, and the stage has correct accessible treatment.
+- [ ] The page has no horizontal scroll at desktop or phone width.
+- [ ] The browser console has no errors.
+- [ ] The file has no external requests or dependencies.

--- a/skills/scroll-story/SKILL.md
+++ b/skills/scroll-story/SKILL.md
@@ -37,7 +37,7 @@ A single focal path or schema delta may involve several related SVG elements, bu
 
 Put the sticky stage and scrolling steps in the same `.scrolly` container.
 The container's height is established by the steps column, so it bounds the sticky element and releases it when the story ends.
-Use two columns on wide screens, vertically center the stage with `top: 50vh` plus a transform, and give the steps generous vertical spacing.
+Use two columns on wide screens, vertically center the stage with a computed sticky offset of `top: calc(50vh - var(--stage-height) / 2)`, and give the steps generous vertical spacing.
 
 ```css
 :root {
@@ -59,8 +59,7 @@ Use two columns on wide screens, vertically center the stage with `top: 50vh` pl
 
 .stage {
   position: sticky;
-  top: 50vh;
-  transform: translateY(-50%);
+  top: calc(50vh - var(--stage-height) / 2);
   height: var(--stage-height);
   overflow: hidden;
 }
@@ -99,6 +98,9 @@ Use two columns on wide screens, vertically center the stage with `top: 50vh` pl
 }
 ```
 
+The computed `top` keeps the stage's painted box identical to its layout box, so the stage stays vertically centered once pinned yet can never paint above its own flow position at first paint.
+Do not center the stage with a `translateY(-50%)` transform instead - before the sticky threshold engages, the transform lifts the stage half its height over whatever content precedes the container.
+If a centering transform is unavoidable, reserve at least half of `--stage-height` in clearance above the stage's flow position.
 Do not place `overflow: hidden`, `auto`, or `scroll` on an ancestor of the sticky stage unless that ancestor is intentionally the scroll container.
 Reserve enough top and bottom padding in `.steps` for the first and last beats to cross the reading line while the stage is still visible.
 
@@ -358,6 +360,7 @@ Before handing over the page, verify every item in a real browser:
 - [ ] Every scroll step contains one idea.
 - [ ] The stage changes exactly one thing per step.
 - [ ] The first and last steps have enough scroll room to activate.
+- [ ] At first paint, before any scrolling, the stage does not overlap the content above the story.
 - [ ] The stage remains pinned inside the story and releases at the story's end.
 - [ ] Fast forward scrolling and reverse scrolling reconstruct the correct state.
 - [ ] The layout collapses into a non-sticky flow at phone width.

--- a/skills/scroll-story/template.html
+++ b/skills/scroll-story/template.html
@@ -1,0 +1,825 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="color-scheme" content="light dark">
+  <title>One request, one durable event</title>
+  <style>
+    :root {
+      color-scheme: light;
+      --page: #f3f0e8;
+      --page-grid: rgba(20, 47, 43, 0.055);
+      --panel: #fffdf7;
+      --panel-raised: #ffffff;
+      --text: #142a27;
+      --muted: #5f716d;
+      --faint: #d7ddd8;
+      --line: #c8d1cc;
+      --accent: #0c7489;
+      --accent-soft: rgba(12, 116, 137, 0.14);
+      --accent-glow: rgba(12, 116, 137, 0.28);
+      --success: #18794e;
+      --added: rgba(24, 121, 78, 0.13);
+      --added-glow: rgba(43, 177, 111, 0.22);
+      --warm: #d87731;
+      --schema-highlight: rgba(216, 119, 49, 0.13);
+      --shadow: 0 24px 70px rgba(31, 47, 44, 0.14);
+      --stage-height: min(68vh, 42rem);
+      --radius: 1.4rem;
+    }
+
+    @media (prefers-color-scheme: dark) {
+      :root {
+        color-scheme: dark;
+        --page: #0b1515;
+        --page-grid: rgba(198, 232, 225, 0.045);
+        --panel: #101f1f;
+        --panel-raised: #152827;
+        --text: #edf6f3;
+        --muted: #a1b7b1;
+        --faint: #2c403d;
+        --line: #38504c;
+        --accent: #67d5ee;
+        --accent-soft: rgba(103, 213, 238, 0.14);
+        --accent-glow: rgba(103, 213, 238, 0.28);
+        --success: #71e0a5;
+        --added: rgba(55, 184, 118, 0.14);
+        --added-glow: rgba(113, 224, 165, 0.2);
+        --warm: #f1a568;
+        --schema-highlight: rgba(241, 165, 104, 0.14);
+        --shadow: 0 26px 80px rgba(0, 0, 0, 0.38);
+      }
+    }
+
+    * {
+      box-sizing: border-box;
+    }
+
+    html {
+      scroll-behavior: smooth;
+    }
+
+    body {
+      margin: 0;
+      overflow-x: hidden;
+      color: var(--text);
+      background-color: var(--page);
+      background-image:
+        linear-gradient(var(--page-grid) 1px, transparent 1px),
+        linear-gradient(90deg, var(--page-grid) 1px, transparent 1px);
+      background-size: 32px 32px;
+      font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      line-height: 1.55;
+    }
+
+    .hero,
+    .outro {
+      width: min(76rem, calc(100% - 2rem));
+      margin-inline: auto;
+    }
+
+    .hero {
+      min-height: 72vh;
+      display: grid;
+      align-content: end;
+      padding-block: 10vh 12vh;
+    }
+
+    .kicker {
+      margin: 0 0 1rem;
+      color: var(--accent);
+      font: 700 0.76rem/1.2 ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+      letter-spacing: 0.14em;
+      text-transform: uppercase;
+    }
+
+    h1,
+    h2,
+    p {
+      margin-top: 0;
+    }
+
+    h1 {
+      max-width: 12ch;
+      margin-bottom: 1.5rem;
+      font-size: clamp(3rem, 8vw, 7.6rem);
+      font-weight: 650;
+      line-height: 0.94;
+      letter-spacing: -0.065em;
+    }
+
+    .dek {
+      max-width: 44rem;
+      margin-bottom: 0;
+      color: var(--muted);
+      font-size: clamp(1.08rem, 2vw, 1.38rem);
+    }
+
+    .scrolly {
+      position: relative;
+      width: min(88rem, calc(100% - 2rem));
+      margin-inline: auto;
+      display: grid;
+      grid-template-columns: minmax(0, 1.25fr) minmax(18rem, 0.75fr);
+      gap: clamp(2rem, 6vw, 6rem);
+      align-items: stretch;
+    }
+
+    .stage-column {
+      min-width: 0;
+      align-self: stretch;
+    }
+
+    .stage {
+      position: sticky;
+      top: 50vh;
+      transform: translateY(-50%);
+      height: var(--stage-height);
+      min-width: 0;
+      overflow: hidden;
+      border: 1px solid var(--line);
+      border-radius: var(--radius);
+      background: var(--panel);
+      box-shadow: var(--shadow);
+    }
+
+    .stage-header {
+      position: absolute;
+      z-index: 5;
+      inset: 0 0 auto;
+      height: 4.3rem;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 1rem;
+      padding: 0 1.25rem;
+      border-bottom: 1px solid var(--line);
+      background: color-mix(in srgb, var(--panel) 93%, transparent);
+    }
+
+    .stage-header strong {
+      font-size: 0.9rem;
+      letter-spacing: -0.01em;
+    }
+
+    .stage-header span {
+      color: var(--muted);
+      font: 650 0.68rem/1.2 ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+      letter-spacing: 0.1em;
+      text-transform: uppercase;
+    }
+
+    .stage-body {
+      position: relative;
+      height: 100%;
+      min-width: 0;
+      padding-top: 4.3rem;
+    }
+
+    .stage-layer {
+      position: absolute;
+      inset: 4.3rem 0 0;
+      min-width: 0;
+      overflow: hidden;
+      opacity: 0;
+      visibility: hidden;
+      pointer-events: none;
+      transition: opacity 240ms ease, visibility 0s linear 240ms;
+    }
+
+    .stage-layer.is-active {
+      opacity: 1;
+      visibility: visible;
+      pointer-events: auto;
+      transition-delay: 0s;
+    }
+
+    .architecture {
+      width: 100%;
+      height: 100%;
+      display: block;
+    }
+
+    .architecture .node {
+      opacity: 0.2;
+      transition: opacity 280ms ease, filter 280ms ease;
+    }
+
+    .architecture .node rect {
+      fill: var(--panel-raised);
+      stroke: var(--line);
+      stroke-width: 2;
+    }
+
+    .architecture .node text {
+      fill: var(--text);
+      font-family: Inter, ui-sans-serif, system-ui, sans-serif;
+    }
+
+    .architecture .node .node-label {
+      font-size: 18px;
+      font-weight: 700;
+    }
+
+    .architecture .node .node-kind {
+      fill: var(--muted);
+      font-size: 12px;
+      font-weight: 650;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+    }
+
+    .architecture .node.is-active {
+      opacity: 1;
+      filter: drop-shadow(0 0 11px var(--accent-glow));
+    }
+
+    .architecture .node.is-active rect {
+      stroke: var(--accent);
+    }
+
+    .architecture .edge {
+      fill: none;
+      stroke: var(--accent);
+      stroke-width: 3;
+      stroke-linecap: round;
+      stroke-dasharray: 1;
+      stroke-dashoffset: 1;
+      opacity: 0.13;
+      marker-end: url(#arrowhead);
+      transition: stroke-dashoffset 650ms ease, opacity 220ms ease;
+    }
+
+    .architecture .edge.is-drawn {
+      stroke-dashoffset: 0;
+      opacity: 1;
+    }
+
+    .code-wrap {
+      height: 100%;
+      display: grid;
+      align-content: center;
+      padding: clamp(1rem, 3vw, 2rem);
+      background:
+        radial-gradient(circle at 12% 12%, var(--accent-soft), transparent 34%),
+        var(--panel);
+    }
+
+    .file-label {
+      display: flex;
+      align-items: center;
+      gap: 0.55rem;
+      margin: 0 0 0.8rem;
+      color: var(--muted);
+      font: 650 0.72rem/1.2 ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+    }
+
+    .file-label::before {
+      content: "";
+      width: 0.62rem;
+      height: 0.62rem;
+      border-radius: 50%;
+      background: var(--success);
+      box-shadow: 0 0 0 0.3rem var(--added);
+    }
+
+    .code-panel {
+      width: 100%;
+      margin: 0;
+      overflow: auto;
+      border: 1px solid var(--line);
+      border-radius: 1rem;
+      background: color-mix(in srgb, var(--panel-raised) 92%, var(--accent) 8%);
+      color: var(--text);
+      font: 500 clamp(0.68rem, 1.22vw, 0.9rem)/1.72 ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+      counter-reset: line;
+    }
+
+    .code-line {
+      display: block;
+      min-width: max-content;
+      padding: 0.08rem 1rem 0.08rem 0;
+      border-left: 3px solid transparent;
+      opacity: 0.38;
+      counter-increment: line;
+      transition: opacity 220ms ease, background 220ms ease, box-shadow 220ms ease;
+    }
+
+    .code-line::before {
+      content: counter(line);
+      display: inline-block;
+      width: 2.65rem;
+      margin-right: 0.75rem;
+      color: var(--muted);
+      text-align: right;
+    }
+
+    .code-line.added {
+      background: color-mix(in srgb, var(--added) 55%, transparent);
+    }
+
+    .code-line.added::before {
+      content: "+ " counter(line);
+      color: var(--success);
+    }
+
+    .code-line.is-active {
+      opacity: 1;
+      border-left-color: var(--accent);
+      background: var(--accent-soft);
+    }
+
+    .code-line.added.is-active {
+      background: var(--added);
+      box-shadow: inset 0 0 1.5rem var(--added-glow);
+    }
+
+    .schema-wrap {
+      height: 100%;
+      display: grid;
+      align-content: center;
+      gap: 1rem;
+      padding: clamp(1rem, 3vw, 2rem);
+      background:
+        radial-gradient(circle at 88% 18%, var(--schema-highlight), transparent 38%),
+        var(--panel);
+    }
+
+    .schema-grid {
+      display: grid;
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+      gap: 1rem;
+    }
+
+    .schema-table {
+      min-width: 0;
+      overflow: hidden;
+      border: 1px solid var(--line);
+      border-radius: 1rem;
+      background: var(--panel-raised);
+      opacity: 0.28;
+      transition: opacity 280ms ease, border-color 280ms ease, box-shadow 280ms ease;
+    }
+
+    .schema-table.is-active {
+      border-color: var(--warm);
+      opacity: 1;
+      box-shadow: 0 0 0 1px var(--warm), 0 16px 34px var(--schema-highlight);
+    }
+
+    .schema-table h3 {
+      margin: 0;
+      padding: 0.85rem 1rem;
+      border-bottom: 1px solid var(--line);
+      font: 700 0.84rem/1.2 ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+    }
+
+    .schema-column {
+      display: grid;
+      grid-template-columns: minmax(0, 1fr) auto;
+      gap: 0.75rem;
+      padding: 0.62rem 1rem;
+      border-bottom: 1px solid var(--faint);
+      color: var(--muted);
+      font-size: 0.77rem;
+      transition: color 220ms ease, background 220ms ease;
+    }
+
+    .schema-column:last-child {
+      border-bottom: 0;
+    }
+
+    .schema-column code {
+      min-width: 0;
+      overflow-wrap: anywhere;
+      color: inherit;
+    }
+
+    .schema-column.is-active {
+      color: var(--text);
+      background: var(--schema-highlight);
+      font-weight: 700;
+    }
+
+    .relationship {
+      margin: 0;
+      color: var(--muted);
+      font: 600 0.72rem/1.4 ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+      text-align: center;
+    }
+
+    .steps {
+      min-width: 0;
+      display: grid;
+      gap: 38vh;
+      padding-block: 34vh 54vh;
+    }
+
+    .step {
+      min-height: 32vh;
+      padding: 1.5rem;
+      border: 1px solid transparent;
+      border-radius: 1.25rem;
+      background: color-mix(in srgb, var(--panel) 74%, transparent);
+      color: var(--muted);
+      opacity: 0.5;
+      transition: color 240ms ease, opacity 240ms ease, border-color 240ms ease, transform 240ms ease;
+    }
+
+    .step.is-active {
+      border-color: var(--line);
+      color: var(--text);
+      opacity: 1;
+      transform: translateX(-0.35rem);
+    }
+
+    .step-number {
+      display: block;
+      margin-bottom: 1.1rem;
+      color: var(--accent);
+      font: 700 0.7rem/1 ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+      letter-spacing: 0.12em;
+      text-transform: uppercase;
+    }
+
+    .step h2 {
+      margin-bottom: 0.75rem;
+      color: inherit;
+      font-size: clamp(1.65rem, 3vw, 2.35rem);
+      line-height: 1.05;
+      letter-spacing: -0.035em;
+    }
+
+    .step p:last-child {
+      margin-bottom: 0;
+    }
+
+    code {
+      font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+    }
+
+    .outro {
+      min-height: 72vh;
+      display: grid;
+      place-content: center;
+      padding-block: 12vh;
+    }
+
+    .outro-card {
+      max-width: 48rem;
+      padding: clamp(1.5rem, 5vw, 4rem);
+      border: 1px solid var(--line);
+      border-radius: var(--radius);
+      background: var(--panel);
+      box-shadow: var(--shadow);
+    }
+
+    .outro h2 {
+      margin-bottom: 1rem;
+      font-size: clamp(2rem, 5vw, 4rem);
+      line-height: 1;
+      letter-spacing: -0.045em;
+    }
+
+    .outro p {
+      margin-bottom: 0;
+      color: var(--muted);
+      font-size: 1.08rem;
+    }
+
+    @media (max-width: 50rem) {
+      :root {
+        --stage-height: min(70vh, 32rem);
+      }
+
+      .hero {
+        min-height: 62vh;
+      }
+
+      .scrolly {
+        display: block;
+        width: min(42rem, calc(100% - 1rem));
+      }
+
+      .stage-column {
+        height: auto;
+      }
+
+      .stage {
+        position: relative;
+        top: auto;
+        transform: none;
+        height: var(--stage-height);
+        margin-bottom: 1rem;
+      }
+
+      .steps {
+        gap: 1rem;
+        padding-block: 1rem 5rem;
+      }
+
+      .step {
+        min-height: auto;
+        opacity: 1;
+      }
+
+      .step.is-active {
+        transform: none;
+      }
+
+      .schema-grid {
+        grid-template-columns: 1fr;
+      }
+    }
+
+    @media (max-width: 31rem) {
+      .stage-header span {
+        display: none;
+      }
+
+      .code-wrap,
+      .schema-wrap {
+        padding: 0.75rem;
+      }
+
+      .code-panel {
+        font-size: 0.58rem;
+      }
+
+      .architecture .node-label {
+        font-size: 15px;
+      }
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+      html {
+        scroll-behavior: auto;
+      }
+
+      *,
+      *::before,
+      *::after {
+        animation-duration: 0.01ms !important;
+        animation-iteration-count: 1 !important;
+        transition-duration: 0.01ms !important;
+      }
+
+      .architecture .edge {
+        stroke-dashoffset: 0;
+      }
+    }
+  </style>
+</head>
+<body>
+  <header class="hero">
+    <p class="kicker">Technical walkthrough / durable writes</p>
+    <h1>One request, one durable event.</h1>
+    <p class="dek">Follow a new order from the HTTP boundary to the database and out through an event, without losing the side effect if publishing fails.</p>
+  </header>
+
+  <main class="scrolly" id="story">
+    <div class="stage-column">
+      <aside class="stage" aria-hidden="true">
+        <div class="stage-header">
+          <strong>Create order transaction</strong>
+          <span>Scroll to trace</span>
+        </div>
+
+        <div class="stage-body">
+          <div class="stage-layer is-active" data-layer="architecture">
+            <svg class="architecture" viewBox="0 0 800 500" preserveAspectRatio="xMidYMid meet">
+              <defs>
+                <marker id="arrowhead" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+                  <path d="M 0 0 L 10 5 L 0 10 z" fill="var(--accent)"></path>
+                </marker>
+              </defs>
+
+              <path id="edge-endpoint-service" class="edge" pathLength="1" d="M 220 235 C 260 235 274 235 320 235"></path>
+              <path id="edge-service-orders" class="edge" pathLength="1" d="M 470 220 C 520 190 536 145 600 130"></path>
+              <path id="edge-service-outbox" class="edge" pathLength="1" d="M 470 250 C 520 270 540 280 600 280"></path>
+              <path id="edge-outbox-broker" class="edge" pathLength="1" d="M 675 325 C 675 345 675 350 675 370"></path>
+
+              <g id="endpoint" class="node" data-focusable>
+                <rect x="65" y="190" width="155" height="90" rx="18"></rect>
+                <text class="node-kind" x="88" y="220">HTTP</text>
+                <text class="node-label" x="88" y="250">POST /orders</text>
+              </g>
+
+              <g id="service" class="node" data-focusable>
+                <rect x="320" y="190" width="150" height="90" rx="18"></rect>
+                <text class="node-kind" x="343" y="220">SERVICE</text>
+                <text class="node-label" x="343" y="250">OrderService</text>
+              </g>
+
+              <g id="orders" class="node" data-focusable>
+                <rect x="600" y="85" width="150" height="90" rx="18"></rect>
+                <text class="node-kind" x="623" y="115">POSTGRES</text>
+                <text class="node-label" x="623" y="145">orders</text>
+              </g>
+
+              <g id="outbox" class="node" data-focusable>
+                <rect x="600" y="235" width="150" height="90" rx="18"></rect>
+                <text class="node-kind" x="623" y="265">POSTGRES</text>
+                <text class="node-label" x="623" y="295">outbox_events</text>
+              </g>
+
+              <g id="broker" class="node" data-focusable>
+                <rect x="600" y="370" width="150" height="90" rx="18"></rect>
+                <text class="node-kind" x="623" y="400">BROKER</text>
+                <text class="node-label" x="623" y="430">orders.created</text>
+              </g>
+            </svg>
+          </div>
+
+          <div class="stage-layer" data-layer="code">
+            <div class="code-wrap">
+              <p class="file-label">order-service.ts / new transaction boundary</p>
+              <pre class="code-panel"><code><span class="code-line" data-line="1">async create(input: CreateOrder) {</span>
+<span class="code-line" data-line="2">  return this.db.transaction(async (tx) =&gt; {</span>
+<span class="code-line added" data-line="3">    const order = await tx.orders.insert({</span>
+<span class="code-line added" data-line="4">      ...input, status: "pending"</span>
+<span class="code-line added" data-line="5">    });</span>
+<span class="code-line added" data-line="6">    await tx.outbox.insert({</span>
+<span class="code-line added" data-line="7">      topic: "orders.created", payload: order</span>
+<span class="code-line added" data-line="8">    });</span>
+<span class="code-line" data-line="9">    return order;</span>
+<span class="code-line" data-line="10">  });</span>
+<span class="code-line" data-line="11">}</span></code></pre>
+            </div>
+          </div>
+
+          <div class="stage-layer" data-layer="schema">
+            <div class="schema-wrap">
+              <div class="schema-grid">
+                <section id="schema-orders" class="schema-table">
+                  <h3>orders</h3>
+                  <div class="schema-column" data-column="orders.id"><code>id</code><span>uuid PK</span></div>
+                  <div class="schema-column" data-column="orders.customer_id"><code>customer_id</code><span>uuid</span></div>
+                  <div class="schema-column" data-column="orders.status"><code>status</code><span>text</span></div>
+                  <div class="schema-column" data-column="orders.created_at"><code>created_at</code><span>timestamptz</span></div>
+                </section>
+
+                <section id="schema-outbox" class="schema-table">
+                  <h3>outbox_events</h3>
+                  <div class="schema-column" data-column="outbox.id"><code>id</code><span>uuid PK</span></div>
+                  <div class="schema-column" data-column="outbox.topic"><code>topic</code><span>text</span></div>
+                  <div class="schema-column" data-column="outbox.payload"><code>payload</code><span>jsonb</span></div>
+                  <div class="schema-column" data-column="outbox.published_at"><code>published_at</code><span>timestamptz?</span></div>
+                </section>
+              </div>
+              <p class="relationship">Both rows commit together; the publisher reads the outbox later.</p>
+            </div>
+          </div>
+        </div>
+      </aside>
+    </div>
+
+    <section class="steps" aria-label="Order creation walkthrough">
+      <article class="step is-active" data-step="entry">
+        <span class="step-number">01 / Entry point</span>
+        <h2>The request enters once.</h2>
+        <p><code>POST /orders</code> validates the payload and calls <code>OrderService.create</code>. The endpoint does not publish an event itself.</p>
+      </article>
+
+      <article class="step" data-step="flow">
+        <span class="step-number">02 / Call flow</span>
+        <h2>Control moves into the service.</h2>
+        <p>The controller delegates one unit of work to <code>OrderService</code>, which owns the transaction and coordinates both repository writes.</p>
+      </article>
+
+      <article class="step" data-step="code">
+        <span class="step-number">03 / New code</span>
+        <h2>The transaction gains an outbox write.</h2>
+        <p>The added lines insert the order and its <code>orders.created</code> payload inside the same database transaction, so neither row can commit alone.</p>
+      </article>
+
+      <article class="step" data-step="write-order">
+        <span class="step-number">04 / Primary write</span>
+        <h2>The order row lands first.</h2>
+        <p>The service inserts a pending order into <code>orders</code>. This is the business record returned to the caller after the transaction commits.</p>
+      </article>
+
+      <article class="step" data-step="write-outbox">
+        <span class="step-number">05 / Durable handoff</span>
+        <h2>The event intent lands beside it.</h2>
+        <p>The service inserts a second row into <code>outbox_events</code> in the same transaction. A later publisher can retry delivery without recreating the order.</p>
+      </article>
+
+      <article class="step" data-step="schema">
+        <span class="step-number">06 / Data layer</span>
+        <h2>Three columns carry the change.</h2>
+        <p><code>orders.status</code> records the initial lifecycle state, while <code>outbox_events.topic</code> and <code>outbox_events.payload</code> describe the message to publish.</p>
+      </article>
+
+      <article class="step" data-step="event">
+        <span class="step-number">07 / Side effect</span>
+        <h2>Publishing is now recoverable.</h2>
+        <p>After commit, an outbox worker publishes <code>orders.created</code>. If the broker is unavailable, the durable outbox row remains available for retry and downstream consumers see no phantom order.</p>
+      </article>
+    </section>
+  </main>
+
+  <footer class="outro">
+    <div class="outro-card">
+      <p class="kicker">Result</p>
+      <h2>Atomic locally, reliable downstream.</h2>
+      <p>The request now creates its record and its event intent as one commit, separating database consistency from eventual message delivery.</p>
+    </div>
+  </footer>
+
+  <script>
+    (() => {
+      const steps = [...document.querySelectorAll("[data-step]")];
+      const layers = [...document.querySelectorAll("[data-layer]")];
+      const nodes = [...document.querySelectorAll(".architecture [data-focusable]")];
+      const edges = [...document.querySelectorAll(".architecture .edge")];
+      const codeLines = [...document.querySelectorAll(".code-line")];
+      const tables = [...document.querySelectorAll(".schema-table")];
+      const columns = [...document.querySelectorAll(".schema-column")];
+
+      const states = {
+        entry: {
+          layer: "architecture",
+          nodes: ["endpoint"]
+        },
+        flow: {
+          layer: "architecture",
+          nodes: ["endpoint", "service"],
+          edge: "edge-endpoint-service"
+        },
+        code: {
+          layer: "code",
+          lines: [3, 4, 5, 6, 7, 8]
+        },
+        "write-order": {
+          layer: "architecture",
+          nodes: ["service", "orders"],
+          edge: "edge-service-orders"
+        },
+        "write-outbox": {
+          layer: "architecture",
+          nodes: ["service", "outbox"],
+          edge: "edge-service-outbox"
+        },
+        schema: {
+          layer: "schema",
+          tables: ["schema-orders", "schema-outbox"],
+          columns: ["orders.status", "outbox.topic", "outbox.payload"]
+        },
+        event: {
+          layer: "architecture",
+          nodes: ["outbox", "broker"],
+          edge: "edge-outbox-broker"
+        }
+      };
+
+      function render(stepId) {
+        const state = states[stepId];
+        if (!state) return;
+
+        document.documentElement.dataset.activeStep = stepId;
+        steps.forEach((step) => {
+          step.classList.toggle("is-active", step.dataset.step === stepId);
+        });
+        layers.forEach((layer) => {
+          layer.classList.toggle("is-active", layer.dataset.layer === state.layer);
+        });
+        nodes.forEach((node) => {
+          node.classList.toggle("is-active", (state.nodes || []).includes(node.id));
+        });
+        edges.forEach((edge) => {
+          edge.classList.toggle("is-drawn", state.edge === edge.id);
+        });
+        codeLines.forEach((line) => {
+          line.classList.toggle("is-active", (state.lines || []).includes(Number(line.dataset.line)));
+        });
+        tables.forEach((table) => {
+          table.classList.toggle("is-active", (state.tables || []).includes(table.id));
+        });
+        columns.forEach((column) => {
+          column.classList.toggle("is-active", (state.columns || []).includes(column.dataset.column));
+        });
+      }
+
+      const observer = new IntersectionObserver((entries) => {
+        const crossing = entries
+          .filter((entry) => entry.isIntersecting)
+          .sort((a, b) => {
+            const readingLine = window.innerHeight * 0.5;
+            return Math.abs(a.boundingClientRect.top - readingLine)
+              - Math.abs(b.boundingClientRect.top - readingLine);
+          });
+
+        if (crossing[0]) render(crossing[0].target.dataset.step);
+      }, {
+        rootMargin: "-46% 0px -46% 0px",
+        threshold: 0
+      });
+
+      steps.forEach((step) => observer.observe(step));
+      render(steps[0].dataset.step);
+    })();
+  </script>
+</body>
+</html>

--- a/skills/scroll-story/template.html
+++ b/skills/scroll-story/template.html
@@ -133,8 +133,7 @@
 
     .stage {
       position: sticky;
-      top: 50vh;
-      transform: translateY(-50%);
+      top: calc(50vh - var(--stage-height) / 2);
       height: var(--stage-height);
       min-width: 0;
       overflow: hidden;

--- a/tests/fm-test-run.test.sh
+++ b/tests/fm-test-run.test.sh
@@ -145,8 +145,11 @@ init_changed_fixture_repo() {
   mkdir -p \
     "$repo/.agents/skills/example" \
     "$repo/.agents/skills/harness-adapters/references/common" \
-    "$repo/.claude" "$repo/.pi/extensions" "$repo/docs" "$repo/src"
+    "$repo/.claude" "$repo/.pi/extensions" "$repo/docs" "$repo/src" \
+    "$repo/skills/example"
   : >"$repo/.agents/skills/example/SKILL.md"
+  : >"$repo/skills/example/SKILL.md"
+  : >"$repo/skills/example/template.html"
   : >"$repo/.agents/skills/harness-adapters/SKILL.md"
   : >"$repo/.agents/skills/harness-adapters/references/common/dispatch.md"
   : >"$repo/.claude/settings.json"
@@ -244,6 +247,13 @@ test_changed_dependency_selection_and_unmapped_failure() {
   assert_contains "$listed" "tests/fm-pi-watch-extension.test.sh" "Pi source selects watcher coverage"
   git -C "$repo" add .agents .claude .pi
   git -C "$repo" -c user.name=test -c user.email=test@example.invalid commit -qm non-bin-source-change
+
+  printf '\n' >>"$repo/skills/example/SKILL.md"
+  printf '\n' >>"$repo/skills/example/template.html"
+  listed=$(cd "$repo" && bin/fm-test-run.sh --list --changed --base HEAD)
+  assert_contains "$listed" "tests/fm-ask-user-authority.test.sh" "public skill source selects pure contract coverage"
+  git -C "$repo" add skills
+  git -C "$repo" -c user.name=test -c user.email=test@example.invalid commit -qm public-skill-change
 
   printf '\n' >>"$repo/.agents/skills/harness-adapters/references/common/dispatch.md"
   listed=$(cd "$repo" && bin/fm-test-run.sh --list --changed --base HEAD)


### PR DESCRIPTION
## Intent

Build a new standalone, installer-facing skill at skills/scroll-story/ in the firstmate repo that teaches an agent to author scroll-driven, pinned scrollytelling pages for technical narratives.

The goal: explain a technical change - a code review, an architecture walkthrough, a data-flow story - as a page where a stage stays pinned (a diagram, a code panel, a DB schema) while the reader scrolls a column of step text beside it. Each step, as it enters the viewport, re-focuses the pinned stage on a different part of the system: highlight a method, glow a table, draw an arrow between services, swap to a code snippet. The visual never jumps; only the focus moves. The skill must let an agent go from "here is a diff / a system" to a finished, self-contained HTML page that does this well.

Required: skills/scroll-story/SKILL.md with YAML frontmatter (name, description, user-invocable: true), following the shape of the existing skills/stow/SKILL.md - standalone, no firstmate-internal paths, no environment branching, no assumptions about tools that only exist in this fleet. Someone who installs only this directory must be able to use it. The description must fire on the real triggers: explaining a code review, PR walkthrough, architecture or data-flow narrative visually; requests for a scrollytelling / sticky-scroll / pinned-diagram / scroll-driven explainer page.

It must cover at minimum: (1) the layout contract - sticky stage plus scrolling steps, two columns on wide screens, stage position:sticky and vertically centered, steps column a tall stack with generous spacing, including the actual CSS and the container that bounds the sticky region so the stage releases at the end; (2) the narrative beat sequence - trigger/entry point, call flow/stack, the new code itself as a code panel with added lines highlighted like a diff, systems talking to each other with arrows drawn per edge, the data layer with affected tables and specific changed columns lighting up, and the result and side effects (events emitted, caches invalidated, downstream consumers) - stated clearly as a starting template, not a fixed six-step form, since the beats come from the change being explained; (3) the two hard design rules stated plainly and repeated in the checklist - one idea per scroll step, and the stage changes exactly one thing per step; (4) stage types with working technique for all three - inline SVG architecture diagram whose nodes and edges carry ids so a step can highlight a node, dim the rest, or animate an edge being drawn via stroke-dasharray/stroke-dashoffset; a code panel where a step highlights a line range plus a diff view where added lines glow; a table/schema stage where affected tables and columns light up - plus how to swap stage content between steps without layout jump using a cross-fade with both layers absolutely positioned in a fixed-height stage; (5) activation mechanics - IntersectionObserver on the step blocks with a sensible rootMargin so a step activates at the reading line rather than the viewport edge, the observer setting one active step id, and a single render function mapping active step to stage state, with explicit warnings against the naive scroll-listener + getBoundingClientRect loop and against per-step ad-hoc DOM mutation instead of one declarative render; (6) responsive and accessibility requirements stated as requirements rather than suggestions - narrow screens collapse the sticky layout, prefers-reduced-motion disables transitions and draws every stage state in its final position, every step readable as plain prose with the stage absent, the stage either aria-hidden decoration or properly labelled, and no content existing only as a highlight; (7) self-containment - one HTML file, no CDN or external dependencies, inline CSS/JS, theme-aware colors as CSS custom properties on :root with a prefers-color-scheme: dark override, so the output works as a plain file and as a published artifact; (8) a ship checklist covering steps and stage states one-to-one, only one change per step, first and last steps having room to activate, working scrolled fast / backwards / at phone width, reduced motion honored, and no horizontal page scroll.

Also required: skills/scroll-story/template.html, a complete, working, self-contained reference page - a small worked example (a request hitting an endpoint, through a service, to two DB tables, emitting an event) exercising an SVG diagram stage, a code panel stage with highlighted lines, and a schema stage. It must be genuinely runnable, not a sketch, and SKILL.md must point to it as the starting point to copy and adapt. Keep the whole skill directory tight - SKILL.md plus the template, no sprawl.

Constraints the captain set: the skill name is scroll-story (the directory is skills/scroll-story/ and frontmatter name: is scroll-story). The internal task identifier "scrollytell-skill" must not appear anywhere in the delivered files or branch content; the generic word "scrollytelling" describing the technique is fine in prose. skills/ is the public, installer-facing surface and is NOT loaded by a running firstmate, while .agents/skills/ is the internal one - this skill belongs in the public skills/ directory only and must NOT be added to .agents/skills/. Do not touch AGENTS.md, bin/, or .agents/skills/. The skill must read as instructions to an agent, not as an essay: concrete, imperative, with the CSS/JS the agent actually needs. One sentence per line in the Markdown, matching this repo's prose style (firstmate-coding-guidelines owns the repo conventions and was loaded before editing).

Acceptance required the template be verified in a real browser with chrome-devtools-axi - load it, scroll through every step, confirm the stage pins, each step activates its own stage state, transitions are single-change, no console errors, and the narrow-width layout collapses on resize - with the verification recorded in the PR body.

Later accepted decision from the captain: screenshots were never the acceptance criterion and could not be captured with the local tooling, so screenshots are deliberately NOT part of this deliverable and no binary images are committed; the behavioral browser checks stand in their place and are recorded in the PR body, which states plainly that screenshots could not be captured locally.

Decisions and findings made while doing the work, which a reviewer reading only the diff would not know:

- The two skill files were authored in an earlier session and inherited uncommitted; this session verified them, re-ran the browser checks, and committed them.
- Browser verification was completed and passed at 1440x900 and at an emulated 390x844 phone viewport: the stage holds a constant viewport box across all 7 steps (pins with no drift), each step activates exactly one stage layer with its own distinct focus set, reverse scrolling and fast jumps reconstruct state correctly (the render function is idempotent), the stage releases with its container at the story end, the narrow layout collapses grid to block with the stage becoming position:relative and no horizontal page scroll, the reduced-motion declarations move an undrawn edge to its final geometric position while collapsing transitions, both light and dark palettes resolve, the accessibility tree exposes all seven steps as complete prose with the aria-hidden stage contributing nothing, and the network log shows exactly one request (the document itself).
- One console line appears on a file:// load: Chrome's "'file:' URLs are treated as unique security origins" message. This was investigated and proven to be an environment artifact rather than a page defect - it reproduces identically on a minimal blank HTML page, and serving the same template over HTTP produces no such error. A speculative change moving marker-end from CSS to an SVG presentation attribute was tried against this and then fully reverted once the evidence disproved the hypothesis, so template.html is byte-identical to the intended design.
- Two repo-integration changes outside skills/ were deliberately required and are in scope: bin/fm-doc-audience-check.sh refuses an unclassified maintained prose surface, so skills/scroll-story/SKILL.md was added to docs/documentation-audiences.json as public-product; and README.md's "Two-tier skill layout" section previously said the public surface was "Today that is skills/stow", which became false, so it now describes both public skills. Neither file is on the do-not-touch list. bin/fm-doc-audience-check.sh passes (surfaces=90) and bin/fm-lint.sh reports no changed lint targets because no shell scripts were modified.

Additional accepted scope decided during validation, all explicitly authorized:

- The sticky stage originally used `top: 50vh` with `transform: translateY(-50%)`, which lifted the card about half its height above its flow position before the sticky threshold engaged and covered the hero headline and subtitle at first paint on desktop. This was confirmed by measurement at 1440x900 and fixed by replacing that pattern with a computed sticky offset, `top: calc(50vh - var(--stage-height) / 2)` and no transform, so the painted box and the layout box coincide and the stage can never paint outside its own flow position. SKILL.md was updated in the same round to teach that clearance rule alongside the layout CSS, so an agent copying the skill cannot reproduce the defect.
- `bin/fm-test-run.sh` maps changed paths to test families and refuses on any unmapped path. It had a case for the internal `.agents/skills/*/SKILL.md` but none for the public `skills/` tree, so this branch's files were unmapped and the test step could not select anything. This is a pre-existing gap that this change merely exercised first: no test references any public `skills/` path, so `skills/stow` would fail identically. The captain authorized the minimal fix, so the public skills tree is now mapped to the pure-contract-unit family, mirroring the internal-skills case, and `tests/fm-test-run.test.sh` was extended to cover the new mapping through the real `--list --changed` executable interface rather than asserting the runner's source bytes. That mapping is what makes `tests/fm-documentation-audiences.test.sh` actually run, which is the real test covering this branch's `docs/documentation-audiences.json` classification entry.
- Four test failures on this machine are accepted as pre-existing and out of scope by explicit captain decision, having been proven to reproduce at the pre-change base commit: `fm-lint` and `fm-lint-workflows` both fail because actionlint is not installed locally, `fm-muse-harness` fails on a macOS trust-cache artifact affecting a copied binary, and `fm-composer-lib` fails an unrelated structural-edge assertion. None involve any file this branch touches.
- Delivery is fork-based: branches push to the fork https://github.com/ammar00sheikh/firstmate and the PR opens against kunchenguid/firstmate, because the signed-in account has read but not write access upstream and fork-based PRs are this repository's established contribution path.

## What Changed
- Adds a new standalone, installer-facing skill at `skills/scroll-story/`: `SKILL.md` teaches an agent to author scroll-driven explainer pages where a pinned stage (SVG diagram, code panel, or DB schema) re-focuses as the reader scrolls narrative steps — covering the sticky layout contract, beat sequence, IntersectionObserver activation, single declarative render, responsive/reduced-motion/accessibility requirements, and a ship checklist — and `template.html` is a complete, runnable, dependency-free reference page exercising all three stage types.
- Registers `skills/scroll-story/SKILL.md` as `public-product` in `docs/documentation-audiences.json` and updates the README's two-tier skill layout section to describe both public skills (`skills/stow` and `skills/scroll-story`).
- Maps the public `skills/` tree to the `pure-contract-unit` test family in `bin/fm-test-run.sh` (mirroring the existing internal `.agents/skills/*/SKILL.md` case, which previously left public skill paths unmapped and made the changed-path test selection refuse), with `tests/fm-test-run.test.sh` extended to cover the new mapping through the real `--list --changed` interface.

## Risk Assessment

✅ Low: The change is an additive, self-contained public skill plus the minimal explicitly authorized integration edits (test-family mapping, audience classification, README), with both prior review findings implemented exactly as directed and no forbidden identifier or intent contradiction in any delivered file.

## Testing

Completed 1 recorded test check.

- Outcome: ⚠️ 1 error across 1 run (4m6s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"2e32b590d2c822c446d8e4d5a948a28b7fc5bd5d","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>⚠️ **Test** - 1 error</summary>

- 🚨 tests failed with exit code 1
- `bin/fm-test-run.sh --changed --exclude-family real-herdr-gated`
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>⚠️ **Lint** - 1 warning</summary>

- ⚠️ linter found issues (exit code 1)
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
