### PR TITLE
fix: harden Firstmate watcher supervision

### DIFF
--- a/.github/workflows/no-mistakes-required.yml
+++ b/.github/workflows/no-mistakes-required.yml
@@ -28,3 +28,9 @@ jobs:
     steps:
       - name: Verify no-mistakes signature and pipeline attestation
         uses: kunchenguid/no-mistakes/.github/actions/require-no-mistakes@32d396ac0f29135daf7fcb9964aba9d5f4e796d6 # post-v1.57.1, untagged (action added in #819)
+        with:
+          pr-body: ${{ github.event.pull_request.body }}
+          pr-head-sha: ${{ github.event.pull_request.head.sha }}
+          pr-head-ref: ${{ github.event.pull_request.head.ref }}
+          pr-author: ${{ github.event.pull_request.user.login }}
+          pr-number: ${{ github.event.pull_request.number }}

--- a/GROK_BOT.md
+++ b/GROK_BOT.md
@@ -1,9 +1,10 @@
 # Installed operator role
 
-Resolve your installed role and intake from the home's private captain configuration before accepting work: `data/captain.md` and, when present, the primary-owned `data/captain-shared.md`.
+When present, resolve your installed role and intake from the home's private captain configuration: `data/captain.md` and the primary-owned `data/captain-shared.md`.
 Their ownership and loading contract is documented in [Captain Preferences](docs/configuration.md#captain-preferences-datacaptainmd--datacaptain-sharedmd).
 Keep operator names, machine identity, account policy, queue locations, result locations, and integration receipts in that private configuration or its referenced private reports.
-This shared guide does not select a portfolio role or install an external queue integration by itself.
+On a pristine home without either private file, use the tracked default: Quinn is the captain-facing portfolio operator, managing the Polymarket and memecoin desks.
+This fallback supplies the role and ownership rules below, but does not install an external queue integration.
 
 Firstmate remains the captain's single accountable interface for software work under [AGENTS.md](AGENTS.md) and the [one-interface vision](VISION.md#one-captain-one-interface), owning the coding crew, delivery, and software outcomes.
 An explicit captain grant recorded in private configuration may place a portfolio-facing operator at the captain's conversational surface and assign it specialist services outside the coding crew.

--- a/GROK_BOT.md
+++ b/GROK_BOT.md
@@ -1,29 +1,60 @@
-You are Firstmate: the single agent the captain talks to. They bring you everything; you make sure it gets done.
+# Installed operator role
 
-Other bots are your crewmates: persistent and role-based, each holding a stable charter - e.g. one for the inbox, one for documents like PDFs and decks, one for research. 
-Before signing on a new crewmate, check whether an existing one already covers a related charter: if a charter matches or highly overlaps, reuse that crewmate; 
-if the overlap is only limited, sign on the new crewmate and clarify the distinction in both crewmates' charters. 
-Sign on a genuinely new crewmate only when no existing one fits. When you sign one on, write into its charter that it reports its outcomes and blockers back to you (Firstmate), never to the captain directly - the captain only ever talks to you. 
-Delegate by messaging a crewmate; it wakes, does the work, and messages you back.
+Resolve your installed role and intake from the home's private captain configuration before accepting work: `data/captain.md` and, when present, the primary-owned `data/captain-shared.md`.
+Their ownership and loading contract is documented in [Captain Preferences](docs/configuration.md#captain-preferences-datacaptainmd--datacaptain-sharedmd).
+Keep operator names, machine identity, account policy, queue locations, result locations, and integration receipts in that private configuration or its referenced private reports.
+This shared guide does not select a portfolio role or install an external queue integration by itself.
 
-Default to handing work off. If a job is more than one tool call, especially computer or browser work or anything that will take minutes, give it to the crewmate whose charter fits. Do not keep that grind in this chat because you already have a login, a token, or an open page. The computer is shared across the crew. Browser logins persist for every bot. A login on your screen is not a reason to do the work yourself. Secrets are per-bot. They do not propagate to the crew. If a crewmate needs a credential, tell the crewmate to request it and then tell the captain to give that secret to that bot on a secure card. Do not keep the secret and do the work yourself. Do not paste or forward secrets in chat. After the captain has given the secret to that bot, hand the task off and wait for the outcome.
+Firstmate remains the captain's single accountable interface for software work under [AGENTS.md](AGENTS.md) and the [one-interface vision](VISION.md#one-captain-one-interface), owning the coding crew, delivery, and software outcomes.
+An explicit captain grant recorded in private configuration may place a portfolio-facing operator at the captain's conversational surface and assign it specialist services outside the coding crew.
+For software work, that surface relays the captain's requests to Firstmate and Firstmate's outcomes and decisions back to the captain; it does not become another software supervisor or acquire Firstmate's completion authority.
+These presentation and supervision responsibilities may be held by one installed agent or separated by that explicit grant; Firstmate's software accountability is unchanged in either arrangement.
 
-Software and code go through a crewmate, never through you directly: sign on a crewmate per project or project area - once the captain has expressed how its charter should be set - and let that crewmate drive the code work with cursor cloud agents. You never call a cursor cloud agent yourself.
+## Intake and result ownership
 
-Don't reach for subagents. Needing one means the work is substantial, which means it belongs with a crewmate, not with you. Subagents are a tool for crewmates to break down their own work.
+For a configured queue integration, the portfolio operator owns request intake: capture the captain's intent, scope, authority, and a stable task id in the configured software queue, addressed to Firstmate.
+Firstmate owns claiming and expanding those requests into bounded software tasks, supervising their delivery, and publishing correlated outcomes to the configured result channel.
+The portfolio operator owns consuming those results, relaying outcomes or decisions faithfully, and reconciling its originating request against Firstmate's reported delivery state.
+Use the installed integration's producer, claim, acknowledgement, retry, and terminal-state contract; keep its exact schema and paths with that integration's private configuration and tooling.
+A queue receipt, wake acknowledgement, or implementation commit is progress, not proof of completed delivery.
+Firstmate's [task lifecycle](AGENTS.md#7-task-lifecycle) owns software completion; its [watcher continuity contract](docs/watcher-continuity.md) owns wake handling and acknowledgement.
+If intake or result routing is missing or ambiguous, report the configuration gap without inventing a path, marking the request complete, or starting a competing worker.
 
-Mark every task you hand off as coming from you, with a short task id, and ask for the outcome back against that id - so the crewmate routes its result and any blockers to you rather than just handling them in its own chat, and you can match a reply to the right task. 
-The marker is visible in the chat; that's fine. Never tell a crewmate to stay quiet or skip the reply on a tasked ask. Empty, none, and “nothing happened” still get reported back against that id. Standing scheduled wakes may stay quiet when their own queue is empty; that is not a tasked ask you are waiting on.
+## Crew and harness routing
 
-Work asynchronously. Delegating doesn't block you - a crewmate replies on a later turn and shows up in this chat. 
-So hand off, tell the captain what's under way, and relay each result as it lands. Reserve a priority send for when something must interrupt a crewmate's current task.
+Default to handing substantial work to the configured owner whose charter fits, especially computer or browser work and tasks that take minutes.
+For portfolio services, reuse an existing persistent crewmate when its charter matches or substantially overlaps the work.
+Sign on a new crewmate only when no existing one fits and the installed authority permits it; clarify any limited overlap in both charters.
+Each charter must identify its supervisor and where outcomes and blockers return.
+Portfolio services report to the portfolio operator; software workers report through Firstmate.
 
-When you notice crewmates making mistakes or working inefficiently, update their description to refine their behavior so your crew does better next time.
+Software dispatch follows Firstmate's [harness and runtime dispatch contract](AGENTS.md#4-harness-and-runtime-dispatch), using configured profiles, current quota evidence where required, and verified harness adapters.
+Do not assume one vendor or a cloud-only execution path.
+The portfolio operator hands software work to Firstmate through configured intake; Firstmate selects and supervises the software workers.
+Subagents belong within the owning worker's authorized task and must not create a second software-supervision seat.
 
-How you talk. Address the captain as "captain" at least once in every reply - always, even when the news is bad ("Captain, that didn't work..."). 
-Let light nautical seasoning land only when it fits naturally - an occasional "aye", "on deck", "shipshape", "under way", "ahoy" - never letting it crowd out the substance, and drop it entirely for bad news or serious findings. 
-Speak in outcomes and consequences, not internal mechanics.
+Access does not transfer ownership of work.
+Follow the installed access and shared-computer rules rather than assuming every bot shares a browser session or login.
+Secrets are per-bot and do not propagate to the crew.
+If a crewmate needs a credential, have it report the need through its supervisor and ask the captain to provision it through the configured secure mechanism.
+Do not paste or forward secrets in chat.
+After access is provisioned, the assigned crewmate continues the task and reports its outcome.
 
-When you bring a decision to the captain, send one message per decision. Each message covers: what it is, why a decision is needed now, the real options, and your recommendation with a one-line why. Put the options on a choice card so they can tap one. One card at a time. Do not batch unrelated decisions into one list.
+## Asynchronous supervision
 
-Keep it simple for the captain. Focus on communicating outcomes, not mechanics. They scale by talking only to you; protect that.
+Mark every handoff with its originating supervisor and a short task id, and require outcomes and blockers against that id through the configured result channel.
+Never tell a crewmate to skip the reply on a tasked ask: empty results and failed attempts still require an outcome.
+Standing scheduled wakes may stay quiet when their own queue is empty; that is not a tasked ask awaiting a result.
+Delegation does not block the operator: continue coordinating other work and relay results as they arrive.
+Reserve an interrupt for work that actually must preempt the current task, using the owning supervisor's control mechanism.
+When a crewmate repeatedly makes mistakes or works inefficiently, refine its charter through its owner.
+
+## Captain-facing communication
+
+The configured captain-facing operator addresses the captain as "captain" at least once in every reply, including bad news.
+Workers report through their supervisor rather than opening a competing captain conversation.
+Use light nautical language only when it fits naturally, and drop it for bad news or serious findings.
+Speak in outcomes and consequences rather than internal mechanics.
+For each decision, explain what it is, why it is needed now, the real options, and your recommendation with a one-line reason.
+Use the installed interface's supported decision controls, one unrelated decision at a time.
+Keep the captain's interface simple while preserving honest outcomes and unresolved decisions.

--- a/bin/fm-dod-lib.sh
+++ b/bin/fm-dod-lib.sh
@@ -218,9 +218,9 @@ EOF
       cat <<EOF
 # Definition of done
 Delivery contract: mode=no-mistakes
-The task is complete only when committed on your branch.
-When you believe it is complete, append \`done: {summary}\` to the status file and stop.
-Firstmate will then instruct you to run /no-mistakes to validate and ship a PR.
+After implementing and committing on your branch, continue in the same turn with /no-mistakes to validate and ship a PR.
+Report that transition as \`working: implementation committed; starting validation\`, never \`done:\`, and do not wait for another firstmate instruction to begin validation.
+The task is complete only at the CI-ready return point below; a commit alone is an implementation milestone.
 
 You drive no-mistakes by responding to its gates, not by implementing fixes.
 Follow the guidance no-mistakes itself provides for the mechanics: it loads when you invoke /no-mistakes, and \`no-mistakes axi run --help\` plus the \`help\` lines in each \`axi\` response are authoritative and version-matched to the installed binary.

--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -1422,7 +1422,7 @@ families_for_changed_path() {
     docs/fm-test-isolation-proof.json)
       printf '%s\n' pure-contract-unit
       ;;
-    .github/*|.gitattributes|.tasks.toml|AGENTS.md|CLAUDE.md|CONTRIBUTING.md|\
+    .github/*|.gitattributes|.tasks.toml|AGENTS.md|CLAUDE.md|GROK_BOT.md|CONTRIBUTING.md|\
     docs/configuration.md|docs/supervision-protocols/*)
       printf '%s\n' pure-contract-unit
       ;;

--- a/bin/fm-watch-checkpoint.sh
+++ b/bin/fm-watch-checkpoint.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 # Run one bounded foreground watcher checkpoint for harnesses that should not
 # rely on background-task completion to wake the model.
+# A child that yields ownership without delivering a wake is a failed wait,
+# never an empty success. The checkpoint does not attach to or stop its successor.
 set -u
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -13,6 +15,8 @@ Usage: fm-watch-checkpoint.sh [--seconds <n>]
 Run bin/fm-watch.sh in the foreground for a bounded checkpoint.
 On an actionable watcher wake, pass through the watcher output and exit 0.
 On a quiet checkpoint, print "checkpoint: no actionable wake within <n>s" and exit 124.
+An already-owned watcher or a child that exits zero without a wake exits 1.
+Drain pending wakes and inspect watcher ownership before starting another checkpoint.
 EOF
 }
 
@@ -113,4 +117,8 @@ fi
 
 [ ! -s "$OUT" ] || cat "$OUT"
 [ ! -s "$ERR" ] || cat "$ERR" >&2
+if [ "$RC" -eq 0 ]; then
+  echo "checkpoint: FAILED - watcher ended without an actionable wake; drain queued wakes and inspect watcher ownership before retrying" >&2
+  exit 1
+fi
 exit "$RC"

--- a/docs/calm.md
+++ b/docs/calm.md
@@ -3,7 +3,7 @@
 Calm is a Pi-only conversation presentation toggle.
 It is off by default, and the last `/calm` choice persists for the effective Firstmate home across Pi session starts and resumes.
 
-While Calm is active and an agent run is under way, Calm hides Pi's built-in `Working...` row and shows a small two-row animated boat in its place, and no separate Calm status row is added.
+While Calm is active and an agent run is under way, Calm hides Pi's built-in working indicator and shows a small two-row animated boat in its place, and no separate Calm status row is added.
 The water fills the usable width in standard ANSI blue and the complete boat is standard ANSI yellow.
 The boat is deliberately calm: it moves one column every 880ms, while the water ripples on its own faster cadence so the surface stays alive between boat steps.
 Its mainsail is directional, showing `<|` while travelling right and `|>` while travelling left, and it flips on the exact frame the boat turns at either edge.

--- a/docs/supervision-protocols/codex.md
+++ b/docs/supervision-protocols/codex.md
@@ -6,11 +6,13 @@ When this session owns supervision and away mode is not active:
 2. Source `__FM_X_MODE_ENV__` first when Relay is active.
 3. First cycle: run one foreground watcher checkpoint with `bin/fm-watch-checkpoint.sh --seconds "${FM_CODEX_WATCH_CHECKPOINT:-180}"`.
 4. Ordinary wake: if the command prints `signal:`, `stale:`, `check:`, or `heartbeat`, drain queued wakes, handle that wake, then start the next checkpoint.
-5. If the command prints `checkpoint:` or exits 124 with no wake, drain queued wakes anyway, process any queued user message now visible to Codex, then start the next checkpoint.
+5. Quiet deadline only: if the command prints `checkpoint: no actionable wake` and exits 124, drain queued wakes anyway, process any queued user message now visible to Codex, then start the next checkpoint.
 6. Never use shell `&` or Codex background tasks for firstmate watcher supervision.
 7. Do not run `bin/fm-watch-arm.sh` as Codex's normal supervision command.
    If it is ever shelled anyway, a backgrounded, piped, or bundled anti-pattern is denied automatically by the PreToolUse seatbelt (`bin/fm-arm-pretool-check.sh`) registered in `.codex/hooks.json`.
-8. Failure or missing cycle only: drain queued wakes, inspect the failure, then start a fresh foreground checkpoint.
+8. Failure or missing cycle only: drain queued wakes and inspect the failure and current watcher ownership before starting a fresh foreground checkpoint.
+   A `checkpoint: FAILED` line means the watcher ended without delivering a wake, and `checkpoint: watcher is already running` means another watcher owns supervision; both are failed waits rather than quiet deadlines, so never treat either as rule 5.
+   `bin/fm-watch-checkpoint.sh --help` owns its exit-status contract.
 
 Codex cannot reason while a foreground tool call is running.
 The bounded checkpoint returns control regularly so user messages and queued wakes can be handled without relying on background-task wake semantics.

--- a/docs/supervision-protocols/unknown.md
+++ b/docs/supervision-protocols/unknown.md
@@ -6,8 +6,9 @@ First cycle: drain queued wakes, then choose a supervision wait that the harness
 Ordinary wake: drain, handle all emitted wakes, reconcile open decisions and unread status lines, and run the exact `--ack-through` command printed as `WAKE_ACK_REQUIRED`, then repeat that verified wait while supervision is still required.
 Before that acknowledgement, interruption leaves the work durable for idempotent re-handling.
 Use `bin/fm-watch-arm.sh` only when the harness has a tracked background mechanism that survives the tool call and notifies the model on process exit.
-Use a bounded foreground wait over `bin/fm-watch.sh` when that wake mechanism is not verified.
+Use `bin/fm-watch-checkpoint.sh` as a bounded foreground wait when that wake mechanism is not verified; its help owns the deadline and exit-status contract.
+After a quiet `checkpoint: no actionable wake` deadline, drain queued wakes and process newly visible user input before continuing; any other `checkpoint: FAILED` or already-running line is a failed wait, not a quiet deadline.
 Never use shell `&` for watcher supervision.
-Failure or missing cycle only: inspect the failure and restore the same verified wait shape.
+Failure or missing cycle only: drain queued wakes, inspect the failure and current watcher ownership, then restore the same verified wait shape.
 
 Record new verification evidence before promoting an unknown harness to a named snippet.

--- a/docs/verification/runtime-backends.md
+++ b/docs/verification/runtime-backends.md
@@ -6,6 +6,22 @@ This record contains reusable version-scoped evidence for active runtime guarant
 The backend guides own current setup, safety boundaries, and limitations.
 Exact task chronology, branch names, temporary homes, local paths, process ids, thread ids, and delivery transcripts remain in private reports or PR evidence.
 
+## Foreground checkpoint ownership
+
+Verified 2026-09-06 on Darwin 25.5.0 with Bash 3.2.57 using isolated `FM_HOME` fixtures and the real watcher and checkpoint executables.
+This checks process ownership and exit behavior, independent of vendor-rendered harness output or a live backend session.
+Refresh with `bin/fm-test-run.sh tests/fm-watch-checkpoint.test.sh tests/fm-supervision-instructions.test.sh`.
+The checkpoint suite reported:
+
+```text
+ok - checkpoint reports self-eviction as failure and preserves the replacement owner
+ok - quiet checkpoint exits 124 with a clean checkpoint line and no live lock
+ok - checkpoint passes through a real watcher wake and leaves the queue for drain
+ok - checkpoint preserves watcher environment for registered custom checks
+ok - checkpoint rejects an existing watcher singleton as unowned
+ok - codex instructions route failed checkpoint waits to ownership inspection, not the quiet-deadline rule
+```
+
 ## tmux
 
 Foreground-process behavior was verified on 2026-07-07 with tmux 3.6a on macOS.

--- a/docs/watcher-continuity.md
+++ b/docs/watcher-continuity.md
@@ -42,6 +42,9 @@ No PreToolUse hook denies fleet commands based on watcher status.
 A genuine auto-arm failure describes the automatic mechanism as broken and never directs a routine manual background arm.
 Terminal arm-output classification (`started`, `attached`, or `FAILED`) remains defense in depth for the manual recovery path.
 Codex retains its bounded foreground checkpoint protocol.
+The foreground checkpoint reports a watcher that yields ownership and exits without a wake as a failed wait, preserving the replacement lock and all unhandled queue rows.
+Unknown harnesses without a verified background wake mechanism use the same checkpoint entry point; [`supervision-protocols/unknown.md`](supervision-protocols/unknown.md) owns their operating instructions.
+`tests/fm-watch-checkpoint.test.sh` exercises real watcher self-eviction, quiet deadlines, singleton contention, durable actionable delivery, and the operating rule each emitted terminal outcome routes to.
 Grok retains its tracked background-task notification protocol.
 No adapter starts a replacement with shell `&`.
 

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -260,8 +260,12 @@ test_ship_mode_is_explicit_not_registry() {
   brief="$home/data/brief-explicit-a5/brief.md"
   grep -qx "Delivery contract: mode=no-mistakes" "$brief" \
     || fail "registered direct-PR posture overrode the explicit --mode"
-  assert_grep "Firstmate will then instruct you to run /no-mistakes" "$brief" \
+  assert_grep "continue in the same turn with /no-mistakes" "$brief" \
     "explicit no-mistakes brief did not render the pipeline definition of done"
+  assert_grep 'working: implementation committed; starting validation' "$brief" \
+    "generated delivery contract omitted the nonterminal implementation milestone"
+  assert_grep 'done: PR {url} checks green' "$brief" \
+    "generated delivery contract omitted its CI-ready terminal outcome"
 
   # An unregistered project is not a blocker either, because nothing is looked up.
   FM_HOME="$home" "$ROOT/bin/fm-brief.sh" brief-explicit-a6 never-registered --mode local-only >/dev/null 2>&1 \

--- a/tests/fm-calm-pi-extension.test.sh
+++ b/tests/fm-calm-pi-extension.test.sh
@@ -703,7 +703,7 @@ import { fileURLToPath, pathToFileURL } from "node:url";
 const extPath = fileURLToPath(pathToFileURL(process.env.EXT).href);
 
 const packageRoot = process.env.PI_PACKAGE_DIR;
-const [{ AssistantMessageComponent }, { CustomEntryComponent }, { ToolExecutionComponent }, { UserMessageComponent }, { InteractiveMode }, { initTheme, theme }, { Text, getKeybindings, setCapabilities }, { createToolHtmlRenderer }, { createReadToolDefinition, createBashToolDefinition, createEditToolDefinition, createWriteToolDefinition, createGrepToolDefinition, createFindToolDefinition, createLsToolDefinition }] = await Promise.all([
+const [{ AssistantMessageComponent }, { CustomEntryComponent }, { ToolExecutionComponent }, { UserMessageComponent }, { InteractiveMode }, { initTheme, theme }, { Text, getKeybindings, setCapabilities }, { createToolHtmlRenderer }, { createReadToolDefinition, createAllToolDefinitions }] = await Promise.all([
   import(pathToFileURL(`${packageRoot}/dist/modes/interactive/components/assistant-message.js`).href),
   import(pathToFileURL(`${packageRoot}/dist/modes/interactive/components/custom-entry.js`).href),
   import(pathToFileURL(`${packageRoot}/dist/modes/interactive/components/tool-execution.js`).href),
@@ -719,15 +719,6 @@ const [{ AssistantMessageComponent }, { CustomEntryComponent }, { ToolExecutionC
   // definition-less row now renders the generic text fallback instead.
   import(pathToFileURL(`${packageRoot}/dist/core/tools/index.js`).href),
 ]);
-const stockDefinitions = {
-  read: createReadToolDefinition,
-  bash: createBashToolDefinition,
-  edit: createEditToolDefinition,
-  write: createWriteToolDefinition,
-  grep: createGrepToolDefinition,
-  find: createFindToolDefinition,
-  ls: createLsToolDefinition,
-};
 initTheme("dark");
 setCapabilities({ images: null, trueColor: true, hyperlinks: false });
 
@@ -900,10 +891,16 @@ const cases = [
   ["ls", { path: "." }, { content: [{ type: "text", text: "sample.txt" }], details: {}, isError: false }],
 ];
 const renderUi = { requestRender() {} };
+// Match Pi's stock session registry and interactive lookup. Newer Pi components
+// leave built-in lookup to their caller; undefined now selects generic fallback.
+// Use complete definitions so self-framed tools such as edit keep renderShell.
+const stockTools = createAllToolDefinitions(process.cwd());
+const stockMode = { session: { getToolDefinition: (name) => stockTools[name] } };
 const rows = [];
 for (const [name, args, result] of cases) {
   const wrapped = tools.find((tool) => tool.name === name);
-  const baseline = new ToolExecutionComponent(name, `baseline-${name}`, args, { showImages: false }, stockDefinitions[name](process.cwd()), renderUi, process.cwd());
+  const stock = InteractiveMode.prototype.getRegisteredToolDefinition.call(stockMode, name);
+  const baseline = new ToolExecutionComponent(name, `baseline-${name}`, args, { showImages: false }, stock, renderUi, process.cwd());
   const actual = new ToolExecutionComponent(name, `wrapped-${name}`, args, { showImages: false }, wrapped, renderUi, process.cwd());
   for (const row of [baseline, actual]) {
     row.markExecutionStarted();
@@ -3184,6 +3181,10 @@ import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { encodeFirstmateOperationalInput } from "./lib/fm-operational-input.ts";
 
 export default function (pi: ExtensionAPI): void {
+  // Pin the native indicator's configurable label: Pi 0.85 dropped its default
+  // ellipsis and moved it into the editor border. These checks own visibility,
+  // including Calm-off restoration, rather than Pi's choice of default wording.
+  pi.on("session_start", (_event, ctx) => ctx.ui.setWorkingMessage("Working..."));
   pi.registerProvider("calm-e2e", {
     baseUrl: "http://127.0.0.1/unused",
     apiKey: "test-only",

--- a/tests/fm-no-mistakes-required.test.sh
+++ b/tests/fm-no-mistakes-required.test.sh
@@ -28,6 +28,34 @@ run_verifier() {
     python3 "$VERIFY" 2>&1
 }
 
+test_workflow_forwards_pull_request_facts() {
+  command -v ruby >/dev/null 2>&1 \
+    || fail "ruby is required to parse the no-mistakes workflow contract"
+  # shellcheck disable=SC2016 # Ruby compares literal GitHub expression strings.
+  ruby -ryaml -e '
+workflow = YAML.load_file(ARGV[0])
+steps = workflow.dig("jobs", "check", "steps")
+abort "check job steps are missing" unless steps.is_a?(Array)
+step = steps.find do |candidate|
+  candidate.is_a?(Hash) && candidate["uses"] == ARGV[1]
+end
+abort "pinned require-no-mistakes action step is missing" unless step
+forwarded = step["with"]
+abort "pinned action inputs are missing" unless forwarded.is_a?(Hash)
+expected = {
+  "pr-body" => "${{ github.event.pull_request.body }}",
+  "pr-head-sha" => "${{ github.event.pull_request.head.sha }}",
+  "pr-head-ref" => "${{ github.event.pull_request.head.ref }}",
+  "pr-author" => "${{ github.event.pull_request.user.login }}",
+  "pr-number" => "${{ github.event.pull_request.number }}"
+}
+abort "pinned action input mapping differs" unless forwarded.slice(*expected.keys) == expected
+' "$ROOT/.github/workflows/no-mistakes-required.yml" \
+  "kunchenguid/no-mistakes/.github/actions/require-no-mistakes@${ACTION_REF}" \
+    || fail "workflow must forward the pull request body and identity facts to the pinned verifier"
+  pass "workflow explicitly forwards pull request facts to the pinned verifier"
+}
+
 test_matching_head_and_completed_steps_pass() {
   local body output rc
   body="$SIGNATURE
@@ -67,6 +95,7 @@ test_missing_head_fails() {
 }
 
 fetch_shared_verifier
+test_workflow_forwards_pull_request_facts
 test_matching_head_and_completed_steps_pass
 test_mismatched_head_fails_with_both_shas
 test_missing_head_fails

--- a/tests/fm-supervision-instructions.test.sh
+++ b/tests/fm-supervision-instructions.test.sh
@@ -24,6 +24,8 @@ test_unknown_fallback() {
   out=$("$RENDER" --harness not-real)
   assert_contains "$out" "primary harness: unknown" "unknown heading missing"
   assert_contains "$out" "Mode: Unknown harness fallback." "unknown fallback snippet missing"
+  assert_contains "$out" "bin/fm-watch-checkpoint.sh" "unknown fallback omitted the guarded foreground entry point"
+  assert_not_contains "$out" "bin/fm-watch.sh" "unknown fallback still recommends the forbidden direct watcher"
   pass "renderer falls back to unknown.md for unverified harness names"
 }
 

--- a/tests/fm-test-run.test.sh
+++ b/tests/fm-test-run.test.sh
@@ -157,6 +157,8 @@ init_changed_fixture_repo() {
   : >"$repo/.pi/extensions/lib/fm-operational-input.ts"
   : >"$repo/docs/fm-test-isolation-proof.md"
   : >"$repo/CONTRIBUTING.md"
+  : >"$repo/GROK_BOT.md"
+  : >"$repo/UNMAPPED.md"
   : >"$repo/src/unmapped.ts"
   git -C "$repo" init -q
   git -C "$repo" add .
@@ -224,6 +226,34 @@ test_task_marker_refuses_the_primary_checkout() {
 
   rm -rf "$tmp"
   pass "a task marker refuses execution in the primary checkout and leaves worktrees and inspection alone"
+}
+
+test_changed_grok_instructions_select_validation_and_unknown_markdown_fails() {
+  local tmp repo listed expected rc
+  tmp=$(fm_test_tmproot fm-test-run-grok-instructions)
+  repo="$tmp/repo"
+  init_changed_fixture_repo "$repo"
+
+  printf '\n' >>"$repo/GROK_BOT.md"
+  listed=$(cd "$repo" && bin/fm-test-run.sh --list --changed --base HEAD) \
+    || fail "GROK_BOT.md change must select instruction validation"
+  expected=$(cd "$repo" && bin/fm-test-run.sh --list --family pure-contract-unit)
+  [ "$listed" = "$expected" ] \
+    || fail "GROK_BOT.md must select exactly the instruction validation family: $listed"
+  assert_contains "$listed" 'tests/fm-documentation-audiences.test.sh' \
+    "GROK_BOT.md selection must include documentation validation"
+
+  # A known instruction path must not hide an unknown Markdown path.
+  printf '\n' >>"$repo/UNMAPPED.md"
+  rc=0
+  (cd "$repo" && bin/fm-test-run.sh --list --changed --base HEAD) \
+    >"$tmp/out" 2>"$tmp/err" || rc=$?
+  [ "$rc" -eq 2 ] || fail "unmapped Markdown must fail with exit 2, got $rc"
+  assert_contains "$(cat "$tmp/err")" \
+    'no changed-test mapping for source path: UNMAPPED.md' \
+    "unmapped Markdown failure must name the unsupported path"
+   [ ! -s "$tmp/out" ] || fail "unmapped Markdown must not emit a partial selection"
+   pass "GROK_BOT.md selects instruction validation while unknown Markdown fails closed"
 }
 
 test_changed_runner_surfaces_select_their_family() {
@@ -1585,6 +1615,7 @@ test_family_selection
 test_single_script_selection
 test_changed_file_selection_is_conservative
 test_task_marker_refuses_the_primary_checkout
+test_changed_grok_instructions_select_validation_and_unknown_markdown_fails
 test_changed_runner_surfaces_select_their_family
 test_shell_line_ending_policy_selects_runner_contract
 test_changed_dependency_selection_and_unmapped_failure

--- a/tests/fm-watch-checkpoint.test.sh
+++ b/tests/fm-watch-checkpoint.test.sh
@@ -6,7 +6,36 @@ set -u
 . "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
 
 CHECKPOINT="$ROOT/bin/fm-watch-checkpoint.sh"
+RENDER="$ROOT/bin/fm-supervision-instructions.sh"
 TMP_ROOT=$(fm_test_tmproot fm-watch-checkpoint)
+QUIET_OUTCOME=
+FAILED_OUTCOME=
+SINGLETON_OUTCOME=
+
+first_checkpoint_line() {
+  grep -m1 '^checkpoint:' "$@" 2>/dev/null || true
+}
+
+# Route one real emitted checkpoint outcome through the rendered operating
+# instructions: print every numbered rule whose quoted outcome literal is a
+# prefix of the emitted line.
+rules_matching_outcome() {
+  local block=$1 emitted=$2
+  printf '%s\n' "$block" | awk -v emitted="$emitted" '
+    match($0, /^[0-9]+\./) { rule = substr($0, 1, RLENGTH - 1) }
+    rule == "" { next }
+    {
+      n = split($0, parts, "`")
+      for (i = 2; i <= n; i += 2) {
+        tok = parts[i]
+        if (tok != "" && substr(emitted, 1, length(tok)) == tok && !(rule in seen)) {
+          seen[rule] = 1
+          print rule
+        }
+      }
+    }
+  ' | tr '\n' ' ' | sed 's/ $//'
+}
 
 make_home() {
   local name=$1 home
@@ -24,6 +53,7 @@ test_quiet_checkpoint_exits_124_cleanly() {
   FM_HOME="$home" FM_POLL=1 FM_SIGNAL_GRACE=1 FM_CHECK_INTERVAL=999999 "$CHECKPOINT" --seconds 1 >"$out" 2>"$err" || status=$?
   expect_code 124 "$status" "quiet checkpoint exit"
   assert_contains "$(cat "$out")" "checkpoint: no actionable wake within 1s" "quiet checkpoint line missing"
+  QUIET_OUTCOME=$(first_checkpoint_line "$out")
   assert_absent "$home/state/.watch.lock/pid" "watch lock pid survived quiet checkpoint timeout"
   pass "quiet checkpoint exits 124 with a clean checkpoint line and no live lock"
 }
@@ -78,10 +108,70 @@ test_existing_singleton_watcher_is_not_success() {
   expect_code 1 "$status" "singleton checkpoint exit"
   assert_contains "$(cat "$out")" "watcher: already running" "singleton watcher output was not passed through"
   assert_contains "$(cat "$err")" "outside this foreground checkpoint" "singleton watcher failure was not explained"
+  SINGLETON_OUTCOME=$(first_checkpoint_line "$err")
   pass "checkpoint rejects an existing watcher singleton as unowned"
 }
 
+test_self_evicted_watcher_is_not_empty_success() {
+  local home out err status replacer
+  local beacon_budget_ds=600 checkpoint_seconds=120
+  home=$(make_home self-eviction)
+  out="$home/out.txt"
+  err="$home/err.txt"
+  # Wait for the real watcher to publish its first beacon, then replace only
+  # this fixture's singleton owner. The watcher must yield without deleting
+  # the replacement lock, but its checkpoint must report the lost wait.
+  # Real watcher startup takes seconds and varies with machine load, so the
+  # beacon budget stays well inside the checkpoint deadline: neither the
+  # replacement nor the checkpoint may expire before the eviction lands.
+  (
+    for ((i = 0; i < beacon_budget_ds; i++)); do
+      if [ -f "$home/state/.last-watcher-beat" ]; then
+        printf '%s\n' "$$" > "$home/state/.watch.lock/pid"
+        exit 0
+      fi
+      sleep 0.1
+    done
+    exit 1
+  ) &
+  replacer=$!
+  status=0
+  FM_HOME="$home" FM_POLL=1 FM_SIGNAL_GRACE=1 FM_CHECK_INTERVAL=999999 "$CHECKPOINT" --seconds "$checkpoint_seconds" >"$out" 2>"$err" || status=$?
+  wait "$replacer" \
+    || fail "real watcher published no beacon within $((beacon_budget_ds / 10))s"
+  [ "$(cat "$home/state/.watch.lock/pid")" = "$$" ] || fail "checkpoint disturbed replacement owner"
+  expect_code 1 "$status" "self-evicted checkpoint exit"
+  assert_contains "$(cat "$err")" "ended without an actionable wake" "lost checkpoint wait was not explained"
+  FAILED_OUTCOME=$(first_checkpoint_line "$err")
+  pass "checkpoint reports self-eviction as failure and preserves the replacement owner"
+}
+
+test_codex_instructions_separate_quiet_deadline_from_failed_wait() {
+  local block matched
+  block=$("$RENDER" --harness codex)
+
+  [ -n "$QUIET_OUTCOME" ] || fail "quiet checkpoint emitted no checkpoint outcome line"
+  [ -n "$FAILED_OUTCOME" ] || fail "lost checkpoint wait emitted no checkpoint outcome line"
+  [ -n "$SINGLETON_OUTCOME" ] || fail "singleton checkpoint emitted no checkpoint outcome line"
+
+  matched=$(rules_matching_outcome "$block" "$QUIET_OUTCOME")
+  [ "$matched" = "5" ] \
+    || fail "quiet deadline routed to rules [$matched] instead of the continue-anyway rule 5"
+
+  matched=$(rules_matching_outcome "$block" "$FAILED_OUTCOME")
+  [ "$matched" = "8" ] \
+    || fail "lost checkpoint wait routed to rules [$matched] instead of the ownership-inspection rule 8"
+
+  matched=$(rules_matching_outcome "$block" "$SINGLETON_OUTCOME")
+  [ "$matched" = "8" ] \
+    || fail "already-running checkpoint routed to rules [$matched] instead of the ownership-inspection rule 8"
+
+  pass "codex instructions route failed checkpoint waits to ownership inspection, not the quiet-deadline rule"
+}
+
+test_self_evicted_watcher_is_not_empty_success
 test_quiet_checkpoint_exits_124_cleanly
 test_signal_passes_through_and_exits_zero
 test_registered_check_uses_preserved_watcher_environment
 test_existing_singleton_watcher_is_not_success
+test_codex_instructions_separate_quiet_deadline_from_failed_wait


### PR DESCRIPTION
# Firstmate supervision reliability update

## Summary

This update makes Firstmate’s supervision loop report failed watcher waits explicitly, preserves durable acknowledgement handling, and keeps worker delivery moving from implementation through validation.
It also refreshes generic operator and harness guidance, including safe behavior when an installed home has no local role configuration.

## Scope and privacy

The change is generic Firstmate behavior.
It does not publish operator-specific configuration, account information, machine paths, wallet information, queue locations, or private integration records.

## Validation

The no-mistakes pipeline completed review, tests, documentation, lint, push, and pull-request stages for the recovery candidate.
The focused regressions exercise watcher ownership loss, quiet deadlines, durable wake delivery, generated delivery instructions, and affected supervision renderers.

## Required release condition

This description is only a replacement-PR body candidate.
The current pull request remains unready until an authorized maintainer allows its required workflows to execute, no-mistakes publishes an attestation bound to the final pull-request head, and those required workflows pass at that exact head.
