### PR TITLE
feat(skills): wire in the installed gnhf orchestrator for unattended runs

### DIFF
--- a/.agents/skills/gnhf/SKILL.md
+++ b/.agents/skills/gnhf/SKILL.md
@@ -1,0 +1,101 @@
+---
+name: gnhf
+description: >-
+  Agent-only procedure for wiring the installed gnhf orchestrator (ralph/autoresearch-style
+  bounded coding loop) into a firstmate ship task.
+  Use when the captain asks for an overnight, unattended, or "keep going until X" autonomous
+  loop on a project, names gnhf explicitly, or asks to check on or steer a running gnhf loop.
+  Owns how firstmate stays out of the loop itself, what the crewmate's brief must require,
+  agent-flag mapping to the crewmate's own harness, Companion vs Hands-Off mapping to firstmate
+  steering, sparse status reporting, the morning-review checklist, and safety rules.
+user-invocable: false
+metadata:
+  internal: true
+---
+
+# gnhf
+
+`gnhf` (npm package `gnhf`, installed at `$(npm root -g)/gnhf`) is an agent orchestrator: it
+repeatedly calls a coding agent against one objective, committing each successful small change
+and rolling back failures, until a stop condition or a runtime cap.
+Its own agent-facing contract lives at `$(npm root -g)/gnhf/skills/gnhf/SKILL.md`, and its CLI
+shape is authoritative from `gnhf --help`; read both before writing the brief below, and read
+them again if this file and the installed package appear to disagree - the installed package
+wins.
+
+## Firstmate never runs gnhf itself
+
+Hard rule 1 still applies: firstmate does not touch project state.
+`gnhf` runs only inside a crewmate's own isolated task worktree, driven by that crewmate, never
+by firstmate in a conversational turn.
+File the request as an ordinary ship task per AGENTS.md section 7 (resolve delivery mode and
+`yolo` posture at intake exactly as any other ship task) and write a brief per section 11 that
+tells the crewmate to invoke `gnhf` itself, on its own branch, as part of doing the work.
+The result reaches `main` through that task's ordinary selected delivery path (no-mistakes,
+direct-PR, or local-only) - gnhf is a tool the crewmate uses mid-task, not a second delivery
+mechanism.
+
+## What the brief must require
+
+- Run `gnhf` with `--current-branch` so every accepted iteration commits land directly on the
+  task's own `fm/<task-id>` branch, never on a separate `gnhf/...` branch the delivery path
+  would not see.
+- Never pass `--push`. The task's selected delivery mode owns every push; gnhf pushing on its
+  own would race or duplicate that path.
+- Never run `gnhf` outside the crewmate's assigned isolated worktree.
+- Pass `--agent <agent>` matching the harness this crewmate was itself spawned with, so the loop
+  reasons with the same model/tooling the captain already chose for this task.
+  Cross-reference the crewmate's harness against gnhf's supported `--agent` roster
+  (`gnhf --help`) before assuming a match; a harness gnhf does not support (or does not support
+  under the same name) is a blocker to report, not a substitution to make silently.
+- A concrete, observable objective and explicit non-goals (`--stop-when` and the prompt body,
+  per the package skill's prompt skeleton).
+- Verification the objective must satisfy: the project's own test and lint gate, run after each
+  meaningful slice, not a new bespoke check invented for the loop.
+- Mandatory runtime caps: `--max-iterations` and/or `--max-tokens` sized to the captain's ask
+  (an unbounded overnight run is never authorized).
+- A stop condition gnhf can observe directly (test suite green, a named script's exit code),
+  never a subjective one like "looks good".
+
+## Hands-Off vs Companion
+
+- **Hands-Off**: the crewmate launches one bounded `gnhf` run per the brief above, waits for it
+  to exit, then reports the final result per the task's normal done/failed reporting. No
+  intervention needed unless one of the package skill's own early-intervention triggers fires
+  (hard failure, runaway scope, destructive behavior, impossible prerequisite).
+- **Companion**: firstmate steers the crewmate between rounds through the ordinary steering
+  inbox (AGENTS.md section 7, `fm-send`), the same as any other live task - there is no separate
+  gnhf-specific channel. Between rounds, apply the package skill's Companion Review procedure
+  (inspect diff/commits, run independent verification, decide mergeable / needs follow-up / do
+  not merge) before authorizing the next bounded `gnhf` invocation or accepting the result as
+  done.
+
+## Status reporting
+
+Per the brief's ordinary sparse status contract: `working:` when the loop starts, one line per
+cap or stop-condition exit (which one, and the observed outcome), and `failed:`/`blocked:` on a
+real failure - never a line per iteration. The loop's own commit history is the source of truth
+for what happened each round; the status file only needs the phase changes a supervisor would
+act on.
+
+## Morning review
+
+When the captain returns asking how an overnight run went, do not answer from memory or relay
+the worker's self-report verbatim.
+Reconcile against the task's actual current state (`bin/fm-crew-state.sh`, the branch's commit
+log, and the task's status file) before reporting mode, branch, changes, verification result,
+stop-condition outcome, and recommended next action - the same reconstruction the package
+skill's own Morning Review section describes, run against firstmate's own state rather than a
+fresh `git log`/`pgrep` guess.
+The captain's own screenshot-verification rule for UI work still applies before anything is
+reported "done"; a passing gnhf stop condition is not a substitute for it.
+
+## Safety
+
+- Never on a project the captain has paused.
+- Never in the primary checkout - only inside the crewmate's assigned isolated worktree.
+- No `--push`; the delivery path owns every push.
+- Runtime caps (`--max-iterations` / `--max-tokens`) are mandatory, not optional, for an
+  unattended run.
+- Destructive git cleanup of a gnhf branch is never authorized; unlanded work rules (AGENTS.md
+  hard rule 3) apply exactly as they would to any other in-progress branch.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -565,6 +565,7 @@ These skills are not captain-invocable; load them only at their precise triggers
 - `fmx-respond` - load on an `x-mention <request_id>` `check:` wake to handle the mention, on an `x-mode-error ...` `check:` wake to report the Relay configuration blocker, on a `public-followup ...` `check:` wake or a startup-surfaced public commitment, and on any milestone or terminal wake for a Relay-linked task before posting its completion follow-up; relevant only when Relay is on.
 - `firstmate-codexapp` - load before coordinating a visible Codex Desktop thread, evaluating a Codex App backend request, or reconciling Codex Desktop host-tool smoke evidence for Firstmate work.
 - `firstmate-coding-guidelines` - load before changing firstmate's shared, tracked material, as defined by section 1's list, whether editing directly or briefing a crewmate for a firstmate-repo task.
+- `gnhf` - load before briefing a ship task that uses the installed `gnhf` orchestrator for an overnight, unattended, or "keep going until X" autonomous loop, when the captain names `gnhf` explicitly, or when checking on or steering a running gnhf loop.
 
 ## 14. Relay
 

--- a/docs/documentation-audiences.json
+++ b/docs/documentation-audiences.json
@@ -157,6 +157,10 @@
       "audience": "agent-runtime"
     },
     {
+      "path": ".agents/skills/gnhf/SKILL.md",
+      "audience": "agent-runtime"
+    },
+    {
       "path": ".agents/skills/harness-adapters/SKILL.md",
       "audience": "agent-runtime"
     },


### PR DESCRIPTION
## Problem

The captain installed `gnhf` (a ralph/autoresearch-style bounded coding-loop orchestrator) and asked firstmate to wire it in so unattended "keep working overnight" requests can be handled without breaking firstmate's own contract: firstmate never writes to a project itself, so a crewmate must run `gnhf` inside its own isolated task worktree, and the result must reach `main` through the project's ordinary delivery path.

## Change

- Add `.agents/skills/gnhf/SKILL.md` (internal agent-only reference), triggered when the captain asks for an overnight/unattended/"keep going until X" loop, names `gnhf` explicitly, or asks to check on or steer a running gnhf loop. It covers:
  - firstmate never runs `gnhf` itself; it files an ordinary ship task and briefs the crewmate to invoke `gnhf` inside its own worktree with `--current-branch` on the task's own `fm/<task-id>` branch, never `--push` (the task's selected delivery mode owns every push).
  - what the brief must require: matching `--agent` to the crewmate's own harness, a concrete objective/non-goals/`--stop-when`, the project's own test+lint gate as verification, and mandatory `--max-iterations`/`--max-tokens` caps.
  - Hands-Off vs Companion mapped onto firstmate's existing steering-inbox mechanics rather than inventing a new channel.
  - sparse status reporting, a morning-review checklist reconciled against firstmate's own live state, and safety rules (no push, never in the primary checkout, never on a paused project, no destructive branch cleanup).
- Add one `AGENTS.md` section 13 bullet naming the new skill and its exact trigger, matching the style of existing bullets.
- Register the new skill in `docs/documentation-audiences.json` (`agent-runtime` audience) so the documentation-audience check classifies it.

## Tests run

- `bin/fm-doc-audience-check.sh` — ok
- `bin/fm-test-run.sh tests/fm-documentation-audiences.test.sh tests/fm-harness-adapter-references.test.sh tests/fm-ensure-agents-md.test.sh` — all pass
- Confirmed `.claude/skills/gnhf/SKILL.md` resolves through the existing `.claude/skills -> ../.agents/skills` symlink.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
