### PR TITLE
fix(spawn): base a pooled worktree on the newer default-branch tip

### DIFF
--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -184,12 +184,23 @@
 #   naming the last path seen and why it was rejected.
 #   Only after this isolation check, every fresh ship or scout requires a clean
 #   task worktree. When an origin configuration is detected, spawn fetches it,
-#   resolves the current remote default branch, and resets to its tip. When none
-#   is detected, spawn skips that remote freshness check and launches from the
-#   clean worktree's current HEAD. Relaunch reuses the recorded worktree without
-#   fetching or resetting its base. An unreachable detected origin, unresolved
-#   default branch, or non-clean worktree refuses a fresh spawn rather than
-#   risking a PR based on stale history or discarding local work.
+#   resolves the current remote default branch, and then picks the base between
+#   `origin/<default>` and the SPAWNING PROJECT's own local `<default>` ref (the
+#   primary checkout's tip, resolved exactly as a secondmate sync resolves it):
+#   origin ahead of or equal to the local tip resets to origin, a local tip ahead
+#   of origin resets to the local tip and says so on stderr, and a genuine
+#   divergence refuses naming both commits rather than silently choosing the older
+#   one. That is what keeps a `local-only` project, whose landed work never leaves
+#   the primary checkout, from launching every task on origin's stale history.
+#   When no origin configuration is detected, spawn skips that freshness check and
+#   launches from the clean worktree's current HEAD. Relaunch reuses the recorded
+#   worktree without fetching or resetting its base. An unreachable detected
+#   origin, unresolved default branch, or non-clean worktree refuses a fresh spawn
+#   rather than risking a PR based on stale history or discarding local work; the
+#   single exception is an unreachable origin whose recorded remote-tracking ref
+#   the local tip strictly descends from, which launches from that local tip with
+#   a one-line notice instead. It is deliberately that narrow: with no tracking
+#   ref, an unpushed local-only project and a misconfigured origin look identical.
 #   A slot whose only deviation is a stale submodule gitlink is refused by that
 #   same clean check, but is reported as a stale checkout naming each submodule
 #   and both pins; nothing is converged or removed, and no remedy is suggested.
@@ -2389,8 +2400,63 @@ spawn_worktree_has_origin_config() {  # <worktree>
   return 1
 }
 
-freshen_spawn_worktree_base() {  # <worktree>
-  local worktree=$1 default target expected actual status
+# Resolve the commit a fresh pooled slot must start from, given the project's own
+# local default-branch tip and origin's. `origin/<default>` alone is wrong for any
+# project whose local default branch is the authoritative one - a `local-only`
+# project never pushes, so every unlanded slice lives only in the primary
+# checkout's `main` and a slot reset to `origin/<default>` silently starts on
+# history the captain already moved past. Reading the primary's default-branch
+# *ref* (bin/fm-ff-lib.sh's primary_head_commit, the same resolution every
+# secondmate sync follows) rather than its HEAD keeps a primary stranded on a
+# feature branch from propagating that branch into the pool.
+#
+# Echoes the chosen commit, or returns 1 after naming the refusal. The primary tip
+# has to be readable from the pool's own object store to be usable at all; when it
+# is not - a slot that is not a worktree of this project's repository - the origin
+# tip stays the only candidate, exactly as before.
+spawn_base_commit() {  # <worktree> <project> <default> <origin-tip>
+  local worktree=$1 project=$2 default=$3 origin_tip=$4 primary
+  primary=$(primary_head_commit "$project" 2>/dev/null) || primary=""
+  if [ -n "$primary" ]; then
+    git -C "$worktree" rev-parse --verify --quiet "$primary^{commit}" >/dev/null 2>&1 || primary=""
+  fi
+  if [ -z "$primary" ] || [ "$primary" = "$origin_tip" ]; then
+    printf '%s\n' "$origin_tip"
+    return 0
+  fi
+  if git -C "$worktree" merge-base --is-ancestor "$primary" "$origin_tip" 2>/dev/null; then
+    printf '%s\n' "$origin_tip"
+    return 0
+  fi
+  if git -C "$worktree" merge-base --is-ancestor "$origin_tip" "$primary" 2>/dev/null; then
+    echo "notice: the project's local '$default' ($primary) is ahead of 'origin/$default' ($origin_tip); launching pooled worktree '$worktree' from the local tip" >&2
+    printf '%s\n' "$primary"
+    return 0
+  fi
+  echo "error: the project's local '$default' ($primary) and 'origin/$default' ($origin_tip) have diverged for pooled worktree '$worktree'; refusing to launch rather than picking one of them" >&2
+  return 1
+}
+
+# The primary's local default-branch tip when it is provably newer than every
+# origin state this machine has ever seen, so an unreachable origin does not have
+# to refuse. It is deliberately narrow: a local remote-tracking ref must exist AND
+# the primary must be a strict descendant of it. With no tracking ref at all,
+# nothing here can tell an unpushed local-only project apart from a slot whose
+# origin is simply misconfigured, and the existing refusal stands. The tracking ref
+# is also only as current as the last successful fetch, so this proves the primary
+# is ahead of what was last seen, never that origin has not moved since.
+spawn_offline_primary_base() {  # <worktree> <project> <default>
+  local worktree=$1 project=$2 default=$3 primary seen
+  primary=$(primary_head_commit "$project" 2>/dev/null) || return 1
+  git -C "$worktree" rev-parse --verify --quiet "$primary^{commit}" >/dev/null 2>&1 || return 1
+  seen=$(git -C "$worktree" rev-parse --verify --quiet "refs/remotes/origin/$default^{commit}" 2>/dev/null) || return 1
+  [ "$seen" != "$primary" ] || return 1
+  git -C "$worktree" merge-base --is-ancestor "$seen" "$primary" 2>/dev/null || return 1
+  printf '%s\n' "$primary"
+}
+
+freshen_spawn_worktree_base() {  # <worktree> <project>
+  local worktree=$1 project=$2 default target expected actual status offline
   status=$(git -C "$worktree" -c core.quotePath=false status --porcelain) || {
     echo "error: could not inspect pooled worktree '$worktree' before refreshing its base" >&2
     return 1
@@ -2407,33 +2473,41 @@ freshen_spawn_worktree_base() {  # <worktree>
     return 0
   fi
   if ! git -C "$worktree" fetch --quiet origin; then
-    echo "error: could not fetch origin for pooled worktree '$worktree'; refusing to launch from a potentially stale base" >&2
-    return 1
+    default=$(default_branch "$worktree" 2>/dev/null || true)
+    if [ -n "$default" ] && offline=$(spawn_offline_primary_base "$worktree" "$project" "$default"); then
+      echo "notice: could not fetch origin for pooled worktree '$worktree'; launching from the project's local '$default' ($offline), which is ahead of the last origin state this checkout saw" >&2
+      expected=$offline
+    else
+      echo "error: could not fetch origin for pooled worktree '$worktree'; refusing to launch from a potentially stale base" >&2
+      return 1
+    fi
+  else
+    if ! git -C "$worktree" remote set-head origin --auto >/dev/null 2>&1; then
+      echo "error: could not resolve origin's current default branch for pooled worktree '$worktree'; refusing to launch from a potentially stale base" >&2
+      return 1
+    fi
+    default=$(default_branch "$worktree") || {
+      echo "error: could not determine origin's default branch for pooled worktree '$worktree'; refusing to launch from a potentially stale base" >&2
+      return 1
+    }
+    target="origin/$default"
+    if ! git -C "$worktree" fetch --quiet origin "+refs/heads/$default:refs/remotes/origin/$default"; then
+      echo "error: could not fetch '$target' for pooled worktree '$worktree'; refusing to launch from a potentially stale base" >&2
+      return 1
+    fi
+    expected=$(git -C "$worktree" rev-parse --verify --quiet "$target^{commit}" 2>/dev/null) || {
+      echo "error: '$target' is not a commit for pooled worktree '$worktree'; refusing to launch from a potentially stale base" >&2
+      return 1
+    }
+    expected=$(spawn_base_commit "$worktree" "$project" "$default" "$expected") || return 1
   fi
-  if ! git -C "$worktree" remote set-head origin --auto >/dev/null 2>&1; then
-    echo "error: could not resolve origin's current default branch for pooled worktree '$worktree'; refusing to launch from a potentially stale base" >&2
-    return 1
-  fi
-  default=$(default_branch "$worktree") || {
-    echo "error: could not determine origin's default branch for pooled worktree '$worktree'; refusing to launch from a potentially stale base" >&2
-    return 1
-  }
-  target="origin/$default"
-  if ! git -C "$worktree" fetch --quiet origin "+refs/heads/$default:refs/remotes/origin/$default"; then
-    echo "error: could not fetch '$target' for pooled worktree '$worktree'; refusing to launch from a potentially stale base" >&2
-    return 1
-  fi
-  expected=$(git -C "$worktree" rev-parse --verify --quiet "$target^{commit}" 2>/dev/null) || {
-    echo "error: '$target' is not a commit for pooled worktree '$worktree'; refusing to launch from a potentially stale base" >&2
-    return 1
-  }
-  if ! git -C "$worktree" reset --hard "$target" >/dev/null; then
-    echo "error: could not reset pooled worktree '$worktree' to '$target'; refusing to launch from a potentially stale base" >&2
+  if ! git -C "$worktree" reset --hard "$expected" >/dev/null; then
+    echo "error: could not reset pooled worktree '$worktree' to '$expected'; refusing to launch from a potentially stale base" >&2
     return 1
   fi
   actual=$(git -C "$worktree" rev-parse --verify --quiet HEAD 2>/dev/null || true)
   if [ "$actual" != "$expected" ]; then
-    echo "error: pooled worktree '$worktree' is at '${actual:-unknown}', not current '$target' ('$expected'); refusing to launch" >&2
+    echo "error: pooled worktree '$worktree' is at '${actual:-unknown}', not the resolved base '$expected' for '$default'; refusing to launch" >&2
     return 1
   fi
 }
@@ -3065,7 +3139,7 @@ elif [ "$KIND" != secondmate ] && [ "$BACKEND" != orca ]; then
   validate_spawn_worktree "treehouse get" "$T"
 fi
 if [ "$RELAUNCH" -eq 0 ] && [ "$KIND" != secondmate ]; then
-  freshen_spawn_worktree_base "$WT" || exit 1
+  freshen_spawn_worktree_base "$WT" "$PROJ_ABS" || exit 1
 fi
 
 # Pre-register Claude's workspace trust for the worktree, at the first point the

--- a/tests/fm-spawn-pool-base-freshen.test.sh
+++ b/tests/fm-spawn-pool-base-freshen.test.sh
@@ -1,11 +1,12 @@
 #!/usr/bin/env bash
 # Regression tests for fm-spawn's pooled-worktree base refresh.
 #
-# A treehouse pool can return a clean detached worktree whose origin/main was
-# advanced after the worktree was allocated.
-# These tests drive the real spawn path with a fake terminal, then prove it
-# starts the worker from the fetched origin tip, launches a clean origin-less
-# pool as-is, or stops when a configured origin is unusable.
+# A treehouse pool can return a clean detached worktree whose default branch moved
+# after the worktree was allocated - on origin, in the primary checkout, or both.
+# These tests drive the real spawn path with a fake terminal, then prove it starts
+# the worker from whichever of origin's tip and the project's own local
+# default-branch tip is the newer, refuses when the two have diverged, launches a
+# clean origin-less pool as-is, or stops when a configured origin is unusable.
 set -u
 
 # shellcheck source=tests/fixtures.sh
@@ -213,6 +214,169 @@ test_non_main_default_branch_refreshes_before_branching() {
   [ "$branch_head" = "$current" ] || fail "spawn did not refresh to current origin/$DEFAULT_BRANCH"
   [ "$branch_head" != "$INITIAL_SHA" ] || fail "fixture did not prove origin/$DEFAULT_BRANCH advanced past the pool base"
   pass "a stale pooled worktree resolves and refreshes a non-main default branch"
+}
+
+# The base a fresh slot starts from is a choice between two commits, not one: the
+# project's own local default-branch tip and origin's. A `local-only` project never
+# pushes, so its landed work exists only in the primary checkout and `origin/main`
+# is the older of the two. These cases drive all three relations through the real
+# spawn path.
+make_local_base_case() {  # <name> <id> <shape: origin-ahead|local-ahead|diverged>
+  local name=$1 id=$2 shape=$3 case_dir home project origin pool publisher fakebin initial local_tip origin_tip
+  case_dir="$TMP_ROOT/$name"
+  home="$case_dir/home"
+  project="$case_dir/project"
+  origin="$case_dir/origin.git"
+  pool="$case_dir/pool"
+  publisher="$case_dir/publisher"
+  fakebin=$(make_spawn_fakebin "$case_dir/fake")
+
+  mkdir -p "$home/data/$id" "$home/projects" "$home/state" "$home/config"
+  printf 'codex\n' > "$home/config/crew-harness"
+  fm_test_spawn_brief "$home" "$id"
+  touch "$home/state/.last-watcher-beat"
+
+  git init --quiet -b main "$project"
+  printf 'base\n' > "$project/README.md"
+  git -C "$project" add README.md
+  git -C "$project" -c user.name='Firstmate Tests' -c user.email='tests@example.invalid' commit -qm initial
+  git clone --quiet --bare "$project" "$origin"
+  git -C "$project" remote add origin "file://$origin"
+  initial=$(git -C "$project" rev-parse HEAD)
+  git -C "$project" worktree add --quiet --detach "$pool" "$initial"
+
+  case "$shape" in
+    origin-ahead|diverged)
+      git clone --quiet "file://$origin" "$publisher"
+      printf 'pushed to origin\n' > "$publisher/origin-side.txt"
+      git -C "$publisher" add origin-side.txt
+      git -C "$publisher" -c user.name='Firstmate Tests' -c user.email='tests@example.invalid' commit -qm advance-origin
+      git -C "$publisher" push --quiet origin main
+      ;;
+  esac
+  case "$shape" in
+    local-ahead|diverged)
+      # Landed in the primary checkout and never pushed: exactly the state a
+      # local-only project is in for every task after the first.
+      printf 'landed locally, never pushed\n' > "$project/local-landed.txt"
+      git -C "$project" add local-landed.txt
+      git -C "$project" -c user.name='Firstmate Tests' -c user.email='tests@example.invalid' commit -qm advance-local
+      ;;
+  esac
+
+  local_tip=$(git -C "$project" rev-parse refs/heads/main)
+  origin_tip=$(git --git-dir="$origin" rev-parse refs/heads/main)
+  printf '%s\n' "$case_dir|$home|$project|$pool|$fakebin|$initial|$local_tip|$origin_tip"
+}
+
+read_local_base_case() {
+  IFS='|' read -r CASE_DIR HOME_DIR PROJECT_DIR POOL_DIR FAKEBIN_DIR INITIAL_SHA LOCAL_TIP ORIGIN_TIP <<EOF
+$1
+EOF
+}
+
+test_origin_ahead_of_local_default_uses_origin_tip() {
+  local rec id out status head
+  id='pool-origin-ahead-r14'
+  rec=$(make_local_base_case origin-ahead "$id" origin-ahead)
+  read_local_base_case "$rec"
+  [ "$LOCAL_TIP" = "$INITIAL_SHA" ] || fail "fixture moved the local default branch in the origin-ahead shape"
+  [ "$ORIGIN_TIP" != "$LOCAL_TIP" ] || fail "fixture did not advance origin past the local default branch"
+
+  out=$(run_spawn "$id" --mode no-mistakes --yolo off)
+  status=$?
+  expect_code 0 "$status" "spawn should launch when origin is ahead of the local default branch"$'\n'"$out"
+  head=$(git -C "$POOL_DIR" rev-parse HEAD)
+  [ "$head" = "$ORIGIN_TIP" ] || fail "spawn did not start from origin's tip when origin was ahead"
+  assert_not_contains "$out" "is ahead of 'origin/main'" \
+    "spawn claimed the local default branch was ahead when origin was ahead"
+  assert_not_contains "$out" "have diverged" \
+    "spawn reported a divergence between an ancestor and its descendant"
+  if [ "${FM_TEST_EVIDENCE:-0}" = 1 ]; then
+    printf '# origin-ahead: HEAD=%s origin=%s local=%s\n' "$head" "$ORIGIN_TIP" "$LOCAL_TIP"
+  fi
+  pass "an origin ahead of the project's local default branch still wins the base"
+}
+
+test_local_default_ahead_of_origin_launches_from_local_tip() {
+  local rec id out status head project_head
+  id='pool-local-ahead-r14'
+  rec=$(make_local_base_case local-ahead "$id" local-ahead)
+  read_local_base_case "$rec"
+  [ "$ORIGIN_TIP" = "$INITIAL_SHA" ] || fail "fixture advanced origin in the local-ahead shape"
+  [ "$LOCAL_TIP" != "$ORIGIN_TIP" ] || fail "fixture did not advance the local default branch past origin"
+  project_head=$(git -C "$PROJECT_DIR" rev-parse HEAD)
+
+  out=$(run_spawn "$id" --mode no-mistakes --yolo off)
+  status=$?
+  expect_code 0 "$status" "spawn should launch a project whose local default branch is ahead of origin"$'\n'"$out"
+  assert_contains "$out" "spawned $id" "spawn did not report success from the local tip"
+  head=$(git -C "$POOL_DIR" rev-parse HEAD)
+  [ "$head" = "$LOCAL_TIP" ] || fail "spawn did not start from the project's local default-branch tip"
+  [ "$head" != "$ORIGIN_TIP" ] || fail "spawn started from origin's older tip"
+  assert_grep 'landed locally, never pushed' "$POOL_DIR/local-landed.txt" \
+    "the launched worktree is missing work that only exists in the primary checkout"
+  assert_contains "$out" "is ahead of 'origin/main'" \
+    "spawn did not say it launched from the local tip instead of origin"
+  [ "$(git -C "$PROJECT_DIR" rev-parse HEAD)" = "$project_head" ] \
+    || fail "spawn moved the spawning project's own checkout"
+  if [ "${FM_TEST_EVIDENCE:-0}" = 1 ]; then
+    printf '# local-ahead: HEAD=%s local=%s origin=%s\n' "$head" "$LOCAL_TIP" "$ORIGIN_TIP"
+    printf '# notice: %s\n' "$(printf '%s\n' "$out" | grep 'is ahead of' | head -n 1)"
+  fi
+  pass "a local default branch ahead of origin becomes the pooled worktree's base"
+}
+
+test_diverged_local_and_origin_refuse_pool() {
+  local rec id out status before
+  id='pool-diverged-r14'
+  rec=$(make_local_base_case diverged "$id" diverged)
+  read_local_base_case "$rec"
+  [ "$LOCAL_TIP" != "$ORIGIN_TIP" ] || fail "fixture did not produce two different tips"
+  git -C "$PROJECT_DIR" merge-base --is-ancestor "$LOCAL_TIP" "$ORIGIN_TIP" 2>/dev/null \
+    && fail "fixture left the local tip an ancestor of origin instead of diverged"
+  before=$(git -C "$POOL_DIR" rev-parse HEAD)
+
+  out=$(run_spawn "$id" --mode no-mistakes --yolo off)
+  status=$?
+  [ "$status" -ne 0 ] || fail "spawn launched from one side of a diverged default branch"
+  assert_contains "$out" "have diverged" "spawn did not name the divergence as the cause"
+  assert_contains "$out" "$LOCAL_TIP" "the refusal did not name the local default-branch commit"
+  assert_contains "$out" "$ORIGIN_TIP" "the refusal did not name origin's commit"
+  [ "$(git -C "$POOL_DIR" rev-parse HEAD)" = "$before" ] \
+    || fail "spawn moved the pooled worktree while refusing a diverged base"
+  [ ! -e "$HOME_DIR/state/$id.meta" ] || fail "refused spawn published task metadata"
+  if [ "${FM_TEST_EVIDENCE:-0}" = 1 ]; then
+    printf '# diverged refusal: %s\n' "$(printf '%s\n' "$out" | grep 'have diverged' | head -n 1)"
+  fi
+  pass "a diverged local default branch and origin refuse the pooled worktree naming both commits"
+}
+
+test_unreachable_origin_launches_from_a_provably_newer_local_tip() {
+  local rec id out status head
+  id='pool-offline-local-ahead-r14'
+  rec=$(make_local_base_case offline-local-ahead "$id" local-ahead)
+  read_local_base_case "$rec"
+  # One successful fetch is what records origin/main; only against that recorded
+  # state can the local tip be proven strictly newer while origin is unreachable.
+  git -C "$POOL_DIR" fetch --quiet origin
+  [ "$(git -C "$POOL_DIR" rev-parse refs/remotes/origin/main)" = "$ORIGIN_TIP" ] \
+    || fail "fixture did not record origin's state before origin became unreachable"
+  git -C "$POOL_DIR" remote set-url origin "file://$CASE_DIR/missing-origin.git"
+
+  out=$(run_spawn "$id" --mode no-mistakes --yolo off)
+  status=$?
+  expect_code 0 "$status" "an unreachable origin should not block a provably newer local tip"$'\n'"$out"
+  head=$(git -C "$POOL_DIR" rev-parse HEAD)
+  [ "$head" = "$LOCAL_TIP" ] || fail "spawn did not launch from the project's local default-branch tip"
+  assert_contains "$out" "which is ahead of the last origin state this checkout saw" \
+    "spawn did not report why it launched without reaching origin"
+  assert_not_contains "$out" "refusing to launch from a potentially stale base" \
+    "spawn refused despite holding a provably newer local tip"
+  if [ "${FM_TEST_EVIDENCE:-0}" = 1 ]; then
+    printf '# offline notice: %s\n' "$(printf '%s\n' "$out" | grep 'could not fetch origin' | head -n 1)"
+  fi
+  pass "an unreachable origin launches from a local tip that provably descends the last origin state seen"
 }
 
 make_originless_case() {  # <name> <id>
@@ -680,6 +844,10 @@ test_remote_seeded_home_spawns_from_treehouse_pool
 test_linked_spawning_home_rejects_primary_before_refresh
 test_stale_pool_base_refreshes_before_branching
 test_non_main_default_branch_refreshes_before_branching
+test_origin_ahead_of_local_default_uses_origin_tip
+test_local_default_ahead_of_origin_launches_from_local_tip
+test_diverged_local_and_origin_refuse_pool
+test_unreachable_origin_launches_from_a_provably_newer_local_tip
 test_direct_pr_and_scout_refresh_before_launch
 test_dirty_pool_refuses_without_discarding_work
 test_unresolved_remote_default_refuses_pool


### PR DESCRIPTION
## Problem

`bin/fm-spawn.sh`'s `freshen_spawn_worktree_base()` reset every fresh ship or scout worktree to `origin/<default>`.

That is the wrong base for any project whose local default branch is the authoritative one. A `local-only` project never pushes, so every landed slice lives only in the primary checkout's `main` and `origin/main` is the older of the two commits. Seen in the field on 2026-09-06: the project's local `main` was 7 (later 20+) commits ahead of `origin/main`, so the scout and every subsequent ship task launched on history the captain had already moved past - each one missing the previously landed slices - and every worker had to be steered back by hand with `git reset --hard main`.

## Change

`freshen_spawn_worktree_base` now resolves the base as a choice between two commits instead of one: `origin/<default>` and the **spawning project's own local `<default>` ref**, read through `bin/fm-ff-lib.sh`'s `primary_head_commit` - the same resolution every secondmate sync already uses, so a primary stranded on a feature branch still yields the true default-branch tip.

- **origin ahead of or equal to the local tip** - unchanged: reset to `origin/<default>`.
- **local tip ahead of origin** - reset to the local tip, with a one-line stderr notice naming both commits.
- **diverged** - refuse, naming both commits, rather than silently taking the older one.

An unreachable origin still refuses, with one narrow exception: when the local tip strictly descends from the `refs/remotes/origin/<default>` this checkout last recorded, the spawn launches from that local tip and says so. The exception requires the tracking ref to exist, because with no tracking ref an unpushed local-only project and a misconfigured origin are indistinguishable.

Unchanged: the dirty-worktree refusal, the stale-submodule-pin diagnosis, the unresolved-remote-default refusal, the origin-less launch-as-is path, relaunch (which never refreshes), and all teardown/merge behaviour - `bin/fm-merge-local.sh` already fast-forwards the primary.

The `fm-spawn.sh` header paragraph that owns this contract is updated. `docs/configuration.md` does not describe the base freshen (`docs/architecture.md` already points at the script header as its owner), so no doc surface moved.

## Tests

`tests/fm-spawn-pool-base-freshen.test.sh` gains four cases driving the real spawn path against a fake terminal:

- `test_origin_ahead_of_local_default_uses_origin_tip` - preserved behaviour.
- `test_local_default_ahead_of_origin_launches_from_local_tip` - asserts the pooled worktree carries the never-pushed commit and that the spawning project's own checkout is untouched.
- `test_diverged_local_and_origin_refuse_pool` - asserts the refusal names both commits, leaves HEAD where it was, and publishes no task metadata.
- `test_unreachable_origin_launches_from_a_provably_newer_local_tip` - the narrow offline exception.

Non-vacuity was checked: the three new behavioural cases each fail against the pre-change `bin/fm-spawn.sh` and pass after it. The origin-ahead case passes both ways by design - it is the regression guard for the preserved path.

Run on this host:

- `bash tests/fm-spawn-pool-base-freshen.test.sh` - 26 passing assertions, up from 22 before this change.
- `bin/fm-lint.sh` (ShellCheck 0.11.0, actionlint 1.7.12) - exit 0.
- `bin/fm-doc-audience-check.sh` - `ok surfaces=97 local_links=348`.
- `bin/fm-test-run.sh --changed` - 52 scripts, 7 failing. All 7 fail identically at the pre-change baseline commit 5592cb6 in a clean clone on the same host, so none is caused by this change: `fm-test-run` (no ruby), `fm-calm-pi-extension` (no Chrome/Chromium), `fm-backend-tmux-smoke` / `fm-tmux-agent-liveness` / `fm-control-relaunch` (tmux task shell never becomes ready under WSL2), `fm-captain-hold-lifecycle`, and `fm-bearings-board`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
