### PR TITLE
fix(bin): inject a project's declared bootstrap contract into every brief

### DIFF
--- a/bin/fm-bootstrap-contract-lib.sh
+++ b/bin/fm-bootstrap-contract-lib.sh
@@ -79,7 +79,7 @@ fm_brief_bootstrap_contract_block() {  # <projects-dir> <repo-name> <quoted-stat
 
 
 # Project bootstrap contract
-$agents declares a mandatory bootstrap contract for every worker on this project (a \`firstmate:bootstrap-contract\` block in its own AGENTS.md). Before investigating, diagnosing, or changing anything, read every document it names, in the order given, and follow its rule for incidents exactly as written:
+$agents declares a mandatory bootstrap contract for every worker on this project (a \`firstmate:bootstrap-contract\` block in its own AGENTS.md). Before any other task work, read every document it names, in the order given, and follow its rule for incidents exactly as written:
 
 $body
 

--- a/bin/fm-bootstrap-contract-lib.sh
+++ b/bin/fm-bootstrap-contract-lib.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# fm-bootstrap-contract-lib.sh - single owner of a project's declared bootstrap
+# contract discovery and its injection into a generated ship/scout brief.
+#
+# Sourced by bin/fm-brief.sh. Exists because a generated brief used to carry no
+# structural link to a project's own mandatory read order at all: a live
+# incident brief could scaffold with zero mentions of a project's declared
+# continuity docs, so a worker never bootstrapped and the captain had to
+# manually supply what the project's own documentation already said.
+#
+# A project opts in by adding one marker block to its own checked-in
+# AGENTS.md (the project's real project-intrinsic knowledge file; see
+# bin/fm-ensure-agents-md.sh), using the same firstmate:-prefixed
+# HTML-comment-marker convention that file's own
+# `<!-- firstmate:maintained-by-project -->` mark established:
+#
+#   <!-- firstmate:bootstrap-contract
+#   <one or more lines: the mandatory read order and any evidence-first
+#   incident rule every worker on this project must follow before starting
+#   task work>
+#   -->
+#
+# The opening line must be exactly `<!-- firstmate:bootstrap-contract`
+# (trailing whitespace only) and the closing line exactly `-->`, each alone on
+# its own line; only the first such block in the file is read, and everything
+# between the two marker lines is copied into the brief verbatim.
+#
+# fm_brief_bootstrap_contract_block <projects-dir> <repo-name> <quoted-status-file>
+# prints the ready-to-splice brief section on stdout when a contract is
+# declared. The caller appends it directly after existing brief text with no
+# separating template blank line, so the output opens with its own blank-line
+# separator and carries no trailing blank line. It prints nothing and returns
+# 0 when the project directory, its AGENTS.md, or the marker itself is absent
+# - that silent-nothing case is what keeps a project declaring nothing
+# byte-identical to a brief scaffolded before this contract existed.
+# It fails closed - one "error:" line on stderr naming the file, return 1 -
+# when AGENTS.md opens the marker but never closes it, or closes an empty
+# block. Both are malformed declarations in the PROJECT's own AGENTS.md, and a
+# brief that silently omitted them would recreate exactly the gap this owner
+# exists to close; bin/fm-brief.sh propagates that failure rather than
+# scaffolding a brief with the contract quietly missing.
+# Ship and scout briefs take a single repo argument that this lookup resolves
+# against `<projects-dir>/<repo-name>/AGENTS.md`; a secondmate charter's
+# multi-project list is out of scope (AGENTS.md section 6 already routes
+# secondmate project knowledge elsewhere), so bin/fm-brief.sh calls this only
+# for ship/scout scaffolds.
+fm_brief_bootstrap_contract_block() {  # <projects-dir> <repo-name> <quoted-status-file>
+  local projects=$1 repo=$2 status_file=$3 agents body status
+  agents="$projects/$repo/AGENTS.md"
+  [ -f "$agents" ] || return 0
+  body=$(awk '
+    state == 1 && /^-->[[:space:]]*$/ { closed = 1; state = 0; next }
+    state == 1 {
+      print
+      if ($0 ~ /[^[:space:]]/) has_content = 1
+      next
+    }
+    !found && /^<!-- firstmate:bootstrap-contract[[:space:]]*$/ { state = 1; found = 1; next }
+    END {
+      if (found && !closed) exit 2
+      if (found && closed && !has_content) exit 3
+    }
+  ' "$agents")
+  status=$?
+  case "$status" in
+    0) ;;
+    2)
+      echo "error: $agents opens a firstmate:bootstrap-contract block with no closing \`-->\`; fix the project's AGENTS.md before a brief can include its declared bootstrap contract" >&2
+      return 1 ;;
+    3)
+      echo "error: $agents declares an empty firstmate:bootstrap-contract block; add its mandatory read order and incident rule, or remove the marker" >&2
+      return 1 ;;
+    *)
+      echo "error: $agents: could not parse its firstmate:bootstrap-contract block" >&2
+      return 1 ;;
+  esac
+  [ -n "$body" ] || return 0
+  cat <<EOF
+
+
+# Project bootstrap contract
+$agents declares a mandatory bootstrap contract for every worker on this project (a \`firstmate:bootstrap-contract\` block in its own AGENTS.md). Before investigating, diagnosing, or changing anything, read every document it names, in the order given, and follow its rule for incidents exactly as written:
+
+$body
+
+State which of the documents above you actually read as your very first status line for this task, before any other status append:
+\`echo "working: bootstrapped, read {documents}" >> $status_file\`
+EOF
+}

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -122,11 +122,6 @@ if [ -n "${FM_STATE_OVERRIDE:-}" ]; then
 else
   STATE="$FM_HOME/state"
 fi
-if [ -n "${FM_PROJECTS_OVERRIDE:-}" ]; then
-  PROJECTS=$(resolve_directory_input FM_PROJECTS_OVERRIDE "$FM_PROJECTS_OVERRIDE") || exit 1
-else
-  PROJECTS="$FM_HOME/projects"
-fi
 KIND=ship
 HERDR_LAB=0
 NO_PROJECTS=0
@@ -322,6 +317,16 @@ fi
 
 REPO=${POS[1]}
 
+# PROJECTS is resolved only here, never above alongside DATA/STATE: a
+# secondmate charter (already scaffolded and returned above) never reads it,
+# so validating it unconditionally for every invocation would fail a
+# secondmate scaffold over a directory it never uses.
+if [ -n "${FM_PROJECTS_OVERRIDE:-}" ]; then
+  PROJECTS=$(resolve_directory_input FM_PROJECTS_OVERRIDE "$FM_PROJECTS_OVERRIDE") || exit 1
+else
+  PROJECTS="$FM_HOME/projects"
+fi
+
 # Fail closed rather than silently scaffolding a brief that omits a project's
 # declared bootstrap contract (bin/fm-bootstrap-contract-lib.sh owns discovery,
 # the marker format, and this failure mode). BOOTSTRAP_SECTION is empty when
@@ -467,9 +472,9 @@ You are in a disposable git worktree of $REPO, at a detached HEAD on a clean def
 
 **Verify isolation before anything else.** Run \`pwd -P\` and \`git rev-parse --show-toplevel\`; both must resolve to the disposable task worktree you were launched in, such as a treehouse pool path or an Orca-managed worktree, not the primary checkout firstmate operates from.
 The path check is authoritative: \`git rev-parse --git-dir\` and \`git rev-parse --git-common-dir\` can help inspect the repo, but they do not prove you are outside the primary checkout.
-If the top-level path is the primary checkout or not the worktree you were launched in, STOP - do not branch or commit here - append \`blocked: launched in primary checkout, not an isolated worktree\` to the status file and stop.
+If the top-level path is the primary checkout or not the worktree you were launched in, STOP - do not branch or commit here - append \`blocked: launched in primary checkout, not an isolated worktree\` to the status file and stop.$BOOTSTRAP_SECTION
 
-1. First action: create your branch: \`git checkout -b fm/$ID\`$SETUP2$BOOTSTRAP_SECTION
+1. First action: create your branch: \`git checkout -b fm/$ID\`$SETUP2
 
 # Rules
 $RULE1

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -67,6 +67,10 @@
 # Scaffolds carry no role scope: fm-spawn.sh supplies fm_brief_worker_role from
 # fm-dod-lib.sh to every ship/scout launch brief, so this file never becomes a
 # second owner of a contract that must stay current across relaunches.
+# Every ship/scout scaffold also injects the target repo's declared bootstrap
+# contract, if any, discovered from <PROJECTS>/<repo-name>/AGENTS.md; see
+# bin/fm-bootstrap-contract-lib.sh for the marker format and its fail-closed
+# behavior on a malformed declaration.
 # Refuses to overwrite an existing brief.
 set -eu
 
@@ -90,6 +94,8 @@ esac
 . "$SCRIPT_DIR/fm-classify-lib.sh"
 # shellcheck source=bin/fm-dod-lib.sh
 . "$SCRIPT_DIR/fm-dod-lib.sh"
+# shellcheck source=bin/fm-bootstrap-contract-lib.sh
+. "$SCRIPT_DIR/fm-bootstrap-contract-lib.sh"
 PAUSED_VERB=${FM_CLASSIFY_PAUSED_VERB:-$FM_CLASSIFY_PAUSED_VERB_DEFAULT}
 
 resolve_directory_input() {
@@ -115,6 +121,11 @@ if [ -n "${FM_STATE_OVERRIDE:-}" ]; then
   STATE=$(resolve_directory_input FM_STATE_OVERRIDE "$FM_STATE_OVERRIDE") || exit 1
 else
   STATE="$FM_HOME/state"
+fi
+if [ -n "${FM_PROJECTS_OVERRIDE:-}" ]; then
+  PROJECTS=$(resolve_directory_input FM_PROJECTS_OVERRIDE "$FM_PROJECTS_OVERRIDE") || exit 1
+else
+  PROJECTS="$FM_HOME/projects"
 fi
 KIND=ship
 HERDR_LAB=0
@@ -311,6 +322,12 @@ fi
 
 REPO=${POS[1]}
 
+# Fail closed rather than silently scaffolding a brief that omits a project's
+# declared bootstrap contract (bin/fm-bootstrap-contract-lib.sh owns discovery,
+# the marker format, and this failure mode). BOOTSTRAP_SECTION is empty when
+# the project declares nothing, which keeps that brief's output unchanged.
+BOOTSTRAP_SECTION=$(fm_brief_bootstrap_contract_block "$PROJECTS" "$REPO" "$STATUS_FILE") || exit 1
+
 if [ "$HERDR_LAB" -eq 1 ]; then
 HERDR_LAB_HELPER=$(shell_quote "$FM_ROOT/bin/fm-herdr-lab.sh")
 # shellcheck disable=SC2016  # single quotes are deliberate: these lines are literal brief text whose backtick-wrapped $(...) and "$HERDR_LAB_SESSION" snippets must reach the reading agent verbatim, not expand at scaffold time; only the '"$VAR"' break-outs interpolate.
@@ -365,7 +382,7 @@ $HERDR_SECTION
 You are in a disposable git worktree of $REPO, at a detached HEAD on a clean default branch.
 This is a SCOUT task: the deliverable is a written report, not a PR.
 The worktree is your laboratory - install, run, edit, and make scratch commits freely; all of it is discarded at teardown.
-The report is the only thing that survives, so anything worth keeping must be in it.
+The report is the only thing that survives, so anything worth keeping must be in it.$BOOTSTRAP_SECTION
 
 # Rules
 1. Never push to any remote and never open a PR.
@@ -452,7 +469,7 @@ You are in a disposable git worktree of $REPO, at a detached HEAD on a clean def
 The path check is authoritative: \`git rev-parse --git-dir\` and \`git rev-parse --git-common-dir\` can help inspect the repo, but they do not prove you are outside the primary checkout.
 If the top-level path is the primary checkout or not the worktree you were launched in, STOP - do not branch or commit here - append \`blocked: launched in primary checkout, not an isolated worktree\` to the status file and stop.
 
-1. First action: create your branch: \`git checkout -b fm/$ID\`$SETUP2
+1. First action: create your branch: \`git checkout -b fm/$ID\`$SETUP2$BOOTSTRAP_SECTION
 
 # Rules
 $RULE1

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -364,6 +364,7 @@ Ship briefs prompt crewmates to create or update those files through the normal 
 Each project `AGENTS.md` carries self-governance guidance; [`bin/fm-ensure-agents-md.sh`](../bin/fm-ensure-agents-md.sh) owns the canonical wording and idempotent insertion, while its header and help document the explicit mark for equivalent project-owned guidance.
 It refuses a case-variant real memory file such as a lowercase `agents.md`, so the pointer's `@AGENTS.md` import resolves to a real `AGENTS.md` on a case-sensitive filesystem, and surfaces the mismatch for manual reconciliation.
 The full ownership rule - what is project-intrinsic versus fleet-private, and how firstmate keeps the two apart without writing into project clones - is owned by [`AGENTS.md`](../AGENTS.md) (project and knowledge management).
+A project may also declare a mandatory bootstrap contract - a required read order and any evidence-first incident rule - in its own `AGENTS.md`, so every generated ship or scout brief for that repo carries it rather than depending on firstmate remembering it at intake; [`bin/fm-bootstrap-contract-lib.sh`](../bin/fm-bootstrap-contract-lib.sh) owns the marker format, discovery, and its fail-closed behavior on a malformed declaration.
 
 ## Operational memory routing
 

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -34,6 +34,7 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-decision-hold.sh`    | One-release compatibility shim mapping the retired decision commands onto fm-captain-hold.sh |
 | `fm-brief.sh`            | Scaffold ship (explicit `--mode`), scout, secondmate-charter, and Herdr-lab briefs, with Captain's intent and Firstmate spec subsections on ship/scout |
 | [`fm-dod-lib.sh`](../bin/fm-dod-lib.sh) | Own ship/scout worker role scope, ship definitions of done, and the no-mistakes `--intent` contract |
+| [`fm-bootstrap-contract-lib.sh`](../bin/fm-bootstrap-contract-lib.sh) | Discover a project's declared bootstrap contract from its own `AGENTS.md` and render it into a ship/scout brief, failing closed on a malformed declaration |
 | `fm-herdr-lab.sh`        | Provision and guardedly operate an isolated, never-default Herdr lab session         |
 | `fm-install-herdr.sh`    | Install CI's exact-version Herdr pin with official asset URL, SHA-256, and protocol checks |
 | `fm-install-treehouse.sh`| Install CI's exact-version Treehouse pin for real-Herdr E2E that needs spawn worktrees |

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -887,6 +887,17 @@ More prose after the marker.'
   assert_grep ">> '$home/state/bootstrap-ship-b1.status'" "$brief" \
     "ship brief's bootstrap acknowledgement did not point at this task's own status file"
 
+  # The declared contract must precede the branch-creation step, so a worker
+  # reading the brief in order sees the mandatory read before its first
+  # repository-changing action (Greptile review on PR #3877).
+  local contract_line branch_line
+  contract_line=$(grep -n "^# Project bootstrap contract$" "$brief" | head -1 | cut -d: -f1)
+  branch_line=$(grep -n "First action: create your branch" "$brief" | head -1 | cut -d: -f1)
+  [ -n "$contract_line" ] && [ -n "$branch_line" ] \
+    || fail "ship brief missing the contract section or the branch-creation step"
+  [ "$contract_line" -lt "$branch_line" ] \
+    || fail "ship brief presents the bootstrap contract (line $contract_line) after branch creation (line $branch_line)"
+
   FM_HOME="$home" "$ROOT/bin/fm-brief.sh" bootstrap-scout-b2 incident-proj --scout >/dev/null 2>&1
   brief="$home/data/bootstrap-scout-b2/brief.md"
   assert_present "$brief" "scout brief was not scaffolded"
@@ -895,6 +906,25 @@ More prose after the marker.'
   assert_grep 'Read fresh `error_logs` first.' "$brief" \
     "scout brief did not carry the declared read-order line verbatim"
   pass "fm-brief.sh: a project's declared bootstrap contract reaches both ship and scout briefs"
+}
+
+test_secondmate_scaffold_ignores_unresolvable_projects_override() {
+  local home status
+  home="$TMP_ROOT/bootstrap-secondmate-override-home"
+  mkdir -p "$home/data"
+
+  # A secondmate charter never looks up a project's bootstrap contract, so an
+  # inherited FM_PROJECTS_OVERRIDE that cannot be resolved must not block it
+  # (Greptile review on PR #3877: PROJECTS used to be validated unconditionally
+  # for every scaffold kind, including one that never reads it).
+  FM_HOME="$home" FM_PROJECTS_OVERRIDE=does-not-exist-relative-dir \
+    FM_SECONDMATE_CHARTER='ops domain' \
+    "$ROOT/bin/fm-brief.sh" bootstrap-secondmate-override --secondmate --no-projects >/dev/null 2>&1
+  status=$?
+  expect_code 0 "$status" "a secondmate scaffold must not fail over an unresolvable FM_PROJECTS_OVERRIDE it never uses"
+  assert_present "$home/data/bootstrap-secondmate-override/brief.md" \
+    "secondmate charter was not scaffolded despite an unresolvable FM_PROJECTS_OVERRIDE"
+  pass "fm-brief.sh: a secondmate scaffold ignores an unresolvable FM_PROJECTS_OVERRIDE it never uses"
 }
 
 test_bootstrap_contract_fails_closed_on_unterminated_block() {
@@ -1004,6 +1034,7 @@ test_pause_verb_override_renders_all_brief_scaffolds
 test_scout_and_secondmate_load_decision_hold_policy
 test_bootstrap_contract_absent_by_default
 test_bootstrap_contract_injected_into_ship_and_scout
+test_secondmate_scaffold_ignores_unresolvable_projects_override
 test_bootstrap_contract_fails_closed_on_unterminated_block
 test_bootstrap_contract_fails_closed_on_empty_block
 test_scout_and_secondmate_scaffold

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -898,6 +898,17 @@ More prose after the marker.'
   [ "$contract_line" -lt "$branch_line" ] \
     || fail "ship brief presents the bootstrap contract (line $contract_line) after branch creation (line $branch_line)"
 
+  # The contract's own lead-in must not claim to precede the isolation
+  # self-check (it textually appears after it, and that check is a
+  # pre-existing, universal, absolute safety step firstmate never delays for
+  # project content): "investigating" collided with that check's own
+  # `pwd -P`/`git rev-parse` environment investigation (Greptile review on
+  # PR #3877). Scope the claim to task work instead.
+  assert_grep "Before any other task work, read every document" "$brief" \
+    "ship brief's contract lead-in lost its task-work scoping"
+  assert_no_grep "Before investigating, diagnosing, or changing anything" "$brief" \
+    "ship brief's contract lead-in still collides with the isolation self-check's own investigation"
+
   FM_HOME="$home" "$ROOT/bin/fm-brief.sh" bootstrap-scout-b2 incident-proj --scout >/dev/null 2>&1
   brief="$home/data/bootstrap-scout-b2/brief.md"
   assert_present "$brief" "scout brief was not scaffolded"

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -817,6 +817,118 @@ test_scout_and_secondmate_load_decision_hold_policy() {
   pass "fm-brief.sh: investigation and visual-review completions load the shared decision policy"
 }
 
+# A project declares its bootstrap contract by adding one
+# `<!-- firstmate:bootstrap-contract ... -->` block to its own committed
+# AGENTS.md, discovered from `<FM_HOME>/projects/<repo>/AGENTS.md`
+# (bin/fm-bootstrap-contract-lib.sh). Absent that block, a brief must render
+# exactly as it did before this contract existed.
+write_project_agents_md() {
+  local home=$1 project=$2 body=$3
+  mkdir -p "$home/projects/$project"
+  printf '%s\n' "$body" > "$home/projects/$project/AGENTS.md"
+}
+
+test_bootstrap_contract_absent_by_default() {
+  local home brief
+  home="$TMP_ROOT/bootstrap-absent-home"
+  mkdir -p "$home/data"
+
+  # No project directory at all: today's ordinary case for an unregistered
+  # or not-yet-cloned repo name.
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" bootstrap-absent-a1 unregistered-proj --mode direct-PR >/dev/null 2>&1
+  brief="$home/data/bootstrap-absent-a1/brief.md"
+  assert_present "$brief" "brief was not scaffolded for an unregistered project"
+  assert_no_grep "# Project bootstrap contract" "$brief" \
+    "an unregistered project injected a bootstrap contract section"
+
+  # A cloned project with a plain AGENTS.md that carries no marker.
+  write_project_agents_md "$home" plain-proj "# Plain project
+No bootstrap marker here."
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" bootstrap-absent-a2 plain-proj --scout >/dev/null 2>&1
+  brief="$home/data/bootstrap-absent-a2/brief.md"
+  assert_present "$brief" "brief was not scaffolded for a plain AGENTS.md project"
+  assert_no_grep "# Project bootstrap contract" "$brief" \
+    "a project with no marker injected a bootstrap contract section"
+  pass "fm-brief.sh: a project declaring no bootstrap contract renders unchanged"
+}
+
+test_bootstrap_contract_injected_into_ship_and_scout() {
+  local home brief agents
+  home="$TMP_ROOT/bootstrap-injected-home"
+  mkdir -p "$home/data"
+  # shellcheck disable=SC2016  # single quotes are deliberate: this fixture's backticks must stay literal
+  write_project_agents_md "$home" incident-proj '# Incident project
+
+Read `START_HERE.md` for the full continuity read order.
+
+<!-- firstmate:bootstrap-contract
+- Read fresh `error_logs` first.
+- Treat missing branch evidence as a product defect; inspect code or ask the user only after.
+-->
+
+More prose after the marker.'
+  agents="$home/projects/incident-proj/AGENTS.md"
+
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" bootstrap-ship-b1 incident-proj --mode direct-PR >/dev/null 2>&1
+  brief="$home/data/bootstrap-ship-b1/brief.md"
+  assert_present "$brief" "ship brief was not scaffolded"
+  assert_grep "# Project bootstrap contract" "$brief" "ship brief missing the injected bootstrap contract section"
+  assert_grep "$agents declares a mandatory bootstrap contract" "$brief" \
+    "ship brief did not name the declaring AGENTS.md"
+  # shellcheck disable=SC2016  # backticked doc-name text must stay literal
+  assert_grep 'Read fresh `error_logs` first.' "$brief" \
+    "ship brief did not carry the declared read-order line verbatim"
+  assert_grep "Treat missing branch evidence as a product defect" "$brief" \
+    "ship brief did not carry the declared incident rule verbatim"
+  assert_no_grep "More prose after the marker." "$brief" \
+    "ship brief leaked AGENTS.md prose outside the declared marker block"
+  assert_grep "working: bootstrapped, read {documents}" "$brief" \
+    "ship brief did not require the worker to state which documents it read"
+  assert_grep ">> '$home/state/bootstrap-ship-b1.status'" "$brief" \
+    "ship brief's bootstrap acknowledgement did not point at this task's own status file"
+
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" bootstrap-scout-b2 incident-proj --scout >/dev/null 2>&1
+  brief="$home/data/bootstrap-scout-b2/brief.md"
+  assert_present "$brief" "scout brief was not scaffolded"
+  assert_grep "# Project bootstrap contract" "$brief" "scout brief missing the injected bootstrap contract section"
+  # shellcheck disable=SC2016  # backticked doc-name text must stay literal
+  assert_grep 'Read fresh `error_logs` first.' "$brief" \
+    "scout brief did not carry the declared read-order line verbatim"
+  pass "fm-brief.sh: a project's declared bootstrap contract reaches both ship and scout briefs"
+}
+
+test_bootstrap_contract_fails_closed_on_unterminated_block() {
+  local home agents out status
+  home="$TMP_ROOT/bootstrap-unterminated-home"
+  mkdir -p "$home/data"
+  write_project_agents_md "$home" broken-proj '<!-- firstmate:bootstrap-contract
+- Read X first.'
+  agents="$home/projects/broken-proj/AGENTS.md"
+
+  out=$(FM_HOME="$home" "$ROOT/bin/fm-brief.sh" bootstrap-broken-c1 broken-proj --mode direct-PR 2>&1); status=$?
+  [ "$status" -ne 0 ] || fail "an unterminated bootstrap-contract block should refuse to scaffold"
+  assert_contains "$out" "$agents" "refusal did not name the malformed AGENTS.md"
+  assert_contains "$out" "no closing" "refusal did not explain the missing closing marker"
+  assert_absent "$home/data/bootstrap-broken-c1/brief.md" "refused scaffold still wrote a brief"
+  pass "fm-brief.sh: an unterminated bootstrap-contract block fails closed rather than omitting it"
+}
+
+test_bootstrap_contract_fails_closed_on_empty_block() {
+  local home agents out status
+  home="$TMP_ROOT/bootstrap-empty-home"
+  mkdir -p "$home/data"
+  write_project_agents_md "$home" empty-proj '<!-- firstmate:bootstrap-contract
+-->'
+  agents="$home/projects/empty-proj/AGENTS.md"
+
+  out=$(FM_HOME="$home" "$ROOT/bin/fm-brief.sh" bootstrap-empty-c2 empty-proj --scout 2>&1); status=$?
+  [ "$status" -ne 0 ] || fail "an empty bootstrap-contract block should refuse to scaffold"
+  assert_contains "$out" "$agents" "refusal did not name the malformed AGENTS.md"
+  assert_contains "$out" "empty" "refusal did not explain the empty declared block"
+  assert_absent "$home/data/bootstrap-empty-c2/brief.md" "refused scaffold still wrote a brief"
+  pass "fm-brief.sh: an empty bootstrap-contract block fails closed rather than omitting it"
+}
+
 # Scout and secondmate paths still scaffold well-formed briefs.
 test_scout_and_secondmate_scaffold() {
   local brief
@@ -890,4 +1002,8 @@ test_secondmate_marked_request_reporting_contract
 test_secondmate_directory_paths_are_absolute_and_output_is_stable
 test_pause_verb_override_renders_all_brief_scaffolds
 test_scout_and_secondmate_load_decision_hold_policy
+test_bootstrap_contract_absent_by_default
+test_bootstrap_contract_injected_into_ship_and_scout
+test_bootstrap_contract_fails_closed_on_unterminated_block
+test_bootstrap_contract_fails_closed_on_empty_block
 test_scout_and_secondmate_scaffold


### PR DESCRIPTION
## Summary
- `bin/fm-brief.sh` scaffolded every ship/scout brief with no structural link to a project's own mandatory continuity read order, so a worker could start a live incident with zero mentions of docs the project's own `AGENTS.md` already required reading first.
- A project can now declare a bootstrap contract (a required read order plus any evidence-first incident rule) as a `<!-- firstmate:bootstrap-contract ... -->` marker block in its own committed `AGENTS.md` (the same marker style `fm-ensure-agents-md.sh`'s `firstmate:maintained-by-project` mark already established).
- `bin/fm-bootstrap-contract-lib.sh` (new, sourced by `fm-brief.sh`) discovers that block from `<projects-dir>/<repo-name>/AGENTS.md` and injects it verbatim into every generated ship and scout brief, instructing the worker to state which documents it read as its first status line for the task.
- This is brief injection only: the generated text asks the worker to self-report which documents it read. Nothing in this PR verifies, enforces, or proves that a worker actually read anything or complied with the contract; there is no runtime check of worker behavior.
- Fails closed on the declaration itself, not on worker behavior: an opened-but-never-closed marker, or a closed-but-empty block, in the project's own `AGENTS.md` refuses the scaffold with a clear error naming the file, rather than silently omitting the declared contract.
- Backward compatible: a project that declares nothing (no `AGENTS.md`, or no marker) scaffolds byte-for-byte as before. Secondmate charters (multi-project) are explicitly out of scope for this change.

## Review history
Greptile Review flagged three issues across two passes; all three are addressed in this branch's history (see commit messages for the full account of each: genuine defect vs. rejected suggestion vs. wording fix). Greptile Review currently reports PASS at head `6a1ac66ad0dc9a8c316b376ba5a5708778d8417c`.

**The `CI` and `Require no-mistakes` GitHub Actions workflows have not executed on this PR.** Both report `conclusion=action_required` at the current head (awaiting workflow-run approval for a fork-originated PR) rather than any pass/fail result. This PR is NOT green, passing, or ready to merge until those two workflows actually run and report a result; only Greptile Review has completed so far.

## Test plan (local, since CI has not run)
- [x] `bin/fm-lint.sh` (ShellCheck 0.11.0, actionlint 1.7.12) - clean
- [x] `bash tests/fm-brief.test.sh` - 28/28 pass (6 new tests: no-declaration backward-compat, ship+scout injection, ship ordering ahead of branch creation, task-work-scoped wording, unresolvable-`FM_PROJECTS_OVERRIDE`-ignored-by-secondmate, unterminated-block fail-closed, empty-block fail-closed)
- [x] `bin/fm-doc-audience-check.sh` - clean
- [x] `bin/fm-test-run.sh --changed --jobs 4` (pure-contract-unit family, 35 files) - 5 pre-existing failures, all unrelated to this change and reproducing identically on unmodified files (missing `ruby`, Node ESM resolution gaps, and an incompatible/missing `tasks-axi` in this sandbox - `tests/fm-test-run.test.sh`, `tests/fm-omp-harness.test.sh`, `tests/fm-calm-pi-extension.test.sh`, `tests/fm-bearings-board.test.sh`, `tests/fm-captain-hold-lifecycle.test.sh`); every `fm-brief.test.sh` case passes
- [ ] `CI` GitHub Actions workflow - not run (action_required, awaiting approval)
- [ ] `Require no-mistakes` GitHub Actions workflow - not run (action_required, awaiting approval)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013mMxs4yhb5PQhNxDtwr3R7
