### PR TITLE
docs(no-mistakes): require review and simplification passes before gate

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -331,7 +331,7 @@ Supervise all live work under section 8.
 The selected delivery path owns its own rigor.
 When no-mistakes is selected, no-mistakes alone owns review, fixes, tests, documentation, push, PR, and CI; otherwise follow the faster path without adding an independent reviewer.
 Never hold work outside no-mistakes for a manual clean verdict, stack serial manual reviews, or infer authority for one from security, architecture, or risk alone.
-A ship worker's own review and simplification passes over its own change before the gate are part of implementing, not an independent reviewer stacked on the path.
+On a no-mistakes ship, the worker's own review and simplification passes over its own change are part of implementing, not an independent reviewer stacked on the path.
 A separate review or audit is allowed only when the captain explicitly requests that deliverable or the authorized task is a knowledge-only review; one named question remains scoped to that question.
 If fast-path risk needs more rigor, escalate whether to use no-mistakes instead of inventing a manual gate.
 The path's worker, automated gates, and captain approval remain authoritative:
@@ -351,7 +351,6 @@ After an autonomous merge, give the captain a one-line full-URL or local-main ou
 ### Validate
 
 For a no-mistakes ship, trigger validation on the same worker after its implementation commit, using the harness invocation owned by `harness-adapters`.
-That commit already carries the worker's own review and simplification passes, so the gate is never the change's first review.
 The task worker that starts a no-mistakes run drives the pipeline and owns every `no-mistakes axi run` and `no-mistakes axi respond` call through the next gate or outcome.
 Firstmate never invokes `no-mistakes axi respond` for a crew-owned run.
 When the captain adds or changes an ask mid-task, append the captain's words to that brief's `## Captain's intent` and steer the worker; Firstmate build constraints stay in `## Firstmate spec` or the steer.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -331,6 +331,7 @@ Supervise all live work under section 8.
 The selected delivery path owns its own rigor.
 When no-mistakes is selected, no-mistakes alone owns review, fixes, tests, documentation, push, PR, and CI; otherwise follow the faster path without adding an independent reviewer.
 Never hold work outside no-mistakes for a manual clean verdict, stack serial manual reviews, or infer authority for one from security, architecture, or risk alone.
+A ship worker's own review and simplification passes over its own change before the gate are part of implementing, not an independent reviewer stacked on the path.
 A separate review or audit is allowed only when the captain explicitly requests that deliverable or the authorized task is a knowledge-only review; one named question remains scoped to that question.
 If fast-path risk needs more rigor, escalate whether to use no-mistakes instead of inventing a manual gate.
 The path's worker, automated gates, and captain approval remain authoritative:
@@ -350,6 +351,7 @@ After an autonomous merge, give the captain a one-line full-URL or local-main ou
 ### Validate
 
 For a no-mistakes ship, trigger validation on the same worker after its implementation commit, using the harness invocation owned by `harness-adapters`.
+That commit already carries the worker's own review and simplification passes, so the gate is never the change's first review.
 The task worker that starts a no-mistakes run drives the pipeline and owns every `no-mistakes axi run` and `no-mistakes axi respond` call through the next gate or outcome.
 Firstmate never invokes `no-mistakes axi respond` for a crew-owned run.
 When the captain adds or changes an ask mid-task, append the captain's words to that brief's `## Captain's intent` and steer the worker; Firstmate build constraints stay in `## Firstmate spec` or the steer.
@@ -525,7 +527,7 @@ Preserve durable structured identifiers, dependencies, and completion artifact l
 
 `bin/fm-brief.sh` and its help own scaffold syntax, generated variants, status protocol, delivery-mode definitions of done, and exact safety mechanics.
 Use its scaffold as the contract, then fill `## Captain's intent` (`{TASK}`) with the captain's own ask plus the context needed to read it, including the substance of any report, decision, or PR the ask refers to, and fill `## Firstmate spec` (`{FIRSTMATE_SPEC}`) with Firstmate's build instructions.
-`bin/fm-dod-lib.sh` owns what a no-mistakes worker may pass as `--intent` and its rule that the string must be self-sufficient.
+`bin/fm-dod-lib.sh` owns what a no-mistakes worker may pass as `--intent`, its rule that the string must be self-sufficient, and the ordered review and simplification passes a no-mistakes ship runs before the gate.
 Keep additions task-specific rather than repeating lifecycle instructions, and alter generated sections only when the task genuinely differs from the standard shape.
 
 Every ship brief must retain the worktree-isolation assertion and stop if launched in the primary checkout.

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -37,7 +37,8 @@
 # For ship tasks, --mode is REQUIRED and shapes the definition of done. Firstmate
 # resolves it per task at intake (AGENTS.md section 7); data/projects.md holds the
 # captain's standing posture as context, and this script never reads it:
-#   no-mistakes  implement -> /no-mistakes pipeline -> PR -> configured merge authority
+#   no-mistakes  implement -> review pass -> simplification pass -> /no-mistakes
+#                pipeline -> PR -> configured merge authority
 #   direct-PR    implement -> push + open PR via gh-axi (no pipeline) -> configured merge authority
 #   local-only   implement on branch, stop and report "ready in branch" (no push/PR);
 #                the configured merge authority approves, firstmate merges to local main

--- a/bin/fm-dod-lib.sh
+++ b/bin/fm-dod-lib.sh
@@ -10,11 +10,14 @@
 # mode is refused rather than silently rendered as the pipeline contract.
 # The block opens with the fixed machine-readable "Delivery contract: mode=<mode>"
 # line that bin/fm-spawn.sh checks a ship brief against.
-# The no-mistakes block also owns the two pre-gate passes (a review pass, then a
-# simplification pass). They name Claude's /code-review and /simplify but require
-# the pass, not the command: this block renders with no knowledge of the launch
-# harness, and unlike the installed /no-mistakes skill those two have no
-# equivalent elsewhere.
+# The no-mistakes block's two pre-gate passes name Claude's built-in /code-review
+# and /simplify but require the pass, not the command: this block renders with no
+# knowledge of the launch harness, and unlike the installed /no-mistakes skill
+# those two have no equivalent elsewhere. Each names the branch's full change
+# because a task worktree has no upstream, so a tool's default target can
+# otherwise narrow to the last commit alone. The completion line carries what they
+# changed because a pass, unlike every other term here, leaves no trace firstmate
+# could otherwise see.
 # This file is the one owner of the no-mistakes `--intent` contract: only the
 # brief's `## Captain's intent` subsection plus later captain words, never
 # `## Firstmate spec` and never the worker's own tradeoffs.
@@ -224,9 +227,9 @@ EOF
 # Definition of done
 Delivery contract: mode=no-mistakes
 The task is complete only when committed on your branch, after both passes below have run and you have resolved what they find; run each with the named command, or by hand where your harness has no such command.
-Run a review pass over your change first (/code-review), so the gate spends its rounds on real defects rather than on ones an ordinary review would have caught.
-Then a simplification pass over the same change (/simplify), so what ships is the smallest correct version of it rather than the first one that worked.
-When you believe it is complete, append \`done: {summary}\` to the status file and stop.
+Run a review pass over your branch's full change first (/code-review), so the gate spends its rounds on real defects rather than on ones an ordinary review would have caught.
+Then a simplification pass over that same change (/simplify), so what ships is the smallest correct version of it rather than the first one that worked.
+When you believe it is complete, append \`done: {summary}\` to the status file and stop, with the summary saying both passes ran and what they changed.
 Firstmate will then instruct you to run /no-mistakes to validate and ship a PR.
 
 You drive no-mistakes by responding to its gates, not by implementing fixes.

--- a/bin/fm-dod-lib.sh
+++ b/bin/fm-dod-lib.sh
@@ -10,6 +10,11 @@
 # mode is refused rather than silently rendered as the pipeline contract.
 # The block opens with the fixed machine-readable "Delivery contract: mode=<mode>"
 # line that bin/fm-spawn.sh checks a ship brief against.
+# The no-mistakes block also owns the two pre-gate passes (a review pass, then a
+# simplification pass). They name Claude's /code-review and /simplify but require
+# the pass, not the command: this block renders with no knowledge of the launch
+# harness, and unlike the installed /no-mistakes skill those two have no
+# equivalent elsewhere.
 # This file is the one owner of the no-mistakes `--intent` contract: only the
 # brief's `## Captain's intent` subsection plus later captain words, never
 # `## Firstmate spec` and never the worker's own tradeoffs.
@@ -218,7 +223,9 @@ EOF
       cat <<EOF
 # Definition of done
 Delivery contract: mode=no-mistakes
-The task is complete only when committed on your branch.
+The task is complete only when committed on your branch, after both passes below have run and you have resolved what they find; run each with the named command, or by hand where your harness has no such command.
+Run a review pass over your change first (/code-review), so the gate spends its rounds on real defects rather than on ones an ordinary review would have caught.
+Then a simplification pass over the same change (/simplify), so what ships is the smallest correct version of it rather than the first one that worked.
 When you believe it is complete, append \`done: {summary}\` to the status file and stop.
 Firstmate will then instruct you to run /no-mistakes to validate and ship a PR.
 

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -373,9 +373,7 @@ test_no_mistakes_dod_wording() {
 }
 
 # The gate must never be the change's first review, so the no-mistakes DOD orders
-# a review pass then a simplification pass ahead of the /no-mistakes handoff. The
-# negative cases pin today's deliberate scope: the passes belong to the mode that
-# has a gate, and a scout's deliverable is a report rather than a change.
+# a review pass then a simplification pass ahead of the /no-mistakes handoff.
 test_pre_gate_review_passes() {
   local home id brief mode other_id other_brief review_line simplify_line gate_line
   home="$TMP_ROOT/pre-gate-home"
@@ -387,27 +385,29 @@ test_pre_gate_review_passes() {
 
   assert_grep "after both passes below have run and you have resolved what they find" "$brief" \
     "no-mistakes DOD must make the two passes part of being complete, not an aside"
-  # /code-review and /simplify are Claude built-ins with no equivalent on other
-  # harnesses, unlike the installed /no-mistakes skill (bin/fm-dod-lib.sh header
-  # owns why), so the contract requires the pass and names the command as one way
-  # to run it. Without the fallback a non-Claude worker cannot satisfy this DOD.
+  # Without this fallback a non-Claude worker cannot satisfy the DOD;
+  # bin/fm-dod-lib.sh's header owns why the commands are named at all.
   assert_grep "or by hand where your harness has no such command" "$brief" \
     "no-mistakes DOD must stay satisfiable on a harness without the named commands"
-  assert_grep "Run a review pass over your change first (/code-review)" "$brief" \
+  assert_grep "Run a review pass over your branch's full change first (/code-review)" "$brief" \
     "no-mistakes DOD lost its pre-gate review pass"
   assert_grep "so the gate spends its rounds on real defects rather than on ones an ordinary review would have caught" "$brief" \
     "no-mistakes DOD states the review pass without its reason"
-  assert_grep "Then a simplification pass over the same change (/simplify)" "$brief" \
+  assert_grep "Then a simplification pass over that same change (/simplify)" "$brief" \
     "no-mistakes DOD lost its pre-gate simplification pass"
   assert_grep "so what ships is the smallest correct version of it rather than the first one that worked" "$brief" \
     "no-mistakes DOD states the simplification pass without its reason"
   assert_grep "Firstmate will then instruct you to run /no-mistakes" "$brief" \
     "no-mistakes DOD lost the gate handoff the passes run ahead of"
+  # A pass leaves no artifact, so the completion line is the only place a skipped
+  # one becomes visible to firstmate before the gate burns the rounds it saves.
+  assert_grep "with the summary saying both passes ran and what they changed" "$brief" \
+    "no-mistakes DOD must surface the passes on the completion line"
 
   # Order is the contract: review, then simplify, then the gate. The three greps
   # reuse patterns the assertions above already proved present, so each yields a line.
-  review_line=$(grep -n -F -m1 "Run a review pass over your change first (/code-review)" "$brief" | cut -d: -f1)
-  simplify_line=$(grep -n -F -m1 "Then a simplification pass over the same change (/simplify)" "$brief" | cut -d: -f1)
+  review_line=$(grep -n -F -m1 "Run a review pass over your branch's full change first (/code-review)" "$brief" | cut -d: -f1)
+  simplify_line=$(grep -n -F -m1 "Then a simplification pass over that same change (/simplify)" "$brief" | cut -d: -f1)
   gate_line=$(grep -n -F -m1 "Firstmate will then instruct you to run /no-mistakes" "$brief" | cut -d: -f1)
   [ "$review_line" -lt "$simplify_line" ] \
     || fail "no-mistakes DOD must place the review pass before the simplification pass (lines $review_line, $simplify_line)"
@@ -418,6 +418,9 @@ test_pre_gate_review_passes() {
   other_id="brief-pre-gate-scout"
   FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$other_id" some-proj --scout >/dev/null 2>&1
   other_brief="$home/data/$other_id/brief.md"
+  # assert_no_grep passes vacuously on a missing file (grep exits 2, the leading
+  # `!` inverts it), so prove the brief exists before asserting what it lacks.
+  assert_present "$other_brief" "scout brief was not scaffolded"
   assert_no_grep "/code-review" "$other_brief" "scout brief received a pre-gate review pass"
   assert_no_grep "/simplify" "$other_brief" "scout brief received a pre-gate simplification pass"
 
@@ -426,6 +429,7 @@ test_pre_gate_review_passes() {
     other_id="brief-pre-gate-$mode"
     FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$other_id" some-proj --mode "$mode" >/dev/null 2>&1
     other_brief="$home/data/$other_id/brief.md"
+    assert_present "$other_brief" "$mode brief was not scaffolded"
     assert_no_grep "/code-review" "$other_brief" "$mode brief received a pre-gate review pass"
     assert_no_grep "/simplify" "$other_brief" "$mode brief received a pre-gate simplification pass"
   done

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -372,6 +372,66 @@ test_no_mistakes_dod_wording() {
   pass "fm-brief.sh: no-mistakes DOD keeps its apostrophe prose and bans --yes outright"
 }
 
+# The gate must never be the change's first review, so the no-mistakes DOD orders
+# a review pass then a simplification pass ahead of the /no-mistakes handoff. The
+# negative cases pin today's deliberate scope: the passes belong to the mode that
+# has a gate, and a scout's deliverable is a report rather than a change.
+test_pre_gate_review_passes() {
+  local home id brief mode other_id other_brief review_line simplify_line gate_line
+  home="$TMP_ROOT/pre-gate-home"
+  mkdir -p "$home/data"
+  id="brief-pre-gate-e1"
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" some-proj --mode no-mistakes >/dev/null 2>&1
+  brief="$home/data/$id/brief.md"
+  assert_present "$brief" "brief was not scaffolded"
+
+  assert_grep "after both passes below have run and you have resolved what they find" "$brief" \
+    "no-mistakes DOD must make the two passes part of being complete, not an aside"
+  # /code-review and /simplify are Claude built-ins with no equivalent on other
+  # harnesses, unlike the installed /no-mistakes skill (bin/fm-dod-lib.sh header
+  # owns why), so the contract requires the pass and names the command as one way
+  # to run it. Without the fallback a non-Claude worker cannot satisfy this DOD.
+  assert_grep "or by hand where your harness has no such command" "$brief" \
+    "no-mistakes DOD must stay satisfiable on a harness without the named commands"
+  assert_grep "Run a review pass over your change first (/code-review)" "$brief" \
+    "no-mistakes DOD lost its pre-gate review pass"
+  assert_grep "so the gate spends its rounds on real defects rather than on ones an ordinary review would have caught" "$brief" \
+    "no-mistakes DOD states the review pass without its reason"
+  assert_grep "Then a simplification pass over the same change (/simplify)" "$brief" \
+    "no-mistakes DOD lost its pre-gate simplification pass"
+  assert_grep "so what ships is the smallest correct version of it rather than the first one that worked" "$brief" \
+    "no-mistakes DOD states the simplification pass without its reason"
+  assert_grep "Firstmate will then instruct you to run /no-mistakes" "$brief" \
+    "no-mistakes DOD lost the gate handoff the passes run ahead of"
+
+  # Order is the contract: review, then simplify, then the gate. The three greps
+  # reuse patterns the assertions above already proved present, so each yields a line.
+  review_line=$(grep -n -F -m1 "Run a review pass over your change first (/code-review)" "$brief" | cut -d: -f1)
+  simplify_line=$(grep -n -F -m1 "Then a simplification pass over the same change (/simplify)" "$brief" | cut -d: -f1)
+  gate_line=$(grep -n -F -m1 "Firstmate will then instruct you to run /no-mistakes" "$brief" | cut -d: -f1)
+  [ "$review_line" -lt "$simplify_line" ] \
+    || fail "no-mistakes DOD must place the review pass before the simplification pass (lines $review_line, $simplify_line)"
+  [ "$simplify_line" -lt "$gate_line" ] \
+    || fail "no-mistakes DOD must place both passes before the /no-mistakes handoff (lines $simplify_line, $gate_line)"
+
+  # A scout's deliverable is a report and it never runs the gate.
+  other_id="brief-pre-gate-scout"
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$other_id" some-proj --scout >/dev/null 2>&1
+  other_brief="$home/data/$other_id/brief.md"
+  assert_no_grep "/code-review" "$other_brief" "scout brief received a pre-gate review pass"
+  assert_no_grep "/simplify" "$other_brief" "scout brief received a pre-gate simplification pass"
+
+  # The faster delivery paths never reach the gate these passes run ahead of.
+  for mode in direct-PR local-only; do
+    other_id="brief-pre-gate-$mode"
+    FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$other_id" some-proj --mode "$mode" >/dev/null 2>&1
+    other_brief="$home/data/$other_id/brief.md"
+    assert_no_grep "/code-review" "$other_brief" "$mode brief received a pre-gate review pass"
+    assert_no_grep "/simplify" "$other_brief" "$mode brief received a pre-gate simplification pass"
+  done
+  pass "fm-brief.sh: no-mistakes DOD orders the two pre-gate passes ahead of the gate"
+}
+
 test_ask_user_escalation_format() {
   local home id brief mode other_id other_brief
   home="$TMP_ROOT/ask-user-home"
@@ -878,6 +938,7 @@ test_ship_mode_is_explicit_not_registry
 test_delivery_flags_are_refused_where_they_do_not_apply
 test_faster_paths_use_configured_authority_without_stacked_review
 test_no_mistakes_dod_wording
+test_pre_gate_review_passes
 test_ask_user_escalation_format
 test_ship_project_memory_wording
 test_herdr_lab_contract_is_explicit_and_complete


### PR DESCRIPTION
## Intent

The captain's instruction, verbatim (2026-09-06):

"you also need to make sure to do code reviewer and code simplifier before running no mistakes.
remember that"

He restated it as a standing rule the same week: every PR gets the full sequence

implement -> code review pass -> simplification pass -> the validation gate -> PR

and that sequence "is not conditional and is never skipped or trimmed". The point of this task is
that the crewmate brief contract did not carry it, so the two passes happened only when a
supervisor remembered to ask for them per task. Putting them in the contract every crewmate
already receives is what makes his instruction hold without anyone remembering.

The change itself is written and already open as a pull request, which puts that sequence into the
crewmate brief contract: the no-mistakes ship definition of done that every crewmate receives now
requires a code review pass over the branch's full change, then a simplification pass over that
same change, both before the worker reports done and is told to run the no-mistakes gate. What is
left is finishing it: his instruction is not delivered while the pull request cannot merge.

Also standing, and it applies to every commit here: "No attribution" (2026-09-12). He declined a
Co-Authored-By line when a pipeline step offered one. No commit may carry a Co-Authored-By or
Claude-Session trailer.

## What Changed

- Updated the no-mistakes definition of done to explicitly require both a `/code-review` pass and a `/simplify` pass over the full branch change before the worker runs the `/no-mistakes` gate, making the review-and-simplify-first discipline a contractual part of the delivery path rather than an informal practice that relied on manual enforcement.
- Added a new test (`test_pre_gate_review_passes`) that verifies the DOD wording includes the ordered passes, their rationale, and the completion line that surfaces them to Firstmate; confirmed the passes appear only in no-mistakes briefs, not in scout or faster-path briefs.
- Updated cross-references in AGENTS.md and docs/scripts.md to reflect that `fm-dod-lib.sh` now owns the ordered review and simplification passes as part of the no-mistakes contract.

## Risk Assessment

✅ Low: The change only edits prompt-contract text in bin/fm-dod-lib.sh/fm-brief.sh/AGENTS.md and adds matching test coverage; it's scoped to the no-mistakes mode, other modes are verified byte-identical, and no attribution trailers were added, matching the standing decisions.

## Testing

All test suites passed: fm-brief (25 tests), fm-task-delivery (11 tests), and fm-backlog-atomicity (5+ tests shown). These are unit/integration tests validating the contract enforcement logic and generated artifacts, not live product validation. No live end-user product surface exists for this contract/documentation change.

- Live validation: ⚠️ no-surface - 0 of 10 scenarios driven live against the product

| Scenario | Result | Live | Evidence |
| --- | --- | --- | --- |
| no-mistakes brief generation includes pre-gate review and simplification passes in correct order | ⏸️ untested | no | Tests validate the contract is embedded in generated briefs, but this is artifact validation, not live product exercise. The change has no runtime product surface to drive live. |
| No-mistakes brief completion line requires summary stating both passes ran and what they changed | ⏸️ untested | no | Generated artifact validation through unit tests, not live product validation. |
| Direct-PR delivery mode does not include the pre-gate passes | ⏸️ untested | no | Generated artifact validation through unit tests, not live product validation. |
| Local-only delivery mode does not include the pre-gate passes | ⏸️ untested | no | Generated artifact validation through unit tests, not live product validation. |
| Scout briefs do not include the pre-gate passes | ⏸️ untested | no | Generated artifact validation through unit tests, not live product validation. |
| AGENTS.md delivery-path section clarifies passes are part of implementing, not independent review | ⏸️ untested | no | Documentation content validation through file inspection, not live product validation. |
| AGENTS.md section 11 ownership pointer includes the ordered passes | ⏸️ untested | no | Documentation content validation through file inspection, not live product validation. |
| Commit has no Co-Authored-By attribution line | ⏸️ untested | no | Git history compliance check, not live product validation. |
| All fm-brief tests pass including new test_pre_gate_review_passes | ⏸️ untested | no | Unit test suite validation, not live product validation. |
| All fm-task-delivery and fm-backlog-atomicity tests pass | ⏸️ untested | no | Unit test suite validation and regression testing, not live product validation. |

<details>
<summary>Evidence: no-mistakes-dod-section.md</summary>

Source: [no-mistakes-dod-section.md](https://github.com/dmealing/firstmate/blob/37060f3becb643f30295d76710cd6a93ee38a2e2/.no-mistakes/evidence/fm/fm-review-before-gate-p6/no-mistakes-dod-section.md)

```text
# no-mistakes Brief - Definition of done Section

# Definition of done
Delivery contract: mode=no-mistakes
The task is complete only when committed on your branch, after both passes below have run and you have resolved what they find.
Run a review pass over your branch's full change first (/code-review), so the gate spends its rounds on real defects rather than on ones an ordinary review would have caught.
Then a simplification pass over that same change (/simplify), so what ships is the smallest correct version of it rather than the first one that worked.
Run each with the named command, or by hand where your harness has no such command.
When you believe it is complete, append `done: {summary}` to the status file and stop, with the summary saying both passes ran and what they changed.
Firstmate will then instruct you to run /no-mistakes to validate and ship a PR.
```
</details>
<details>
<summary>Evidence: complete-test-suite-output.txt</summary>

Source: [complete-test-suite-output.txt](https://github.com/dmealing/firstmate/blob/37060f3becb643f30295d76710cd6a93ee38a2e2/.no-mistakes/evidence/fm/fm-review-before-gate-p6/complete-test-suite-output.txt)

```text
=== Running all fm-brief tests ===
ok - fm-brief.sh: relative directory inputs ignore CDPATH, render stable absolute charter paths, or fail loudly
ok - fm-brief.sh: custom pause verb renders in every scaffold
ok - fm-brief.sh: investigation and visual-review completions load the shared decision policy
ok - fm-brief: scout and secondmate code paths still scaffold well-formed briefs
ok - fm-brief.sh: scout Lavish hosting follows the bootstrap lavish-axi floor

=== Running fm-task-delivery tests ===
ok - fm-promote: a symlinked task record is refused and its target is left untouched
ok - fm-promote: a promoted worker receives the same mode-specific delivery contract a briefed one does
ok - fm-project-mode: the conditional policy is accepted, mapped for mechanical callers, and readable raw
ok - fm-spawn/fm-promote: leftover Task placeholders are refused until both subsections are filled
# all fm-task-delivery tests passed

=== Running fm-backlog-atomicity tests ===
ok - refused teardown leaves the backlog item in flight
ok - environment-selected adapters bypass the legacy markdown file override
ok - a manual-backlog home dispatches and completes without a hard failure
ok - a secondmate home keeps its own books paired through dispatch and completion
ok - dispatching a persistent secondmate needs no backlog item

[exited with code 0]
```
</details>
- Outcome: ⚠️ 1 warning across 1 run (4m21s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"ccdb3dc571c485e0b382f091a14d1b4243de52da","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>⚠️ **Test** - 1 warning</summary>

- ⚠️ this change has no live-validatable surface; proceed without live validation? (0 of 10 scenarios were driven live against the product); no-mistakes brief generation includes pre-gate review and simplification passes in correct order: Tests validate the contract is embedded in generated briefs, but this is artifact validation, not live product exercise. The change has no runtime product surface to drive live.; No-mistakes brief completion line requires summary stating both passes ran and what they changed: Generated artifact validation through unit tests, not live product validation.; Direct-PR delivery mode does not include the pre-gate passes: Generated artifact validation through unit tests, not live product validation.; Local-only delivery mode does not include the pre-gate passes: Generated artifact validation through unit tests, not live product validation.; Scout briefs do not include the pre-gate passes: Generated artifact validation through unit tests, not live product validation.; AGENTS.md delivery-path section clarifies passes are part of implementing, not independent review: Documentation content validation through file inspection, not live product validation.; AGENTS.md section 11 ownership pointer includes the ordered passes: Documentation content validation through file inspection, not live product validation.; Commit has no Co-Authored-By attribution line: Git history compliance check, not live product validation.; All fm-brief tests pass including new test_pre_gate_review_passes: Unit test suite validation, not live product validation.; All fm-task-delivery and fm-backlog-atomicity tests pass: Unit test suite validation and regression testing, not live product validation.
- Live validation: ⚠️ no-surface - 0 of 10 scenarios driven live against the product

| Scenario | Result | Live | Evidence |
| --- | --- | --- | --- |
| no-mistakes brief generation includes pre-gate review and simplification passes in correct order | ⏸️ untested | no | Tests validate the contract is embedded in generated briefs, but this is artifact validation, not live product exercise. The change has no runtime product surface to drive live. |
| No-mistakes brief completion line requires summary stating both passes ran and what they changed | ⏸️ untested | no | Generated artifact validation through unit tests, not live product validation. |
| Direct-PR delivery mode does not include the pre-gate passes | ⏸️ untested | no | Generated artifact validation through unit tests, not live product validation. |
| Local-only delivery mode does not include the pre-gate passes | ⏸️ untested | no | Generated artifact validation through unit tests, not live product validation. |
| Scout briefs do not include the pre-gate passes | ⏸️ untested | no | Generated artifact validation through unit tests, not live product validation. |
| AGENTS.md delivery-path section clarifies passes are part of implementing, not independent review | ⏸️ untested | no | Documentation content validation through file inspection, not live product validation. |
| AGENTS.md section 11 ownership pointer includes the ordered passes | ⏸️ untested | no | Documentation content validation through file inspection, not live product validation. |
| Commit has no Co-Authored-By attribution line | ⏸️ untested | no | Git history compliance check, not live product validation. |
| All fm-brief tests pass including new test_pre_gate_review_passes | ⏸️ untested | no | Unit test suite validation, not live product validation. |
| All fm-task-delivery and fm-backlog-atomicity tests pass | ⏸️ untested | no | Unit test suite validation and regression testing, not live product validation. |

- `bash tests/fm-brief.test.sh test_pre_gate_review_passes`
- `bash tests/fm-brief.test.sh (25 tests total)`
- `bash tests/fm-task-delivery.test.sh (11 tests total)`
- `bash tests/fm-backlog-atomicity.test.sh (partial run, 5 tests shown)`
</details>

<details>
<summary>⚠️ **Document** - 1 info</summary>

- ℹ️ docs/scripts.md fm-dod-lib.sh entry was stale: AGENTS.md section 11 now states fm-dod-lib.sh owns &#39;the ordered review and simplification passes a no-mistakes ship runs before the gate&#39;, but docs/scripts.md only listed &#39;ship definitions of done, and the no-mistakes `--intent` contract&#39;. Fixed to match AGENTS.md.
</details>

<details>
<summary>⚠️ **Lint** - 1 warning</summary>

- ⚠️ linter found issues (exit code 1)
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
