### PR TITLE
fix(bin): use absolute /usr/bin/stat for Darwin stat -f calls

### DIFF
--- a/bin/backends/herdr.sh
+++ b/bin/backends/herdr.sh
@@ -661,7 +661,7 @@ fm_backend_herdr_presentation_lock_namespace() {
 
 fm_backend_herdr_presentation_lock_namespace_mode() {
   if [ "$(uname -s 2>/dev/null)" = Darwin ]; then
-    stat -f '%Lp' "$1" 2>/dev/null
+    /usr/bin/stat -f '%Lp' "$1" 2>/dev/null
   else
     stat -c '%a' "$1" 2>/dev/null
   fi
@@ -669,7 +669,7 @@ fm_backend_herdr_presentation_lock_namespace_mode() {
 
 fm_backend_herdr_presentation_lock_namespace_uid() {
   if [ "$(uname -s 2>/dev/null)" = Darwin ]; then
-    stat -f '%u' "$1" 2>/dev/null
+    /usr/bin/stat -f '%u' "$1" 2>/dev/null
   else
     stat -c '%u' "$1" 2>/dev/null
   fi

--- a/bin/fm-backlog-receive.sh
+++ b/bin/fm-backlog-receive.sh
@@ -57,7 +57,7 @@ list_keys() { # <file>
 lock_age() {
   local modified now
   if [ "$(uname 2>/dev/null)" = Darwin ]; then
-    modified=$(stat -f '%m' "$1" 2>/dev/null) || return 1
+    modified=$(/usr/bin/stat -f '%m' "$1" 2>/dev/null) || return 1
   else
     modified=$(stat -c '%Y' "$1" 2>/dev/null) || return 1
   fi

--- a/bin/fm-bootstrap.sh
+++ b/bin/fm-bootstrap.sh
@@ -938,14 +938,14 @@ x_mode_write_if_changed() {
   [ "$parent" != "$dest" ] || return 1
   [ -d "$parent" ] && [ ! -L "$parent" ] || return 1
   if [ "$(uname)" = Darwin ]; then
-    parent_device=$(stat -f %d "$parent" 2>/dev/null) || return 1
+    parent_device=$(/usr/bin/stat -f %d "$parent" 2>/dev/null) || return 1
   else
     parent_device=$(stat -c %d "$parent" 2>/dev/null) || return 1
   fi
   if [ -e "$dest" ] || [ -L "$dest" ]; then
     fmx_single_link_file_valid "$dest" "$parent_device" || return 1
     if [ "$(uname)" = Darwin ]; then
-      current_mode=$(stat -f %Lp "$dest" 2>/dev/null) || return 1
+      current_mode=$(/usr/bin/stat -f %Lp "$dest" 2>/dev/null) || return 1
     else
       current_mode=$(stat -c %a "$dest" 2>/dev/null) || return 1
     fi

--- a/bin/fm-busy-event.sh
+++ b/bin/fm-busy-event.sh
@@ -103,7 +103,7 @@ LOCK="$REC.lock"
 # gets a non-numeric token. Detect the platform once and pick the right form,
 # exactly as bin/fm-watch.sh does.
 if [ "$(uname)" = Darwin ]; then
-  lock_mtime() { stat -f %m "$1" 2>/dev/null; }
+  lock_mtime() { /usr/bin/stat -f %m "$1" 2>/dev/null; }
 else
   lock_mtime() { stat -c %Y "$1" 2>/dev/null; }
 fi

--- a/bin/fm-classify-lib.sh
+++ b/bin/fm-classify-lib.sh
@@ -652,9 +652,9 @@ _fm_open_decisions_file_ident() {  # <file> -> strongest available identity
     return
   fi
   if [ "$(uname -s 2>/dev/null)" = Darwin ]; then
-    ident=$(LC_ALL=C stat -f '%d:%i' "$f" 2>/dev/null) || return 1
-    epoch=$(LC_ALL=C stat -f '%B' "$f" 2>/dev/null) || epoch=0
-    if [ "$epoch" != 0 ]; then birth=$(LC_ALL=C stat -f '%FB' "$f" 2>/dev/null) || birth=''; else birth=''; fi
+    ident=$(LC_ALL=C /usr/bin/stat -f '%d:%i' "$f" 2>/dev/null) || return 1
+    epoch=$(LC_ALL=C /usr/bin/stat -f '%B' "$f" 2>/dev/null) || epoch=0
+    if [ "$epoch" != 0 ]; then birth=$(LC_ALL=C /usr/bin/stat -f '%FB' "$f" 2>/dev/null) || birth=''; else birth=''; fi
   else
     ident=$(LC_ALL=C stat -c '%d:%i' "$f" 2>/dev/null) || return 1
     epoch=$(LC_ALL=C stat -c '%W' "$f" 2>/dev/null) || epoch=0
@@ -671,7 +671,7 @@ _fm_status_file_size() {  # <status-file>
     return
   fi
   if [ "$(uname -s 2>/dev/null)" = Darwin ]; then
-    LC_ALL=C stat -f '%z' "$f" 2>/dev/null
+    LC_ALL=C /usr/bin/stat -f '%z' "$f" 2>/dev/null
   else
     LC_ALL=C stat -c '%s' "$f" 2>/dev/null
   fi
@@ -1071,7 +1071,7 @@ status_presentation_marker_parse() {
 
 _status_observed_path_state() {
   if [ "$(uname -s 2>/dev/null)" = Darwin ]; then
-    LC_ALL=C stat -f '%HT:%p' "$1" 2>/dev/null
+    LC_ALL=C /usr/bin/stat -f '%HT:%p' "$1" 2>/dev/null
   else
     LC_ALL=C stat -c '%F:%f' "$1" 2>/dev/null
   fi

--- a/bin/fm-classify-lib.sh
+++ b/bin/fm-classify-lib.sh
@@ -680,7 +680,7 @@ _fm_status_file_size() {  # <status-file>
 _fm_status_file_mtime() {  # <status-file>
   local f=$1
   if [ "$(uname -s 2>/dev/null)" = Darwin ]; then
-    LC_ALL=C stat -f '%m' "$f" 2>/dev/null
+    LC_ALL=C /usr/bin/stat -f '%m' "$f" 2>/dev/null
   else
     LC_ALL=C stat -c '%Y' "$f" 2>/dev/null
   fi

--- a/bin/fm-config-inherit-lib.sh
+++ b/bin/fm-config-inherit-lib.sh
@@ -103,7 +103,7 @@ fm_config_source_present() {
 
 fm_inherit_file_mode() {
   if [ "$(uname)" = Darwin ]; then
-    stat -f %Lp "$1" 2>/dev/null
+    /usr/bin/stat -f %Lp "$1" 2>/dev/null
   else
     stat -c %a "$1" 2>/dev/null
   fi
@@ -111,7 +111,7 @@ fm_inherit_file_mode() {
 
 fm_inherit_file_device() {
   if [ "$(uname)" = Darwin ]; then
-    stat -f %d "$1" 2>/dev/null
+    /usr/bin/stat -f %d "$1" 2>/dev/null
   else
     stat -c %d "$1" 2>/dev/null
   fi
@@ -119,7 +119,7 @@ fm_inherit_file_device() {
 
 fm_inherit_file_link_count() {
   if [ "$(uname)" = Darwin ]; then
-    stat -f %l "$1" 2>/dev/null
+    /usr/bin/stat -f %l "$1" 2>/dev/null
   else
     stat -c %h "$1" 2>/dev/null
   fi

--- a/bin/fm-fleet-snapshot.sh
+++ b/bin/fm-fleet-snapshot.sh
@@ -1086,8 +1086,8 @@ case "$FM_SNAPSHOT_SECONDMATE_LANDED_PER_HOME" in ''|*[!0-9]*) FM_SNAPSHOT_SECON
 # pollute arithmetic input before failing. Select the platform syntax once.
 if [ "$(uname 2>/dev/null || true)" = Darwin ]; then
   SNAPSHOT_STAT_STYLE=bsd
-  file_mtime_epoch() { stat -f '%m' "$1" 2>/dev/null || true; }
-  file_mode_octal() { stat -f '%Lp' "$1" 2>/dev/null || true; }
+  file_mtime_epoch() { /usr/bin/stat -f '%m' "$1" 2>/dev/null || true; }
+  file_mode_octal() { /usr/bin/stat -f '%Lp' "$1" 2>/dev/null || true; }
 else
   SNAPSHOT_STAT_STYLE=gnu
   file_mtime_epoch() { stat -c '%Y' "$1" 2>/dev/null || true; }
@@ -1440,7 +1440,7 @@ bounded_parent_activities_json() {  # <status-file>
     stat_style=$6
     . "$classify"
     if [ "$stat_style" = bsd ]; then
-      size=$(stat -f "%z" "$f" 2>/dev/null) || exit 3
+      size=$(/usr/bin/stat -f "%z" "$f" 2>/dev/null) || exit 3
     else
       size=$(stat -c "%s" "$f" 2>/dev/null) || exit 3
     fi

--- a/bin/fm-inactive-reconcile.sh
+++ b/bin/fm-inactive-reconcile.sh
@@ -121,7 +121,7 @@ if [ "$FM_INACTIVE_RECONCILE_BUDGET_SECS" -gt 30 ]; then
 fi
 
 if [ "$(uname)" = Darwin ]; then
-  file_mtime() { stat -f %m "$1" 2>/dev/null; }
+  file_mtime() { /usr/bin/stat -f %m "$1" 2>/dev/null; }
 else
   file_mtime() { stat -c %Y "$1" 2>/dev/null; }
 fi

--- a/bin/fm-lock-lib.sh
+++ b/bin/fm-lock-lib.sh
@@ -24,7 +24,7 @@ fm_lock_log() {
 # no wake-queue machinery when a caller only needs the staleness proof.
 fm_lock_path_mtime() {
   if [ "$(uname)" = Darwin ]; then
-    stat -f %m "$1" 2>/dev/null
+    /usr/bin/stat -f %m "$1" 2>/dev/null
   else
     stat -c %Y "$1" 2>/dev/null
   fi

--- a/bin/fm-pending-reply-lib.sh
+++ b/bin/fm-pending-reply-lib.sh
@@ -571,7 +571,7 @@ fm_pending_reply_file_signature() {  # <path>
   local path=$1
   [ -f "$path" ] || { printf 'missing'; return 0; }
   if [ "$(uname -s 2>/dev/null)" = Darwin ]; then
-    LC_ALL=C stat -f '%d:%i:%z:%m:%c' "$path" 2>/dev/null || printf 'unreadable'
+    LC_ALL=C /usr/bin/stat -f '%d:%i:%z:%m:%c' "$path" 2>/dev/null || printf 'unreadable'
   else
     LC_ALL=C stat -c '%d:%i:%s:%Y:%Z' "$path" 2>/dev/null || printf 'unreadable'
   fi

--- a/bin/fm-pr-lib.sh
+++ b/bin/fm-pr-lib.sh
@@ -215,7 +215,7 @@ fm_pr_head_valid() {
 
 fm_pr_file_mode() {
   if [ "$(uname)" = Darwin ]; then
-    stat -f %Lp "$1" 2>/dev/null
+    /usr/bin/stat -f %Lp "$1" 2>/dev/null
   else
     stat -c %a "$1" 2>/dev/null
   fi
@@ -223,7 +223,7 @@ fm_pr_file_mode() {
 
 fm_pr_file_device() {
   if [ "$(uname)" = Darwin ]; then
-    stat -f %d "$1" 2>/dev/null
+    /usr/bin/stat -f %d "$1" 2>/dev/null
   else
     stat -c %d "$1" 2>/dev/null
   fi
@@ -231,7 +231,7 @@ fm_pr_file_device() {
 
 fm_pr_file_link_count() {
   if [ "$(uname)" = Darwin ]; then
-    stat -f %l "$1" 2>/dev/null
+    /usr/bin/stat -f %l "$1" 2>/dev/null
   else
     stat -c %h "$1" 2>/dev/null
   fi
@@ -239,7 +239,7 @@ fm_pr_file_link_count() {
 
 fm_pr_file_inode() {
   if [ "$(uname)" = Darwin ]; then
-    stat -f %i "$1" 2>/dev/null
+    /usr/bin/stat -f %i "$1" 2>/dev/null
   else
     stat -c %i "$1" 2>/dev/null
   fi

--- a/bin/fm-procevent-lib.sh
+++ b/bin/fm-procevent-lib.sh
@@ -642,7 +642,7 @@ fm_procevent_path_normalize() {
 fm_procevent_directory_owned_by_current_user() {
   local owner
   if [ "$(uname)" = Darwin ]; then
-    owner=$(stat -f %u "$1" 2>/dev/null)
+    owner=$(/usr/bin/stat -f %u "$1" 2>/dev/null)
   else
     owner=$(stat -c %u "$1" 2>/dev/null)
   fi

--- a/bin/fm-remote-file.sh
+++ b/bin/fm-remote-file.sh
@@ -77,7 +77,7 @@ snapshot_bounded_file() { # <file> <max-bytes> <destination> <size-file>
 
 directory_identity() {
   if [ "$(uname)" = Darwin ]; then
-    stat -f '%d:%i' . 2>/dev/null
+    /usr/bin/stat -f '%d:%i' . 2>/dev/null
   else
     stat -c '%d:%i' . 2>/dev/null
   fi

--- a/bin/fm-remote-inherit-push.sh
+++ b/bin/fm-remote-inherit-push.sh
@@ -27,7 +27,7 @@ sha256_file() {
   if command -v shasum >/dev/null 2>&1; then shasum -a 256 "$1" | awk '{print $1}'; else sha256sum "$1" | awk '{print $1}'; fi
 }
 file_link_count() {
-  if [ "$(uname)" = Darwin ]; then stat -f %l "$1" 2>/dev/null; else stat -c %h "$1" 2>/dev/null; fi
+  if [ "$(uname)" = Darwin ]; then /usr/bin/stat -f %l "$1" 2>/dev/null; else stat -c %h "$1" 2>/dev/null; fi
 }
 shared_captain_header_valid() {
   local head

--- a/bin/fm-remote-inherit.sh
+++ b/bin/fm-remote-inherit.sh
@@ -22,7 +22,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 die() { printf 'error: %s\n' "$1" >&2; exit 1; }
 usage() { sed -n '2,10p' "$0" | sed 's/^# \{0,1\}//'; exit 2; }
 file_link_count() {
-  if [ "$(uname)" = Darwin ]; then stat -f %l "$1" 2>/dev/null; else stat -c %h "$1" 2>/dev/null; fi
+  if [ "$(uname)" = Darwin ]; then /usr/bin/stat -f %l "$1" 2>/dev/null; else stat -c %h "$1" 2>/dev/null; fi
 }
 sha256_file() {
   if command -v shasum >/dev/null 2>&1; then shasum -a 256 "$1" | awk '{print $1}'; else sha256sum "$1" | awk '{print $1}'; fi

--- a/bin/fm-remote-job-lib.sh
+++ b/bin/fm-remote-job-lib.sh
@@ -758,7 +758,7 @@ fm_remote_job_reap() { # <account-home> <id>; only removes an exact completed re
 fm_remote_job_path_mtime() { # <path>
   # The platform override controls worker shape in isolated tests, not the host
   # kernel's stat syntax.
-  if [ "$(uname -s 2>/dev/null || true)" = Darwin ]; then stat -f %m "$1" 2>/dev/null; else stat -c %Y "$1" 2>/dev/null; fi
+  if [ "$(uname -s 2>/dev/null || true)" = Darwin ]; then /usr/bin/stat -f %m "$1" 2>/dev/null; else stat -c %Y "$1" 2>/dev/null; fi
 }
 
 fm_remote_job_stage_owner_alive() { # <stage-dir>

--- a/bin/fm-startup-memory-budget-lib.sh
+++ b/bin/fm-startup-memory-budget-lib.sh
@@ -23,7 +23,7 @@ fm_startup_memory_budget_fail() {
 
 fm_startup_memory_budget_link_count() {
   if [ "$(uname)" = Darwin ]; then
-    stat -f %l "$1" 2>/dev/null
+    /usr/bin/stat -f %l "$1" 2>/dev/null
   else
     stat -c %h "$1" 2>/dev/null
   fi

--- a/bin/fm-supervise-daemon.sh
+++ b/bin/fm-supervise-daemon.sh
@@ -236,7 +236,7 @@ _state_root() { printf '%s' "${FM_STATE_OVERRIDE:-$FM_HOME/state}"; }
 
 # --- portable stat (same trap as fm-watch.sh: no `stat -f || stat -c`) -------
 if [ "$(uname)" = Darwin ]; then
-  _stat_file_mtime() { stat -f %m "$1" 2>/dev/null; }
+  _stat_file_mtime() { /usr/bin/stat -f %m "$1" 2>/dev/null; }
 else
   _stat_file_mtime() { stat -c %Y "$1" 2>/dev/null; }
 fi

--- a/bin/fm-supervision-lib.sh
+++ b/bin/fm-supervision-lib.sh
@@ -15,7 +15,7 @@
 # Portable mtime; Linux stat lacks -f, macOS stat lacks -c.
 fm_sup_stat_mtime() {
   if [ "$(uname)" = Darwin ]; then
-    stat -f %m "$1" 2>/dev/null
+    /usr/bin/stat -f %m "$1" 2>/dev/null
   else
     stat -c %Y "$1" 2>/dev/null
   fi

--- a/bin/fm-test-isolation-proof.sh
+++ b/bin/fm-test-isolation-proof.sh
@@ -216,8 +216,8 @@ EOF
 
 dir_mode() {
   local path=$1
-  if stat -f %Lp "$path" >/dev/null 2>&1; then
-    stat -f %Lp "$path"
+  if /usr/bin/stat -f %Lp "$path" >/dev/null 2>&1; then
+    /usr/bin/stat -f %Lp "$path"
   else
     stat -c %a "$path"
   fi

--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -2273,7 +2273,7 @@ else
       cat "$out"
     fi
     if worker_root_mode_is_enforceable; then
-      mode=$(stat -c %a "$work" 2>/dev/null || stat -f %Lp "$work" 2>/dev/null || echo unknown)
+      mode=$(stat -c %a "$work" 2>/dev/null || /usr/bin/stat -f %Lp "$work" 2>/dev/null || echo unknown)
       case "$mode" in
         700|0700) ;;
         *)

--- a/bin/fm-wake-lib.sh
+++ b/bin/fm-wake-lib.sh
@@ -92,7 +92,7 @@ fm_pid_identity() {
 
 fm_path_mtime() {
   if [ "$_FM_UNAME" = Darwin ]; then
-    stat -f %m "$1" 2>/dev/null
+    /usr/bin/stat -f %m "$1" 2>/dev/null
   else
     stat -c %Y "$1" 2>/dev/null
   fi
@@ -1763,7 +1763,7 @@ fm_wake_signal_sig() {  # <file> -> reported-state signature
       status_observed_signature "$1"
       ;;
     *)
-      if [ "$_FM_UNAME" = Darwin ]; then stat -f '%z:%Fm' "$1" 2>/dev/null; else stat -c '%s:%Y' "$1" 2>/dev/null; fi
+      if [ "$_FM_UNAME" = Darwin ]; then /usr/bin/stat -f '%z:%Fm' "$1" 2>/dev/null; else stat -c '%s:%Y' "$1" 2>/dev/null; fi
       ;;
   esac
 }

--- a/bin/fm-watch.sh
+++ b/bin/fm-watch.sh
@@ -154,7 +154,7 @@ WATCHER_STALE_GRACE=${FM_WATCHER_STALE_GRACE:-${FM_GUARD_GRACE:-300}}
 # token (e.g. the word "File" read as an unset variable), which silently kills the
 # watcher mid-cycle. Detect the platform once and pick the right form.
 if [ "$(uname)" = Darwin ]; then
-  stat_mtime() { stat -f %m "$1" 2>/dev/null; }        # epoch seconds of mtime
+  stat_mtime() { /usr/bin/stat -f %m "$1" 2>/dev/null; }        # epoch seconds of mtime
 else
   stat_mtime() { stat -c %Y "$1" 2>/dev/null; }
 fi

--- a/bin/fm-x-lib.sh
+++ b/bin/fm-x-lib.sh
@@ -89,8 +89,8 @@ fmx_single_link_file_valid() {
   local file=$1 expected_device=${2-} links device
   [ -f "$file" ] && [ ! -L "$file" ] || return 1
   if [ "$(uname)" = Darwin ]; then
-    links=$(stat -f %l "$file" 2>/dev/null) || return 1
-    device=$(stat -f %d "$file" 2>/dev/null) || return 1
+    links=$(/usr/bin/stat -f %l "$file" 2>/dev/null) || return 1
+    device=$(/usr/bin/stat -f %d "$file" 2>/dev/null) || return 1
   else
     links=$(stat -c %h "$file" 2>/dev/null) || return 1
     device=$(stat -c %d "$file" 2>/dev/null) || return 1
@@ -103,7 +103,7 @@ fmx_single_link_file_mode_valid() {
   local file=$1 expected_mode=$2 expected_device=${3-} mode
   fmx_single_link_file_valid "$file" "$expected_device" || return 1
   if [ "$(uname)" = Darwin ]; then
-    mode=$(stat -f %Lp "$file" 2>/dev/null) || return 1
+    mode=$(/usr/bin/stat -f %Lp "$file" 2>/dev/null) || return 1
   else
     mode=$(stat -c %a "$file" 2>/dev/null) || return 1
   fi
@@ -114,8 +114,8 @@ fmx_private_artifact_dir_device() {
   local dir=$1 mode device
   [ -d "$dir" ] && [ ! -L "$dir" ] || return 1
   if [ "$(uname)" = Darwin ]; then
-    mode=$(stat -f %Lp "$dir" 2>/dev/null) || return 1
-    device=$(stat -f %d "$dir" 2>/dev/null) || return 1
+    mode=$(/usr/bin/stat -f %Lp "$dir" 2>/dev/null) || return 1
+    device=$(/usr/bin/stat -f %d "$dir" 2>/dev/null) || return 1
   else
     mode=$(stat -c %a "$dir" 2>/dev/null) || return 1
     device=$(stat -c %d "$dir" 2>/dev/null) || return 1
@@ -410,7 +410,7 @@ fmx_request_relay_context() {
 
 fmx_context_registry_mtime() {
   local file=$1 mtime
-  mtime=$(stat -f '%m' "$file" 2>/dev/null) || mtime=$(stat -c '%Y' "$file" 2>/dev/null) || return 1
+  mtime=$(/usr/bin/stat -f '%m' "$file" 2>/dev/null) || mtime=$(stat -c '%Y' "$file" 2>/dev/null) || return 1
   case "$mtime" in
     ''|*[!0-9]*) return 1 ;;
   esac

--- a/tests/fm-stat-shadowing.test.sh
+++ b/tests/fm-stat-shadowing.test.sh
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+# tests/fm-stat-shadowing.test.sh - verify Darwin stat helpers survive GNU coreutils
+# stat shadowing /usr/bin/stat on hosts where ~/.local/bin/stat (GNU) precedes
+# /usr/bin/stat in PATH.
+#
+# When GNU stat shadows BSD stat, `stat -f <fmt>` no longer means "format the
+# output" — it means "print a filesystem dump" and prints the literal text
+# `File: "<path>"` to stdout before failing on the format token. Callers that
+# feed the output into arithmetic (e.g. `age=$(( $(date +%s) - m ))`) crash
+# under `set -u` with "unbound variable" on the stray token.
+#
+# The fix: all Darwin `stat -f` calls in bin/ are prefixed with `/usr/bin/stat`
+# to bypass any PATH-shadowing wrapper.
+#
+# This test proves the fix works by installing a fake GNU-like stat that shadows
+# /usr/bin/stat and asserting the helpers still return correct values.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+[ "$(uname)" = Darwin ] || { echo "skip: Darwin only"; exit 0; }
+
+TMP_ROOT=$(mktemp -d "${TMPDIR:-/tmp}/fm-stat-shadowing.XXXXXX") || exit 1
+trap 'rm -rf "$TMP_ROOT"' EXIT
+
+# --- fake GNU stat that mimics ~/.local/bin/stat shadowing /usr/bin/stat -------
+
+# GNU stat -f <fmt> prints a filesystem dump starting with `File: "<path>"` and
+# exits non-zero when the format token is unrecognized by the filesystem path.
+# We simulate this for the tokens used in our helpers so callers fail or produce
+# garbage when they use the shadowed stat instead of /usr/bin/stat.
+FAKE_STAT="$TMP_ROOT/fakebin/stat"
+mkdir -p "$(dirname "$FAKE_STAT")"
+
+cat > "$FAKE_STAT" <<'FAKESTAT'
+#!/usr/bin/env bash
+# Mimics GNU coreutils stat when it shadows BSD /usr/bin/stat.
+# On Darwin: BSD stat uses %m (mtime), %z (size), etc.
+# GNU stat -f treats its argument as a filesystem-path option, not a format.
+# For the format tokens our code uses, GNU stat prints the filesystem dump
+# starting with `File: "..."` and exits non-zero on the format token.
+# We simulate exactly that failure mode.
+opt1=${1:-} opt2=${2:-}
+if [ "$opt1" = "-f" ]; then
+  case "$opt2" in
+    %m|%l|%z|%d|%Lp|%i|%u|%B|%FB|%HT:%p|%d:%i|%d:%i:%z:%m:%c)
+      printf 'File: "%s"\n' "${3:-}" >&2
+      exit 1
+      ;;
+    *)
+      printf 'GNU stat: unknown -f format: %s\n' "$opt2" >&2
+      exit 1
+      ;;
+  esac
+fi
+printf 'GNU stat: unknown invocation: %s\n' "$*" >&2
+exit 1
+FAKESTAT
+chmod +x "$FAKE_STAT"
+
+# Prepend fakebin so the fake GNU stat shadows /usr/bin/stat
+ORIGINAL_PATH="$PATH"
+export PATH="$TMP_ROOT/fakebin:$ORIGINAL_PATH"
+
+# Verify the shadowing is active: a bare `stat -f %m /` must fail (not use BSD)
+if stat -f %m / >/dev/null 2>&1; then
+  # The fake stat didn't catch this — something is wrong with the PATH setup
+  PATH="$ORIGINAL_PATH"
+  fail "shadowing sanity check: bare stat -f %m / should fail under GNU-shadow but did not"
+fi
+
+# Also verify /usr/bin/stat still works when called directly
+REAL_MTIME=$(/usr/bin/stat -f %m "$0" 2>/dev/null) || true
+[ -n "$REAL_MTIME" ] && [ "$REAL_MTIME" -ge 0 ] || {
+  PATH="$ORIGINAL_PATH"
+  fail "/usr/bin/stat -f %m sanity check failed — /usr/bin/stat is not working"
+}
+pass "shadowing: fake GNU stat shadows /usr/bin/stat in PATH"
+
+# --- test the fixed helpers under shadowing ----------------------------------
+
+. "$ROOT/bin/fm-supervision-lib.sh"
+. "$ROOT/bin/fm-startup-memory-budget-lib.sh"
+
+TESTFILE="$TMP_ROOT/testfile"
+printf 'hello world\n' > "$TESTFILE"
+
+# 1. fm_sup_stat_mtime from bin/fm-supervision-lib.sh
+RESULT_MTIME=$(fm_sup_stat_mtime "$TESTFILE") || true
+EXPECTED_MTIME=$(/usr/bin/stat -f %m "$TESTFILE" 2>/dev/null)
+if [ -z "$RESULT_MTIME" ] || [ "$RESULT_MTIME" != "$EXPECTED_MTIME" ]; then
+  PATH="$ORIGINAL_PATH"
+  fail "fm_sup_stat_mtime: expected $EXPECTED_MTIME, got '$RESULT_MTIME'"
+fi
+pass "fm_sup_stat_mtime returns correct epoch mtime under GNU stat shadowing"
+
+# 2. fm_startup_memory_budget_link_count from bin/fm-startup-memory-budget-lib.sh
+RESULT_LINKS=$(fm_startup_memory_budget_link_count "$TESTFILE") || true
+EXPECTED_LINKS=$(/usr/bin/stat -f %l "$TESTFILE" 2>/dev/null)
+if [ -z "$RESULT_LINKS" ] || [ "$RESULT_LINKS" != "$EXPECTED_LINKS" ]; then
+  PATH="$ORIGINAL_PATH"
+  fail "fm_startup_memory_budget_link_count: expected $EXPECTED_LINKS, got '$RESULT_LINKS'"
+fi
+pass "fm_startup_memory_budget_link_count returns correct link count under GNU stat shadowing"
+
+# 3. _fm_status_file_size from bin/fm-classify-lib.sh (LC_ALL=C stat -f '%z')
+#    We source it and call the internal function directly.
+RESULT_SIZE=$(LC_ALL=C /usr/bin/stat -f '%z' "$TESTFILE" 2>/dev/null) || true
+# The fixed code uses /usr/bin/stat so it should produce the same value as direct call
+if [ -z "$RESULT_SIZE" ]; then
+  PATH="$ORIGINAL_PATH"
+  fail "_fm_status_file_size: could not get size via /usr/bin/stat"
+fi
+# Verify the helper itself works by checking that calling it with /usr/bin/stat prefix matches
+. "$ROOT/bin/fm-classify-lib.sh"
+HELPER_SIZE=$(_fm_status_file_size "$TESTFILE") || true
+if [ -z "$HELPER_SIZE" ] || [ "$HELPER_SIZE" != "$RESULT_SIZE" ]; then
+  PATH="$ORIGINAL_PATH"
+  fail "_fm_status_file_size: expected $RESULT_SIZE, got '$HELPER_SIZE'"
+fi
+pass "_fm_status_file_size returns correct byte size under GNU stat shadowing"
+
+# 4. stat_mtime from bin/fm-watch.sh
+. "$ROOT/bin/fm-watch.sh"
+RESULT_WATCH_MTIME=$(stat_mtime "$TESTFILE") || true
+if [ -z "$RESULT_WATCH_MTIME" ] || [ "$RESULT_WATCH_MTIME" != "$EXPECTED_MTIME" ]; then
+  PATH="$ORIGINAL_PATH"
+  fail "stat_mtime (fm-watch.sh): expected $EXPECTED_MTIME, got '$RESULT_WATCH_MTIME'"
+fi
+pass "stat_mtime from fm-watch.sh returns correct epoch mtime under GNU stat shadowing"
+
+# Restore PATH before exit
+PATH="$ORIGINAL_PATH"


### PR DESCRIPTION
## Intent

The developer needed to make the stale PR 3305 (https://github.com/kunchenguid/firstmate/pull/3305) mergeable again: its CI was green but GitHub reported the branch as conflicting with current main. Their goal was to rebase the PR branch onto current origin/main, resolve the conflicts, and preserve the PR's original fix that prefixes Darwin `stat -f` invocations with `/usr/bin/stat` so PATH shadowing does not break macOS stat flag parsing. They required that conflict resolution take the PR's `stat -f` fix where it touched files and keep main's other changes elsewhere, verify the fix still worked via the colocated tests, and then push the rebased branch. As steering during the work, the developer decided to drop a carried-over commit that removed the `synchronize` CI trigger (a change beyond the stat fix) and to push to the PR's actual head ref (fm/darwin-stat-shadowing-fix-21 on the fork) rather than the local fm/firstmate-3305 branch. Delivery was to go through the no-mistakes pipeline, which owns the push, PR, and CI steps.

## What Changed

- Prefixed every Darwin `stat -f` invocation across the `bin/` scripts with the absolute `/usr/bin/stat` path, so a GNU `stat` earlier in `PATH` (e.g. `~/.local/bin/stat`) can no longer shadow BSD `stat` and break format-token parsing on macOS.
- Added `tests/fm-stat-shadowing.test.sh`, which installs a fake GNU-like `stat` ahead of `/usr/bin/stat` and asserts the affected helpers still return correct values (skipped on non-Darwin hosts).

## Risk Assessment

✅ Low: Mechanical, consistent prefixing of Darwin stat -f calls with /usr/bin/stat that only affects macOS shadowing behavior, with a behavioral regression test and no workflow or logic changes.

## Testing

Ran the colocated Darwin regression test `tests/fm-stat-shadowing.test.sh`, which simulates a GNU stat shadowing /usr/bin/stat and exercises the four fixed helper functions end-to-end — all five assertions pass. I also reproduced the pre-fix failure mode directly to confirm the test is a genuine regression guard rather than a no-op. Worktree left clean; temp shims created via mktemp outside the tree. This is a shell/CLI change with no rendered UI surface, so the reviewer-visible evidence is the CLI transcript captured to the evidence directory.

<details>
<summary>Evidence: stat-shadowing regression test + pre-fix reproduction transcript</summary>

Source: [stat-shadowing regression test + pre-fix reproduction transcript](https://github.com/0x7067/firstmate/blob/cab0645b584ffe559b98fbc5a85430d16f91a147/.no-mistakes/evidence/fm/firstmate-3305/stat-shadowing-test.txt)

```text
# Darwin stat -f shadowing fix — PR 3305 test evidence
# host: Darwin 25.6.0; date: Mon Sep  7 13:47:15 -03 2026

## 1. Regression test under simulated GNU-stat shadowing
$ bash tests/fm-stat-shadowing.test.sh
ok - shadowing: fake GNU stat shadows /usr/bin/stat in PATH
ok - fm_sup_stat_mtime returns correct epoch mtime under GNU stat shadowing
ok - fm_startup_memory_budget_link_count returns correct link count under GNU stat shadowing
ok - _fm_status_file_size returns correct byte size under GNU stat shadowing
ok - stat_mtime from fm-watch.sh returns correct epoch mtime under GNU stat shadowing
exit=0

## 2. Proof the shim breaks bare stat but /usr/bin/stat (the fix) survives
$ stat -f %m <file>        # bare, PATH-shadowed (pre-fix behavior)
File: "/var/folders/9p/7pl_yxb55vqf1cg3mrjs19d00000gn/T/tmp.dtPvBykv4b/f"
exit=1
$ /usr/bin/stat -f %m <file>   # absolute path (the PR fix)
1788799635
exit=0
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"49b1b5916c4f36813ce98ca48ba01945ff6c6fde","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`bash tests/fm-stat-shadowing.test.sh` (Darwin-only regression; 5/5 ok, exit 0)</code>
- <code>Negative check: bare `stat -f %m` vs `/usr/bin/stat -f %m` under a GNU-stat PATH shim, confirming the shim breaks bare stat (exit 1, `File: &#34;...&#34;`) but the fix survives (correct mtime, exit 0)</code>
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
