### PR TITLE
test(bin): pin teardown outcomes for squash-merged rebased branches

### DIFF
--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -38,6 +38,15 @@
 # already present in the up-to-date default branch. This recognizes the common
 # squash-merge-then-delete-branch flow, where the branch's own commits live nowhere
 # on a remote yet the change is fully in main.
+# Squash merges collapse the branch's commits, so per-commit patch ids against main
+# no longer match, and a pipeline rebase can leave the local worktree on a pre-rebase
+# duplicate of the same work. When the forge reports that PR merged and its merge
+# commit is an ancestor of the default branch, a local branch that is behind or
+# diverged from the pipeline push (the live PR head, else recorded pr_head=) is
+# stale rather than unlanded, provided every locally changed path is also in that
+# landed ref. A path the PR never landed still refuses. When the forge cannot be
+# reached, the same path-coverage check runs against a PR head whose content is
+# already in the default branch (recorded pr_head= or refs/pull/<n>/head).
 # The PR itself is resolved from the task's recorded pr= when present, or - when
 # no pr= was ever recorded (e.g. a yolo-authorized merge on a repo with no PR CI,
 # where the usual "checks green" fm-pr-check.sh trigger never fires) - by looking
@@ -826,6 +835,10 @@ if [ "${FM_TEARDOWN_GUARD_DONE:-0}" != 1 ]; then
 fi
 HOME_PATH=$(grep '^home=' "$META" | cut -d= -f2- || true)
 PR_URL=$(grep '^pr=' "$META" | tail -1 | cut -d= -f2- || true)
+PR_HEAD=$(grep '^pr_head=' "$META" | tail -1 | cut -d= -f2- || true)
+if ! fm_pr_head_valid "$PR_HEAD"; then
+  PR_HEAD=
+fi
 # tasktmp is recorded by fm-spawn for tasks that set up a per-task temp root
 # (/tmp/fm-<id>/); absent for tasks spawned before that change, so tolerate empty.
 TASK_TMP=$(grep '^tasktmp=' "$META" | cut -d= -f2- || true)
@@ -1168,6 +1181,60 @@ ensure_commit_object() {
   git -C "$WT" cat-file -e "$commit^{commit}" 2>/dev/null
 }
 
+fetch_github_pull_head() {
+  local target=$1 n oid
+  n=$(pr_number_from_target "$target") || return 1
+  git -C "$WT" remote get-url origin >/dev/null 2>&1 || return 1
+  git -C "$WT" fetch --quiet origin "refs/pull/$n/head" >/dev/null 2>&1 || return 1
+  oid=$(git -C "$WT" rev-parse --verify FETCH_HEAD 2>/dev/null) || return 1
+  fm_pr_head_valid "$oid" || return 1
+  printf '%s\n' "$oid"
+}
+
+fetch_default_ref() {
+  local name
+  name=$(default_branch) || return 1
+  if git -C "$WT" remote get-url origin >/dev/null 2>&1; then
+    git -C "$WT" fetch --quiet origin "+refs/heads/$name:refs/remotes/origin/$name" >/dev/null 2>&1 || return 1
+    printf '%s\n' "refs/remotes/origin/$name"
+  elif git -C "$WT" rev-parse --quiet --verify "refs/heads/$name" >/dev/null 2>&1; then
+    printf '%s\n' "refs/heads/$name"
+  else
+    return 1
+  fi
+}
+
+trees_merge_equal() {
+  local landed=$1 other=$2 landed_tree merged_tree
+  landed_tree=$(git -C "$WT" rev-parse --quiet --verify "$landed^{tree}" 2>/dev/null) || return 1
+  [ -n "$landed_tree" ] || return 1
+  merged_tree=$(git -C "$WT" merge-tree --write-tree "$landed" "$other" 2>/dev/null) || return 1
+  merged_tree=$(printf '%s\n' "$merged_tree" | head -1)
+  [ "$merged_tree" = "$landed_tree" ]
+}
+
+# True when every path HEAD changed since merge-base with <ref> is also changed
+# on <ref> since that same base. Local is then a stale or equivalent copy of
+# landed work (behind or diverged after a rebase), not extra unlanded files.
+# A path HEAD changed that <ref> did not still refuses.
+local_changes_covered_by_ref() {
+  local landed=$1 current base local_files landed_files path
+  current=$(git -C "$WT" rev-parse --verify HEAD 2>/dev/null) || return 1
+  git -C "$WT" cat-file -e "$landed^{commit}" 2>/dev/null || return 1
+  if git -C "$WT" merge-base --is-ancestor "$current" "$landed" 2>/dev/null; then
+    return 0
+  fi
+  base=$(git -C "$WT" merge-base "$current" "$landed" 2>/dev/null) || return 1
+  local_files=$(git -C "$WT" diff --name-only --no-renames "$base" "$current" -- 2>/dev/null) || return 1
+  landed_files=$(git -C "$WT" diff --name-only --no-renames "$base" "$landed" -- 2>/dev/null) || return 1
+  while IFS= read -r path; do
+    [ -n "$path" ] || continue
+    printf '%s\n' "$landed_files" | grep -qxF "$path" || return 1
+  done <<EOF
+$local_files
+EOF
+}
+
 patch_id_for_commit() {
   local commit=$1
   git -C "$WT" show --pretty=medium --no-ext-diff "$commit" 2>/dev/null \
@@ -1200,36 +1267,79 @@ $unpushed
 EOF
 }
 
+pr_view_merged() {
+  local target=$1 view
+  view=$(cd "$WT" && gh pr view "$target" --json state,headRefOid,url,mergeCommit \
+    -q '.state + "\t" + .headRefOid + "\t" + .url + "\t" + (.mergeCommit.oid // "")' \
+    2>/dev/null) && {
+    printf '%s\n' "$view"
+    return 0
+  }
+  (cd "$WT" && gh pr view "$target" --json state,headRefOid,url \
+    -q '.state + "\t" + .headRefOid + "\t" + .url') 2>/dev/null
+}
+
+# True when a merged PR's merge commit sits on the default branch and local
+# HEAD only repeats paths that landed in the pipeline push or that merge.
+merged_pr_covers_stale_local() {
+  local head=$1 merge_oid=$2 default_ref cover_head
+  fm_pr_head_valid "$merge_oid" || return 1
+  default_ref=$(fetch_default_ref) || return 1
+  git -C "$WT" cat-file -e "$merge_oid^{commit}" 2>/dev/null \
+    || return 1
+  git -C "$WT" merge-base --is-ancestor "$merge_oid" "$default_ref" 2>/dev/null \
+    || return 1
+  cover_head=$head
+  if ! git -C "$WT" cat-file -e "$cover_head^{commit}" 2>/dev/null; then
+    cover_head=$PR_HEAD
+  fi
+  if git -C "$WT" cat-file -e "$cover_head^{commit}" 2>/dev/null \
+     && local_changes_covered_by_ref "$cover_head"; then
+    return 0
+  fi
+  local_changes_covered_by_ref "$merge_oid"
+}
+
 # Is the worktree's PR merged for local work contained in that PR? Resolves the
 # PR from the recorded pr= URL first, then from the branch name, and asks GitHub
-# for both the PR state and head. Returns non-zero when the PR is not merged, the
-# current work is not contained in the PR head, no PR is found, or any gh error
-# occurs - the caller then falls back to the content check.
+# for the PR state, head, and merge commit. Returns non-zero when the PR is not
+# merged, the current work is not contained in the PR head or covered as a stale
+# copy of that landed merge, no PR is found, or any gh error occurs - the caller
+# then falls back to the content check.
 pr_is_merged() {
-  local branch=$1 target view state remainder head resolved_url current landed=0
+  local branch=$1 target view state rest head resolved_url merge_oid current landed=0
   if [ -n "$PR_URL" ]; then
     target=$PR_URL
   else
     target=$(pr_number_from_branch "$branch") || return 1
   fi
   [ -n "$target" ] || return 1
-  view=$(cd "$WT" && gh pr view "$target" --json state,headRefOid,url -q '.state + "\t" + .headRefOid + "\t" + .url' 2>/dev/null) || return 1
+  view=$(pr_view_merged "$target") || return 1
   state=${view%%$'\t'*}
-  remainder=${view#*$'\t'}
+  rest=${view#*$'\t'}
   [ "$state" != "$view" ] || return 1
-  head=${remainder%%$'\t'*}
-  resolved_url=${remainder#*$'\t'}
-  [ "$head" != "$remainder" ] || return 1
+  head=${rest%%$'\t'*}
+  rest=${rest#*$'\t'}
+  [ "$head" != "$rest" ] || return 1
+  resolved_url=${rest%%$'\t'*}
+  merge_oid=${rest#*$'\t'}
+  if [ "$merge_oid" = "$rest" ]; then
+    merge_oid=
+  fi
   case "$state" in
     MERGED|merged) ;;
     *) return 1 ;;
   esac
   [ -n "$head" ] || return 1
-  ensure_commit_object "$target" "$head" || return 1
   current=$(git -C "$WT" rev-parse --verify HEAD 2>/dev/null) || return 1
-  if git -C "$WT" merge-base --is-ancestor "$current" "$head" 2>/dev/null; then
-    landed=1
-  elif unpushed_patches_are_in_pr_head "$head"; then
+  if ensure_commit_object "$target" "$head"; then
+    if git -C "$WT" merge-base --is-ancestor "$current" "$head" 2>/dev/null; then
+      landed=1
+    elif unpushed_patches_are_in_pr_head "$head"; then
+      landed=1
+    fi
+  fi
+  if [ "$landed" != 1 ] && merged_pr_covers_stale_local "$head" "$merge_oid"; then
     landed=1
   fi
   [ "$landed" = 1 ] || return 1
@@ -1240,36 +1350,46 @@ pr_is_merged() {
   return 0
 }
 
+pr_head_content_covers_local() {
+  local pr_head=$1 default_ref
+  [ -n "$pr_head" ] || return 1
+  git -C "$WT" cat-file -e "$pr_head^{commit}" 2>/dev/null || return 1
+  default_ref=$(fetch_default_ref) || return 1
+  trees_merge_equal "$default_ref" "$pr_head" || return 1
+  local_changes_covered_by_ref "$pr_head"
+}
+
 # Is the branch's content already present in the up-to-date default branch? Fetches
 # first, then 3-way merges the default branch with HEAD: when HEAD introduces nothing
 # the default branch does not already contain (e.g. its change landed via squash) the
 # merged tree equals the default branch's tree. This isolates branch-only changes, so
 # unrelated commits the default branch gained past the merge-base do not count as
-# "added". Returns non-zero when inconclusive (no default ref, or a merge conflict),
-# so the caller refuses rather than guesses.
+# "added". When that merge conflicts - typical of a pre-rebase local copy versus a
+# squash of the rebased PR - a PR head whose own content is already in default and
+# that covers every locally changed path still settles it. Returns non-zero when
+# inconclusive, so the caller refuses rather than guesses.
 content_in_default() {
-  local name ref default_tree merged_tree
-  name=$(default_branch) || return 1
-  if git -C "$WT" remote get-url origin >/dev/null 2>&1; then
-    git -C "$WT" fetch --quiet origin "+refs/heads/$name:refs/remotes/origin/$name" >/dev/null 2>&1 || return 1
-    ref="refs/remotes/origin/$name"
-  elif git -C "$WT" rev-parse --quiet --verify "refs/heads/$name" >/dev/null 2>&1; then
-    ref="refs/heads/$name"
-  else
-    return 1
+  local ref oid
+  ref=$(fetch_default_ref) || return 1
+  if trees_merge_equal "$ref" HEAD; then
+    return 0
   fi
-  default_tree=$(git -C "$WT" rev-parse --quiet --verify "$ref^{tree}" 2>/dev/null) || return 1
-  [ -n "$default_tree" ] || return 1
-  merged_tree=$(git -C "$WT" merge-tree --write-tree "$ref" HEAD 2>/dev/null) || return 1
-  merged_tree=$(printf '%s\n' "$merged_tree" | head -1)
-  [ "$merged_tree" = "$default_tree" ]
+  if [ -n "$PR_HEAD" ]; then
+    ensure_commit_object "${PR_URL:-}" "$PR_HEAD" || true
+    pr_head_content_covers_local "$PR_HEAD" && return 0
+  fi
+  if [ -n "$PR_URL" ] && oid=$(fetch_github_pull_head "$PR_URL"); then
+    pr_head_content_covers_local "$oid" && return 0
+  fi
+  return 1
 }
 
 # Has the worktree's committed work actually LANDED, though its commits are not
 # reachable from any remote-tracking branch? True when a merged PR proves the
-# current local work is contained in the PR head, OR the content is already in the
-# default branch (fallback, which also covers the no-PR and gh-error paths). False
-# only for genuinely unlanded work.
+# current local work is contained in the PR head or is a stale copy of that
+# landed squash, OR the content is already in the default branch (fallback, which
+# also covers the no-PR and gh-error paths). False only for genuinely unlanded
+# work.
 work_is_landed() {
   local branch=$1
   pr_is_merged "$branch" && return 0

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -833,10 +833,6 @@ if [ "${FM_TEARDOWN_GUARD_DONE:-0}" != 1 ]; then
 fi
 HOME_PATH=$(grep '^home=' "$META" | cut -d= -f2- || true)
 PR_URL=$(grep '^pr=' "$META" | tail -1 | cut -d= -f2- || true)
-PR_HEAD=$(grep '^pr_head=' "$META" | tail -1 | cut -d= -f2- || true)
-if ! fm_pr_head_valid "$PR_HEAD"; then
-  PR_HEAD=
-fi
 # tasktmp is recorded by fm-spawn for tasks that set up a per-task temp root
 # (/tmp/fm-<id>/); absent for tasks spawned before that change, so tolerate empty.
 TASK_TMP=$(grep '^tasktmp=' "$META" | cut -d= -f2- || true)
@@ -1179,28 +1175,6 @@ ensure_commit_object() {
   git -C "$WT" cat-file -e "$commit^{commit}" 2>/dev/null
 }
 
-fetch_default_ref() {
-  local name
-  name=$(default_branch) || return 1
-  if git -C "$WT" remote get-url origin >/dev/null 2>&1; then
-    git -C "$WT" fetch --quiet origin "+refs/heads/$name:refs/remotes/origin/$name" >/dev/null 2>&1 || return 1
-    printf '%s\n' "refs/remotes/origin/$name"
-  elif git -C "$WT" rev-parse --quiet --verify "refs/heads/$name" >/dev/null 2>&1; then
-    printf '%s\n' "refs/heads/$name"
-  else
-    return 1
-  fi
-}
-
-trees_merge_equal() {
-  local landed=$1 other=$2 landed_tree merged_tree
-  landed_tree=$(git -C "$WT" rev-parse --quiet --verify "$landed^{tree}" 2>/dev/null) || return 1
-  [ -n "$landed_tree" ] || return 1
-  merged_tree=$(git -C "$WT" merge-tree --write-tree "$landed" "$other" 2>/dev/null) || return 1
-  merged_tree=$(printf '%s\n' "$merged_tree" | head -1)
-  [ "$merged_tree" = "$landed_tree" ]
-}
-
 patch_id_for_commit() {
   local commit=$1
   git -C "$WT" show --pretty=medium --no-ext-diff "$commit" 2>/dev/null \
@@ -1235,12 +1209,11 @@ EOF
 
 # Is the worktree's PR merged for local work contained in that PR? Resolves the
 # PR from the recorded pr= URL first, then from the branch name, and asks GitHub
-# for both the PR state and head. Recorded pr_head= is used only when the live
-# head object cannot be fetched. Returns non-zero when the PR is not merged, the
+# for both the PR state and head. Returns non-zero when the PR is not merged, the
 # current work is not contained in the PR head, no PR is found, or any gh error
 # occurs - the caller then falls back to the content check.
 pr_is_merged() {
-  local branch=$1 target view state remainder head resolved_url current cover_head landed=0
+  local branch=$1 target view state remainder head resolved_url current landed=0
   if [ -n "$PR_URL" ]; then
     target=$PR_URL
   else
@@ -1259,16 +1232,11 @@ pr_is_merged() {
     *) return 1 ;;
   esac
   [ -n "$head" ] || return 1
-  cover_head=$head
-  if ! ensure_commit_object "$target" "$cover_head"; then
-    cover_head=$PR_HEAD
-    [ -n "$cover_head" ] || return 1
-    ensure_commit_object "$target" "$cover_head" || return 1
-  fi
+  ensure_commit_object "$target" "$head" || return 1
   current=$(git -C "$WT" rev-parse --verify HEAD 2>/dev/null) || return 1
-  if git -C "$WT" merge-base --is-ancestor "$current" "$cover_head" 2>/dev/null; then
+  if git -C "$WT" merge-base --is-ancestor "$current" "$head" 2>/dev/null; then
     landed=1
-  elif unpushed_patches_are_in_pr_head "$cover_head"; then
+  elif unpushed_patches_are_in_pr_head "$head"; then
     landed=1
   fi
   [ "$landed" = 1 ] || return 1
@@ -1287,9 +1255,21 @@ pr_is_merged() {
 # "added". Returns non-zero when inconclusive (no default ref, or a merge conflict),
 # so the caller refuses rather than guesses.
 content_in_default() {
-  local ref
-  ref=$(fetch_default_ref) || return 1
-  trees_merge_equal "$ref" HEAD
+  local name ref default_tree merged_tree
+  name=$(default_branch) || return 1
+  if git -C "$WT" remote get-url origin >/dev/null 2>&1; then
+    git -C "$WT" fetch --quiet origin "+refs/heads/$name:refs/remotes/origin/$name" >/dev/null 2>&1 || return 1
+    ref="refs/remotes/origin/$name"
+  elif git -C "$WT" rev-parse --quiet --verify "refs/heads/$name" >/dev/null 2>&1; then
+    ref="refs/heads/$name"
+  else
+    return 1
+  fi
+  default_tree=$(git -C "$WT" rev-parse --quiet --verify "$ref^{tree}" 2>/dev/null) || return 1
+  [ -n "$default_tree" ] || return 1
+  merged_tree=$(git -C "$WT" merge-tree --write-tree "$ref" HEAD 2>/dev/null) || return 1
+  merged_tree=$(printf '%s\n' "$merged_tree" | head -1)
+  [ "$merged_tree" = "$default_tree" ]
 }
 
 # Has the worktree's committed work actually LANDED, though its commits are not

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -39,14 +39,12 @@
 # squash-merge-then-delete-branch flow, where the branch's own commits live nowhere
 # on a remote yet the change is fully in main.
 # Squash merges collapse the branch's commits, so per-commit patch ids against main
-# no longer match, and a pipeline rebase can leave the local worktree on a pre-rebase
-# duplicate of the same work. When the forge reports that PR merged and its merge
-# commit is an ancestor of the default branch, a local branch that is behind or
-# diverged from the pipeline push (the live PR head, else recorded pr_head=) is
-# stale rather than unlanded, provided every locally changed path is also in that
-# landed ref. A path the PR never landed still refuses. When the forge cannot be
-# reached, the same path-coverage check runs against a PR head whose content is
-# already in the default branch (recorded pr_head= or refs/pull/<n>/head).
+# no longer match, and a pipeline rebase can leave the local worktree diverged from
+# the PR head. A diverged copy is not treated as landed: path-set coverage, git
+# cherry, and merge-tree containment each fail to prove content landed without also
+# accepting unlanded edits to the same paths. Teardown still accepts a merged PR
+# whose head contains the current local work (ancestor or equivalent patch ids),
+# or a clean content-in-default tree match. Anything else refuses.
 # The PR itself is resolved from the task's recorded pr= when present, or - when
 # no pr= was ever recorded (e.g. a yolo-authorized merge on a repo with no PR CI,
 # where the usual "checks green" fm-pr-check.sh trigger never fires) - by looking
@@ -1181,16 +1179,6 @@ ensure_commit_object() {
   git -C "$WT" cat-file -e "$commit^{commit}" 2>/dev/null
 }
 
-fetch_github_pull_head() {
-  local target=$1 n oid
-  n=$(pr_number_from_target "$target") || return 1
-  git -C "$WT" remote get-url origin >/dev/null 2>&1 || return 1
-  git -C "$WT" fetch --quiet origin "refs/pull/$n/head" >/dev/null 2>&1 || return 1
-  oid=$(git -C "$WT" rev-parse --verify FETCH_HEAD 2>/dev/null) || return 1
-  fm_pr_head_valid "$oid" || return 1
-  printf '%s\n' "$oid"
-}
-
 fetch_default_ref() {
   local name
   name=$(default_branch) || return 1
@@ -1211,28 +1199,6 @@ trees_merge_equal() {
   merged_tree=$(git -C "$WT" merge-tree --write-tree "$landed" "$other" 2>/dev/null) || return 1
   merged_tree=$(printf '%s\n' "$merged_tree" | head -1)
   [ "$merged_tree" = "$landed_tree" ]
-}
-
-# True when every path HEAD changed since merge-base with <ref> is also changed
-# on <ref> since that same base. Local is then a stale or equivalent copy of
-# landed work (behind or diverged after a rebase), not extra unlanded files.
-# A path HEAD changed that <ref> did not still refuses.
-local_changes_covered_by_ref() {
-  local landed=$1 current base local_files landed_files path
-  current=$(git -C "$WT" rev-parse --verify HEAD 2>/dev/null) || return 1
-  git -C "$WT" cat-file -e "$landed^{commit}" 2>/dev/null || return 1
-  if git -C "$WT" merge-base --is-ancestor "$current" "$landed" 2>/dev/null; then
-    return 0
-  fi
-  base=$(git -C "$WT" merge-base "$current" "$landed" 2>/dev/null) || return 1
-  local_files=$(git -C "$WT" diff --name-only --no-renames "$base" "$current" -- 2>/dev/null) || return 1
-  landed_files=$(git -C "$WT" diff --name-only --no-renames "$base" "$landed" -- 2>/dev/null) || return 1
-  while IFS= read -r path; do
-    [ -n "$path" ] || continue
-    printf '%s\n' "$landed_files" | grep -qxF "$path" || return 1
-  done <<EOF
-$local_files
-EOF
 }
 
 patch_id_for_commit() {
@@ -1267,79 +1233,42 @@ $unpushed
 EOF
 }
 
-pr_view_merged() {
-  local target=$1 view
-  view=$(cd "$WT" && gh pr view "$target" --json state,headRefOid,url,mergeCommit \
-    -q '.state + "\t" + .headRefOid + "\t" + .url + "\t" + (.mergeCommit.oid // "")' \
-    2>/dev/null) && {
-    printf '%s\n' "$view"
-    return 0
-  }
-  (cd "$WT" && gh pr view "$target" --json state,headRefOid,url \
-    -q '.state + "\t" + .headRefOid + "\t" + .url') 2>/dev/null
-}
-
-# True when a merged PR's merge commit sits on the default branch and local
-# HEAD only repeats paths that landed in the pipeline push or that merge.
-merged_pr_covers_stale_local() {
-  local head=$1 merge_oid=$2 default_ref cover_head
-  fm_pr_head_valid "$merge_oid" || return 1
-  default_ref=$(fetch_default_ref) || return 1
-  git -C "$WT" cat-file -e "$merge_oid^{commit}" 2>/dev/null \
-    || return 1
-  git -C "$WT" merge-base --is-ancestor "$merge_oid" "$default_ref" 2>/dev/null \
-    || return 1
-  cover_head=$head
-  if ! git -C "$WT" cat-file -e "$cover_head^{commit}" 2>/dev/null; then
-    cover_head=$PR_HEAD
-  fi
-  if git -C "$WT" cat-file -e "$cover_head^{commit}" 2>/dev/null \
-     && local_changes_covered_by_ref "$cover_head"; then
-    return 0
-  fi
-  local_changes_covered_by_ref "$merge_oid"
-}
-
 # Is the worktree's PR merged for local work contained in that PR? Resolves the
 # PR from the recorded pr= URL first, then from the branch name, and asks GitHub
-# for the PR state, head, and merge commit. Returns non-zero when the PR is not
-# merged, the current work is not contained in the PR head or covered as a stale
-# copy of that landed merge, no PR is found, or any gh error occurs - the caller
-# then falls back to the content check.
+# for both the PR state and head. Recorded pr_head= is used only when the live
+# head object cannot be fetched. Returns non-zero when the PR is not merged, the
+# current work is not contained in the PR head, no PR is found, or any gh error
+# occurs - the caller then falls back to the content check.
 pr_is_merged() {
-  local branch=$1 target view state rest head resolved_url merge_oid current landed=0
+  local branch=$1 target view state remainder head resolved_url current cover_head landed=0
   if [ -n "$PR_URL" ]; then
     target=$PR_URL
   else
     target=$(pr_number_from_branch "$branch") || return 1
   fi
   [ -n "$target" ] || return 1
-  view=$(pr_view_merged "$target") || return 1
+  view=$(cd "$WT" && gh pr view "$target" --json state,headRefOid,url -q '.state + "\t" + .headRefOid + "\t" + .url' 2>/dev/null) || return 1
   state=${view%%$'\t'*}
-  rest=${view#*$'\t'}
+  remainder=${view#*$'\t'}
   [ "$state" != "$view" ] || return 1
-  head=${rest%%$'\t'*}
-  rest=${rest#*$'\t'}
-  [ "$head" != "$rest" ] || return 1
-  resolved_url=${rest%%$'\t'*}
-  merge_oid=${rest#*$'\t'}
-  if [ "$merge_oid" = "$rest" ]; then
-    merge_oid=
-  fi
+  head=${remainder%%$'\t'*}
+  resolved_url=${remainder#*$'\t'}
+  [ "$head" != "$remainder" ] || return 1
   case "$state" in
     MERGED|merged) ;;
     *) return 1 ;;
   esac
   [ -n "$head" ] || return 1
-  current=$(git -C "$WT" rev-parse --verify HEAD 2>/dev/null) || return 1
-  if ensure_commit_object "$target" "$head"; then
-    if git -C "$WT" merge-base --is-ancestor "$current" "$head" 2>/dev/null; then
-      landed=1
-    elif unpushed_patches_are_in_pr_head "$head"; then
-      landed=1
-    fi
+  cover_head=$head
+  if ! ensure_commit_object "$target" "$cover_head"; then
+    cover_head=$PR_HEAD
+    [ -n "$cover_head" ] || return 1
+    ensure_commit_object "$target" "$cover_head" || return 1
   fi
-  if [ "$landed" != 1 ] && merged_pr_covers_stale_local "$head" "$merge_oid"; then
+  current=$(git -C "$WT" rev-parse --verify HEAD 2>/dev/null) || return 1
+  if git -C "$WT" merge-base --is-ancestor "$current" "$cover_head" 2>/dev/null; then
+    landed=1
+  elif unpushed_patches_are_in_pr_head "$cover_head"; then
     landed=1
   fi
   [ "$landed" = 1 ] || return 1
@@ -1350,46 +1279,24 @@ pr_is_merged() {
   return 0
 }
 
-pr_head_content_covers_local() {
-  local pr_head=$1 default_ref
-  [ -n "$pr_head" ] || return 1
-  git -C "$WT" cat-file -e "$pr_head^{commit}" 2>/dev/null || return 1
-  default_ref=$(fetch_default_ref) || return 1
-  trees_merge_equal "$default_ref" "$pr_head" || return 1
-  local_changes_covered_by_ref "$pr_head"
-}
-
 # Is the branch's content already present in the up-to-date default branch? Fetches
 # first, then 3-way merges the default branch with HEAD: when HEAD introduces nothing
 # the default branch does not already contain (e.g. its change landed via squash) the
 # merged tree equals the default branch's tree. This isolates branch-only changes, so
 # unrelated commits the default branch gained past the merge-base do not count as
-# "added". When that merge conflicts - typical of a pre-rebase local copy versus a
-# squash of the rebased PR - a PR head whose own content is already in default and
-# that covers every locally changed path still settles it. Returns non-zero when
-# inconclusive, so the caller refuses rather than guesses.
+# "added". Returns non-zero when inconclusive (no default ref, or a merge conflict),
+# so the caller refuses rather than guesses.
 content_in_default() {
-  local ref oid
+  local ref
   ref=$(fetch_default_ref) || return 1
-  if trees_merge_equal "$ref" HEAD; then
-    return 0
-  fi
-  if [ -n "$PR_HEAD" ]; then
-    ensure_commit_object "${PR_URL:-}" "$PR_HEAD" || true
-    pr_head_content_covers_local "$PR_HEAD" && return 0
-  fi
-  if [ -n "$PR_URL" ] && oid=$(fetch_github_pull_head "$PR_URL"); then
-    pr_head_content_covers_local "$oid" && return 0
-  fi
-  return 1
+  trees_merge_equal "$ref" HEAD
 }
 
 # Has the worktree's committed work actually LANDED, though its commits are not
 # reachable from any remote-tracking branch? True when a merged PR proves the
-# current local work is contained in the PR head or is a stale copy of that
-# landed squash, OR the content is already in the default branch (fallback, which
-# also covers the no-PR and gh-error paths). False only for genuinely unlanded
-# work.
+# current local work is contained in the PR head, OR the content is already in the
+# default branch (fallback, which also covers the no-PR and gh-error paths). False
+# only for genuinely unlanded work.
 work_is_landed() {
   local branch=$1
   pr_is_merged "$branch" && return 0

--- a/tests/fm-teardown.test.sh
+++ b/tests/fm-teardown.test.sh
@@ -39,9 +39,9 @@
 #   (p) fm-pr-check when local HEAD lags                        -> record remote PR head
 #   (q) no-mistakes + NO pr= recorded, PR discovered by branch  -> ALLOW  (yolo/no-CI merge)
 #   (q2) no-mistakes + squash-merged, local followed pipeline rebase -> ALLOW
-#   (q3) no-mistakes + squash-merged, local still on pre-rebase head -> ALLOW
+#   (q3) no-mistakes + squash-merged, same file, different content   -> REFUSE
 #   (q4) no-mistakes + squash-merged stale local plus extra commit   -> REFUSE
-#   (q5) gh down + squash-merged stale local, PR head on default     -> ALLOW
+#   (q5) gh down + squash-merged stale local, content not in default -> REFUSE
 #
 # Also covers backlog teardown-lock-race: a git index.lock left in the worktree by a
 # killed crew process (bin/fm-teardown.sh's teardown_treehouse_return).
@@ -950,10 +950,13 @@ test_squash_merged_rebased_branch_allows() {
   pass "squash-merged task whose local branch followed the pipeline rebase is torn down"
 }
 
-test_squash_merged_stale_pre_rebase_local_allows() {
+test_squash_merged_same_file_different_content_refuses() {
   local case_dir rc pr_head merge_commit
-  case_dir=$(make_case squash-stale-local)
+  case_dir=$(make_case squash-same-path-diverged)
   write_meta "$case_dir" no-mistakes ship
+  # Reviewer's exact sequence: pipeline rebase produced a different blob for
+  # shared.txt than the stale local still holds, then squash-merged. Same path
+  # is not proof the local content landed.
   read -r pr_head merge_commit < <(setup_squash_rebased_history "$case_dir" stale)
   printf '%s\n' \
     'pr=https://github.com/example/repo/pull/7' \
@@ -965,9 +968,9 @@ test_squash_merged_stale_pre_rebase_local_allows() {
   rc=$?
   set -e
 
-  expect_code 0 "$rc" "squash-stale-local: teardown should succeed when local is a pre-rebase duplicate of a squash-merged PR"$'\n'"$(cat "$case_dir/stderr")"
-  ! grep -q REFUSED "$case_dir/stderr" || fail "squash-stale-local: teardown printed a REFUSED line"
-  pass "squash-merged task whose local branch stayed on the pre-rebase head is torn down"
+  expect_code 1 "$rc" "squash-same-path-diverged: teardown should refuse when the same file has different content"$'\n'"$(cat "$case_dir/stderr")"
+  grep -q REFUSED "$case_dir/stderr" || fail "squash-same-path-diverged: no REFUSED line in stderr"
+  pass "squash-merged same-path different content still refuses"
 }
 
 test_squash_merged_stale_local_with_unlanded_commit_refuses() {
@@ -990,8 +993,8 @@ test_squash_merged_stale_local_with_unlanded_commit_refuses() {
   pass "squash-merged stale local still refuses genuinely unlanded commits"
 }
 
-test_squash_merged_stale_local_allows_when_forge_unreachable() {
-  local case_dir rc pr_head merge_commit
+test_squash_merged_stale_local_refuses_when_forge_unreachable() {
+  local case_dir rc pr_head
   case_dir=$(make_case squash-stale-offline)
   write_meta "$case_dir" no-mistakes ship
   read -r pr_head _ < <(setup_squash_rebased_history "$case_dir" stale)
@@ -1005,9 +1008,9 @@ test_squash_merged_stale_local_allows_when_forge_unreachable() {
   rc=$?
   set -e
 
-  expect_code 0 "$rc" "squash-stale-offline: teardown should succeed from PR-head content already on default"$'\n'"$(cat "$case_dir/stderr")"
-  ! grep -q REFUSED "$case_dir/stderr" || fail "squash-stale-offline: teardown printed a REFUSED line"
-  pass "squash-merged stale local is torn down when the forge is unreachable"
+  expect_code 1 "$rc" "squash-stale-offline: teardown should refuse when the forge is down and trees conflict"$'\n'"$(cat "$case_dir/stderr")"
+  grep -q REFUSED "$case_dir/stderr" || fail "squash-stale-offline: no REFUSED line in stderr"
+  pass "squash-merged stale local still refuses when the forge is unreachable"
 }
 
 test_pr_check_does_not_refresh_stale_pr_head() {
@@ -3651,9 +3654,9 @@ test_no_pr_recorded_discovers_merged_pr_by_branch_allows
 test_squash_merged_pr_allows_replayed_unpushed_patch
 test_merged_pr_with_later_local_commit_refuses
 test_squash_merged_rebased_branch_allows
-test_squash_merged_stale_pre_rebase_local_allows
+test_squash_merged_same_file_different_content_refuses
 test_squash_merged_stale_local_with_unlanded_commit_refuses
-test_squash_merged_stale_local_allows_when_forge_unreachable
+test_squash_merged_stale_local_refuses_when_forge_unreachable
 test_pr_check_does_not_refresh_stale_pr_head
 test_pr_check_records_remote_head_when_local_lags
 test_content_in_default_fallback_allows

--- a/tests/fm-teardown.test.sh
+++ b/tests/fm-teardown.test.sh
@@ -38,6 +38,10 @@
 #   (o) fm-pr-check rerun after HEAD moved                      -> no stale pr_head
 #   (p) fm-pr-check when local HEAD lags                        -> record remote PR head
 #   (q) no-mistakes + NO pr= recorded, PR discovered by branch  -> ALLOW  (yolo/no-CI merge)
+#   (q2) no-mistakes + squash-merged, local followed pipeline rebase -> ALLOW
+#   (q3) no-mistakes + squash-merged, local still on pre-rebase head -> ALLOW
+#   (q4) no-mistakes + squash-merged stale local plus extra commit   -> REFUSE
+#   (q5) gh down + squash-merged stale local, PR head on default     -> ALLOW
 #
 # Also covers backlog teardown-lock-race: a git index.lock left in the worktree by a
 # killed crew process (bin/fm-teardown.sh's teardown_treehouse_return).
@@ -243,8 +247,10 @@ land_on_origin_main() {
 }
 
 # Override GitHub lookups to report PR 7 as merged with the supplied head.
+# Optional third argument is the merge commit oid (squash commit on the default
+# branch). The four-field pattern must stay above the three-field substring.
 add_gh_pr_merged_for_head() {
-  local case_dir=$1 head=$2
+  local case_dir=$1 head=$2 merge=${3:-}
   cat > "$case_dir/fakebin/gh-axi" <<'SH'
 #!/usr/bin/env bash
 case "${1:-} ${2:-}" in
@@ -260,7 +266,9 @@ SH
 case "\${1:-} \${2:-}" in
   "pr view")
     case " \$* " in
+      *"state,headRefOid,url,mergeCommit"*) printf '%s\t%s\t%s\t%s\n' 'MERGED' '$head' 'https://github.com/example/repo/pull/7' '$merge' ; exit 0 ;;
       *"state,headRefOid,url"*) printf '%s\t%s\t%s\n' 'MERGED' '$head' 'https://github.com/example/repo/pull/7' ; exit 0 ;;
+      *"mergeCommit"*) printf '%s\n' '$merge' ; exit 0 ;;
       *"headRefOid"*) printf '%s\n' '$head' ; exit 0 ;;
     esac
     ;;
@@ -269,6 +277,77 @@ echo "error: pull request not found" >&2
 exit 1
 SH
   chmod +x "$case_dir/fakebin/gh-axi" "$case_dir/fakebin/gh"
+}
+
+# Squash-merged history whose pipeline rebased the branch onto a newer main that
+# edited the same shared file. Per-commit patch ids against the rebased head
+# differ, and merge-tree against main conflicts, which is the false-refusal case.
+# local_mode: rebased | stale | stale-plus-unlanded
+# Echoes: <pr_head> <merge_commit>
+setup_squash_rebased_history() {
+  local case_dir=$1 local_mode=$2 tmp local_head pr_head merge_commit
+  tmp="$case_dir/_shared_base"
+  git clone -q "$case_dir/origin.git" "$tmp"
+  printf '%s\n' base > "$tmp/shared.txt"
+  git -C "$tmp" add -- shared.txt
+  git -C "$tmp" -c user.email=t@t -c user.name=t commit -q -m "shared base"
+  git -C "$tmp" push -q origin main
+  git -C "$case_dir/wt" fetch -q origin
+  git -C "$case_dir/wt" reset -q --hard origin/main
+  rm -rf "$tmp"
+
+  wt_commit_file "$case_dir" feature.txt hello "add feature"
+  printf '%s\n' base feature-edit > "$case_dir/wt/shared.txt"
+  git -C "$case_dir/wt" add -- shared.txt
+  git -C "$case_dir/wt" -c user.email=t@t -c user.name=t \
+    commit -q -m "edit shared from feature"
+  local_head=$(git -C "$case_dir/wt" rev-parse HEAD)
+
+  tmp="$case_dir/_main_move"
+  git clone -q "$case_dir/origin.git" "$tmp"
+  printf '%s\n' base main-edit > "$tmp/shared.txt"
+  git -C "$tmp" add -- shared.txt
+  git -C "$tmp" -c user.email=t@t -c user.name=t commit -q -m "main edits shared"
+  git -C "$tmp" push -q origin main
+  rm -rf "$tmp"
+
+  tmp="$case_dir/_pipeline"
+  git clone -q "$case_dir/origin.git" "$tmp"
+  git -C "$tmp" checkout -q -b fm/task-x1
+  printf '%s\n' hello > "$tmp/feature.txt"
+  git -C "$tmp" add -- feature.txt
+  git -C "$tmp" -c user.email=t@t -c user.name=t commit -q -m "add feature"
+  printf '%s\n' base main-edit feature-edit > "$tmp/shared.txt"
+  git -C "$tmp" add -- shared.txt
+  git -C "$tmp" -c user.email=t@t -c user.name=t \
+    commit -q -m "edit shared from feature"
+  pr_head=$(git -C "$tmp" rev-parse HEAD)
+  git -C "$tmp" push -q origin "HEAD:refs/pull/7/head"
+  git -C "$tmp" checkout -q main
+  git -C "$tmp" merge -q --squash fm/task-x1
+  git -C "$tmp" -c user.email=t@t -c user.name=t commit -q -m "feat: squash (#7)"
+  git -C "$tmp" push -q origin main
+  merge_commit=$(git -C "$tmp" rev-parse HEAD)
+  rm -rf "$tmp"
+
+  git -C "$case_dir/project" fetch -q origin
+  git -C "$case_dir/wt" fetch -q origin "refs/pull/7/head:refs/fm-test/pr-head"
+  case "$local_mode" in
+    rebased)
+      git -C "$case_dir/wt" reset -q --hard "$pr_head"
+      ;;
+    stale)
+      git -C "$case_dir/wt" reset -q --hard "$local_head"
+      ;;
+    stale-plus-unlanded)
+      git -C "$case_dir/wt" reset -q --hard "$local_head"
+      wt_commit_file "$case_dir" later.txt local-only "local follow-up"
+      ;;
+    *)
+      fail "setup_squash_rebased_history: unknown local_mode $local_mode"
+      ;;
+  esac
+  printf '%s %s\n' "$pr_head" "$merge_commit"
 }
 
 append_pr_meta_for_current_head() {
@@ -849,6 +928,86 @@ test_merged_pr_with_later_local_commit_refuses() {
   expect_code 1 "$rc" "stale-pr-head: teardown should refuse when HEAD moved after PR recording"
   grep -q REFUSED "$case_dir/stderr" || fail "stale-pr-head: no REFUSED line in stderr"
   pass "merged PR does not allow teardown after a later local commit"
+}
+
+test_squash_merged_rebased_branch_allows() {
+  local case_dir rc pr_head merge_commit
+  case_dir=$(make_case squash-rebased)
+  write_meta "$case_dir" no-mistakes ship
+  read -r pr_head merge_commit < <(setup_squash_rebased_history "$case_dir" rebased)
+  printf '%s\n' \
+    'pr=https://github.com/example/repo/pull/7' \
+    "pr_head=$pr_head" >> "$case_dir/state/task-x1.meta"
+  add_gh_pr_merged_for_head "$case_dir" "$pr_head" "$merge_commit"
+
+  set +e
+  run_teardown "$case_dir" > "$case_dir/stdout" 2> "$case_dir/stderr"
+  rc=$?
+  set -e
+
+  expect_code 0 "$rc" "squash-rebased: teardown should succeed when the worktree followed the pipeline rebase"$'\n'"$(cat "$case_dir/stderr")"
+  ! grep -q REFUSED "$case_dir/stderr" || fail "squash-rebased: teardown printed a REFUSED line"
+  pass "squash-merged task whose local branch followed the pipeline rebase is torn down"
+}
+
+test_squash_merged_stale_pre_rebase_local_allows() {
+  local case_dir rc pr_head merge_commit
+  case_dir=$(make_case squash-stale-local)
+  write_meta "$case_dir" no-mistakes ship
+  read -r pr_head merge_commit < <(setup_squash_rebased_history "$case_dir" stale)
+  printf '%s\n' \
+    'pr=https://github.com/example/repo/pull/7' \
+    "pr_head=$pr_head" >> "$case_dir/state/task-x1.meta"
+  add_gh_pr_merged_for_head "$case_dir" "$pr_head" "$merge_commit"
+
+  set +e
+  run_teardown "$case_dir" > "$case_dir/stdout" 2> "$case_dir/stderr"
+  rc=$?
+  set -e
+
+  expect_code 0 "$rc" "squash-stale-local: teardown should succeed when local is a pre-rebase duplicate of a squash-merged PR"$'\n'"$(cat "$case_dir/stderr")"
+  ! grep -q REFUSED "$case_dir/stderr" || fail "squash-stale-local: teardown printed a REFUSED line"
+  pass "squash-merged task whose local branch stayed on the pre-rebase head is torn down"
+}
+
+test_squash_merged_stale_local_with_unlanded_commit_refuses() {
+  local case_dir rc pr_head merge_commit
+  case_dir=$(make_case squash-stale-unlanded)
+  write_meta "$case_dir" no-mistakes ship
+  read -r pr_head merge_commit < <(setup_squash_rebased_history "$case_dir" stale-plus-unlanded)
+  printf '%s\n' \
+    'pr=https://github.com/example/repo/pull/7' \
+    "pr_head=$pr_head" >> "$case_dir/state/task-x1.meta"
+  add_gh_pr_merged_for_head "$case_dir" "$pr_head" "$merge_commit"
+
+  set +e
+  run_teardown "$case_dir" > "$case_dir/stdout" 2> "$case_dir/stderr"
+  rc=$?
+  set -e
+
+  expect_code 1 "$rc" "squash-stale-unlanded: teardown should refuse extra local commits that never landed"$'\n'"$(cat "$case_dir/stderr")"
+  grep -q REFUSED "$case_dir/stderr" || fail "squash-stale-unlanded: no REFUSED line in stderr"
+  pass "squash-merged stale local still refuses genuinely unlanded commits"
+}
+
+test_squash_merged_stale_local_allows_when_forge_unreachable() {
+  local case_dir rc pr_head merge_commit
+  case_dir=$(make_case squash-stale-offline)
+  write_meta "$case_dir" no-mistakes ship
+  read -r pr_head _ < <(setup_squash_rebased_history "$case_dir" stale)
+  printf '%s\n' \
+    'pr=https://github.com/example/repo/pull/7' \
+    "pr_head=$pr_head" >> "$case_dir/state/task-x1.meta"
+  add_gh_axi_error "$case_dir"
+
+  set +e
+  run_teardown "$case_dir" > "$case_dir/stdout" 2> "$case_dir/stderr"
+  rc=$?
+  set -e
+
+  expect_code 0 "$rc" "squash-stale-offline: teardown should succeed from PR-head content already on default"$'\n'"$(cat "$case_dir/stderr")"
+  ! grep -q REFUSED "$case_dir/stderr" || fail "squash-stale-offline: teardown printed a REFUSED line"
+  pass "squash-merged stale local is torn down when the forge is unreachable"
 }
 
 test_pr_check_does_not_refresh_stale_pr_head() {
@@ -3491,6 +3650,10 @@ test_squash_merged_pr_allows_when_head_ancestor_of_pr_head
 test_no_pr_recorded_discovers_merged_pr_by_branch_allows
 test_squash_merged_pr_allows_replayed_unpushed_patch
 test_merged_pr_with_later_local_commit_refuses
+test_squash_merged_rebased_branch_allows
+test_squash_merged_stale_pre_rebase_local_allows
+test_squash_merged_stale_local_with_unlanded_commit_refuses
+test_squash_merged_stale_local_allows_when_forge_unreachable
 test_pr_check_does_not_refresh_stale_pr_head
 test_pr_check_records_remote_head_when_local_lags
 test_content_in_default_fallback_allows

--- a/tests/fm-teardown.test.sh
+++ b/tests/fm-teardown.test.sh
@@ -276,8 +276,10 @@ SH
 }
 
 # Squash-merged history whose pipeline rebased the branch onto a newer main that
-# edited the same shared file. Per-commit patch ids against the rebased head
-# differ, and merge-tree against main conflicts, which is the false-refusal case.
+# edited the same shared file. A local copy left behind by that rebase holds
+# different content for the shared file, so its per-commit patch ids against the
+# PR head differ and merge-tree against main conflicts; teardown refuses it on
+# purpose rather than reading a shared path as proof the local content landed.
 # local_mode: rebased | stale | rebased-plus-unlanded
 # Echoes: <pr_head>
 setup_squash_rebased_history() {
@@ -949,9 +951,9 @@ test_squash_merged_same_file_different_content_refuses() {
   local case_dir rc pr_head
   case_dir=$(make_case squash-same-path-diverged)
   write_meta "$case_dir" no-mistakes ship
-  # Reviewer's exact sequence: pipeline rebase produced a different blob for
-  # shared.txt than the stale local still holds, then squash-merged. Same path
-  # is not proof the local content landed.
+  # The pipeline rebase produced a different blob for shared.txt than the stale
+  # local still holds, then squash-merged. Same path is not proof the local
+  # content landed.
   pr_head=$(setup_squash_rebased_history "$case_dir" stale)
   printf '%s\n' \
     'pr=https://github.com/example/repo/pull/7' \

--- a/tests/fm-teardown.test.sh
+++ b/tests/fm-teardown.test.sh
@@ -40,7 +40,7 @@
 #   (q) no-mistakes + NO pr= recorded, PR discovered by branch  -> ALLOW  (yolo/no-CI merge)
 #   (q2) no-mistakes + squash-merged, local followed pipeline rebase -> ALLOW
 #   (q3) no-mistakes + squash-merged, same file, different content   -> REFUSE
-#   (q4) no-mistakes + squash-merged stale local plus extra commit   -> REFUSE
+#   (q4) no-mistakes + squash-merged rebased local plus extra commit -> REFUSE
 #   (q5) gh down + squash-merged stale local, content not in default -> REFUSE
 #
 # Also covers backlog teardown-lock-race: a git index.lock left in the worktree by a
@@ -278,7 +278,7 @@ SH
 # Squash-merged history whose pipeline rebased the branch onto a newer main that
 # edited the same shared file. Per-commit patch ids against the rebased head
 # differ, and merge-tree against main conflicts, which is the false-refusal case.
-# local_mode: rebased | stale | stale-plus-unlanded
+# local_mode: rebased | stale | rebased-plus-unlanded
 # Echoes: <pr_head>
 setup_squash_rebased_history() {
   local case_dir=$1 local_mode=$2 tmp local_head pr_head
@@ -334,8 +334,8 @@ setup_squash_rebased_history() {
     stale)
       git -C "$case_dir/wt" reset -q --hard "$local_head"
       ;;
-    stale-plus-unlanded)
-      git -C "$case_dir/wt" reset -q --hard "$local_head"
+    rebased-plus-unlanded)
+      git -C "$case_dir/wt" reset -q --hard "$pr_head"
       wt_commit_file "$case_dir" later.txt local-only "local follow-up"
       ;;
     *)
@@ -968,11 +968,14 @@ test_squash_merged_same_file_different_content_refuses() {
   pass "squash-merged same-path different content still refuses"
 }
 
-test_squash_merged_stale_local_with_unlanded_commit_refuses() {
+# The local branch followed the pipeline rebase, so without later.txt this is the
+# q2 ALLOW case exactly. The one unlanded follow-up commit is the sole difference
+# and must be the sole reason teardown refuses.
+test_squash_merged_rebased_local_with_unlanded_commit_refuses() {
   local case_dir rc pr_head
-  case_dir=$(make_case squash-stale-unlanded)
+  case_dir=$(make_case squash-rebased-unlanded)
   write_meta "$case_dir" no-mistakes ship
-  pr_head=$(setup_squash_rebased_history "$case_dir" stale-plus-unlanded)
+  pr_head=$(setup_squash_rebased_history "$case_dir" rebased-plus-unlanded)
   printf '%s\n' \
     'pr=https://github.com/example/repo/pull/7' \
     "pr_head=$pr_head" >> "$case_dir/state/task-x1.meta"
@@ -983,9 +986,9 @@ test_squash_merged_stale_local_with_unlanded_commit_refuses() {
   rc=$?
   set -e
 
-  expect_code 1 "$rc" "squash-stale-unlanded: teardown should refuse extra local commits that never landed"$'\n'"$(cat "$case_dir/stderr")"
-  grep -q REFUSED "$case_dir/stderr" || fail "squash-stale-unlanded: no REFUSED line in stderr"
-  pass "squash-merged stale local still refuses genuinely unlanded commits"
+  expect_code 1 "$rc" "squash-rebased-unlanded: teardown should refuse extra local commits that never landed"$'\n'"$(cat "$case_dir/stderr")"
+  grep -q REFUSED "$case_dir/stderr" || fail "squash-rebased-unlanded: no REFUSED line in stderr"
+  pass "squash-merged rebased local still refuses a genuinely unlanded follow-up commit"
 }
 
 test_squash_merged_stale_local_refuses_when_forge_unreachable() {
@@ -3650,7 +3653,7 @@ test_squash_merged_pr_allows_replayed_unpushed_patch
 test_merged_pr_with_later_local_commit_refuses
 test_squash_merged_rebased_branch_allows
 test_squash_merged_same_file_different_content_refuses
-test_squash_merged_stale_local_with_unlanded_commit_refuses
+test_squash_merged_rebased_local_with_unlanded_commit_refuses
 test_squash_merged_stale_local_refuses_when_forge_unreachable
 test_pr_check_does_not_refresh_stale_pr_head
 test_pr_check_records_remote_head_when_local_lags

--- a/tests/fm-teardown.test.sh
+++ b/tests/fm-teardown.test.sh
@@ -347,6 +347,22 @@ setup_squash_rebased_history() {
   printf '%s\n' "$pr_head"
 }
 
+# A refusal must leave every recovery route intact: the isolated copy, its task
+# branch still at the unlanded commit, and the durable task record. A completed
+# teardown detaches and deletes that branch and removes the record, so these hold
+# only while nothing destructive ran before the refusal was reported.
+# Args: case_dir label head-before-teardown
+assert_refusal_retained_task_state() {
+  local case_dir=$1 label=$2 head=$3
+  [ -d "$case_dir/wt" ] || fail "$label: refusal removed the isolated copy"
+  [ "$(git -C "$case_dir/wt" rev-parse --abbrev-ref HEAD 2>/dev/null)" = fm/task-x1 ] \
+    || fail "$label: refusal dropped the task branch"
+  [ "$(git -C "$case_dir/wt" rev-parse HEAD 2>/dev/null)" = "$head" ] \
+    || fail "$label: refusal moved the task branch off the unlanded commit"
+  [ -e "$case_dir/state/task-x1.meta" ] \
+    || fail "$label: refusal erased the durable task record"
+}
+
 append_pr_meta_for_current_head() {
   local case_dir=$1 head
   head=$(git -C "$case_dir/wt" rev-parse HEAD)
@@ -948,13 +964,14 @@ test_squash_merged_rebased_branch_allows() {
 }
 
 test_squash_merged_same_file_different_content_refuses() {
-  local case_dir rc pr_head
+  local case_dir rc pr_head local_head
   case_dir=$(make_case squash-same-path-diverged)
   write_meta "$case_dir" no-mistakes ship
   # The pipeline rebase produced a different blob for shared.txt than the stale
   # local still holds, then squash-merged. Same path is not proof the local
   # content landed.
   pr_head=$(setup_squash_rebased_history "$case_dir" stale)
+  local_head=$(git -C "$case_dir/wt" rev-parse HEAD)
   printf '%s\n' \
     'pr=https://github.com/example/repo/pull/7' \
     "pr_head=$pr_head" >> "$case_dir/state/task-x1.meta"
@@ -967,6 +984,7 @@ test_squash_merged_same_file_different_content_refuses() {
 
   expect_code 1 "$rc" "squash-same-path-diverged: teardown should refuse when the same file has different content"$'\n'"$(cat "$case_dir/stderr")"
   grep -q REFUSED "$case_dir/stderr" || fail "squash-same-path-diverged: no REFUSED line in stderr"
+  assert_refusal_retained_task_state "$case_dir" squash-same-path-diverged "$local_head"
   pass "squash-merged same-path different content still refuses"
 }
 
@@ -974,10 +992,11 @@ test_squash_merged_same_file_different_content_refuses() {
 # q2 ALLOW case exactly. The one unlanded follow-up commit is the sole difference
 # and must be the sole reason teardown refuses.
 test_squash_merged_rebased_local_with_unlanded_commit_refuses() {
-  local case_dir rc pr_head
+  local case_dir rc pr_head local_head
   case_dir=$(make_case squash-rebased-unlanded)
   write_meta "$case_dir" no-mistakes ship
   pr_head=$(setup_squash_rebased_history "$case_dir" rebased-plus-unlanded)
+  local_head=$(git -C "$case_dir/wt" rev-parse HEAD)
   printf '%s\n' \
     'pr=https://github.com/example/repo/pull/7' \
     "pr_head=$pr_head" >> "$case_dir/state/task-x1.meta"
@@ -990,14 +1009,16 @@ test_squash_merged_rebased_local_with_unlanded_commit_refuses() {
 
   expect_code 1 "$rc" "squash-rebased-unlanded: teardown should refuse extra local commits that never landed"$'\n'"$(cat "$case_dir/stderr")"
   grep -q REFUSED "$case_dir/stderr" || fail "squash-rebased-unlanded: no REFUSED line in stderr"
+  assert_refusal_retained_task_state "$case_dir" squash-rebased-unlanded "$local_head"
   pass "squash-merged rebased local still refuses a genuinely unlanded follow-up commit"
 }
 
 test_squash_merged_stale_local_refuses_when_forge_unreachable() {
-  local case_dir rc pr_head
+  local case_dir rc pr_head local_head
   case_dir=$(make_case squash-stale-offline)
   write_meta "$case_dir" no-mistakes ship
   pr_head=$(setup_squash_rebased_history "$case_dir" stale)
+  local_head=$(git -C "$case_dir/wt" rev-parse HEAD)
   printf '%s\n' \
     'pr=https://github.com/example/repo/pull/7' \
     "pr_head=$pr_head" >> "$case_dir/state/task-x1.meta"
@@ -1010,6 +1031,7 @@ test_squash_merged_stale_local_refuses_when_forge_unreachable() {
 
   expect_code 1 "$rc" "squash-stale-offline: teardown should refuse when the forge is down and trees conflict"$'\n'"$(cat "$case_dir/stderr")"
   grep -q REFUSED "$case_dir/stderr" || fail "squash-stale-offline: no REFUSED line in stderr"
+  assert_refusal_retained_task_state "$case_dir" squash-stale-offline "$local_head"
   pass "squash-merged stale local still refuses when the forge is unreachable"
 }
 

--- a/tests/fm-teardown.test.sh
+++ b/tests/fm-teardown.test.sh
@@ -247,10 +247,8 @@ land_on_origin_main() {
 }
 
 # Override GitHub lookups to report PR 7 as merged with the supplied head.
-# Optional third argument is the merge commit oid (squash commit on the default
-# branch). The four-field pattern must stay above the three-field substring.
 add_gh_pr_merged_for_head() {
-  local case_dir=$1 head=$2 merge=${3:-}
+  local case_dir=$1 head=$2
   cat > "$case_dir/fakebin/gh-axi" <<'SH'
 #!/usr/bin/env bash
 case "${1:-} ${2:-}" in
@@ -266,9 +264,7 @@ SH
 case "\${1:-} \${2:-}" in
   "pr view")
     case " \$* " in
-      *"state,headRefOid,url,mergeCommit"*) printf '%s\t%s\t%s\t%s\n' 'MERGED' '$head' 'https://github.com/example/repo/pull/7' '$merge' ; exit 0 ;;
       *"state,headRefOid,url"*) printf '%s\t%s\t%s\n' 'MERGED' '$head' 'https://github.com/example/repo/pull/7' ; exit 0 ;;
-      *"mergeCommit"*) printf '%s\n' '$merge' ; exit 0 ;;
       *"headRefOid"*) printf '%s\n' '$head' ; exit 0 ;;
     esac
     ;;
@@ -283,9 +279,9 @@ SH
 # edited the same shared file. Per-commit patch ids against the rebased head
 # differ, and merge-tree against main conflicts, which is the false-refusal case.
 # local_mode: rebased | stale | stale-plus-unlanded
-# Echoes: <pr_head> <merge_commit>
+# Echoes: <pr_head>
 setup_squash_rebased_history() {
-  local case_dir=$1 local_mode=$2 tmp local_head pr_head merge_commit
+  local case_dir=$1 local_mode=$2 tmp local_head pr_head
   tmp="$case_dir/_shared_base"
   git clone -q "$case_dir/origin.git" "$tmp"
   printf '%s\n' base > "$tmp/shared.txt"
@@ -327,7 +323,6 @@ setup_squash_rebased_history() {
   git -C "$tmp" merge -q --squash fm/task-x1
   git -C "$tmp" -c user.email=t@t -c user.name=t commit -q -m "feat: squash (#7)"
   git -C "$tmp" push -q origin main
-  merge_commit=$(git -C "$tmp" rev-parse HEAD)
   rm -rf "$tmp"
 
   git -C "$case_dir/project" fetch -q origin
@@ -347,7 +342,7 @@ setup_squash_rebased_history() {
       fail "setup_squash_rebased_history: unknown local_mode $local_mode"
       ;;
   esac
-  printf '%s %s\n' "$pr_head" "$merge_commit"
+  printf '%s\n' "$pr_head"
 }
 
 append_pr_meta_for_current_head() {
@@ -931,14 +926,14 @@ test_merged_pr_with_later_local_commit_refuses() {
 }
 
 test_squash_merged_rebased_branch_allows() {
-  local case_dir rc pr_head merge_commit
+  local case_dir rc pr_head
   case_dir=$(make_case squash-rebased)
   write_meta "$case_dir" no-mistakes ship
-  read -r pr_head merge_commit < <(setup_squash_rebased_history "$case_dir" rebased)
+  pr_head=$(setup_squash_rebased_history "$case_dir" rebased)
   printf '%s\n' \
     'pr=https://github.com/example/repo/pull/7' \
     "pr_head=$pr_head" >> "$case_dir/state/task-x1.meta"
-  add_gh_pr_merged_for_head "$case_dir" "$pr_head" "$merge_commit"
+  add_gh_pr_merged_for_head "$case_dir" "$pr_head"
 
   set +e
   run_teardown "$case_dir" > "$case_dir/stdout" 2> "$case_dir/stderr"
@@ -951,17 +946,17 @@ test_squash_merged_rebased_branch_allows() {
 }
 
 test_squash_merged_same_file_different_content_refuses() {
-  local case_dir rc pr_head merge_commit
+  local case_dir rc pr_head
   case_dir=$(make_case squash-same-path-diverged)
   write_meta "$case_dir" no-mistakes ship
   # Reviewer's exact sequence: pipeline rebase produced a different blob for
   # shared.txt than the stale local still holds, then squash-merged. Same path
   # is not proof the local content landed.
-  read -r pr_head merge_commit < <(setup_squash_rebased_history "$case_dir" stale)
+  pr_head=$(setup_squash_rebased_history "$case_dir" stale)
   printf '%s\n' \
     'pr=https://github.com/example/repo/pull/7' \
     "pr_head=$pr_head" >> "$case_dir/state/task-x1.meta"
-  add_gh_pr_merged_for_head "$case_dir" "$pr_head" "$merge_commit"
+  add_gh_pr_merged_for_head "$case_dir" "$pr_head"
 
   set +e
   run_teardown "$case_dir" > "$case_dir/stdout" 2> "$case_dir/stderr"
@@ -974,14 +969,14 @@ test_squash_merged_same_file_different_content_refuses() {
 }
 
 test_squash_merged_stale_local_with_unlanded_commit_refuses() {
-  local case_dir rc pr_head merge_commit
+  local case_dir rc pr_head
   case_dir=$(make_case squash-stale-unlanded)
   write_meta "$case_dir" no-mistakes ship
-  read -r pr_head merge_commit < <(setup_squash_rebased_history "$case_dir" stale-plus-unlanded)
+  pr_head=$(setup_squash_rebased_history "$case_dir" stale-plus-unlanded)
   printf '%s\n' \
     'pr=https://github.com/example/repo/pull/7' \
     "pr_head=$pr_head" >> "$case_dir/state/task-x1.meta"
-  add_gh_pr_merged_for_head "$case_dir" "$pr_head" "$merge_commit"
+  add_gh_pr_merged_for_head "$case_dir" "$pr_head"
 
   set +e
   run_teardown "$case_dir" > "$case_dir/stdout" 2> "$case_dir/stderr"
@@ -997,7 +992,7 @@ test_squash_merged_stale_local_refuses_when_forge_unreachable() {
   local case_dir rc pr_head
   case_dir=$(make_case squash-stale-offline)
   write_meta "$case_dir" no-mistakes ship
-  read -r pr_head _ < <(setup_squash_rebased_history "$case_dir" stale)
+  pr_head=$(setup_squash_rebased_history "$case_dir" stale)
   printf '%s\n' \
     'pr=https://github.com/example/repo/pull/7' \
     "pr_head=$pr_head" >> "$case_dir/state/task-x1.meta"

--- a/tests/fm-teardown.test.sh
+++ b/tests/fm-teardown.test.sh
@@ -320,7 +320,7 @@ setup_squash_rebased_history() {
   pr_head=$(git -C "$tmp" rev-parse HEAD)
   git -C "$tmp" push -q origin "HEAD:refs/pull/7/head"
   git -C "$tmp" checkout -q main
-  git -C "$tmp" merge -q --squash fm/task-x1
+  git -C "$tmp" merge -q --squash fm/task-x1 >/dev/null
   git -C "$tmp" -c user.email=t@t -c user.name=t commit -q -m "feat: squash (#7)"
   git -C "$tmp" push -q origin main
   rm -rf "$tmp"


### PR DESCRIPTION
## Intent

Firstmate cannot finish cleaning up a task whose work is demonstrably merged, and the only route the tool offers is a force the captain should not have to authorise.

It bit a real task today. The connection clone landed as PR 12 and is on main, verified three ways: the merge itself reported merged, main's head is the squash of that pull request, and the feature code is present in the tree. Cleanup still refused, naming the branch commits as unlanded work.

The captain's standing position, given plainly on 2026-09-06, is that proof an override is safe is not a reason to want one, and that the route which overrides nothing is the one to offer. So the refusal was left in place and the task is sitting there unfinished. That is the right call and it is also not sustainable, because every squash-merged task whose branch the pipeline rebased will land in the same state and keep waking firstmate.

## What Changed

- Adds four regression cases to `tests/fm-teardown.test.sh` covering squash-merged tasks whose branch the pipeline rebased: teardown succeeds when the worktree followed the rebase and matches the merged PR head (q2), and refuses when a stale local holds different content on a shared path (q3), when a rebased local carries an extra unlanded follow-up commit (q4), and when that stale local is checked with the forge unreachable (q5).
- Adds a shared `setup_squash_rebased_history` fixture that builds a main that edits a shared file, a rebased PR head pushed to `refs/pull/7/head`, and a squash merge of that head onto main, parameterized by `local_mode` (`rebased` | `stale` | `rebased-plus-unlanded`).
- Extends the `bin/fm-teardown.sh` header comment to record why a diverged local copy is not treated as landed after a squash merge — per-commit patch ids no longer match, and path-set coverage, `git cherry`, and merge-tree containment each also accept unlanded edits — and which proofs teardown still accepts. No executable code in the script changed.

## Risk Assessment

✅ Low: The branch changes no production logic at all - only a header comment and four tests whose expected ALLOW/REFUSE outcomes I verified hold against the unchanged guard - so it cannot loosen the unlanded-work refusal, and the unresolved intent behind it is captain-authorized containment from round 1.

## Testing

I ran the whole of tests/fm-teardown.test.sh first; it aborts partway through at `herdr-preflight-missing-adapter`, before ever reaching the four new tests, so I ran the landed-work tests in isolation from scratch copies of the base and target trees. All four new tests plus the nine neighbouring landed-work tests pass at the target commit. For end-user evidence I drove the real fm-teardown.sh against real git repositories where PR 7 was genuinely squash-merged after the pipeline rebased the branch onto a main that had edited the same file, and captured the CLI transcripts: the reported case (worktree followed the pipeline rebase) finishes cleanly with exit 0 and no --force, invoking the destructive worktree return; the three unsafe shapes print REFUSED with exit 1, never invoke the destructive return, and leave the task record and branch intact. Two caveats worth a reviewer's attention. The branch's only production change is seven comment lines — the same 13-test subset passes identically against unmodified origin/main — so these tests document the existing boundary rather than prove a fix, and the real-world symptom in the intent (a stale local copy that did not follow the rebase) still refuses, which is the captain's recorded decision. On the two round-1 failures: the fm-teardown one reproduces identically on unmodified main and is a stock macOS bash 3.2 defect (under `set -e`, a failed `source` of a missing file kills the shell despite `|| return 1`, and the EXIT trap then reports exit 0), which I isolated to an 8-line standalone repro; CI runs this file on Linux bash 5, where the macOS lane never touches it. fm-pr-check-security.test.sh ran clean end to end, so its earlier failure was a flake. Neither is a regression from this branch, and I changed no production or test code.

<details>
<summary>Evidence: fm-teardown CLI transcripts: squash-merged / pipeline-rebased task cleanup (q2 ALLOW, q3/q4/q5 REFUSE)</summary>

Source: [fm-teardown CLI transcripts: squash-merged / pipeline-rebased task cleanup (q2 ALLOW, q3/q4/q5 REFUSE)](https://github.com/MortenGad/firstmate/blob/2ad240999cf0e84d0ca55741d805d74f85d1dc39/.no-mistakes/evidence/fm/fm-teardown-squash-blind-q38/teardown-squash-merge-transcripts.txt)

```text
fm-teardown.sh - squash-merged / pipeline-rebased task cleanup
branch fm/fm-teardown-squash-blind-q38 @ 7325c58   generated 2026-09-06T20:56:07Z

Every run below is the real bin/fm-teardown.sh against a real git origin whose
PR 7 was genuinely squash-merged after the pipeline rebased the branch onto a
main that had edited the same file. Only the forge client (gh/gh-axi) and the
worktree-return helper (treehouse) are stubbed; the landed-work decision is the
product's own.

===============================================================================
SCENARIO q2
The reported case: PR squash-merged, local worktree followed the pipeline rebase.
Teardown must FINISH - no --force, no override.
===============================================================================
PR 7 on the forge        : MERGED (squash), head 7b92acf
origin/main              : 23c1a7a  feat: squash (#7)
local task HEAD          : 7b92acf  edit shared from feature
local HEAD vs PR head    : identical (worktree followed the pipeline rebase)
commits not on origin/main:
    7b92acf edit shared from feature
    9296bdf add feature

$ fm-teardown.sh task-x1
  /private/var/folders/hg/5q3jmyw50ln9sxy7c8800vgr0000gn/T/fm-teardown-tests.ErIIE6/tx-q2/project: synced d274db6..23c1a7a
  teardown task-x1 complete (window firstmate:fm-task-x1, worktree /private/var/folders/hg/5q3jmyw50ln9sxy7c8800vgr0000gn/T/fm-teardown-tests.ErIIE6/tx-q2/wt)
  Backlog: task-x1 just finished (this home keeps no backlog at /private/var/folders/hg/5q3jmyw50ln9sxy7c8800vgr0000gn/T/fm-teardown-tests.ErIIE6/tx-q2/data/backlog.md). Update /private/var/folders/hg/5q3jmyw50ln9sxy7c8800vgr0000gn/T/fm-teardown-tests.ErIIE6/tx-q2/data/backlog.md - move task-x1 to Done, keep Done to the 10 most recent, then re-scan Queued and dispatch only work whose blockers are gone and date is due.
  $? = 0

observable outcome
  destructive worktree return : INVOKED -> treehouse return --force /private/var/folders/hg/5q3jmyw50ln9sxy7c8800vgr0000gn/T/fm-teardown-tests.ErIIE6/tx-q2/wt
  task record task-x1.meta    : cleared - task finished
  task branch fm/task-x1      : HEAD

===============================================================================
SCENARIO q3
PR squash-merged, but the local worktree still holds a DIFFERENT version of the
same file the PR landed. Same path is not proof the local content landed.
Teardown must REFUSE.
===============================================================================
PR 7 on the forge        : MERGED (squash), head 7506a86
origin/main              : 03be079  feat: squash (#7)
local task HEAD          : 5bb7952  edit shared from feature
local HEAD vs PR head    : DIVERGED
commits not on origin/main:
    5bb7952 edit shared from feature
    4faa91f add feature

$ fm-teardown.sh task-x1
  REFUSED: worktree /private/var/folders/hg/5q3jmyw50ln9sxy7c8800vgr0000gn/T/fm-teardown-tests.ErIIE6/tx-q3/wt has work not on any remote and not landed.
  unpushed commits:
  5bb7952 edit shared from feature
  4faa91f add feature
  Push the branch, land its PR, or get the captain's explicit OK to discard, then --force.
  $? = 1

observable outcome
  destructive worktree return : never invoked (nothing was returned or reset)
  task record task-x1.meta    : RETAINED - task still open, captain can retry
  task branch fm/task-x1      : fm/task-x1

===============================================================================
SCENARIO q4
Exactly the q2 ALLOW case plus ONE genuinely unlanded local follow-up commit.
That commit alone must flip the decision. Teardown must REFUSE.
===============================================================================
PR 7 on the forge        : MERGED (squash), head 5e1b8a3
origin/main              : 080ba9b  feat: squash (#7)
local task HEAD          : e64a48f  local follow-up
local HEAD vs PR head    : DIVERGED
commits not on origin/main:
    e64a48f local follow-up
    5e1b8a3 edit shared from feature
    80ac090 add feature

$ fm-teardown.sh task-x1
  REFUSED: worktree /private/var/folders/hg/5q3jmyw50ln9sxy7c8800vgr0000gn/T/fm-teardown-tests.ErIIE6/tx-q4/wt has work not on any remote and not landed.
  unpushed commits:
  e64a48f local follow-up
  5e1b8a3 edit shared from feature
  80ac090 add feature
  Push the branch, land its PR, or get the captain's explicit OK to discard, then --force.
  $? = 1

observable outcome
  destructive worktree return : never invoked (nothing was returned or reset)
  task record task-x1.meta    : RETAINED - task still open, captain can retry
  task branch fm/task-x1      : fm/task-x1

===============================================================================
SCENARIO q5
Forge unreachable and the local content is not in the default branch.
Teardown must REFUSE rather than guess. 
===============================================================================
PR 7 on the forge        : UNREACHABLE (gh/gh-axi erroring)
origin/main              : 1e4ce86  feat: squash (#7)
local task HEAD          : 3d5a6d8  edit shared from feature
local HEAD vs PR head    : DIVERGED
commits not on origin/main:
    3d5a6d8 edit shared from feature
    2113d28 add feature

$ fm-teardown.sh task-x1
  REFUSED: worktree /private/var/folders/hg/5q3jmyw50ln9sxy7c8800vgr0000gn/T/fm-teardown-tests.ErIIE6/tx-q5/wt has work not on any remote and not landed.
  unpushed commits:
  3d5a6d8 edit shared from feature
  2113d28 add feature
  Push the branch, land its PR, or get the captain's explicit OK to discard, then --force.
  $? = 1

observable outcome
  destructive worktree return : never invoked (nothing was returned or reset)
  task record task-x1.meta    : RETAINED - task still open, captain can retry
  task branch fm/task-x1      : fm/task-x1
```
</details>
<details>
<summary>Evidence: Reproduction of the pre-existing macOS bash 3.2 herdr-preflight failure at base and target, with isolated root cause</summary>

Source: [Reproduction of the pre-existing macOS bash 3.2 herdr-preflight failure at base and target, with isolated root cause](https://github.com/MortenGad/firstmate/blob/2ad240999cf0e84d0ca55741d805d74f85d1dc39/.no-mistakes/evidence/fm/fm-teardown-squash-blind-q38/preexisting-herdr-preflight-bash32.txt)

```text
Pre-existing failure: tests/fm-teardown.test.sh :: herdr-preflight-missing-adapter
Reproduced on stock macOS /bin/bash, GNU bash, version 3.2.57(1)-release (arm64-apple-darwin26)
generated 2026-09-06T20:58:44Z

1) Same test, unmodified origin/main (base commit f91a950):
   $ cd <worktree of f91a950> && bash tests/<only test_herdr_flat_teardown_preflight_refuses_before_changes>
   not ok - herdr-preflight-missing-adapter: teardown continued without its required preflight
   exit=1

2) Same test at this branch's target commit (7325c58):
   not ok - herdr-preflight-missing-adapter: teardown continued without its required preflight
   exit=1

   Identical failure. bin/fm-teardown.sh on this branch adds 7 lines, all of them
   full-line comments; with comment lines stripped the two files are byte-identical:
   $ diff <(grep -v '^#' base/bin/fm-teardown.sh) <(grep -v '^#' head/bin/fm-teardown.sh)
   (no differences)

3) Root cause, isolated to 8 lines of shell (no firstmate code involved):
   set -eu
   cleanup() { local s=0; echo "trap-ran"; return 0; }
   trap cleanup EXIT
   inner() {
     local name=$1
     case "$name" in
       herdr)
         if [ -z "${_G:-}" ]; then
           . "/tmp/nm-scratch/backends/herdr.sh" || return 1
           _G=1
         fi
         ;;
     esac
   }
   outer() {
     if ! inner herdr; then echo "converted-to-refusal" >&2; return 1; fi
     echo "prereqs-ok"
   }
   outer || { echo "outer-failed"; exit 1; }
   echo "reached-end"

   $ /bin/bash srctest2.sh
   /tmp/nm-scratch/srctest2.sh: line 9: /tmp/nm-scratch/backends/herdr.sh: No such file or directory
   trap-ran
   exit=0

   Under 'set -e', bash 3.2 treats a failed 'source' of a missing file as fatal and
   exits the shell immediately - the '|| return 1' never runs, so fm_backend_source's
   refusal path (bin/fm-backend.sh:614) is never reached and
   teardown_herdr_require_prerequisites never prints its 'nothing was changed' refusal.
   The EXIT trap (teardown_release_locks) then succeeds, and bash 3.2 reports the
   trap's status, so the process exits 0 - which is what the assertion sees.

   Variant matrix on this /bin/bash (exit status of the shell itself):
   no set -e, no trap     exit=0   output: f rc=1 | after | /bin/bash: /nope/x.sh: No such file or directory
   set -e, no trap        exit=1   output: /bin/bash: /nope/x.sh: No such file or directory
   set -e + EXIT trap     exit=0   output: trap-ran | /bin/bash: /nope/x.sh: No such file or directory

   CI runs tests/fm-teardown.test.sh on ubuntu-latest (bash 5); the stock macOS
   bash 3.2 lane in .github/workflows/ci.yml runs only parse checks and three named
   snapshot tests, not this file. So this failure is local-environment-only and
   pre-existing on main - out of scope for this branch.
```
</details>
<details>
<summary>Evidence: Landed-work test subset — target commit 7325c58 (all 13 pass, including the 4 new squash-merge tests)</summary>

```text
ok - squash-merged + deleted-branch worktree (PR merged) is torn down (the fix)
ok - squash-merged PR accepts a local HEAD that is an ancestor of the final PR head
ok - teardown discovers a merged PR by branch name and tears down when no pr= was ever recorded
ok - squash-merged PR accepts replayed unpushed local patches contained in the PR head
ok - merged PR does not allow teardown after a later local commit
ok - squash-merged task whose local branch followed the pipeline rebase is torn down
ok - squash-merged same-path different content still refuses
ok - squash-merged rebased local still refuses a genuinely unlanded follow-up commit
ok - squash-merged stale local still refuses when the forge is unreachable
ok - worktree whose content already landed in the default branch is torn down (content fallback)
ok - content fallback refreshes origin default before comparing trees
ok - dirty worktree is refused even when its committed work has landed (dirty always wins)
ok - gh lookup error with content not in default refuses (fail-safe)
EXIT=0
```
</details>
<details>
<summary>Evidence: Same subset against BASE commit f91a950 (= origin/main) — also all 13 pass, so the new tests document existing behavior</summary>

```text
$ cd <base f91a950 tree> && bash tests/sel-landed.test.sh
ok - squash-merged + deleted-branch worktree (PR merged) is torn down (the fix)
ok - squash-merged PR accepts a local HEAD that is an ancestor of the final PR head
ok - teardown discovers a merged PR by branch name and tears down when no pr= was ever recorded
ok - squash-merged PR accepts replayed unpushed local patches contained in the PR head
ok - merged PR does not allow teardown after a later local commit
ok - squash-merged task whose local branch followed the pipeline rebase is torn down
ok - squash-merged same-path different content still refuses
ok - squash-merged rebased local still refuses a genuinely unlanded follow-up commit
ok - squash-merged stale local still refuses when the forge is unreachable
ok - worktree whose content already landed in the default branch is torn down (content fallback)
ok - content fallback refreshes origin default before comparing trees
ok - dirty worktree is refused even when its committed work has landed (dirty always wins)
ok - gh lookup error with content not in default refuses (fail-safe)
EXIT=0

$ diff <(grep -v '^#' base/bin/fm-teardown.sh) <(grep -v '^#' head/bin/fm-teardown.sh)
(no differences - all 7 added production lines are comments)
```
</details>
- Outcome: ⚠️ 2 issues (1 warning, 1 info) across 1 run (20m0s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"457baf2e5a3a78d11df313a9124515f58dcd8416","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>⚠️ **Review** - 2 infos</summary>

- ℹ️ `bin/fm-teardown.sh:41` - No action needed; recorded for the merge decision. The only production change on this branch is this 7-line header comment - `git diff f91a950 7325c58 -- bin/` contains no executable line. `eeeb58d` added squash/rebase landed-work coverage and `049c4d4`+`b192c56` removed all of it, so `work_is_landed`, `pr_is_merged`, `unpushed_patches_are_in_pr_head`, `content_in_default` and `ensure_commit_object` are identical to the base commit. The task named in the User intent therefore still refuses: I replayed the fixture on git 2.54.0 and for a stale local worktree `unpushed_patches_are_in_pr_head` fails on the shared.txt patch-id mismatch (local 0d0e7d58 vs pipeline 4c499e9d) and `content_in_default` exits 1 on a merge-tree conflict. That outcome is the captain&#39;s round-1 authorized containment (&#34;prefer keeping the current refusal over widening it on a guess&#34;), which supersedes the intent wording, so this is honest containment rather than an intent contradiction - noted only so the deferred symptom (squash-merged rebased tasks keep waking firstmate) stays visible.
- ℹ️ `tests/fm-teardown.test.sh:279` - The `setup_squash_rebased_history` docstring says &#34;Per-commit patch ids against the rebased head differ, and merge-tree against main conflicts, which is the false-refusal case.&#34; That is true only for `stale`. After 7325c58 retargeted q4 onto `rebased-plus-unlanded`, two of the three modes behave the opposite way: I verified that for `rebased` merge-tree produces exactly origin/main&#39;s tree (equal, no conflict) and for `rebased-plus-unlanded` it produces main&#39;s tree plus later.txt (clean, no conflict), and in both modes `base..pr_head` is empty so there are no per-commit patch ids to compare at all. Only the mode list on the next line was updated. A maintainer picking a mode from this comment will pick the wrong one. Mechanical doc fix: scope the sentence to `stale` and state that the two `rebased*` modes are decided by the ancestor check and the tree comparison instead.
</details>

<details>
<summary>⚠️ **Test** - 2 issues (1 warning, 1 info)</summary>

- ⚠️ `tests/fm-teardown.test.sh:2181` - Pre-existing, not a regression from this branch: `tests/fm-teardown.test.sh :: herdr-preflight-missing-adapter` fails on stock macOS /bin/bash 3.2 and, because the file runs its tests sequentially and exits on first failure, it aborts before ever reaching the four new squash-merge tests locally. It fails identically at base commit f91a950 (= origin/main), and this branch&#39;s only production change is 7 comment lines (executable content byte-identical to main). Root cause is a bash 3.2 defect, not firstmate logic: under `set -e`, `. &lt;missing-file&gt; || return 1` terminates the shell immediately instead of returning 1, so `fm_backend_source`&#39;s refusal path (bin/fm-backend.sh:614) never runs and `teardown_herdr_require_prerequisites` never prints its &#39;nothing was changed&#39; refusal; the EXIT trap `teardown_release_locks` then succeeds and bash 3.2 reports the trap&#39;s status, so the process exits 0 — which is exactly what the assertion sees. CI runs this file on ubuntu-latest (bash 5); the stock-macOS-bash lane in .github/workflows/ci.yml runs only parse checks and three named snapshot tests, not this file. Per the round-1 instruction I did not skip, delete, or paper over it. Deciding whether to make the adapter-source failure bash-3.2-safe (e.g. an explicit `[ -r ... ]` guard before the source) is a separate change on main and the captain&#39;s call. Full reproduction in evidence/preexisting-herdr-preflight-bash32.txt.
- ℹ️ `tests/fm-pr-check-security.test.sh` - The round-1 `tests/fm-pr-check-security.test.sh` failure (&#39;first merged watcher cycle failed with an empty reason&#39;) did not reproduce: the suite ran clean end to end with exit 0 and no failing assertions. Consistent with the round-1 read that it was a flake. No code change made.
- <code>`bash tests/fm-teardown.test.sh` (full file) — aborts at the pre-existing `herdr-preflight-missing-adapter` failure before reaching the new tests on macOS bash 3.2</code>
- <code>Targeted landed-work subset at target commit 7325c58 (13 tests, all pass): `test_squash_merged_rebased_branch_allows`, `test_squash_merged_same_file_different_content_refuses`, `test_squash_merged_rebased_local_with_unlanded_commit_refuses`, `test_squash_merged_stale_local_refuses_when_forge_unreachable`, plus `test_squash_merged_branch_deleted_allows`, `test_squash_merged_pr_allows_when_head_ancestor_of_pr_head`, `test_no_pr_recorded_discovers_merged_pr_by_branch_allows`, `test_squash_merged_pr_allows_replayed_unpushed_patch`, `test_merged_pr_with_later_local_commit_refuses`, `test_content_in_default_fallback_allows`, `test_content_fallback_refreshes_stale_origin_ref`, `test_dirty_worktree_refuses`, `test_gh_error_and_content_absent_refuses`</code>
- `Same 13-test subset re-run against base commit f91a950 (= origin/main) production code — all 13 pass there too, so the four new tests characterize pre-existing behavior rather than a fix`
- <code>Manual end-to-end CLI verification: drove the real `bin/fm-teardown.sh` against real git origins with a genuinely squash-merged PR 7 over a pipeline-rebased branch, in all four scenarios (q2/q3/q4/q5), capturing stdout, stderr, exit status, whether the destructive `treehouse return` was invoked, and whether the task record survived</code>
- <code>`test_herdr_flat_teardown_preflight_refuses_before_changes` run in isolation at BOTH base f91a950 and target 7325c58 — identical `not ok` at both</code>
- <code>Root-caused the herdr-preflight failure to bash 3.2 semantics with an 8-line standalone repro plus a 3-variant matrix (`set -e` + failed `source` exits the shell despite `|| return 1`; the EXIT trap then masks the status as 0)</code>
- <code>`diff &lt;(grep -v &#39;^#&#39; base/bin/fm-teardown.sh) &lt;(grep -v &#39;^#&#39; head/bin/fm-teardown.sh)` — no differences; all 7 added production lines are comments</code>
- <code>`bash tests/fm-pr-check-security.test.sh` — full clean run, exit 0, no failures (round-1 flake did not reproduce)</code>
- <code>`bash tests/sel-full-minus.test.sh` (whole fm-teardown file minus the one bash-3.2-broken test) — still in progress when I reported; no failures in the portion that had completed</code>
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>⚠️ **Lint** - 1 warning</summary>

- ⚠️ linter found issues (exit code 1)

🔧 Fix: install pinned shellcheck and actionlint; lint clean, no code changes
1 warning still open:

- ⚠️ linter found issues (exit code 1)
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
