### PR TITLE
fix(secondmate): bind worker pools to owning homes

### DIFF
--- a/.agents/skills/bootstrap-diagnostics/SKILL.md
+++ b/.agents/skills/bootstrap-diagnostics/SKILL.md
@@ -18,6 +18,7 @@ When any diagnostic needs captain attention, report the plain consequence and re
 
 - `MISSING: <tool> (install: <command>)` - list the missing tools to the captain with a one-line purpose each plus the printed install commands, wait for consent (one approval may cover the list), then run `bin/fm-bootstrap.sh install <approved tools...>`.
   For `treehouse`, this also covers an installed version whose `treehouse get` lacks `--lease`; treat it as an upgrade request.
+  It also covers a non-primary home whose `treehouse get` lacks `--root`, because that home must not fall back into another home's pool.
   For `no-mistakes`, this also covers an installed version older than 1.46.0, because this repo's PR gate requires structured pipeline attestation that older builds do not write.
   For any axi-family tool - `gh-axi`, `lavish-axi`, `tasks-axi`, `quota-axi` - an installed version below its floor is a plain upgrade request; [`bin/fm-bootstrap.sh`](../../../bin/fm-bootstrap.sh) owns the floor policy, and never argue the floor down to whatever the home happens to have installed.
   For `tasks-axi`, this additionally covers an installed build that fails the separate feature probe (`bin/fm-tasks-axi-lib.sh` owns the definition); `config/backlog-backend=manual` only suppresses the verbose `BOOTSTRAP_INFO: tasks-axi available` fact, not this missing-tool report.

--- a/.agents/skills/secondmate-provisioning/SKILL.md
+++ b/.agents/skills/secondmate-provisioning/SKILL.md
@@ -52,7 +52,7 @@ bin/fm-brief.sh <id> --secondmate {<project>...|--no-projects}
 The scaffold writes a charter brief instead of a task brief.
 Set `FM_SECONDMATE_CHARTER='<charter>'` to fill the charter text and `FM_SECONDMATE_SCOPE='<scope>'` when the routing scope differs.
 If you scaffold without `FM_SECONDMATE_CHARTER`, replace the `{TASK}` placeholder before seeding.
-Pass `--no-projects` instead of a project list to scaffold a project-less charter for a domain whose subject is the firstmate repo itself, whose home is a firstmate worktree and whose crews take pooled worktrees of the same repo.
+Pass `--no-projects` instead of a project list to scaffold a project-less charter for a domain whose subject is the firstmate repo itself, whose home is a firstmate worktree and whose crews take worktrees from that home's bound pool.
 `--no-projects` is mutually exclusive with a project list, and omitting both still fails loudly, so an accidental omission is never mistaken for a deliberate project-less seed.
 Re-seeding a populated home as project-less is refused non-destructively when the home contains project clones or `data/projects.md` entries.
 Retire or clean that home first, and re-scaffold a stale project-bearing charter with `--no-projects` before seeding.

--- a/bin/fm-bootstrap.sh
+++ b/bin/fm-bootstrap.sh
@@ -52,7 +52,9 @@
 #          on a feature branch instead of its default branch - a crewmate's work
 #          landed in the primary instead of its own worktree; restore it per the line.
 #          treehouse is also MISSING when its installed version lacks
-#          "treehouse get --lease" support.
+#          "treehouse get --lease" support, or when this home needs its own pool
+#          root and the installed version lacks the global --root option
+#          (docs/configuration.md owns the per-home pool contract).
 #          no-mistakes is also MISSING when its installed version is older than
 #          1.46.0 (structured pipeline attestation floor; see CONTRIBUTING.md).
 #          The AXI-family floor policy is owned beside GH_AXI_MIN and
@@ -181,6 +183,8 @@ DATA="${FM_DATA_OVERRIDE:-$FM_HOME/data}"
 # deferred network stage sets, so an ordinary bootstrap run records nothing.
 # shellcheck source=bin/fm-timing-lib.sh disable=SC1091
 . "$SCRIPT_DIR/fm-timing-lib.sh"
+# shellcheck source=bin/fm-treehouse-lib.sh disable=SC1091
+. "$SCRIPT_DIR/fm-treehouse-lib.sh"
 
 # Network-phase selection (see the header). An unrecognized value resolves to
 # `all` so a malformed override runs every step rather than silently dropping a
@@ -911,6 +915,16 @@ treehouse_supports_lease() {
   treehouse get --help 2>&1 | grep -Eq '(^|[^[:alnum:]_-])--lease([^[:alnum:]_-]|$)'
 }
 
+# This home needs Treehouse's --root option only when it resolves a pool root of
+# its own; the primary home keeps Treehouse's default precedence and never does.
+# An unresolvable root is its own detect-only diagnostic, so treat it as needing
+# the option rather than quietly clearing the gate.
+treehouse_root_option_required() {
+  local root
+  root=$(fm_treehouse_root_for_home "$FM_ROOT" "$FM_HOME") || return 0
+  [ -n "$root" ]
+}
+
 # Shared semantic-version floor for the tool gates below. A version string that
 # cannot be parsed into exactly one major.minor.patch triple is incompatible,
 # never assumed current, so a development or vendored build cannot pass a floor
@@ -1414,8 +1428,13 @@ detect_local_tools() {
   # The treehouse lease-support upgrade check is only relevant when the resolved
   # backend actually requires treehouse (every backend except orca, which owns its
   # own worktrees); an orca home must not be told to upgrade a provider it never uses.
+  # The same backend condition covers the per-home pool root: a non-primary home
+  # cannot bind its workers to its own project clone without Treehouse's --root
+  # option (v2.2.0 or newer), and docs/configuration.md owns that contract.
   if fm_backend_list_contains "$TOOLS" treehouse \
-    && command -v treehouse >/dev/null 2>&1 && ! treehouse_supports_lease; then
+    && command -v treehouse >/dev/null 2>&1 \
+    && { ! treehouse_supports_lease \
+      || { treehouse_root_option_required && ! fm_treehouse_supports_root; }; }; then
     echo "MISSING: treehouse (install: $(install_cmd treehouse))"
   fi
   if command -v no-mistakes >/dev/null 2>&1 && ! tool_version_at_least no-mistakes "$NO_MISTAKES_MIN"; then

--- a/bin/fm-claude-trust.sh
+++ b/bin/fm-claude-trust.sh
@@ -34,6 +34,7 @@
 # whatever a mutable env var names, and add exactly the policy surface this
 # registration must not grow. The structural test is verified for treehouse
 # worktrees, which are linked git worktrees. Orca's worktree shape is UNVERIFIED:
+# Per-home Treehouse root selection is owned by docs/configuration.md and bin/fm-treehouse-lib.sh.
 # docs/orca-backend.md calls it an "independent worktree", which does not
 # establish a shared git common dir, and orca is macOS-only and was not installed
 # where this was written. If Orca clones instead of linking, its git dir equals

--- a/bin/fm-install-treehouse.sh
+++ b/bin/fm-install-treehouse.sh
@@ -9,12 +9,15 @@
 # Usage:
 #   fm-install-treehouse.sh <destination-directory>
 #
-# Pins Treehouse v2.0.1, the version exercised by the local real-Herdr suite.
+# Pins Treehouse v2.3.0, the version exercised by the local real-Herdr suite.
+# The floor is v2.2.0, the first release carrying the global --root flag that
+# bin/fm-treehouse-lib.sh needs to bind a non-primary home's pool to its own
+# project clone (docs/configuration.md owns that contract).
 set -eu
 
-FM_TREEHOUSE_CI_VERSION=2.0.1
+FM_TREEHOUSE_CI_VERSION=2.3.0
 FM_TREEHOUSE_CI_TAG="v${FM_TREEHOUSE_CI_VERSION}"
-# Bounded download ceiling (bytes). Official 2.0.1 archives are under 8 MiB.
+# Bounded download ceiling (bytes). Official 2.3.0 archives are under 8 MiB.
 FM_TREEHOUSE_CI_MAX_BYTES=15000000
 FM_TREEHOUSE_CI_REPO=kunchenguid/treehouse
 
@@ -30,19 +33,19 @@ arch=$(uname -m)
 case "${os}-${arch}" in
   Linux-x86_64)
     ARCHIVE=treehouse-v${FM_TREEHOUSE_CI_VERSION}-linux-amd64.tar.gz
-    SHA256=1d5a32751ab921670103fd201ddb2b91b47338cb13976f45642b827cf8976af2
+    SHA256=94fd2b2c20c35aac1ddc2941317890ad82c9916f5ccecbac4a50cda783eed10f
     ;;
   Linux-aarch64|Linux-arm64)
     ARCHIVE=treehouse-v${FM_TREEHOUSE_CI_VERSION}-linux-arm64.tar.gz
-    SHA256=eaccc9c5b98125df8bd77425598eeecee66cb0371db4eb1cf75f0d813c18fab9
+    SHA256=408589ba72b58d5e942071ed863a83fd96566cfd1e514945daa59defde528bbb
     ;;
   Darwin-arm64)
     ARCHIVE=treehouse-v${FM_TREEHOUSE_CI_VERSION}-darwin-arm64.tar.gz
-    SHA256=7ee5078f3d1f33c01196548797fce65408e459d53530b77d4ba56e074fa1c1a2
+    SHA256=1cb09bcfa830b4eec5e54beeaa71589adb9c5d828573dda0f5150e2d80cf13d5
     ;;
   Darwin-x86_64)
     ARCHIVE=treehouse-v${FM_TREEHOUSE_CI_VERSION}-darwin-amd64.tar.gz
-    SHA256=1cf44580a5837f995e1d3bb74f4fbd3112b642acd20406087d9735a8106112fd
+    SHA256=349afcc13c2beb20d846eb560a11b30e1a5cab8e2dfb22988a36aa7f213b5881
     ;;
   *)
     die "unsupported platform ${os}-${arch}; official Treehouse assets are linux/darwin amd64 and arm64"
@@ -68,7 +71,7 @@ fi
 [ "$ACTUAL_SHA256" = "$SHA256" ] || die "checksum mismatch for $ARCHIVE (expected $SHA256, got $ACTUAL_SHA256)"
 
 tar -xzf "$TMP/$ARCHIVE" -C "$TMP"
-# Archive layout: a single `treehouse` binary at the archive root (verified for v2.0.1).
+# Archive layout: a single `treehouse` binary at the archive root (verified for v2.3.0).
 if [ -f "$TMP/treehouse" ]; then
   BIN="$TMP/treehouse"
 elif [ -f "$TMP/treehouse-v${FM_TREEHOUSE_CI_VERSION}/treehouse" ]; then
@@ -82,7 +85,7 @@ mkdir -p "$DESTINATION"
 install -m 0755 "$BIN" "$DESTINATION/treehouse"
 
 installed_version=$("$DESTINATION/treehouse" --version 2>/dev/null | tr -d '[:space:]')
-# treehouse prints "v2.0.1" (leading v) on --version.
+# treehouse prints "v2.3.0" (leading v) on --version.
 case "$installed_version" in
   "v${FM_TREEHOUSE_CI_VERSION}"|"${FM_TREEHOUSE_CI_VERSION}") ;;
   *)

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -3018,7 +3018,7 @@ elif [ "$KIND" != secondmate ] && [ "$BACKEND" != orca ]; then
       echo "error: this home needs its own Treehouse pool root, but the installed treehouse has no --root option; upgrade treehouse to v2.2.0 or newer and rerun" >&2
       exit 1
     fi
-    TREEHOUSE_GET_COMMAND="treehouse get --root $(printf '%q' "$TREEHOUSE_HOME_ROOT")"
+    TREEHOUSE_GET_COMMAND="treehouse get --root $(shell_quote "$TREEHOUSE_HOME_ROOT")"
   else
     TREEHOUSE_GET_COMMAND='treehouse get'
   fi

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -1339,7 +1339,7 @@ shell_quote() {
 # apostrophe literally in both POSIX shells and fish.
 pane_shell_quote() {
   printf '"'
-  printf '%s' "$1" | sed 's/[\\$`"]/\\&/g'
+  printf '%s' "$1" | sed 's/[\\$`"!]/\\&/g'
   printf '"'
 }
 

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -3005,7 +3005,10 @@ if [ "$RELAUNCH" -eq 1 ]; then
   fi
   [ "$KIND" = secondmate ] || validate_spawn_worktree "relaunch" "$T"
 elif [ "$KIND" != secondmate ] && [ "$BACKEND" != orca ]; then
-  TREEHOUSE_HOME_ROOT=$(fm_treehouse_root_for_home "$FM_ROOT" "$FM_HOME")
+  if ! TREEHOUSE_HOME_ROOT=$(fm_treehouse_root_for_home "$FM_ROOT" "$FM_HOME"); then
+    echo "error: could not resolve the Treehouse root for this home's worker pool" >&2
+    exit 1
+  fi
   if [ -n "$TREEHOUSE_HOME_ROOT" ]; then
     TREEHOUSE_GET_COMMAND="treehouse get --root $(printf '%q' "$TREEHOUSE_HOME_ROOT")"
   else

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -3026,7 +3026,7 @@ elif [ "$KIND" != secondmate ] && [ "$BACKEND" != orca ]; then
       echo "error: this home needs its own Treehouse pool root, but the installed treehouse has no --root option; upgrade treehouse to v2.2.0 or newer and rerun" >&2
       exit 1
     fi
-    TREEHOUSE_GET_COMMAND="treehouse get --root $(pane_shell_quote "$TREEHOUSE_HOME_ROOT")"
+    TREEHOUSE_GET_COMMAND="treehouse get --root $(shell_quote "$TREEHOUSE_HOME_ROOT")"
   else
     TREEHOUSE_GET_COMMAND='treehouse get'
   fi

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -3010,6 +3010,14 @@ elif [ "$KIND" != secondmate ] && [ "$BACKEND" != orca ]; then
     exit 1
   fi
   if [ -n "$TREEHOUSE_HOME_ROOT" ]; then
+    # An installed Treehouse without --root would silently hand this home a
+    # worktree of whichever clone owns the shared pool identity, which is the
+    # exact cross-home leak this root binding exists to prevent. Refuse before
+    # any worker endpoint holds work in another home's clone.
+    if ! fm_treehouse_supports_root; then
+      echo "error: this home needs its own Treehouse pool root, but the installed treehouse has no --root option; upgrade treehouse to v2.2.0 or newer and rerun" >&2
+      exit 1
+    fi
     TREEHOUSE_GET_COMMAND="treehouse get --root $(printf '%q' "$TREEHOUSE_HOME_ROOT")"
   else
     TREEHOUSE_GET_COMMAND='treehouse get'

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -1335,6 +1335,14 @@ shell_quote() {
   printf "'"
 }
 
+# Commands typed into an existing pane shell need quoting that treats an
+# apostrophe literally in both POSIX shells and fish.
+pane_shell_quote() {
+  printf '"'
+  printf '%s' "$1" | sed 's/[\\$`"]/\\&/g'
+  printf '"'
+}
+
 resolve_pi_executable() {
   local candidate dir
   candidate=$(type -P -- "$1" 2>/dev/null) || return 1
@@ -3018,7 +3026,7 @@ elif [ "$KIND" != secondmate ] && [ "$BACKEND" != orca ]; then
       echo "error: this home needs its own Treehouse pool root, but the installed treehouse has no --root option; upgrade treehouse to v2.2.0 or newer and rerun" >&2
       exit 1
     fi
-    TREEHOUSE_GET_COMMAND="treehouse get --root $(shell_quote "$TREEHOUSE_HOME_ROOT")"
+    TREEHOUSE_GET_COMMAND="treehouse get --root $(pane_shell_quote "$TREEHOUSE_HOME_ROOT")"
   else
     TREEHOUSE_GET_COMMAND='treehouse get'
   fi

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -3005,8 +3005,13 @@ if [ "$RELAUNCH" -eq 1 ]; then
   fi
   [ "$KIND" = secondmate ] || validate_spawn_worktree "relaunch" "$T"
 elif [ "$KIND" != secondmate ] && [ "$BACKEND" != orca ]; then
-  TREEHOUSE_ROOT_OPTION=$(fm_treehouse_root_option_for_home "$FM_ROOT" "$FM_HOME")
-  spawn_send_text_line "$WT_TARGET" "treehouse get${TREEHOUSE_ROOT_OPTION}"
+  TREEHOUSE_HOME_ROOT=$(fm_treehouse_root_for_home "$FM_ROOT" "$FM_HOME")
+  if [ -n "$TREEHOUSE_HOME_ROOT" ]; then
+    TREEHOUSE_GET_COMMAND="treehouse get --root $(printf '%q' "$TREEHOUSE_HOME_ROOT")"
+  else
+    TREEHOUSE_GET_COMMAND='treehouse get'
+  fi
+  spawn_send_text_line "$WT_TARGET" "$TREEHOUSE_GET_COMMAND"
 
   # Wait for the treehouse subshell: the pane's cwd moves from the project to the worktree.
   # Target the stable window id, not the name: if the name is ever lost (e.g. an

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -402,6 +402,8 @@ fm_backlog_directory_present "$STATE" "state directory" || {
 }
 # shellcheck source=bin/fm-secondmate-nudge-lib.sh
 . "$SCRIPT_DIR/fm-secondmate-nudge-lib.sh"
+# shellcheck source=bin/fm-treehouse-lib.sh
+. "$SCRIPT_DIR/fm-treehouse-lib.sh"
 # shellcheck source=bin/fm-backend.sh
 . "$SCRIPT_DIR/fm-backend.sh"
 # shellcheck source=bin/fm-control-lib.sh
@@ -3003,7 +3005,8 @@ if [ "$RELAUNCH" -eq 1 ]; then
   fi
   [ "$KIND" = secondmate ] || validate_spawn_worktree "relaunch" "$T"
 elif [ "$KIND" != secondmate ] && [ "$BACKEND" != orca ]; then
-  spawn_send_text_line "$WT_TARGET" 'treehouse get'
+  TREEHOUSE_ROOT_OPTION=$(fm_treehouse_root_option_for_home "$FM_ROOT" "$FM_HOME")
+  spawn_send_text_line "$WT_TARGET" "treehouse get${TREEHOUSE_ROOT_OPTION}"
 
   # Wait for the treehouse subshell: the pane's cwd moves from the project to the worktree.
   # Target the stable window id, not the name: if the name is ever lost (e.g. an

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -2740,8 +2740,9 @@ FMEOF
 }
 
 teardown_herdr_require_prerequisites() {  # <task-id>
-  local task_id=$1 prerequisite
-  if ! fm_backend_source herdr; then
+  local task_id=$1 prerequisite adapter
+  adapter="$FM_BACKEND_LIB_DIR/backends/herdr.sh"
+  if [ ! -r "$adapter" ] || ! fm_backend_source herdr; then
     echo "error: herdr teardown prerequisites are unavailable for $task_id; nothing was changed - restore the adapter and rerun teardown" >&2
     return 1
   fi

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -1561,16 +1561,21 @@ cleanup_stale_lock_for_safety_check() {
 # stale git index.lock left by a killed crew process. See the script header.
 teardown_treehouse_return() {
   local dir=$1 cd_dir=$2 label=$3 post_cleanup_check=${4:-} pool_home=${5:-$FM_HOME}
-  local out lock attempt=0 max_retries lock_desc treehouse_root_option
+  local out lock attempt=0 max_retries lock_desc treehouse_root
+  local -a treehouse_args
 
-  treehouse_root_option=$(fm_treehouse_root_option_for_home "$FM_ROOT" "$pool_home") || {
+  treehouse_root=$(fm_treehouse_root_for_home "$FM_ROOT" "$pool_home") || {
     echo "teardown: could not resolve the Treehouse root for $label; leaving it in place" >&2
     return 1
   }
+  treehouse_args=(return --force "$dir")
+  if [ -n "$treehouse_root" ]; then
+    treehouse_args=(return --root "$treehouse_root" --force "$dir")
+  fi
 
   # Capture stdout+stderr so non-lock failures stay visible and lock failures can
   # be matched by signature even when the lock file is already gone mid-check.
-  if out=$( ( cd "$cd_dir" && treehouse return${treehouse_root_option} --force "$dir" ) 2>&1 ); then
+  if out=$( ( cd "$cd_dir" && treehouse "${treehouse_args[@]}" ) 2>&1 ); then
     [ -n "$out" ] && printf '%s\n' "$out"
     return 0
   fi
@@ -1595,7 +1600,7 @@ teardown_treehouse_return() {
     echo "teardown: $label return failed with transient git lock ($lock_desc); waiting ${TREEHOUSE_RETURN_LOCK_RETRY_WAIT_SECS}s and retrying ($attempt/${max_retries})" >&2
     sleep "$TREEHOUSE_RETURN_LOCK_RETRY_WAIT_SECS"
 
-    if out=$( ( cd "$cd_dir" && treehouse return${treehouse_root_option} --force "$dir" ) 2>&1 ); then
+    if out=$( ( cd "$cd_dir" && treehouse "${treehouse_args[@]}" ) 2>&1 ); then
       [ -n "$out" ] && printf '%s\n' "$out"
       echo "teardown: $label return succeeded on retry; lock cleared on its own" >&2
       return 0
@@ -1622,7 +1627,7 @@ teardown_treehouse_return() {
           return 1
         fi
       fi
-      if out=$( ( cd "$cd_dir" && treehouse return${treehouse_root_option} --force "$dir" ) 2>&1 ); then
+      if out=$( ( cd "$cd_dir" && treehouse "${treehouse_args[@]}" ) 2>&1 ); then
         [ -n "$out" ] && printf '%s\n' "$out"
         echo "teardown: $label return succeeded after stale-lock cleanup" >&2
         return 0

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -248,6 +248,8 @@ SUB_HOME_PARENT_MARKER=".fm-secondmate-parent"
 . "$SCRIPT_DIR/fm-secondmate-registry-lib.sh"
 # shellcheck source=bin/fm-secondmate-parent-lib.sh
 . "$SCRIPT_DIR/fm-secondmate-parent-lib.sh"
+# shellcheck source=bin/fm-treehouse-lib.sh
+. "$SCRIPT_DIR/fm-treehouse-lib.sh"
 # shellcheck source=bin/fm-pending-reply-lib.sh
 . "$SCRIPT_DIR/fm-pending-reply-lib.sh"
 # shellcheck source=bin/fm-nm-run-lib.sh
@@ -1558,12 +1560,17 @@ cleanup_stale_lock_for_safety_check() {
 # Return a worktree/home via `treehouse return --force`, tolerating a transient or
 # stale git index.lock left by a killed crew process. See the script header.
 teardown_treehouse_return() {
-  local dir=$1 cd_dir=$2 label=$3 post_cleanup_check=${4:-}
-  local out lock attempt=0 max_retries lock_desc
+  local dir=$1 cd_dir=$2 label=$3 post_cleanup_check=${4:-} pool_home=${5:-$FM_HOME}
+  local out lock attempt=0 max_retries lock_desc treehouse_root_option
+
+  treehouse_root_option=$(fm_treehouse_root_option_for_home "$FM_ROOT" "$pool_home") || {
+    echo "teardown: could not resolve the Treehouse root for $label; leaving it in place" >&2
+    return 1
+  }
 
   # Capture stdout+stderr so non-lock failures stay visible and lock failures can
   # be matched by signature even when the lock file is already gone mid-check.
-  if out=$( ( cd "$cd_dir" && treehouse return --force "$dir" ) 2>&1 ); then
+  if out=$( ( cd "$cd_dir" && treehouse return${treehouse_root_option} --force "$dir" ) 2>&1 ); then
     [ -n "$out" ] && printf '%s\n' "$out"
     return 0
   fi
@@ -1588,7 +1595,7 @@ teardown_treehouse_return() {
     echo "teardown: $label return failed with transient git lock ($lock_desc); waiting ${TREEHOUSE_RETURN_LOCK_RETRY_WAIT_SECS}s and retrying ($attempt/${max_retries})" >&2
     sleep "$TREEHOUSE_RETURN_LOCK_RETRY_WAIT_SECS"
 
-    if out=$( ( cd "$cd_dir" && treehouse return --force "$dir" ) 2>&1 ); then
+    if out=$( ( cd "$cd_dir" && treehouse return${treehouse_root_option} --force "$dir" ) 2>&1 ); then
       [ -n "$out" ] && printf '%s\n' "$out"
       echo "teardown: $label return succeeded on retry; lock cleared on its own" >&2
       return 0
@@ -1615,7 +1622,7 @@ teardown_treehouse_return() {
           return 1
         fi
       fi
-      if out=$( ( cd "$cd_dir" && treehouse return --force "$dir" ) 2>&1 ); then
+      if out=$( ( cd "$cd_dir" && treehouse return${treehouse_root_option} --force "$dir" ) 2>&1 ); then
         [ -n "$out" ] && printf '%s\n' "$out"
         echo "teardown: $label return succeeded after stale-lock cleanup" >&2
         return 0
@@ -2360,7 +2367,7 @@ remove_firstmate_home() {
       restore_firstmate_home_process_events "$abs_home_path" "$label" "$process_event_backup" || return $?
       return 1
     }
-    teardown_treehouse_return "$abs_home_path" "$FM_ROOT" "$label" || {
+    teardown_treehouse_return "$abs_home_path" "$FM_ROOT" "$label" "" "$FM_ROOT" || {
       echo "error: treehouse return failed for $label $abs_home_path; lease may still be held" >&2
       restore_firstmate_home_process_events "$abs_home_path" "$label" "$process_event_backup" || return $?
       return 1
@@ -2906,7 +2913,7 @@ cleanup_firstmate_home_children() {
         "$child_wt/.opencode/plugins/fm-busy-state.js" \
         "$child_wt/.fm-grok-turnend" "$child_wt/.fm-kimi-turnend"
       if [ -n "$child_proj" ] && [ -d "$child_proj" ] && command -v treehouse >/dev/null 2>&1; then
-        if teardown_treehouse_return "$child_wt" "$child_proj" "child worktree"; then
+        if teardown_treehouse_return "$child_wt" "$child_proj" "child worktree" "" "$home"; then
           :
         else
           child_return_rc=$?

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -1497,6 +1497,11 @@ STALE_WORKTREE_LOCK_RETRY_WAIT_SECS=$TREEHOUSE_RETURN_LOCK_RETRY_WAIT_SECS
 TEARDOWN_TREEHOUSE_LOCK_REFUSED=2
 TEARDOWN_WORKTREE_SAFETY_LOCK_BLOCKED=3
 TEARDOWN_PROCEVENT_RESTORE_FAILED=4
+# A home that owns its own Treehouse pool cannot release a worktree through a
+# build with no --root option, and raw removal is not a substitute: it would
+# strand the lease and delete work the right pool still owns. Its own code so
+# every caller refuses instead of falling back to removal.
+TEARDOWN_TREEHOUSE_ROOT_UNSUPPORTED=5
 
 # True when treehouse/git stderr shows the transient index.lock "File exists" race.
 # Other return failures must not enter the retry path.
@@ -1570,6 +1575,13 @@ teardown_treehouse_return() {
   }
   treehouse_args=(return --force "$dir")
   if [ -n "$treehouse_root" ]; then
+    # Returning without the home's own root would address the default pool
+    # instead of the one that handed this worktree out, so refuse rather than
+    # release a lease in the wrong pool.
+    if ! fm_treehouse_supports_root; then
+      echo "teardown: this home needs its own Treehouse pool root, but the installed treehouse has no --root option; upgrade treehouse to v2.2.0 or newer to release $label" >&2
+      return "$TEARDOWN_TREEHOUSE_ROOT_UNSUPPORTED"
+    fi
     treehouse_args=(return --root "$treehouse_root" --force "$dir")
   fi
 
@@ -2923,7 +2935,8 @@ cleanup_firstmate_home_children() {
           :
         else
           child_return_rc=$?
-          if [ "$child_return_rc" -eq "$TEARDOWN_TREEHOUSE_LOCK_REFUSED" ]; then
+          if [ "$child_return_rc" -eq "$TEARDOWN_TREEHOUSE_LOCK_REFUSED" ] \
+            || [ "$child_return_rc" -eq "$TEARDOWN_TREEHOUSE_ROOT_UNSUPPORTED" ]; then
             return "$child_return_rc"
           fi
           safe_rm_rf_child_worktree "$child_wt" "$child_proj"

--- a/bin/fm-treehouse-lib.sh
+++ b/bin/fm-treehouse-lib.sh
@@ -32,7 +32,7 @@ fm_treehouse_root_for_home() {
   [ "$code_real" != "$home_real" ] || return 0
 
   home_top=$(git -C "$home_real" rev-parse --show-toplevel 2>/dev/null) || {
-    fm_root_is_secondmate_home "$home_real" && return 1
+    fm_root_is_secondmate_home "$home_real" && printf '%s' "$home_real/config" && return 0
     return 0
   }
   home_top_real=$(fm_treehouse_real_dir "$home_top") || {

--- a/bin/fm-treehouse-lib.sh
+++ b/bin/fm-treehouse-lib.sh
@@ -27,25 +27,34 @@ fm_treehouse_root_for_home() {
   local code_root=$1 active_home=$2 code_real home_real home_top home_top_real
   local code_common home_common home_git pool_root
 
-  code_real=$(fm_treehouse_real_dir "$code_root") || return 0
-  home_real=$(fm_treehouse_real_dir "$active_home") || return 0
+  code_real=$(fm_treehouse_real_dir "$code_root") || return 1
+  home_real=$(fm_treehouse_real_dir "$active_home") || return 1
   [ "$code_real" != "$home_real" ] || return 0
 
-  home_top=$(git -C "$home_real" rev-parse --show-toplevel 2>/dev/null) || return 0
-  home_top_real=$(fm_treehouse_real_dir "$home_top") || return 0
-  [ "$home_top_real" = "$home_real" ] || return 0
+  home_top=$(git -C "$home_real" rev-parse --show-toplevel 2>/dev/null) || {
+    fm_root_is_secondmate_home "$home_real" && return 1
+    return 0
+  }
+  home_top_real=$(fm_treehouse_real_dir "$home_top") || {
+    fm_root_is_secondmate_home "$home_real" && return 1
+    return 0
+  }
+  [ "$home_top_real" = "$home_real" ] || {
+    fm_root_is_secondmate_home "$home_real" && return 1
+    return 0
+  }
 
-  home_common=$(git -C "$home_real" rev-parse --path-format=absolute --git-common-dir 2>/dev/null) || return 0
-  home_common=$(fm_treehouse_real_dir "$home_common") || return 0
-  home_git=$(git -C "$home_real" rev-parse --absolute-git-dir 2>/dev/null) || return 0
-  home_git=$(fm_treehouse_real_dir "$home_git") || return 0
-  code_common=$(git -C "$code_real" rev-parse --path-format=absolute --git-common-dir 2>/dev/null) || return 0
-  code_common=$(fm_treehouse_real_dir "$code_common") || return 0
+  home_common=$(git -C "$home_real" rev-parse --path-format=absolute --git-common-dir 2>/dev/null) || return 1
+  home_common=$(fm_treehouse_real_dir "$home_common") || return 1
+  home_git=$(git -C "$home_real" rev-parse --absolute-git-dir 2>/dev/null) || return 1
+  home_git=$(fm_treehouse_real_dir "$home_git") || return 1
+  code_common=$(git -C "$code_real" rev-parse --path-format=absolute --git-common-dir 2>/dev/null) || return 1
+  code_common=$(fm_treehouse_real_dir "$code_common") || return 1
 
   if [ "$home_git" != "$home_common" ] && [ "$home_common" = "$code_common" ]; then
     :
   elif ! fm_root_is_secondmate_home "$home_real"; then
-    return 0
+    return 1
   fi
 
   pool_root="$home_real/config"

--- a/bin/fm-treehouse-lib.sh
+++ b/bin/fm-treehouse-lib.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Shared Treehouse root selection for task worktree acquisition and return.
+#
+# The primary home deliberately leaves Treehouse's existing root precedence
+# untouched.
+# A non-primary Firstmate home gets a root under its own ignored config tree so
+# identical project remotes cannot make its workers land in another home's pool.
+#
+# fm_treehouse_root_option_for_home <code-root> <active-home>
+#   Echoes an empty string for the primary home or an argument fragment beginning
+#   with ` --root ` for a structurally identified secondmate home.
+#
+# A local secondmate is identified as a linked git worktree whose common dir is
+# the code root's common dir and whose physical top level is the active home.
+# A marked standalone Firstmate home is also accepted for remote secondmates.
+# Plain directories and unrelated clones retain the primary default behavior.
+
+_FM_TREEHOUSE_LIB_DIR=$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)
+# shellcheck source=bin/fm-primary-scope-lib.sh
+. "$_FM_TREEHOUSE_LIB_DIR/fm-primary-scope-lib.sh"
+
+fm_treehouse_real_dir() {
+  CDPATH='' cd -P -- "$1" 2>/dev/null && pwd -P
+}
+
+fm_treehouse_root_option_for_home() {
+  local code_root=$1 active_home=$2 code_real home_real home_top home_top_real
+  local code_common home_common home_git pool_root
+
+  code_real=$(fm_treehouse_real_dir "$code_root") || return 0
+  home_real=$(fm_treehouse_real_dir "$active_home") || return 0
+  [ "$code_real" != "$home_real" ] || return 0
+
+  home_top=$(git -C "$home_real" rev-parse --show-toplevel 2>/dev/null) || return 0
+  home_top_real=$(fm_treehouse_real_dir "$home_top") || return 0
+  [ "$home_top_real" = "$home_real" ] || return 0
+
+  home_common=$(git -C "$home_real" rev-parse --path-format=absolute --git-common-dir 2>/dev/null) || return 0
+  home_common=$(fm_treehouse_real_dir "$home_common") || return 0
+  home_git=$(git -C "$home_real" rev-parse --absolute-git-dir 2>/dev/null) || return 0
+  home_git=$(fm_treehouse_real_dir "$home_git") || return 0
+  code_common=$(git -C "$code_real" rev-parse --path-format=absolute --git-common-dir 2>/dev/null) || return 0
+  code_common=$(fm_treehouse_real_dir "$code_common") || return 0
+
+  if [ "$home_git" != "$home_common" ] && [ "$home_common" = "$code_common" ]; then
+    :
+  elif ! fm_root_is_secondmate_home "$home_real"; then
+    return 0
+  fi
+
+  pool_root="$home_real/config"
+  printf ' --root %q' "$pool_root"
+}

--- a/bin/fm-treehouse-lib.sh
+++ b/bin/fm-treehouse-lib.sh
@@ -6,9 +6,9 @@
 # A non-primary Firstmate home gets a root under its own ignored config tree so
 # identical project remotes cannot make its workers land in another home's pool.
 #
-# fm_treehouse_root_option_for_home <code-root> <active-home>
-#   Echoes an empty string for the primary home or an argument fragment beginning
-#   with ` --root ` for a structurally identified secondmate home.
+# fm_treehouse_root_for_home <code-root> <active-home>
+#   Echoes an empty string for the primary home or the root path for a
+#   structurally identified secondmate home.
 #
 # A local secondmate is identified as a linked git worktree whose common dir is
 # the code root's common dir and whose physical top level is the active home.
@@ -23,7 +23,7 @@ fm_treehouse_real_dir() {
   CDPATH='' cd -P -- "$1" 2>/dev/null && pwd -P
 }
 
-fm_treehouse_root_option_for_home() {
+fm_treehouse_root_for_home() {
   local code_root=$1 active_home=$2 code_real home_real home_top home_top_real
   local code_common home_common home_git pool_root
 
@@ -49,5 +49,5 @@ fm_treehouse_root_option_for_home() {
   fi
 
   pool_root="$home_real/config"
-  printf ' --root %q' "$pool_root"
+  printf '%s' "$pool_root"
 }

--- a/bin/fm-treehouse-lib.sh
+++ b/bin/fm-treehouse-lib.sh
@@ -14,6 +14,16 @@
 # the code root's common dir and whose physical top level is the active home.
 # A marked standalone Firstmate home is also accepted for remote secondmates.
 # Plain directories and unrelated clones retain the primary default behavior.
+#
+# fm_treehouse_supports_root
+#   Succeeds when the installed Treehouse accepts the global --root option, the
+#   only mechanism a typed pool command can carry into a worker pane on every
+#   session-provider backend.
+#   Treehouse added it in v2.2.0; an older build silently ignores TREEHOUSE_ROOT
+#   too, so a home that needs its own root must refuse rather than pool into
+#   another home's clone.
+#   Probed from help output like bin/fm-bootstrap.sh's --lease gate, so no
+#   version string has to be parsed.
 
 _FM_TREEHOUSE_LIB_DIR=$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)
 # shellcheck source=bin/fm-primary-scope-lib.sh
@@ -21,6 +31,10 @@ _FM_TREEHOUSE_LIB_DIR=$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)
 
 fm_treehouse_real_dir() {
   CDPATH='' cd -P -- "$1" 2>/dev/null && pwd -P
+}
+
+fm_treehouse_supports_root() {
+  treehouse get --help 2>&1 | grep -Eq '(^|[^[:alnum:]_-])--root([^[:alnum:]_-]|$)'
 }
 
 fm_treehouse_root_for_home() {

--- a/bin/fm-wake-lib.sh
+++ b/bin/fm-wake-lib.sh
@@ -1162,7 +1162,7 @@ fm_firstmate_root_home() {
 # separate clones of one origin share a single lock; an origin-less local-only
 # project falls back to its own worktree top instead of failing to resolve.
 fm_treehouse_project_lock_path() {  # <project-dir>
-  local project=$1 root origin identity hash top
+  local project=$1 root origin identity hash top state_dir
   [ -d "$project" ] || return 1
   root=$(fm_firstmate_root_home "$FM_HOME") || return 1
   origin=$(git -C "$project" remote get-url origin 2>/dev/null || true)
@@ -1179,8 +1179,9 @@ fm_treehouse_project_lock_path() {  # <project-dir>
     identity=$top
   fi
   hash=$(printf '%s' "$identity" | git hash-object --stdin 2>/dev/null) || return 1
-  [ -d "$root/state" ] || return 1
-  printf '%s/.treehouse-project-%s.lock\n' "$root/state" "$hash"
+  state_dir=${FM_STATE_OVERRIDE:-$root/state}
+  [ -d "$state_dir" ] || return 1
+  printf '%s/.treehouse-project-%s.lock\n' "$state_dir" "$hash"
 }
 
 fm_failure_episode_reset() {

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -202,6 +202,7 @@ Codex App support is recorded in `docs/codex-app-backend.md`; it is not selectab
 ## Worktrees, not branches in your checkout
 
 Crewmates never intentionally touch your project clone; [treehouse](https://github.com/kunchenguid/treehouse) pools clean worktrees for tmux, herdr, zellij, and cmux tasks, while Orca creates its own worktrees for `backend=orca`.
+The primary home keeps Treehouse's default pool, while each non-primary Firstmate home binds its workers to a pool rooted at its own `FM_HOME/config`; [configuration](configuration.md#per-home-treehouse-pool-root) owns the detection, compatibility, and teardown contract.
 The [`fm-spawn.sh` header](../bin/fm-spawn.sh) owns ship/scout worktree isolation and fresh-base refusal rules, including spawns from linked homes.
 Portable regressions live in [`tests/fm-spawn-pool-base-freshen.test.sh`](../tests/fm-spawn-pool-base-freshen.test.sh) for spawn isolation and base freshness, and [`tests/fm-control-relaunch.test.sh`](../tests/fm-control-relaunch.test.sh) for preserving the recorded copy on relaunch.
 
@@ -246,7 +247,7 @@ A local route points directly at its home, while a remote route adds an SSH alia
 Remote placement pins the remote second-mate agent to Herdr while leaving the remote home's worker backend selection independent, and every non-doctor primary-to-remote `fm-on` command runs through the remote account's Firstmate-owned job worker rather than its SSH process or a Herdr pane.
 [`remote-secondmates.md`](remote-secondmates.md) owns current setup, supplied-origin provisioning, transport, relay, failure, and retirement behavior.
 `fm-home-seed.sh` provisions a local isolated home, clones the listed PR-based projects into it, initializes newly cloned `no-mistakes` projects, copies the charter to `data/charter.md`, and `fm-spawn.sh --secondmate` launches it through the same session-provider and status-file path as any direct report.
-For a domain whose subject is the firstmate repo itself, a deliberate `--no-projects` seed creates a project-less home whose crews take pooled worktrees of that repo instead of separate clones.
+For a domain whose subject is the firstmate repo itself, a deliberate `--no-projects` seed creates a project-less home whose crews take worktrees from that home's bound pool instead of separate project clones.
 The signal cannot be mixed with project names or omitted accidentally, and a populated home cannot be converted in place; the full seed contract is in [configuration.md](configuration.md#secondmate-routes-datasecondmatesmd).
 Herdr secondmate and child placement follows the launcher-binding contract in [Watching and task containers](herdr-backend.md#watching-and-task-containers).
 When seeded with `-`, the home is a durable treehouse lease under the secondmate id, so it survives with no live process and is not recycled by later `treehouse get` or pruning.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -294,6 +294,15 @@ The full zellij home label also includes a short hash of the resolved `FM_ROOT` 
 For the cmux backend, `FM_CONFIG_OVERRIDE` overrides where `config/cmux-socket-password` is read from, while `FM_HOME` determines the default config path and readable home prefix embedded in workspace titles.
 The full cmux home label also includes a short hash of the resolved `FM_ROOT` path, and there is no per-home container split.
 
+## Per-home Treehouse pool root
+
+The primary Firstmate home keeps Treehouse's normal root precedence and pool location unchanged.
+Task workers launched from a non-primary Firstmate home pass Treehouse's explicit `--root` option on both acquisition and return commands, so the typed command is independent of the active tmux, Herdr, Zellij, or cmux backend.
+For a local secondmate, the structural home check is a linked git worktree of the Firstmate code root with a different physical top level and shared git common directory; a marked standalone home is supported for remote secondmates.
+The per-home option uses `FM_HOME/config` as Treehouse's root, which makes the effective pool location `FM_HOME/config/treehouse/` and keeps it inside the home-local gitignored configuration area.
+This choice changes no project clone, project-level `treehouse.toml`, user-level Treehouse configuration, or primary-home pool.
+Relaunches reuse the recorded worktree, while teardown passes the same home-specific root when returning a task worktree and retains the primary root when releasing a leased secondmate home.
+
 ## Harness support
 
 claude, codex, opencode, pi, pi-signed, grok, kimi, cursor, and omp are empirically verified for crewmate and secondmate launches; gemini is verified for crewmate and scout launches only, and [README requirements](../README.md#requirements) own the set supported for the primary session.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -299,7 +299,8 @@ The full cmux home label also includes a short hash of the resolved `FM_ROOT` pa
 The primary Firstmate home keeps Treehouse's normal root precedence and pool location unchanged.
 Task workers launched from a non-primary Firstmate home pass Treehouse's explicit `--root` option on both acquisition and return commands, so the typed command is independent of the active tmux, Herdr, Zellij, or cmux backend.
 For a local secondmate, the structural home check is a linked git worktree of the Firstmate code root with a different physical top level and shared git common directory; a marked standalone home is supported for remote secondmates.
-The per-home option uses `FM_HOME/config` as Treehouse's root, which makes the effective pool location `FM_HOME/config/treehouse/` and keeps it inside the home-local gitignored configuration area.
+The per-home option uses `FM_HOME/config` as Treehouse's root, which makes the effective pool location `FM_HOME/config/.treehouse/` and keeps it inside the home-local gitignored configuration area.
+The `--root` option exists from Treehouse v2.2.0, and an older build ignores the `TREEHOUSE_ROOT` environment variable too, so a home that resolves a root of its own refuses to spawn or to return a task worktree rather than pooling into another home's clone; the session-start bootstrap reports that same home as needing a treehouse upgrade.
 This choice changes no project clone, project-level `treehouse.toml`, user-level Treehouse configuration, or primary-home pool.
 Relaunches reuse the recorded worktree, while teardown passes the same home-specific root when returning a task worktree and retains the primary root when releasing a leased secondmate home.
 

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -43,6 +43,7 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-ensure-agents-md.sh` | Ensure a project's real `AGENTS.md`, its `CLAUDE.md` `@AGENTS.md` pointer, and self-governance guidance (explicit project mark documented in the helper's header and help) |
 | `fm-guard.sh`            | Warn on primary-checkout tangles, main-session pending wakes, and unhealthy supervision |
 | `fm-primary-scope-lib.sh` | Shared marker-or-plain-checkout primary-home predicate for tracked hooks             |
+| `fm-treehouse-lib.sh` | Shared structural per-home Treehouse root selection for task worktree acquisition and return |
 | `fm-session-lock-lib.sh` | Shared session-lock harness identity (ancestry walk and holder liveness) for fm-lock.sh and the Claude Stop auto-arm |
 | `fm-claude-stop-autoarm.sh` | Claude Stop `asyncRewake` hook owning tokenless watcher continuity with single-flight exit-2 rewake (docs/watcher-continuity.md) |
 | `fm-turnend-guard.sh`    | Shared primary turn-end guard predicate so no turn ends blind (docs/turnend-guard.md) |

--- a/tests/fixtures.sh
+++ b/tests/fixtures.sh
@@ -251,14 +251,17 @@ EOF
 }
 
 # fm_test_make_spawn_fakebin <dir> [extra-exit0-tool...]
-# Creates <dir>/fakebin with the spawn tmux stub, a no-op treehouse, and any
-# extra exit-0 tools. Echoes the fakebin path.
+# Creates <dir>/fakebin with the spawn tmux stub, a treehouse stub that models
+# the pinned build's advertised options, and any extra exit-0 tools. Echoes the
+# fakebin path. The treehouse stub must advertise --root because a home that
+# owns its own pool refuses to spawn without it (docs/configuration.md).
 fm_test_make_spawn_fakebin() {
   local dir=$1 fakebin
   shift
   fakebin=$(fm_fakebin "$dir")
   fm_test_fake_tmux_spawn "$fakebin"
-  fm_fake_exit0 "$fakebin" treehouse "$@"
+  fm_fake_exit0 "$fakebin" "$@"
+  fm_fake_treehouse "$fakebin"
   printf '%s\n' "$fakebin"
 }
 

--- a/tests/fm-backend-herdr-presentation-e2e.test.sh
+++ b/tests/fm-backend-herdr-presentation-e2e.test.sh
@@ -199,6 +199,12 @@ SH
 cat > "$FAKEBIN/treehouse" <<'SH'
 #!/usr/bin/env bash
 set -u
+# Model the pinned build's global options: a home that owns its own Treehouse
+# pool needs --root, and a stub that advertises nothing reads as too old.
+if [ "${1:-}" = get ] && [ "${2:-}" = --help ]; then
+  printf '%s\n' '      --root string   Worktree root directory'
+  exit 0
+fi
 {
   first=1
   for arg in "$@"; do

--- a/tests/fm-backend-herdr-presentation-e2e.test.sh
+++ b/tests/fm-backend-herdr-presentation-e2e.test.sh
@@ -1278,6 +1278,19 @@ done
 pass "real Herdr lab: Hi Bit and Wheelhouse-style same-identity restarts reclaim one nested space with exact focus and idempotence"
 
 # A secondmate child binds and reclaims only inside its own home and parent.
+# Retire the original multi-home fixtures before this child gets a replacement
+# slot in the same secondmate pool.
+for META_HOME_PAIR in \
+  "a1:$SECOND_HOME_A" "a2:$SECOND_HOME_A"
+do
+  TASK_ID=${META_HOME_PAIR%%:*}
+  TASK_HOME=${META_HOME_PAIR#*:}
+  if [ -e "$TASK_HOME/state/$TASK_ID.meta" ]; then
+    teardown_task "$TASK_ID" "$TASK_HOME" > "$TMP_ROOT/td-before-cross-restart-$TASK_ID.out" 2> "$TMP_ROOT/td-before-cross-restart-$TASK_ID.err" \
+      || fail "pre-cross-restart teardown of $TASK_ID failed: $(cat "$TMP_ROOT/td-before-cross-restart-$TASK_ID.err")"
+  fi
+done
+
 CROSS_RESTART_ID=wheel-child-resume
 mkdir -p "$SECOND_HOME_A/data/$CROSS_RESTART_ID"
 write_ship_brief "$SECOND_HOME_A" "$CROSS_RESTART_ID" 'Cross-home restart fixture.'
@@ -1314,6 +1327,18 @@ pass "real Herdr lab: secondmate restart binding and reclaim stay isolated to th
 
 # Two homes recovering concurrently serialize on the named session lock and
 # each replace only their own exact husk.
+# Release earlier live fixtures so replacement slots cannot collide with them.
+for META_HOME_PAIR in \
+  "p1:$HOME_DIR" "p2:$HOME_DIR" \
+  "a1:$SECOND_HOME_A" "a2:$SECOND_HOME_A" \
+  "b1:$SECOND_HOME_B" "b2:$SECOND_HOME_B"
+do
+  TASK_ID=${META_HOME_PAIR%%:*}
+  TASK_HOME=${META_HOME_PAIR#*:}
+  teardown_task "$TASK_ID" "$TASK_HOME" > "$TMP_ROOT/td-before-recovery-$TASK_ID.out" 2> "$TMP_ROOT/td-before-recovery-$TASK_ID.err" \
+    || fail "pre-recovery teardown of $TASK_ID failed: $(cat "$TMP_ROOT/td-before-recovery-$TASK_ID.err")"
+done
+
 PRIMARY_WAVE_ID=resume-wave-primary
 BRAVO_WAVE_ID=resume-wave-bravo
 mkdir -p "$HOME_DIR/data/$PRIMARY_WAVE_ID" "$SECOND_HOME_B/data/$BRAVO_WAVE_ID"
@@ -1388,10 +1413,10 @@ pass "real Herdr lab: legacy projection labels and flat secondmate tabs are left
 
 # Teardown multi-home projected tasks by exact pane only.
 for META_HOME_PAIR in \
-  "p1:$HOME_DIR" "p2:$HOME_DIR" "pcw:$HOME_DIR" "post-legacy:$HOME_DIR" \
-  "a1:$SECOND_HOME_A" "a2:$SECOND_HOME_A" "acw:$SECOND_HOME_A" \
+  "pcw:$HOME_DIR" "post-legacy:$HOME_DIR" \
+  "acw:$SECOND_HOME_A" \
   "alpha:$HOME_DIR" \
-  "b1:$SECOND_HOME_B" "b2:$SECOND_HOME_B" "bcw:$SECOND_HOME_B"
+  "bcw:$SECOND_HOME_B"
 do
   TASK_ID=${META_HOME_PAIR%%:*}
   TASK_HOME=${META_HOME_PAIR#*:}

--- a/tests/fm-backend-herdr-presentation-e2e.test.sh
+++ b/tests/fm-backend-herdr-presentation-e2e.test.sh
@@ -1335,8 +1335,10 @@ for META_HOME_PAIR in \
 do
   TASK_ID=${META_HOME_PAIR%%:*}
   TASK_HOME=${META_HOME_PAIR#*:}
-  teardown_task "$TASK_ID" "$TASK_HOME" > "$TMP_ROOT/td-before-recovery-$TASK_ID.out" 2> "$TMP_ROOT/td-before-recovery-$TASK_ID.err" \
-    || fail "pre-recovery teardown of $TASK_ID failed: $(cat "$TMP_ROOT/td-before-recovery-$TASK_ID.err")"
+  if [ -f "$TASK_HOME/state/$TASK_ID.meta" ]; then
+    teardown_task "$TASK_ID" "$TASK_HOME" > "$TMP_ROOT/td-before-recovery-$TASK_ID.out" 2> "$TMP_ROOT/td-before-recovery-$TASK_ID.err" \
+      || fail "pre-recovery teardown of $TASK_ID failed: $(cat "$TMP_ROOT/td-before-recovery-$TASK_ID.err")"
+  fi
 done
 
 PRIMARY_WAVE_ID=resume-wave-primary

--- a/tests/fm-backend.test.sh
+++ b/tests/fm-backend.test.sh
@@ -807,7 +807,7 @@ esac
 exit 0
 SH
   chmod +x "$fb/tmux"
-  fm_fake_exit0 "$fb" treehouse
+  fm_fake_treehouse "$fb"
   printf '%s\n' "$fb"
 }
 
@@ -877,7 +877,7 @@ esac
 exit 0
 SH
   chmod +x "$fb/tmux"
-  fm_fake_exit0 "$fb" treehouse
+  fm_fake_treehouse "$fb"
   printf '%s\n' "$fb"
 }
 
@@ -938,6 +938,12 @@ SH
   cat > "$fb/treehouse" <<'SH'
 #!/usr/bin/env bash
 set -u
+# Model the pinned build's global options: a home that owns its own Treehouse
+# pool needs --root, and a stub that advertises nothing reads as too old.
+if [ "${1:-}" = get ] && [ "${2:-}" = --help ]; then
+  printf '%s\n' '      --root string   Worktree root directory'
+  exit 0
+fi
 { printf 'treehouse'; for a in "$@"; do printf '\x1f%s' "$a"; done; printf '\n'; } >> "${FM_TMUX_LOG:?}"
 exit 0
 SH

--- a/tests/fm-backlog-atomicity.test.sh
+++ b/tests/fm-backlog-atomicity.test.sh
@@ -77,7 +77,10 @@ case "${1:-}" in display-message) printf 'firstmate\n'; exit 0 ;; esac
 exit 0
 SH
   chmod +x "$fakebin/tmux"
-  fm_fake_exit0 "$fakebin" treehouse gh gh-axi no-mistakes
+  fm_fake_exit0 "$fakebin" gh gh-axi no-mistakes
+  # A secondmate-shaped home refuses to spawn unless treehouse advertises the
+  # --root option that scopes its pool, so model the pinned build here.
+  fm_fake_treehouse "$fakebin"
 
   fm_git_init_commit "$case_dir/project"
   fm_git_add_origin "$case_dir/project" "$case_dir/project.origin.git"
@@ -422,6 +425,12 @@ exit 0
 SH
   cat > "$case_dir/fakebin/treehouse" <<SH
 #!/usr/bin/env bash
+# Model the pinned build's global options: a home that owns its own Treehouse
+# pool needs --root, and a stub that advertises nothing reads as too old.
+if [ "\${1:-}" = get ] && [ "\${2:-}" = --help ]; then
+  printf '%s\n' '      --root string   Worktree root directory'
+  exit 0
+fi
 : > "$case_dir/local-copy-resource-action"
 exit 0
 SH
@@ -432,6 +441,12 @@ interrupt_teardown_during_treehouse_return() {  # <case-dir>
   local case_dir=$1
   cat > "$case_dir/fakebin/treehouse" <<SH
 #!/usr/bin/env bash
+# Model the pinned build's global options: a home that owns its own Treehouse
+# pool needs --root, and a stub that advertises nothing reads as too old.
+if [ "\${1:-}" = get ] && [ "\${2:-}" = --help ]; then
+  printf '%s\n' '      --root string   Worktree root directory'
+  exit 0
+fi
 if [ "\${1:-}" = return ] && [ ! -f "$case_dir/teardown-interrupted" ]; then
   : > "$case_dir/teardown-interrupted"
   teardown_pid=\$(ps -o ppid= -p "\$PPID" | tr -d ' ')

--- a/tests/fm-bootstrap-network-parallel.test.sh
+++ b/tests/fm-bootstrap-network-parallel.test.sh
@@ -184,7 +184,8 @@ test_remote_probe_scheduling_keeps_per_mate_lines() { # <parallel|fallback>
   git -C "$primary" add AGENTS.md bin
   git -C "$primary" commit -qm 'seed primary default branch'
   fakebin=$(fm_fakebin "$dir")
-  fm_fake_exit0 "$fakebin" gh treehouse tmux node
+  fm_fake_exit0 "$fakebin" gh tmux node
+  fm_fake_treehouse "$fakebin"
   log="$dir/probe.log"
   : > "$log"
   install_fake_ssh "$fakebin"

--- a/tests/fm-bootstrap.test.sh
+++ b/tests/fm-bootstrap.test.sh
@@ -71,6 +71,7 @@ if [ "${1:-}" = get ] && [ "${2:-}" = --help ]; then
   else
     printf '%s\n' 'Usage: treehouse get'
   fi
+  printf '%s\n' '      --root string   Worktree root directory'
   exit 0
 fi
 exit 0

--- a/tests/fm-captain-hold-lifecycle.test.sh
+++ b/tests/fm-captain-hold-lifecycle.test.sh
@@ -29,7 +29,8 @@ make_home() {  # <name>
 ## Done
 EOF
   fakebin=$(fm_fakebin "$home")
-  fm_fake_exit0 "$fakebin" tmux treehouse no-mistakes gh gh-axi
+  fm_fake_exit0 "$fakebin" tmux no-mistakes gh gh-axi
+  fm_fake_treehouse "$fakebin"
   printf '%s\n' "$home"
 }
 
@@ -1192,7 +1193,8 @@ test_secondmate_hold_stays_in_authoritative_home() {
 ## Done
 EOF
   fakebin=$(fm_fakebin "$mate")
-  fm_fake_exit0 "$fakebin" tmux treehouse no-mistakes gh gh-axi
+  fm_fake_exit0 "$fakebin" tmux no-mistakes gh gh-axi
+  fm_fake_treehouse "$fakebin"
   origin=sample-mate-review
   mkdir -p "$mate/data/$origin"
   tasks_in "$mate" add "$origin" "Investigate secondmate sample" --kind scout --repo sample --start >/dev/null
@@ -1249,7 +1251,8 @@ test_secondmate_home_publishes_holds_and_answers() {
 ## Done
 EOF
   fakebin=$(fm_fakebin "$mate")
-  fm_fake_exit0 "$fakebin" tmux treehouse no-mistakes gh gh-axi
+  fm_fake_exit0 "$fakebin" tmux no-mistakes gh gh-axi
+  fm_fake_treehouse "$fakebin"
   channel="$parent/state/channel-mate.status"
   decision="$mate/decision.txt"
 
@@ -2464,6 +2467,12 @@ test_interrupted_cleanup_keeps_the_captain_call_recoverable() {
     || fail "completion gate failed for the cleanup-failure fixture"
   cat > "$home/fakebin/treehouse" <<'SH'
 #!/usr/bin/env bash
+# Model the pinned build's global options: a home that owns its own Treehouse
+# pool needs --root, and a stub that advertises nothing reads as too old.
+if [ "${1:-}" = get ] && [ "${2:-}" = --help ]; then
+  printf '%s\n' '      --root string   Worktree root directory'
+  exit 0
+fi
 exit 1
 SH
   chmod +x "$home/fakebin/treehouse"
@@ -2485,7 +2494,7 @@ SH
   assert_not_contains "$show" "Deliverable of the finished work" \
     "the deliverable was recorded before destructive cleanup succeeded"
 
-  fm_fake_exit0 "$home/fakebin" treehouse
+  fm_fake_treehouse "$home/fakebin"
   bootstrap=$(PATH="$home/fakebin:$PATH" FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$home" \
     FM_STATE_OVERRIDE="$home/state" FM_DATA_OVERRIDE="$home/data" \
     FM_CONFIG_OVERRIDE="$home/config" FM_BOOTSTRAP_NETWORK=skip \

--- a/tests/fm-gotmp.test.sh
+++ b/tests/fm-gotmp.test.sh
@@ -84,6 +84,8 @@ SH
   ln -s "$ROOT/bin/fm-x-lib.sh" "$fake/bin/fm-x-lib.sh"
   ln -s "$ROOT/bin/fm-secondmate-registry-lib.sh" "$fake/bin/fm-secondmate-registry-lib.sh"
   ln -s "$ROOT/bin/fm-secondmate-parent-lib.sh" "$fake/bin/fm-secondmate-parent-lib.sh"
+  ln -s "$ROOT/bin/fm-treehouse-lib.sh" "$fake/bin/fm-treehouse-lib.sh"
+  ln -s "$ROOT/bin/fm-primary-scope-lib.sh" "$fake/bin/fm-primary-scope-lib.sh"
   # Receiver-wake retirement sources the pending-reply library, which in turn
   # requires the marker helper even for this ordinary-task teardown fixture.
   ln -s "$ROOT/bin/fm-pending-reply-lib.sh" "$fake/bin/fm-pending-reply-lib.sh"
@@ -184,6 +186,8 @@ SH
   ln -s "$ROOT/bin/fm-x-lib.sh" "$fake/bin/fm-x-lib.sh"
   ln -s "$ROOT/bin/fm-secondmate-registry-lib.sh" "$fake/bin/fm-secondmate-registry-lib.sh"
   ln -s "$ROOT/bin/fm-secondmate-parent-lib.sh" "$fake/bin/fm-secondmate-parent-lib.sh"
+  ln -s "$ROOT/bin/fm-treehouse-lib.sh" "$fake/bin/fm-treehouse-lib.sh"
+  ln -s "$ROOT/bin/fm-primary-scope-lib.sh" "$fake/bin/fm-primary-scope-lib.sh"
   ln -s "$ROOT/bin/fm-pending-reply-lib.sh" "$fake/bin/fm-pending-reply-lib.sh"
   ln -s "$ROOT/bin/fm-marker-lib.sh" "$fake/bin/fm-marker-lib.sh"
   ln -s "$ROOT/bin/fm-operational-input.sh" "$fake/bin/fm-operational-input.sh"

--- a/tests/fm-kimi-harness.test.sh
+++ b/tests/fm-kimi-harness.test.sh
@@ -131,7 +131,8 @@ esac
 exit 0
 SH
   chmod +x "$fakebin/tmux"
-  fm_fake_exit0 "$fakebin" treehouse gh-axi gh
+  fm_fake_exit0 "$fakebin" gh-axi gh
+  fm_fake_treehouse "$fakebin"
   fm_fake_exit0 "$fakebin" kimi
   ln -s "$JQ_BIN" "$fakebin/jq"
   printf '%s\n' "$fakebin"

--- a/tests/fm-muse-harness.test.sh
+++ b/tests/fm-muse-harness.test.sh
@@ -112,7 +112,8 @@ set -u
 exec "$FM_FAKE_MUSE_VERSIONED" -c 'result=$($FM_FAKE_HARNESS_PROBE); printf "%s" "$result" > "$FM_FAKE_HARNESS_RESULT"'
 SH
   chmod +x "$fakebin/muse"
-  fm_fake_exit0 "$fakebin" treehouse gh-axi gh
+  fm_fake_exit0 "$fakebin" gh-axi gh
+  fm_fake_treehouse "$fakebin"
   printf '%s\n' "$fakebin"
 }
 

--- a/tests/fm-public-followup.test.sh
+++ b/tests/fm-public-followup.test.sh
@@ -125,7 +125,8 @@ make_home() {  # <name> [relay-on|relay-off]
 EOF
   [ "$relay" = relay-off ] || printf 'FMX_PAIRING_TOKEN=test-token\n' > "$home/.env"
   make_fake_curl "$home" >/dev/null
-  fm_fake_exit0 "$home/fakebin" tmux treehouse no-mistakes gh gh-axi
+  fm_fake_exit0 "$home/fakebin" tmux no-mistakes gh gh-axi
+  fm_fake_treehouse "$home/fakebin"
   printf '%s\n' "$home"
 }
 
@@ -797,7 +798,8 @@ test_secondmate_teardown_resolves_parent_from_durable_record_when_env_lost() {
   child=$(cd "$child" && pwd -P)
   parent_resolved=$(cd "$parent" && pwd -P)
   make_fake_curl "$child" >/dev/null
-  fm_fake_exit0 "$child/fakebin" tmux treehouse no-mistakes gh gh-axi
+  fm_fake_exit0 "$child/fakebin" tmux no-mistakes gh gh-axi
+  fm_fake_treehouse "$child/fakebin"
 
   assert_local_secondmate_parent_record "$child" "$parent_resolved"
 
@@ -834,7 +836,8 @@ test_secondmate_teardown_durable_record_missing_parent_registration_still_refuse
   child=$(cd "$child" && pwd -P)
   parent_resolved=$(cd "$parent" && pwd -P)
   make_fake_curl "$child" >/dev/null
-  fm_fake_exit0 "$child/fakebin" tmux treehouse no-mistakes gh gh-axi
+  fm_fake_exit0 "$child/fakebin" tmux no-mistakes gh gh-axi
+  fm_fake_treehouse "$child/fakebin"
   assert_local_secondmate_parent_record "$child" "$parent_resolved"
   fm_write_meta "$child/state/work-child.meta" \
     "window=firstmate:fm-work-child" "endpoint_task_id=work-child" \
@@ -865,7 +868,8 @@ test_secondmate_teardown_durable_record_with_unknown_field_succeeds() {
   child=$(cd "$child" && pwd -P)
   parent_resolved=$(cd "$parent" && pwd -P)
   make_fake_curl "$child" >/dev/null
-  fm_fake_exit0 "$child/fakebin" tmux treehouse no-mistakes gh gh-axi
+  fm_fake_exit0 "$child/fakebin" tmux no-mistakes gh gh-axi
+  fm_fake_treehouse "$child/fakebin"
   assert_local_secondmate_parent_record "$child" "$parent_resolved"
   printf 'some_future_field=value\n' >> "$child/.fm-secondmate-parent"
   parent_alias="$TMP_ROOT/teardown-durable-clean-parent-alias"
@@ -900,7 +904,8 @@ test_secondmate_teardown_rejects_conflicting_live_and_durable_parent_bindings() 
   child=$(cd "$child" && pwd -P)
   parent_resolved=$(cd "$durable_parent" && pwd -P)
   make_fake_curl "$child" >/dev/null
-  fm_fake_exit0 "$child/fakebin" tmux treehouse no-mistakes gh gh-axi
+  fm_fake_exit0 "$child/fakebin" tmux no-mistakes gh gh-axi
+  fm_fake_treehouse "$child/fakebin"
   assert_local_secondmate_parent_record "$child" "$parent_resolved"
   fm_write_meta "$durable_parent/state/mate.meta" "kind=secondmate" "home=$child"
   fm_git_init_commit "$child/projects/worktree"
@@ -932,7 +937,8 @@ test_secondmate_teardown_rejects_unsafe_durable_parent_records() {
       || fail "real secondmate seeding failed for $case_name"
     child=$(cd "$child" && pwd -P)
     make_fake_curl "$child" >/dev/null
-    fm_fake_exit0 "$child/fakebin" tmux treehouse no-mistakes gh gh-axi
+    fm_fake_exit0 "$child/fakebin" tmux no-mistakes gh gh-axi
+    fm_fake_treehouse "$child/fakebin"
     fm_write_meta "$child/state/work-child.meta" \
       "window=firstmate:fm-work-child" "endpoint_task_id=work-child" \
       "worktree=$child" "project=$child" "kind=ship" "mode=local-only" "spawn_gen=public-followup-fixture"
@@ -994,7 +1000,8 @@ test_secondmate_teardown_rejects_nul_bearing_durable_parent_record() {
   child=$(cd "$child" && pwd -P)
   parent_resolved=$(cd "$parent" && pwd -P)
   make_fake_curl "$child" >/dev/null
-  fm_fake_exit0 "$child/fakebin" tmux treehouse no-mistakes gh gh-axi
+  fm_fake_exit0 "$child/fakebin" tmux no-mistakes gh gh-axi
+  fm_fake_treehouse "$child/fakebin"
   assert_local_secondmate_parent_record "$child" "$parent_resolved"
   fm_write_meta "$parent/state/mate.meta" "kind=secondmate" "home=$child"
   fm_git_init_commit "$child/projects/worktree"
@@ -1425,7 +1432,8 @@ test_dropped_baton_now_surfaces_open_loop() {
     "$ROOT/bin/fm-home-seed.sh" mate "$child" --no-projects >/dev/null || fail "seed failed"
   child=$(cd "$child" && pwd -P)
   make_fake_curl "$child" >/dev/null
-  fm_fake_exit0 "$child/fakebin" tmux treehouse no-mistakes gh gh-axi
+  fm_fake_exit0 "$child/fakebin" tmux no-mistakes gh gh-axi
+  fm_fake_treehouse "$child/fakebin"
   log="$TMP_ROOT/curl.log"; : > "$log"
 
   seed_repro_commitment "$parent" public-final-pi-rearm-repro req-pirearm \
@@ -1475,7 +1483,8 @@ test_control_registered_followon_is_guarded() {
     "$ROOT/bin/fm-home-seed.sh" mate "$child" --no-projects >/dev/null || fail "seed failed"
   child=$(cd "$child" && pwd -P)
   make_fake_curl "$child" >/dev/null
-  fm_fake_exit0 "$child/fakebin" tmux treehouse no-mistakes gh gh-axi
+  fm_fake_exit0 "$child/fakebin" tmux no-mistakes gh gh-axi
+  fm_fake_treehouse "$child/fakebin"
   seed_repro_commitment "$parent" public-final-pi-rearm-ship req-pirearm2 \
     secondmate:mate pi-rearm-loop-fix-r1
   fm_write_meta "$parent/state/mate.meta" "kind=secondmate" "home=$child"

--- a/tests/fm-remote-doctor.test.sh
+++ b/tests/fm-remote-doctor.test.sh
@@ -198,6 +198,12 @@ esac
 SH
   cat > "$CASE_BIN/treehouse" <<'SH'
 #!/usr/bin/env bash
+# Model the pinned build's global options: a home that owns its own Treehouse
+# pool needs --root, and a stub that advertises nothing reads as too old.
+if [ "${1:-}" = get ] && [ "${2:-}" = --help ]; then
+  printf '%s\n' '      --root string   Worktree root directory'
+  exit 0
+fi
 exit 0
 SH
   cat > "$CASE_BIN/claude" <<'SH'

--- a/tests/fm-remote-secondmate-parent-binding.test.sh
+++ b/tests/fm-remote-secondmate-parent-binding.test.sh
@@ -242,10 +242,13 @@ write_child_meta() {
     "mode=local-only" "yolo=off"
 }
 mkdir -p "$TMP_ROOT/childfake"
-for t in tmux treehouse no-mistakes gh gh-axi tasks-axi; do
+for t in tmux no-mistakes gh gh-axi tasks-axi; do
   printf '#!/usr/bin/env bash\nexit 0\n' > "$TMP_ROOT/childfake/$t"
   chmod +x "$TMP_ROOT/childfake/$t"
 done
+# This remote home owns its own Treehouse pool, so the stub must advertise the
+# pinned build's --root option or the return is refused as too old a treehouse.
+fm_fake_treehouse "$TMP_ROOT/childfake"
 
 run_child_teardown() { # <extra env assignments...>
   local out rc=0

--- a/tests/fm-secondmate-harness.test.sh
+++ b/tests/fm-secondmate-harness.test.sh
@@ -1095,6 +1095,7 @@ SH
 if [ "${1:-}" = get ] && [ "${2:-}" = --help ]; then
   printf '%s\n' 'Usage: treehouse get [--lease]'
 fi
+  printf '%s\n' '      --root string   Worktree root directory'
 exit 0
 SH
   chmod +x "$fakebin/treehouse"

--- a/tests/fm-secondmate-liveness.test.sh
+++ b/tests/fm-secondmate-liveness.test.sh
@@ -227,6 +227,7 @@ SH
 if [ "${1:-}" = get ] && [ "${2:-}" = --help ]; then
   printf '%s\n' 'Usage: treehouse get [--lease]'
 fi
+  printf '%s\n' '      --root string   Worktree root directory'
 exit 0
 SH
   chmod +x "$fakebin/treehouse"

--- a/tests/fm-secondmate-safety.test.sh
+++ b/tests/fm-secondmate-safety.test.sh
@@ -2029,6 +2029,13 @@ EOF
 #!/usr/bin/env bash
 set -u
 printf 'treehouse %s\n' "$*" >> "${FM_FAKE_TMUX_LOG:-/dev/null}"
+if [ "${1:-}" = get ] && [ "${2:-}" = --help ]; then
+  # Model the pinned build's global options, including the --root a home that
+  # owns its own pool requires (docs/configuration.md).
+  printf '%s\n' 'Usage: treehouse get [--lease] [--lease-holder <holder>]'
+  printf '%s\n' '      --root string   Worktree root directory'
+  exit 0
+fi
 case "${1:-}" in
   return)
     shift
@@ -2036,6 +2043,8 @@ case "${1:-}" in
     while [ $# -gt 0 ]; do
       case "$1" in
         --force) ;;
+        --root) shift ;;
+        --root=*) ;;
         *) target=$1 ;;
       esac
       shift

--- a/tests/fm-secondmate-sync.test.sh
+++ b/tests/fm-secondmate-sync.test.sh
@@ -364,6 +364,7 @@ SH
 if [ "${1:-}" = get ] && [ "${2:-}" = --help ]; then
   printf '%s\n' 'Usage: treehouse get [--lease]'
 fi
+  printf '%s\n' '      --root string   Worktree root directory'
 exit 0
 SH
   chmod +x "$fakebin/treehouse"
@@ -1241,7 +1242,8 @@ test_bootstrap_syncs_remote_home_to_primary_commit() {
     'herdr_workspace_id=w1' 'herdr_tab_id=t1' 'herdr_pane_id=p1'
 
   fakebin=$(make_remote_leg_ssh_stub "$w")
-  fm_fake_exit0 "$fakebin" gh treehouse tmux node
+  fm_fake_exit0 "$fakebin" gh tmux node
+  fm_fake_treehouse "$fakebin"
   out=$(PATH="$fakebin:$BASE_PATH" \
     FM_HOME="$home" FM_ROOT_OVERRIDE="$w/main" \
     FM_BOOTSTRAP_NETWORK=only \
@@ -1279,7 +1281,8 @@ test_bootstrap_reports_outdated_host_actionably() {
   printf 'remote_host=host-sm\n' >> "$home/state/sm.meta"
 
   fakebin=$(make_remote_leg_ssh_stub "$w")
-  fm_fake_exit0 "$fakebin" gh treehouse tmux node
+  fm_fake_exit0 "$fakebin" gh tmux node
+  fm_fake_treehouse "$fakebin"
   out=$(PATH="$fakebin:$BASE_PATH" \
     FM_HOME="$home" FM_ROOT_OVERRIDE="$w/main" \
     FM_BOOTSTRAP_NETWORK=only \
@@ -1320,7 +1323,8 @@ test_remote_launch_does_not_retarget_host_copy() {
   install_remote_herdr_fixture "$herdrbin" "$w/herdr.state" "$w/herdr.log" \
     "$w/herdr.sendfail" "$w/herdr.sock"
   cp "$herdrbin/bin/herdr" "$fakebin/herdr"
-  fm_fake_exit0 "$fakebin" gh treehouse tmux node
+  fm_fake_exit0 "$fakebin" gh tmux node
+  fm_fake_treehouse "$fakebin"
 
   # The real launch leg, exactly as the parent invokes it after its own sync.
   launch_out=$(PATH="$fakebin:$BASE_PATH" \

--- a/tests/fm-session-start.test.sh
+++ b/tests/fm-session-start.test.sh
@@ -91,6 +91,7 @@ SH
 #!/usr/bin/env bash
 if [ "${1:-}" = get ] && [ "${2:-}" = --help ]; then
   printf '%s\n' 'Usage: treehouse get [--lease]'
+  printf '%s\n' '      --root string   Worktree root directory'
   exit 0
 fi
 exit 0

--- a/tests/fm-shared-captain-inheritance.test.sh
+++ b/tests/fm-shared-captain-inheritance.test.sh
@@ -219,7 +219,8 @@ SH
 # Version-aware stubs so bootstrap's tool floors stay quiet in fixture PATH.
 add_bootstrap_compatible_tools() {
   local fakebin=$1
-  fm_fake_exit0 "$fakebin" node chrome-devtools-axi gh treehouse
+  fm_fake_exit0 "$fakebin" node chrome-devtools-axi gh
+  fm_fake_treehouse "$fakebin"
   fm_fake_version_tool "$fakebin" lavish-axi FM_FAKE_LAVISH_AXI_VERSION 0.1.46
   cat > "$fakebin/gh-axi" <<'SH'
 #!/usr/bin/env bash

--- a/tests/fm-spawn-worktree-settle.test.sh
+++ b/tests/fm-spawn-worktree-settle.test.sh
@@ -70,7 +70,9 @@ esac
 exit 0
 SH
   chmod +x "$fakebin/tmux"
-  fm_fake_exit0 "$fakebin" treehouse
+  # The stub advertises the pinned build's --root option, which a home owning its
+  # own pool requires; the older-Treehouse case re-stubs it with --no-root.
+  fm_fake_treehouse "$fakebin"
   printf '%s\n' "$fakebin"
 }
 
@@ -320,10 +322,35 @@ test_secondmate_home_uses_own_treehouse_pool() {
   pass "a linked secondmate home scopes Treehouse get to its own project pool and passes Claude trust"
 }
 
+test_secondmate_home_refuses_treehouse_without_root_option() {
+  local rec id out status
+  id=settle-secondmate-pool-oldth-z4
+  rec=$(make_secondmate_pool_case settle-secondmate-pool-oldth "$id")
+  read_secondmate_pool_record "$rec"
+  # Treehouse before v2.2.0 has no --root and ignores TREEHOUSE_ROOT too, so the
+  # pool identity would silently resolve to whichever clone shares this remote -
+  # the primary home's. Refusing is the only safe outcome.
+  fm_fake_treehouse "$SECOND_FAKEBIN" --no-root
+
+  out=$(run_secondmate_pool_spawn "$id")
+  status=$?
+  [ "$status" -ne 0 ] || fail "spawn should refuse when treehouse cannot scope the pool to this home"
+  assert_contains "$out" "no --root option" \
+    "the refusal did not name the missing Treehouse option"
+  assert_absent "$SECOND_HOME/state/$id.meta" \
+    "a refused spawn must not record task metadata"
+  # The refusal lands before anything is typed, so the log usually does not exist
+  # at all; guard the read so the case still states the invariant that matters.
+  [ ! -f "$SECOND_LAUNCHLOG" ] || assert_no_grep "treehouse get" "$SECOND_LAUNCHLOG" \
+    "a refused spawn must not type an unscoped Treehouse acquisition"
+  pass "a secondmate home refuses to acquire a worktree when treehouse cannot scope the pool to it"
+}
+
 test_single_stale_first_read_is_not_accepted
 test_already_settled_pane_costs_one_confirm_read
 test_transient_primary_checkout_is_not_accepted
 test_primary_checkout_that_never_settles_fails_at_the_deadline
 test_secondmate_home_uses_own_treehouse_pool
+test_secondmate_home_refuses_treehouse_without_root_option
 
 echo "# all fm-spawn-worktree-settle tests passed"

--- a/tests/fm-spawn-worktree-settle.test.sh
+++ b/tests/fm-spawn-worktree-settle.test.sh
@@ -315,7 +315,7 @@ test_secondmate_home_uses_own_treehouse_pool() {
   status=$?
   expect_code 0 "$status" "secondmate-home spawn should succeed with its own pooled worktree"
   assert_contains "$out" "spawned $id" "secondmate-home spawn did not report success"
-  assert_grep "treehouse get --root $SECOND_HOME/config" "$SECOND_LAUNCHLOG" \
+  assert_grep "treehouse get --root '$SECOND_HOME/config'" "$SECOND_LAUNCHLOG" \
     "secondmate-home spawn did not type the home-specific Treehouse root"
   assert_grep "worktree=$SECOND_HOME_WT" "$SECOND_HOME/state/$id.meta" \
     "secondmate-home spawn did not record the worktree from its own pool"

--- a/tests/fm-spawn-worktree-settle.test.sh
+++ b/tests/fm-spawn-worktree-settle.test.sh
@@ -56,7 +56,16 @@ case "${1:-}" in
   display-message) printf 'firstmate\n'; exit 0 ;;
   list-windows) exit 0 ;;
   has-session|new-session|new-window|kill-window) exit 0 ;;
-  send-keys) exit 0 ;;
+  send-keys)
+    if [ -n "${FM_FAKE_LAUNCH_LOG:-}" ]; then
+      if [ "${4:-}" = "-l" ]; then
+        printf '%s\n' "${5:-}" >> "$FM_FAKE_LAUNCH_LOG"
+      else
+        printf '%s\n' "${4:-}" >> "$FM_FAKE_LAUNCH_LOG"
+      fi
+    fi
+    exit 0
+    ;;
 esac
 exit 0
 SH
@@ -94,6 +103,69 @@ Record only the pane's stable worktree.
 EOF
   touch "$home/state/.last-watcher-beat"
   printf '%s\n' "$case_dir|$home|$proj|$wt|$stale|$fakebin|$countfile|$stale_reads"
+}
+
+# make_secondmate_pool_case <name> <id> builds a real linked Firstmate home and
+# matching project clones whose worktree common dirs are intentionally distinct.
+make_secondmate_pool_case() {
+  local name=$1 id=$2 case_dir code_root home source origin project primary_project
+  local primary_wt home_wt fakebin countfile launchlog
+  case_dir="$TMP_ROOT/$name"
+  code_root="$case_dir/code-root"
+  home="$case_dir/secondmate-home"
+  source="$case_dir/project-source"
+  origin="$case_dir/project-origin.git"
+  project="$home/projects/widget"
+  primary_project="$case_dir/primary-project"
+  primary_wt="$case_dir/primary-pool-worktree"
+  home_wt="$case_dir/secondmate-pool-worktree"
+  countfile="$case_dir/pane-call-count"
+  launchlog="$case_dir/launch.log"
+
+  git clone --quiet --local "$ROOT" "$code_root"
+  git -C "$code_root" worktree add --quiet --detach "$home" HEAD
+  mkdir -p "$home/data/$id" "$home/projects" "$home/state" "$home/config"
+  printf 'codex\n' > "$home/config/crew-harness"
+  cat > "$home/data/$id/brief.md" <<EOF
+# Task
+## Captain's intent
+Exercise the secondmate-specific Treehouse pool root for $id.
+
+## Firstmate spec
+Use the active home's own project pool.
+EOF
+  touch "$home/state/.last-watcher-beat"
+
+  fm_git_init_commit "$source"
+  git -C "$source" branch -M main
+  fm_git_add_origin "$source" "$origin"
+  git clone --quiet "file://$origin" "$project"
+  git clone --quiet "file://$origin" "$primary_project"
+  git -C "$primary_project" worktree add --quiet --detach "$primary_wt" HEAD
+  git -C "$project" worktree add --quiet --detach "$home_wt" HEAD
+
+  fakebin=$(make_settle_fakebin "$case_dir/fake")
+  fm_fake_exit0 "$fakebin" codex
+  printf '%s\n' "$case_dir|$code_root|$home|$project|$primary_wt|$home_wt|$fakebin|$countfile|$launchlog"
+}
+
+read_secondmate_pool_record() {
+  IFS='|' read -r SECOND_CASE SECOND_CODE_ROOT SECOND_HOME SECOND_PROJECT \
+    SECOND_PRIMARY_WT SECOND_HOME_WT SECOND_FAKEBIN SECOND_COUNTFILE SECOND_LAUNCHLOG <<EOF
+$1
+EOF
+}
+
+run_secondmate_pool_spawn() {
+  local id=$1
+  FM_ROOT_OVERRIDE="$SECOND_CODE_ROOT" FM_HOME="$SECOND_HOME" \
+    FM_STATE_OVERRIDE="$SECOND_HOME/state" FM_DATA_OVERRIDE="$SECOND_HOME/data" \
+    FM_PROJECTS_OVERRIDE="$SECOND_HOME/projects" FM_CONFIG_OVERRIDE="$SECOND_HOME/config" \
+    FM_SPAWN_NO_GUARD=1 TMUX="fake,1,0" \
+    FM_FAKE_PANE_PATH="$SECOND_HOME_WT" FM_FAKE_PANE_STALE_READS=0 \
+    FM_FAKE_PANE_COUNTFILE="$SECOND_COUNTFILE" FM_FAKE_LAUNCH_LOG="$SECOND_LAUNCHLOG" \
+    PATH="$SECOND_FAKEBIN:$PATH" \
+    "$SPAWN" "$id" "$SECOND_PROJECT" --mode no-mistakes --yolo off 2>&1
 }
 
 read_settle_record() {
@@ -221,9 +293,37 @@ test_primary_checkout_that_never_settles_fails_at_the_deadline() {
   pass "a pane stuck on the primary checkout fails loudly at the deadline"
 }
 
+test_secondmate_home_uses_own_treehouse_pool() {
+  local rec id out status trust_home
+  id=settle-secondmate-pool-z3
+  rec=$(make_secondmate_pool_case settle-secondmate-pool "$id")
+  read_secondmate_pool_record "$rec"
+  trust_home="$SECOND_CASE/claude-home"
+  mkdir -p "$trust_home"
+
+  if HOME="$trust_home" CLAUDE_CONFIG_DIR='' \
+    "$ROOT/bin/fm-claude-trust.sh" "$SECOND_PRIMARY_WT" "$SECOND_PROJECT" >/dev/null 2>&1; then
+    fail "Claude trust accepted a worktree from the primary project clone for a secondmate project"
+  fi
+  HOME="$trust_home" CLAUDE_CONFIG_DIR='' \
+    "$ROOT/bin/fm-claude-trust.sh" "$SECOND_HOME_WT" "$SECOND_PROJECT" >/dev/null \
+    || fail "Claude trust rejected the secondmate project's own worktree"
+
+  out=$(run_secondmate_pool_spawn "$id")
+  status=$?
+  expect_code 0 "$status" "secondmate-home spawn should succeed with its own pooled worktree"
+  assert_contains "$out" "spawned $id" "secondmate-home spawn did not report success"
+  assert_grep "treehouse get --root $SECOND_HOME/config" "$SECOND_LAUNCHLOG" \
+    "secondmate-home spawn did not type the home-specific Treehouse root"
+  assert_grep "worktree=$SECOND_HOME_WT" "$SECOND_HOME/state/$id.meta" \
+    "secondmate-home spawn did not record the worktree from its own pool"
+  pass "a linked secondmate home scopes Treehouse get to its own project pool and passes Claude trust"
+}
+
 test_single_stale_first_read_is_not_accepted
 test_already_settled_pane_costs_one_confirm_read
 test_transient_primary_checkout_is_not_accepted
 test_primary_checkout_that_never_settles_fails_at_the_deadline
+test_secondmate_home_uses_own_treehouse_pool
 
 echo "# all fm-spawn-worktree-settle tests passed"

--- a/tests/fm-spawn-worktree-settle.test.sh
+++ b/tests/fm-spawn-worktree-settle.test.sh
@@ -316,7 +316,7 @@ test_secondmate_home_uses_own_treehouse_pool() {
   status=$?
   expect_code 0 "$status" "secondmate-home spawn should succeed with its own pooled worktree"
   assert_contains "$out" "spawned $id" "secondmate-home spawn did not report success"
-  assert_grep "treehouse get --root \"$SECOND_HOME/config\"" "$SECOND_LAUNCHLOG" \
+  assert_grep "treehouse get --root '$SECOND_HOME/config'" "$SECOND_LAUNCHLOG" \
     "secondmate-home spawn did not type the home-specific Treehouse root"
   assert_grep "worktree=$SECOND_HOME_WT" "$SECOND_HOME/state/$id.meta" \
     "secondmate-home spawn did not record the worktree from its own pool"
@@ -324,7 +324,7 @@ test_secondmate_home_uses_own_treehouse_pool() {
 }
 
 test_secondmate_home_quotes_apostrophe_in_treehouse_root() {
-  local rec id out status
+  local rec id out status expected_root
   id=settle-secondmate-apostrophe-z4
   rec=$(make_secondmate_pool_case settle-secondmate-apostrophe "$id" "secondmate-home's-copy")
   read_secondmate_pool_record "$rec"
@@ -333,7 +333,9 @@ test_secondmate_home_quotes_apostrophe_in_treehouse_root() {
   status=$?
   expect_code 0 "$status" "secondmate-home spawn should preserve an apostrophe in its pool root"
   assert_contains "$out" "spawned $id" "apostrophe-path spawn did not report success"
-  assert_grep "treehouse get --root \"$SECOND_HOME/config\"" "$SECOND_LAUNCHLOG" \
+  expected_root=$(printf '%s' "$SECOND_HOME/config" | sed "s/'/'\\\\''/g")
+  expected_root="'$expected_root'"
+  assert_grep "treehouse get --root $expected_root" "$SECOND_LAUNCHLOG" \
     "apostrophe-path spawn did not quote its home-specific Treehouse root"
   assert_grep "worktree=$SECOND_HOME_WT" "$SECOND_HOME/state/$id.meta" \
     "apostrophe-path spawn did not record the worktree from its own pool"
@@ -350,8 +352,8 @@ test_secondmate_home_quotes_history_expansion_in_treehouse_root() {
   status=$?
   expect_code 0 "$status" "secondmate-home spawn should preserve history expansion in its pool root"
   assert_contains "$out" "spawned $id" "history-expansion-path spawn did not report success"
-  expected_root=$(printf '%s' "$SECOND_HOME/config" | sed 's/!/\\!/g')
-  assert_grep "treehouse get --root \"$expected_root\"" "$SECOND_LAUNCHLOG" \
+  expected_root="'$SECOND_HOME/config'"
+  assert_grep "treehouse get --root $expected_root" "$SECOND_LAUNCHLOG" \
     "history-expansion-path spawn did not escape ! for the pane shell"
   pass "a secondmate home escapes history expansion in the Treehouse root passed to its pane shell"
 }

--- a/tests/fm-spawn-worktree-settle.test.sh
+++ b/tests/fm-spawn-worktree-settle.test.sh
@@ -110,11 +110,12 @@ EOF
 # make_secondmate_pool_case <name> <id> builds a real linked Firstmate home and
 # matching project clones whose worktree common dirs are intentionally distinct.
 make_secondmate_pool_case() {
-  local name=$1 id=$2 case_dir code_root home source origin project primary_project
+  local name=$1 id=$2 home_leaf=${3:-secondmate-home}
+  local case_dir code_root home source origin project primary_project
   local primary_wt home_wt fakebin countfile launchlog
   case_dir="$TMP_ROOT/$name"
   code_root="$case_dir/code-root"
-  home="$case_dir/secondmate-home"
+  home="$case_dir/$home_leaf"
   source="$case_dir/project-source"
   origin="$case_dir/project-origin.git"
   project="$home/projects/widget"
@@ -315,11 +316,28 @@ test_secondmate_home_uses_own_treehouse_pool() {
   status=$?
   expect_code 0 "$status" "secondmate-home spawn should succeed with its own pooled worktree"
   assert_contains "$out" "spawned $id" "secondmate-home spawn did not report success"
-  assert_grep "treehouse get --root '$SECOND_HOME/config'" "$SECOND_LAUNCHLOG" \
+  assert_grep "treehouse get --root \"$SECOND_HOME/config\"" "$SECOND_LAUNCHLOG" \
     "secondmate-home spawn did not type the home-specific Treehouse root"
   assert_grep "worktree=$SECOND_HOME_WT" "$SECOND_HOME/state/$id.meta" \
     "secondmate-home spawn did not record the worktree from its own pool"
   pass "a linked secondmate home scopes Treehouse get to its own project pool and passes Claude trust"
+}
+
+test_secondmate_home_quotes_apostrophe_in_treehouse_root() {
+  local rec id out status
+  id=settle-secondmate-apostrophe-z4
+  rec=$(make_secondmate_pool_case settle-secondmate-apostrophe "$id" "secondmate-home's-copy")
+  read_secondmate_pool_record "$rec"
+
+  out=$(run_secondmate_pool_spawn "$id")
+  status=$?
+  expect_code 0 "$status" "secondmate-home spawn should preserve an apostrophe in its pool root"
+  assert_contains "$out" "spawned $id" "apostrophe-path spawn did not report success"
+  assert_grep "treehouse get --root \"$SECOND_HOME/config\"" "$SECOND_LAUNCHLOG" \
+    "apostrophe-path spawn did not quote its home-specific Treehouse root"
+  assert_grep "worktree=$SECOND_HOME_WT" "$SECOND_HOME/state/$id.meta" \
+    "apostrophe-path spawn did not record the worktree from its own pool"
+  pass "a secondmate home preserves an apostrophe in the Treehouse root passed to its pane shell"
 }
 
 test_secondmate_home_refuses_treehouse_without_root_option() {
@@ -351,6 +369,7 @@ test_already_settled_pane_costs_one_confirm_read
 test_transient_primary_checkout_is_not_accepted
 test_primary_checkout_that_never_settles_fails_at_the_deadline
 test_secondmate_home_uses_own_treehouse_pool
+test_secondmate_home_quotes_apostrophe_in_treehouse_root
 test_secondmate_home_refuses_treehouse_without_root_option
 
 echo "# all fm-spawn-worktree-settle tests passed"

--- a/tests/fm-spawn-worktree-settle.test.sh
+++ b/tests/fm-spawn-worktree-settle.test.sh
@@ -340,6 +340,22 @@ test_secondmate_home_quotes_apostrophe_in_treehouse_root() {
   pass "a secondmate home preserves an apostrophe in the Treehouse root passed to its pane shell"
 }
 
+test_secondmate_home_quotes_history_expansion_in_treehouse_root() {
+  local rec id out status expected_root
+  id=settle-secondmate-history-z5
+  rec=$(make_secondmate_pool_case settle-secondmate-history "$id" "secondmate-home!copy")
+  read_secondmate_pool_record "$rec"
+
+  out=$(run_secondmate_pool_spawn "$id")
+  status=$?
+  expect_code 0 "$status" "secondmate-home spawn should preserve history expansion in its pool root"
+  assert_contains "$out" "spawned $id" "history-expansion-path spawn did not report success"
+  expected_root=$(printf '%s' "$SECOND_HOME/config" | sed 's/!/\\!/g')
+  assert_grep "treehouse get --root \"$expected_root\"" "$SECOND_LAUNCHLOG" \
+    "history-expansion-path spawn did not escape ! for the pane shell"
+  pass "a secondmate home escapes history expansion in the Treehouse root passed to its pane shell"
+}
+
 test_secondmate_home_refuses_treehouse_without_root_option() {
   local rec id out status
   id=settle-secondmate-pool-oldth-z4
@@ -370,6 +386,7 @@ test_transient_primary_checkout_is_not_accepted
 test_primary_checkout_that_never_settles_fails_at_the_deadline
 test_secondmate_home_uses_own_treehouse_pool
 test_secondmate_home_quotes_apostrophe_in_treehouse_root
+test_secondmate_home_quotes_history_expansion_in_treehouse_root
 test_secondmate_home_refuses_treehouse_without_root_option
 
 echo "# all fm-spawn-worktree-settle tests passed"

--- a/tests/fm-startup-memory-budget.test.sh
+++ b/tests/fm-startup-memory-budget.test.sh
@@ -65,6 +65,7 @@ case "$*" in
   *list-windows*) printf '%s\n' fm-sm ;;
   *capture-pane*) printf '❯\n' ;;
 esac
+  printf '%s\n' '      --root string   Worktree root directory'
 exit 0
 SH
   chmod +x "$fakebin"/*

--- a/tests/fm-tangle-guard.test.sh
+++ b/tests/fm-tangle-guard.test.sh
@@ -238,7 +238,7 @@ esac
 exit 0
 SH
   chmod +x "$fakebin/tmux"
-  fm_fake_exit0 "$fakebin" treehouse
+  fm_fake_treehouse "$fakebin"
   printf '%s\n' "$fakebin"
 }
 

--- a/tests/fm-teardown-endpoint-safety.test.sh
+++ b/tests/fm-teardown-endpoint-safety.test.sh
@@ -26,6 +26,12 @@ exit 0
 SH
   cat > "$TMP_ROOT/$dir/fakebin/treehouse" <<'SH'
 #!/usr/bin/env bash
+# Model the pinned build's global options: a home that owns its own Treehouse
+# pool needs --root, and a stub that advertises nothing reads as too old.
+if [ "${1:-}" = get ] && [ "${2:-}" = --help ]; then
+  printf '%s\n' '      --root string   Worktree root directory'
+  exit 0
+fi
 printf 'treehouse' >> "${FM_RUNTIME_LOG:?}"
 printf ' <%s>' "$@" >> "${FM_RUNTIME_LOG:?}"
 printf '\n' >> "${FM_RUNTIME_LOG:?}"

--- a/tests/fm-teardown.test.sh
+++ b/tests/fm-teardown.test.sh
@@ -84,11 +84,10 @@ make_case() {
 
   # Mocks for the post-check teardown steps. Refuse logic exits before these
   # run; the ALLOW cases need them so the script can complete cleanly.
-  cat > "$fakebin/treehouse" <<'SH'
-#!/usr/bin/env bash
-# `treehouse return --force <wt>`: succeed silently.
-exit 0
-SH
+  # `treehouse return [--root <root>] --force <wt>`: succeed silently. The stub
+  # advertises the global --root option the pinned build carries, so a case whose
+  # home owns its own pool is not refused for an apparently older Treehouse.
+  fm_fake_treehouse "$fakebin"
   cat > "$fakebin/tmux" <<'SH'
 #!/usr/bin/env bash
 # tmux kill-window etc.: succeed silently.
@@ -420,6 +419,12 @@ add_lock_aware_treehouse() {
   local case_dir=$1
   cat > "$case_dir/fakebin/treehouse" <<'SH'
 #!/usr/bin/env bash
+# Model the pinned build's global options: a home that owns its own Treehouse
+# pool needs --root, and a stub that advertises nothing reads as too old.
+if [ "${1:-}" = get ] && [ "${2:-}" = --help ]; then
+  printf '%s\n' '      --root string   Worktree root directory'
+  exit 0
+fi
 if [ "${1:-}" = return ]; then
   shift
   wt=""
@@ -454,6 +459,12 @@ add_transient_lock_treehouse() {
   local case_dir=$1
   cat > "$case_dir/fakebin/treehouse" <<'SH'
 #!/usr/bin/env bash
+# Model the pinned build's global options: a home that owns its own Treehouse
+# pool needs --root, and a stub that advertises nothing reads as too old.
+if [ "${1:-}" = get ] && [ "${2:-}" = --help ]; then
+  printf '%s\n' '      --root string   Worktree root directory'
+  exit 0
+fi
 if [ "${1:-}" = return ]; then
   shift
   wt=""
@@ -499,6 +510,12 @@ add_persistent_lock_treehouse() {
   local case_dir=$1
   cat > "$case_dir/fakebin/treehouse" <<'SH'
 #!/usr/bin/env bash
+# Model the pinned build's global options: a home that owns its own Treehouse
+# pool needs --root, and a stub that advertises nothing reads as too old.
+if [ "${1:-}" = get ] && [ "${2:-}" = --help ]; then
+  printf '%s\n' '      --root string   Worktree root directory'
+  exit 0
+fi
 if [ "${1:-}" = return ]; then
   shift
   wt=""
@@ -1860,6 +1877,37 @@ test_secondmate_pr_registration_publishes_ready_line() {
 # Tearing a child down inside a secondmate home delivers the child's final
 # ledger line to the parent before the record goes, and refuses (retaining
 # every record) while the parent channel cannot be written; a rerun after the
+# A home that owns its own Treehouse pool cannot release a worktree through a
+# build that predates the --root option: addressing the default pool would return
+# somebody else's worktree, and raw removal would strand this pool's lease and
+# delete the work it still owns. The only safe outcome is to refuse and change
+# nothing.
+test_secondmate_home_teardown_refuses_treehouse_without_root_option() {
+  local case_dir rc wt_head
+
+  case_dir=$(make_case mate-teardown-old-treehouse)
+  configure_secondmate_home "$case_dir" local "$case_dir/parent"
+  mkdir -p "$case_dir/parent/state"
+  fm_fake_treehouse "$case_dir/fakebin" --no-root
+  write_meta "$case_dir" local-only ship
+  wt_commit "$case_dir" "merged work"
+  wt_head=$(git -C "$case_dir/wt" rev-parse HEAD)
+  git -C "$case_dir/project" update-ref refs/heads/main "$wt_head"
+  set +e
+  FM_HOME="$case_dir/home" run_teardown "$case_dir" > "$case_dir/stdout" 2> "$case_dir/stderr"
+  rc=$?
+  set -e
+
+  [ "$rc" -ne 0 ] || fail "mate-teardown-old-treehouse: teardown should refuse without a scoped pool root"
+  grep -F 'no --root option' "$case_dir/stderr" >/dev/null \
+    || fail "mate-teardown-old-treehouse: the refusal did not name the missing Treehouse option: $(cat "$case_dir/stderr")"
+  [ -d "$case_dir/wt" ] \
+    || fail "mate-teardown-old-treehouse: a refused teardown must leave the local copy in place"
+  [ -e "$case_dir/state/task-x1.meta" ] \
+    || fail "mate-teardown-old-treehouse: a refused teardown must keep the task record"
+  pass "a home owning its own pool refuses teardown when treehouse cannot scope the return"
+}
+
 # repair delivers and completes.
 test_secondmate_home_teardown_delivers_final_line_or_refuses() {
   local case_dir rc channel wt_head err seq generation
@@ -2060,6 +2108,12 @@ test_herdr_flat_teardown_refuses_orphaning_records_then_retry_completes() {
   thlog="$case_dir/treehouse.log"; : > "$thlog"
   cat > "$case_dir/fakebin/treehouse" <<SH
 #!/usr/bin/env bash
+# Model the pinned build's global options: a home that owns its own Treehouse
+# pool needs --root, and a stub that advertises nothing reads as too old.
+if [ "\${1:-}" = get ] && [ "\${2:-}" = --help ]; then
+  printf '%s\n' '      --root string   Worktree root directory'
+  exit 0
+fi
 printf '%s\n' "\$*" >> "$thlog"
 exit 0
 SH
@@ -2156,6 +2210,12 @@ assert_herdr_teardown_preflight_refuses_before_changes() {
   thlog="$case_dir/treehouse.log"; : > "$thlog"
   cat > "$case_dir/fakebin/treehouse" <<SH
 #!/usr/bin/env bash
+# Model the pinned build's global options: a home that owns its own Treehouse
+# pool needs --root, and a stub that advertises nothing reads as too old.
+if [ "\${1:-}" = get ] && [ "\${2:-}" = --help ]; then
+  printf '%s\n' '      --root string   Worktree root directory'
+  exit 0
+fi
 printf '%s\n' "\$*" >> "$thlog"
 exit 0
 SH
@@ -2270,6 +2330,12 @@ test_forced_secondmate_herdr_child_preflight_refuses_before_changes() {
   : > "$log"; : > "$thlog"
   cat > "$case_dir/fakebin/treehouse" <<SH
 #!/usr/bin/env bash
+# Model the pinned build's global options: a home that owns its own Treehouse
+# pool needs --root, and a stub that advertises nothing reads as too old.
+if [ "\${1:-}" = get ] && [ "\${2:-}" = --help ]; then
+  printf '%s\n' '      --root string   Worktree root directory'
+  exit 0
+fi
 printf '%s\n' "\$*" >> "$thlog"
 exit 0
 SH
@@ -2322,9 +2388,14 @@ test_forced_secondmate_teardown_holds_descendant_lifecycle_locks() {
 printf '%s\n' "\$*" >> "$case_dir/kill.log"
 exit 0
 SH
+  # Logs every call and, like the pinned build, advertises the global --root a
+  # home that owns its own pool needs on the return.
   cat > "$case_dir/fakebin/treehouse" <<SH
 #!/usr/bin/env bash
 printf '%s\n' "\$*" >> "$case_dir/treehouse.log"
+if [ "\${1:-}" = get ] && [ "\${2:-}" = --help ]; then
+  printf '%s\n' '      --root string   Worktree root directory'
+fi
 exit 0
 SH
   chmod +x "$case_dir/fakebin/tmux" "$case_dir/fakebin/treehouse"
@@ -3194,6 +3265,12 @@ test_parked_own_run_refuses_when_abort_is_unconfirmed() {
 
   cat > "$case_dir/fakebin/treehouse" <<EOF
 #!/usr/bin/env bash
+# Model the pinned build's global options: a home that owns its own Treehouse
+# pool needs --root, and a stub that advertises nothing reads as too old.
+if [ "\${1:-}" = get ] && [ "\${2:-}" = --help ]; then
+  printf '%s\n' '      --root string   Worktree root directory'
+  exit 0
+fi
 printf 'return\n' >> "$case_dir/treehouse.log"
 EOF
   chmod +x "$case_dir/fakebin/treehouse"
@@ -3364,6 +3441,12 @@ exit 1
 SH
   cat > "$case_dir/fakebin/treehouse" <<EOF
 #!/usr/bin/env bash
+# Model the pinned build's global options: a home that owns its own Treehouse
+# pool needs --root, and a stub that advertises nothing reads as too old.
+if [ "\${1:-}" = get ] && [ "\${2:-}" = --help ]; then
+  printf '%s\n' '      --root string   Worktree root directory'
+  exit 0
+fi
 printf 'return\n' >> "$case_dir/treehouse.log"
 EOF
   chmod +x "$case_dir/fakebin/lsof" "$case_dir/fakebin/treehouse"
@@ -3590,6 +3673,12 @@ exec "$REAL_PS_FOR_TEST" "$@"
 SH
   cat > "$case_dir/fakebin/treehouse" <<EOF
 #!/usr/bin/env bash
+# Model the pinned build's global options: a home that owns its own Treehouse
+# pool needs --root, and a stub that advertises nothing reads as too old.
+if [ "\${1:-}" = get ] && [ "\${2:-}" = --help ]; then
+  printf '%s\n' '      --root string   Worktree root directory'
+  exit 0
+fi
 printf 'returned\n' > "$case_dir/treehouse.log"
 EOF
   chmod +x "$case_dir/fakebin/lsof" "$case_dir/fakebin/ps" "$case_dir/fakebin/treehouse"
@@ -3626,6 +3715,12 @@ test_run_abort_precedes_process_reap_precedes_worktree_removal() {
   # real observed state, not a source-text or line-number correlation.
   cat > "$case_dir/fakebin/treehouse" <<EOF
 #!/usr/bin/env bash
+# Model the pinned build's global options: a home that owns its own Treehouse
+# pool needs --root, and a stub that advertises nothing reads as too old.
+if [ "\${1:-}" = get ] && [ "\${2:-}" = --help ]; then
+  printf '%s\n' '      --root string   Worktree root directory'
+  exit 0
+fi
 if [ -s "$abort_log" ]; then echo "abort-already-happened" >> "$case_dir/order.log"; fi
 if ! kill -0 $pid 2>/dev/null; then echo "reap-already-happened" >> "$case_dir/order.log"; fi
 exit 0
@@ -3658,6 +3753,7 @@ test_no_mistakes_truly_unpushed_refuses
 test_local_only_force_overrides_unpushed
 test_secondmate_pr_registration_publishes_ready_line
 test_secondmate_home_teardown_delivers_final_line_or_refuses
+test_secondmate_home_teardown_refuses_treehouse_without_root_option
 test_teardown_missing_busy_sidecar_completes
 test_herdr_teardown_clears_escalation_marker
 test_herdr_flat_teardown_refuses_orphaning_records_then_retry_completes

--- a/tests/fm-trace-context-spawn.test.sh
+++ b/tests/fm-trace-context-spawn.test.sh
@@ -89,7 +89,7 @@ esac
 exit 0
 SH
   chmod +x "$fakebin/tmux"
-  fm_fake_exit0 "$fakebin" treehouse
+  fm_fake_treehouse "$fakebin"
   printf '%s\n' "$fakebin"
 }
 

--- a/tests/fm-x-mode.test.sh
+++ b/tests/fm-x-mode.test.sh
@@ -810,6 +810,7 @@ SH
 #!/usr/bin/env bash
 if [ "${1:-}" = get ] && [ "${2:-}" = --help ]; then
   printf '%s\n' 'Usage: treehouse get [--lease] [--lease-holder <holder>]'
+  printf '%s\n' '      --root string   Worktree root directory'
   exit 0
 fi
 exit 0

--- a/tests/lib.sh
+++ b/tests/lib.sh
@@ -191,6 +191,27 @@ SH
   done
 }
 
+# fm_fake_treehouse <fakebin> [--no-root]
+# Drops a treehouse stub whose `get --help` advertises the global --root option
+# the way the pinned CI build does, so a fixture that exercises a non-primary
+# home's own pool is not refused simply because a no-op stub answers with
+# nothing. Pass --no-root to model a build older than Treehouse v2.2.0.
+fm_fake_treehouse() {
+  local fakebin=$1 root_help=1
+  [ "${2:-}" != "--no-root" ] || root_help=0
+  cat > "$fakebin/treehouse" <<SH
+#!/usr/bin/env bash
+set -u
+if [ "\${1:-}" = get ] && [ "\${2:-}" = --help ]; then
+  printf '%s\\n' 'Usage: treehouse get [--lease] [--lease-holder <holder>]'
+  [ "$root_help" = 1 ] && printf '%s\\n' '      --root string   Worktree root directory'
+  exit 0
+fi
+exit 0
+SH
+  chmod +x "$fakebin/treehouse"
+}
+
 # fm_fake_crash_injector <fakebin>
 # Drops an `fm-crash-inject <pid>` shim that a PATH fake calls to simulate a
 # hard crash of the process under test. It SIGKILLs <pid> and then returns only

--- a/tests/secondmate-helpers.sh
+++ b/tests/secondmate-helpers.sh
@@ -72,6 +72,13 @@ SH
 #!/usr/bin/env bash
 set -u
 printf 'treehouse %s\n' "$*" >> "${FM_FAKE_TMUX_LOG:-/dev/null}"
+if [ "${1:-}" = get ] && [ "${2:-}" = --help ]; then
+  # Model the pinned build's global options, including the --root a home that
+  # owns its own pool requires (docs/configuration.md).
+  printf '%s\n' 'Usage: treehouse get [--lease] [--lease-holder <holder>]'
+  printf '%s\n' '      --root string   Worktree root directory'
+  exit 0
+fi
 case "${1:-}" in
   get)
     # Durable lease: print only the worktree path to stdout (banners to stderr),
@@ -81,6 +88,8 @@ case "${1:-}" in
     while [ $# -gt 0 ]; do
       case "$1" in
         --lease) ;;
+        --root) shift ;;
+        --root=*) ;;
         --lease-holder) shift; holder=${1:-} ;;
         --lease-holder=*) holder=${1#--lease-holder=} ;;
       esac
@@ -100,6 +109,8 @@ case "${1:-}" in
     while [ $# -gt 0 ]; do
       case "$1" in
         --force) ;;
+        --root) shift ;;
+        --root=*) ;;
         *) target=$1 ;;
       esac
       shift


### PR DESCRIPTION
## Intent

The captain, 2026-09-07: "zajmij sie prami w firstmate" and "firstmate ma byc zielony, z no-mistakes i 5/5 greptile review". He wants our open firstmate pull requests pushed as far as they can go.

This one is https://github.com/kunchenguid/firstmate/pull/3736, "fix(secondmate): bind worker pools to their owning homes". It is CONFLICTING against main.

Why it matters more than the other three: it is what lets Claude workers spawn inside second-mate homes at all. Without it every home shares the primary's worktree pool, and we hit exactly that today - the business-web-app second mate had to borrow the main home's copy because its own launch was refused by the trust guard with "is not a worktree of project". That is the concrete bug this pull request fixes.

## What Changed

- Bind secondmate worker acquisition and teardown to each home’s own Treehouse pool root, preventing workers and leases from crossing into another home’s clone.
- Add Treehouse root capability detection and fail safely when a secondmate requires `--root` but the installed version does not support it.
- Extend spawn, teardown, bootstrap, documentation, and regression coverage for per-home pool isolation and related safety paths.

## Risk Assessment

✅ Low: The change consistently binds non-primary homes to their own Treehouse pool, refuses unsafe operation when --root is unavailable, preserves primary-home behavior, and updates acquisition, return, detection, and tests coherently.

## Testing

Ran the focused spawn-settle regression and real-Herdr workspace-per-home E2E; both passed, including end-user-visible secondmate workspace isolation and selective teardown. Worktree is clean. No full-suite, lint, formatter, or static-analysis commands were run.

<details>
<summary>Evidence: Secondmate pool-binding end-to-end evidence</summary>

```text
Real Herdr E2E: --secondmate spawn landed in the secondmate’s own labeled workspace, a crewmate spawned from that home landed in the same workspace, and teardown closed only the requested task tabs. Focused settle tests also verified scoped pool acquisition and refusal when root scoping is unsupported.
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"42736073b77248214e977d5311f2d37e161b298a","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `bash tests/fm-spawn-worktree-settle.test.sh`
- `bash tests/fm-backend-herdr-workspace-per-home-e2e.test.sh`
- `git status --short`
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
