### PR TITLE
feat: check watched tools against published npm and GitHub releases

### DIFF
--- a/bin/fm-tool-update-check.sh
+++ b/bin/fm-tool-update-check.sh
@@ -444,6 +444,7 @@ command_findings() {
   while IFS= read -r hit; do
     [ -n "$hit" ] || continue
     if budget_exhausted; then
+      INCOMPLETE_REPORTED=1
       emit "$name check failed: the time budget ran out before every copy answered"
       break
     fi
@@ -479,6 +480,7 @@ EOF
       if budget_exhausted; then
         # The version probe's output cannot carry the announcement, so searching
         # it would present a source that was never asked as a clean result.
+        INCOMPLETE_REPORTED=1
         emit "$name check failed: the time budget ran out before the update announcement was checked"
         announce_out=
       else
@@ -533,10 +535,7 @@ published_findings() {
   local url field version status bound
   # command_findings already reports a missing or unreadable resolved command.
   [ -n "$installed" ] || return 0
-  if ! budget_allows "$name published source"; then
-    emit "$name check failed: the time budget ran out before its published source was checked"
-    return 0
-  fi
+  budget_allows "$name published source" || return 0
   if ! command -v curl >/dev/null 2>&1; then
     emit "$name check failed: curl is required to read its published source"
     return 0
@@ -606,6 +605,7 @@ git_probe_answered() {
   local status=$1 name=$2 subject=$3 question=$4
   case "$status" in
     "$GIT_PROBE_NOT_ISSUED")
+      INCOMPLETE_REPORTED=1
       emit "$name check failed: the time budget ran out before $subject was asked $question"
       return 1
       ;;
@@ -818,8 +818,10 @@ action_check() {
   if [ -n "$line" ] && [ "$FINDINGS" != "$RECORD_REPORTED" ]; then
     printf '%s\n' "$line"
   fi
-  # A partial sweep must not replace the last complete report or cadence epoch.
-  if [ "$INCOMPLETE_REPORTED" -eq 0 ] && ! budget_exhausted; then
+  # Only skipped work makes the sweep incomplete. The last issued probe can
+  # finish after the deadline without leaving anything unchecked; keep that
+  # complete result and cadence epoch so its finding is not reported again.
+  if [ "$INCOMPLETE_REPORTED" -eq 0 ]; then
     record_write "$FINDINGS" || true
   fi
   return 0

--- a/bin/fm-tool-update-check.sh
+++ b/bin/fm-tool-update-check.sh
@@ -444,7 +444,6 @@ command_findings() {
   while IFS= read -r hit; do
     [ -n "$hit" ] || continue
     if budget_exhausted; then
-      INCOMPLETE_REPORTED=1
       emit "$name check failed: the time budget ran out before every copy answered"
       break
     fi
@@ -480,7 +479,6 @@ EOF
       if budget_exhausted; then
         # The version probe's output cannot carry the announcement, so searching
         # it would present a source that was never asked as a clean result.
-        INCOMPLETE_REPORTED=1
         emit "$name check failed: the time budget ran out before the update announcement was checked"
         announce_out=
       else
@@ -605,7 +603,6 @@ git_probe_answered() {
   local status=$1 name=$2 subject=$3 question=$4
   case "$status" in
     "$GIT_PROBE_NOT_ISSUED")
-      INCOMPLETE_REPORTED=1
       emit "$name check failed: the time budget ran out before $subject was asked $question"
       return 1
       ;;
@@ -818,12 +815,7 @@ action_check() {
   if [ -n "$line" ] && [ "$FINDINGS" != "$RECORD_REPORTED" ]; then
     printf '%s\n' "$line"
   fi
-  # Only skipped work makes the sweep incomplete. The last issued probe can
-  # finish after the deadline without leaving anything unchecked; keep that
-  # complete result and cadence epoch so its finding is not reported again.
-  if [ "$INCOMPLETE_REPORTED" -eq 0 ]; then
-    record_write "$FINDINGS" || true
-  fi
+  record_write "$FINDINGS" || true
   return 0
 }
 

--- a/bin/fm-tool-update-check.sh
+++ b/bin/fm-tool-update-check.sh
@@ -31,6 +31,9 @@
 # manager's "latest" directory can hold an older build. A copy that will not
 # report a version is reported as a check failure rather than assumed current.
 #
+# Published versions are read from the public npm registry or GitHub latest
+# release API with curl and jq. No vendor CLI update command is invoked.
+#
 # What this script never does: it reports, and it repairs nothing. It does not
 # install, update, uninstall, reorder PATH, or touch any version manager's
 # configuration, and it never fetches into a watched git repository. Every git
@@ -251,11 +254,15 @@ version_newer() {
   IFS=. read -r -a bp <<< "$b"
   i=0
   while [ "$i" -lt "${#ap[@]}" ] || [ "$i" -lt "${#bp[@]}" ]; do
-    left=$((10#${ap[i]:-0}))
-    right=$((10#${bp[i]:-0}))
-    if [ "$left" -gt "$right" ]; then
+    left=${ap[i]:-0}
+    right=${bp[i]:-0}
+    # Compare decimal strings so untrusted large components cannot overflow
+    # shell arithmetic. Leading zeroes and omitted components are insignificant.
+    while [ "${#left}" -gt 1 ] && [ "${left#0}" != "$left" ]; do left=${left#0}; done
+    while [ "${#right}" -gt 1 ] && [ "${right#0}" != "$right" ]; do right=${right#0}; done
+    if [ "${#left}" -gt "${#right}" ] || { [ "${#left}" -eq "${#right}" ] && [[ "$left" > "$right" ]]; }; then
       return 0
-    elif [ "$left" -lt "$right" ]; then
+    elif [ "$left" != "$right" ]; then
       return 1
     fi
     i=$((i + 1))
@@ -303,18 +310,14 @@ config_announce_patterns_usable() {
   return 0
 }
 
-config_validate() {
-  local problem status
-  if ! command -v jq >/dev/null 2>&1; then
-    CONFIG_PROBLEM='jq is required to read the watched tool registry'
-    return 1
-  fi
-  problem=$(jq -r '
+# Shared validation keeps arm strict while check isolates malformed entries.
+# shellcheck disable=SC2016  # jq variables, not shell expansions.
+CONFIG_RULES='
     def tool_problem($t):
       if ($t | type) != "object" then "every entry in tools must be an object"
       elif ($t.name | type) != "string" or ($t.name | length) == 0 then "every tool needs a non-empty name"
       elif ($t.name | test("^[A-Za-z0-9._+-]+$") | not) then "tool name \($t.name) may use only letters, digits, dot, underscore, plus, and dash"
-      elif ($t | has("command") | not) and ($t | has("git") | not) then "tool \($t.name) needs command, git, or both"
+      elif ($t | has("command") | not) and ($t | has("git") | not) and ($t | has("published") | not) then "tool \($t.name) needs command, git, or published"
       elif ($t | has("command")) and (($t.command | type) != "string" or ($t.command | test("^[A-Za-z0-9._+-]+$") | not)) then "tool \($t.name) command must be a bare executable name"
       elif ($t | has("version_args")) and (($t.version_args | type) != "array" or ($t.version_args | length) == 0) then "tool \($t.name) version_args must be a non-empty array"
       elif ($t | has("version_args")) and ([$t.version_args[] | select((type != "string") or (test("^[A-Za-z0-9._=+/:-]+$") | not))] | length) > 0 then "tool \($t.name) version_args must be simple flag strings without spaces"
@@ -327,17 +330,35 @@ config_validate() {
       elif ($t | has("git")) and (($t.git.repo | type) != "string" or ($t.git.repo | startswith("/") | not) or ($t.git.repo | test("[[:cntrl:]]"))) then "tool \($t.name) git.repo must be an absolute path on one line"
       elif ($t | has("git")) and ($t.git | has("remote")) and (($t.git.remote | type) != "string" or ($t.git.remote | test("^[A-Za-z0-9._-]+$") | not)) then "tool \($t.name) git.remote must be a simple remote name"
       elif ($t | has("git")) and ($t.git | has("branch")) and (($t.git.branch | type) != "string" or ($t.git.branch | test("^[A-Za-z0-9._/-]+$") | not)) then "tool \($t.name) git.branch must be a simple branch name"
+      elif ($t | has("published")) and (($t.published | type) != "object") then "tool \($t.name) published must be an object"
+      elif ($t | has("published")) and (($t | has("command")) | not) then "tool \($t.name) published needs command to report the installed version"
+      elif ($t | has("published")) and ($t.published.source != "npm" and $t.published.source != "github") then "tool \($t.name) published.source must be npm or github"
+      elif ($t | has("published")) and $t.published.source == "npm" and
+        (($t.published.package | type) != "string" or ($t.published.package | test("^(@[a-z0-9][a-z0-9._-]*/)?[a-z0-9][a-z0-9._-]*$") | not)) then "tool \($t.name) published.package must be an npm package name"
+      elif ($t | has("published")) and $t.published.source == "github" and
+        (($t.published.repo | type) != "string" or ($t.published.repo | test("^[A-Za-z0-9][A-Za-z0-9-]*/[A-Za-z0-9_.-]+$") | not)) then "tool \($t.name) published.repo must be a GitHub owner/repo"
+      elif ($t | has("published")) and
+        (($t.published | keys) - (if $t.published.source == "npm" then ["source", "package"] else ["source", "repo"] end) | length) > 0 then "tool \($t.name) published has unsupported fields"
       else empty
       end;
-    def problems:
-      if type != "object" then ["the top level must be an object"]
-      elif (.tools | type) != "array" then ["tools must be an array"]
-      elif (.tools | length) == 0 then ["tools must list at least one tool"]
-      else
-        [.tools[] | tool_problem(.)]
-        + (if ([.tools[].name] | unique | length) != (.tools | length) then ["tool names must be unique"] else [] end)
-      end;
-    problems | .[0] // "ok"
+    def entry_problem($tools; $t):
+      tool_problem($t) //
+      (if ([$tools[] | objects | select(.name == $t.name)] | length) > 1
+       then "tool names must be unique: \($t.name)" else empty end);
+'
+
+config_validate() {
+  local problem status
+  if ! command -v jq >/dev/null 2>&1; then
+    CONFIG_PROBLEM='jq is required to read the watched tool registry'
+    return 1
+  fi
+  problem=$(jq -r --arg mode "${1:-arm}" "$CONFIG_RULES"'
+    if type != "object" then "the top level must be an object"
+    elif (.tools | type) != "array" then "tools must be an array"
+    elif (.tools | length) == 0 then "tools must list at least one tool"
+    elif $mode == "arm" then [.tools as $tools | .tools[] | entry_problem($tools; .)] | .[0] // "ok"
+    else "ok" end
   ' "$CONFIG" 2>/dev/null)
   status=$?
   if [ "$status" -ne 0 ] || [ -z "$problem" ]; then
@@ -358,8 +379,15 @@ config_validate() {
 FIELD_SEP=$(printf '\037')
 
 config_records() {
-  jq -r '
-    .tools[] | [
+  jq -r "$CONFIG_RULES"'
+    .tools as $tools | .tools | to_entries[] |
+    .key as $index | .value |
+    (entry_problem($tools; .) // "") as $problem |
+    if $problem != "" then
+      [(if type == "object" and (.name | type) == "string" and (.name | test("^[A-Za-z0-9._+-]+$"))
+        then .name else "entry-\($index + 1)" end)] +
+      ([range(9)] | map("")) + [($problem | gsub("[[:cntrl:]]"; " "))]
+    else [
       .name,
       (.command // ""),
       ((.version_args // ["--version"]) | join(" ")),
@@ -367,8 +395,11 @@ config_records() {
       ((.announce_args // .version_args // ["--version"]) | join(" ")),
       (.git.repo // ""),
       (.git.remote // "origin"),
-      (.git.branch // "")
-    ] | join("\u001f")
+      (.git.branch // ""),
+      (.published.source // ""),
+      (.published.package // .published.repo // ""),
+      ""
+    ] end | join("\u001f")
   ' "$CONFIG" 2>/dev/null
 }
 
@@ -401,11 +432,14 @@ probe_output() {
   fm_run_timed "$(probe_bound)" "$path" "$@" 2>&1
 }
 
+COMMAND_VERSION=
+
 command_findings() {
   local name=$1 command_name=$2 args_joined=$3 announce=$4 announce_args=$5
   local hit out version matched announce_out status
   local resolved_path='' resolved_version='' resolved_out=''
   local best_path='' best_version='' unreadable='' hits=''
+  COMMAND_VERSION=
 
   # This tool's announcement source is dead if its pattern cannot be used, which
   # is reported here, for this tool alone, so the rest of the sweep still runs.
@@ -428,7 +462,9 @@ command_findings() {
     fi
     # shellcheck disable=SC2086  # deliberate split on validated space-free tokens
     out=$(probe_output "$hit" $args_joined)
-    version=$(parse_version "$out")
+    status=$?
+    version=
+    [ "$status" -ne 0 ] || version=$(parse_version "$out")
     if [ -z "$resolved_path" ]; then
       resolved_path=$hit
       resolved_version=$version
@@ -490,6 +526,8 @@ EOF
     return 0
   fi
 
+  COMMAND_VERSION=$resolved_version
+
   if [ -n "$best_version" ] && [ "$best_path" != "$resolved_path" ] \
     && version_newer "$best_version" "$resolved_version"; then
     emit "$name update not in effect: PATH resolves $resolved_version at $resolved_path but $best_version is installed at $best_path"
@@ -499,6 +537,62 @@ EOF
     emit "$name check failed: $unreadable did not report a version"
   fi
   return 0
+}
+
+# --- published release probes -----------------------------------------------
+
+published_findings() {
+  local name=$1 source=$2 package=$3 installed=$4
+  local url field version status bound
+  # command_findings already reports a missing or unreadable resolved command.
+  [ -n "$installed" ] || return 0
+  if ! budget_allows "$name published source"; then
+    emit "$name check failed: the time budget ran out before its published source was checked"
+    return 0
+  fi
+  if ! command -v curl >/dev/null 2>&1; then
+    emit "$name check failed: curl is required to read its published source"
+    return 0
+  fi
+  case "$source" in
+    npm)
+      # Encode scoped package names as one URL path component.
+      url="https://registry.npmjs.org/$(jq -rn --arg package "$package" '$package | @uri')/latest"
+      field=version
+      ;;
+    github)
+      url="https://api.github.com/repos/$package/releases/latest"
+      field=tag_name
+      ;;
+  esac
+  bound=$(probe_bound)
+  # -q must be first: ignore curlrc (credentials, output files, or write methods).
+  # No credentials, redirects, retries, or stdin; HTTP errors are failed probes.
+  # Keep HTTP and JSON parsing in the same bound, including blocking DNS builds.
+  # Only the documented version field counts, never dotted text in release notes
+  # or errors. Exit 65 distinguishes an unsupported response from a failed read.
+  # shellcheck disable=SC2016  # Expanded by the bounded child shell and jq.
+  version=$(fm_run_timed "$bound" bash -c '
+    body=$(curl -q --fail --silent --show-error \
+      --proto "=https" --connect-timeout "$1" --max-time "$1" \
+      --header "Accept: application/json" --url "$2") || exit "$?"
+    version=$(printf "%s" "$body" | jq -ser --arg field "$3" "$4") || exit 65
+    [ -n "$version" ] || exit 65
+    printf "%s\n" "$version"
+  ' published-probe "$bound" "$url" "$field" \
+    'select(length == 1) | .[0][$field] | strings | select(test("^v?[0-9]+(\\.[0-9]+)+$"))' </dev/null 2>/dev/null)
+  status=$?
+  if [ "$status" -eq 65 ]; then
+    emit "$name check failed: published source $url did not report a supported version"
+    return 0
+  elif [ "$status" -ne 0 ]; then
+    emit "$name check failed: published source $url could not be reached or read (exit $status)"
+    return 0
+  fi
+  version=${version#v}
+  if version_newer "$version" "$installed"; then
+    emit "$name update available: installed $installed, published $version at $url"
+  fi
 }
 
 # --- git probes -------------------------------------------------------------
@@ -689,7 +783,7 @@ record_write() {
 
 action_check() {
   local name command_name args_joined announce announce_args repo remote branch
-  local line now
+  local line now source package problem
 
   [ -f "$CONFIG" ] || return 0
 
@@ -706,13 +800,19 @@ action_check() {
     emit "sweep budget ${BUDGET_CUT_FROM}s cut to ${BUDGET_SECS}s to stay inside the watcher check timeout of ${CHECK_TIMEOUT}s"
   fi
 
-  if ! config_validate; then
+  if ! config_validate check; then
     emit "watched tool registry: $CONFIG_PROBLEM"
   else
-    while IFS=$FIELD_SEP read -r name command_name args_joined announce announce_args repo remote branch; do
+    while IFS=$FIELD_SEP read -r name command_name args_joined announce announce_args repo remote branch source package problem; do
       [ -n "$name" ] || continue
       budget_allows "$name" || break
+      if [ -n "$problem" ]; then
+        emit "$name check failed: $problem"
+        continue
+      fi
+      COMMAND_VERSION=
       [ -z "$command_name" ] || command_findings "$name" "$command_name" "$args_joined" "$announce" "$announce_args"
+      [ -z "$source" ] || published_findings "$name" "$source" "$package" "$COMMAND_VERSION"
       [ -z "$repo" ] || git_findings "$name" "$repo" "$remote" "$branch"
     done < <(config_records)
   fi
@@ -735,7 +835,10 @@ action_check() {
   if [ -n "$line" ] && [ "$FINDINGS" != "$RECORD_REPORTED" ]; then
     printf '%s\n' "$line"
   fi
-  record_write "$FINDINGS" || true
+  # A partial sweep must not replace the last complete report or cadence epoch.
+  if [ "$INCOMPLETE_REPORTED" -eq 0 ] && ! budget_exhausted; then
+    record_write "$FINDINGS" || true
+  fi
   return 0
 }
 

--- a/bin/fm-tool-update-check.sh
+++ b/bin/fm-tool-update-check.sh
@@ -310,14 +310,18 @@ config_announce_patterns_usable() {
   return 0
 }
 
-# Shared validation keeps arm strict while check isolates malformed entries.
-# shellcheck disable=SC2016  # jq variables, not shell expansions.
-CONFIG_RULES='
+config_validate() {
+  local problem status
+  if ! command -v jq >/dev/null 2>&1; then
+    CONFIG_PROBLEM='jq is required to read the watched tool registry'
+    return 1
+  fi
+  problem=$(jq -r '
     def tool_problem($t):
       if ($t | type) != "object" then "every entry in tools must be an object"
       elif ($t.name | type) != "string" or ($t.name | length) == 0 then "every tool needs a non-empty name"
       elif ($t.name | test("^[A-Za-z0-9._+-]+$") | not) then "tool name \($t.name) may use only letters, digits, dot, underscore, plus, and dash"
-      elif ($t | has("command") | not) and ($t | has("git") | not) and ($t | has("published") | not) then "tool \($t.name) needs command, git, or published"
+      elif ($t | has("command") | not) and ($t | has("git") | not) then "tool \($t.name) needs command, git, or both"
       elif ($t | has("command")) and (($t.command | type) != "string" or ($t.command | test("^[A-Za-z0-9._+-]+$") | not)) then "tool \($t.name) command must be a bare executable name"
       elif ($t | has("version_args")) and (($t.version_args | type) != "array" or ($t.version_args | length) == 0) then "tool \($t.name) version_args must be a non-empty array"
       elif ($t | has("version_args")) and ([$t.version_args[] | select((type != "string") or (test("^[A-Za-z0-9._=+/:-]+$") | not))] | length) > 0 then "tool \($t.name) version_args must be simple flag strings without spaces"
@@ -341,24 +345,15 @@ CONFIG_RULES='
         (($t.published | keys) - (if $t.published.source == "npm" then ["source", "package"] else ["source", "repo"] end) | length) > 0 then "tool \($t.name) published has unsupported fields"
       else empty
       end;
-    def entry_problem($tools; $t):
-      tool_problem($t) //
-      (if ([$tools[] | objects | select(.name == $t.name)] | length) > 1
-       then "tool names must be unique: \($t.name)" else empty end);
-'
-
-config_validate() {
-  local problem status
-  if ! command -v jq >/dev/null 2>&1; then
-    CONFIG_PROBLEM='jq is required to read the watched tool registry'
-    return 1
-  fi
-  problem=$(jq -r --arg mode "${1:-arm}" "$CONFIG_RULES"'
-    if type != "object" then "the top level must be an object"
-    elif (.tools | type) != "array" then "tools must be an array"
-    elif (.tools | length) == 0 then "tools must list at least one tool"
-    elif $mode == "arm" then [.tools as $tools | .tools[] | entry_problem($tools; .)] | .[0] // "ok"
-    else "ok" end
+    def problems:
+      if type != "object" then ["the top level must be an object"]
+      elif (.tools | type) != "array" then ["tools must be an array"]
+      elif (.tools | length) == 0 then ["tools must list at least one tool"]
+      else
+        [.tools[] | tool_problem(.)]
+        + (if ([.tools[].name] | unique | length) != (.tools | length) then ["tool names must be unique"] else [] end)
+      end;
+    problems | .[0] // "ok"
   ' "$CONFIG" 2>/dev/null)
   status=$?
   if [ "$status" -ne 0 ] || [ -z "$problem" ]; then
@@ -379,15 +374,8 @@ config_validate() {
 FIELD_SEP=$(printf '\037')
 
 config_records() {
-  jq -r "$CONFIG_RULES"'
-    .tools as $tools | .tools | to_entries[] |
-    .key as $index | .value |
-    (entry_problem($tools; .) // "") as $problem |
-    if $problem != "" then
-      [(if type == "object" and (.name | type) == "string" and (.name | test("^[A-Za-z0-9._+-]+$"))
-        then .name else "entry-\($index + 1)" end)] +
-      ([range(9)] | map("")) + [($problem | gsub("[[:cntrl:]]"; " "))]
-    else [
+  jq -r '
+    .tools[] | [
       .name,
       (.command // ""),
       ((.version_args // ["--version"]) | join(" ")),
@@ -397,9 +385,8 @@ config_records() {
       (.git.remote // "origin"),
       (.git.branch // ""),
       (.published.source // ""),
-      (.published.package // .published.repo // ""),
-      ""
-    ] end | join("\u001f")
+      (.published.package // .published.repo // "")
+    ] | join("\u001f")
   ' "$CONFIG" 2>/dev/null
 }
 
@@ -783,7 +770,7 @@ record_write() {
 
 action_check() {
   local name command_name args_joined announce announce_args repo remote branch
-  local line now source package problem
+  local line now source package
 
   [ -f "$CONFIG" ] || return 0
 
@@ -800,16 +787,12 @@ action_check() {
     emit "sweep budget ${BUDGET_CUT_FROM}s cut to ${BUDGET_SECS}s to stay inside the watcher check timeout of ${CHECK_TIMEOUT}s"
   fi
 
-  if ! config_validate check; then
+  if ! config_validate; then
     emit "watched tool registry: $CONFIG_PROBLEM"
   else
-    while IFS=$FIELD_SEP read -r name command_name args_joined announce announce_args repo remote branch source package problem; do
+    while IFS=$FIELD_SEP read -r name command_name args_joined announce announce_args repo remote branch source package; do
       [ -n "$name" ] || continue
       budget_allows "$name" || break
-      if [ -n "$problem" ]; then
-        emit "$name check failed: $problem"
-        continue
-      fi
       COMMAND_VERSION=
       [ -z "$command_name" ] || command_findings "$name" "$command_name" "$args_joined" "$announce" "$announce_args"
       [ -z "$source" ] || published_findings "$name" "$source" "$package" "$COMMAND_VERSION"

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -546,7 +546,7 @@ Adding, removing, or changing a watched tool is an edit to this file and needs n
 This file is not inherited by secondmate homes, so each home watches the tools it actually depends on.
 
 `FM_TOOL_UPDATE_INTERVAL` (default 900 seconds, `0` to probe on every run) sets how often probes actually run, `FM_TOOL_UPDATE_PROBE_SECS` (default 5) bounds one probe, and `FM_TOOL_UPDATE_BUDGET_SECS` (default 20) bounds a whole sweep.
-A sweep that skips work because its budget runs out reports the incomplete check and leaves the previous complete report record unchanged, so the unfinished sweep is retried.
+A sweep that skips work because its budget runs out records the partial findings, including the incomplete check, and waits until the next configured interval before probing again.
 A sweep that completes its last probe after the deadline still records the completed result and cadence epoch.
 The sweep must finish inside `FM_CHECK_TIMEOUT` (default 30), because a run the watcher kills prints nothing and records nothing and would then repeat that silence on every poll.
 So a budget larger than that timeout allows is cut down to what fits instead of being refused, and the cut is reported in the report line.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -526,7 +526,7 @@ A `published` object selects one public release source:
 
 `published` accepts only the fields shown for its source, and requires a package name or `owner/repo`, without a URL, query, or credentials.
 It compares that source with the version from the command that `PATH` resolves, and reports an update only when the published version is numerically newer.
-The installed version is the first dotted number in the command output, so `0.1.49`, `v0.8.2`, and `herdr 0.8.2` work.
+The installed version is the first dotted number in the output of a version command that exits successfully, so `0.1.49`, `v0.8.2`, and `herdr 0.8.2` work.
 The published version must be a dotted numeric version with an optional leading `v`; other formats, including prerelease suffixes, produce a check failure.
 Components are compared numerically, with leading zeroes and missing trailing zero components ignored.
 These queries use `curl` and the existing `jq` parser, without an npm installation or a GitHub login; `curl` is required only for a `published` probe.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -546,7 +546,8 @@ Adding, removing, or changing a watched tool is an edit to this file and needs n
 This file is not inherited by secondmate homes, so each home watches the tools it actually depends on.
 
 `FM_TOOL_UPDATE_INTERVAL` (default 900 seconds, `0` to probe on every run) sets how often probes actually run, `FM_TOOL_UPDATE_PROBE_SECS` (default 5) bounds one probe, and `FM_TOOL_UPDATE_BUDGET_SECS` (default 20) bounds a whole sweep.
-A sweep that runs out of budget reports the incomplete check and leaves the previous complete report record unchanged, so the unfinished sweep is retried.
+A sweep that skips work because its budget runs out reports the incomplete check and leaves the previous complete report record unchanged, so the unfinished sweep is retried.
+A sweep that completes its last probe after the deadline still records the completed result and cadence epoch.
 The sweep must finish inside `FM_CHECK_TIMEOUT` (default 30), because a run the watcher kills prints nothing and records nothing and would then repeat that silence on every poll.
 So a budget larger than that timeout allows is cut down to what fits instead of being refused, and the cut is reported in the report line.
 A budget that is not a whole number from 1 to 120 is still refused outright.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -511,7 +511,7 @@ This section is the single owner of the canonical schema.
 }
 ```
 
-Each entry needs a unique non-empty `name` and at least one probe: `command`, `git`, or `published`.
+Each entry needs a unique non-empty `name` and at least one of `command` or `git`; an entry may carry both.
 A `published` probe also requires `command` to supply the installed version; it can accompany `git` and an announcement on the same entry.
 A `command` entry gives the `PATH` comparison above, and adding `announce_pattern` also reports the tool's own update announcement, which is how a tool that already reports its own updates is read rather than reimplemented.
 A tool does not always announce a new release on the command that prints its version: `no-mistakes --version` prints only the version, while its other commands carry the announcement.
@@ -533,7 +533,7 @@ These queries use `curl` and the existing `jq` parser, without an npm installati
 The HTTP reads ignore curl configuration and send no credentials, follow no redirects, and fail within the probe bound on an unavailable source, HTTP error, or unreadable version.
 All probe kinds are read-only and bounded, and a probe that cannot answer is reported as a check failure rather than assumed current.
 Malformed configuration stops `arm` with a diagnostic.
-During a sweep, a malformed tool entry is reported as that tool's check failure while the other entries are checked; an unreadable registry or invalid top-level structure is reported as a registry failure.
+During a sweep, malformed configuration is reported as a registry failure and no tools are checked.
 See [`docs/examples/watched-tools.json`](examples/watched-tools.json) for a starting point to copy into local `config/watched-tools.json`.
 
 Arm the check once per home with `bin/fm-tool-update-check.sh arm`.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -497,6 +497,10 @@ This section is the single owner of the canonical schema.
       "version_args": ["<optional args that make it print its version, default --version>"],
       "announce_pattern": "<optional extended regex matching the tool's own update announcement>",
       "announce_args": ["<optional args for the command that carries that announcement, default version_args>"],
+      "published": {
+        "source": "npm",
+        "package": "<npm package name, including an optional @scope/>"
+      },
       "git": {
         "repo": "<optional absolute path to a local clone>",
         "remote": "<optional remote name, default origin>",
@@ -507,14 +511,29 @@ This section is the single owner of the canonical schema.
 }
 ```
 
-Each entry needs a `name` and at least one of `command` or `git`; an entry may carry both.
+Each entry needs a unique non-empty `name` and at least one probe: `command`, `git`, or `published`.
+A `published` probe also requires `command` to supply the installed version; it can accompany `git` and an announcement on the same entry.
 A `command` entry gives the `PATH` comparison above, and adding `announce_pattern` also reports the tool's own update announcement, which is how a tool that already reports its own updates is read rather than reimplemented.
 A tool does not always announce a new release on the command that prints its version: `no-mistakes --version` prints only the version, while its other commands carry the announcement.
 `announce_args` names the command to search for the announcement in that case, and it is asked only of the copy `PATH` resolves; without it the version probe's own output is searched.
 An `announce_pattern` that is not a usable extended regular expression stops `arm`, and during a sweep it is reported as that one tool's own check failure so one broken pattern never stops the other watched tools from being checked.
 A `git` entry reports how many commits the local clone is behind its remote branch, and stays silent when the clone is current or ahead.
 An omitted `branch` uses the remote's default branch, taken from the clone's own record of it and otherwise asked of the remote directly, so a `--single-branch` clone still resolves.
-Both probe kinds are read-only and bounded, and a probe that cannot answer is reported as a check failure rather than assumed current.
+A `published` object selects one public release source:
+
+- `{"source":"npm","package":"tasks-axi"}` reads the public npm registry version selected by the package's `latest` dist-tag; scoped names such as `@scope/tool` are supported.
+- `{"source":"github","repo":"herdrdev/herdr"}` reads the `tag_name` of GitHub's latest published release for that public repository; draft releases, prereleases, and tags without a release are not selected.
+
+`published` accepts only the fields shown for its source, and requires a package name or `owner/repo`, without a URL, query, or credentials.
+It compares that source with the version from the command that `PATH` resolves, and reports an update only when the published version is numerically newer.
+The installed version is the first dotted number in the command output, so `0.1.49`, `v0.8.2`, and `herdr 0.8.2` work.
+The published version must be a dotted numeric version with an optional leading `v`; other formats, including prerelease suffixes, produce a check failure.
+Components are compared numerically, with leading zeroes and missing trailing zero components ignored.
+These queries use `curl` and the existing `jq` parser, without an npm installation or a GitHub login; `curl` is required only for a `published` probe.
+The HTTP reads ignore curl configuration and send no credentials, follow no redirects, and fail within the probe bound on an unavailable source, HTTP error, or unreadable version.
+All probe kinds are read-only and bounded, and a probe that cannot answer is reported as a check failure rather than assumed current.
+Malformed configuration stops `arm` with a diagnostic.
+During a sweep, a malformed tool entry is reported as that tool's check failure while the other entries are checked; an unreadable registry or invalid top-level structure is reported as a registry failure.
 See [`docs/examples/watched-tools.json`](examples/watched-tools.json) for a starting point to copy into local `config/watched-tools.json`.
 
 Arm the check once per home with `bin/fm-tool-update-check.sh arm`.
@@ -527,7 +546,7 @@ Adding, removing, or changing a watched tool is an edit to this file and needs n
 This file is not inherited by secondmate homes, so each home watches the tools it actually depends on.
 
 `FM_TOOL_UPDATE_INTERVAL` (default 900 seconds, `0` to probe on every run) sets how often probes actually run, `FM_TOOL_UPDATE_PROBE_SECS` (default 5) bounds one probe, and `FM_TOOL_UPDATE_BUDGET_SECS` (default 20) bounds a whole sweep.
-A sweep that runs out of budget says which tool it did not reach rather than reporting the rest as current.
+A sweep that runs out of budget reports the incomplete check and leaves the previous complete report record unchanged, so the unfinished sweep is retried.
 The sweep must finish inside `FM_CHECK_TIMEOUT` (default 30), because a run the watcher kills prints nothing and records nothing and would then repeat that silence on every poll.
 So a budget larger than that timeout allows is cut down to what fits instead of being refused, and the cut is reported in the report line.
 A budget that is not a whole number from 1 to 120 is still refused outright.

--- a/docs/examples/watched-tools.json
+++ b/docs/examples/watched-tools.json
@@ -11,7 +11,27 @@
     {
       "name": "herdr",
       "command": "herdr",
-      "version_args": ["--version"]
+      "version_args": ["--version"],
+      "published": {
+        "source": "github",
+        "repo": "herdrdev/herdr"
+      }
+    },
+    {
+      "name": "tasks-axi",
+      "command": "tasks-axi",
+      "published": {
+        "source": "npm",
+        "package": "tasks-axi"
+      }
+    },
+    {
+      "name": "gnhf",
+      "command": "gnhf",
+      "published": {
+        "source": "npm",
+        "package": "gnhf"
+      }
     },
     {
       "name": "no-mistakes",

--- a/tests/fm-tool-update-check.test.sh
+++ b/tests/fm-tool-update-check.test.sh
@@ -615,6 +615,242 @@ SH
   pass "a stalled repository probe is reported as no answer, not as not a repository"
 }
 
+# --- published release sources ----------------------------------------------
+
+# Fake only the HTTP transport; the executable still validates the registry,
+# chooses the endpoint, parses real response shapes, and compares command output.
+make_release_transport() {
+  local dir=$1
+  mkdir -p "$dir"
+  cat > "$dir/curl" <<'SH'
+#!/usr/bin/env bash
+[ "$1" = -q ] || exit 90
+printf '%s\n' "$@" >> "$FM_RELEASE_LOG"
+# A query must not consume stdin even if its caller has input waiting.
+if IFS= read -r input; then exit 91; fi
+if [ "${FM_RELEASE_SLEEP:-0}" != 0 ]; then sleep "$FM_RELEASE_SLEEP"; fi
+cat "$FM_RELEASE_RESPONSE"
+exit "${FM_RELEASE_STATUS:-0}"
+SH
+  chmod 0755 "$dir/curl"
+}
+
+write_release_config() {
+  local home=$1 name=$2 source=$3 package=$4
+  jq -n --arg name "$name" --arg command "$TOOL" --arg source "$source" --arg package "$package" '
+    {tools: [{name: $name, command: $command, published:
+      ({source: $source} + (if $source == "npm" then {package: $package} else {repo: $package} end))}]}
+  ' > "$home/config/watched-tools.json"
+}
+
+test_published_versions_for_the_three_motivating_tools() {
+  local name source package current older ahead field prefix home dir out installed
+  while read -r name source package current older ahead field prefix; do
+    home=$(make_home "release-$name")
+    dir="$home/bin"
+    out="$home/out.txt"
+    make_release_transport "$dir"
+    write_release_config "$home" "$name" "$source" "$package"
+    jq -n --arg field "$field" --arg version "$prefix$current" '{($field): $version}' > "$home/response"
+    for installed in "$older" "$current" "$ahead"; do
+      case "$name" in
+        herdr) make_copy "$dir" "$TOOL" "herdr $installed" ;;
+        tasks-axi) make_copy "$dir" "$TOOL" "v$installed" ;;
+        gnhf) make_copy "$dir" "$TOOL" "$installed" ;;
+      esac
+      run_check "$home" "$(fixture_path "$dir")" "$out" FM_RELEASE_RESPONSE="$home/response" FM_RELEASE_LOG="$home/http.log"
+      if [ "$installed" = "$older" ]; then
+        assert_contains "$(cat "$out")" "$name update available: installed $older, published $current" "the published newer $name was missed"
+      else
+        [ ! -s "$out" ] || fail "$name installed $installed against published $current was not silent: $(cat "$out")"
+      fi
+    done
+    case "$source" in
+      github) assert_grep "https://api.github.com/repos/$package/releases/latest" "$home/http.log" "wrong GitHub source" ;;
+      npm) assert_grep "https://registry.npmjs.org/$package/latest" "$home/http.log" "wrong npm source" ;;
+    esac
+    assert_grep --max-time "$home/http.log" "HTTP query had no internal time bound"
+    assert_grep --fail "$home/http.log" "HTTP errors were not refused"
+  done <<'EOF'
+herdr github herdrdev/herdr 0.8.2 0.8.0 0.9.0 tag_name v
+tasks-axi npm tasks-axi 0.2.5 0.2.4 0.3.0 version v
+gnhf npm gnhf 0.1.49 0.1.47 0.2.0 version
+EOF
+  pass "published herdr, tasks-axi and gnhf report older fixtures and stay silent when equal or ahead"
+}
+
+test_published_failures_do_not_blind_other_tools() {
+  local home dir out response status
+  home=$(make_home release-failures)
+  dir="$home/bin"
+  out="$home/out.txt"
+  make_release_transport "$dir"
+  make_copy "$dir" "$TOOL" 'herdr 0.8.0'
+  write_release_config "$home" herdr github herdrdev/herdr
+  jq '.tools += [{name:"other",command:"fm-absent-release-fixture"}]' "$home/config/watched-tools.json" > "$home/config-next"
+  mv "$home/config-next" "$home/config/watched-tools.json"
+  for response in 'not json 0.9.0' '{}' '{"tag_name":7}' '{"message":"error 0.9.0"}' '{"tag_name":"unknown 0.9.0"}' '{"tag_name":"v0.9.0-rc.1"}' '{"tag_name":"v0.9.0"} {}'; do
+    printf '%s\n' "$response" > "$home/response"
+    rm -f "$home/state/.tool-updates"
+    run_check "$home" "$(fixture_path "$dir")" "$out" FM_RELEASE_RESPONSE="$home/response" FM_RELEASE_LOG="$home/http.log"
+    assert_contains "$(cat "$out")" 'herdr check failed: published source' "bad response was treated as current: $response"
+    assert_contains "$(cat "$out")" 'other check failed:' "a bad source stopped the other tools"
+    assert_not_contains "$(cat "$out")" 'update available' "a malformed version was treated as an update"
+  done
+  # Even a partial response that carries a newer version is no answer when the
+  # HTTP request failed (connection failure, HTTP error, or curl timeout).
+  printf '%s\n' '{"tag_name":"v0.9.0"}' > "$home/response"
+  for status in 7 22 28; do
+    run_check "$home" "$(fixture_path "$dir")" "$out" FM_RELEASE_RESPONSE="$home/response" FM_RELEASE_LOG="$home/http.log" FM_RELEASE_STATUS="$status"
+    assert_contains "$(cat "$out")" "could not be reached or read (exit $status)" "HTTP failure was not reported"
+    assert_contains "$(cat "$out")" 'other check failed:' "HTTP failure stopped the sweep"
+    assert_not_contains "$(cat "$out")" 'update available' "failed HTTP request leaked a version"
+  done
+  pass "unreachable and unparseable published sources fail for their own tool and the sweep continues"
+}
+
+test_published_probe_bounds_and_incomplete_record() {
+  local home dir out start elapsed record real_jq
+  home=$(make_home release-bounds)
+  dir="$home/bin"
+  out="$home/out.txt"
+  make_release_transport "$dir"
+  make_copy "$dir" "$TOOL" '0.8.0'
+  write_release_config "$home" herdr github herdrdev/herdr
+  printf '%s\n' '{"tag_name":"v0.8.2"}' > "$home/response"
+  start=$(date +%s)
+  run_check "$home" "$(fixture_path "$dir")" "$out" FM_RELEASE_RESPONSE="$home/response" FM_RELEASE_LOG="$home/http.log" FM_RELEASE_SLEEP=20 FM_TOOL_UPDATE_PROBE_SECS=1
+  elapsed=$(($(date +%s) - start))
+  [ "$elapsed" -lt 10 ] || fail "published probe escaped its bound: ${elapsed}s"
+  assert_contains "$(cat "$out")" 'could not be reached or read (exit 124)' "hung HTTP source was not a check failure"
+  record=$(cat "$home/state/.tool-updates")
+  # Spend the whole sweep budget, leaving a later tool unchecked.
+  jq '.tools += [{name:"unreached",command:"fm-absent-release-fixture"}]' "$home/config/watched-tools.json" > "$home/config-next"
+  mv "$home/config-next" "$home/config/watched-tools.json"
+  run_check "$home" "$(fixture_path "$dir")" "$out" FM_RELEASE_RESPONSE="$home/response" FM_RELEASE_LOG="$home/http.log" FM_RELEASE_SLEEP=20 FM_TOOL_UPDATE_PROBE_SECS=5 FM_TOOL_UPDATE_BUDGET_SECS=2
+  assert_contains "$(cat "$out")" 'check incomplete:' "incomplete sweep was silent"
+  [ "$(cat "$home/state/.tool-updates")" = "$record" ] || fail "incomplete sweep replaced the complete report record"
+  rm "$home/state/.tool-updates"
+  run_check "$home" "$(fixture_path "$dir")" "$out" FM_RELEASE_RESPONSE="$home/response" FM_RELEASE_LOG="$home/http.log" FM_RELEASE_SLEEP=20 FM_TOOL_UPDATE_PROBE_SECS=5 FM_TOOL_UPDATE_BUDGET_SECS=2
+  assert_absent "$home/state/.tool-updates" "incomplete sweep created a report record"
+  # A stalled parser must have the same bound as the HTTP read. Registry parsing
+  # still goes through the real jq, so this only stalls response parsing.
+  real_jq=$(command -v jq)
+  cat > "$dir/jq" <<SH
+#!/usr/bin/env bash
+if [ "\$1" = -ser ]; then sleep 20; fi
+exec '$real_jq' "\$@"
+SH
+  chmod 0755 "$dir/jq"
+  start=$(date +%s)
+  run_check "$home" "$(fixture_path "$dir")" "$out" FM_RELEASE_RESPONSE="$home/response" FM_RELEASE_LOG="$home/http.log" FM_TOOL_UPDATE_PROBE_SECS=1
+  elapsed=$(($(date +%s) - start))
+  [ "$elapsed" -lt 10 ] || fail "response parser escaped the probe bound: ${elapsed}s"
+  assert_contains "$(cat "$out")" 'could not be reached or read (exit 124)' "stalled parser was not bounded"
+  pass "published probes obey their bound and incomplete sweeps leave no record"
+}
+
+test_malformed_published_config_is_refused_and_isolated() {
+  local home dir out entry status
+  home=$(make_home release-invalid)
+  dir="$home/bin"
+  out="$home/out.txt"
+  make_copy "$dir" "$TOOL" '0.8.0'
+  while IFS= read -r entry; do
+    write_config "$home" "{\"tools\":[$entry,{\"name\":\"other\",\"command\":\"fm-absent-release-fixture\"}]}"
+    status=0
+    FM_HOME="$home" "$CHECK" arm > "$out" 2>&1 || status=$?
+    expect_code 1 "$status" "arm with invalid entry $entry"
+    [ -s "$out" ] || fail "arm refused invalid entry without a diagnostic"
+    assert_absent "$home/state/tool-updates.check.sh" "invalid entry armed the watcher"
+    rm -f "$home/state/.tool-updates"
+    run_check "$home" "$(fixture_path "$dir")" "$out"
+    assert_contains "$(cat "$out")" 'check failed:' "malformed entry was ignored"
+    assert_contains "$(cat "$out")" 'other check failed:' "malformed entry prevented checking the next tool"
+  done <<'EOF'
+{"name":"bad","command":"herdr-fixture","published":null}
+{"name":"bad","published":{"source":"npm","package":"gnhf"}}
+{"name":"bad","command":"herdr-fixture","published":{"source":"unknown"}}
+{"name":"bad","command":"herdr-fixture","published":{"source":"npm","package":"../gnhf"}}
+{"name":"bad","command":"herdr-fixture","published":{"source":"npm","package":3}}
+{"name":"bad","command":"herdr-fixture","published":{"source":"github","repo":"https://github.com/herdrdev/herdr"}}
+{"name":"bad","command":"herdr-fixture","published":{"source":"github","repo":"herdrdev/herdr","tag":"v0.8.2"}}
+{"name":"bad","command":"herdr-fixture","published":{"source":"npm","package":"gnhf","repo":"x/y"}}
+{"command":"herdr-fixture"}
+{"name":"bad"}
+{"name":"bad","command":"bad command"}
+{"name":"other","command":"herdr-fixture"}
+42
+EOF
+  pass "arm refuses malformed entries and a sweep isolates them from other tools"
+}
+
+test_published_dedupe_and_composition() {
+  local home dir fresh out path
+  home=$(make_home release-compose)
+  dir="$home/bin"
+  fresh="$home/fresh"
+  out="$home/out.txt"
+  make_release_transport "$dir"
+  make_copy "$dir" "$TOOL" 'herdr 0.8.0 (update to 0.8.2)'
+  make_copy "$fresh" "$TOOL" 'herdr 0.8.2'
+  write_release_config "$home" herdr npm '@scope/tool'
+  jq '.tools[0] += {announce_pattern:"update to [0-9.]+",git:{repo:"/fm-absent-release-fixture"}}' "$home/config/watched-tools.json" > "$home/config-next"
+  mv "$home/config-next" "$home/config/watched-tools.json"
+  printf '%s\n' '{"version":"0.8.2"}' > "$home/response"
+  path=$(fixture_path "$dir:$fresh")
+  run_check "$home" "$path" "$out" FM_RELEASE_RESPONSE="$home/response" FM_RELEASE_LOG="$home/http.log"
+  assert_contains "$(cat "$out")" 'update not in effect:' "published source replaced PATH skew"
+  assert_contains "$(cat "$out")" 'update available: update to 0.8.2' "published source replaced the announcement"
+  assert_contains "$(cat "$out")" 'update available: installed 0.8.0, published 0.8.2' "published source did not compare the resolved copy"
+  assert_contains "$(cat "$out")" 'is not a directory' "published source replaced the git probe"
+  assert_grep 'https://registry.npmjs.org/%40scope%2Ftool/latest' "$home/http.log" "scoped npm package was not encoded"
+  run_check "$home" "$path" "$out" FM_RELEASE_RESPONSE="$home/response" FM_RELEASE_LOG="$home/http.log"
+  [ ! -s "$out" ] || fail "same published condition was reported twice"
+  printf '%s\n' '{"version":"0.8.3"}' > "$home/response"
+  run_check "$home" "$path" "$out" FM_RELEASE_RESPONSE="$home/response" FM_RELEASE_LOG="$home/http.log"
+  assert_contains "$(cat "$out")" 'published 0.8.3' "changed published update was suppressed"
+  printf '%s\n' '{"version":"0.8.0"}' > "$home/response"
+  run_check "$home" "$path" "$out" FM_RELEASE_RESPONSE="$home/response" FM_RELEASE_LOG="$home/http.log"
+  assert_not_contains "$(cat "$out")" 'published 0.8.0' "current source reported an update"
+  printf '%s\n' '{"version":"0.8.3"}' > "$home/response"
+  run_check "$home" "$path" "$out" FM_RELEASE_RESPONSE="$home/response" FM_RELEASE_LOG="$home/http.log"
+  assert_contains "$(cat "$out")" 'published 0.8.3' "returning published update was suppressed"
+  pass "published sources compose with PATH skew, announcements and git, with changed and returning update dedupe"
+}
+
+test_published_numeric_comparison_and_failed_installed_command() {
+  local home dir out installed published verdict
+  home=$(make_home release-numeric)
+  dir="$home/bin"
+  out="$home/out.txt"
+  make_release_transport "$dir"
+  write_release_config "$home" gnhf npm gnhf
+  while read -r installed published verdict; do
+    make_copy "$dir" "$TOOL" "$installed"
+    printf '{"version":"%s"}\n' "$published" > "$home/response"
+    run_check "$home" "$(fixture_path "$dir")" "$out" FM_RELEASE_RESPONSE="$home/response" FM_RELEASE_LOG="$home/http.log"
+    if [ "$verdict" = newer ]; then
+      assert_contains "$(cat "$out")" 'gnhf update available:' "numeric comparison missed $published > $installed"
+    else
+      [ ! -s "$out" ] || fail "numeric comparison falsely reported $published > $installed"
+    fi
+  done <<'EOF'
+0.9.0 0.10.0 newer
+0.10.0 0.9.0 silent
+v000.010.0 0.10 silent
+0.10.0 0.10.0.1 newer
+0.10.0 0.99999999999999999999999999 newer
+0.99999999999999999999999999 0.10.0 silent
+EOF
+  # Failure output can contain a version, but is not a usable installed answer.
+  printf '#!/bin/sh\nprintf "0.8.0\\n"\nexit 1\n' > "$dir/$TOOL"
+  run_check "$home" "$(fixture_path "$dir")" "$out" FM_RELEASE_RESPONSE="$home/response" FM_RELEASE_LOG="$home/http.log"
+  assert_contains "$(cat "$out")" 'did not report a version' "failed installed command was treated as usable"
+  assert_not_contains "$(cat "$out")" 'update available' "failed installed command supplied a comparison baseline"
+  pass "published versions compare numeric components without overflow and require a successful installed answer"
+}
+
 # --- registry and reporting contract ----------------------------------------
 
 test_absent_registry_is_silent() {
@@ -638,7 +874,7 @@ test_malformed_registry_is_reported_not_ignored() {
   printf '%s\n' '{"tools":[{"name":"herdr"}]}' > "$home/config/watched-tools.json"
   rm -f "$home/state/.tool-updates"
   run_check "$home" "$PATH" "$out"
-  assert_contains "$(cat "$out")" "tool herdr needs command, git, or both" "a tool entry with no update source was accepted"
+  assert_contains "$(cat "$out")" "tool herdr needs command, git, or published" "a tool entry with no update source was accepted"
 
   printf '%s\n' '{"tools":[{"name":"herdr","command":"herdr; rm -rf /"}]}' > "$home/config/watched-tools.json"
   rm -f "$home/state/.tool-updates"
@@ -1004,6 +1240,13 @@ test_armed_check_wakes_the_watcher_with_the_skew_report() {
   assert_contains "$(cat "$out")" "tool updates: herdr update not in effect" "the wake did not carry the PATH skew report"
   pass "the armed check reaches the watcher as an ordinary check wake"
 }
+
+test_published_versions_for_the_three_motivating_tools
+test_published_failures_do_not_blind_other_tools
+test_published_probe_bounds_and_incomplete_record
+test_malformed_published_config_is_refused_and_isolated
+test_published_dedupe_and_composition
+test_published_numeric_comparison_and_failed_installed_command
 
 test_path_skew_is_reported_from_every_copy
 test_newest_copy_first_on_path_is_silent

--- a/tests/fm-tool-update-check.test.sh
+++ b/tests/fm-tool-update-check.test.sh
@@ -347,7 +347,7 @@ SH
   run_check "$home" "$(fixture_path "$dir")" "$out" FM_TOOL_UPDATE_BUDGET_SECS=2
   report=$(cat "$out")
   assert_contains "$report" "no-mistakes check failed: the time budget ran out before the update announcement was checked" "an announcement source that was never asked was not reported"
-  assert_absent "$home/state/.tool-updates" "an unchecked announcement produced a complete record"
+  assert_grep 'reported=' "$home/state/.tool-updates" "an unchecked announcement did not record its finding"
   pass "an announcement source the budget could not reach is reported, not read as current"
 }
 
@@ -711,8 +711,8 @@ test_published_failures_do_not_blind_other_tools() {
   pass "unreachable and unparseable published sources fail for their own tool and the sweep continues"
 }
 
-test_published_probe_bounds_and_incomplete_record() {
-  local home dir out start elapsed record real_jq
+test_published_probe_bounds_and_report_record() {
+  local home dir out start elapsed real_jq
   home=$(make_home release-bounds)
   dir="$home/bin"
   out="$home/out.txt"
@@ -725,16 +725,15 @@ test_published_probe_bounds_and_incomplete_record() {
   elapsed=$(($(date +%s) - start))
   [ "$elapsed" -lt 10 ] || fail "published probe escaped its bound: ${elapsed}s"
   assert_contains "$(cat "$out")" 'could not be reached or read (exit 124)' "hung HTTP source was not a check failure"
-  record=$(cat "$home/state/.tool-updates")
   # Spend the whole sweep budget, leaving a later tool unchecked.
   jq '.tools += [{name:"unreached",command:"fm-absent-release-fixture"}]' "$home/config/watched-tools.json" > "$home/config-next"
   mv "$home/config-next" "$home/config/watched-tools.json"
   run_check "$home" "$(fixture_path "$dir")" "$out" FM_RELEASE_RESPONSE="$home/response" FM_RELEASE_LOG="$home/http.log" FM_RELEASE_SLEEP=20 FM_TOOL_UPDATE_PROBE_SECS=5 FM_TOOL_UPDATE_BUDGET_SECS=2
   assert_contains "$(cat "$out")" 'check incomplete:' "incomplete sweep was silent"
-  [ "$(cat "$home/state/.tool-updates")" = "$record" ] || fail "incomplete sweep replaced the complete report record"
+  assert_grep 'check incomplete:' "$home/state/.tool-updates" "incomplete sweep did not record its finding"
   rm "$home/state/.tool-updates"
   run_check "$home" "$(fixture_path "$dir")" "$out" FM_RELEASE_RESPONSE="$home/response" FM_RELEASE_LOG="$home/http.log" FM_RELEASE_SLEEP=20 FM_TOOL_UPDATE_PROBE_SECS=5 FM_TOOL_UPDATE_BUDGET_SECS=2
-  assert_absent "$home/state/.tool-updates" "incomplete sweep created a report record"
+  assert_grep 'reported=' "$home/state/.tool-updates" "incomplete sweep did not create a report record"
   # A stalled parser must have the same bound as the HTTP read. Registry parsing
   # still goes through the real jq, so this only stalls response parsing.
   real_jq=$(command -v jq)
@@ -749,7 +748,7 @@ SH
   elapsed=$(($(date +%s) - start))
   [ "$elapsed" -lt 10 ] || fail "response parser escaped the probe bound: ${elapsed}s"
   assert_contains "$(cat "$out")" 'could not be reached or read (exit 124)' "stalled parser was not bounded"
-  pass "published probes obey their bound and incomplete sweeps leave no record"
+  pass "published probes obey their bound and incomplete sweeps record their findings"
 }
 
 # Advance the check's clock only when a fixture probe finishes. This pins the
@@ -800,19 +799,27 @@ test_completed_late_sweep_records_and_deduplicates() {
   [ "$(wc -l < "$home/http.log")" = "$queries" ] || fail "late sweep cadence epoch did not suppress probes"
 
   # Counterfactual: the same late probe with another configured tool after it
-  # leaves work unchecked. That partial sweep must preserve the previous record.
-  cp "$home/state/.tool-updates" "$home/previous-record"
+  # leaves work unchecked.
   jq '.tools += [{name:"unreached",command:"fm-unreached-budget-fixture"}]' "$home/config/watched-tools.json" > "$home/next-config"
   mv "$home/next-config" "$home/config/watched-tools.json"
   printf '100\n' > "$clock"
   run_check "$home" "$path" "$out" FM_RELEASE_RESPONSE="$home/response" FM_RELEASE_LOG="$home/http.log" FM_RELEASE_CLOCK="$clock" FM_TOOL_UPDATE_BUDGET_SECS=5 FM_TOOL_UPDATE_NOW=1700001000
   assert_contains "$(cat "$out")" 'check incomplete: the time budget ran out before unreached' "an unreached tool was treated as checked"
-  cmp -s "$home/previous-record" "$home/state/.tool-updates" || fail "partial sweep replaced the complete record"
+  assert_grep 'epoch=1700001000' "$home/state/.tool-updates" "partial sweep discarded its cadence epoch"
+  assert_grep 'check incomplete:' "$home/state/.tool-updates" "partial sweep discarded its finding"
+  queries=$(wc -l < "$home/http.log")
+  status=0
+  env FM_HOME="$home" PATH="$path" FM_CHECK_TIMEOUT=30 FM_TOOL_UPDATE_INTERVAL=900 FM_TOOL_UPDATE_NOW=1700001300 \
+    FM_TOOL_UPDATE_BUDGET_SECS=5 FM_RELEASE_RESPONSE="$home/response" FM_RELEASE_LOG="$home/http.log" FM_RELEASE_CLOCK="$clock" \
+    "$CHECK" > "$out" 2>&1 || status=$?
+  expect_code 0 "$status" "partial sweep cadence poll"
+  [ ! -s "$out" ] || fail "partial sweep cadence poll reported again"
+  [ "$(wc -l < "$home/http.log")" = "$queries" ] || fail "partial sweep cadence epoch did not suppress probes"
   rm "$home/state/.tool-updates"
   printf '100\n' > "$clock"
   run_check "$home" "$path" "$out" FM_RELEASE_RESPONSE="$home/response" FM_RELEASE_LOG="$home/http.log" FM_RELEASE_CLOCK="$clock" FM_TOOL_UPDATE_BUDGET_SECS=5
-  assert_absent "$home/state/.tool-updates" "partial sweep created a record"
-  pass "a last probe that finishes late records once, while an unreached later tool prevents recording"
+  assert_grep 'reported=' "$home/state/.tool-updates" "partial sweep did not create a record"
+  pass "complete and partial late sweeps record findings and retain cadence"
 }
 
 test_unstarted_published_probe_reports_budget_once() {
@@ -834,7 +841,7 @@ SH
   [ "$(cat "$out")" = 'tool updates: check incomplete: the time budget ran out before herdr published source' ] \
     || fail "an unstarted published probe reported its budget failure more than once: $(cat "$out")"
   assert_absent "$home/http.log" "published source was asked after its budget was gone"
-  assert_absent "$home/state/.tool-updates" "unstarted published probe produced a complete record"
+  assert_grep 'reported=' "$home/state/.tool-updates" "unstarted published probe did not record its finding"
 
   # A skipped PATH copy is also unfinished work, even within the last tool.
   fresh="$home/fresh"
@@ -843,8 +850,8 @@ SH
   printf '100\n' > "$clock"
   run_check "$home" "$(fixture_path "$dir:$fresh")" "$out" FM_TOOL_UPDATE_BUDGET_SECS=5
   assert_contains "$(cat "$out")" 'the time budget ran out before every copy answered' "skipped PATH copy was treated as checked"
-  assert_absent "$home/state/.tool-updates" "skipped PATH copy produced a complete record"
-  pass "a skipped published probe reports its budget failure once and skipped probes leave no record"
+  assert_grep 'reported=' "$home/state/.tool-updates" "skipped PATH copy did not record its finding"
+  pass "a skipped published probe reports its budget failure once and skipped probes record their findings"
 }
 
 test_malformed_published_config_refuses_whole_registry() {
@@ -1341,7 +1348,7 @@ test_armed_check_wakes_the_watcher_with_the_skew_report() {
 
 test_published_versions_for_the_three_motivating_tools
 test_published_failures_do_not_blind_other_tools
-test_published_probe_bounds_and_incomplete_record
+test_published_probe_bounds_and_report_record
 test_completed_late_sweep_records_and_deduplicates
 test_unstarted_published_probe_reports_budget_once
 test_malformed_published_config_refuses_whole_registry

--- a/tests/fm-tool-update-check.test.sh
+++ b/tests/fm-tool-update-check.test.sh
@@ -347,6 +347,7 @@ SH
   run_check "$home" "$(fixture_path "$dir")" "$out" FM_TOOL_UPDATE_BUDGET_SECS=2
   report=$(cat "$out")
   assert_contains "$report" "no-mistakes check failed: the time budget ran out before the update announcement was checked" "an announcement source that was never asked was not reported"
+  assert_absent "$home/state/.tool-updates" "an unchecked announcement produced a complete record"
   pass "an announcement source the budget could not reach is reported, not read as current"
 }
 
@@ -629,6 +630,7 @@ printf '%s\n' "$@" >> "$FM_RELEASE_LOG"
 # A query must not consume stdin even if its caller has input waiting.
 if IFS= read -r input; then exit 91; fi
 if [ "${FM_RELEASE_SLEEP:-0}" != 0 ]; then sleep "$FM_RELEASE_SLEEP"; fi
+if [ -n "${FM_RELEASE_CLOCK:-}" ]; then printf '110\n' > "$FM_RELEASE_CLOCK"; fi
 cat "$FM_RELEASE_RESPONSE"
 exit "${FM_RELEASE_STATUS:-0}"
 SH
@@ -748,6 +750,101 @@ SH
   [ "$elapsed" -lt 10 ] || fail "response parser escaped the probe bound: ${elapsed}s"
   assert_contains "$(cat "$out")" 'could not be reached or read (exit 124)' "stalled parser was not bounded"
   pass "published probes obey their bound and incomplete sweeps leave no record"
+}
+
+# Advance the check's clock only when a fixture probe finishes. This pins the
+# deadline boundary without waiting for a wall-clock second or a real network.
+make_budget_clock() {
+  local dir=$1 clock=$2 real_date
+  real_date=$(command -v date)
+  mkdir -p "$dir"
+  printf '100\n' > "$clock"
+  cat > "$dir/date" <<SH
+#!/usr/bin/env bash
+if [ "\$1" = +%s ]; then cat '$clock'; else exec '$real_date' "\$@"; fi
+SH
+  chmod 0755 "$dir/date"
+}
+
+test_completed_late_sweep_records_and_deduplicates() {
+  local home dir out clock path status queries
+  home=$(make_home release-finish-late)
+  dir="$home/bin"
+  out="$home/out.txt"
+  clock="$home/clock"
+  make_budget_clock "$dir" "$clock"
+  make_release_transport "$dir"
+  make_copy "$dir" "$TOOL" 'herdr 0.8.0'
+  write_release_config "$home" herdr github herdrdev/herdr
+  printf '%s\n' '{"tag_name":"v0.8.2"}' > "$home/response"
+  path=$(fixture_path "$dir")
+
+  # Starts at 100 with deadline 105, returns a valid newer version at 110.
+  run_check "$home" "$path" "$out" FM_RELEASE_RESPONSE="$home/response" FM_RELEASE_LOG="$home/http.log" FM_RELEASE_CLOCK="$clock" FM_TOOL_UPDATE_BUDGET_SECS=5 FM_TOOL_UPDATE_NOW=1700000000
+  [ "$(cat "$clock")" = 110 ] || fail "the final probe did not cross the deadline"
+  assert_contains "$(cat "$out")" 'herdr update available:' "late completed sweep did not report its update"
+  assert_grep 'epoch=1700000000' "$home/state/.tool-updates" "late completed sweep discarded its cadence epoch"
+  assert_grep 'reported=herdr update available:' "$home/state/.tool-updates" "late completed sweep discarded its finding"
+
+  printf '100\n' > "$clock"
+  run_check "$home" "$path" "$out" FM_RELEASE_RESPONSE="$home/response" FM_RELEASE_LOG="$home/http.log" FM_RELEASE_CLOCK="$clock" FM_TOOL_UPDATE_BUDGET_SECS=5 FM_TOOL_UPDATE_NOW=1700000000
+  [ ! -s "$out" ] || fail "same completed late sweep reported its update twice"
+  queries=$(wc -l < "$home/http.log")
+  # A normal cadence-gated poll must not issue another HTTP query at all.
+  status=0
+  env FM_HOME="$home" PATH="$path" FM_CHECK_TIMEOUT=30 FM_TOOL_UPDATE_INTERVAL=900 FM_TOOL_UPDATE_NOW=1700000300 \
+    FM_TOOL_UPDATE_BUDGET_SECS=5 FM_RELEASE_RESPONSE="$home/response" FM_RELEASE_LOG="$home/http.log" FM_RELEASE_CLOCK="$clock" \
+    "$CHECK" > "$out" 2>&1 || status=$?
+  expect_code 0 "$status" "late sweep cadence poll"
+  [ ! -s "$out" ] || fail "late sweep cadence poll reported again"
+  [ "$(wc -l < "$home/http.log")" = "$queries" ] || fail "late sweep cadence epoch did not suppress probes"
+
+  # Counterfactual: the same late probe with another configured tool after it
+  # leaves work unchecked. That partial sweep must preserve the previous record.
+  cp "$home/state/.tool-updates" "$home/previous-record"
+  jq '.tools += [{name:"unreached",command:"fm-unreached-budget-fixture"}]' "$home/config/watched-tools.json" > "$home/next-config"
+  mv "$home/next-config" "$home/config/watched-tools.json"
+  printf '100\n' > "$clock"
+  run_check "$home" "$path" "$out" FM_RELEASE_RESPONSE="$home/response" FM_RELEASE_LOG="$home/http.log" FM_RELEASE_CLOCK="$clock" FM_TOOL_UPDATE_BUDGET_SECS=5 FM_TOOL_UPDATE_NOW=1700001000
+  assert_contains "$(cat "$out")" 'check incomplete: the time budget ran out before unreached' "an unreached tool was treated as checked"
+  cmp -s "$home/previous-record" "$home/state/.tool-updates" || fail "partial sweep replaced the complete record"
+  rm "$home/state/.tool-updates"
+  printf '100\n' > "$clock"
+  run_check "$home" "$path" "$out" FM_RELEASE_RESPONSE="$home/response" FM_RELEASE_LOG="$home/http.log" FM_RELEASE_CLOCK="$clock" FM_TOOL_UPDATE_BUDGET_SECS=5
+  assert_absent "$home/state/.tool-updates" "partial sweep created a record"
+  pass "a last probe that finishes late records once, while an unreached later tool prevents recording"
+}
+
+test_unstarted_published_probe_reports_budget_once() {
+  local home dir out clock fresh
+  home=$(make_home release-budget-once)
+  dir="$home/bin"
+  out="$home/out.txt"
+  clock="$home/clock"
+  make_budget_clock "$dir" "$clock"
+  make_release_transport "$dir"
+  cat > "$dir/$TOOL" <<SH
+#!/usr/bin/env bash
+printf '110\n' > '$clock'
+printf 'herdr 0.8.0\n'
+SH
+  chmod 0755 "$dir/$TOOL"
+  write_release_config "$home" herdr github herdrdev/herdr
+  run_check "$home" "$(fixture_path "$dir")" "$out" FM_RELEASE_LOG="$home/http.log" FM_TOOL_UPDATE_BUDGET_SECS=5
+  [ "$(cat "$out")" = 'tool updates: check incomplete: the time budget ran out before herdr published source' ] \
+    || fail "an unstarted published probe reported its budget failure more than once: $(cat "$out")"
+  assert_absent "$home/http.log" "published source was asked after its budget was gone"
+  assert_absent "$home/state/.tool-updates" "unstarted published probe produced a complete record"
+
+  # A skipped PATH copy is also unfinished work, even within the last tool.
+  fresh="$home/fresh"
+  make_copy "$fresh" "$TOOL" 'herdr 0.8.2'
+  write_config "$home" "{\"tools\":[{\"name\":\"herdr\",\"command\":\"$TOOL\"}]}"
+  printf '100\n' > "$clock"
+  run_check "$home" "$(fixture_path "$dir:$fresh")" "$out" FM_TOOL_UPDATE_BUDGET_SECS=5
+  assert_contains "$(cat "$out")" 'the time budget ran out before every copy answered' "skipped PATH copy was treated as checked"
+  assert_absent "$home/state/.tool-updates" "skipped PATH copy produced a complete record"
+  pass "a skipped published probe reports its budget failure once and skipped probes leave no record"
 }
 
 test_malformed_published_config_refuses_whole_registry() {
@@ -1245,6 +1342,8 @@ test_armed_check_wakes_the_watcher_with_the_skew_report() {
 test_published_versions_for_the_three_motivating_tools
 test_published_failures_do_not_blind_other_tools
 test_published_probe_bounds_and_incomplete_record
+test_completed_late_sweep_records_and_deduplicates
+test_unstarted_published_probe_reports_budget_once
 test_malformed_published_config_refuses_whole_registry
 test_published_dedupe_and_composition
 test_published_numeric_comparison_and_failed_installed_command

--- a/tests/fm-tool-update-check.test.sh
+++ b/tests/fm-tool-update-check.test.sh
@@ -750,14 +750,14 @@ SH
   pass "published probes obey their bound and incomplete sweeps leave no record"
 }
 
-test_malformed_published_config_is_refused_and_isolated() {
+test_malformed_published_config_refuses_whole_registry() {
   local home dir out entry status
   home=$(make_home release-invalid)
   dir="$home/bin"
   out="$home/out.txt"
-  make_copy "$dir" "$TOOL" '0.8.0'
+  make_counting_copy "$dir" "$TOOL" '0.8.0' "$home/probes"
   while IFS= read -r entry; do
-    write_config "$home" "{\"tools\":[$entry,{\"name\":\"other\",\"command\":\"fm-absent-release-fixture\"}]}"
+    write_config "$home" "{\"tools\":[{\"name\":\"other\",\"command\":\"$TOOL\"},$entry]}"
     status=0
     FM_HOME="$home" "$CHECK" arm > "$out" 2>&1 || status=$?
     expect_code 1 "$status" "arm with invalid entry $entry"
@@ -765,8 +765,9 @@ test_malformed_published_config_is_refused_and_isolated() {
     assert_absent "$home/state/tool-updates.check.sh" "invalid entry armed the watcher"
     rm -f "$home/state/.tool-updates"
     run_check "$home" "$(fixture_path "$dir")" "$out"
-    assert_contains "$(cat "$out")" 'check failed:' "malformed entry was ignored"
-    assert_contains "$(cat "$out")" 'other check failed:' "malformed entry prevented checking the next tool"
+    assert_contains "$(cat "$out")" 'watched tool registry:' "malformed entry was not a registry failure"
+    assert_not_contains "$(cat "$out")" 'other check failed:' "malformed registry produced a per-tool failure"
+    assert_absent "$home/probes" "malformed registry allowed a valid tool to be probed"
   done <<'EOF'
 {"name":"bad","command":"herdr-fixture","published":null}
 {"name":"bad","published":{"source":"npm","package":"gnhf"}}
@@ -782,7 +783,7 @@ test_malformed_published_config_is_refused_and_isolated() {
 {"name":"other","command":"herdr-fixture"}
 42
 EOF
-  pass "arm refuses malformed entries and a sweep isolates them from other tools"
+  pass "arm and sweep refuse the whole registry for malformed entries"
 }
 
 test_published_dedupe_and_composition() {
@@ -874,7 +875,7 @@ test_malformed_registry_is_reported_not_ignored() {
   printf '%s\n' '{"tools":[{"name":"herdr"}]}' > "$home/config/watched-tools.json"
   rm -f "$home/state/.tool-updates"
   run_check "$home" "$PATH" "$out"
-  assert_contains "$(cat "$out")" "tool herdr needs command, git, or published" "a tool entry with no update source was accepted"
+  assert_contains "$(cat "$out")" "tool herdr needs command, git, or both" "a tool entry with no update source was accepted"
 
   printf '%s\n' '{"tools":[{"name":"herdr","command":"herdr; rm -rf /"}]}' > "$home/config/watched-tools.json"
   rm -f "$home/state/.tool-updates"
@@ -1244,7 +1245,7 @@ test_armed_check_wakes_the_watcher_with_the_skew_report() {
 test_published_versions_for_the_three_motivating_tools
 test_published_failures_do_not_blind_other_tools
 test_published_probe_bounds_and_incomplete_record
-test_malformed_published_config_is_refused_and_isolated
+test_malformed_published_config_refuses_whole_registry
 test_published_dedupe_and_composition
 test_published_numeric_comparison_and_failed_installed_command
 


### PR DESCRIPTION
## Intent

This branch is being revalidated to rescue an existing pull request against an upstream staleness clock. Upstream closes pull requests after 14 days of author silence, counted only from a push or comment by the author: a maintainer comment, a maintainer rebase, and a CI run do not reset it. A stale close is irreversible - when an earlier pull request was closed that way the forge refused to reopen it, the work had to be re-raised fresh, and the whole review thread was orphaned. The most recent such close recorded that the work was still real; it was judged silent, not wrong. This branch is about 12 days into that clock, so it must be revalidated and re-pushed rather than left untouched. The existing pull request must be reused, never replaced.

The underlying work this branch delivers is unchanged, and its original goal was this. The captain asked which version of Herdr this home runs and asked for an audit of the tools this home depends on against their upstream repositories, then said: "in fact, this is probably something we should make a skill to check all of the various skills we are using so we can regularly run a skill like 'checkskills' which checks if there are updates we should implement."

Firstmate found that the machinery for exactly that already existed - bin/fm-tool-update-check.sh plus config/watched-tools.json - and had simply never been configured in this home. Configuring and arming it revealed five tools behind their published versions.

That audit exposed a real gap. The check could learn a newer version existed in only two ways: a git entry measuring how far a local clone is behind its remote branch, or an announce_pattern reading the tool's own update announcement. Three tools offer neither, and give no way to ask whether a newer version exists without actually installing one. Herdr's update subcommand downloads and installs immediately with no check-only form, and its version flag prints only the running version with no announcement. tasks-axi's update subcommand edits a task rather than the tool, so there is no self-update path at all. gnhf has no update or upgrade subcommand and is updated through npm. For those three the check detected only PATH skew, so a newly published release went unreported and the captain was back to auditing by hand - the exact thing he asked to stop doing.

The captain reviewed that gap and approved closing it, saying: "yes, please proceed on both".

So the accepted goal is to let the check compare the version resolved through PATH against published npm and GitHub releases, report available updates without installing anything, bound and validate those release queries and their responses, reject failed version commands, avoid numeric comparison overflow, document the release sources with worked examples for the three tools above, and cover the new behaviour with regression tests. Detection behaviour that already worked must be preserved.

One deliberate decision already settled during review should not be reopened: an incomplete sweep records its partial findings and advances the cadence unconditionally, rather than withholding the report and retrying from the start on the next poll. Withholding was tried and deliberately removed, because it amounted to a retry policy for every watched tool beyond the requested published-release detection, and let one early tool that repeatedly consumed the budget repeat the same alert while later tools went unchecked. Immediate retries were judged to need their own separate decision. The documentation was corrected to describe this restored behaviour.

## What Changed

- `bin/fm-tool-update-check.sh` gains an optional `published` probe per watched tool, reading the npm registry `latest` version or a GitHub repository's latest release `tag_name` with bounded `curl` and `jq`, and reporting "update available" against the version of the copy `PATH` resolves without installing anything. The query ignores curl configuration, sends no credentials, follows no redirects, and accepts only a dotted numeric version field; an unreachable source, HTTP error, or unsupported response is reported as that tool's check failure instead of silence.
- Supporting hardening in the same script: `published` entries are schema-validated (source, package or `owner/repo`, required `command`, no extra fields), a version command that exits non-zero no longer yields a version, and `version_newer` compares version components as decimal strings so large untrusted components cannot overflow shell arithmetic. A sweep that runs out of budget still records its partial findings and advances the cadence.
- `docs/configuration.md` documents the `published` schema, both release sources, the comparison and failure rules, and the restored budget-boundary behaviour; `docs/examples/watched-tools.json` adds worked entries for herdr (GitHub), tasks-axi, and gnhf (npm). `tests/fm-tool-update-check.test.sh` adds 8 regression tests covering the three motivating tools, probe bounds and report records, budget exhaustion, dedupe and composition with git and announcement probes, malformed configuration, numeric comparison, and failed installed-version commands.

## Risk Assessment

✅ Low: The change is well-bounded and additive: the new published-release probe is per-tool, read-only, time-bounded, validated at both config and response level, and fails loudly per tool without stopping the sweep; the version comparison rewrite traces correctly on every boundary case I constructed, and the implementation conforms to the stated intent and to both recorded user decisions about incomplete-sweep recording and whole-registry validation.

## Testing

I ran the focused regression suite for this script (tests/fm-tool-update-check.test.sh, 45 cases, all passing) and then drove the check itself as an operator would, in throwaway homes with real HTTP to npm and GitHub. The strongest evidence is the documented example registry: armed and swept, it reported "herdr update available: installed 0.8.2, published 0.9.1" from the real GitHub release API while tasks-axi 0.2.5 and gnhf 0.1.49 were correctly silent - exactly the manual audit the change was meant to replace. I also confirmed the reverse cases (installed equal or ahead stays silent), one-shot deduplication and re-reporting when the version changes, composition with PATH skew, announce_pattern and a real git clone behind its remote in one report, and the settled decision that a budget-exhausted sweep records its partial findings and advances the cadence so the next poll inside the interval is silent. Adversarial pushes all failed loudly and per tool rather than reporting a tool as current: unreachable and unpublished sources, a version command that exits non-zero, and five malformed `published` entries that refuse the whole registry at both arm and sweep. One scenario was not driven live - a hung or stalled release endpoint - because I have no control over npm or GitHub latency; the only coverage for it is a suite case that stubs the HTTP transport, which is not a live result, so it is reported as untested. This is a CLI change, so the reviewer-visible evidence is command transcripts rather than screenshots. The worktree is clean; no source or test files were changed.

- Live validation: ✅ go - 11 of 12 scenarios driven live against the product

| Scenario | Result | Live | Evidence |
| --- | --- | --- | --- |
| An operator copies the documented example registry, arms the check, and learns a newer Herdr release exists without installing anything | ✅ pass | live | live-documented-example-transcript.txt: arm succeeded, sweep reported &#34;herdr update available: installed 0.8.2, published 0.9.1 at https://api.github.com/repos/herdrdev/herdr/releases/latest&#34;; tasks-a… |
| A watched npm tool behind its published latest dist-tag is reported with both versions and the source URL | ✅ pass | live | live-published-transcript.txt S1: &#34;gnhf update available: installed 0.1.1, published 0.1.49 at https://registry.npmjs.org/gnhf/latest&#34; from a real registry query |
| A watched GitHub tool behind its latest release tag is reported the same way | ✅ pass | live | live-published-transcript.txt S1/S2: &#34;gh update available: installed 2.0.0, published 2.101.0 at https://api.github.com/repos/cli/cli/releases/latest&#34; |
| A tool level with or ahead of its published release stays silent | ✅ pass | live | live-published-transcript.txt S3: installed 99.0.0 for both npm and GitHub entries produced no output at all |
| The same published update is reported once, and a changed version is news again | ✅ pass | live | live-published-transcript.txt S4a (second identical sweep silent) and S4b (installed 0.1.2 reported again) |
| Detection that already worked - PATH skew, the tool&#39;s own announcement, and a git clone behind its remote - still reports alongside a published source | ✅ pass | live | live-composition-transcript.txt S11: all four findings emitted for one watched tool, including a real local clone one commit behind its real remote |
| Adversarial: an unreachable or unpublished release source fails for its own tool and never reports it as current, while the sweep continues | ✅ pass | live | live-published-transcript.txt S5: both ghost entries reported &#34;check failed: published source ... could not be reached or read (exit 56)&#34; and the sweep still checked the following tool; no &#34;update ava… |
| Adversarial: a version command that exits non-zero is refused as a comparison baseline even though its output contains a version | ✅ pass | live | live-published-transcript.txt S6: &#34;gnhf check failed: ... did not report a version&#34; and no published comparison was made |
| Adversarial: malformed published configuration refuses the whole registry loudly at arm and at sweep, leaving no shim | ✅ pass | live | live-published-transcript.txt S8 (arm exits 1, no shim written, sweep reports &#34;watched tool registry: tool bad published.source must be npm or github&#34;) plus live-budget-and-guards-transcript.txt S8d-S… |
| Adversarial: version components too large for shell arithmetic compare without overflow | ✅ pass | live | live-published-transcript.txt S7: installed 0.99999999999999999999999999 against published 0.1.49 produced no false update report |
| A sweep that runs out of budget records its partial findings and advances the cadence rather than retrying from the start (the settled decision) | ✅ pass | live | live-budget-and-guards-transcript.txt S9: the incomplete sweep printed &#34;check incomplete: the time budget ran out before later&#34;, wrote that finding plus a fresh epoch into state/.tool-updates, and the… |
| A hung or stalled release endpoint is cut off at the probe bound and reported as a check failure | ⏸️ untested | no | Not driven against the live product: the only coverage is a unit-suite case that stubs the HTTP transport and response parser to stall, which does not establish live behaviour. Driving it live needs c… |

<details>
<summary>Evidence: Live sweep of the documented example registry (real npm + GitHub)</summary>

Source: [Live sweep of the documented example registry (real npm + GitHub)](https://github.com/AgardnerAU/firstmate/blob/e6b5cd676509626af64843f0e052999c9b177509/.no-mistakes/evidence/fm/fm-tool-update-release-source/live-documented-example-transcript.txt)

<code>=== arm the documented example ===&#10;armed: state/tool-updates.check.sh&#10;=== sweep it against the real release sources ===&#10;tool updates: herdr update available: installed 0.8.2, published 0.9.1 at https://api.github.com/repos/herdrdev/herdr/releases/latest&#10;--- installed versions this host actually reports:&#10;herdr: herdr 0.8.2&#10;tasks-axi: 0.2.5&#10;gnhf: 0.1.49</code>

```text
home=/tmp/fm-live-iNQ7Em

--- registry under test:
{
  "tools": [
    {
      "name": "herdr",
      "command": "herdr",
      "version_args": [
        "--version"
      ],
      "published": {
        "source": "github",
        "repo": "herdrdev/herdr"
      }
    },
    {
      "name": "tasks-axi",
      "command": "tasks-axi",
      "published": {
        "source": "npm",
        "package": "tasks-axi"
      }
    },
    {
      "name": "gnhf",
      "command": "gnhf",
      "published": {
        "source": "npm",
        "package": "gnhf"
      }
    }
  ]
}

=== S12: arm the documented example ===
armed: state/tool-updates.check.sh
[arm exit 0]

=== S12: sweep it against the real release sources ===
tool updates: herdr update available: installed 0.8.2, published 0.9.1 at https://api.github.com/repos/herdrdev/herdr/releases/latest
[check exit 0]

--- installed versions this host actually reports, for comparison:
herdr: herdr 0.8.2
tasks-axi: 0.2.5
gnhf: 0.1.49
disarmed: state/tool-updates.check.sh
[disarm exit 0]
```
</details>
<details>
<summary>Evidence: Live published-source scenarios: detection, dedupe, failures, malformed registry</summary>

Source: [Live published-source scenarios: detection, dedupe, failures, malformed registry](https://github.com/AgardnerAU/firstmate/blob/e6b5cd676509626af64843f0e052999c9b177509/.no-mistakes/evidence/fm/fm-tool-update-release-source/live-published-transcript.txt)

```text
home=/tmp/fm-live-pztLga

=== S1/S2: real npm and real GitHub published sources, installed copies behind ===
tool updates: gnhf update available: installed 0.1.1, published 0.1.49 at https://registry.npmjs.org/gnhf/latest; gh update available: installed 2.0.0, published 2.101.0 at https://api.github.com/repos/cli/cli/releases/latest
[exit 0]

=== S4a: an identical second sweep is deduplicated (expect silence) ===
[exit 0]

=== S3: installed copies at or ahead of published stay silent ===
[exit 0]

=== S4b: a changed installed version is news again ===
tool updates: gnhf update available: installed 0.1.2, published 0.1.49 at https://registry.npmjs.org/gnhf/latest
[exit 0]

=== S7: huge version components compare without arithmetic overflow ===
installed 0.99999999999999999999999999 against published 0.1.x (expect silence):
[exit 0]

=== S5: an unpublished package is a per-tool check failure, and the sweep goes on ===
tool updates: ghost check failed: published source https://registry.npmjs.org/fm-no-such-package-live-fixture-zzz/latest could not be reached or read (exit 56); ghost-gh check failed: published source https://api.github.com/repos/fm-no-such-owner-zzz/fm-no-such-repo-zzz/releases/latest could not be reached or read (exit 56)
[exit 0]

=== S6: a version command that fails is not a usable baseline ===
tool updates: gnhf check failed: /tmp/fm-live-pztLga/bin/gnhf-live-fixture did not report a version
[exit 0]

=== S8: a malformed published entry refuses the whole registry, at arm and at check ===
--- arm:
fm-tool-update-check: tool bad published.source must be npm or github (/tmp/fm-live-pztLga/config/watched-tools.json)
[exit 1]
--- shim present? no
--- check:
tool updates: watched tool registry: tool bad published.source must be npm or github
[exit 0]

=== S8b: published without a version command is refused too ===
tool updates: watched tool registry: tool bad needs command, git, or both
[exit 0]

=== S8c: a valid registry arms cleanly ===
armed: state/tool-updates.check.sh
[arm exit 0]
--- shim: #!/usr/bin/env bash
# Auto-generated by fm-tool-update-check.sh - watched tool update poll shim.
# The watcher validates these bytes, then dispatches the trusted check script.
export FM_HOME=/tmp/fm-live-pztLga
exec ~/.no-mistakes/worktrees/c272d8f3fc4c/01M2TDFZN9WFMBX2HPJ48ZPHP0/bin/fm-tool-update-check.sh check
--- dispatching the armed shim the way the watcher does:
tool updates: gnhf update available: installed 0.1.1, published 0.1.49 at https://registry.npmjs.org/gnhf/latest
[exit 0]
disarmed: state/tool-updates.check.sh
[disarm exit 0]

=== S9: a sweep that runs out of budget records its partial findings and advances the cadence ===
--- sweep with a 3s budget (expect an incomplete report):
tool updates: slow check failed: /tmp/fm-live-pztLga/bin/slow-live-fixture did not report a version; later update available: installed 0.1.1, published 0.1.49 at https://registry.npmjs.org/gnhf/latest
[exit 0]
--- record written by that incomplete sweep:
fm-tool-updates-v1
epoch=<redacted>
reported=slow check failed: /tmp/fm-live-pztLga/bin/slow-live-fixture did not report a version; later update available: installed 0.1.1, published 0.1.49 at https://registry.npmjs.org/gnhf/latest
--- immediate second poll inside the 900s interval (expect silence, no probes):
[exit 0]

cleanup: /tmp/fm-live-pztLga
```
</details>
<details>
<summary>Evidence: Live budget-exhaustion and validation-guard scenarios</summary>

Source: [Live budget-exhaustion and validation-guard scenarios](https://github.com/AgardnerAU/firstmate/blob/e6b5cd676509626af64843f0e052999c9b177509/.no-mistakes/evidence/fm/fm-tool-update-release-source/live-budget-and-guards-transcript.txt)

<code>tool updates: slow check failed: ... did not report a version; check incomplete: the time budget ran out before later&#10;--- record left by the incomplete sweep:&#10;fm-tool-updates-v1&#10;epoch=&lt;an epoch, i.e. the cadence advanced&gt;&#10;reported=slow check failed: ...; check incomplete: the time budget ran out before later&#10;--- immediate second poll inside the 900s interval: (silent)</code>

```text
home=/tmp/fm-live-gTNS7U

=== S9: the slow tool eats the whole 3s budget, so the later tool is never reached ===
tool updates: slow check failed: /tmp/fm-live-gTNS7U/bin/slow-live-fixture did not report a version; check incomplete: the time budget ran out before later
[exit 0]
--- record left by the incomplete sweep:
fm-tool-updates-v1
epoch=<an epoch, i.e. the cadence advanced>
reported=slow check failed: /tmp/fm-live-gTNS7U/bin/slow-live-fixture did not report a version; check incomplete: the time budget ran out before later
--- immediate second poll inside the 900s interval (expect silence: the cadence advanced):
[exit 0]

=== S8d: published on an entry with no version command is refused by name ===
tool updates: watched tool registry: tool bad published needs command to report the installed version
[exit 0]

=== S8e: a package name that tries to escape its URL path is refused ===
tool updates: watched tool registry: tool bad published.package must be an npm package name
[exit 0]

=== S8f: a GitHub repo given as a URL is refused ===
tool updates: watched tool registry: tool bad published.repo must be a GitHub owner/repo
[exit 0]

=== S8g: an unsupported extra published field is refused ===
tool updates: watched tool registry: tool bad published has unsupported fields
[exit 0]

=== S10: a watched command missing from PATH is still reported, with no published comparison ===
tool updates: absent check failed: fm-absent-live-fixture is not on PATH
[exit 0]
```
</details>
<details>
<summary>Evidence: Live composition: announcement, PATH skew, published and git in one report</summary>

Source: [Live composition: announcement, PATH skew, published and git in one report](https://github.com/AgardnerAU/firstmate/blob/e6b5cd676509626af64843f0e052999c9b177509/.no-mistakes/evidence/fm/fm-tool-update-release-source/live-composition-transcript.txt)

`tool updates: gnhf update available: update to 0.1.49; gnhf update not in effect: PATH resolves 0.1.1 at .../bin/gnhf-live-fixture but 0.1.2 is installed at .../fresh/gnhf-live-fixture; gnhf update available: installed 0.1.1, published 0.1.49 at https://registry.npmjs.org/gnhf/latest; gnhf update available: origin/main is at b74e5b13d773 which this copy does not have`

```text
home=/tmp/fm-live-QOjl8W

=== S11: all four sources report together for one watched tool ===
tool updates: sweep budget 30s cut to 27s to stay inside the watcher check timeout of 30s; gnhf update available: update to 0.1.49; gnhf update not in effect: PATH resolves 0.1.1 at /tmp/fm-live-QOjl8W/bin/gnhf-live-fixture but 0.1.2 is installed at /tmp/fm-live-QOjl8W/fresh/gnhf-live-fixture; gnhf update available: installed 0.1.1, published 0.1.49 at https://registry.npmjs.org/gnhf/latest; gnhf update available: origin/main is at b74e5b13d773 which this copy does not have
[exit 0]
```
</details>
<details>
<summary>Evidence: Driver scripts used to stand the check up and drive each scenario</summary>

Source: [Driver scripts used to stand the check up and drive each scenario](https://github.com/AgardnerAU/firstmate/blob/e6b5cd676509626af64843f0e052999c9b177509/.no-mistakes/evidence/fm/fm-tool-update-release-source/drive-published-sources.sh)

```text
#!/usr/bin/env bash
# Drives bin/fm-tool-update-check.sh the way an operator runs it: an isolated
# FM_HOME, a real watched-tools registry, synthetic installed copies on PATH,
# and real HTTP queries to the public npm registry and GitHub release API.
set -u
W=~/.no-mistakes/worktrees/c272d8f3fc4c/01M2TDFZN9WFMBX2HPJ48ZPHP0
CHECK="$W/bin/fm-tool-update-check.sh"
H=$(mktemp -d /tmp/fm-live-XXXXXX)
mkdir -p "$H/state" "$H/config" "$H/bin"

mk() {
  printf '#!/usr/bin/env bash\nprintf "%%s\\n" %s\n' "'$2'" > "$H/bin/$1"
  chmod 0755 "$H/bin/$1"
}

run() {
  env FM_HOME="$H" PATH="$H/bin:$PATH" FM_CHECK_TIMEOUT=30 FM_TOOL_UPDATE_INTERVAL=0 "$@" "$CHECK" check
  printf '[exit %s]\n' "$?"
}

echo "home=$H"
echo
echo "=== S1/S2: real npm and real GitHub published sources, installed copies behind ==="
mk gnhf-live-fixture '0.1.1'
mk ghcli-live-fixture 'gh version 2.0.0 (2021-01-01)'
cat > "$H/config/watched-tools.json" <<'JSON'
{"tools":[
 {"name":"gnhf","command":"gnhf-live-fixture","published":{"source":"npm","package":"gnhf"}},
 {"name":"gh","command":"ghcli-live-fixture","published":{"source":"github","repo":"cli/cli"}}
]}
JSON
run

echo
echo "=== S4a: an identical second sweep is deduplicated (expect silence) ==="
run

echo
echo "=== S3: installed copies at or ahead of published stay silent ==="
rm -f "$H/state/.tool-updates"
mk gnhf-live-fixture '99.0.0'
mk ghcli-live-fixture 'gh version 99.0.0 (2026-01-01)'
run

echo
echo "=== S4b: a changed installed version is news again ==="
mk gnhf-live-fixture '0.1.2'
run

echo
echo "=== S7: huge version components compare without arithmetic overflow ==="
rm -f "$H/state/.tool-updates"
mk gnhf-live-fixture '0.99999999999999999999999999'
cat > "$H/config/watched-tools.json" <<'JSON'
{"tools":[{"name":"gnhf","command":"gnhf-live-fixture","published":{"source":"npm","package":"gnhf"}}]}
JSON
echo "installed 0.99999999999999999999999999 against published 0.1.x (expect silence):"
run

echo
echo "=== S5: an unpublished package is a per-tool check failure, and the sweep goes on ==="
rm -f "$H/state/.tool-updates"
mk gnhf-live-fixture '0.1.1'
mk other-live-fixture '1.0.0'
cat > "$H/config/watched-tools.json" <<'JSON'
{"tools":[
 {"name":"ghost","command":"gnhf-live-fixture","published":{"source":"npm","package":"fm-no-such-package-live-fixture-zzz"}},
 {"name":"ghost-gh","command":"gnhf-live-fixture","published":{"source":"github","repo":"fm-no-such-owner-zzz/fm-no-such-repo-zzz"}},
 {"name":"other","command":"other-live-fixture","published":{"source":"npm","package":"gnhf"}}
]}
JSON
run

echo
echo "=== S6: a version command that fails is not a usable baseline ==="
rm -f "$H/state/.tool-updates"
printf '#!/bin/sh\nprintf "0.0.1\\n"\nexit 1\n' > "$H/bin/gnhf-live-fixture"
chmod 0755 "$H/bin/gnhf-live-fixture"
cat > "$H/config/watched-tools.json" <<'JSON'
{"tools":[{"name":"gnhf","command":"gnhf-live-fixture","published":{"source":"npm","package":"gnhf"}}]}
JSON
run

echo
echo "=== S8: a malformed published entry refuses the whole registry, at arm and at check ==="
mk gnhf-live-fixture '0.1.1'
cat > "$H/config/watched-tools.json" <<'JSON'
{"tools":[
 {"name":"good","command":"gnhf-live-fixture"},
 {"name":"bad","command":"gnhf-live-fixture","published":{"source":"sourceforge","package":"gnhf"}}
]}
JSON
rm -f "$H/state/.tool-updates"
echo "--- arm:"
env FM_HOME="$H" PATH="$H/bin:$PATH" "$CHECK" arm; echo "[exit $?]"
echo "--- shim present? $( [ -e "$H/state/tool-updates.check.sh" ] && echo yes || echo no)"
echo "--- check:"
run

echo
echo "=== S8b: published without a version command is refused too ==="
cat > "$H/config/watched-tools.json" <<'JSON'
{"tools":[{"name":"bad","published":{"source":"npm","package":"gnhf"}}]}
JSON
run
echo
echo "=== S8c: a valid registry arms cleanly ==="
cat > "$H/config/watched-tools.json" <<'JSON'
{"tools":[{"name":"gnhf","command":"gnhf-live-fixture","published":{"source":"npm","package":"gnhf"}}]}
JSON
env FM_HOME="$H" PATH="$H/bin:$PATH" "$CHECK" arm; echo "[arm exit $?]"
echo "--- shim: $(cat "$H/state/tool-updates.check.sh")"
echo "--- dispatching the armed shim the way the watcher does:"
rm -f "$H/state/.tool-updates"
env PATH="$H/bin:$PATH" FM_CHECK_TIMEOUT=30 FM_TOOL_UPDATE_INTERVAL=0 "$H/state/tool-updates.check.sh"; echo "[exit $?]"
env FM_HOME="$H" PATH="$H/bin:$PATH" "$CHECK" disarm; echo "[disarm exit $?]"

echo
echo "=== S9: a sweep that runs out of budget records its partial findings and advances the cadence ==="
rm -f "$H/state/.tool-updates"
cat > "$H/bin/slow-live-fixture" <<'SH'
#!/usr/bin/env bash
sleep 30
printf '0.0.1\n'
SH
chmod 0755 "$H/bin/slow-live-fixture"
cat > "$H/config/watched-tools.json" <<'JSON'
{"tools":[
 {"name":"slow","command":"slow-live-fixture"},
 {"name":"later","command":"gnhf-live-fixture","published":{"source":"npm","package":"gnhf"}}
]}
JSON
echo "--- sweep with a 3s budget (expect an incomplete report):"
env FM_HOME="$H" PATH="$H/bin:$PATH" FM_CHECK_TIMEOUT=30 FM_TOOL_UPDATE_INTERVAL=900 \
  FM_TOOL_UPDATE_BUDGET_SECS=3 FM_TOOL_UPDATE_PROBE_SECS=2 "$CHECK" check
printf '[exit %s]\n' "$?"
echo "--- record written by that incomplete sweep:"
sed -e 's/^epoch=.*/epoch=<redacted>/' "$H/state/.tool-updates"
echo "--- immediate second poll inside the 900s interval (expect silence, no probes):"
env FM_HOME="$H" PATH="$H/bin:$PATH" FM_CHECK_TIMEOUT=30 FM_TOOL_UPDATE_INTERVAL=900 \
  FM_TOOL_UPDATE_BUDGET_SECS=3 FM_TOOL_UPDATE_PROBE_SECS=2 "$CHECK" check
printf '[exit %s]\n' "$?"

echo
echo "cleanup: $H"
rm -rf "$H"
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"f31a568b0590af950fce5da6d9fdcf439f450b61","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>⚠️ **Review** - 3 issues (1 warning, 2 infos)</summary>

- ⚠️ `bin/fm-tool-update-check.sh:341` - Simplification: the npm package acceptance path includes scoped names (the `(@[a-z0-9][a-z0-9._-]*/)?` alternative in the validation regex, plus the `jq -rn ... @uri` encoding step at line 544 that exists only to percent-encode the scope separator). The intent requires published-release detection for herdr (github), tasks-axi (npm) and gnhf (npm); none of these is a scoped package, and no stated requirement needs scope support. The narrower form that satisfies the intent is an unscoped package regex and a direct `https://registry.npmjs.org/&lt;package&gt;/latest` path with no encoding step. Recommend removing the scope alternative, the @uri encoding, the documentation sentence about `@scope/tool`, and the scoped assertion in test_published_dedupe_and_composition, rather than keeping and hardening them.
- ℹ️ `bin/fm-tool-update-check.sh:560` - The release query bounds time (`--connect-timeout`/`--max-time` plus the outer fm_run_timed process-group kill) but not response size: the whole body is read into the shell variable `body` and then piped to jq. The intent requires these queries and their responses to be bounded. Within the default 5s probe bound a fast or misbehaving endpoint can deliver a large body into shell memory before the group is killed. Adding `--max-filesize` (a few hundred KB is far above a npm `/latest` document or a GitHub release object) closes the one unbounded dimension; an oversize body then exits non-zero and is reported as an ordinary per-tool check failure.
- ℹ️ `bin/fm-tool-update-check.sh:548` - The GitHub endpoint is queried unauthenticated, which shares the 60-requests-per-hour-per-IP limit. At the default 900s interval this is ~4 requests/hour and safe, but `FM_TOOL_UPDATE_INTERVAL=0` is a documented setting (&#34;0 to probe on every run&#34;) and would issue one GitHub query per watcher poll, so a busy home can exhaust the limit; GitHub then answers 403, curl `--fail` exits 22, and the tool reports a persistent &#34;could not be reached or read (exit 22)&#34; check failure. Noted as a tradeoff only: the behaviour fails loudly rather than reporting the tool as current, and the remedy (caching or backoff) would add new durable state beyond this change&#39;s scope.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- Live validation: ✅ go - 11 of 12 scenarios driven live against the product

| Scenario | Result | Live | Evidence |
| --- | --- | --- | --- |
| An operator copies the documented example registry, arms the check, and learns a newer Herdr release exists without installing anything | ✅ pass | live | live-documented-example-transcript.txt: arm succeeded, sweep reported &#34;herdr update available: installed 0.8.2, published 0.9.1 at https://api.github.com/repos/herdrdev/herdr/releases/latest&#34;; tasks-a… |
| A watched npm tool behind its published latest dist-tag is reported with both versions and the source URL | ✅ pass | live | live-published-transcript.txt S1: &#34;gnhf update available: installed 0.1.1, published 0.1.49 at https://registry.npmjs.org/gnhf/latest&#34; from a real registry query |
| A watched GitHub tool behind its latest release tag is reported the same way | ✅ pass | live | live-published-transcript.txt S1/S2: &#34;gh update available: installed 2.0.0, published 2.101.0 at https://api.github.com/repos/cli/cli/releases/latest&#34; |
| A tool level with or ahead of its published release stays silent | ✅ pass | live | live-published-transcript.txt S3: installed 99.0.0 for both npm and GitHub entries produced no output at all |
| The same published update is reported once, and a changed version is news again | ✅ pass | live | live-published-transcript.txt S4a (second identical sweep silent) and S4b (installed 0.1.2 reported again) |
| Detection that already worked - PATH skew, the tool&#39;s own announcement, and a git clone behind its remote - still reports alongside a published source | ✅ pass | live | live-composition-transcript.txt S11: all four findings emitted for one watched tool, including a real local clone one commit behind its real remote |
| Adversarial: an unreachable or unpublished release source fails for its own tool and never reports it as current, while the sweep continues | ✅ pass | live | live-published-transcript.txt S5: both ghost entries reported &#34;check failed: published source ... could not be reached or read (exit 56)&#34; and the sweep still checked the following tool; no &#34;update ava… |
| Adversarial: a version command that exits non-zero is refused as a comparison baseline even though its output contains a version | ✅ pass | live | live-published-transcript.txt S6: &#34;gnhf check failed: ... did not report a version&#34; and no published comparison was made |
| Adversarial: malformed published configuration refuses the whole registry loudly at arm and at sweep, leaving no shim | ✅ pass | live | live-published-transcript.txt S8 (arm exits 1, no shim written, sweep reports &#34;watched tool registry: tool bad published.source must be npm or github&#34;) plus live-budget-and-guards-transcript.txt S8d-S… |
| Adversarial: version components too large for shell arithmetic compare without overflow | ✅ pass | live | live-published-transcript.txt S7: installed 0.99999999999999999999999999 against published 0.1.49 produced no false update report |
| A sweep that runs out of budget records its partial findings and advances the cadence rather than retrying from the start (the settled decision) | ✅ pass | live | live-budget-and-guards-transcript.txt S9: the incomplete sweep printed &#34;check incomplete: the time budget ran out before later&#34;, wrote that finding plus a fresh epoch into state/.tool-updates, and the… |
| A hung or stalled release endpoint is cut off at the probe bound and reported as a check failure | ⏸️ untested | no | Not driven against the live product: the only coverage is a unit-suite case that stubs the HTTP transport and response parser to stall, which does not establish live behaviour. Driving it live needs c… |

- <code>`bash tests/fm-tool-update-check.test.sh` (45 cases, all ok)</code>
- <code>`bin/fm-tool-update-check.sh check` against real `https://registry.npmjs.org/&lt;pkg&gt;/latest` and `https://api.github.com/repos/&lt;owner&gt;/&lt;repo&gt;/releases/latest`</code>
- <code>`bin/fm-tool-update-check.sh arm` / armed shim dispatch / `disarm` in an isolated FM_HOME</code>
- <code>documented starting point `docs/examples/watched-tools.json` copied into a home, armed and swept live</code>
- <code>adversarial registries: unknown source, missing command, `../../evil` package, GitHub repo given as a URL, unsupported extra `published` field</code>
- `adversarial sources: unpublished npm package, non-existent GitHub repo, version command exiting non-zero, 26-digit version components`
- <code>budget exhaustion sweep (`FM_TOOL_UPDATE_BUDGET_SECS=3`, slow fixture) followed by an immediate cadence-gated poll</code>
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
