### PR TITLE
fix: snooze watched tool updates by identity

### DIFF
--- a/bin/fm-tool-update-check.sh
+++ b/bin/fm-tool-update-check.sh
@@ -306,6 +306,10 @@ budget_exhausted() {
   [ "$(real_epoch)" -ge "$DEADLINE" ]
 }
 
+mark_incomplete() {
+  INCOMPLETE_REPORTED=1
+}
+
 # True while the sweep budget still has room for another probe. When it does not,
 # it records once which tool the sweep did not finish, so a sweep that cannot
 # finish says so rather than being killed by the watcher with nothing printed.
@@ -313,7 +317,7 @@ budget_allows() {
   local name=$1
   budget_exhausted || return 0
   if [ "$INCOMPLETE_REPORTED" -eq 0 ]; then
-    INCOMPLETE_REPORTED=1
+    mark_incomplete
     emit "check incomplete: the time budget ran out before $name"
   fi
   return 1
@@ -519,6 +523,7 @@ command_findings() {
   while IFS= read -r hit; do
     [ -n "$hit" ] || continue
     if budget_exhausted; then
+      mark_incomplete
       emit "$name check failed: the time budget ran out before every copy answered"
       break
     fi
@@ -550,6 +555,7 @@ EOF
     announce_out=$resolved_out
     if [ "$announce_args" != "$args_joined" ]; then
       if budget_exhausted; then
+        mark_incomplete
         # The version probe's output cannot carry the announcement, so searching
         # it would present a source that was never asked as a clean result.
         emit "$name check failed: the time budget ran out before the update announcement was checked"
@@ -613,7 +619,10 @@ GIT_PROBE_NOT_ISSUED=3
 git_probe() {
   local repo=$1
   shift
-  budget_exhausted && return "$GIT_PROBE_NOT_ISSUED"
+  if budget_exhausted; then
+    mark_incomplete
+    return "$GIT_PROBE_NOT_ISSUED"
+  fi
   fm_run_timed "$(probe_bound)" git -C "$repo" "$@"
 }
 

--- a/bin/fm-tool-update-check.sh
+++ b/bin/fm-tool-update-check.sh
@@ -988,6 +988,10 @@ EOF
   # same filtered set that a subsequent check will compare.
   SNOOZE_CAPTURE=0
   run_sweep
+  if [ "$SWEEP_COMPLETE" -eq 0 ]; then
+    printf 'fm-tool-update-check: cannot record a snooze from an incomplete sweep\n' >&2
+    return 1
+  fi
   snoozes_prune
   record_write "$FINDINGS" "$RECORD_SNOOZES" || {
     printf 'fm-tool-update-check: could not record the snooze\n' >&2

--- a/bin/fm-tool-update-check.sh
+++ b/bin/fm-tool-update-check.sh
@@ -4,6 +4,8 @@
 #
 # Usage:
 #   fm-tool-update-check.sh [check]
+#   fm-tool-update-check.sh snooze <tool> --until YYYY-MM-DD
+#   fm-tool-update-check.sh snooze <tool> --until-commit <commit>
 #   fm-tool-update-check.sh arm
 #   fm-tool-update-check.sh disarm
 #   fm-tool-update-check.sh --help
@@ -62,6 +64,10 @@
 # while a new finding that lands past the one-line cut is still news. A sweep
 # killed part way through leaves no record and is retried, instead of
 # suppressing its finding.
+# A captain can snooze one tool's current update identities until a date, or a
+# git update until the exact commit that was reported. A later update gets a new
+# identity and remains visible, while a snoozed identity is removed once it is
+# no longer present.
 set -u
 export LC_ALL=C
 # A watched git remote must never stop to ask for credentials; an unauthenticated
@@ -95,6 +101,8 @@ usage() {
   cat <<'EOF'
 Usage:
   fm-tool-update-check.sh [check]   report watched tools needing attention (silent when current)
+  fm-tool-update-check.sh snooze <tool> --until YYYY-MM-DD
+  fm-tool-update-check.sh snooze <tool> --until-commit <commit>
   fm-tool-update-check.sh arm       write and register state/tool-updates.check.sh
   fm-tool-update-check.sh disarm    remove the check shim, its trust binding, and the record
   fm-tool-update-check.sh --help    print this help
@@ -193,6 +201,10 @@ real_epoch() { date +%s; }
 FINDINGS=
 DEADLINE=0
 INCOMPLETE_REPORTED=0
+CURRENT_UPDATE_ENTRIES=
+RECORD_SNOOZES=
+SWEEP_COMPLETE=0
+SNOOZE_CAPTURE=0
 
 # Each finding is flattened to a single line here, because the whole report must
 # stay one line for the wake record.
@@ -204,6 +216,80 @@ emit() {
   else
     FINDINGS="$FINDINGS; $text"
   fi
+}
+
+update_fingerprint() {
+  local identity=$1
+  if command -v shasum >/dev/null 2>&1; then
+    printf '%s' "$identity" | shasum -a 256 | awk '{print $1}'
+  elif command -v sha256sum >/dev/null 2>&1; then
+    printf '%s' "$identity" | sha256sum | awk '{print $1}'
+  else
+    printf '%s' "$identity" | cksum | awk '{print $1}'
+  fi
+}
+
+current_update_add() {
+  local entry=$1
+  if [ -z "$CURRENT_UPDATE_ENTRIES" ]; then
+    CURRENT_UPDATE_ENTRIES=$entry
+  else
+    CURRENT_UPDATE_ENTRIES="$CURRENT_UPDATE_ENTRIES
+$entry"
+  fi
+}
+
+snooze_until_active() {
+  local until=$1 today
+  [ "$until" = '-' ] && return 0
+  case "$until" in
+    [0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9])
+      today=$(date -u +%Y-%m-%d)
+      [ "$today" \< "$until" ]
+      ;;
+    *) return 1 ;;
+  esac
+}
+
+snooze_key_active() {
+  local name=$1 key=$2 entry entry_name entry_key until
+  while IFS= read -r entry; do
+    [ -n "$entry" ] || continue
+    IFS='|' read -r entry_name entry_key until <<EOF
+$entry
+EOF
+    if [ "$entry_name" = "$name" ] && [ "$entry_key" = "$key" ] \
+      && snooze_until_active "$until"; then
+      return 0
+    fi
+  done <<EOF
+$RECORD_SNOOZES
+EOF
+  return 1
+}
+
+emit_update() {
+  local name=$1 kind=$2 value=$3 text=$4 key
+  key=$(update_fingerprint "$kind|$name|$value")
+  current_update_add "$name|$key|$kind|$value"
+  if [ "$SNOOZE_CAPTURE" -eq 0 ] && snooze_key_active "$name" "$key"; then
+    return 0
+  fi
+  emit "$text"
+}
+
+current_update_has_key() {
+  local name=$1 key=$2 entry entry_name entry_key
+  while IFS= read -r entry; do
+    [ -n "$entry" ] || continue
+    IFS='|' read -r entry_name entry_key _ <<EOF
+$entry
+EOF
+    [ "$entry_name" = "$name" ] && [ "$entry_key" = "$key" ] && return 0
+  done <<EOF
+$CURRENT_UPDATE_ENTRIES
+EOF
+  return 1
 }
 
 budget_exhausted() {
@@ -478,7 +564,8 @@ EOF
       if [ "$status" -gt 1 ]; then
         emit "$name check failed: announce_pattern is not a usable extended regular expression"
       elif [ -n "$matched" ]; then
-        emit "$name update available: $(printf '%s\n' "$matched" | head -n 1)"
+      matched=$(printf '%s\n' "$matched" | head -n 1)
+      emit_update "$name" announce "$matched" "$name update available: $matched"
       fi
     fi
   fi
@@ -492,7 +579,8 @@ EOF
 
   if [ -n "$best_version" ] && [ "$best_path" != "$resolved_path" ] \
     && version_newer "$best_version" "$resolved_version"; then
-    emit "$name update not in effect: PATH resolves $resolved_version at $resolved_path but $best_version is installed at $best_path"
+    emit_update "$name" command "$resolved_version|$best_version" \
+      "$name update not in effect: PATH resolves $resolved_version at $resolved_path but $best_version is installed at $best_path"
   fi
 
   if [ -n "$unreadable" ]; then
@@ -633,12 +721,14 @@ git_findings() {
       ''|*[!0-9]*|0) count= ;;
     esac
     if [ -n "$count" ]; then
-      emit "$name update available: $local_label is $(commit_phrase "$count") behind $remote/$branch"
+      emit_update "$name" git "$remote_sha" \
+        "$name update available: $local_label is $(commit_phrase "$count") behind $remote/$branch"
       return 0
     fi
   fi
 
-  emit "$name update available: $remote/$branch is at $short which this copy does not have"
+  emit_update "$name" git "$remote_sha" \
+    "$name update available: $remote/$branch is at $short which this copy does not have"
   return 0
 }
 
@@ -651,6 +741,7 @@ record_read() {
   local line first=1
   RECORD_EPOCH=0
   RECORD_REPORTED=
+  RECORD_SNOOZES=
   [ -f "$RECORD" ] || return 0
   while IFS= read -r line; do
     if [ "$first" = 1 ]; then
@@ -667,19 +758,34 @@ record_read() {
         esac
         ;;
       reported=*) RECORD_REPORTED=${line#reported=} ;;
+      snooze=*)
+        line=${line#snooze=}
+        if [ -z "$RECORD_SNOOZES" ]; then
+          RECORD_SNOOZES=$line
+        else
+          RECORD_SNOOZES="$RECORD_SNOOZES
+$line"
+        fi
+        ;;
     esac
   done < "$RECORD"
   return 0
 }
 
 record_write() {
-  local reported=$1 tmp
+  local reported=$1 snoozes=${2:-} tmp entry
   tmp=$(mktemp "$RECORD.XXXXXX" 2>/dev/null) || return 1
   chmod 0600 "$tmp" 2>/dev/null || { rm -f -- "$tmp"; return 1; }
   {
     printf '%s\n' "$RECORD_SCHEMA"
     printf 'epoch=%s\n' "$(record_epoch_now)"
     printf 'reported=%s\n' "$reported"
+    while IFS= read -r entry; do
+      [ -n "$entry" ] || continue
+      printf 'snooze=%s\n' "$entry"
+    done <<EOF
+$snoozes
+EOF
   } > "$tmp" || { rm -f -- "$tmp"; return 1; }
   mv -f -- "$tmp" "$RECORD" || { rm -f -- "$tmp"; return 1; }
   return 0
@@ -687,19 +793,12 @@ record_write() {
 
 # --- actions ----------------------------------------------------------------
 
-action_check() {
+run_sweep() {
   local name command_name args_joined announce announce_args repo remote branch
-  local line now
-
-  [ -f "$CONFIG" ] || return 0
-
-  record_read
-  now=$(record_epoch_now)
-  if [ "$INTERVAL" -ne 0 ] && [ "$RECORD_EPOCH" -gt 0 ] \
-    && [ "$now" -ge "$RECORD_EPOCH" ] && [ $((now - RECORD_EPOCH)) -lt "$INTERVAL" ]; then
-    return 0
-  fi
-
+  FINDINGS=
+  CURRENT_UPDATE_ENTRIES=
+  INCOMPLETE_REPORTED=0
+  SWEEP_COMPLETE=0
   DEADLINE=$(($(real_epoch) + BUDGET_SECS))
 
   if [ -n "$BUDGET_CUT_FROM" ]; then
@@ -715,7 +814,87 @@ action_check() {
       [ -z "$command_name" ] || command_findings "$name" "$command_name" "$args_joined" "$announce" "$announce_args"
       [ -z "$repo" ] || git_findings "$name" "$repo" "$remote" "$branch"
     done < <(config_records)
+    [ "$INCOMPLETE_REPORTED" -eq 0 ] && SWEEP_COMPLETE=1
   fi
+}
+
+snoozes_prune() {
+  local entry name key until retained=
+  while IFS= read -r entry; do
+    [ -n "$entry" ] || continue
+    IFS='|' read -r name key until <<EOF
+$entry
+EOF
+    snooze_until_active "$until" || continue
+    if [ "$SWEEP_COMPLETE" -eq 0 ] || current_update_has_key "$name" "$key"; then
+      if [ -z "$retained" ]; then
+        retained=$entry
+      else
+        retained="$retained
+$entry"
+      fi
+    fi
+  done <<EOF
+$RECORD_SNOOZES
+EOF
+  RECORD_SNOOZES=$retained
+}
+
+snooze_add() {
+  local name=$1 key=$2 until=$3 entry existing entry_name entry_key kept=
+  while IFS= read -r existing; do
+    [ -n "$existing" ] || continue
+    IFS='|' read -r entry_name entry_key _ <<EOF
+$existing
+EOF
+    [ "$entry_name" = "$name" ] && [ "$entry_key" = "$key" ] && continue
+    if [ -z "$kept" ]; then
+      kept=$existing
+    else
+      kept="$kept
+$existing"
+    fi
+  done <<EOF
+$RECORD_SNOOZES
+EOF
+  entry="$name|$key|$until"
+  if [ -z "$kept" ]; then
+    RECORD_SNOOZES=$entry
+  else
+    RECORD_SNOOZES="$kept
+$entry"
+  fi
+}
+
+valid_until_date() {
+  local value=$1 parsed
+  case "$value" in
+    [0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]) : ;;
+    *) return 1 ;;
+  esac
+  if parsed=$(date -u -j -f "%Y-%m-%d" "$value" "+%Y-%m-%d" 2>/dev/null); then
+    :
+  elif parsed=$(date -u -d "$value" "+%Y-%m-%d" 2>/dev/null); then
+    :
+  else
+    return 1
+  fi
+  [ "$parsed" = "$value" ]
+}
+
+action_check() {
+  local line now
+
+  [ -f "$CONFIG" ] || return 0
+
+  record_read
+  now=$(record_epoch_now)
+  if [ "$INTERVAL" -ne 0 ] && [ "$RECORD_EPOCH" -gt 0 ] \
+    && [ "$now" -ge "$RECORD_EPOCH" ] && [ $((now - RECORD_EPOCH)) -lt "$INTERVAL" ]; then
+    return 0
+  fi
+
+  run_sweep
 
   line=
   if [ -n "$FINDINGS" ]; then
@@ -735,7 +914,70 @@ action_check() {
   if [ -n "$line" ] && [ "$FINDINGS" != "$RECORD_REPORTED" ]; then
     printf '%s\n' "$line"
   fi
-  record_write "$FINDINGS" || true
+  snoozes_prune
+  record_write "$FINDINGS" "$RECORD_SNOOZES" || true
+  return 0
+}
+
+action_snooze() {
+  local name=${1:-} option=${2:-} value=${3:-} entry entry_name entry_key kind update_value
+  local until='' count=0 commit
+  [ "$#" -eq 3 ] || die_usage 'snooze needs a tool and exactly one until option'
+  case "$option" in
+    --until)
+      valid_until_date "$value" || die_usage "--until must be a YYYY-MM-DD date: $value"
+      until=$value
+      ;;
+    --until-commit)
+      case "$value" in
+        [0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]*) ;;
+        *) die_usage "--until-commit must be a hexadecimal commit id: $value" ;;
+      esac
+      commit=$(printf '%s' "$value" | tr 'A-F' 'a-f')
+      until=-
+      ;;
+    *) die_usage "unknown snooze option: $option" ;;
+  esac
+  [ -f "$CONFIG" ] || { printf 'fm-tool-update-check: no watched tool registry at %s\n' "$CONFIG" >&2; return 1; }
+  record_read
+  SNOOZE_CAPTURE=1
+  run_sweep
+  snoozes_prune
+  while IFS= read -r entry; do
+    [ -n "$entry" ] || continue
+    IFS='|' read -r entry_name entry_key kind update_value <<EOF
+$entry
+EOF
+    [ "$entry_name" = "$name" ] || continue
+    if [ "$option" = '--until-commit' ]; then
+      [ "$kind" = git ] || continue
+      case "$update_value" in
+        "$commit"*) ;;
+        *) continue ;;
+      esac
+    fi
+    snooze_add "$entry_name" "$entry_key" "$until"
+    count=$((count + 1))
+  done <<EOF
+$CURRENT_UPDATE_ENTRIES
+EOF
+  if [ "$count" -eq 0 ]; then
+    if [ "$option" = '--until-commit' ]; then
+      printf 'fm-tool-update-check: no current git update for %s at commit %s\n' "$name" "$value" >&2
+    else
+      printf 'fm-tool-update-check: no current update for %s\n' "$name" >&2
+    fi
+    return 1
+  fi
+  record_write "$FINDINGS" "$RECORD_SNOOZES" || {
+    printf 'fm-tool-update-check: could not record the snooze\n' >&2
+    return 1
+  }
+  if [ "$option" = '--until-commit' ]; then
+    printf 'snoozed: %s until commit %s\n' "$name" "$value"
+  else
+    printf 'snoozed: %s until %s\n' "$name" "$value"
+  fi
   return 0
 }
 
@@ -891,6 +1133,7 @@ action_disarm() {
 
 case "${1:-check}" in
   check) action_check ;;
+  snooze) shift; action_snooze "$@" ;;
   arm) action_arm ;;
   disarm) action_disarm ;;
   -h|--help) usage ;;

--- a/bin/fm-tool-update-check.sh
+++ b/bin/fm-tool-update-check.sh
@@ -220,10 +220,20 @@ emit() {
 
 update_fingerprint() {
   local identity=$1
-  # cksum is the stable fallback across the supported hosts. Do not select a
-  # digest utility from PATH: a later run must derive the same key if PATH
-  # changes between the snooze and the check.
-  printf '%s' "$identity" | cksum | awk '{print $1 ":" $2}'
+  if [ -x /usr/bin/shasum ]; then
+    printf '%s' "$identity" | /usr/bin/shasum -a 256 | awk '{print $1}'
+  elif [ -x /usr/bin/sha256sum ]; then
+    printf '%s' "$identity" | /usr/bin/sha256sum | awk '{print $1}'
+  elif [ -x /bin/sha256sum ]; then
+    printf '%s' "$identity" | /bin/sha256sum | awk '{print $1}'
+  elif [ -x /usr/bin/openssl ]; then
+    printf '%s' "$identity" | /usr/bin/openssl dgst -sha256 -r | awk '{print $1}'
+  elif [ -x /bin/openssl ]; then
+    printf '%s' "$identity" | /bin/openssl dgst -sha256 -r | awk '{print $1}'
+  else
+    printf '%s\n' 'fm-tool-update-check: no SHA-256 implementation available' >&2
+    return 1
+  fi
 }
 
 current_update_add() {

--- a/bin/fm-tool-update-check.sh
+++ b/bin/fm-tool-update-check.sh
@@ -939,6 +939,10 @@ action_snooze() {
   record_read
   SNOOZE_CAPTURE=1
   run_sweep
+  if [ "$SWEEP_COMPLETE" -eq 0 ]; then
+    printf 'fm-tool-update-check: cannot record a snooze from an incomplete sweep\n' >&2
+    return 1
+  fi
   snoozes_prune
   while IFS= read -r entry; do
     [ -n "$entry" ] || continue

--- a/bin/fm-tool-update-check.sh
+++ b/bin/fm-tool-update-check.sh
@@ -529,6 +529,14 @@ command_findings() {
     fi
     # shellcheck disable=SC2086  # deliberate split on validated space-free tokens
     out=$(probe_output "$hit" $args_joined)
+    status=$?
+    if [ "$status" -eq 124 ]; then
+      if [ "$INCOMPLETE_REPORTED" -eq 0 ]; then
+        emit "check incomplete: the time budget ran out before $name"
+      fi
+      mark_incomplete
+      emit "$name check failed: $hit did not answer when asked for its version"
+    fi
     version=$(parse_version "$out")
     if [ -z "$resolved_path" ]; then
       resolved_path=$hit
@@ -624,6 +632,9 @@ git_probe() {
     return "$GIT_PROBE_NOT_ISSUED"
   fi
   fm_run_timed "$(probe_bound)" git -C "$repo" "$@"
+  local status=$?
+  [ "$status" -eq 124 ] && mark_incomplete
+  return "$status"
 }
 
 # The single place that reads a probe status as no answer at all, so every probe

--- a/bin/fm-tool-update-check.sh
+++ b/bin/fm-tool-update-check.sh
@@ -277,7 +277,10 @@ EOF
 
 emit_update() {
   local name=$1 kind=$2 value=$3 text=$4 key
-  key=$(update_fingerprint "$kind|$name|$value")
+  if ! key=$(update_fingerprint "$kind|$name|$value") || [ -z "$key" ]; then
+    emit "$name check failed: could not fingerprint update identity"
+    return 1
+  fi
   current_update_add "$name|$key|$kind|$value"
   if [ "$SNOOZE_CAPTURE" -eq 0 ] && snooze_key_active "$name" "$key"; then
     return 0

--- a/bin/fm-tool-update-check.sh
+++ b/bin/fm-tool-update-check.sh
@@ -220,13 +220,10 @@ emit() {
 
 update_fingerprint() {
   local identity=$1
-  if command -v shasum >/dev/null 2>&1; then
-    printf '%s' "$identity" | shasum -a 256 | awk '{print $1}'
-  elif command -v sha256sum >/dev/null 2>&1; then
-    printf '%s' "$identity" | sha256sum | awk '{print $1}'
-  else
-    printf '%s' "$identity" | cksum | awk '{print $1}'
-  fi
+  # cksum is the stable fallback across the supported hosts. Do not select a
+  # digest utility from PATH: a later run must derive the same key if PATH
+  # changes between the snooze and the check.
+  printf '%s' "$identity" | cksum | awk '{print $1 ":" $2}'
 }
 
 current_update_add() {
@@ -969,6 +966,12 @@ EOF
     fi
     return 1
   fi
+  # The first sweep is deliberately unfiltered so every current identity can
+  # be selected. Re-run after adding the snooze so the persisted report is the
+  # same filtered set that a subsequent check will compare.
+  SNOOZE_CAPTURE=0
+  run_sweep
+  snoozes_prune
   record_write "$FINDINGS" "$RECORD_SNOOZES" || {
     printf 'fm-tool-update-check: could not record the snooze\n' >&2
     return 1

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -522,6 +522,10 @@ Registering the check is itself a reason to watch, so the home keeps a watcher f
 `bin/fm-tool-update-check.sh disarm` removes the shim, its trust binding, and the report record.
 The check prints nothing when everything is current, and `state/.tool-updates` records the findings the last report was made from so the same pending update is reported once instead of on every poll.
 A changed or returning condition is reported again.
+Use `bin/fm-tool-update-check.sh snooze <tool> --until YYYY-MM-DD` to defer the currently reported update identities for that tool until the date.
+Use `bin/fm-tool-update-check.sh snooze <tool> --until-commit <commit>` for a git update when the deferral should last until that exact reported commit is no longer current.
+The record stores each snooze against the update identity it was taken against, so a later version or commit is reported immediately even when an earlier snooze date has not arrived.
+Snoozes are removed automatically when their exact update clears, and an expired date snooze is reported again.
 Adding, removing, or changing a watched tool is an edit to this file and needs no code change or re-arming.
 This file is not inherited by secondmate homes, so each home watches the tools it actually depends on.
 

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -122,7 +122,7 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-check-register.sh`   | Bind an intentional custom watcher check to its current bytes                       |
 | `fm-check-unregister.sh` | Retire a custom watcher check and its trust binding by validated task id            |
 | `fm-check-lib.sh`        | Validate custom-check registrations and prepare private execution snapshots          |
-| `fm-tool-update-check.sh` | Report watched tooling with an update available, and updates installed but left inert by PATH order |
+| `fm-tool-update-check.sh` | Report watched tooling updates, detect updates left inert by PATH order, and snooze current updates until a date or commit |
 | `fm-pr-lib.sh`           | Own canonical task and PR validation plus private atomic PR-poll publication, merge-notification identity, and retirement |
 | `fm-pr-poll.sh`          | Provide the byte-static watcher program for validated PR/MR-poll sidecars           |
 | `fm-pr-check.sh`         | Record validated `pr=` and `pr_head=` values, then atomically arm a static merge poll |

--- a/tests/fm-tool-update-check.test.sh
+++ b/tests/fm-tool-update-check.test.sh
@@ -684,6 +684,75 @@ test_findings_are_reported_once_until_they_change() {
   pass "the same pending update is reported once, and a change is reported again"
 }
 
+test_snooze_suppresses_only_the_current_command_update() {
+  local home stale fresh out path status
+  home=$(make_home snooze-command)
+  stale="$TMP_ROOT/snooze-command/old/bin"
+  fresh="$TMP_ROOT/snooze-command/new/bin"
+  make_copy "$stale" "$TOOL" 'herdr 0.8.0'
+  make_copy "$fresh" "$TOOL" 'herdr 0.8.2'
+  write_config "$home" "{\"tools\":[{\"name\":\"$TOOL\",\"command\":\"$TOOL\"}]}"
+  out="$home/out.txt"
+  path=$(fixture_path "$stale:$fresh")
+
+  run_check "$home" "$path" "$out"
+  assert_contains "$(cat "$out")" "0.8.2 is installed" "the command update was not reported before snoozing"
+  status=0
+  env FM_HOME="$home" PATH="$path" FM_CHECK_TIMEOUT=30 FM_TOOL_UPDATE_INTERVAL=0 \
+    "$CHECK" snooze "$TOOL" --until 2099-12-31 >"$out" 2>&1 || status=$?
+  expect_code 0 "$status" "command snooze exit"
+  assert_contains "$(cat "$home/state/.tool-updates")" "snooze=" "the command snooze was not recorded"
+
+  run_check "$home" "$path" "$out"
+  [ ! -s "$out" ] || fail "a snoozed command update was reported again: $(cat "$out")"
+
+  make_copy "$fresh" "$TOOL" 'herdr 0.9.0'
+  run_check "$home" "$path" "$out"
+  assert_contains "$(cat "$out")" "0.9.0 is installed" "a new command update was hidden by the earlier snooze"
+
+  make_copy "$stale" "$TOOL" 'herdr 0.9.0'
+  run_check "$home" "$path" "$out"
+  [ ! -s "$out" ] || fail "a landed command update still produced a report: $(cat "$out")"
+  assert_not_contains "$(cat "$home/state/.tool-updates")" "snooze=" "the landed command update left its snooze behind"
+  pass "a command snooze suppresses its exact update, reports a newer version, and clears when it lands"
+}
+
+test_snooze_commit_reports_a_new_remote_head() {
+  local home work advance out path status old_head new_head
+  home=$(make_home snooze-commit)
+  work=$(git_fixture snooze-commit-repo)
+  git -C "$work" reset -q --hard HEAD~2
+  old_head=$(git -C "$work" rev-parse origin/main)
+  write_config "$home" "{\"tools\":[{\"name\":\"firstmate\",\"git\":{\"repo\":\"$work\",\"branch\":\"main\"}}]}"
+  out="$home/out.txt"
+  path="$PATH"
+
+  run_check "$home" "$path" "$out"
+  assert_contains "$(cat "$out")" "2 commits behind" "the git update was not reported before snoozing"
+  status=0
+  env FM_HOME="$home" PATH="$path" FM_CHECK_TIMEOUT=30 FM_TOOL_UPDATE_INTERVAL=0 \
+    "$CHECK" snooze firstmate --until-commit "$old_head" >"$out" 2>&1 || status=$?
+  expect_code 0 "$status" "commit snooze exit"
+
+  run_check "$home" "$path" "$out"
+  [ ! -s "$out" ] || fail "the snoozed git update was reported again: $(cat "$out")"
+
+  advance="$TMP_ROOT/snooze-commit-advance"
+  git clone -q "$TMP_ROOT/snooze-commit-repo.git" "$advance"
+  printf 'four\n' > "$advance/f4"
+  git -C "$advance" add f4
+  git -C "$advance" commit -qm four
+  git -C "$advance" push -q origin main
+  new_head=$(git -C "$advance" rev-parse HEAD)
+  [ "$new_head" != "$old_head" ] || fail "the git fixture did not advance its remote head"
+
+  run_check "$home" "$path" "$out"
+  assert_contains "$(cat "$out")" "update available" "a new remote head was hidden by the old commit snooze"
+  assert_contains "$(cat "$out")" "$(printf 'at %.12s' "$new_head")" "the report did not identify the new remote head"
+  assert_not_contains "$(cat "$home/state/.tool-updates")" "snooze=" "the landed or superseded commit snooze was not cleared"
+  pass "a commit snooze suppresses one remote head and reports the next head"
+}
+
 test_an_overlong_report_says_it_was_cut() {
   local home out report i tools=
   # Many watched tools can outgrow one line. The report must say it was cut
@@ -1031,6 +1100,8 @@ test_a_stalled_repository_probe_is_not_reported_as_not_a_repository
 test_absent_registry_is_silent
 test_malformed_registry_is_reported_not_ignored
 test_findings_are_reported_once_until_they_change
+test_snooze_suppresses_only_the_current_command_update
+test_snooze_commit_reports_a_new_remote_head
 test_an_overlong_report_says_it_was_cut
 test_a_finding_past_the_cut_is_still_reported
 test_probes_are_skipped_between_intervals

--- a/tests/fm-tool-update-check.test.sh
+++ b/tests/fm-tool-update-check.test.sh
@@ -370,6 +370,23 @@ test_snooze_refuses_a_command_sweep_that_runs_out_of_budget() {
   pass "a command sweep that exhausts its budget cannot persist a snooze"
 }
 
+test_snooze_refuses_a_command_sweep_with_a_timed_out_probe() {
+  local home slow out status
+  home=$(make_home snooze-probe-timeout)
+  slow="$TMP_ROOT/snooze-probe-timeout/slow"
+  make_slow_copy "$slow" "$TOOL" 30
+  write_config "$home" "{\"tools\":[{\"name\":\"herdr\",\"command\":\"$TOOL\"}]}"
+  out="$home/out.txt"
+  status=0
+  env FM_HOME="$home" PATH="$(fixture_path "$slow")" FM_CHECK_TIMEOUT=30 FM_TOOL_UPDATE_INTERVAL=0 \
+    FM_TOOL_UPDATE_PROBE_SECS=1 FM_TOOL_UPDATE_BUDGET_SECS=10 \
+    "$CHECK" snooze herdr --until 2099-12-31 >"$out" 2>&1 || status=$?
+  expect_code 1 "$status" "timed-out command snooze exit"
+  assert_contains "$(cat "$out")" "cannot record a snooze from an incomplete sweep" "a timed-out command probe was accepted for snoozing"
+  [ ! -f "$home/state/.tool-updates" ] || fail "a timed-out command probe persisted a snooze record"
+  pass "a command sweep with a timed-out probe cannot persist a snooze"
+}
+
 test_an_announcement_probe_that_does_not_answer_is_reported() {
   local home dir out report
   # no-mistakes learns about a new release from the network, so the command that
@@ -1107,6 +1124,7 @@ test_one_broken_pattern_does_not_blind_the_rest_of_the_sweep
 test_an_unchecked_announcement_source_is_not_read_as_current
 test_an_announcement_probe_that_does_not_answer_is_reported
 test_snooze_refuses_a_command_sweep_that_runs_out_of_budget
+test_snooze_refuses_a_command_sweep_with_a_timed_out_probe
 test_quiet_tool_with_announce_pattern_is_silent
 test_commits_behind_origin_are_reported
 test_default_branch_is_detected_when_branch_is_omitted

--- a/tests/fm-tool-update-check.test.sh
+++ b/tests/fm-tool-update-check.test.sh
@@ -350,6 +350,26 @@ SH
   pass "an announcement source the budget could not reach is reported, not read as current"
 }
 
+test_snooze_refuses_a_command_sweep_that_runs_out_of_budget() {
+  local home slow fast fresh out status
+  home=$(make_home snooze-budget)
+  fast="$TMP_ROOT/snooze-budget/fast"
+  fresh="$TMP_ROOT/snooze-budget/fresh"
+  slow="$TMP_ROOT/snooze-budget/slow"
+  make_copy "$fast" "$TOOL" 'herdr 0.8.0'
+  make_copy "$fresh" "$TOOL" 'herdr 0.8.2'
+  make_slow_copy "$slow" "$TOOL" 30
+  write_config "$home" "{\"tools\":[{\"name\":\"herdr\",\"command\":\"$TOOL\"}]}"
+  out="$home/out.txt"
+  status=0
+  env FM_HOME="$home" PATH="$(fixture_path "$fast:$fresh:$slow")" FM_CHECK_TIMEOUT=30 FM_TOOL_UPDATE_INTERVAL=0 \
+    FM_TOOL_UPDATE_BUDGET_SECS=1 "$CHECK" snooze herdr --until 2099-12-31 >"$out" 2>&1 || status=$?
+  expect_code 1 "$status" "incomplete command snooze exit"
+  assert_contains "$(cat "$out")" "cannot record a snooze from an incomplete sweep" "an incomplete command sweep was accepted for snoozing"
+  [ ! -f "$home/state/.tool-updates" ] || fail "an incomplete command sweep persisted a snooze record"
+  pass "a command sweep that exhausts its budget cannot persist a snooze"
+}
+
 test_an_announcement_probe_that_does_not_answer_is_reported() {
   local home dir out report
   # no-mistakes learns about a new release from the network, so the command that
@@ -1086,6 +1106,7 @@ test_unusable_announce_pattern_is_reported_not_read_as_silence
 test_one_broken_pattern_does_not_blind_the_rest_of_the_sweep
 test_an_unchecked_announcement_source_is_not_read_as_current
 test_an_announcement_probe_that_does_not_answer_is_reported
+test_snooze_refuses_a_command_sweep_that_runs_out_of_budget
 test_quiet_tool_with_announce_pattern_is_silent
 test_commits_behind_origin_are_reported
 test_default_branch_is_detected_when_branch_is_omitted


### PR DESCRIPTION
## Intent

The captain, 2026-09-07: "zajmij sie prami w firstmate" and, of the fixes to firstmate itself, "popchnij wszystkie te tematy ile sie da". His bar for any of it: "firstmate ma byc zielony, z no-mistakes i 5/5 greptile review". This one is a defect that has been actively costing supervision attention. With a tool update deliberately deferred to a gate, the watched-tool check wakes the session on EVERY upstream advance, because each new commit changes the report record - the behind-count or the head - so the once-per-pending-update dedupe never holds. It fired six times in a few hours on 2026-09-06, and roughly eight more times today while a deferral was in force for a good reason. Every one of those costs a supervision turn and reports nothing new.

## What Changed

- Added identity-based snoozing for watched tool updates, including date- and commit-based deferrals.
- Ensured newer versions or remote commits are reported immediately, while cleared or expired snoozes are pruned.
- Documented the snooze commands and added coverage for command and Git update scenarios.

## Risk Assessment

✅ Low: The changed snooze implementation uses stable SHA-256 identities, rejects fingerprint failures before persistence, and preserves per-update deduplication without a substantiated remaining defect.

## Testing

Ran the focused fm-tool-update-check test file (not the complete repository suite); exact snoozes suppressed only their matching update, newer updates remained visible, landed updates cleared snoozes, and the armed check produced the expected watcher wake. No actionable failures or transient worktree artifacts remain.

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"40660c31bf3f4e795780c5599bddb2124a2ae62c","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed (2) ✅</summary>

- ⚠️ `bin/fm-tool-update-check.sh:270` - The snooze identity is reduced to a 32-bit `cksum` value, so two distinct update identities can collide and a snooze for one update can suppress another unrelated update. This violates the documented exact-identity behavior; use a collision-resistant stable digest or retain the canonical identity directly.

🔧 Fix: Use portable SHA-256 snooze fingerprints
1 warning still open:

- ⚠️ `bin/fm-tool-update-check.sh:280` - `update_fingerprint` returns failure when no hard-coded SHA-256 utility exists, but `emit_update` ignores that failure and continues with an empty key. On such a host, every update for a tool is recorded as `name||...`; snoozing one update then matches and suppresses every subsequent update for that tool. Handle fingerprint failure as a failed check/snooze operation instead of persisting an empty identity.

🔧 Fix: Reject failed update fingerprints before snoozing
✅ Re-checked - no issues remain.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `rtk ./tests/fm-tool-update-check.test.sh`
- `Behavioral snooze coverage for exact command updates and new remote Git heads`
- <code>Armed check wake delivery through `fm-watch-checkpoint.sh`</code>
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
