### PR TITLE
fix(bin): recover interrupted remote-job quarantine publication

### DIFF
--- a/bin/fm-remote-job-worker.sh
+++ b/bin/fm-remote-job-worker.sh
@@ -225,7 +225,7 @@ worker_recover_quarantine() { # <account-home>
 # the established acquisition path below.
 worker_staged_quarantine_inventory() {
   local LC_ALL=C
-  local entry base staged_count=0 owner_fields=0 unsafe=0 status
+  local entry base staged_count=0 owner_fields=0 official=0 unsafe=0 status
   WORKER_STAGED_QUARANTINE=
   WORKER_STAGED_OWNER_FIELDS=0
   for entry in "$WORKER_LOCK"/* "$WORKER_LOCK"/.[!.]* "$WORKER_LOCK"/..?*; do
@@ -235,7 +235,7 @@ worker_staged_quarantine_inventory() {
       pid) owner_fields=$((owner_fields | 1)) ;;
       start) owner_fields=$((owner_fields | 2)) ;;
       command) owner_fields=$((owner_fields | 4)) ;;
-      quarantine) unsafe=1 ;;
+      quarantine) official=1 ;;
       .quarantine.[A-Za-z0-9][A-Za-z0-9][A-Za-z0-9][A-Za-z0-9][A-Za-z0-9][A-Za-z0-9])
         staged_count=$((staged_count + 1))
         WORKER_STAGED_QUARANTINE=$entry
@@ -244,8 +244,8 @@ worker_staged_quarantine_inventory() {
     esac
   done
   if [ "$staged_count" -eq 0 ]; then
-    status=1
-  elif [ "$staged_count" -ne 1 ] || [ "$unsafe" -ne 0 ]; then
+    if [ "$unsafe" -eq 0 ]; then status=1; else status=2; fi
+  elif [ "$staged_count" -ne 1 ] || [ "$official" -ne 0 ] || [ "$unsafe" -ne 0 ]; then
     status=2
   else
     case "$owner_fields" in 0|7) status=0 ;; *) status=2 ;; esac

--- a/bin/fm-remote-job-worker.sh
+++ b/bin/fm-remote-job-worker.sh
@@ -82,11 +82,20 @@ WORKER_QUARANTINE_SENTINEL='active execution could not be confirmed stopped'
 worker_error() { printf 'remote-job-worker: %s\n' "$1" >&2; }
 
 worker_path_stat() { # <path>; uid mode device inode
+  local value uid mode device inode extra
   if [ "$(uname -s 2>/dev/null || true)" = Darwin ]; then
-    stat -f '%u %Lp %d %i' "$1" 2>/dev/null
+    value=$(stat -f '%u %OMp%OLp %d %i' "$1" 2>/dev/null) || return 1
   else
-    stat -c '%u %a %d %i' -- "$1" 2>/dev/null
+    value=$(stat -c '%u %a %d %i' -- "$1" 2>/dev/null) || return 1
   fi
+  read -r uid mode device inode extra <<< "$value"
+  case "$uid:$device:$inode" in *[!0-9:]*) return 1 ;; esac
+  case "$mode" in ''|*[!0-7]*) return 1 ;; esac
+  [ -n "$uid" ] && [ -n "$device" ] && [ -n "$inode" ] || return 1
+  [ -z "${extra:-}" ] || return 1
+  while [ "${mode#0}" != "$mode" ]; do mode=${mode#0}; done
+  [ -n "$mode" ] || mode=0
+  printf '%s %s %s %s\n' "$uid" "$mode" "$device" "$inode"
 }
 
 worker_owned_mode_stat() { # <path> file|dir <mode> <uid>
@@ -318,6 +327,7 @@ worker_promote_staged_quarantine() { # <account-home>
   mv -n -- "$staged" "$WORKER_LOCK/quarantine" || return 2
   [ ! -e "$staged" ] && [ ! -L "$staged" ] || return 2
   [ "$(worker_owned_mode_stat "$WORKER_LOCK/quarantine" file 600 "$uid" 2>/dev/null || true)" = "$staged_stat" ] || return 2
+  cmp -s "$WORKER_LOCK/quarantine" <(printf '%s\n' "$WORKER_QUARANTINE_SENTINEL") || return 2
 }
 
 worker_acquire_lock() {

--- a/bin/fm-remote-job-worker.sh
+++ b/bin/fm-remote-job-worker.sh
@@ -34,8 +34,15 @@
 # between immediate failures up to
 # FM_REMOTE_JOB_SUPERVISOR_MAX_BACKOFF_SECONDS and gives up after
 # FM_REMOTE_JOB_SUPERVISOR_MAX_RESTARTS failed children in total, since a
-# restart loop only burns CPU and grows its log without bound. A child that
-# stays up for FM_REMOTE_JOB_SUPERVISOR_HEALTHY_SECONDS clears the
+# restart loop only burns CPU and grows its log without bound. Interrupted
+# quarantine publication is recovered only when the lock contains one exact,
+# completed publisher staging file plus either no owner records or one complete
+# owner identity. The worker verifies account ownership, restrictive modes,
+# nonsymlink object identity, exact sentinel bytes, legacy and current worker
+# liveness, and the existing running-job quarantine checks before reclaiming;
+# every ambiguous or additional entry remains untouched.
+#
+# A child that stays up for FM_REMOTE_JOB_SUPERVISOR_HEALTHY_SECONDS clears the
 # consecutive-failure backoff, but not that total restart guard, so a child
 # that dies just past the healthy threshold cannot restart without bound
 # either. fm-on's ensure path restarts a worker that gave up.
@@ -68,8 +75,53 @@ WORKER_LANE_HOMES=()
 WORKER_LANE_PIDS=()
 WORKER_LANE_STARTS=()
 WORKER_LANE_JOBS=()
+WORKER_STAGED_QUARANTINE=
+WORKER_STAGED_OWNER_FIELDS=0
+WORKER_QUARANTINE_SENTINEL='active execution could not be confirmed stopped'
 
 worker_error() { printf 'remote-job-worker: %s\n' "$1" >&2; }
+
+worker_path_stat() { # <path>; uid mode device inode
+  if [ "$(uname -s 2>/dev/null || true)" = Darwin ]; then
+    stat -f '%u %Lp %d %i' "$1" 2>/dev/null
+  else
+    stat -c '%u %a %d %i' -- "$1" 2>/dev/null
+  fi
+}
+
+worker_owned_mode_stat() { # <path> file|dir <mode> <uid>
+  local path=$1 kind=$2 expected_mode=$3 expected_uid=$4 value uid mode device inode extra
+  case "$kind" in
+    file) [ -f "$path" ] && [ ! -L "$path" ] || return 1 ;;
+    dir) [ -d "$path" ] && [ ! -L "$path" ] || return 1 ;;
+    *) return 1 ;;
+  esac
+  value=$(worker_path_stat "$path") || return 1
+  read -r uid mode device inode extra <<< "$value"
+  case "$uid:$mode:$device:$inode" in *[!0-9:]*) return 1 ;; esac
+  [ -n "$uid" ] && [ -n "$mode" ] && [ -n "$device" ] && [ -n "$inode" ] || return 1
+  [ -z "${extra:-}" ] || return 1
+  [ "$uid" = "$expected_uid" ] && [ "$mode" = "$expected_mode" ] || return 1
+  printf '%s\n' "$value"
+}
+
+worker_path_object_identity() { # <path>; account uid, device, and inode
+  local value uid mode device inode extra
+  value=$(worker_path_stat "$1") || return 1
+  read -r uid mode device inode extra <<< "$value"
+  case "$uid:$mode:$device:$inode" in *[!0-9:]*) return 1 ;; esac
+  [ -n "$uid" ] && [ -n "$mode" ] && [ -n "$device" ] && [ -n "$inode" ] || return 1
+  [ -z "${extra:-}" ] || return 1
+  printf '%s %s %s\n' "$uid" "$device" "$inode"
+}
+
+worker_remove_publisher_temp() { # <path> <object-identity>
+  local path=$1 expected=$2 actual
+  [ -f "$path" ] && [ ! -L "$path" ] || return 1
+  actual=$(worker_path_object_identity "$path") || return 1
+  [ "$actual" = "$expected" ] || return 1
+  rm -f -- "$path"
+}
 
 worker_account_home() {
   local home=${HOME:-}
@@ -157,8 +209,118 @@ worker_recover_quarantine() { # <account-home>
   rm -f -- "$WORKER_LOCK/quarantine"
 }
 
+# Return 0 for one exact staging candidate, 1 when none exists, and 2 for an
+# unsafe or conflicting shape. Ordinary locks with no staging candidate retain
+# the established acquisition path below.
+worker_staged_quarantine_inventory() {
+  local entry base staged_count=0 owner_fields=0 unsafe=0
+  WORKER_STAGED_QUARANTINE=
+  WORKER_STAGED_OWNER_FIELDS=0
+  for entry in "$WORKER_LOCK"/* "$WORKER_LOCK"/.[!.]* "$WORKER_LOCK"/..?*; do
+    [ -e "$entry" ] || [ -L "$entry" ] || continue
+    base=${entry##*/}
+    case "$base" in
+      pid) owner_fields=$((owner_fields | 1)) ;;
+      start) owner_fields=$((owner_fields | 2)) ;;
+      command) owner_fields=$((owner_fields | 4)) ;;
+      quarantine) unsafe=1 ;;
+      .quarantine.[A-Za-z0-9][A-Za-z0-9][A-Za-z0-9][A-Za-z0-9][A-Za-z0-9][A-Za-z0-9])
+        staged_count=$((staged_count + 1))
+        WORKER_STAGED_QUARANTINE=$entry
+        ;;
+      *) unsafe=1 ;;
+    esac
+  done
+  [ "$staged_count" -gt 0 ] || return 1
+  [ "$staged_count" -eq 1 ] && [ "$unsafe" -eq 0 ] || return 2
+  case "$owner_fields" in 0|7) ;; *) return 2 ;; esac
+  WORKER_STAGED_OWNER_FIELDS=$owner_fields
+}
+
+# Return 0 for the exact live owner, 1 for a definitively stale or reused pid,
+# and 2 when the complete modern identity cannot be interpreted safely.
+worker_staged_lock_owner_status() { # <account-home> <uid>
+  local account_home=$1 uid=$2 pid recorded_start actual_start recorded_command actual_command
+  worker_owned_mode_stat "$WORKER_LOCK/pid" file 600 "$uid" >/dev/null || return 2
+  worker_owned_mode_stat "$WORKER_LOCK/start" file 600 "$uid" >/dev/null || return 2
+  worker_owned_mode_stat "$WORKER_LOCK/command" file 600 "$uid" >/dev/null || return 2
+  if fm_remote_job_lock_owner_matches_process "$account_home"; then return 0; fi
+  pid=$(fm_remote_job_read_single_line "$WORKER_LOCK/pid" 64 2>/dev/null) || return 2
+  case "$pid" in ''|*[!0-9]*) return 2 ;; esac
+  [ "$pid" -gt 1 ] || return 2
+  recorded_start=$(fm_remote_job_read_single_line "$WORKER_LOCK/start" 256 2>/dev/null) || return 2
+  actual_start=$(fm_remote_job_process_start "$pid" 2>/dev/null) || {
+    kill -0 "$pid" 2>/dev/null && return 2
+    return 1
+  }
+  [ "$recorded_start" = "$actual_start" ] || return 1
+  recorded_command=$(fm_remote_job_read_single_line "$WORKER_LOCK/command" 8192 2>/dev/null) || return 2
+  actual_command=$(fm_remote_job_process_command "$pid" 2>/dev/null) || {
+    kill -0 "$pid" 2>/dev/null && return 2
+    return 1
+  }
+  [ "$recorded_command" = "$actual_command" ] && return 0
+  return 2
+}
+
+# Legacy locks had no pid/start/command children. Their account-level pid file
+# remains enough to refuse a live worker, while a different live command proves
+# pid reuse and a dead pid is stale.
+worker_staged_legacy_owner_status() { # <uid>
+  local uid=$1 pid_file pid command
+  pid_file=$(fm_remote_job_worker_pid_path)
+  [ -e "$pid_file" ] || [ -L "$pid_file" ] || return 1
+  worker_owned_mode_stat "$pid_file" file 600 "$uid" >/dev/null || return 2
+  pid=$(fm_remote_job_read_single_line "$pid_file" 64 2>/dev/null) || return 2
+  case "$pid" in ''|*[!0-9]*) return 2 ;; esac
+  [ "$pid" -gt 1 ] || return 2
+  command=$(fm_remote_job_process_command "$pid" 2>/dev/null) || {
+    kill -0 "$pid" 2>/dev/null && return 2
+    return 1
+  }
+  case "$command" in *fm-remote-job-worker.sh*) return 0 ;; *) return 1 ;; esac
+}
+
+# Promote only the worker publisher's one completed staging artifact. The final
+# quarantine name then enters worker_recover_quarantine, so live job and owner
+# checks stay owned by the established quarantine path.
+worker_promote_staged_quarantine() { # <account-home>
+  local account_home=$1 uid lock_stat staged_stat staged owner_status legacy_status
+  worker_staged_quarantine_inventory
+  case "$?" in 0) ;; 1) return 1 ;; *) return 2 ;; esac
+  staged=$WORKER_STAGED_QUARANTINE
+  uid=$(id -u 2>/dev/null) || return 2
+  case "$uid" in ''|*[!0-9]*) return 2 ;; esac
+  lock_stat=$(worker_owned_mode_stat "$WORKER_LOCK" dir 700 "$uid") || return 2
+  staged_stat=$(worker_owned_mode_stat "$staged" file 600 "$uid") || return 2
+  cmp -s "$staged" <(printf '%s\n' "$WORKER_QUARANTINE_SENTINEL") || return 2
+
+  owner_status=1
+  if [ "$WORKER_STAGED_OWNER_FIELDS" -eq 7 ]; then
+    worker_staged_lock_owner_status "$account_home" "$uid"
+    owner_status=$?
+    [ "$owner_status" -ne 2 ] || return 2
+  fi
+  worker_staged_legacy_owner_status "$uid"
+  legacy_status=$?
+  case "$legacy_status" in
+    0) [ "$owner_status" -eq 0 ] || return 2 ;;
+    1) ;;
+    *) return 2 ;;
+  esac
+
+  worker_staged_quarantine_inventory || return 2
+  [ "$WORKER_STAGED_QUARANTINE" = "$staged" ] || return 2
+  [ "$(worker_owned_mode_stat "$WORKER_LOCK" dir 700 "$uid" 2>/dev/null || true)" = "$lock_stat" ] || return 2
+  [ "$(worker_owned_mode_stat "$staged" file 600 "$uid" 2>/dev/null || true)" = "$staged_stat" ] || return 2
+  [ ! -e "$WORKER_LOCK/quarantine" ] && [ ! -L "$WORKER_LOCK/quarantine" ] || return 2
+  mv -n -- "$staged" "$WORKER_LOCK/quarantine" || return 2
+  [ ! -e "$staged" ] && [ ! -L "$staged" ] || return 2
+  [ "$(worker_owned_mode_stat "$WORKER_LOCK/quarantine" file 600 "$uid" 2>/dev/null || true)" = "$staged_stat" ] || return 2
+}
+
 worker_acquire_lock() {
-  local account_home=$1 attempt=0
+  local account_home=$1 attempt=0 staged_status
   while [ "$attempt" -lt 150 ]; do
     if (umask 077; mkdir "$WORKER_LOCK") 2>/dev/null; then
       WORKER_LOCK_HELD=1
@@ -166,6 +328,16 @@ worker_acquire_lock() {
       return 0
     fi
     [ -d "$WORKER_LOCK" ] && [ ! -L "$WORKER_LOCK" ] || return 1
+    worker_promote_staged_quarantine "$account_home"
+    staged_status=$?
+    case "$staged_status" in
+      0)
+        worker_recover_quarantine "$account_home" || return 3
+        continue
+        ;;
+      1) ;;
+      *) return 1 ;;
+    esac
     if [ -e "$WORKER_LOCK/quarantine" ] || [ -L "$WORKER_LOCK/quarantine" ]; then
       worker_recover_quarantine "$account_home" || return 3
       continue
@@ -184,12 +356,22 @@ worker_acquire_lock() {
 }
 
 worker_publish_quarantine() {
-  local tmp
+  local tmp tmp_identity
   [ "$WORKER_LOCK_HELD" -eq 1 ] || return 1
   tmp=$(umask 077; mktemp "$WORKER_LOCK/.quarantine.XXXXXX") || return 1
-  printf 'active execution could not be confirmed stopped\n' > "$tmp" || { rm -f -- "$tmp"; return 1; }
-  chmod 600 "$tmp" || { rm -f -- "$tmp"; return 1; }
-  mv -f -- "$tmp" "$WORKER_LOCK/quarantine"
+  tmp_identity=$(worker_path_object_identity "$tmp") || return 1
+  printf '%s\n' "$WORKER_QUARANTINE_SENTINEL" > "$tmp" || {
+    worker_remove_publisher_temp "$tmp" "$tmp_identity" || true
+    return 1
+  }
+  chmod 600 "$tmp" || {
+    worker_remove_publisher_temp "$tmp" "$tmp_identity" || true
+    return 1
+  }
+  if ! mv -f -- "$tmp" "$WORKER_LOCK/quarantine"; then
+    worker_remove_publisher_temp "$tmp" "$tmp_identity" || true
+    return 1
+  fi
 }
 
 worker_clear_quarantine() {

--- a/bin/fm-remote-job-worker.sh
+++ b/bin/fm-remote-job-worker.sh
@@ -47,6 +47,8 @@
 # that dies just past the healthy threshold cannot restart without bound
 # either. fm-on's ensure path restarts a worker that gave up.
 set -u
+unset GLOBIGNORE
+shopt -u dotglob failglob nocaseglob nocasematch nullglob
 
 # A non-numeric override falls back to the default rather than crashing the
 # arithmetic that bounds these loops.
@@ -223,7 +225,7 @@ worker_recover_quarantine() { # <account-home>
 # the established acquisition path below.
 worker_staged_quarantine_inventory() {
   local LC_ALL=C
-  local entry base staged_count=0 owner_fields=0 unsafe=0
+  local entry base staged_count=0 owner_fields=0 unsafe=0 status
   WORKER_STAGED_QUARANTINE=
   WORKER_STAGED_OWNER_FIELDS=0
   for entry in "$WORKER_LOCK"/* "$WORKER_LOCK"/.[!.]* "$WORKER_LOCK"/..?*; do
@@ -241,10 +243,15 @@ worker_staged_quarantine_inventory() {
       *) unsafe=1 ;;
     esac
   done
-  [ "$staged_count" -gt 0 ] || return 1
-  [ "$staged_count" -eq 1 ] && [ "$unsafe" -eq 0 ] || return 2
-  case "$owner_fields" in 0|7) ;; *) return 2 ;; esac
-  WORKER_STAGED_OWNER_FIELDS=$owner_fields
+  if [ "$staged_count" -eq 0 ]; then
+    status=1
+  elif [ "$staged_count" -ne 1 ] || [ "$unsafe" -ne 0 ]; then
+    status=2
+  else
+    case "$owner_fields" in 0|7) status=0 ;; *) status=2 ;; esac
+  fi
+  if [ "$status" -eq 0 ]; then WORKER_STAGED_OWNER_FIELDS=$owner_fields; fi
+  return "$status"
 }
 
 # Return 0 for the exact live owner, 1 for a definitively stale or reused pid,
@@ -309,12 +316,11 @@ worker_promote_staged_quarantine() { # <account-home>
   if [ "$WORKER_STAGED_OWNER_FIELDS" -eq 7 ]; then
     worker_staged_lock_owner_status "$account_home" "$uid"
     owner_status=$?
-    [ "$owner_status" -ne 2 ] || return 2
+    case "$owner_status" in 1) ;; *) return 2 ;; esac
   fi
   worker_staged_legacy_owner_status "$uid"
   legacy_status=$?
   case "$legacy_status" in
-    0) [ "$owner_status" -eq 0 ] || return 2 ;;
     1) ;;
     *) return 2 ;;
   esac

--- a/bin/fm-remote-job-worker.sh
+++ b/bin/fm-remote-job-worker.sh
@@ -213,6 +213,7 @@ worker_recover_quarantine() { # <account-home>
 # unsafe or conflicting shape. Ordinary locks with no staging candidate retain
 # the established acquisition path below.
 worker_staged_quarantine_inventory() {
+  local LC_ALL=C
   local entry base staged_count=0 owner_fields=0 unsafe=0
   WORKER_STAGED_QUARANTINE=
   WORKER_STAGED_OWNER_FIELDS=0

--- a/bin/fm-remote-job-worker.sh
+++ b/bin/fm-remote-job-worker.sh
@@ -250,12 +250,12 @@ worker_staged_lock_owner_status() { # <account-home> <uid>
   case "$pid" in ''|*[!0-9]*) return 2 ;; esac
   [ "$pid" -gt 1 ] || return 2
   recorded_start=$(fm_remote_job_read_single_line "$WORKER_LOCK/start" 256 2>/dev/null) || return 2
+  recorded_command=$(fm_remote_job_read_single_line "$WORKER_LOCK/command" 8192 2>/dev/null) || return 2
   actual_start=$(fm_remote_job_process_start "$pid" 2>/dev/null) || {
     kill -0 "$pid" 2>/dev/null && return 2
     return 1
   }
   [ "$recorded_start" = "$actual_start" ] || return 1
-  recorded_command=$(fm_remote_job_read_single_line "$WORKER_LOCK/command" 8192 2>/dev/null) || return 2
   actual_command=$(fm_remote_job_process_command "$pid" 2>/dev/null) || {
     kill -0 "$pid" 2>/dev/null && return 2
     return 1

--- a/docs/remote-secondmates.md
+++ b/docs/remote-secondmates.md
@@ -99,6 +99,8 @@ bin/fm-on.sh <secondmate-id|ssh-alias> fm-remote-doctor.sh --fix
 Over the plain SSH doctor bootstrap, it writes and reloads the Firstmate-owned `dev.firstmate.remote-job` and `dev.firstmate.herdr.fm-remote` launch agents on macOS, both scoped with `LimitLoadToSessionType=Aqua` and bootstrapped in `gui/<uid>`.
 It starts the same workers directly on Linux, recreates the `~/.local/bin/fm-remote-entrypoint.sh` symlink when it is absent, and creates only Firstmate-owned required-tool wrappers that it can prove resolve to a version-manager target, stopping after one harness satisfies the at-least-one requirement.
 It never installs packages or overwrites a non-Firstmate file at a reserved wrapper path.
+Worker startup can recover an interrupted quarantine publication only when the lock contains one exact completed staging marker with account ownership, restrictive modes, unchanged nonsymlink identity, no conflicting entries, and no live worker or recorded job execution under the existing quarantine checks.
+Malformed, ambiguous, foreign, or entry-conflicting staging candidates remain untouched, while an otherwise valid marker that reaches a live-execution refusal remains published as official quarantine for investigation.
 The dedicated Herdr launch agent owns only the remote-secondmate `fm-remote` server and does not inspect, rewrite, start, stop, or require the user's interactive `default` session or its `dev.firstmate.herdr` launch agent.
 It re-derives every check from the host afterwards, so what it prints is the state after the repair rather than the intent of one.
 

--- a/tests/fm-remote-job.test.sh
+++ b/tests/fm-remote-job.test.sh
@@ -957,6 +957,31 @@ expect_code 1 "$QUARANTINE_TEST_RC" "a malformed quarantine staging name was rec
 assert_present "$QUARANTINE_TEST_STATE/worker.lock/.quarantine.short" \
   "malformed quarantine staging was removed"
 
+new_staged_quarantine_fixture malformed-name-with-stale-owner
+QUARANTINE_TEST_STAGE="$QUARANTINE_TEST_STATE/worker.lock/.quarantine.short"
+mv "$QUARANTINE_TEST_STATE/worker.lock/.quarantine.A1b2C3" "$QUARANTINE_TEST_STAGE"
+sleep 30 &
+QUARANTINE_TEST_AUX_PID=$!
+printf '%s\n' "$QUARANTINE_TEST_AUX_PID" > "$QUARANTINE_TEST_STATE/worker.lock/pid"
+fm_remote_job_process_start "$QUARANTINE_TEST_AUX_PID" > "$QUARANTINE_TEST_STATE/worker.lock/start"
+fm_remote_job_process_command "$QUARANTINE_TEST_AUX_PID" > "$QUARANTINE_TEST_STATE/worker.lock/command"
+chmod 600 "$QUARANTINE_TEST_STATE/worker.lock/pid" "$QUARANTINE_TEST_STATE/worker.lock/start" \
+  "$QUARANTINE_TEST_STATE/worker.lock/command"
+kill "$QUARANTINE_TEST_AUX_PID" 2>/dev/null || true
+wait "$QUARANTINE_TEST_AUX_PID" 2>/dev/null || true
+QUARANTINE_TEST_AUX_PID=
+MALFORMED_STALE_EXPECTED="$QUARANTINE_TEST_DIR/expected-lock"
+mkdir -p "$MALFORMED_STALE_EXPECTED"
+cp "$QUARANTINE_TEST_STATE/worker.lock/pid" "$QUARANTINE_TEST_STATE/worker.lock/start" \
+  "$QUARANTINE_TEST_STATE/worker.lock/command" "$QUARANTINE_TEST_STAGE" \
+  "$MALFORMED_STALE_EXPECTED/"
+touch -t 200001010000 "$QUARANTINE_TEST_STATE/worker.lock"
+expect_staged_quarantine_identity_refusal "$MALFORMED_STALE_EXPECTED" \
+  "a malformed staging name beside a stale owner identity"
+cmp -s "$MALFORMED_STALE_EXPECTED/.quarantine.short" "$QUARANTINE_TEST_STAGE" \
+  || fail "malformed staging refusal changed the malformed entry"
+pass "malformed staging preserves stale owner records and the unknown entry"
+
 INHERITED_SHOPT_ENV="$QUARANTINE_TEST_DIR/inherited-shopt"
 printf 'shopt -s nocasematch\n' > "$INHERITED_SHOPT_ENV"
 new_staged_quarantine_fixture inherited-nocasematch

--- a/tests/fm-remote-job.test.sh
+++ b/tests/fm-remote-job.test.sh
@@ -759,9 +759,11 @@ fm_remote_job_process_command "$QUARANTINE_TEST_AUX_PID" > "$QUARANTINE_TEST_STA
 chmod 600 "$QUARANTINE_TEST_STATE/worker.lock/pid" "$QUARANTINE_TEST_STATE/worker.lock/start" \
   "$QUARANTINE_TEST_STATE/worker.lock/command"
 run_staged_quarantine_worker
-expect_code 75 "$QUARANTINE_TEST_RC" "a completed staging marker displaced its matching live lock owner"
-assert_present "$QUARANTINE_TEST_STATE/worker.lock/quarantine" \
-  "a matching live lock owner lost the published quarantine protection"
+expect_code 1 "$QUARANTINE_TEST_RC" "a completed staging marker displaced its matching live lock owner"
+assert_present "$QUARANTINE_TEST_STAGE" \
+  "a matching live lock owner lost its staged quarantine protection"
+assert_absent "$QUARANTINE_TEST_STATE/worker.lock/quarantine" \
+  "a matching live lock owner's staging marker was consumed"
 kill -0 "$QUARANTINE_TEST_AUX_PID" 2>/dev/null || fail "staged recovery signalled the matching live lock owner"
 kill "$QUARANTINE_TEST_AUX_PID" 2>/dev/null || true
 wait "$QUARANTINE_TEST_AUX_PID" 2>/dev/null || true
@@ -955,6 +957,32 @@ expect_code 1 "$QUARANTINE_TEST_RC" "a malformed quarantine staging name was rec
 assert_present "$QUARANTINE_TEST_STATE/worker.lock/.quarantine.short" \
   "malformed quarantine staging was removed"
 
+INHERITED_SHOPT_ENV="$QUARANTINE_TEST_DIR/inherited-shopt"
+printf 'shopt -s nocasematch\n' > "$INHERITED_SHOPT_ENV"
+new_staged_quarantine_fixture inherited-nocasematch
+mv "$QUARANTINE_TEST_STAGE" "$QUARANTINE_TEST_STATE/worker.lock/.QUARANTINE.A1b2C3"
+QUARANTINE_TEST_STAGE="$QUARANTINE_TEST_STATE/worker.lock/.QUARANTINE.A1b2C3"
+touch -t 200001010000 "$QUARANTINE_TEST_STATE/worker.lock"
+export BASH_ENV=$INHERITED_SHOPT_ENV
+run_staged_quarantine_worker
+unset BASH_ENV
+expect_code 1 "$QUARANTINE_TEST_RC" \
+  "nocasematch made a malformed quarantine prefix recoverable"
+assert_present "$QUARANTINE_TEST_STAGE" \
+  "nocasematch allowed malformed quarantine staging to be removed"
+
+INHERITED_SHOPT_ENV="$QUARANTINE_TEST_DIR/inherited-shopt"
+printf '%s\n' 'shopt -s dotglob failglob nocaseglob nocasematch nullglob' \
+  "GLOBIGNORE='*:.*'" > "$INHERITED_SHOPT_ENV"
+new_staged_quarantine_fixture inherited-glob-options
+export BASH_ENV=$INHERITED_SHOPT_ENV
+start_staged_quarantine_worker
+unset BASH_ENV
+wait_for_quarantine_recovery \
+  || fail "inherited glob options prevented exact staged-quarantine recovery"
+stop_quarantine_test_worker
+pass "quarantine staging classification is independent of inherited shell options"
+
 LOCALE_RANGE_TEST_SHELL=(bash)
 if bash -c 'shopt -u globasciiranges' >/dev/null 2>&1; then
   LOCALE_RANGE_TEST_SHELL=(bash +O globasciiranges)
@@ -1021,20 +1049,26 @@ QUARANTINE_TEST_AUX_PID=
 new_staged_quarantine_fixture wrong-owner
 WRONG_OWNER_BIN="$QUARANTINE_TEST_DIR/fakebin"
 mkdir -p "$WRONG_OWNER_BIN"
-REAL_ID=$(command -v id)
-cat > "$WRONG_OWNER_BIN/id" <<'SH'
+REAL_STAT=$(command -v stat)
+cat > "$WRONG_OWNER_BIN/stat" <<'SH'
 #!/bin/bash
-if [ "${1:-}" = -u ]; then
-  printf '%s\n' "$FM_TEST_OTHER_UID"
-  exit 0
-fi
-exec "$FM_TEST_REAL_ID" "$@"
+last=${!#}
+case "$last" in
+  */worker.lock/.quarantine.A1b2C3)
+    value=$("$FM_TEST_REAL_STAT" "$@") || exit 1
+    read -r _ mode device inode extra <<< "$value"
+    [ -z "${extra:-}" ] || exit 1
+    printf '%s %s %s %s\n' "$FM_TEST_OTHER_UID" "$mode" "$device" "$inode"
+    exit 0
+    ;;
+esac
+exec "$FM_TEST_REAL_STAT" "$@"
 SH
-chmod +x "$WRONG_OWNER_BIN/id"
-export FM_TEST_REAL_ID="$REAL_ID"
+chmod +x "$WRONG_OWNER_BIN/stat"
+export FM_TEST_REAL_STAT="$REAL_STAT"
 export FM_TEST_OTHER_UID="$(( $(id -u) + 1 ))"
 run_staged_quarantine_worker "$WRONG_OWNER_BIN:$PATH"
-unset FM_TEST_REAL_ID FM_TEST_OTHER_UID
+unset FM_TEST_REAL_STAT FM_TEST_OTHER_UID
 expect_code 1 "$QUARANTINE_TEST_RC" "a foreign-owner quarantine staging file was recovered"
 assert_present "$QUARANTINE_TEST_STAGE" "foreign-owner quarantine staging was removed"
 pass "malformed, ambiguous, symlinked, and foreign quarantine staging remains untouched"
@@ -1067,12 +1101,58 @@ case "${FM_TEST_QUARANTINE_PUBLISH_ACTION:-}:$last" in
     sleep 0.1
     exit 1
     ;;
+  race:*/worker.lock/quarantine)
+    : > "$FM_TEST_RACE_READY"
+    while [ ! -e "$FM_TEST_RACE_RELEASE" ]; do sleep 0.01; done
+    ;;
 esac
 exec "$FM_TEST_REAL_MV" "$@"
 SH
 chmod +x "$PUBLISH_FAKEBIN/chmod" "$PUBLISH_FAKEBIN/mv"
 export FM_TEST_REAL_CHMOD="$REAL_CHMOD"
 export FM_TEST_REAL_MV="$REAL_MV"
+
+new_staged_quarantine_fixture live-publisher-race
+rm -rf "$QUARANTINE_TEST_STATE/worker.lock"
+FM_TEST_RACE_READY="$QUARANTINE_TEST_DIR/publisher-ready"
+FM_TEST_RACE_RELEASE="$QUARANTINE_TEST_DIR/publisher-release"
+export FM_TEST_RACE_READY FM_TEST_RACE_RELEASE
+export FM_TEST_QUARANTINE_PUBLISH_ACTION=race
+start_staged_quarantine_worker "$PUBLISH_FAKEBIN:$PATH"
+for _ in $(seq 1 300); do
+  [ -f "$QUARANTINE_TEST_STATE/worker.ready" ] && break
+  sleep 0.05
+done
+assert_present "$QUARANTINE_TEST_STATE/worker.ready" \
+  "the live-publisher race worker did not become ready"
+kill -TERM "$QUARANTINE_TEST_WORKER_PID"
+for _ in $(seq 1 300); do
+  [ -f "$FM_TEST_RACE_READY" ] && break
+  sleep 0.05
+done
+assert_present "$FM_TEST_RACE_READY" \
+  "the live publisher did not reach completed quarantine staging"
+QUARANTINE_TEST_STAGE=$(find "$QUARANTINE_TEST_STATE/worker.lock" -maxdepth 1 \
+  -name '.quarantine.??????' -print)
+[ -n "$QUARANTINE_TEST_STAGE" ] \
+  || fail "the live publisher did not retain its completed staging marker"
+run_staged_quarantine_worker
+expect_code 1 "$QUARANTINE_TEST_RC" \
+  "a replacement consumed an active publisher's quarantine staging"
+assert_present "$QUARANTINE_TEST_STAGE" \
+  "a replacement removed an active publisher's quarantine staging"
+assert_absent "$QUARANTINE_TEST_STATE/worker.lock/quarantine" \
+  "a replacement promoted an active publisher's quarantine staging"
+kill -0 "$QUARANTINE_TEST_WORKER_PID" 2>/dev/null \
+  || fail "a replacement disturbed the active quarantine publisher"
+: > "$FM_TEST_RACE_RELEASE"
+wait "$QUARANTINE_TEST_WORKER_PID" \
+  || fail "the active quarantine publisher did not finish shutdown"
+QUARANTINE_TEST_WORKER_PID=
+unset FM_TEST_QUARANTINE_PUBLISH_ACTION FM_TEST_RACE_READY FM_TEST_RACE_RELEASE
+assert_absent "$QUARANTINE_TEST_STATE/worker.lock" \
+  "the active quarantine publisher did not release ownership"
+pass "a replacement preserves an active publisher's quarantine staging"
 
 for PUBLISH_FAILURE in chmod mv; do
   new_staged_quarantine_fixture "publish-$PUBLISH_FAILURE"

--- a/tests/fm-remote-job.test.sh
+++ b/tests/fm-remote-job.test.sh
@@ -20,6 +20,8 @@ OTHER_PID=
 RECOVERY_WORKER_PID=
 REPEAT_WORKER_PID=
 RESTART_SUPERVISOR_PID=
+QUARANTINE_TEST_WORKER_PID=
+QUARANTINE_TEST_AUX_PID=
 mkdir -p "$REMOTE_ROOT/bin" "$REMOTE_HOME" "$ACCOUNT_HOME" "$RUNTIME_BIN"
 # worker.pid records the serving child, not its restart supervisor, so stopping
 # that pid alone leaves the supervisor to respawn - the leak
@@ -29,6 +31,8 @@ cleanup_remote_job_fixture() {
   [ -z "$RECOVERY_WORKER_PID" ] || kill "$RECOVERY_WORKER_PID" 2>/dev/null || true
   [ -z "$REPEAT_WORKER_PID" ] || kill "$REPEAT_WORKER_PID" 2>/dev/null || true
   [ -z "$RESTART_SUPERVISOR_PID" ] || kill -KILL "$RESTART_SUPERVISOR_PID" 2>/dev/null || true
+  [ -z "$QUARANTINE_TEST_WORKER_PID" ] || kill -KILL "$QUARANTINE_TEST_WORKER_PID" 2>/dev/null || true
+  [ -z "$QUARANTINE_TEST_AUX_PID" ] || kill -KILL "$QUARANTINE_TEST_AUX_PID" 2>/dev/null || true
   if [ -f "$STATE_ROOT/worker.pid" ]; then
     fm_remote_job_stop_worker_tree "$(cat "$STATE_ROOT/worker.pid")" || true
   fi
@@ -647,6 +651,358 @@ RECOVERY_WORKER_PID=
 kill "$QUARANTINED_PROCESS_PID" 2>/dev/null || true
 wait "$QUARANTINED_PROCESS_PID" 2>/dev/null || true
 pass "quarantine recovery refuses unverifiable supervisors and ignores reused pids"
+
+QUARANTINE_SENTINEL='active execution could not be confirmed stopped'
+
+new_staged_quarantine_fixture() { # <name>
+  local name=$1
+  QUARANTINE_TEST_DIR="$TMP_ROOT/quarantine-$name"
+  QUARANTINE_TEST_HOME="$QUARANTINE_TEST_DIR/home"
+  QUARANTINE_TEST_STATE="$QUARANTINE_TEST_DIR/state"
+  QUARANTINE_TEST_STAGE="$QUARANTINE_TEST_STATE/worker.lock/.quarantine.A1b2C3"
+  mkdir -p "$QUARANTINE_TEST_HOME" "$QUARANTINE_TEST_STATE/jobs" \
+    "$QUARANTINE_TEST_STATE/logs" "$QUARANTINE_TEST_STATE/worker.lock"
+  chmod 700 "$QUARANTINE_TEST_HOME" "$QUARANTINE_TEST_STATE" \
+    "$QUARANTINE_TEST_STATE/jobs" "$QUARANTINE_TEST_STATE/logs" \
+    "$QUARANTINE_TEST_STATE/worker.lock"
+  printf '%s\n' "$QUARANTINE_SENTINEL" > "$QUARANTINE_TEST_STAGE"
+  chmod 600 "$QUARANTINE_TEST_STAGE"
+  touch -t 200001010000 "$QUARANTINE_TEST_STATE/worker.lock"
+}
+
+run_staged_quarantine_worker() { # [path]
+  local worker_path=${1:-$PATH}
+  set +e
+  HOME="$QUARANTINE_TEST_HOME" PATH="$worker_path" FM_ROOT_OVERRIDE="$REMOTE_ROOT" \
+    FM_REMOTE_JOB_STATE_ROOT="$QUARANTINE_TEST_STATE" FM_REMOTE_JOB_PLATFORM_OVERRIDE=Linux \
+    "$REMOTE_ROOT/bin/fm-remote-job-worker.sh" --serve \
+    > "$QUARANTINE_TEST_DIR/worker.out" 2> "$QUARANTINE_TEST_DIR/worker.err"
+  QUARANTINE_TEST_RC=$?
+  set -e
+}
+
+start_staged_quarantine_worker() { # [path]
+  local worker_path=${1:-$PATH}
+  HOME="$QUARANTINE_TEST_HOME" PATH="$worker_path" FM_ROOT_OVERRIDE="$REMOTE_ROOT" \
+    FM_REMOTE_JOB_STATE_ROOT="$QUARANTINE_TEST_STATE" FM_REMOTE_JOB_PLATFORM_OVERRIDE=Linux \
+    "$REMOTE_ROOT/bin/fm-remote-job-worker.sh" --serve \
+    > "$QUARANTINE_TEST_DIR/worker.out" 2> "$QUARANTINE_TEST_DIR/worker.err" &
+  QUARANTINE_TEST_WORKER_PID=$!
+}
+
+wait_for_quarantine_recovery() {
+  local i=0
+  while [ "$i" -lt 300 ]; do
+    if [ ! -e "$QUARANTINE_TEST_STAGE" ] && [ ! -L "$QUARANTINE_TEST_STAGE" ] \
+      && [ ! -e "$QUARANTINE_TEST_STATE/worker.lock/quarantine" ] \
+      && [ ! -L "$QUARANTINE_TEST_STATE/worker.lock/quarantine" ]; then
+      return 0
+    fi
+    kill -0 "$QUARANTINE_TEST_WORKER_PID" 2>/dev/null || return 1
+    i=$((i + 1))
+    sleep 0.05
+  done
+  return 1
+}
+
+stop_quarantine_test_worker() {
+  [ -n "$QUARANTINE_TEST_WORKER_PID" ] || return 0
+  kill -KILL "$QUARANTINE_TEST_WORKER_PID" 2>/dev/null || true
+  wait "$QUARANTINE_TEST_WORKER_PID" 2>/dev/null || true
+  QUARANTINE_TEST_WORKER_PID=
+}
+
+new_staged_quarantine_fixture live-owner
+sleep 30 &
+QUARANTINE_TEST_AUX_PID=$!
+printf '%s\n' "$QUARANTINE_TEST_AUX_PID" > "$QUARANTINE_TEST_STATE/worker.lock/pid"
+fm_remote_job_process_start "$QUARANTINE_TEST_AUX_PID" > "$QUARANTINE_TEST_STATE/worker.lock/start"
+fm_remote_job_process_command "$QUARANTINE_TEST_AUX_PID" > "$QUARANTINE_TEST_STATE/worker.lock/command"
+chmod 600 "$QUARANTINE_TEST_STATE/worker.lock/pid" "$QUARANTINE_TEST_STATE/worker.lock/start" \
+  "$QUARANTINE_TEST_STATE/worker.lock/command"
+run_staged_quarantine_worker
+expect_code 75 "$QUARANTINE_TEST_RC" "a completed staging marker displaced its matching live lock owner"
+assert_present "$QUARANTINE_TEST_STATE/worker.lock/quarantine" \
+  "a matching live lock owner lost the published quarantine protection"
+kill -0 "$QUARANTINE_TEST_AUX_PID" 2>/dev/null || fail "staged recovery signalled the matching live lock owner"
+kill "$QUARANTINE_TEST_AUX_PID" 2>/dev/null || true
+wait "$QUARANTINE_TEST_AUX_PID" 2>/dev/null || true
+QUARANTINE_TEST_AUX_PID=
+pass "completed quarantine staging preserves a matching live lock owner"
+
+new_staged_quarantine_fixture live-job
+QUARANTINE_JOB="$QUARANTINE_TEST_STATE/jobs/job-live-staged-quarantine"
+mkdir -p "$QUARANTINE_JOB/.claim"
+chmod 700 "$QUARANTINE_JOB" "$QUARANTINE_JOB/.claim"
+sleep 30 &
+QUARANTINE_TEST_AUX_PID=$!
+printf 'running\n' > "$QUARANTINE_JOB/state"
+printf '%s\n' "$QUARANTINE_TEST_AUX_PID" > "$QUARANTINE_JOB/.claim/supervisor"
+fm_remote_job_process_start "$QUARANTINE_TEST_AUX_PID" > "$QUARANTINE_JOB/.claim/supervisor_start"
+chmod 600 "$QUARANTINE_JOB/state" "$QUARANTINE_JOB/.claim/supervisor" \
+  "$QUARANTINE_JOB/.claim/supervisor_start"
+run_staged_quarantine_worker
+expect_code 75 "$QUARANTINE_TEST_RC" "a completed staging marker displaced a matching live job supervisor"
+assert_present "$QUARANTINE_TEST_STATE/worker.lock/quarantine" \
+  "a matching live job supervisor lost the published quarantine protection"
+kill -0 "$QUARANTINE_TEST_AUX_PID" 2>/dev/null || fail "staged recovery signalled the live job supervisor"
+kill "$QUARANTINE_TEST_AUX_PID" 2>/dev/null || true
+wait "$QUARANTINE_TEST_AUX_PID" 2>/dev/null || true
+QUARANTINE_TEST_AUX_PID=
+pass "completed quarantine staging enters the existing live-job safety checks"
+
+new_staged_quarantine_fixture reused-owner-pid
+sleep 30 &
+QUARANTINE_TEST_AUX_PID=$!
+printf '%s\n' "$QUARANTINE_TEST_AUX_PID" > "$QUARANTINE_TEST_STATE/worker.lock/pid"
+printf 'stale process start identity\n' > "$QUARANTINE_TEST_STATE/worker.lock/start"
+fm_remote_job_process_command "$QUARANTINE_TEST_AUX_PID" > "$QUARANTINE_TEST_STATE/worker.lock/command"
+chmod 600 "$QUARANTINE_TEST_STATE/worker.lock/pid" "$QUARANTINE_TEST_STATE/worker.lock/start" \
+  "$QUARANTINE_TEST_STATE/worker.lock/command"
+start_staged_quarantine_worker
+wait_for_quarantine_recovery || fail "a reused owner pid prevented exact staged-quarantine promotion"
+kill -0 "$QUARANTINE_TEST_AUX_PID" 2>/dev/null || fail "staged recovery signalled a reused owner pid"
+stop_quarantine_test_worker
+kill "$QUARANTINE_TEST_AUX_PID" 2>/dev/null || true
+wait "$QUARANTINE_TEST_AUX_PID" 2>/dev/null || true
+QUARANTINE_TEST_AUX_PID=
+pass "staged quarantine recovery distinguishes pid reuse by process start identity"
+
+new_staged_quarantine_fixture live-legacy-worker
+LEGACY_WORKER="$QUARANTINE_TEST_DIR/fm-remote-job-worker.sh"
+cat > "$LEGACY_WORKER" <<'SH'
+#!/bin/bash
+sleep 30
+SH
+chmod +x "$LEGACY_WORKER"
+"$LEGACY_WORKER" &
+QUARANTINE_TEST_AUX_PID=$!
+printf '%s\n' "$QUARANTINE_TEST_AUX_PID" > "$QUARANTINE_TEST_STATE/worker.pid"
+chmod 600 "$QUARANTINE_TEST_STATE/worker.pid"
+run_staged_quarantine_worker
+expect_code 1 "$QUARANTINE_TEST_RC" "a completed staging marker displaced a live legacy worker"
+assert_present "$QUARANTINE_TEST_STAGE" "a live legacy worker lost its staged quarantine protection"
+kill -0 "$QUARANTINE_TEST_AUX_PID" 2>/dev/null || fail "staged recovery signalled a live legacy worker"
+kill "$QUARANTINE_TEST_AUX_PID" 2>/dev/null || true
+wait "$QUARANTINE_TEST_AUX_PID" 2>/dev/null || true
+QUARANTINE_TEST_AUX_PID=
+pass "completed quarantine staging refuses a live legacy worker"
+
+new_staged_quarantine_fixture wrong-content
+printf 'not the quarantine sentinel\n' > "$QUARANTINE_TEST_STAGE"
+run_staged_quarantine_worker
+expect_code 1 "$QUARANTINE_TEST_RC" "a wrong-content quarantine staging file was recovered"
+assert_present "$QUARANTINE_TEST_STAGE" "wrong-content quarantine staging was removed"
+
+new_staged_quarantine_fixture wrong-mode
+chmod 640 "$QUARANTINE_TEST_STAGE"
+run_staged_quarantine_worker
+expect_code 1 "$QUARANTINE_TEST_RC" "a wrong-mode quarantine staging file was recovered"
+assert_present "$QUARANTINE_TEST_STAGE" "wrong-mode quarantine staging was removed"
+
+new_staged_quarantine_fixture symlink
+printf '%s\n' "$QUARANTINE_SENTINEL" > "$QUARANTINE_TEST_STATE/symlink-target"
+rm -f "$QUARANTINE_TEST_STAGE"
+ln -s "$QUARANTINE_TEST_STATE/symlink-target" "$QUARANTINE_TEST_STAGE"
+run_staged_quarantine_worker
+expect_code 1 "$QUARANTINE_TEST_RC" "a symlinked quarantine staging file was recovered"
+[ -L "$QUARANTINE_TEST_STAGE" ] || fail "symlinked quarantine staging was removed"
+
+new_staged_quarantine_fixture multiple
+printf '%s\n' "$QUARANTINE_SENTINEL" > "$QUARANTINE_TEST_STATE/worker.lock/.quarantine.D4e5F6"
+chmod 600 "$QUARANTINE_TEST_STATE/worker.lock/.quarantine.D4e5F6"
+run_staged_quarantine_worker
+expect_code 1 "$QUARANTINE_TEST_RC" "multiple quarantine staging files were recovered ambiguously"
+assert_present "$QUARANTINE_TEST_STAGE" "ambiguous quarantine staging was removed"
+
+new_staged_quarantine_fixture unexpected-entry
+printf 'unknown\n' > "$QUARANTINE_TEST_STATE/worker.lock/mystery"
+chmod 600 "$QUARANTINE_TEST_STATE/worker.lock/mystery"
+run_staged_quarantine_worker
+expect_code 1 "$QUARANTINE_TEST_RC" "quarantine staging with an unknown lock entry was recovered"
+assert_present "$QUARANTINE_TEST_STAGE" "quarantine staging beside an unknown entry was removed"
+
+new_staged_quarantine_fixture malformed-name
+mv "$QUARANTINE_TEST_STAGE" "$QUARANTINE_TEST_STATE/worker.lock/.quarantine.short"
+touch -t 200001010000 "$QUARANTINE_TEST_STATE/worker.lock"
+run_staged_quarantine_worker
+expect_code 1 "$QUARANTINE_TEST_RC" "a malformed quarantine staging name was recovered"
+assert_present "$QUARANTINE_TEST_STATE/worker.lock/.quarantine.short" \
+  "malformed quarantine staging was removed"
+
+new_staged_quarantine_fixture ambiguous-owner
+sleep 30 &
+QUARANTINE_TEST_AUX_PID=$!
+printf '%s\n' "$QUARANTINE_TEST_AUX_PID" > "$QUARANTINE_TEST_STATE/worker.lock/pid"
+chmod 600 "$QUARANTINE_TEST_STATE/worker.lock/pid"
+run_staged_quarantine_worker
+expect_code 1 "$QUARANTINE_TEST_RC" "a partial live owner identity permitted staged recovery"
+assert_present "$QUARANTINE_TEST_STAGE" "ambiguous live ownership lost quarantine staging"
+kill "$QUARANTINE_TEST_AUX_PID" 2>/dev/null || true
+wait "$QUARANTINE_TEST_AUX_PID" 2>/dev/null || true
+QUARANTINE_TEST_AUX_PID=
+
+new_staged_quarantine_fixture wrong-owner
+WRONG_OWNER_BIN="$QUARANTINE_TEST_DIR/fakebin"
+mkdir -p "$WRONG_OWNER_BIN"
+REAL_ID=$(command -v id)
+cat > "$WRONG_OWNER_BIN/id" <<'SH'
+#!/bin/bash
+if [ "${1:-}" = -u ]; then
+  printf '%s\n' "$FM_TEST_OTHER_UID"
+  exit 0
+fi
+exec "$FM_TEST_REAL_ID" "$@"
+SH
+chmod +x "$WRONG_OWNER_BIN/id"
+export FM_TEST_REAL_ID="$REAL_ID"
+export FM_TEST_OTHER_UID="$(( $(id -u) + 1 ))"
+run_staged_quarantine_worker "$WRONG_OWNER_BIN:$PATH"
+unset FM_TEST_REAL_ID FM_TEST_OTHER_UID
+expect_code 1 "$QUARANTINE_TEST_RC" "a foreign-owner quarantine staging file was recovered"
+assert_present "$QUARANTINE_TEST_STAGE" "foreign-owner quarantine staging was removed"
+pass "malformed, ambiguous, symlinked, and foreign quarantine staging remains untouched"
+
+PUBLISH_FAKEBIN="$TMP_ROOT/quarantine-publish-fakebin"
+mkdir -p "$PUBLISH_FAKEBIN"
+REAL_CHMOD=$(command -v chmod)
+REAL_MV=$(command -v mv)
+cat > "$PUBLISH_FAKEBIN/chmod" <<'SH'
+#!/bin/bash
+last=${!#}
+case "${FM_TEST_QUARANTINE_PUBLISH_ACTION:-}:$last" in
+  chmod:*/worker.lock/.quarantine.??????)
+    printf 'chmod: No space left on device\n' >&2
+    exit 1
+    ;;
+esac
+exec "$FM_TEST_REAL_CHMOD" "$@"
+SH
+cat > "$PUBLISH_FAKEBIN/mv" <<'SH'
+#!/bin/bash
+last=${!#}
+case "${FM_TEST_QUARANTINE_PUBLISH_ACTION:-}:$last" in
+  mv:*/worker.lock/quarantine)
+    printf 'mv: No space left on device\n' >&2
+    exit 1
+    ;;
+  crash:*/worker.lock/quarantine)
+    kill -KILL "$PPID" 2>/dev/null || true
+    sleep 0.1
+    exit 1
+    ;;
+esac
+exec "$FM_TEST_REAL_MV" "$@"
+SH
+chmod +x "$PUBLISH_FAKEBIN/chmod" "$PUBLISH_FAKEBIN/mv"
+export FM_TEST_REAL_CHMOD="$REAL_CHMOD"
+export FM_TEST_REAL_MV="$REAL_MV"
+
+for PUBLISH_FAILURE in chmod mv; do
+  new_staged_quarantine_fixture "publish-$PUBLISH_FAILURE"
+  rm -rf "$QUARANTINE_TEST_STATE/worker.lock"
+  export FM_TEST_QUARANTINE_PUBLISH_ACTION=$PUBLISH_FAILURE
+  start_staged_quarantine_worker "$PUBLISH_FAKEBIN:$PATH"
+  for _ in $(seq 1 300); do
+    [ -f "$QUARANTINE_TEST_STATE/worker.ready" ] && break
+    sleep 0.05
+  done
+  assert_present "$QUARANTINE_TEST_STATE/worker.ready" \
+    "the $PUBLISH_FAILURE publication-failure worker did not become ready"
+  printf 'preserve\n' > "$QUARANTINE_TEST_STATE/worker.lock/keep"
+  chmod 600 "$QUARANTINE_TEST_STATE/worker.lock/keep"
+  kill -TERM "$QUARANTINE_TEST_WORKER_PID"
+  for _ in $(seq 1 100); do
+    grep -F 'cannot guard worker ownership for shutdown' "$QUARANTINE_TEST_DIR/worker.err" >/dev/null 2>&1 && break
+    sleep 0.05
+  done
+  assert_grep 'cannot guard worker ownership for shutdown' "$QUARANTINE_TEST_DIR/worker.err" \
+    "the $PUBLISH_FAILURE publication failure was not reported"
+  [ "$(find "$QUARANTINE_TEST_STATE/worker.lock" -maxdepth 1 -name '.quarantine.??????' | wc -l | tr -d ' ')" -eq 0 ] \
+    || fail "the $PUBLISH_FAILURE publication failure retained its temporary artifact"
+  assert_present "$QUARANTINE_TEST_STATE/worker.lock/keep" \
+    "the $PUBLISH_FAILURE publication failure removed an unrelated lock artifact"
+  stop_quarantine_test_worker
+done
+unset FM_TEST_QUARANTINE_PUBLISH_ACTION
+pass "reported chmod and ENOSPC rename failures clean only their publisher temporary artifact"
+
+new_staged_quarantine_fixture interrupted-publication
+rm -rf "$QUARANTINE_TEST_STATE/worker.lock"
+export FM_TEST_QUARANTINE_PUBLISH_ACTION=crash
+start_staged_quarantine_worker "$PUBLISH_FAKEBIN:$PATH"
+for _ in $(seq 1 300); do
+  [ -f "$QUARANTINE_TEST_STATE/worker.ready" ] && break
+  sleep 0.05
+done
+assert_present "$QUARANTINE_TEST_STATE/worker.ready" "the interrupted-publication worker did not become ready"
+kill -TERM "$QUARANTINE_TEST_WORKER_PID"
+wait "$QUARANTINE_TEST_WORKER_PID" 2>/dev/null || true
+QUARANTINE_TEST_WORKER_PID=
+unset FM_TEST_QUARANTINE_PUBLISH_ACTION
+INTERRUPTED_STAGE=$(find "$QUARANTINE_TEST_STATE/worker.lock" -maxdepth 1 -name '.quarantine.??????' -print)
+[ -n "$INTERRUPTED_STAGE" ] && [ "$(printf '%s\n' "$INTERRUPTED_STAGE" | wc -l | tr -d ' ')" -eq 1 ] \
+  || fail "the interruption did not leave one completed quarantine staging artifact"
+cmp -s "$INTERRUPTED_STAGE" <(printf '%s\n' "$QUARANTINE_SENTINEL") \
+  || fail "the interrupted quarantine staging artifact was incomplete"
+QUARANTINE_TEST_STAGE=$INTERRUPTED_STAGE
+start_staged_quarantine_worker
+wait_for_quarantine_recovery || fail "a worker could not safely recover interrupted quarantine publication"
+stop_quarantine_test_worker
+pass "the next worker safely recovers interruption between staging and quarantine publication"
+
+unset FM_TEST_REAL_CHMOD FM_TEST_REAL_MV
+
+new_staged_quarantine_fixture doctor-recovery
+DOCTOR_BIN="$QUARANTINE_TEST_HOME/.local/bin"
+DOCTOR_FM_HOME="$QUARANTINE_TEST_HOME/project-home"
+mkdir -p "$DOCTOR_BIN" "$DOCTOR_FM_HOME"
+ln -s "$(command -v git)" "$DOCTOR_BIN/git"
+ln -s "$(command -v jq)" "$DOCTOR_BIN/jq"
+cat > "$DOCTOR_BIN/herdr" <<'SH'
+#!/bin/bash
+case "${1:-}:${2:-}" in
+  status:--json) printf '{"client":{"version":"test","protocol":16},"server":{"running":true}}\n' ;;
+esac
+SH
+cat > "$DOCTOR_BIN/tasks-axi" <<'SH'
+#!/bin/bash
+case "${1:-}:${2:-}" in
+  --version:*) printf '0.2.4\n' ;;
+  update:--help) printf '%s\n' --archive-body ;;
+  mv:--help) printf '%s\n' 'usage: tasks-axi mv <id> [<id>...]' ;;
+esac
+SH
+for tool in treehouse claude; do
+  cat > "$DOCTOR_BIN/$tool" <<'SH'
+#!/bin/bash
+exit 0
+SH
+done
+chmod +x "$DOCTOR_BIN/herdr" "$DOCTOR_BIN/tasks-axi" "$DOCTOR_BIN/treehouse" "$DOCTOR_BIN/claude"
+set +e
+DOCTOR_RECOVERY_OUT=$(
+  HOME="$QUARANTINE_TEST_HOME" FM_HOME="$DOCTOR_FM_HOME" \
+    PATH="$ROOT/bin:$DOCTOR_BIN:/usr/bin:/bin:/usr/sbin:/sbin" FM_ROOT_OVERRIDE="$ROOT" \
+    FM_REMOTE_JOB_STATE_ROOT="$QUARANTINE_TEST_STATE" FM_REMOTE_JOB_PLATFORM_OVERRIDE=Linux \
+    "$ROOT/bin/fm-remote-doctor.sh" --fix 2>&1
+)
+DOCTOR_RECOVERY_RC=$?
+set -e
+expect_code 0 "$DOCTOR_RECOVERY_RC" \
+  "the supported doctor did not recover one exact completed quarantine staging marker: $DOCTOR_RECOVERY_OUT"
+assert_contains "$DOCTOR_RECOVERY_OUT" \
+  'check remote-job-probe=ok: the remote job worker completed the required-tool probe' \
+  "the recovered doctor did not complete a fresh worker tool probe"
+assert_absent "$QUARANTINE_TEST_STATE/worker.lock/quarantine" \
+  "the successful doctor probe retained the official quarantine marker"
+[ "$(find "$QUARANTINE_TEST_STATE/worker.lock" -maxdepth 1 -name '.quarantine.??????' | wc -l | tr -d ' ')" -eq 0 ] \
+  || fail "the successful doctor probe retained quarantine staging"
+QUARANTINE_TEST_WORKER_PID=$(cat "$QUARANTINE_TEST_STATE/worker.pid")
+fm_remote_job_stop_worker_tree "$QUARANTINE_TEST_WORKER_PID" \
+  || fail "the doctor-recovery worker did not stop cleanly"
+QUARANTINE_TEST_WORKER_PID=
+pass "the supported doctor reaches a fresh required-tool probe after safe staged-quarantine recovery"
 
 # A replacement stops a Linux worker by signalling its whole isolated group, and
 # the supervisor in that group forwards a second stop signal to the same serving

--- a/tests/fm-remote-job.test.sh
+++ b/tests/fm-remote-job.test.sh
@@ -1013,6 +1013,8 @@ if bash -c 'shopt -u globasciiranges' >/dev/null 2>&1; then
   LOCALE_RANGE_TEST_SHELL=(bash +O globasciiranges)
 fi
 LOCALE_RANGE_TEST_LOCALE=$(
+  # candidate expands in the nested shell, not this test process.
+  # shellcheck disable=SC2016
   "${LOCALE_RANGE_TEST_SHELL[@]}" -c '
     while IFS= read -r candidate; do
       LC_ALL=$candidate

--- a/tests/fm-remote-job.test.sh
+++ b/tests/fm-remote-job.test.sh
@@ -670,6 +670,14 @@ new_staged_quarantine_fixture() { # <name>
   touch -t 200001010000 "$QUARANTINE_TEST_STATE/worker.lock"
 }
 
+quarantine_test_identity() { # <path>
+  if [ "$(uname -s)" = Darwin ]; then
+    stat -f '%u %d %i' "$1"
+  else
+    stat -c '%u %d %i' -- "$1"
+  fi
+}
+
 run_staged_quarantine_worker() { # [path]
   local worker_path=${1:-$PATH}
   set +e
@@ -869,6 +877,53 @@ chmod 640 "$QUARANTINE_TEST_STAGE"
 run_staged_quarantine_worker
 expect_code 1 "$QUARANTINE_TEST_RC" "a wrong-mode quarantine staging file was recovered"
 assert_present "$QUARANTINE_TEST_STAGE" "wrong-mode quarantine staging was removed"
+
+for SPECIAL_MODE_CASE in lock-sticky:1700 lock-setgid:2700 marker-setuid:4600; do
+  SPECIAL_MODE_NAME=${SPECIAL_MODE_CASE%%:*}
+  SPECIAL_MODE=${SPECIAL_MODE_CASE##*:}
+  new_staged_quarantine_fixture "special-mode-$SPECIAL_MODE_NAME"
+  case "$SPECIAL_MODE_NAME" in
+    lock-*) chmod "$SPECIAL_MODE" "$QUARANTINE_TEST_STATE/worker.lock" ;;
+    marker-*) chmod "$SPECIAL_MODE" "$QUARANTINE_TEST_STAGE" ;;
+  esac
+  run_staged_quarantine_worker
+  expect_code 1 "$QUARANTINE_TEST_RC" \
+    "a $SPECIAL_MODE_NAME quarantine staging fixture was recovered"
+  assert_present "$QUARANTINE_TEST_STAGE" \
+    "the $SPECIAL_MODE_NAME quarantine staging fixture was removed"
+done
+pass "quarantine staging requires exact modes including special permission bits"
+
+new_staged_quarantine_fixture changed-after-validation
+MUTATE_FAKEBIN="$QUARANTINE_TEST_DIR/fakebin"
+mkdir -p "$MUTATE_FAKEBIN"
+REAL_MV=$(command -v mv)
+cat > "$MUTATE_FAKEBIN/mv" <<'SH'
+#!/bin/bash
+last=${!#}
+case "$last" in
+  */worker.lock/quarantine) printf X >&9 ;;
+esac
+exec "$FM_TEST_REAL_MV" "$@"
+SH
+chmod +x "$MUTATE_FAKEBIN/mv"
+export FM_TEST_REAL_MV="$REAL_MV"
+STAGED_IDENTITY=$(quarantine_test_identity "$QUARANTINE_TEST_STAGE")
+exec 9<> "$QUARANTINE_TEST_STAGE"
+run_staged_quarantine_worker "$MUTATE_FAKEBIN:$PATH"
+exec 9>&-
+unset FM_TEST_REAL_MV
+expect_code 1 "$QUARANTINE_TEST_RC" \
+  "in-place staging content change after validation was recovered"
+assert_absent "$QUARANTINE_TEST_STAGE" \
+  "in-place changed quarantine staging was not atomically promoted"
+assert_present "$QUARANTINE_TEST_STATE/worker.lock/quarantine" \
+  "in-place changed promoted quarantine marker was deleted"
+[ "$(quarantine_test_identity "$QUARANTINE_TEST_STATE/worker.lock/quarantine")" = "$STAGED_IDENTITY" ] \
+  || fail "in-place changed quarantine marker lost its original object identity"
+cmp -s "$QUARANTINE_TEST_STATE/worker.lock/quarantine" <(printf '%s\n' "$QUARANTINE_SENTINEL") \
+  && fail "the in-place quarantine content change did not occur"
+pass "promoted quarantine content is revalidated before recovery"
 
 new_staged_quarantine_fixture symlink
 printf '%s\n' "$QUARANTINE_SENTINEL" > "$QUARANTINE_TEST_STATE/symlink-target"

--- a/tests/fm-remote-job.test.sh
+++ b/tests/fm-remote-job.test.sh
@@ -712,6 +712,36 @@ stop_quarantine_test_worker() {
   QUARANTINE_TEST_WORKER_PID=
 }
 
+expect_staged_quarantine_identity_refusal() { # <expected-owner-dir> <description>
+  local expected_owner=$1 description=$2 i=0 rc field
+  start_staged_quarantine_worker
+  while kill -0 "$QUARANTINE_TEST_WORKER_PID" 2>/dev/null; do
+    if [ ! -e "$QUARANTINE_TEST_STAGE" ] && [ ! -L "$QUARANTINE_TEST_STAGE" ]; then
+      stop_quarantine_test_worker
+      fail "$description permitted staged recovery"
+    fi
+    [ "$i" -lt 100 ] || {
+      stop_quarantine_test_worker
+      fail "$description did not make the worker refuse ownership"
+    }
+    i=$((i + 1))
+    sleep 0.05
+  done
+  set +e
+  wait "$QUARANTINE_TEST_WORKER_PID" 2>/dev/null
+  rc=$?
+  set -e
+  QUARANTINE_TEST_WORKER_PID=
+  expect_code 1 "$rc" "$description returned the wrong ownership-refusal status"
+  assert_present "$QUARANTINE_TEST_STAGE" "$description removed quarantine staging"
+  assert_absent "$QUARANTINE_TEST_STATE/worker.lock/quarantine" \
+    "$description promoted quarantine staging"
+  for field in pid start command; do
+    cmp -s "$expected_owner/$field" "$QUARANTINE_TEST_STATE/worker.lock/$field" \
+      || fail "$description changed the recorded $field identity"
+  done
+}
+
 new_staged_quarantine_fixture live-owner
 sleep 30 &
 QUARANTINE_TEST_AUX_PID=$!
@@ -767,6 +797,46 @@ kill "$QUARANTINE_TEST_AUX_PID" 2>/dev/null || true
 wait "$QUARANTINE_TEST_AUX_PID" 2>/dev/null || true
 QUARANTINE_TEST_AUX_PID=
 pass "staged quarantine recovery distinguishes pid reuse by process start identity"
+
+new_staged_quarantine_fixture dead-owner-malformed-command
+sleep 30 &
+QUARANTINE_TEST_AUX_PID=$!
+printf '%s\n' "$QUARANTINE_TEST_AUX_PID" > "$QUARANTINE_TEST_STATE/worker.lock/pid"
+fm_remote_job_process_start "$QUARANTINE_TEST_AUX_PID" > "$QUARANTINE_TEST_STATE/worker.lock/start"
+: > "$QUARANTINE_TEST_STATE/worker.lock/command"
+chmod 600 "$QUARANTINE_TEST_STATE/worker.lock/pid" "$QUARANTINE_TEST_STATE/worker.lock/start" \
+  "$QUARANTINE_TEST_STATE/worker.lock/command"
+kill "$QUARANTINE_TEST_AUX_PID" 2>/dev/null || true
+wait "$QUARANTINE_TEST_AUX_PID" 2>/dev/null || true
+QUARANTINE_TEST_AUX_PID=
+DEAD_OWNER_EXPECTED="$QUARANTINE_TEST_DIR/expected-owner"
+mkdir -p "$DEAD_OWNER_EXPECTED"
+cp "$QUARANTINE_TEST_STATE/worker.lock/pid" "$QUARANTINE_TEST_STATE/worker.lock/start" \
+  "$QUARANTINE_TEST_STATE/worker.lock/command" "$DEAD_OWNER_EXPECTED/"
+expect_staged_quarantine_identity_refusal "$DEAD_OWNER_EXPECTED" \
+  "a dead owner with an empty command identity"
+pass "completed quarantine staging refuses malformed dead-owner identity"
+
+new_staged_quarantine_fixture reused-owner-malformed-command
+sleep 30 &
+QUARANTINE_TEST_AUX_PID=$!
+printf '%s\n' "$QUARANTINE_TEST_AUX_PID" > "$QUARANTINE_TEST_STATE/worker.lock/pid"
+printf 'stale process start identity\n' > "$QUARANTINE_TEST_STATE/worker.lock/start"
+printf 'first command line\nsecond command line\n' > "$QUARANTINE_TEST_STATE/worker.lock/command"
+chmod 600 "$QUARANTINE_TEST_STATE/worker.lock/pid" "$QUARANTINE_TEST_STATE/worker.lock/start" \
+  "$QUARANTINE_TEST_STATE/worker.lock/command"
+REUSED_OWNER_EXPECTED="$QUARANTINE_TEST_DIR/expected-owner"
+mkdir -p "$REUSED_OWNER_EXPECTED"
+cp "$QUARANTINE_TEST_STATE/worker.lock/pid" "$QUARANTINE_TEST_STATE/worker.lock/start" \
+  "$QUARANTINE_TEST_STATE/worker.lock/command" "$REUSED_OWNER_EXPECTED/"
+expect_staged_quarantine_identity_refusal "$REUSED_OWNER_EXPECTED" \
+  "a reused owner pid with a multiline command identity"
+kill -0 "$QUARANTINE_TEST_AUX_PID" 2>/dev/null \
+  || fail "staged recovery signalled a reused pid with malformed owner identity"
+kill "$QUARANTINE_TEST_AUX_PID" 2>/dev/null || true
+wait "$QUARANTINE_TEST_AUX_PID" 2>/dev/null || true
+QUARANTINE_TEST_AUX_PID=
+pass "completed quarantine staging refuses malformed reused-owner identity"
 
 new_staged_quarantine_fixture live-legacy-worker
 LEGACY_WORKER="$QUARANTINE_TEST_DIR/fm-remote-job-worker.sh"

--- a/tests/fm-remote-job.test.sh
+++ b/tests/fm-remote-job.test.sh
@@ -830,6 +830,57 @@ expect_code 1 "$QUARANTINE_TEST_RC" "a malformed quarantine staging name was rec
 assert_present "$QUARANTINE_TEST_STATE/worker.lock/.quarantine.short" \
   "malformed quarantine staging was removed"
 
+LOCALE_RANGE_TEST_SHELL=(bash)
+if bash -c 'shopt -u globasciiranges' >/dev/null 2>&1; then
+  LOCALE_RANGE_TEST_SHELL=(bash +O globasciiranges)
+fi
+LOCALE_RANGE_TEST_LOCALE=$(
+  "${LOCALE_RANGE_TEST_SHELL[@]}" -c '
+    while IFS= read -r candidate; do
+      LC_ALL=$candidate
+      export LC_ALL
+      case é in [A-Za-z0-9]) printf "%s\n" "$candidate"; exit 0 ;; esac
+    done
+    exit 1
+  ' < <(locale -a 2>/dev/null)
+) || LOCALE_RANGE_TEST_LOCALE=
+if [ -n "$LOCALE_RANGE_TEST_LOCALE" ]; then
+  new_staged_quarantine_fixture locale-expanded-name
+  LOCALE_EXPANDED_STAGE="$QUARANTINE_TEST_STATE/worker.lock/.quarantine.é12345"
+  mv "$QUARANTINE_TEST_STAGE" "$LOCALE_EXPANDED_STAGE"
+  QUARANTINE_TEST_STAGE=$LOCALE_EXPANDED_STAGE
+  touch -t 200001010000 "$QUARANTINE_TEST_STATE/worker.lock"
+  set +e
+  HOME="$QUARANTINE_TEST_HOME" PATH="$PATH" FM_ROOT_OVERRIDE="$REMOTE_ROOT" \
+    FM_REMOTE_JOB_STATE_ROOT="$QUARANTINE_TEST_STATE" FM_REMOTE_JOB_PLATFORM_OVERRIDE=Linux \
+    LC_ALL="$LOCALE_RANGE_TEST_LOCALE" "${LOCALE_RANGE_TEST_SHELL[@]}" \
+    "$REMOTE_ROOT/bin/fm-remote-job-worker.sh" --serve \
+    > "$QUARANTINE_TEST_DIR/worker.out" 2> "$QUARANTINE_TEST_DIR/worker.err"
+  QUARANTINE_TEST_RC=$?
+  set -e
+  expect_code 1 "$QUARANTINE_TEST_RC" \
+    "a locale-expanded malformed quarantine staging name was recovered"
+  assert_present "$QUARANTINE_TEST_STAGE" \
+    "locale-expanded malformed quarantine staging was removed"
+  pass "locale-expanded malformed quarantine staging remains untouched"
+else
+  pass "skipped: no installed locale expands the quarantine suffix range"
+fi
+
+new_staged_quarantine_fixture conflicting-official
+printf '%s\n' "$QUARANTINE_SENTINEL" > "$QUARANTINE_TEST_STATE/worker.lock/quarantine"
+chmod 600 "$QUARANTINE_TEST_STATE/worker.lock/quarantine"
+run_staged_quarantine_worker
+expect_code 1 "$QUARANTINE_TEST_RC" "conflicting official and staged quarantine markers were recovered"
+assert_present "$QUARANTINE_TEST_STAGE" "a conflicting official marker displaced quarantine staging"
+assert_present "$QUARANTINE_TEST_STATE/worker.lock/quarantine" \
+  "staged quarantine recovery removed a conflicting official marker"
+cmp -s "$QUARANTINE_TEST_STAGE" <(printf '%s\n' "$QUARANTINE_SENTINEL") \
+  || fail "a conflicting staged quarantine marker changed"
+cmp -s "$QUARANTINE_TEST_STATE/worker.lock/quarantine" <(printf '%s\n' "$QUARANTINE_SENTINEL") \
+  || fail "a conflicting official quarantine marker changed"
+pass "conflicting official and staged quarantine markers remain untouched"
+
 new_staged_quarantine_fixture ambiguous-owner
 sleep 30 &
 QUARANTINE_TEST_AUX_PID=$!
@@ -980,6 +1031,24 @@ exit 0
 SH
 done
 chmod +x "$DOCTOR_BIN/herdr" "$DOCTOR_BIN/tasks-axi" "$DOCTOR_BIN/treehouse" "$DOCTOR_BIN/claude"
+set +e
+DOCTOR_CHECK_OUT=$(
+  HOME="$QUARANTINE_TEST_HOME" FM_HOME="$DOCTOR_FM_HOME" \
+    PATH="$ROOT/bin:$DOCTOR_BIN:/usr/bin:/bin:/usr/sbin:/sbin" FM_ROOT_OVERRIDE="$ROOT" \
+    FM_REMOTE_JOB_STATE_ROOT="$QUARANTINE_TEST_STATE" FM_REMOTE_JOB_PLATFORM_OVERRIDE=Linux \
+    "$ROOT/bin/fm-remote-doctor.sh" 2>&1
+)
+DOCTOR_CHECK_RC=$?
+set -e
+expect_code 1 "$DOCTOR_CHECK_RC" \
+  "read-only doctor unexpectedly accepted interrupted quarantine publication: $DOCTOR_CHECK_OUT"
+assert_contains "$DOCTOR_CHECK_OUT" \
+  'check remote-job-probe=fixable: the remote job worker has not reported a fresh probe' \
+  "read-only doctor did not report the missing fresh worker probe"
+assert_present "$QUARANTINE_TEST_STAGE" "read-only doctor removed quarantine staging"
+assert_absent "$QUARANTINE_TEST_STATE/worker.lock/quarantine" \
+  "read-only doctor promoted quarantine staging"
+
 set +e
 DOCTOR_RECOVERY_OUT=$(
   HOME="$QUARANTINE_TEST_HOME" FM_HOME="$DOCTOR_FM_HOME" \


### PR DESCRIPTION
## Intent

Ship the captain-approved bounded interrupted remote-job quarantine-publication fix, based on the existing reproduction and recovery evidence. The user-visible defect is that a sole completed hidden quarantine staging file left in worker.lock after interrupted publication causes the real remote worker to fail ownership acquisition with Directory not empty and prevents the supported remote doctor from obtaining a fresh worker probe. The source fix must remain small and owned by the existing remote-job worker code, with no generic lock cleaner, new control plane, queue deletion, unrelated hardening campaign, changed deadlines, or changed execution custody.

When quarantine publication reports a chmod or rename failure, clean up only the publisher's own temporary artifact after proving that path still identifies the same nonsymlink object. Recover only one exact completed publisher staging marker: the lock must be account-owned, nonsymlink mode 0700; the marker must be an account-owned, nonsymlink mode 0600 regular file with the exact quarantine sentinel bytes and unchanged object identity; the official marker must not conflict; the lock inventory may contain no unknown entries and only either no modern owner records or the complete pid/start/command identity. Atomically promote that marker to the official quarantine name and route it through the existing quarantine safety checks. Never simply delete the sentinel or its lock directory.

Preserve conservative refusal for ambiguous or unreadable identities, a matching live current worker, a live legacy worker represented by the account worker pid, live recorded job supervisors or process groups, wrong marker content, wrong modes, wrong ownership, symlinks, malformed or multiple staging markers, a conflicting official marker, partial owner records, and unexpected lock entries. PID reuse with a different process-start identity must be distinguished without signalling the reused process. Do not introduce safety predicates weaker than the existing ownership and recorded-execution checks. Account for supported macOS and Linux filesystem-stat differences.

Behavioral regression coverage must drive the real scripts in isolated task-owned fixture state. It must preserve the original end-user-aligned reproduction as the regression: before the fix, one exact complete hidden staging marker alone causes the ownership refusal and read-only doctor readiness failure; after safe recovery, a supported doctor --fix run reaches a fresh required-tool worker probe. Cover reported chmod and ENOSPC rename failures, interruption after completed staging but before final rename, matching live lock-owner rejection, matching live recorded-job rejection through the existing quarantine path, live legacy worker rejection, PID reuse with a mismatched start identity, malformed and ambiguous staging, wrong content/mode/owner, symlinks, multiple markers, unexpected entries, and successful next-start recovery. Keep all existing remote-job, remote-doctor, fm-on, and orphan-reaper tests green.

Update only authoritative current-behavior or help documentation for this behavior, keep incident chronology in private evidence, and run the repository's required shell lint, targeted real-script tests, documentation-audience check, and normal no-mistakes delivery through a PR. Do not access the real Mac Mini, use SSH, operate any live queue, service, runner, credential, private dataset, or production system, start or restart Herdr, or restart or upgrade any shared daemon. Use only isolated fixture state. Report concrete blockers rather than installing missing tools. Never merge the PR or answer an ask-user finding from the implementation worker.

## What Changed
- Recover one safely validated quarantine staging marker through the worker’s existing quarantine checks, while conservatively refusing ambiguous locks and live executions.
- Clean up only identity-verified publisher artifacts after quarantine publication failures.
- Document the recovery behavior and add real-script regression coverage for successful recovery, publication failures, and unsafe staging states.

## Risk Assessment

✅ Low: The fix is bounded to quarantine publication and recovery, preserves conservative refusal paths, and includes behavior-driven coverage for the required failure and recovery cases.

## Testing

After correcting two evidence-harness-only setup issues involving canonical temporary paths and a subshell-scoped postcheck, all targeted remote-job, remote-doctor, fm-on, and orphan-reaper tests passed. The end-to-end fixture reproduced the base worker’s `Directory not empty` ownership failure, confirmed read-only doctor remained non-mutating and unready, then showed target doctor `--fix` safely removed the staging marker and reached a fresh required-tool probe.

<details>
<summary>Evidence: End-to-end base failure and target doctor recovery transcript</summary>

```text
=== Reproduction with the base worker ===
base worker exit: 1
rmdir: /private/var/folders/0c/gglt88j97vg9yytc3yvr9dnh0000gn/T/no-mistakes-evidence/01M1WQQPH6K0DZF6SFJ0CMYTJB/remote-job-quarantine-demo-runtime/state/worker.lock: Directory not empty
remote-job-worker: cannot acquire or safely reclaim worker ownership
staging marker after base worker: PRESENT
official quarantine after base worker: ABSENT

=== Supported read-only doctor before recovery ===
read-only doctor exit: 1
mode=check
path=/Users/camiloslaptop/.no-mistakes/worktrees/af1f7764a4ae/01M1WQQPH6K0DZF6SFJ0CMYTJB/bin:/private/var/folders/0c/gglt88j97vg9yytc3yvr9dnh0000gn/T/no-mistakes-evidence/01M1WQQPH6K0DZF6SFJ0CMYTJB/remote-job-quarantine-demo-runtime/home/.local/bin:/usr/bin:/bin:/usr/sbin:/sbin
entrypoint=yes
platform=linux
required git=/private/var/folders/0c/gglt88j97vg9yytc3yvr9dnh0000gn/T/no-mistakes-evidence/01M1WQQPH6K0DZF6SFJ0CMYTJB/remote-job-quarantine-demo-runtime/home/.local/bin/git
required jq=/private/var/folders/0c/gglt88j97vg9yytc3yvr9dnh0000gn/T/no-mistakes-evidence/01M1WQQPH6K0DZF6SFJ0CMYTJB/remote-job-quarantine-demo-runtime/home/.local/bin/jq
required herdr=/private/var/folders/0c/gglt88j97vg9yytc3yvr9dnh0000gn/T/no-mistakes-evidence/01M1WQQPH6K0DZF6SFJ0CMYTJB/remote-job-quarantine-demo-runtime/home/.local/bin/herdr
required tasks-axi=/private/var/folders/0c/gglt88j97vg9yytc3yvr9dnh0000gn/T/no-mistakes-evidence/01M1WQQPH6K0DZF6SFJ0CMYTJB/remote-job-quarantine-demo-runtime/home/.local/bin/tasks-axi
required treehouse=/private/var/folders/0c/gglt88j97vg9yytc3yvr9dnh0000gn/T/no-mistakes-evidence/01M1WQQPH6K0DZF6SFJ0CMYTJB/remote-job-quarantine-demo-runtime/home/.local/bin/treehouse
required harness=claude:/private/var/folders/0c/gglt88j97vg9yytc3yvr9dnh0000gn/T/no-mistakes-evidence/01M1WQQPH6K0DZF6SFJ0CMYTJB/remote-job-quarantine-demo-runtime/home/.local/bin/claude
optional tmux=absent
optional no-mistakes=absent
optional gh=absent
check herdr=ok: /private/var/folders/0c/gglt88j97vg9yytc3yvr9dnh0000gn/T/no-mistakes-evidence/01M1WQQPH6K0DZF6SFJ0CMYTJB/remote-job-quarantine-demo-runtime/home/.local/bin/herdr
check gui-session=skip: no Aqua login session applies on linux
check remote-job-worker=fixable: the Linux remote job worker is not running
check remote-job-worker-loaded=skip: Aqua launch agents do not apply on linux
check remote-job-probe=fixable: the remote job worker has not reported a fresh probe
check launchagent=skip: launch agents apply only on darwin
check launchagent-scope=skip: launch agents apply only on darwin
check launchagent-loaded=skip: launch agents apply only on darwin
check herdr-server=ok: session fm-remote is running
check entrypoint-link=fixable: no entrypoint symlink at /private/var/folders/0c/gglt88j97vg9yytc3yvr9dnh0000gn/T/no-mistakes-evidence/01M1WQQPH6K0DZF6SFJ0CMYTJB/remote-job-quarantine-demo-runtime/home/.local/bin/fm-remote-entrypoint.sh
action: remote-job-worker: rerun this command with --fix to start it
action: remote-job-probe: rerun this command with --fix to restart the worker, then rerun through fm-on.sh
action: entrypoint-link: rerun this command with --fix to create it
error: this host is not ready for a remote second mate; unresolved: remote-job-worker remote-job-probe entrypoint-link
staging marker after read-only doctor: PRESENT

=== Supported doctor --fix with the target worker ===
doctor --fix exit: 0
mode=fix
path=/Users/camiloslaptop/.no-mistakes/worktrees/af1f7764a4ae/01M1WQQPH6K0DZF6SFJ0CMYTJB/bin:/private/var/folders/0c/gglt88j97vg9yytc3yvr9dnh0000gn/T/no-mistakes-evidence/01M1WQQPH6K0DZF6SFJ0CMYTJB/remote-job-quarantine-demo-runtime/home/.local/bin:/usr/bin:/bin:/usr/sbin:/sbin
entrypoint=yes
platform=linux
fix remote-job-worker=applied: installed or reloaded dev.firstmate.remote-job
fix entrypoint-link=applied: linked /private/var/folders/0c/gglt88j97vg9yytc3yvr9dnh0000gn/T/no-mistakes-evidence/01M1WQQPH6K0DZF6SFJ0CMYTJB/remote-job-quarantine-demo-runtime/home/.local/bin/fm-remote-entrypoint.sh to /Users/camiloslaptop/.no-mistakes/worktrees/af1f7764a4ae/01M1WQQPH6K0DZF6SFJ0CMYTJB/bin/fm-remote-entrypoint.sh
required git=/private/var/folders/0c/gglt88j97vg9yytc3yvr9dnh0000gn/T/no-mistakes-evidence/01M1WQQPH6K0DZF6SFJ0CMYTJB/remote-job-quarantine-demo-runtime/home/.local/bin/git
required jq=/private/var/folders/0c/gglt88j97vg9yytc3yvr9dnh0000gn/T/no-mistakes-evidence/01M1WQQPH6K0DZF6SFJ0CMYTJB/remote-job-quarantine-demo-runtime/home/.local/bin/jq
required herdr=/private/var/folders/0c/gglt88j97vg9yytc3yvr9dnh0000gn/T/no-mistakes-evidence/01M1WQQPH6K0DZF6SFJ0CMYTJB/remote-job-quarantine-demo-runtime/home/.local/bin/herdr
required tasks-axi=/private/var/folders/0c/gglt88j97vg9yytc3yvr9dnh0000gn/T/no-mistakes-evidence/01M1WQQPH6K0DZF6SFJ0CMYTJB/remote-job-quarantine-demo-runtime/home/.local/bin/tasks-axi
required treehouse=/private/var/folders/0c/gglt88j97vg9yytc3yvr9dnh0000gn/T/no-mistakes-evidence/01M1WQQPH6K0DZF6SFJ0CMYTJB/remote-job-quarantine-demo-runtime/home/.local/bin/treehouse
required harness=claude:/private/var/folders/0c/gglt88j97vg9yytc3yvr9dnh0000gn/T/no-mistakes-evidence/01M1WQQPH6K0DZF6SFJ0CMYTJB/remote-job-quarantine-demo-runtime/home/.local/bin/claude
optional tmux=absent
optional no-mistakes=absent
optional gh=absent
check herdr=ok: /private/var/folders/0c/gglt88j97vg9yytc3yvr9dnh0000gn/T/no-mistakes-evidence/01M1WQQPH6K0DZF6SFJ0CMYTJB/remote-job-quarantine-demo-runtime/home/.local/bin/herdr
check gui-session=skip: no Aqua login session applies on linux
check remote-job-worker=ok: the Linux remote job worker is running
check remote-job-worker-loaded=skip: Aqua launch agents do not apply on linux
check remote-job-probe=ok: the remote job worker completed the required-tool probe
check launchagent=skip: launch agents apply only on darwin
check launchagent-scope=skip: launch agents apply only on darwin
check launchagent-loaded=skip: launch agents apply only on darwin
check herdr-server=ok: session fm-remote is running
check entrypoint-link=ok: /private/var/folders/0c/gglt88j97vg9yytc3yvr9dnh0000gn/T/no-mistakes-evidence/01M1WQQPH6K0DZF6SFJ0CMYTJB/remote-job-quarantine-demo-runtime/home/.local/bin/fm-remote-entrypoint.sh
ok: remote second-mate readiness confirmed on this host
staging marker after doctor --fix: ABSENT
official quarantine after doctor --fix: ABSENT
fresh worker readiness marker: PRESENT
```
</details>
<details>
<summary>Evidence: Remote-job targeted behavioral test log</summary>

```text
ok - default queue and execution bounds independently cover long polls
ok - operator PATH excludes a symlinked local bin
ok - operator PATH honors nvm defaults with a deterministic fallback
ok - operator PATH resolves the authorized Nix profile bin link
ok - operator PATH orders discovered tool installs deterministically
ok - the worker preserves bounded argv and stdin in an empty environment
ok - active jobs keep the worker ready for concurrent requests
ok - ensure replaces a live worker after its code changes
ok - worker identity binds the canonical configured code root
ok - stale ownership is reclaimed without signaling a reused pid
ok - the worker enforces the job timeout and publishes its result
ok - the worker expires queued jobs before they can mutate
ok - queued jobs receive a fresh bounded execution window
ok - a queued short command preempts a running long poll instead of waiting its window
ok - a poll re-armed after preemption reads the same cursor with nothing lost
ok - sibling polls never preempt each other into a re-arm churn loop
ok - worker shutdown terminates the active command tree before replacement
ok - Linux supervision recovers crashes and stops orphaned commands
ok - pre-execution validation obeys the job timeout
ok - the worker drains bounded output without changing command results
ok - the worker refuses symlinked job fields before command execution
ok - failed shutdown quarantines ownership against replacement workers
ok - quarantine recovery refuses unverifiable supervisors and ignores reused pids
ok - completed quarantine staging preserves a matching live lock owner
ok - completed quarantine staging enters the existing live-job safety checks
ok - staged quarantine recovery distinguishes pid reuse by process start identity
ok - completed quarantine staging refuses malformed dead-owner identity
ok - completed quarantine staging refuses malformed reused-owner identity
ok - completed quarantine staging refuses a live legacy worker
ok - quarantine staging requires exact modes including special permission bits
ok - promoted quarantine content is revalidated before recovery
ok - malformed staging preserves stale owner records and the unknown entry
ok - quarantine staging classification is independent of inherited shell options
ok - locale-expanded malformed quarantine staging remains untouched
ok - conflicting official and staged quarantine markers remain untouched
ok - malformed, ambiguous, symlinked, and foreign quarantine staging remains untouched
ok - a replacement preserves an active publisher's quarantine staging
ok - reported chmod and ENOSPC rename failures clean only their publisher temporary artifact
ok - the next worker safely recovers interruption between staging and quarantine publication
ok - the supported doctor reaches a fresh required-tool probe after safe staged-quarantine recovery
ok - a repeatedly signalled shutdown still releases ownership for the next worker
ok - barely healthy worker failures remain bounded by the restart guard
ALL TESTS PASSED
```
</details>
<details>
<summary>Evidence: Remote-doctor regression test log</summary>

```text
ok - a missing herdr CLI is a human gap that --fix never claims to close
ok - an absent launch agent is a fixable gap and the read-only run changes nothing
ok - --fix installs the dedicated fm-remote launch agent without touching default
ok - --fix is idempotent once the host is ready
ok - a loaded and running launch agent must match the complete owned contract
ok - a failed reload leaves stale effective launch-agent state unready
ok - a launch agent outside the Aqua session scope is rewritten in place
ok - launchd failures are reported and delayed server readiness is awaited
ok - human gaps are reported with their operator step and never claimed as fixed
ok - a non-darwin host skips launch agents and starts its herdr server directly
ok - --fix creates only owned version-manager wrappers and never clobbers an operator file
ok - doctor refreshes stale worker identity before probing tools
ok - the entrypoint symlink is recreated when absent and never overwritten when operator-owned
```
</details>
<details>
<summary>Evidence: fm-on regression test log</summary>

```text
ok - fm-on --stdin preserves argv, stdin, stdout, stderr, and exit status without shell interpretation
ok - fm-on defaults the remote command's stdin to /dev/null
ok - fm-on arms a bounded SSH dead-peer detection window by default (15s x 3 = 45s)
ok - fm-on's dead-peer detection window is env-overridable
ok - fm-on rejects invalid dead-peer settings before launching ssh
ok - the fixed entrypoint runs every command in the worker's explicit environment
ok - the entrypoint composes a deduplicated discovered child PATH (kept 4 existing, omitted 7 absent)
ok - read-only doctor inspects worker gaps over plain SSH without repair
ok - the remote doctor reports the same PATH the entrypoint hands its children
ok - the remote doctor derives tool readiness from the installed worker
ok - the remote doctor reports its required runtime tool set and optional tools
ok - multiple fm-*.sh executables work without a command table
ok - tracked-command authorization excludes checkout-local git
ok - doctor bootstrap remains authenticated when git is unavailable
ok - transport rejects shell escape, traversal, symlink, and option-injection surfaces
ok - the fixed entrypoint refuses incompatible protocols and unsafe roots
ok - ambiguous aliases refuse while exact secondmate ids remain routable
ok - unreachable and ambiguous transport failures are surfaced without retry
ALL TESTS PASSED
```
</details>
<details>
<summary>Evidence: Orphan-reaper regression test log</summary>

```text
ok - the Linux start path puts the whole worker tree in its own process group
ok - removing the state root and killing the recorded worker pid leaves the tree running at ppid 1
ok - a worker whose code root still exists is never reaped
ok - a worker stops its whole tree once its code root is pruned
ok - a dry run reports the abandoned worker and signals nothing
ok - the reaper stops an abandoned worker's whole tree
ok - the reaper is idempotent
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 2 issues found → auto-fixed (5) ✅</summary>

- 🚨 `bin/fm-remote-job-worker.sh:227` - Intent requires “one exact completed publisher staging marker” and conservative refusal of malformed staging. This new `[A-Za-z0-9]` case pattern uses ambient locale collation; on supported shells/locales where ranges include non-ASCII characters, a six-character suffix that `mktemp` could not publish can qualify, be promoted, and then be removed when no execution is live. Bind inventory matching to `LC_ALL=C` at this earliest boundary and cover a locale-expanded malformed suffix behaviorally.
- 🚨 `tests/fm-remote-job.test.sh:956` - Intent requires the regression to preserve the sole-marker read-only doctor readiness failure and explicitly cover a conflicting official marker. The added doctor fixture jumps directly to `fm-remote-doctor.sh --fix`, and no fixture creates both an exact staging marker and official quarantine. Add real-script assertions that check-mode doctor fails before `--fix`, then `--fix` reaches the fresh probe, plus a conflict case that refuses and preserves both markers.

🔧 Fix: Harden staged quarantine matching and regression coverage
1 error still open:
- 🚨 `bin/fm-remote-job-worker.sh:253` - The required conservative refusal for ambiguous identities remains bypassable: when the recorded PID is dead or its start identity differs, this function returns stale at lines 253-257 before validating `command`. An empty, multiline, or otherwise unreadable `command` record is therefore promoted and later deleted despite the requirement for a complete interpretable pid/start/command identity. Parse all three records before classifying the owner as dead or reused, and cover a dead/reused PID with malformed `command` through the real worker.

🔧 Fix: Validate complete owner identity before quarantine recovery
2 errors still open:
- 🚨 `bin/fm-remote-job-worker.sh:86` - The required lock mode 0700 and marker mode 0600 checks are not exact on macOS: Darwin `stat %Lp` reports only the low permission bits, excluding setuid/setgid/sticky bits. Consequently modes such as 01700 or 04600 pass as 700/600, contradicting the exact-mode criterion. Include Darwin&#39;s special mode bits in the normalized mode value before comparison.
- 🚨 `bin/fm-remote-job-worker.sh:320` - The criterion requires exact sentinel bytes and unchanged object identity, but after the initial `cmp` the code only rechecks metadata. A same-account writer retaining an open descriptor can alter the marker in place without changing uid/device/inode/mode; the modified file is then promoted and the existing quarantine path only checks bounded regular-file shape before deleting it. Revalidate the official marker&#39;s exact bytes after atomic promotion and before quarantine recovery.

🔧 Fix: Harden quarantine mode and content revalidation
3 errors still open:
- 🚨 `bin/fm-remote-job-worker.sh:327` - A replacement can promote a completed staging file while its recorded owner is still the publishing worker. The replacement then refuses recovery and leaves official quarantine, but the original publisher&#39;s `mv` fails because its source vanished; `worker_shutdown` treats that as an unguarded publication failure and resumes serving jobs behind the quarantine marker. Treat an official marker with the publisher temporary&#39;s exact identity and sentinel as successful publication, or otherwise prevent consuming a live publisher&#39;s staging file, and cover this race with two real workers.
- 🚨 `bin/fm-remote-job-worker.sh:231` - The required “one exact completed publisher staging marker” remains dependent on ambient Bash options. If `nocasematch` is enabled through inherited `BASHOPTS` or `BASH_ENV`, `.QUARANTINE.A1b2C3` matches the lowercase case arm and can be promoted and deleted even though `mktemp` never publishes that prefix. Make classification explicitly case-sensitive and add a real-worker regression under `nocasematch`; also isolate glob options such as `dotglob`, which currently double-counts valid hidden entries.
- 🚨 `tests/fm-remote-job.test.sh:1036` - The required wrong-ownership regression changes `id -u`, making the account-owned lock itself appear foreign. Recovery exits at the lock ownership check before inspecting the staging marker, so this test would still pass if marker ownership validation were removed. Add a fixture that keeps the lock account-owned while making only the marker report or carry a different owner.

🔧 Fix: Preserve live publishers and normalize quarantine staging classification
1 error still open:
- 🚨 `bin/fm-remote-job-worker.sh:246` - Intent requires conservative refusal for malformed staging, partial identities, and unexpected entries, while documentation says malformed candidates remain untouched. When no exact marker exists, this branch returns “no staging” even if `unsafe=1`; an old lock containing owner records plus `.quarantine.short` therefore falls through and deletes `pid/start/command` at line 369 before `rmdir` fails. Return the unsafe status for malformed/unknown inventory and add a real-worker regression proving the owner tuple is preserved.

🔧 Fix: Preserve malformed staging and stale owner evidence
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`git rev-parse HEAD` and base-to-target diff inspection for commits `cf7e2fa8..c74094f0`</code>
- `bash tests/fm-remote-job.test.sh`
- `bash tests/fm-remote-doctor.test.sh`
- `bash tests/fm-on.test.sh`
- `bash tests/fm-remote-job-orphan-reap.test.sh`
- <code>`run-remote-job-quarantine-demo.sh &#34;$PWD&#34; cf7e2fa81524397a3a36b31daab02cdd958983fe &lt;evidence-dir&gt;` to execute the base worker reproduction, read-only doctor check, and target doctor `--fix` recovery</code>
- <code>Verified the evidence fixture was removed, no fixture worker remained, and `git status --short` was clean</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Lint** - 1 issue found → auto-fixed ✅</summary>

- ⚠️ linter found issues (exit code 1)

🔧 Fix: Suppress intentional nested-shell locale expansion warning
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
