### PR TITLE
fix(spawn): preserve codex max effort requests

### DIFF
--- a/.agents/skills/harness-adapters/references/common/model-and-effort.md
+++ b/.agents/skills/harness-adapters/references/common/model-and-effort.md
@@ -18,7 +18,8 @@ If an adapter lacks `xhigh`, cap at its highest supported non-`max` level rather
 Never select `max` through this fallback; only an explicit per-task or standing captain preference permits it.
 
 If requested effort is outside the adapter's accepted set, the spawn records `effort=` in task metadata but emits no effort flag.
-This preserves launch success instead of passing a known-bad value.
+For an accepted value with a narrower runtime capability, follow the selected tool reference's compatibility rule instead of passing a known-bad value.
+This preserves launch success while keeping the requested profile auditable.
 A harness with no verified interactive effort flag follows the same record-and-omit contract.
 
 ## Harness and provider identity

--- a/.agents/skills/harness-adapters/references/harness/codex.md
+++ b/.agents/skills/harness-adapters/references/harness/codex.md
@@ -12,7 +12,7 @@ Verified on 2026-06-11 with codex-cli 0.139.0 unless a fact gives a newer versio
 | Skill invocation | `$<skill>`, for example `$no-mistakes`; `/<skill>` is Claude-only and Codex rejects it as "Unrecognized command". |
 | Resume | `codex resume <session-id>`, using the id printed on quit. |
 | Model flag | `--model <model>`. |
-| Effort flag | `-c 'model_reasoning_effort="<low\|medium\|high\|xhigh>"'`, verified on codex-cli 0.142.1; `max` is an accepted Firstmate request, passed through only when `codex debug models` reports it for the selected model, and otherwise clamped to `xhigh`. |
+| Effort flag | `-c 'model_reasoning_effort="<low\|medium\|high\|xhigh\|max>"'`. `max` is an accepted Firstmate request, passed through when the installed codex CLI advertises a `max` reasoning level in its bundled catalog (codex-cli 0.153.4 does) and clamped to `xhigh` when it does not, so a spawn never emits an unsupported value. The capability check is model-agnostic - it asks whether the CLI supports `max`, not a specific model. |
 | Model discovery | Open the current interactive session's `/model` picker. |
 
 A directory trust dialog appears on the first run for a repository root: "Do you trust the contents of this directory?"

--- a/.agents/skills/harness-adapters/references/harness/codex.md
+++ b/.agents/skills/harness-adapters/references/harness/codex.md
@@ -12,7 +12,7 @@ Verified on 2026-06-11 with codex-cli 0.139.0 unless a fact gives a newer versio
 | Skill invocation | `$<skill>`, for example `$no-mistakes`; `/<skill>` is Claude-only and Codex rejects it as "Unrecognized command". |
 | Resume | `codex resume <session-id>`, using the id printed on quit. |
 | Model flag | `--model <model>`. |
-| Effort flag | `-c 'model_reasoning_effort="<low\|medium\|high\|xhigh\|max>"'`. codex-cli 0.142.1's bundled catalog advertised only low through xhigh, but codex-cli 0.153.4's catalog adds `max` (and an `ultra` level above it that firstmate's shared vocabulary never emits), so a requested `max` is passed through rather than omitted. |
+| Effort flag | `-c 'model_reasoning_effort="<low\|medium\|high\|xhigh\|max>"'`. codex-cli 0.142.1's bundled catalog advertised only low through xhigh; codex-cli 0.153.4's catalog adds `max` (and an `ultra` level above it that firstmate's shared vocabulary never emits). A requested `max` is passed through when the installed CLI advertises it and clamped to `xhigh` when it does not, so a spawn never emits an unsupported value. |
 | Model discovery | Open the current interactive session's `/model` picker. |
 
 A directory trust dialog appears on the first run for a repository root: "Do you trust the contents of this directory?"

--- a/.agents/skills/harness-adapters/references/harness/codex.md
+++ b/.agents/skills/harness-adapters/references/harness/codex.md
@@ -16,8 +16,10 @@ Verified on 2026-06-11 with codex-cli 0.139.0 unless a fact gives a newer versio
 | Model discovery | Open the current interactive session's `/model` picker. |
 
 Codex `max` is an accepted Firstmate request.
-Firstmate passes `max` through only when the requested or active default Codex model advertises `max` in its `supported_reasoning_levels`; otherwise it clamps to `xhigh`, so a spawn never emits an unsupported value.
-When the caller omits `--model`, the active default model is discovered from `~/.codex/config.toml` (or `$CODEX_HOME/config.toml`) before checking capability levels.
+Firstmate passes `max` through only when the requested model, or the default model resolved from this `fm-spawn` process's Codex config, advertises `max` in its `supported_reasoning_levels`.
+Otherwise it clamps to `xhigh`, so a spawn never emits an unsupported value.
+When the caller omits `--model`, the default model is read from `$CODEX_HOME/config.toml` or `$HOME/.codex/config.toml` before checking capability levels.
+If no default model can be resolved, the `max` capability is unconfirmed and the request clamps to `xhigh`.
 
 A directory trust dialog appears on the first run for a repository root: "Do you trust the contents of this directory?"
 Accept it with Enter and verify the instructions begin processing.

--- a/.agents/skills/harness-adapters/references/harness/codex.md
+++ b/.agents/skills/harness-adapters/references/harness/codex.md
@@ -12,7 +12,7 @@ Verified on 2026-06-11 with codex-cli 0.139.0 unless a fact gives a newer versio
 | Skill invocation | `$<skill>`, for example `$no-mistakes`; `/<skill>` is Claude-only and Codex rejects it as "Unrecognized command". |
 | Resume | `codex resume <session-id>`, using the id printed on quit. |
 | Model flag | `--model <model>`. |
-| Effort flag | `-c 'model_reasoning_effort="<low\|medium\|high\|xhigh>"'`, verified on codex-cli 0.142.1 whose installed schema contains `model_reasoning_effort`, active config uses it, and bundled catalog advertises only these four values while omitting `max`. |
+| Effort flag | `-c 'model_reasoning_effort="<low\|medium\|high\|xhigh\|max>"'`. codex-cli 0.142.1's bundled catalog advertised only low through xhigh, but codex-cli 0.153.4's catalog adds `max` (and an `ultra` level above it that firstmate's shared vocabulary never emits), so a requested `max` is passed through rather than omitted. |
 | Model discovery | Open the current interactive session's `/model` picker. |
 
 A directory trust dialog appears on the first run for a repository root: "Do you trust the contents of this directory?"

--- a/.agents/skills/harness-adapters/references/harness/codex.md
+++ b/.agents/skills/harness-adapters/references/harness/codex.md
@@ -12,7 +12,7 @@ Verified on 2026-06-11 with codex-cli 0.139.0 unless a fact gives a newer versio
 | Skill invocation | `$<skill>`, for example `$no-mistakes`; `/<skill>` is Claude-only and Codex rejects it as "Unrecognized command". |
 | Resume | `codex resume <session-id>`, using the id printed on quit. |
 | Model flag | `--model <model>`. |
-| Effort flag | `-c 'model_reasoning_effort="<low\|medium\|high\|xhigh\|max>"'`. codex-cli 0.142.1's bundled catalog advertised only low through xhigh; codex-cli 0.153.4's catalog adds `max` (and an `ultra` level above it that firstmate's shared vocabulary never emits). A requested `max` is passed through when the installed CLI advertises it and clamped to `xhigh` when it does not, so a spawn never emits an unsupported value. |
+| Effort flag | `-c 'model_reasoning_effort="<low\|medium\|high\|xhigh\|max>"'`; a requested `max` is passed through only when the selected model's local catalog entry advertises it, otherwise it clamps to `xhigh`. |
 | Model discovery | Open the current interactive session's `/model` picker. |
 
 A directory trust dialog appears on the first run for a repository root: "Do you trust the contents of this directory?"

--- a/.agents/skills/harness-adapters/references/harness/codex.md
+++ b/.agents/skills/harness-adapters/references/harness/codex.md
@@ -16,8 +16,8 @@ Verified on 2026-06-11 with codex-cli 0.139.0 unless a fact gives a newer versio
 | Model discovery | Open the current interactive session's `/model` picker. |
 
 Codex `max` is an accepted Firstmate request.
-Firstmate passes `max` through when the installed codex CLI advertises a `max` reasoning level in its bundled catalog (codex-cli 0.153.4 does) and clamps it to `xhigh` when it does not, so a spawn never emits an unsupported value.
-The capability check is model-agnostic - it asks whether the CLI supports `max`, not a specific model.
+Firstmate passes `max` through only when the requested or active default Codex model advertises `max` in its `supported_reasoning_levels`; otherwise it clamps to `xhigh`, so a spawn never emits an unsupported value.
+When the caller omits `--model`, the active default model is discovered from `~/.codex/config.toml` (or `$CODEX_HOME/config.toml`) before checking capability levels.
 
 A directory trust dialog appears on the first run for a repository root: "Do you trust the contents of this directory?"
 Accept it with Enter and verify the instructions begin processing.

--- a/.agents/skills/harness-adapters/references/harness/codex.md
+++ b/.agents/skills/harness-adapters/references/harness/codex.md
@@ -12,8 +12,12 @@ Verified on 2026-06-11 with codex-cli 0.139.0 unless a fact gives a newer versio
 | Skill invocation | `$<skill>`, for example `$no-mistakes`; `/<skill>` is Claude-only and Codex rejects it as "Unrecognized command". |
 | Resume | `codex resume <session-id>`, using the id printed on quit. |
 | Model flag | `--model <model>`. |
-| Effort flag | `-c 'model_reasoning_effort="<low\|medium\|high\|xhigh\|max>"'`. `max` is an accepted Firstmate request, passed through when the installed codex CLI advertises a `max` reasoning level in its bundled catalog (codex-cli 0.153.4 does) and clamped to `xhigh` when it does not, so a spawn never emits an unsupported value. The capability check is model-agnostic - it asks whether the CLI supports `max`, not a specific model. |
+| Effort flag | `-c 'model_reasoning_effort="<low\|medium\|high\|xhigh\|max>"'`. |
 | Model discovery | Open the current interactive session's `/model` picker. |
+
+Codex `max` is an accepted Firstmate request.
+Firstmate passes `max` through when the installed codex CLI advertises a `max` reasoning level in its bundled catalog (codex-cli 0.153.4 does) and clamps it to `xhigh` when it does not, so a spawn never emits an unsupported value.
+The capability check is model-agnostic - it asks whether the CLI supports `max`, not a specific model.
 
 A directory trust dialog appears on the first run for a repository root: "Do you trust the contents of this directory?"
 Accept it with Enter and verify the instructions begin processing.

--- a/.agents/skills/harness-adapters/references/harness/codex.md
+++ b/.agents/skills/harness-adapters/references/harness/codex.md
@@ -12,7 +12,7 @@ Verified on 2026-06-11 with codex-cli 0.139.0 unless a fact gives a newer versio
 | Skill invocation | `$<skill>`, for example `$no-mistakes`; `/<skill>` is Claude-only and Codex rejects it as "Unrecognized command". |
 | Resume | `codex resume <session-id>`, using the id printed on quit. |
 | Model flag | `--model <model>`. |
-| Effort flag | `-c 'model_reasoning_effort="<low\|medium\|high\|xhigh\|max>"'`; a requested `max` is passed through only when the selected model's local catalog entry advertises it, otherwise it clamps to `xhigh`. |
+| Effort flag | `-c 'model_reasoning_effort="<low\|medium\|high\|xhigh>"'`, verified on codex-cli 0.142.1; `max` is an accepted Firstmate request, passed through only when `codex debug models` reports it for the selected model, and otherwise clamped to `xhigh`. |
 | Model discovery | Open the current interactive session's `/model` picker. |
 
 A directory trust dialog appears on the first run for a repository root: "Do you trust the contents of this directory?"

--- a/bin/fm-bootstrap.sh
+++ b/bin/fm-bootstrap.sh
@@ -1109,7 +1109,7 @@ crew_dispatch_validate() {
       if $e == null then true
       elif ($e | type) != "string" then false
       elif $h == "claude" then (["low","medium","high","xhigh","max"] | index($e))
-      elif $h == "codex" then (["low","medium","high","xhigh"] | index($e))
+      elif $h == "codex" then (["low","medium","high","xhigh","max"] | index($e))
       elif $h == "grok" then (["low","medium","high"] | index($e))
       elif $h == "pi" or $h == "pi-signed" or $h == "omp" then (["low","medium","high","xhigh","max"] | index($e))
       elif $h == "muse" then (["low","medium","high","xhigh","max"] | index($e))

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -1825,18 +1825,17 @@ model_flag_for_harness() {
   esac
 }
 
-codex_model_supports_max_effort() {
-  local model=$1 catalog
-  [ -n "$model" ] && [ "$model" != default ] || return 1
+# codex_supports_max_effort: 0 when the installed codex CLI advertises a "max"
+# reasoning level in its bundled model catalog. The check is deliberately
+# model-agnostic: a requested max is a CLI-capability question, so we probe
+# whether the installed codex supports max at all rather than gating on a
+# specific model. Reads the local catalog via `codex debug models`; returns
+# non-zero when codex is absent, the subcommand is unavailable, or no model
+# lists a max effort - the fail-safe direction is the clamp, never an
+# unsupported pass-through.
+codex_supports_max_effort() {
   command -v codex >/dev/null 2>&1 || return 1
-  command -v jq >/dev/null 2>&1 || return 1
-  catalog=$(codex debug models --bundled 2>/dev/null || codex debug models 2>/dev/null) || return 1
-  printf '%s' "$catalog" | jq -e --arg model "$model" '
-    .models[]?
-    | select(.slug == $model or .id == $model or .model == $model or .name == $model or .selector == $model or .display_name == $model)
-    | .supported_reasoning_levels[]?
-    | select((if type == "object" then .effort else . end) == "max")
-  ' >/dev/null 2>&1
+  codex debug models 2>/dev/null | grep -q '"effort"[[:space:]]*:[[:space:]]*"max"'
 }
 
 effort_flag_for_harness() {
@@ -1850,7 +1849,7 @@ effort_flag_for_harness() {
       ;;
     codex)
       local codex_effort=$effort
-      if [ "$effort" = max ] && ! codex_model_supports_max_effort "$model"; then
+      if [ "$effort" = max ] && ! codex_supports_max_effort; then
         codex_effort=xhigh
       fi
       case "$codex_effort" in

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -1825,12 +1825,13 @@ model_flag_for_harness() {
   esac
 }
 
-# codex_default_model: print the active default Codex model from the local
-# codex configuration. Reads $CODEX_HOME/config.toml, falling back to
+# codex_default_model: print the default Codex model from this fm-spawn
+# process's codex configuration. Reads $CODEX_HOME/config.toml, falling back to
 # $HOME/.codex/config.toml. It looks only at top-level keys before the first
 # table header, and only for an exact `model = "..."` assignment. Returns
 # non-zero when the config is missing, unreadable, or contains no top-level
-# model, so an omitted/default model is not treated as unsupported.
+# model, so callers can fail closed instead of treating an unknown default as
+# max-capable.
 codex_default_model() {
   local config
   config="${CODEX_HOME:-$HOME/.codex}/config.toml"
@@ -1855,11 +1856,12 @@ AWK
 }
 
 # codex_model_supports_max_effort: 0 when the selected Codex model (or, when
-# the caller passes an empty/default model, the active default model from
-# codex config) advertises a "max" reasoning level. Reads the local catalog
-# via `codex debug models` and queries it with jq. Returns non-zero when
-# codex is absent, jq is absent, the catalog is unreachable, the model cannot
-# be found, or the model's supported_reasoning_levels does not contain max.
+# the caller passes an empty/default model, the default model from this
+# fm-spawn process's codex config) advertises a "max" reasoning level. Reads
+# the local catalog via `codex debug models` and queries it with jq. Returns
+# non-zero when codex is absent, jq is absent, the catalog is unreachable, the
+# model cannot be found, or the model's supported_reasoning_levels does not
+# contain max.
 # The fail-safe direction is the clamp, never an unsupported pass-through.
 codex_model_supports_max_effort() {
   local model=$1 catalog
@@ -1889,8 +1891,9 @@ effort_flag_for_harness() {
       # The installed codex config schema uses model_reasoning_effort. The
       # bundled catalog lists per-model supported reasoning levels, so a
       # requested max is passed through only when the selected model (or the
-      # active default model when none is selected) advertises it. Otherwise
-      # it clamps to xhigh rather than launching with an unsupported value.
+      # default from this fm-spawn process's codex config when none is selected)
+      # advertises it. Otherwise it clamps to xhigh rather than launching with
+      # an unsupported value.
       local codex_effort=$effort
       if [ "$effort" = max ] && ! codex_model_supports_max_effort "$model"; then
         codex_effort=xhigh

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -1824,18 +1824,22 @@ model_flag_for_harness() {
   esac
 }
 
-# codex_supports_max_effort: 0 when the installed codex CLI advertises a "max"
-# reasoning level in its bundled model catalog. Reads the local catalog via
-# `codex debug models`; returns non-zero when codex is absent, the subcommand
-# is unavailable, or no model lists a max effort - the fail-safe direction is
-# the clamp, never an unsupported pass-through.
-codex_supports_max_effort() {
+codex_model_supports_max_effort() {
+  local model=$1 catalog
+  [ -n "$model" ] && [ "$model" != default ] || return 1
   command -v codex >/dev/null 2>&1 || return 1
-  codex debug models 2>/dev/null | grep -q '"effort"[[:space:]]*:[[:space:]]*"max"'
+  command -v jq >/dev/null 2>&1 || return 1
+  catalog=$(codex debug models --bundled 2>/dev/null || codex debug models 2>/dev/null) || return 1
+  printf '%s' "$catalog" | jq -e --arg model "$model" '
+    .models[]?
+    | select(.slug == $model or .id == $model or .model == $model or .name == $model or .selector == $model or .display_name == $model)
+    | .supported_reasoning_levels[]?
+    | select((if type == "object" then .effort else . end) == "max")
+  ' >/dev/null 2>&1
 }
 
 effort_flag_for_harness() {
-  local harness=$1 effort=$2
+  local harness=$1 effort=$2 model=${3:-}
   [ -n "$effort" ] && [ "$effort" != default ] || return 0
   case "$harness" in
     claude)
@@ -1844,16 +1848,8 @@ effort_flag_for_harness() {
       esac
       ;;
     codex)
-      # The installed codex config schema uses model_reasoning_effort. codex-cli
-      # 0.153.4's bundled model catalog advertises low|medium|high|xhigh|max (and
-      # an "ultra" level above max that firstmate's shared vocabulary never
-      # emits), but older codex builds top out at xhigh. A requested max is
-      # passed through only when the installed CLI actually advertises it;
-      # otherwise it clamps to xhigh rather than launching with an unsupported
-      # value. The capability probe reads the local catalog via `codex debug
-      # models` and fails safe to the clamp when it cannot confirm support.
       local codex_effort=$effort
-      if [ "$effort" = max ] && ! codex_supports_max_effort; then
+      if [ "$effort" = max ] && ! codex_model_supports_max_effort "$model"; then
         codex_effort=xhigh
       fi
       case "$codex_effort" in
@@ -3738,7 +3734,7 @@ sq_ompcfg=$(shell_quote "${OMP_WORKER_CFG:-$FM_ROOT/.omp/fm-worker-overlay.yml}"
 sq_opinput=$(shell_quote "$FM_ROOT/bin/fm-operational-input.sh")
 sq_worktree=$(shell_quote "$WT")
 MODELFLAG=$(model_flag_for_harness "$HARNESS" "$MODEL")
-EFFORTFLAG=$(effort_flag_for_harness "$HARNESS" "$EFFORT")
+EFFORTFLAG=$(effort_flag_for_harness "$HARNESS" "$EFFORT" "$MODEL")
 LAUNCH=${LAUNCH//__MODELFLAG__/$MODELFLAG}
 LAUNCH=${LAUNCH//__EFFORTFLAG__/$EFFORTFLAG}
 if [ "$HARNESS" = rovo ]; then

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -1824,6 +1824,16 @@ model_flag_for_harness() {
   esac
 }
 
+# codex_supports_max_effort: 0 when the installed codex CLI advertises a "max"
+# reasoning level in its bundled model catalog. Reads the local catalog via
+# `codex debug models`; returns non-zero when codex is absent, the subcommand
+# is unavailable, or no model lists a max effort - the fail-safe direction is
+# the clamp, never an unsupported pass-through.
+codex_supports_max_effort() {
+  command -v codex >/dev/null 2>&1 || return 1
+  codex debug models 2>/dev/null | grep -q '"effort"[[:space:]]*:[[:space:]]*"max"'
+}
+
 effort_flag_for_harness() {
   local harness=$1 effort=$2
   [ -n "$effort" ] && [ "$effort" != default ] || return 0
@@ -1834,13 +1844,20 @@ effort_flag_for_harness() {
       esac
       ;;
     codex)
-      # The installed codex config schema uses model_reasoning_effort, and the
-      # bundled model catalog (codex-cli 0.153.4) advertises
-      # low|medium|high|xhigh|max, so every shared effort level maps straight
-      # across. codex also advertises an "ultra" level above max, but firstmate's
-      # shared vocabulary stops at max and never emits ultra.
-      case "$effort" in
-        low|medium|high|xhigh|max) printf -- '-c %s ' "$(shell_quote "model_reasoning_effort=\"$effort\"")" ;;
+      # The installed codex config schema uses model_reasoning_effort. codex-cli
+      # 0.153.4's bundled model catalog advertises low|medium|high|xhigh|max (and
+      # an "ultra" level above max that firstmate's shared vocabulary never
+      # emits), but older codex builds top out at xhigh. A requested max is
+      # passed through only when the installed CLI actually advertises it;
+      # otherwise it clamps to xhigh rather than launching with an unsupported
+      # value. The capability probe reads the local catalog via `codex debug
+      # models` and fails safe to the clamp when it cannot confirm support.
+      local codex_effort=$effort
+      if [ "$effort" = max ] && ! codex_supports_max_effort; then
+        codex_effort=xhigh
+      fi
+      case "$codex_effort" in
+        low|medium|high|xhigh|max) printf -- '-c %s ' "$(shell_quote "model_reasoning_effort=\"$codex_effort\"")" ;;
       esac
       ;;
     grok)

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -46,8 +46,9 @@
 #   positional harness arg still works for back-compat.
 #   --model <name> and --effort <low|medium|high|xhigh|max> are concrete profile
 #   axes chosen by firstmate at intake. They are only threaded into harnesses whose
-#   installed CLIs were verified to support that axis; unsupported axes are omitted
-#   from that harness's launch rather than guessed.
+#   installed CLIs were verified to support that axis; adapter-specific compatibility
+#   logic may clamp an accepted request when runtime discovery cannot confirm it,
+#   while unsupported axes are omitted from that harness's launch rather than guessed.
 #   --backend <name> is the explicit runtime session-provider backend for this
 #   exact task only (docs/configuration.md "Runtime backend" owns when that flag
 #   is authorized). Without it, the script resolves FM_BACKEND, then

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -1835,10 +1835,12 @@ effort_flag_for_harness() {
       ;;
     codex)
       # The installed codex config schema uses model_reasoning_effort, and the
-      # bundled model catalog advertises low|medium|high|xhigh. Omit max rather
-      # than passing an unsupported value.
+      # bundled model catalog (codex-cli 0.153.4) advertises
+      # low|medium|high|xhigh|max, so every shared effort level maps straight
+      # across. codex also advertises an "ultra" level above max, but firstmate's
+      # shared vocabulary stops at max and never emits ultra.
       case "$effort" in
-        low|medium|high|xhigh) printf -- '-c %s ' "$(shell_quote "model_reasoning_effort=\"$effort\"")" ;;
+        low|medium|high|xhigh|max) printf -- '-c %s ' "$(shell_quote "model_reasoning_effort=\"$effort\"")" ;;
       esac
       ;;
     grok)

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -1825,17 +1825,55 @@ model_flag_for_harness() {
   esac
 }
 
-# codex_supports_max_effort: 0 when the installed codex CLI advertises a "max"
-# reasoning level in its bundled model catalog. The check is deliberately
-# model-agnostic: a requested max is a CLI-capability question, so we probe
-# whether the installed codex supports max at all rather than gating on a
-# specific model. Reads the local catalog via `codex debug models`; returns
-# non-zero when codex is absent, the subcommand is unavailable, or no model
-# lists a max effort - the fail-safe direction is the clamp, never an
-# unsupported pass-through.
-codex_supports_max_effort() {
+# codex_default_model: print the active default Codex model from the local
+# codex configuration. Reads $CODEX_HOME/config.toml, falling back to
+# $HOME/.codex/config.toml. It looks only at top-level keys before the first
+# table header, and only for an exact `model = "..."` assignment. Returns
+# non-zero when the config is missing, unreadable, or contains no top-level
+# model, so an omitted/default model is not treated as unsupported.
+codex_default_model() {
+  local config
+  config="${CODEX_HOME:-$HOME/.codex}/config.toml"
+  [ -f "$config" ] || return 1
+  awk -f - "$config" <<'AWK'
+/^[[:space:]]*[[]/ { in_table=1; next }
+in_table { next }
+/^[[:space:]]*model[[:space:]]*=/ {
+  val=$0
+  sub(/^[[:space:]]*model[[:space:]]*=[[:space:]]*/, "", val)
+  sub(/[[:space:]]*#.*$/, "", val)
+  gsub(/^[[:space:]]+|[[:space:]]+$/, "", val)
+  if (val ~ /^".*"$/ || val ~ /^'.*'$/) {
+    gsub(/^["']|["']$/, "", val)
+    if (val != "") {
+      print val
+      exit 0
+    }
+  }
+}
+AWK
+}
+
+# codex_model_supports_max_effort: 0 when the selected Codex model (or, when
+# the caller passes an empty/default model, the active default model from
+# codex config) advertises a "max" reasoning level. Reads the local catalog
+# via `codex debug models` and queries it with jq. Returns non-zero when
+# codex is absent, jq is absent, the catalog is unreachable, the model cannot
+# be found, or the model's supported_reasoning_levels does not contain max.
+# The fail-safe direction is the clamp, never an unsupported pass-through.
+codex_model_supports_max_effort() {
+  local model=$1 catalog
+  [ -n "$model" ] && [ "$model" != default ] || model=$(codex_default_model)
+  [ -n "$model" ] || return 1
   command -v codex >/dev/null 2>&1 || return 1
-  codex debug models 2>/dev/null | grep -q '"effort"[[:space:]]*:[[:space:]]*"max"'
+  command -v jq >/dev/null 2>&1 || return 1
+  catalog=$(codex debug models 2>/dev/null) || return 1
+  printf '%s' "$catalog" | jq -e --arg model "$model" '
+    .models[]?
+    | select(.slug == $model or .id == $model or .model == $model or .name == $model or .selector == $model or .display_name == $model)
+    | .supported_reasoning_levels[]?
+    | select((if type == "object" then .effort else . end) == "max")
+  ' >/dev/null 2>&1
 }
 
 effort_flag_for_harness() {
@@ -1848,8 +1886,13 @@ effort_flag_for_harness() {
       esac
       ;;
     codex)
+      # The installed codex config schema uses model_reasoning_effort. The
+      # bundled catalog lists per-model supported reasoning levels, so a
+      # requested max is passed through only when the selected model (or the
+      # active default model when none is selected) advertises it. Otherwise
+      # it clamps to xhigh rather than launching with an unsupported value.
       local codex_effort=$effort
-      if [ "$effort" = max ] && ! codex_supports_max_effort; then
+      if [ "$effort" = max ] && ! codex_model_supports_max_effort "$model"; then
         codex_effort=xhigh
       fi
       case "$codex_effort" in

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -244,7 +244,8 @@ The shell scripts validate the JSON shape and verified harness/effort combinatio
 The session-start bootstrap step keeps valid dispatch configuration silent unless verbose facts are enabled and surfaces a concise invalid-config line when validation fails.
 When the file exists, `fm-spawn.sh` refuses crewmate and scout launches without an explicit harness, so `config/crew-harness` is only automatic when no dispatch profile file is active.
 Secondmate launches are exempt because they resolve the secondmate harness and any optional secondmate model or effort tokens instead.
-Unsupported effort values are still recorded in task meta when passed to `fm-spawn.sh`, but the launch template omits any effort flag that the selected harness does not accept.
+Unsupported effort requests are still recorded in task meta when passed to `fm-spawn.sh`, but the launch template follows the selected harness adapter's compatibility behavior instead of passing a known-bad value.
+The adapter reference owns whether that behavior omits the flag or uses a safe fallback for a runtime capability gap.
 That keeps spawn launch compatible across claude, codex, opencode, pi, pi-signed, grok, kimi, cursor, gemini, muse, rovo, and omp while preserving the requested profile for later audit.
 
 ## Optional secondmates

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -421,11 +421,12 @@ Profile `model` and `effort` fields and rule `why` are optional.
 An omitted model or effort means the selected harness uses its own default for that axis.
 Every profile array is an implicit quota-aware choice resolved through `quota-array-dispatch`.
 If no dispatch rule fits, firstmate resolves `default` through the same object-or-array path before falling back to `config/crew-harness`.
-If a selected profile carries an effort value the chosen harness does not accept, `fm-spawn.sh` records the requested `effort=` in task meta for traceability but omits the launch flag, and bootstrap reports the invalid harness/effort pair as a `CREW_DISPATCH` diagnostic when it is visible in the file.
+If a selected profile carries an effort value outside the chosen harness's static accepted set, bootstrap reports the invalid harness/effort pair as a `CREW_DISPATCH` diagnostic when it is visible in the file.
+When `fm-spawn.sh` receives an effort that cannot be launched exactly as requested, it still records the requested `effort=` in task meta for traceability and follows that harness adapter's documented compatibility behavior instead of passing a known-bad value.
 See [`docs/examples/crew-dispatch.json`](examples/crew-dispatch.json) for a starting point to copy into local `config/crew-dispatch.json`.
 When the file exists, bootstrap validates it with `jq`.
 Valid files stay silent by default; with `FM_BOOTSTRAP_VERBOSE_FACTS=1`, bootstrap emits `BOOTSTRAP_INFO: crew dispatch active config/crew-dispatch.json`, one `BOOTSTRAP_INFO:` fact per rule, and one fact for the optional default profile set.
-Malformed JSON, an empty or malformed rule/default array, an unverified harness, or an effort value unsupported by that harness is reported as `CREW_DISPATCH: invalid config/crew-dispatch.json - ...`; missing `jq` is reported through the normal `MISSING: jq` install-consent flow.
+Malformed JSON, an empty or malformed rule/default array, an unverified harness, or an effort value outside that harness's static accepted set is reported as `CREW_DISPATCH: invalid config/crew-dispatch.json - ...`; missing `jq` is reported through the normal `MISSING: jq` install-consent flow.
 While the file remains present, no crewmate or scout spawn may proceed without an explicit resolved harness; malformed configuration must be reported and corrected rather than selected around.
 Secondmate homes inherit this file from the primary, so a secondmate's own crewmates apply the same dispatch profile behavior.
 

--- a/tests/fixtures.sh
+++ b/tests/fixtures.sh
@@ -289,6 +289,7 @@ fm_test_run_spawn() {
   mkdir -p "$spawn_home"
   FM_ROOT_OVERRIDE='' FM_HOME="$home" HOME="$spawn_home" \
     CLAUDE_CONFIG_DIR="${FM_TEST_CLAUDE_CONFIG_DIR:-}" \
+    CODEX_HOME="${FM_TEST_CODEX_HOME:-}" \
     FM_STATE_OVERRIDE="$home/state" FM_DATA_OVERRIDE="$home/data" \
     FM_PROJECTS_OVERRIDE="$home/projects" FM_CONFIG_OVERRIDE="$home/config" \
     FM_SPAWN_NO_GUARD=1 FM_FAKE_PANE_PATH="$pane" TMUX="${TMUX:-fake,1,0}" \

--- a/tests/fm-bootstrap.test.sh
+++ b/tests/fm-bootstrap.test.sh
@@ -1118,7 +1118,7 @@ test_crew_dispatch_validation() {
   done <<'ROWS'
 malformed dispatch config is flagged^{"rules":[^exact^CREW_DISPATCH: invalid config/crew-dispatch.json - malformed JSON
 unverified dispatch harness is flagged^{"rules":[{"when":"anything","use":{"harness":"spaceship"}}],"default":{"harness":"codex"}}^exact^CREW_DISPATCH: invalid config/crew-dispatch.json - unverified harness: spaceship
-unsupported codex max effort is flagged^{"rules":[{"when":"big feature","use":{"harness":"codex","model":"gpt-5","effort":"max"}}]}^exact^CREW_DISPATCH: invalid config/crew-dispatch.json - invalid effort: codex:max
+codex max effort is accepted^{"rules":[{"when":"big feature","use":{"harness":"codex","model":"gpt-5","effort":"max"}}]}^empty^
 unsupported grok max effort is flagged^{"rules":[{"when":"deep current work","use":{"harness":"grok","model":"grok-4","effort":"max"}}]}^exact^CREW_DISPATCH: invalid config/crew-dispatch.json - invalid effort: grok:max
 unsupported grok xhigh effort is flagged^{"rules":[{"when":"deep current work","use":{"harness":"grok","model":"grok-4","effort":"xhigh"}}]}^exact^CREW_DISPATCH: invalid config/crew-dispatch.json - invalid effort: grok:xhigh
 pi max effort is accepted^{"rules":[{"when":"deep coding","use":{"harness":"pi","model":"openai-codex/gpt-5.6-sol","effort":"max"}}]}^empty^
@@ -1139,7 +1139,7 @@ empty array use is flagged^{"rules":[{"when":"big feature","use":[]}]}^exact^CRE
 array profile without harness is flagged^{"rules":[{"when":"big feature","use":[{"model":"gpt-5.5"}]}]}^exact^CREW_DISPATCH: invalid config/crew-dispatch.json - each use profile needs harness
 array profile with malformed model is flagged^{"rules":[{"when":"big feature","use":[{"harness":"codex","model":5}]}]}^exact^CREW_DISPATCH: invalid config/crew-dispatch.json - use profile model and effort must be non-empty strings when present
 unknown select is flagged^{"rules":[{"when":"big feature","use":[{"harness":"claude"},{"harness":"codex"}],"select":"mystery"}]}^exact^CREW_DISPATCH: invalid config/crew-dispatch.json - unknown select: mystery
-array profile unsupported effort is flagged^{"rules":[{"when":"big feature","use":[{"harness":"codex","effort":"max"}]}]}^exact^CREW_DISPATCH: invalid config/crew-dispatch.json - invalid effort: codex:max
+array profile codex max effort is accepted^{"rules":[{"when":"big feature","use":[{"harness":"codex","effort":"max"}]}]}^empty^
 empty default array is flagged^{"default":[]}^exact^CREW_DISPATCH: invalid config/crew-dispatch.json - default needs at least one profile
 non-object default array entry is flagged^{"default":["codex"]}^exact^CREW_DISPATCH: invalid config/crew-dispatch.json - each default profile must be an object
 default array profile without harness is flagged^{"default":[{"model":"gpt-5.5"}]}^exact^CREW_DISPATCH: invalid config/crew-dispatch.json - each default profile needs harness

--- a/tests/fm-spawn-dispatch-profile.test.sh
+++ b/tests/fm-spawn-dispatch-profile.test.sh
@@ -47,6 +47,21 @@ fi
 exit 0
 SH
   chmod +x "$fakebin/timeout" "$fakebin/cursor-agent"
+  # codex answers `debug models` with a catalog whose supported reasoning
+  # levels include max only when FM_FAKE_CODEX_MAX=1 (the default); setting it
+  # to 0 exercises the xhigh clamp for a codex build that tops out at xhigh.
+  cat > "$fakebin/codex" <<'SH'
+#!/usr/bin/env bash
+if [ "${1:-}" = debug ] && [ "${2:-}" = models ]; then
+  if [ "${FM_FAKE_CODEX_MAX:-1}" = 1 ]; then
+    printf '%s\n' '{"models":[{"supported_reasoning_levels":[{"effort":"low"},{"effort":"medium"},{"effort":"high"},{"effort":"xhigh"},{"effort":"max"}]}]}'
+  else
+    printf '%s\n' '{"models":[{"supported_reasoning_levels":[{"effort":"low"},{"effort":"medium"},{"effort":"high"},{"effort":"xhigh"}]}]}'
+  fi
+fi
+exit 0
+SH
+  chmod +x "$fakebin/codex"
   make_spawn_pi_probe "$fakebin" pi
   make_spawn_pi_probe "$fakebin" pi-signed
   printf '%s\n' "$fakebin"
@@ -423,14 +438,34 @@ test_codex_threads_max_effort() {
   rec=$(make_spawn_case profile-codex-max codex "$id")
   read_case_record "$rec"
 
+  # Default fake codex advertises max (FM_FAKE_CODEX_MAX=1): pass through.
   out=$(run_ship_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" "$id" "$PROJ_DIR" --model gpt-5 --effort max)
   status=$?
   expect_code 0 "$status" "codex spawn with max effort should succeed"
   assert_meta_profile "$HOME_DIR/state/$id.meta" codex gpt-5 max
   launch=$(cat "$LAUNCH_LOG")
   assert_contains "$launch" "codex --model 'gpt-5' -c 'model_reasoning_effort=\"max\"' --dangerously-bypass-approvals-and-sandbox" \
-    "codex launch did not thread model and max reasoning effort config"
-  pass "codex passes a requested max effort through to model_reasoning_effort"
+    "codex launch did not pass a supported max effort through"
+  pass "codex passes a requested max effort through when the CLI supports it"
+}
+
+test_codex_clamps_max_effort_when_unsupported() {
+  local rec id out status launch
+  id=profile-codex-maxclamp-z4b
+  rec=$(make_spawn_case profile-codex-maxclamp codex "$id")
+  read_case_record "$rec"
+
+  # FM_FAKE_CODEX_MAX=0 makes the fake codex catalog top out at xhigh, so a
+  # requested max must clamp to xhigh rather than emit an unsupported value.
+  out=$(FM_FAKE_CODEX_MAX=0 run_ship_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" "$id" "$PROJ_DIR" --model gpt-5 --effort max)
+  status=$?
+  expect_code 0 "$status" "codex spawn with max effort on an xhigh-only CLI should succeed"
+  assert_meta_profile "$HOME_DIR/state/$id.meta" codex gpt-5 max
+  launch=$(cat "$LAUNCH_LOG")
+  assert_contains "$launch" "codex --model 'gpt-5' -c 'model_reasoning_effort=\"xhigh\"' --dangerously-bypass-approvals-and-sandbox" \
+    "codex launch did not clamp an unsupported max effort to xhigh"
+  assert_not_contains "$launch" 'model_reasoning_effort=\"max\"' "codex launch must not emit an unsupported max effort"
+  pass "codex clamps a requested max effort to xhigh when the CLI lacks max"
 }
 
 test_grok_threads_model_and_reasoning_effort() {
@@ -1149,6 +1184,7 @@ test_active_dispatch_profile_allows_raw_launch_command
 test_claude_threads_model_and_effort
 test_codex_threads_model_and_effort
 test_codex_threads_max_effort
+test_codex_clamps_max_effort_when_unsupported
 test_grok_threads_model_and_reasoning_effort
 test_grok_omits_invalid_max_reasoning_effort
 test_grok_omits_invalid_xhigh_reasoning_effort

--- a/tests/fm-spawn-dispatch-profile.test.sh
+++ b/tests/fm-spawn-dispatch-profile.test.sh
@@ -47,16 +47,13 @@ fi
 exit 0
 SH
   chmod +x "$fakebin/timeout" "$fakebin/cursor-agent"
-  # codex answers `debug models` with a catalog whose supported reasoning
-  # levels include max only when FM_FAKE_CODEX_MAX=1 (the default); setting it
-  # to 0 exercises the xhigh clamp for a codex build that tops out at xhigh.
   cat > "$fakebin/codex" <<'SH'
 #!/usr/bin/env bash
 if [ "${1:-}" = debug ] && [ "${2:-}" = models ]; then
   if [ "${FM_FAKE_CODEX_MAX:-1}" = 1 ]; then
-    printf '%s\n' '{"models":[{"supported_reasoning_levels":[{"effort":"low"},{"effort":"medium"},{"effort":"high"},{"effort":"xhigh"},{"effort":"max"}]}]}'
+    printf '%s\n' '{"models":[{"slug":"gpt-5","supported_reasoning_levels":[{"effort":"low"},{"effort":"medium"},{"effort":"high"},{"effort":"xhigh"},{"effort":"max"}]},{"slug":"gpt-5.5","supported_reasoning_levels":[{"effort":"low"},{"effort":"medium"},{"effort":"high"},{"effort":"xhigh"}]}]}'
   else
-    printf '%s\n' '{"models":[{"supported_reasoning_levels":[{"effort":"low"},{"effort":"medium"},{"effort":"high"},{"effort":"xhigh"}]}]}'
+    printf '%s\n' '{"models":[{"slug":"gpt-5","supported_reasoning_levels":[{"effort":"low"},{"effort":"medium"},{"effort":"high"},{"effort":"xhigh"}]},{"slug":"gpt-5.5","supported_reasoning_levels":[{"effort":"low"},{"effort":"medium"},{"effort":"high"},{"effort":"xhigh"}]}]}'
   fi
 fi
 exit 0
@@ -438,7 +435,6 @@ test_codex_threads_max_effort() {
   rec=$(make_spawn_case profile-codex-max codex "$id")
   read_case_record "$rec"
 
-  # Default fake codex advertises max (FM_FAKE_CODEX_MAX=1): pass through.
   out=$(run_ship_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" "$id" "$PROJ_DIR" --model gpt-5 --effort max)
   status=$?
   expect_code 0 "$status" "codex spawn with max effort should succeed"
@@ -455,8 +451,6 @@ test_codex_clamps_max_effort_when_unsupported() {
   rec=$(make_spawn_case profile-codex-maxclamp codex "$id")
   read_case_record "$rec"
 
-  # FM_FAKE_CODEX_MAX=0 makes the fake codex catalog top out at xhigh, so a
-  # requested max must clamp to xhigh rather than emit an unsupported value.
   out=$(FM_FAKE_CODEX_MAX=0 run_ship_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" "$id" "$PROJ_DIR" --model gpt-5 --effort max)
   status=$?
   expect_code 0 "$status" "codex spawn with max effort on an xhigh-only CLI should succeed"
@@ -464,8 +458,25 @@ test_codex_clamps_max_effort_when_unsupported() {
   launch=$(cat "$LAUNCH_LOG")
   assert_contains "$launch" "codex --model 'gpt-5' -c 'model_reasoning_effort=\"xhigh\"' --dangerously-bypass-approvals-and-sandbox" \
     "codex launch did not clamp an unsupported max effort to xhigh"
-  assert_not_contains "$launch" 'model_reasoning_effort=\"max\"' "codex launch must not emit an unsupported max effort"
+  assert_not_contains "$launch" 'model_reasoning_effort="max"' "codex launch must not emit an unsupported max effort"
   pass "codex clamps a requested max effort to xhigh when the CLI lacks max"
+}
+
+test_codex_clamps_max_effort_for_models_without_max() {
+  local rec id out status launch
+  id=profile-codex-model-maxclamp-z4c
+  rec=$(make_spawn_case profile-codex-model-maxclamp codex "$id")
+  read_case_record "$rec"
+
+  out=$(run_ship_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" "$id" "$PROJ_DIR" --model gpt-5.5 --effort max)
+  status=$?
+  expect_code 0 "$status" "codex spawn with max effort on an xhigh-only model should succeed"
+  assert_meta_profile "$HOME_DIR/state/$id.meta" codex gpt-5.5 max
+  launch=$(cat "$LAUNCH_LOG")
+  assert_contains "$launch" "codex --model 'gpt-5.5' -c 'model_reasoning_effort=\"xhigh\"' --dangerously-bypass-approvals-and-sandbox" \
+    "codex launch did not clamp max effort for a model that lacks max"
+  assert_not_contains "$launch" 'model_reasoning_effort="max"' "codex launch must not emit max for a model that lacks max"
+  pass "codex clamps requested max to xhigh for a model without max"
 }
 
 test_grok_threads_model_and_reasoning_effort() {
@@ -1185,6 +1196,7 @@ test_claude_threads_model_and_effort
 test_codex_threads_model_and_effort
 test_codex_threads_max_effort
 test_codex_clamps_max_effort_when_unsupported
+test_codex_clamps_max_effort_for_models_without_max
 test_grok_threads_model_and_reasoning_effort
 test_grok_omits_invalid_max_reasoning_effort
 test_grok_omits_invalid_xhigh_reasoning_effort

--- a/tests/fm-spawn-dispatch-profile.test.sh
+++ b/tests/fm-spawn-dispatch-profile.test.sh
@@ -462,24 +462,69 @@ test_codex_clamps_max_effort_when_unsupported() {
   pass "codex clamps a requested max effort to xhigh when the CLI lacks max"
 }
 
-test_codex_passes_max_for_model_when_cli_supports_it() {
+test_codex_clamps_max_for_model_that_lacks_max() {
   local rec id out status launch
   id=profile-codex-model-maxclamp-z4c
   rec=$(make_spawn_case profile-codex-model-maxclamp codex "$id")
   read_case_record "$rec"
 
-  # The capability check is model-agnostic: it asks whether the installed codex
-  # CLI supports max, not whether a specific model does. The fake catalog has
-  # gpt-5.5 topping out at xhigh, but because another catalog model advertises
-  # max the CLI is treated as max-capable and the request passes through.
+  # The capability check is model-aware: gpt-5.5's own catalog entry stops at
+  # xhigh, so a requested max clamps to xhigh even though gpt-5 in the same
+  # catalog advertises max.
   out=$(run_ship_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" "$id" "$PROJ_DIR" --model gpt-5.5 --effort max)
   status=$?
-  expect_code 0 "$status" "codex spawn with max effort on a max-capable CLI should succeed"
+  expect_code 0 "$status" "codex spawn with max effort on a model that lacks max should clamp"
   assert_meta_profile "$HOME_DIR/state/$id.meta" codex gpt-5.5 max
   launch=$(cat "$LAUNCH_LOG")
-  assert_contains "$launch" "codex --model 'gpt-5.5' -c 'model_reasoning_effort=\"max\"' --dangerously-bypass-approvals-and-sandbox" \
-    "codex launch did not pass max through on a max-capable CLI"
-  pass "codex passes max through for any model when the CLI supports max"
+  assert_contains "$launch" "codex --model 'gpt-5.5' -c 'model_reasoning_effort=\"xhigh\"' --dangerously-bypass-approvals-and-sandbox" \
+    "codex launch did not clamp max to xhigh for a model that lacks max"
+  assert_not_contains "$launch" 'model_reasoning_effort="max"' "codex launch must not emit an unsupported max effort for gpt-5.5"
+  pass "codex clamps max to xhigh for a selected model that does not support it"
+}
+
+test_codex_passes_max_for_default_model_with_max() {
+  local rec id out status launch fake_codex_home
+  id=profile-codex-default-max-z4d
+  rec=$(make_spawn_case profile-codex-default-max codex "$id")
+  read_case_record "$rec"
+
+  # The active default model in codex config is gpt-5, which the catalog says
+  # supports max, so an omitted --model with effort=max passes through.
+  fake_codex_home="$HOME_DIR/fake-codex"
+  mkdir -p "$fake_codex_home"
+  printf 'model = "gpt-5"\n' > "$fake_codex_home/config.toml"
+  out=$(FM_TEST_CODEX_HOME="$fake_codex_home" run_ship_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" "$id" "$PROJ_DIR" --effort max)
+  status=$?
+  expect_code 0 "$status" "codex spawn with max effort and a max-capable default model should succeed"
+  assert_meta_profile "$HOME_DIR/state/$id.meta" codex default max
+  launch=$(cat "$LAUNCH_LOG")
+  assert_contains "$launch" "codex -c 'model_reasoning_effort=\"max\"' --dangerously-bypass-approvals-and-sandbox" \
+    "codex launch did not pass a supported max effort through for the default model"
+  assert_not_contains "$launch" "--model" "codex launch must not add a --model flag when none was requested"
+  pass "codex passes max through for the active default model when it supports max"
+}
+
+test_codex_clamps_max_for_default_model_without_max() {
+  local rec id out status launch fake_codex_home
+  id=profile-codex-default-xhigh-z4e
+  rec=$(make_spawn_case profile-codex-default-xhigh codex "$id")
+  read_case_record "$rec"
+
+  # The active default model in codex config is gpt-5.5, which the catalog says
+  # only supports up to xhigh, so an omitted --model with effort=max clamps.
+  fake_codex_home="$HOME_DIR/fake-codex"
+  mkdir -p "$fake_codex_home"
+  printf 'model = "gpt-5.5"\n' > "$fake_codex_home/config.toml"
+  out=$(FM_TEST_CODEX_HOME="$fake_codex_home" run_ship_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" "$id" "$PROJ_DIR" --effort max)
+  status=$?
+  expect_code 0 "$status" "codex spawn with max effort and a default model that lacks max should clamp"
+  assert_meta_profile "$HOME_DIR/state/$id.meta" codex default max
+  launch=$(cat "$LAUNCH_LOG")
+  assert_contains "$launch" "codex -c 'model_reasoning_effort=\"xhigh\"' --dangerously-bypass-approvals-and-sandbox" \
+    "codex launch did not clamp max to xhigh for the active default model"
+  assert_not_contains "$launch" "--model" "codex launch must not add a --model flag when none was requested"
+  assert_not_contains "$launch" 'model_reasoning_effort="max"' "codex launch must not emit an unsupported max effort for the default model"
+  pass "codex clamps max to xhigh for the active default model when it does not support max"
 }
 
 test_grok_threads_model_and_reasoning_effort() {
@@ -1199,7 +1244,9 @@ test_claude_threads_model_and_effort
 test_codex_threads_model_and_effort
 test_codex_threads_max_effort
 test_codex_clamps_max_effort_when_unsupported
-test_codex_passes_max_for_model_when_cli_supports_it
+test_codex_clamps_max_for_model_that_lacks_max
+test_codex_passes_max_for_default_model_with_max
+test_codex_clamps_max_for_default_model_without_max
 test_grok_threads_model_and_reasoning_effort
 test_grok_omits_invalid_max_reasoning_effort
 test_grok_omits_invalid_xhigh_reasoning_effort

--- a/tests/fm-spawn-dispatch-profile.test.sh
+++ b/tests/fm-spawn-dispatch-profile.test.sh
@@ -417,7 +417,7 @@ test_codex_threads_model_and_effort() {
   pass "codex receives --model and model_reasoning_effort profile flags"
 }
 
-test_codex_omits_invalid_max_effort() {
+test_codex_threads_max_effort() {
   local rec id out status launch
   id=profile-codex-max-z4
   rec=$(make_spawn_case profile-codex-max codex "$id")
@@ -425,13 +425,12 @@ test_codex_omits_invalid_max_effort() {
 
   out=$(run_ship_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" "$id" "$PROJ_DIR" --model gpt-5 --effort max)
   status=$?
-  expect_code 0 "$status" "codex spawn with unsupported max effort should omit the effort flag"
+  expect_code 0 "$status" "codex spawn with max effort should succeed"
   assert_meta_profile "$HOME_DIR/state/$id.meta" codex gpt-5 max
   launch=$(cat "$LAUNCH_LOG")
-  assert_contains "$launch" "codex --model 'gpt-5' --dangerously-bypass-approvals-and-sandbox" \
-    "codex launch did not preserve the model flag when max effort was omitted"
-  assert_not_contains "$launch" "model_reasoning_effort" "codex launch must omit unsupported max reasoning effort"
-  pass "codex omits unsupported max effort instead of passing a bad config value"
+  assert_contains "$launch" "codex --model 'gpt-5' -c 'model_reasoning_effort=\"max\"' --dangerously-bypass-approvals-and-sandbox" \
+    "codex launch did not thread model and max reasoning effort config"
+  pass "codex passes a requested max effort through to model_reasoning_effort"
 }
 
 test_grok_threads_model_and_reasoning_effort() {
@@ -1149,7 +1148,7 @@ test_active_dispatch_profile_allows_positional_harness
 test_active_dispatch_profile_allows_raw_launch_command
 test_claude_threads_model_and_effort
 test_codex_threads_model_and_effort
-test_codex_omits_invalid_max_effort
+test_codex_threads_max_effort
 test_grok_threads_model_and_reasoning_effort
 test_grok_omits_invalid_max_reasoning_effort
 test_grok_omits_invalid_xhigh_reasoning_effort

--- a/tests/fm-spawn-dispatch-profile.test.sh
+++ b/tests/fm-spawn-dispatch-profile.test.sh
@@ -462,21 +462,24 @@ test_codex_clamps_max_effort_when_unsupported() {
   pass "codex clamps a requested max effort to xhigh when the CLI lacks max"
 }
 
-test_codex_clamps_max_effort_for_models_without_max() {
+test_codex_passes_max_for_model_when_cli_supports_it() {
   local rec id out status launch
   id=profile-codex-model-maxclamp-z4c
   rec=$(make_spawn_case profile-codex-model-maxclamp codex "$id")
   read_case_record "$rec"
 
+  # The capability check is model-agnostic: it asks whether the installed codex
+  # CLI supports max, not whether a specific model does. The fake catalog has
+  # gpt-5.5 topping out at xhigh, but because another catalog model advertises
+  # max the CLI is treated as max-capable and the request passes through.
   out=$(run_ship_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" "$id" "$PROJ_DIR" --model gpt-5.5 --effort max)
   status=$?
-  expect_code 0 "$status" "codex spawn with max effort on an xhigh-only model should succeed"
+  expect_code 0 "$status" "codex spawn with max effort on a max-capable CLI should succeed"
   assert_meta_profile "$HOME_DIR/state/$id.meta" codex gpt-5.5 max
   launch=$(cat "$LAUNCH_LOG")
-  assert_contains "$launch" "codex --model 'gpt-5.5' -c 'model_reasoning_effort=\"xhigh\"' --dangerously-bypass-approvals-and-sandbox" \
-    "codex launch did not clamp max effort for a model that lacks max"
-  assert_not_contains "$launch" 'model_reasoning_effort="max"' "codex launch must not emit max for a model that lacks max"
-  pass "codex clamps requested max to xhigh for a model without max"
+  assert_contains "$launch" "codex --model 'gpt-5.5' -c 'model_reasoning_effort=\"max\"' --dangerously-bypass-approvals-and-sandbox" \
+    "codex launch did not pass max through on a max-capable CLI"
+  pass "codex passes max through for any model when the CLI supports max"
 }
 
 test_grok_threads_model_and_reasoning_effort() {
@@ -1196,7 +1199,7 @@ test_claude_threads_model_and_effort
 test_codex_threads_model_and_effort
 test_codex_threads_max_effort
 test_codex_clamps_max_effort_when_unsupported
-test_codex_clamps_max_effort_for_models_without_max
+test_codex_passes_max_for_model_when_cli_supports_it
 test_grok_threads_model_and_reasoning_effort
 test_grok_omits_invalid_max_reasoning_effort
 test_grok_omits_invalid_xhigh_reasoning_effort


### PR DESCRIPTION
## Intent

firstmate currently omits the `max` reasoning-effort value when spawning the codex harness, because the bundled codex model catalog only advertises low|medium|high|xhigh. Update firstmate so that when a task profile requests `effort=max` for codex, it is accepted and passed through correctly instead of being silently dropped. If the installed codex CLI accepts `max` in `model_reasoning_effort`, pass it; if it only accepts xhigh as the top level, clamp max to xhigh; in either case, do not silently omit a captain-requested max effort for codex. Update any tests and docs that assert the old omission behavior.

## What Changed

- Accept `effort=max` for Codex dispatch profiles instead of rejecting the harness/effort pair as invalid.
- Resolve Codex max-effort launch behavior from the selected or configured default model: pass `model_reasoning_effort="max"` when the catalog advertises it, otherwise clamp to `xhigh`.
- Update spawn/bootstrap tests, fixtures, and docs for the new Codex max-effort pass-through and clamp behavior.

## Risk Assessment

⚠️ Medium: The change is focused, but the new default-model probing can make the max-vs-xhigh decision against the wrong Codex environment for a documented launch path.

## Testing

The first targeted spawn-profile run hit the 120s harness timeout after the relevant codex cases had passed, so I reran it with a longer timeout and it completed; I also drove live isolated fm-spawn sessions through real tmux and the installed Codex catalog for max pass-through and xhigh clamping, then verified bootstrap no longer rejects a codex max dispatch profile.

- Live validation: ✅ go - 3 of 3 scenarios driven live against the product

| Scenario | Result | Live | Evidence |
| --- | --- | --- | --- |
| Spawn a Codex worker with effort=max on a max-capable selected model and observe model_reasoning_effort=&#34;max&#34; in the live launch | ✅ pass | live | Live Codex max spawn evidence |
| Spawn a Codex worker with effort=max on a selected model whose catalog tops out at xhigh and observe model_reasoning_effort=&#34;xhigh&#34; without model_reasoning_effort=&#34;max&#34; | ✅ pass | live | Live Codex max spawn evidence |
| Bootstrap an isolated home whose crew-dispatch profile requests codex effort=max and observe no invalid-effort rejection | ✅ pass | live | Bootstrap codex max dispatch evidence |

<details>
<summary>Evidence: Live Codex max spawn evidence</summary>

Source: [Live Codex max spawn evidence](https://github.com/0x7067/firstmate/blob/2b8023fd805c2d4c2c61fc07ad53d83127d95b2d/.no-mistakes/evidence/fm/firstmate-3212/codex-max-live-spawn.txt)

```text
# Codex max live spawn evidence
codex binary: ~/.local/bin/codex
codex version: codex-cli 0.153.4
catalog reasoning levels used by fm-spawn:
- gpt-6-astra: low,medium,high,xhigh,max,ultra
- gpt-5.5: low,medium,high,xhigh

## max_supported (gpt-6-astra)
fm-spawn exit: 0
fm-spawn output:
warning: ~/.no-mistakes/worktrees/b764898e6d62/01M1ZHRD3PSRTEGHHRA2XHGXR2/.tmp-codex-max-live/runs/max_supported/home/data/codex-max_supported-live/launch-brief.md records no delivery contract line (scaffolded before ship briefs recorded one); launching on the explicit --mode local-only - confirm its definition of done matches
notice: codex-max_supported-live ships mode=local-only while the standing posture for project is no-mistakes - less rigor than the captain's standing posture; proceed only on a current explicit captain instruction or an intake judgment you can state
spawned codex-max_supported-live harness=codex kind=ship mode=local-only yolo=off window=fmlive:fm-codex-max_supported-live worktree=~/.no-mistakes/worktrees/b764898e6d62/01M1ZHRD3PSRTEGHHRA2XHGXR2/.tmp-codex-max-live/runs/max_supported/project/.treehouse/.treehouse/project-bc0b1d/1/project

live task pane capture after launch:
treehouse get

project main  
❯ treehouse get
🌳 Setting up worktree...
🌳 Entered worktree at ~/.no-mistakes/worktrees/b764898e6d62/01M1ZHRD3PSRTEGHHRA2XHGXR2/.tmp-codex-max-live/runs/max_supported/project/.treehouse/.treehouse/project-bc0b1d/1/project. Type 'exit' to return.

project HEAD  
❯ export GOTMPDIR=/tmp/fm-codex-max_supported-live/gotmp
export FM_TASK_ID=codex-max_supported-live                                                                                                                                                                                                      

project HEAD  
❯ export FM_TASK_ID=codex-max_supported-live

project HEAD  
❯ env -u CURSOR_AGENT -u CURSOR_INVOKED_AS -u GEMINI_CLI codex --model 'gpt-6-astra' -c 'model_reasoning_effort="max"' --dangerously-bypass-approvals-and-sandbox -c "notify=[\"bash\",\"-c\",\"touch '~/.no-mistakes/worktrees/b764898e6d62/01M1ZHRD3PSRTEGHHRA2XHGXR2/.tmp-codex-max-live/runs/max_supported/home/state/codex-max_supported-live.turn-ended'\"]" "$('~/.no-mistakes/worktrees/b764898e6d62/01M1ZHRD3PSRTEGHHRA2XHGXR2/bin/fm-operational-input.sh' encod
e launch-brief < '~/.no-mistakes/worktrees/b764898e6d62/01M1ZHRD3PSRTEGHHRA2XHGXR2/.tmp-codex-max-live/runs/max_supported/home/data/codex-max_supported-live/launch-brief.md')"
> You are in ~/.no-mistakes/worktrees/b764898e6d62/01M1ZHRD3PSRTEGHHRA2XHGXR2/.tmp-codex-max-live/runs/max_supported/project/.treehouse/.treehouse/project-bc0b1d/1/project

  Note: You’re in a subdirectory of a Git project. Trusting will apply to the repository root: ~/.no-mistakes/worktrees/b764898e6d62/01M1ZHRD3PSRTEGHHRA2XHGXR2/.tmp-codex-max-live/runs/max_supported/project

  Do you trust the contents of this directory? Working with untrusted contents comes with higher risk of prompt injection. Trusting the directory allows project-local config, hooks, and exec policies to load.

› 1. Yes, continue
  2. No, quit

  Press enter to continue







































































## max_clamped (gpt-5.5)
fm-spawn exit: 0
fm-spawn output:
warning: ~/.no-mistakes/worktrees/b764898e6d62/01M1ZHRD3PSRTEGHHRA2XHGXR2/.tmp-codex-max-live/runs/max_clamped/home/data/codex-max_clamped-live/launch-brief.md records no delivery contract line (scaffolded before ship briefs recorded one); launching on the explicit --mode local-only - confirm its definition of done matches
notice: codex-max_clamped-live ships mode=local-only while the standing posture for project is no-mistakes - less rigor than the captain's standing posture; proceed only on a current explicit captain instruction or an intake judgment you can state
spawned codex-max_clamped-live harness=codex kind=ship mode=local-only yolo=off window=fmlive:fm-codex-max_clamped-live worktree=~/.no-mistakes/worktrees/b764898e6d62/01M1ZHRD3PSRTEGHHRA2XHGXR2/.tmp-codex-max-live/runs/max_clamped/project/.treehouse/.treehouse/project-55fc1c/1/project

live task pane capture after launch:
treehouse get

project main  
❯ treehouse get
🌳 Setting up worktree...
🌳 Entered worktree at ~/.no-mistakes/worktrees/b764898e6d62/01M1ZHRD3PSRTEGHHRA2XHGXR2/.tmp-codex-max-live/runs/max_clamped/project/.treehouse/.treehouse/project-55fc1c/1/project. Type 'exit' to return.

project HEAD  
❯ export GOTMPDIR=/tmp/fm-codex-max_clamped-live/gotmp
export FM_TASK_ID=codex-max_clamped-live                                                                                                                                                                                                        

project HEAD  
❯ export FM_TASK_ID=codex-max_clamped-live

project HEAD  
❯ env -u CURSOR_AGENT -u CURSOR_INVOKED_AS -u GEMINI_CLI codex --model 'gpt-5.5' -c 'model_reasoning_effort="xhigh"' --dangerously-bypass-approvals-and-sandbox -c "notify=[\"bash\",\"-c\",\"touch '~/.no-mistakes/worktrees/b764898e6d62/01M1ZHRD3PSRTEGHHRA2XHGXR2/.tmp-codex-max-live/runs/max_clamped/home/state/codex-max_clamped-live.turn-ended'\"]" "$('~/.no-mistakes/worktrees/b764898e6d62/01M1ZHRD3PSRTEGHHRA2XHGXR2/bin/fm-operational-input.sh' encode laun
ch-brief < '~/.no-mistakes/worktrees/b764898e6d62/01M1ZHRD3PSRTEGHHRA2XHGXR2/.tmp-codex-max-live/runs/max_clamped/home/data/codex-max_clamped-live/launch-brief.md')"
> You are in ~/.no-mistakes/worktrees/b764898e6d62/01M1ZHRD3PSRTEGHHRA2XHGXR2/.tmp-codex-max-live/runs/max_clamped/project/.treehouse/.treehouse/project-55fc1c/1/project

  Note: You’re in a subdirectory of a Git project. Trusting will apply to the repository root: ~/.no-mistakes/worktrees/b764898e6d62/01M1ZHRD3PSRTEGHHRA2XHGXR2/.tmp-codex-max-live/runs/max_clamped/project

  Do you trust the contents of this directory? Working with untrusted contents comes with higher risk of prompt injection. Trusting the directory allows project-local config, hooks, and exec policies to load.

› 1. Yes, continue
  2. No, quit

  Press enter to continue
```
</details>
<details>
<summary>Evidence: Bootstrap codex max dispatch evidence</summary>

Source: [Bootstrap codex max dispatch evidence](https://github.com/0x7067/firstmate/blob/2b8023fd805c2d4c2c61fc07ad53d83127d95b2d/.no-mistakes/evidence/fm/firstmate-3212/codex-max-bootstrap.txt)

```text
# Bootstrap crew-dispatch codex max evidence
config/crew-dispatch.json requests harness=codex model=gpt-6-astra effort=max.
fm-bootstrap output:

RESULT: no invalid-effort rejection for codex:max
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"ccd61fafb90c31c1d304961f307e16ce77414e0c","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>⚠️ **Review** - 1 warning</summary>

- ⚠️ `bin/fm-spawn.sh:1836` - For `--harness codex --effort max` with no explicit `--model`, the capability check reads `$CODEX_HOME`/`$HOME/.codex` from the fm-spawn process, but the actual launch may run with different pane-provided `HOME`/`CODEX_HOME` values (including allowlisted `CODEX_HOME`). A concrete pane whose Codex default is xhigh-only can still receive `model_reasoning_effort=&#34;max&#34;` if the spawner environment&#39;s default model supports max. Treat an omitted model as unconfirmed unless the check can use the same environment the worker will run with, and fail closed to xhigh otherwise.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- Live validation: ✅ go - 3 of 3 scenarios driven live against the product

| Scenario | Result | Live | Evidence |
| --- | --- | --- | --- |
| Spawn a Codex worker with effort=max on a max-capable selected model and observe model_reasoning_effort=&#34;max&#34; in the live launch | ✅ pass | live | Live Codex max spawn evidence |
| Spawn a Codex worker with effort=max on a selected model whose catalog tops out at xhigh and observe model_reasoning_effort=&#34;xhigh&#34; without model_reasoning_effort=&#34;max&#34; | ✅ pass | live | Live Codex max spawn evidence |
| Bootstrap an isolated home whose crew-dispatch profile requests codex effort=max and observe no invalid-effort rejection | ✅ pass | live | Bootstrap codex max dispatch evidence |

- <code>`./tests/fm-spawn-dispatch-profile.test.sh` with the default 120s harness timeout; it reached and passed the codex max/clamp cases before timing out later in the broader targeted file.</code>
- <code>`./tests/fm-spawn-dispatch-profile.test.sh` rerun with a 360s timeout; completed and passed.</code>
- <code>Live isolated tmux/product run of `bin/fm-spawn.sh ... --harness codex --model gpt-6-astra --effort max` against the installed `codex-cli 0.153.4` catalog.</code>
- <code>Live isolated tmux/product run of `bin/fm-spawn.sh ... --harness codex --model gpt-5.5 --effort max` against the installed `codex-cli 0.153.4` catalog.</code>
- <code>Isolated `bin/fm-bootstrap.sh` run with `config/crew-dispatch.json` requesting `harness=codex`, `model=gpt-6-astra`, `effort=max`.</code>
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
