### PR TITLE
docs: distinguish provider-quota exhaustion from a real dependency in the blocked/parked vocabulary

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -417,7 +417,8 @@ Treat any `UNREAD STATUS` section as newly surfaced status that must be read thi
 Treat any `RECORD DIVERGENCE` section as a contradiction between two records of one captain call, never as proof the captain ruled; load `captain-hold-lifecycle` and reconcile it in whichever direction the evidence supports.
 After handling all emitted wakes and reconciling the OPEN DECISIONS and UNREAD STATUS sections, run the exact generation-bound `--ack-through` command printed as `WAKE_ACK_REQUIRED`; interruption before that acknowledgement deliberately leaves the work durable for idempotent re-handling.
 A status line is a wake event, not current state; use `bin/fm-crew-state.sh` when current state matters, especially before re-escalating an old decision, blocker, or pause.
-A declared `paused:` event means a bounded external wait expected to clear on its own, while `blocked:` means firstmate action is needed.
+A declared `paused:` event means a bounded external wait expected to clear on its own, while `blocked:` means firstmate action is needed, and a blocked or parked report resolves to exactly one of seven states - `BLOCKED - PROVIDER QUOTA`, `BLOCKED - WAITING FOR INPUT`, `BLOCKED - DEPENDENCY`, `BLOCKED - HUMAN DECISION`, `BLOCKED - ACCESS/PERMISSION`, `BLOCKED - FAILED EXECUTION`, or `PARKED - NO WORK ASSIGNED` (idle by design and healthy, including an otherwise-idle agent whose provider happens to be unavailable); [`docs/configuration.md`](docs/configuration.md) owns each state's full definition.
+Check the live pane and provider quota before treating any blocked report as a stuck-crewmate signal, since conflating provider exhaustion with a real dependency causes false escalations and unnecessary relaunches.
 
 Handle actionable wakes as follows:
 
@@ -476,6 +477,13 @@ When evidence uses an internal label, rewrite it before sending:
 - status file, metadata, state, task id, or raw path -> durable record, local record, or omit it unless the captain needs the file path to act.
 - fail-closed, fails closed, fail loudly, or refuses loudly -> stops safely when something goes wrong, refuses rather than proceeding, or reports the concrete missing requirement.
 - fail-open, fails open, passive fail-open, or degraded-open -> steps aside and lets work continue when the check cannot complete, or continues without that optional protection.
+- `BLOCKED - PROVIDER QUOTA` -> stopped responding because its tool ran out of usage, without naming the provider unless the tool choice itself blocks work.
+- `BLOCKED - WAITING FOR INPUT` -> waiting on your answer or the material it asked for.
+- `BLOCKED - DEPENDENCY` -> waiting on another piece of work to finish first.
+- `BLOCKED - HUMAN DECISION` -> waiting on your decision.
+- `BLOCKED - ACCESS/PERMISSION` -> needs access or a credential it does not have.
+- `BLOCKED - FAILED EXECUTION` -> stopped after its last attempt failed, holding rather than retrying blindly.
+- `PARKED - NO WORK ASSIGNED` -> idle and healthy, holding no work.
 
 Never relay worker reports, status lines, tool output, validation-state labels, or decision records verbatim into captain chat.
 Read them as evidence, then send the plain-English outcome and consequence.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -489,8 +489,7 @@ Never relay worker reports, status lines, tool output, validation-state labels, 
 Read them as evidence, then send the plain-English outcome and consequence.
 Private evidence reports may retain exact identifiers, paths, status lines, validation labels, and internal terms when they are useful, but the captain-facing chat summary that points to the report still follows this translation rule.
 
-Every escalation must stand alone and remain concise.
-Lead directly with concrete evidence, then the consequence, options when applicable, and a recommendation.
+A substantive report - work ready for review, investigation findings, or a real blocker - stands alone, remains concise, and uses four labeled sections: `RESULT` for the outcome and its consequence, `EVIDENCE` for the concrete support, `NEXT ACTION` for options and a recommendation, and `HUMAN DECISION` for the call itself, included only when one is actually needed.
 Use the same evidence-first form for objections or clarifying challenges rather than unsupported deference.
 
 Reach the captain immediately for:
@@ -504,9 +503,10 @@ Reach the captain immediately for:
 
 In a secondmate home, reaching the captain means appending the outcome to the parent channel your charter names; a captain-facing sentence in that home's chat has not been sent, and [`docs/secondmate-parent-channel.md`](docs/secondmate-parent-channel.md) owns which outcomes the home's own scripts deliver there without you.
 Do not surface automatic fixes, retries, routine progress, or internal supervision mechanics.
-When a routine operational update's specific event requires no action but a response must be sent, reply exactly `Captain, shipshape.` without characterizing the visible session's unrelated decisions.
+A routine status update carries no action and is exactly one sentence; when its specific event requires no action but a response must be sent, reply exactly `Captain, shipshape.` without characterizing the visible session's unrelated decisions.
 Batch non-urgent updates into the next natural reply.
 Use plain chat for a yes-or-no decision and `lavish-axi` only when several options or a structured report benefit from a visual surface.
+When a report uses color, color is an enhancement only, never the sole carrier of meaning: every distinction it marks must also be legible from the text alone.
 Whenever a PR is mentioned, include its full `https://...` URL when the task's ready status or `pr=` metadata holds one, copied verbatim and never assembled from memory; when neither does yet, report only the identifier you actually have.
 Mention cost as a courtesy when unusually much work is running, but never block on it.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -489,7 +489,8 @@ Never relay worker reports, status lines, tool output, validation-state labels, 
 Read them as evidence, then send the plain-English outcome and consequence.
 Private evidence reports may retain exact identifiers, paths, status lines, validation labels, and internal terms when they are useful, but the captain-facing chat summary that points to the report still follows this translation rule.
 
-A substantive report - work ready for review, investigation findings, or a real blocker - stands alone, remains concise, and uses four labeled sections: `RESULT` for the outcome and its consequence, `EVIDENCE` for the concrete support, `NEXT ACTION` for options and a recommendation, and `HUMAN DECISION` for the call itself, included only when one is actually needed.
+Every escalation must stand alone and remain concise.
+Lead directly with concrete evidence, then the consequence, options when applicable, and a recommendation.
 Use the same evidence-first form for objections or clarifying challenges rather than unsupported deference.
 
 Reach the captain immediately for:
@@ -503,10 +504,9 @@ Reach the captain immediately for:
 
 In a secondmate home, reaching the captain means appending the outcome to the parent channel your charter names; a captain-facing sentence in that home's chat has not been sent, and [`docs/secondmate-parent-channel.md`](docs/secondmate-parent-channel.md) owns which outcomes the home's own scripts deliver there without you.
 Do not surface automatic fixes, retries, routine progress, or internal supervision mechanics.
-A routine status update carries no action and is exactly one sentence; when its specific event requires no action but a response must be sent, reply exactly `Captain, shipshape.` without characterizing the visible session's unrelated decisions.
+When a routine operational update's specific event requires no action but a response must be sent, reply exactly `Captain, shipshape.` without characterizing the visible session's unrelated decisions.
 Batch non-urgent updates into the next natural reply.
 Use plain chat for a yes-or-no decision and `lavish-axi` only when several options or a structured report benefit from a visual surface.
-When a report uses color, color is an enhancement only, never the sole carrier of meaning: every distinction it marks must also be legible from the text alone.
 Whenever a PR is mentioned, include its full `https://...` URL when the task's ready status or `pr=` metadata holds one, copied verbatim and never assembled from memory; when neither does yet, report only the identifier you actually have.
 Mention cost as a courtesy when unusually much work is running, but never block on it.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -25,6 +25,20 @@ Wake, watcher, away-mode, and Relay-specific state mechanics remain with their n
 `AGENTS.md` retains the run-once and read-once operator rules, lock-refusal safety, installation consent, and direct-report recovery boundaries because those facts apply at every session start.
 Ordinary dead-direct-report recovery is owned by `stuck-crewmate-recovery`, while persistent-secondmate recovery is owned by `secondmate-provisioning`.
 
+## Blocked/parked-state vocabulary
+
+A blocked or parked agent resolves to exactly one of the states below; `AGENTS.md` section 8 owns the compact operating summary and the anti-conflation diagnostic rule.
+
+| State | Meaning |
+| --- | --- |
+| `BLOCKED - PROVIDER QUOTA` | The agent is alive and controllable, its provider account is exhausted, it is waiting on nothing, and recovery is a runtime reroute or a provider reset. |
+| `BLOCKED - WAITING FOR INPUT` | The agent needs a specific piece of information or material and has asked for it. |
+| `BLOCKED - DEPENDENCY` | The agent needs another task, artifact, or upstream deliverable first. |
+| `BLOCKED - HUMAN DECISION` | The agent has reached a genuine captain-reserved choice and is holding for it. |
+| `BLOCKED - ACCESS/PERMISSION` | The agent needs a credential, grant, or access path it does not have. |
+| `BLOCKED - FAILED EXECUTION` | The agent's last attempt errored or failed and it is holding rather than retrying blindly. |
+| `PARKED - NO WORK ASSIGNED` | The agent is idle by design, holding no work, and healthy, including an idle agent whose provider happens to be unavailable but which has no work waiting regardless. |
+
 ## Pi Calm preference (config/calm)
 
 The Pi Calm extension stores the captain's home-local presentation choice in gitignored `config/calm` under the effective Firstmate home, resolved from `FM_HOME`, then `FM_ROOT_OVERRIDE`, then the tracked code root derived from the extension path, or under `FM_CONFIG_OVERRIDE` when that test and specialized-setup override is present.


### PR DESCRIPTION
**What**

Adds a small, closed vocabulary for the "blocked" and "parked" states a supervised agent can report, and documents it in two places:

- `AGENTS.md` section 8 gets a compact one-paragraph summary of the seven states plus a one-line diagnostic rule.
- `docs/configuration.md` gets a full reference table with one sentence per state.

Section 9's existing plain-language translation table (used when reporting an agent's state to a human) is extended with one row per new state, so a report never has to expose internal words like "quota," "harness," or a provider's name unless the tool choice itself is what's blocking work.

**Why**

Today "blocked" is a single flat state. In practice a supervisor needs to react very differently depending on what's actually happening:

- An agent that is alive, controllable, and simply out of provider usage is not stuck - it needs a runtime reroute or to wait for a quota reset, and there is nothing else to check.
- An agent waiting on a real upstream dependency, a human decision, missing credentials, or a failed execution each need a different response.
- An agent idling by design with no work assigned is healthy, not blocked, even when its provider happens to be temporarily unavailable.

Without a name for the first case, a supervisor reading a generic "blocked" status can easily mistake a temporary provider-quota exhaustion for a genuine dependency or a hung agent, and take an unnecessary and disruptive action (for example relaunching an agent that would just hit the same exhausted quota again). This change gives that specific situation - and the other blocked/parked cases - names precise enough that a diagnostic check (looking at the live session and the provider's quota state) settles which one applies before any escalation happens.

**What's in this PR**

- The seven-state taxonomy: `BLOCKED - PROVIDER QUOTA`, `BLOCKED - WAITING FOR INPUT`, `BLOCKED - DEPENDENCY`, `BLOCKED - HUMAN DECISION`, `BLOCKED - ACCESS/PERMISSION`, `BLOCKED - FAILED EXECUTION`, and `PARKED - NO WORK ASSIGNED`.
- The diagnostic rule: check the live pane and provider quota before treating any blocked report as a stuck-agent signal, since conflating provider exhaustion with a real dependency causes false escalations and unnecessary relaunches.
- Plain-language translations for each state, consistent with the existing translation-rule table in section 9, for use when reporting an agent's state to a human without exposing internal machinery.

**What's not in this PR**

No behavior change: no script, no state machine, and no dispatch logic is touched. This documents a distinction operators should already be making; it doesn't introduce a new field or a new automated check.

**Testing**

`bin/fm-doc-audience-check.sh` passes (documentation classification, link targets, and owner-pointer checks).
