### PR TITLE
fix(bin): lead every generated Definition of done with its terminal condition

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -350,7 +350,7 @@ After an autonomous merge, give the captain a one-line full-URL or local-main ou
 
 ### Validate
 
-For a no-mistakes ship, trigger validation on the same worker after its implementation commit, using the harness invocation owned by `harness-adapters`.
+A no-mistakes ship worker reports its implementation commit as a nonterminal `working:` line and waits, because `done:` on that mode is reserved for the delivered PR; trigger validation on that same worker using the harness invocation owned by `harness-adapters`.
 The task worker that starts a no-mistakes run drives the pipeline and owns every `no-mistakes axi run` and `no-mistakes axi respond` call through the next gate or outcome.
 Firstmate never invokes `no-mistakes axi respond` for a crew-owned run.
 When the captain adds or changes an ask mid-task, append the captain's words to that brief's `## Captain's intent` and steer the worker; Firstmate build constraints stay in `## Firstmate spec` or the steer.

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -17,6 +17,8 @@
 #        fm-brief.sh <task-id> --secondmate {<project>...|--no-projects}
 #   --scout writes the scout contract instead: the deliverable is a report at
 #   data/<task-id>/report.md (no branch, no push, no PR) and the worktree is scratch.
+#   Like every ship mode's block in bin/fm-dod-lib.sh, its Definition of done opens
+#   with the one "Terminal condition:" line naming the single legal `done:` form.
 #   --secondmate writes a persistent secondmate charter. The project list
 #   is cloned into the secondmate home, while the natural-language scope
 #   tells the main firstmate when to route work there; routine churn stays in its own home;
@@ -405,11 +407,11 @@ The report is the only thing that survives, so anything worth keeping must be in
 $INBOX_SECTION
 
 # Definition of done
+Terminal condition: \`done: {one-line conclusion}\`. That is this task's ONLY legal \`done:\` line, and it is legal only once the report below exists and the completion gate passes; then stop.
 Write your findings to \`$DATA/$ID/report.md\`.
 The report must stand alone: what you did, what you found, the evidence (commands run, output, file:line references), and what you recommend.
 If your deliverable is a visual artifact the captain will review and iterate on, you may host the Lavish review loop yourself (poll, revise, re-serve, staying alive) instead of handing it back to firstmate.
 Before reporting done, read and follow \`$FM_ROOT/.agents/skills/captain-hold-lifecycle/SKILL.md\` and pass its shared completion gate for the report and any visual review.
-When the report is complete, append \`done: {one-line conclusion}\` to the status file and stop.
 If your findings reveal work that should ship (e.g. you reproduced a bug and the fix is clear), say so in the report; firstmate may promote this task in place, and you would then receive mode-specific ship instructions as a follow-up message.
 EOF
 echo "scaffolded: $BRIEF (scout; replace {TASK} and {FIRSTMATE_SPEC})"
@@ -469,7 +471,7 @@ $RULE1
    https:// URL exactly as the forge printed it, never a bare number such as "PR 108"; firstmate
    copies that URL from your line rather than assembling one.
    A mid-task \`working:\` line (including setup complete) is nonterminal: do not end the
-   turn after it; continue the same stage until a defined \`done:\` gate under Definition of done.
+   turn after it; continue the same stage until a stop gate the Definition of done names.
    Use \`$PAUSED_VERB: {why}\` - distinct from \`blocked:\` - ONLY when you are deliberately idling on a
    known external wait you expect to clear on its own (an upstream release, a rate-limit reset,
    a scheduled window): firstmate then leaves your idle pane alone and rechecks it on a long

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -17,8 +17,8 @@
 #        fm-brief.sh <task-id> --secondmate {<project>...|--no-projects}
 #   --scout writes the scout contract instead: the deliverable is a report at
 #   data/<task-id>/report.md (no branch, no push, no PR) and the worktree is scratch.
-#   Like every ship mode's block in bin/fm-dod-lib.sh, its Definition of done opens
-#   with the one "Terminal condition:" line naming the single legal `done:` form.
+#   Its Definition of done opens with the "Terminal condition:" line;
+#   bin/fm-dod-lib.sh owns the ship modes' completion contracts.
 #   --secondmate writes a persistent secondmate charter. The project list
 #   is cloned into the secondmate home, while the natural-language scope
 #   tells the main firstmate when to route work there; routine churn stays in its own home;

--- a/bin/fm-dod-lib.sh
+++ b/bin/fm-dod-lib.sh
@@ -10,11 +10,10 @@
 # mode is refused rather than silently rendered as the pipeline contract.
 # The block opens with the fixed machine-readable "Delivery contract: mode=<mode>"
 # line that bin/fm-spawn.sh checks a ship brief against, then one "Terminal
-# condition:" line naming the single legal `done:` form for that mode. That line
-# leads the block because a worker that has finished coding reaches for "done":
-# three of three no-mistakes workers once reported done on a local commit with
-# nothing pushed, which the old opening ("complete only when committed", "append
-# `done: {summary}`") licensed. `done:` is terminal to every consumer -
+# condition:" line naming the single legal `done:` form for that mode.
+# Keep the terminal condition before the implementation handoff so a local
+# commit cannot be mistaken for delivery (tests/fm-brief.test.sh).
+# `done:` is terminal to status consumers -
 # bin/fm-inactive-reconcile.sh republishes it to a secondmate's parent channel as
 # a delivered outcome - so a no-mistakes implementation commit hands off with
 # nonterminal `working:` instead. That handoff still reaches firstmate:

--- a/bin/fm-dod-lib.sh
+++ b/bin/fm-dod-lib.sh
@@ -9,7 +9,17 @@
 # stdout with no trailing blank line. The caller validates the mode; an unknown
 # mode is refused rather than silently rendered as the pipeline contract.
 # The block opens with the fixed machine-readable "Delivery contract: mode=<mode>"
-# line that bin/fm-spawn.sh checks a ship brief against.
+# line that bin/fm-spawn.sh checks a ship brief against, then one "Terminal
+# condition:" line naming the single legal `done:` form for that mode. That line
+# leads the block because a worker that has finished coding reaches for "done":
+# three of three no-mistakes workers once reported done on a local commit with
+# nothing pushed, which the old opening ("complete only when committed", "append
+# `done: {summary}`") licensed. `done:` is terminal to every consumer -
+# bin/fm-inactive-reconcile.sh republishes it to a secondmate's parent channel as
+# a delivered outcome - so a no-mistakes implementation commit hands off with
+# nonterminal `working:` instead. That handoff still reaches firstmate:
+# bin/fm-watch.sh surfaces any crew that stopped its turn without positive
+# evidence it is still executing.
 # This file is the one owner of the no-mistakes `--intent` contract: only the
 # brief's `## Captain's intent` subsection plus later captain words, never
 # `## Firstmate spec` and never the worker's own tradeoffs.
@@ -197,20 +207,20 @@ fm_dod_block() {  # <mode> <task-id>
       cat <<EOF
 # Definition of done
 Delivery contract: mode=direct-PR
-This task ships **direct-PR**: you raise the PR yourself, without the no-mistakes pipeline.
-The task is complete only when committed on your branch.
-When it is implemented and committed, push your branch and open a PR with \`gh-axi\`, then append \`done: PR {url}\` to the status file and stop.
-Do NOT run /no-mistakes. The configured merge authority decides whether to merge the PR; firstmate relays the outcome.
+Terminal condition: \`done: PR {url}\`. That is this task's ONLY legal \`done:\` line: a commit with no PR is not done.
+This task ships **direct-PR**: you raise the PR yourself. Do NOT run /no-mistakes.
+When the implementation is committed, push your branch and open a PR with \`gh-axi\`, then append that terminal line to the status file and stop.
+The configured merge authority decides whether to merge the PR; firstmate relays the outcome.
 EOF
       ;;
     local-only)
       cat <<EOF
 # Definition of done
 Delivery contract: mode=local-only
-This task ships **local-only**: no remote, no PR, no pipeline.
-The task is complete only when committed on your branch \`fm/$id\`. Do NOT push, do NOT open a PR, do NOT merge.
+Terminal condition: \`done: ready in branch fm/$id\`. That is this task's ONLY legal \`done:\` line.
+This task ships **local-only**: no remote, no PR, no pipeline. Do NOT push, do NOT open a PR, do NOT merge.
 Keep your branch a clean fast-forward onto the current default branch - if \`main\` has advanced, rebase onto it so the eventual merge stays a fast-forward.
-When it is implemented and committed, append \`done: ready in branch fm/$id\` to the status file and stop.
+When the work is implemented and committed on \`fm/$id\`, append that terminal line to the status file and stop.
 The configured merge authority approves the ready branch, then firstmate merges it into local \`main\` through the guarded fast-forward path.
 EOF
       ;;
@@ -218,9 +228,8 @@ EOF
       cat <<EOF
 # Definition of done
 Delivery contract: mode=no-mistakes
-The task is complete only when committed on your branch.
-When you believe it is complete, append \`done: {summary}\` to the status file and stop.
-Firstmate will then instruct you to run /no-mistakes to validate and ship a PR.
+Terminal condition: \`done: PR {url} checks green\`. That is this task's ONLY legal \`done:\` line: a commit with no PR is not done.
+Report the finished implementation with \`working: implemented, ready for the pipeline\` and stop the turn; firstmate then sends the pipeline invocation for your runtime.
 
 You drive no-mistakes by responding to its gates, not by implementing fixes.
 Follow the guidance no-mistakes itself provides for the mechanics: it loads when you invoke /no-mistakes, and \`no-mistakes axi run --help\` plus the \`help\` lines in each \`axi\` response are authoritative and version-matched to the installed binary.
@@ -245,7 +254,7 @@ Two firstmate-specific rules layer on top of that guidance:
 - NEVER pass \`--yes\` (or \`-y\`) to \`no-mistakes axi run\` or \`no-mistakes axi respond\`. It is banned fleet-wide.
   It auto-resolves every gate including ask-user findings with no escalation, and answering your own ask-user finding is a hard rule violation.
 
-After /no-mistakes reports CI green (the CI-ready return point - do not wait for it to keep monitoring in the background until merge), append \`done: PR {url} checks green\` and stop. You are finished.
+Only now is the terminal condition reachable: after /no-mistakes reports CI green (the CI-ready return point - do not wait for it to keep monitoring in the background until merge), append \`done: PR {url} checks green\` and stop. You are finished.
 EOF
       ;;
     *)

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -260,7 +260,7 @@ test_ship_mode_is_explicit_not_registry() {
   brief="$home/data/brief-explicit-a5/brief.md"
   grep -qx "Delivery contract: mode=no-mistakes" "$brief" \
     || fail "registered direct-PR posture overrode the explicit --mode"
-  assert_grep "Firstmate will then instruct you to run /no-mistakes" "$brief" \
+  assert_grep "Terminal condition: \`done: PR {url} checks green\`" "$brief" \
     "explicit no-mistakes brief did not render the pipeline definition of done"
 
   # An unregistered project is not a blocker either, because nothing is looked up.
@@ -370,6 +370,106 @@ test_no_mistakes_dod_wording() {
   assert_no_grep "no-mistakes refuses" "$brief" \
     "no-mistakes DOD must not claim the tool itself refuses --yes"
   pass "fm-brief.sh: no-mistakes DOD keeps its apostrophe prose and bans --yes outright"
+}
+
+# Print a generated brief's "# Definition of done" body, heading excluded.
+dod_body() {  # <brief>
+  awk '/^# Definition of done$/ { emit = 1; next } emit' "$1"
+}
+
+# Print the <n>th line of that body.
+dod_body_line() {  # <brief> <n>
+  dod_body "$1" | sed -n "$2p"
+}
+
+# On 2026-09-05 three of three no-mistakes ship workers reported `done:` on a
+# local commit with nothing pushed: the block opened with "complete only when
+# committed on your branch" and "append `done: {summary}`", while the real
+# terminal line sat far below the setup, --intent, and gate prose. Position is
+# the fix, so pin position rather than mere presence: every scaffold's
+# Definition of done leads with one "Terminal condition:" line naming that
+# mode's single legal `done:` form, immediately after the machine-readable
+# Delivery contract line a ship brief opens with.
+test_definition_of_done_leads_with_its_terminal_condition() {
+  local home id kind flag expect first second
+  home="$TMP_ROOT/terminal-condition-home"
+  mkdir -p "$home/data"
+  while IFS='|' read -r kind flag expect; do
+    [ -n "$kind" ] || continue
+    id="brief-terminal-$kind"
+    # shellcheck disable=SC2086  # flag is an intentional word-split arg list
+    FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" some-proj $flag >/dev/null 2>&1 \
+      || fail "$kind: scaffold should exit 0"
+    brief="$home/data/$id/brief.md"
+    first=$(dod_body_line "$brief" 1)
+    second=$(dod_body_line "$brief" 2)
+    if [ "$kind" = scout ]; then
+      [ "$first" = "$expect" ] \
+        || fail "$kind: Definition of done must open with its terminal condition, got: $first"
+    else
+      [ "$first" = "Delivery contract: mode=$kind" ] \
+        || fail "$kind: Definition of done must open with its delivery contract line, got: $first"
+      [ "$second" = "$expect" ] \
+        || fail "$kind: terminal condition must be the line after the delivery contract, got: $second"
+    fi
+  done <<ROWS
+no-mistakes|--mode no-mistakes|Terminal condition: \`done: PR {url} checks green\`. That is this task's ONLY legal \`done:\` line: a commit with no PR is not done.
+direct-PR|--mode direct-PR|Terminal condition: \`done: PR {url}\`. That is this task's ONLY legal \`done:\` line: a commit with no PR is not done.
+local-only|--mode local-only|Terminal condition: \`done: ready in branch fm/brief-terminal-local-only\`. That is this task's ONLY legal \`done:\` line.
+scout|--scout|Terminal condition: \`done: {one-line conclusion}\`. That is this task's ONLY legal \`done:\` line, and it is legal only once the report below exists and the completion gate passes; then stop.
+ROWS
+  pass "fm-brief.sh: every scaffold's Definition of done leads with its mode-specific terminal condition"
+}
+
+# `done:` is a terminal verb every consumer treats as delivered, so a
+# no-mistakes worker must not spend it on an implementation commit. Its
+# implementation stop gate is the nonterminal `working:` handoff instead, and
+# none of the wording that licensed the premature report may return.
+test_no_mistakes_hands_off_the_implementation_commit_without_done() {
+  local home id brief mode
+  home="$TMP_ROOT/premature-done-home"
+  mkdir -p "$home/data"
+  id="brief-premature-e1"
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" some-proj --mode no-mistakes >/dev/null 2>&1
+  brief="$home/data/$id/brief.md"
+  assert_present "$brief" "no-mistakes brief was not scaffolded"
+  assert_grep "Report the finished implementation with \`working: implemented, ready for the pipeline\`" "$brief" \
+    "no-mistakes DOD must hand off the implementation commit with the nonterminal working verb"
+  assert_no_grep "done: {summary}" "$brief" \
+    "no-mistakes DOD still licenses a done: line for a bare implementation commit"
+  assert_no_grep "Firstmate will then instruct you to run /no-mistakes" "$brief" \
+    "no-mistakes DOD still stops the worker at the commit before naming its terminal condition"
+
+  # A PR-delivering mode is never complete at a commit. local-only is excluded
+  # deliberately: its terminal condition really is the committed branch.
+  for mode in no-mistakes direct-PR; do
+    id="brief-premature-$mode"
+    FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" some-proj --mode "$mode" >/dev/null 2>&1
+    assert_no_grep "The task is complete only when committed on your branch" "$home/data/$id/brief.md" \
+      "$mode: brief still calls a commit with no PR complete"
+  done
+
+  # The handoff belongs to the pipeline mode alone; the faster paths deliver in
+  # one stage and must not learn to stop halfway.
+  for mode in direct-PR local-only; do
+    id="brief-nohandoff-$mode"
+    FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" some-proj --mode "$mode" >/dev/null 2>&1
+    assert_no_grep "ready for the pipeline" "$home/data/$id/brief.md" \
+      "$mode: brief must not carry the no-mistakes implementation handoff"
+  done
+
+  # Rule 4 forbids ending a turn on a mid-task working: line, and the Definition
+  # of done owns the exceptions. It must name them as stop gates, not as `done:`
+  # gates, or it contradicts the no-mistakes handoff above.
+  for mode in no-mistakes direct-PR local-only; do
+    id="brief-stopgate-$mode"
+    FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" some-proj --mode "$mode" >/dev/null 2>&1
+    assert_grep "continue the same stage until a stop gate the Definition of done names" "$home/data/$id/brief.md" \
+      "$mode: rule 4 must defer its stop gates to the Definition of done"
+    assert_no_grep "until a defined \`done:\` gate" "$home/data/$id/brief.md" \
+      "$mode: rule 4 still requires every stop gate to be a done: line"
+  done
+  pass "fm-brief.sh: no-mistakes reserves done: for the delivered PR and hands off with working:"
 }
 
 test_ask_user_escalation_format() {
@@ -878,6 +978,8 @@ test_ship_mode_is_explicit_not_registry
 test_delivery_flags_are_refused_where_they_do_not_apply
 test_faster_paths_use_configured_authority_without_stacked_review
 test_no_mistakes_dod_wording
+test_definition_of_done_leads_with_its_terminal_condition
+test_no_mistakes_hands_off_the_implementation_commit_without_done
 test_ask_user_escalation_format
 test_ship_project_memory_wording
 test_herdr_lab_contract_is_explicit_and_complete


### PR DESCRIPTION
## Intent

The captain chose this on 2026-09-08 as one of three jobs to start now, from a shortlist of ready work.
His reason for including it: it protects the trustworthiness of every future completion report firstmate gives him.

THE DEFECT. On 2026-09-05, three of three workers on no-mistakes ship tasks reported "done" on a local commit, with nothing pushed and no pull request. Firstmate had to steer each one to finish the pipeline.

agfp-audit-timeout-false-vuln "done: committed fail-closed three-state audit handling ... at d597df7d"
agfp-workflow-pin-bot-bumps "done: self-clearing Dependabot workflow-action pin path committed"
fm-writing-style-all-runtimes "done: committed cross-runtime worker writing-style propagation at 5da252f"

All three ran on the same runtime. Each had a correct brief carrying "Delivery contract: mode=no-mistakes" and the generated Definition of done section. Each did excellent work and then stopped one step early, in the same way, at the same boundary.

Three for three is a contract-communication defect, not three independent lapses. The generated brief evidently reads as "implement, validate locally, commit, report" when the mode requires "implement, run the pipeline, open a pull request, report it green".

COST. Firstmate caught all three, so no work was lost. The cost is a supervision round trip per task, and the risk that a less attentive session accepts the premature report and cleans the work up before it ever ships.

## What Changed

- `bin/fm-dod-lib.sh` now opens each ship mode's Definition of done with a single `Terminal condition:` line naming that mode's only legal `done:` form (`done: PR {url} checks green`, `done: PR {url}`, `done: ready in branch fm/<id>`), placed immediately after the machine-readable `Delivery contract:` line, and drops the "complete only when committed on your branch" wording from the PR-delivering modes. The no-mistakes block now tells the worker to commit and hand off with a nonterminal `working: implemented, ready for the pipeline` line instead of spending `done:` on the implementation commit.
- `bin/fm-brief.sh` gives the scout scaffold the same leading `Terminal condition:` line, and relaxes rule 4 from "continue until a defined `done:` gate" to "continue until a stop gate the Definition of done names", with an explicit exception for a Definition of done that names a `working:` line as its stop gate.
- `AGENTS.md` and `.agents/skills/afk/SKILL.md` record the matching expectations: a no-mistakes ship worker reports its implementation commit as `working:` and waits for validation, and the afk wedge rationale notes the sanctioned mid-task handoff wake. `tests/fm-brief.test.sh` adds two tests pinning the terminal condition's position in every scaffold and asserting the retired premature-done wording cannot return.

## Risk Assessment

✅ Low: The change is a well-bounded rewording of four generated brief Definition-of-done blocks plus matching regression tests; no machine-readable contract consumer depends on the changed prose, the one parsed line (Delivery contract) is read position-independently, and the previously reported vacuous test assertions are genuinely fixed.

## Testing

I generated all four brief kinds from this branch's code in an isolated FM_HOME and read the rendered Definition of done for each, which is the change's end-user surface. All four lead with their mode-specific terminal condition, the two PR-delivering modes state that a commit with no PR is not done, no-mistakes hands the commit off with the nonterminal `working:` line and names the status file as the append destination, scout both names and instructs its append, and rule 4's exception renders in all three ship briefs. The live no-mistakes brief contains exactly one `done:` form - the PR-green one - so no earlier completion gate remains reachable. Adversarially I reverted the generator to the base commit and both new tests fail on the exact 2026-09-05 wording, and I mutated the generator to emit nothing for the hardened loops' ids, which shows the pre-hardening assertions passing vacuously and the hardened ones failing loudly. The targeted suites fm-brief, fm-task-delivery and fm-documentation-audiences pass, and the watcher turn-end cases confirm the new nonterminal handoff still wakes firstmate rather than stranding the worker. The surface is generated text rather than rendered UI, so the evidence is the generated briefs themselves rather than screenshots. Overall result: every scenario passed.

- Live validation: ✅ go - 10 of 11 scenarios driven live against the product

| Scenario | Result | Live | Evidence |
| --- | --- | --- | --- |
| A no-mistakes ship brief tells the worker the only legal done: is a delivered PR, and hands the implementation commit off with working: | ✅ pass | live | generated-dod-all-modes.txt and live-no-mistakes-brief.md: the DOD opens with `Delivery contract: mode=no-mistakes` then `Terminal condition: \`done: PR {url} checks green\`. ... a commit with no PR i… |
| No earlier done: gate remains reachable in a no-mistakes brief (adversarial: hunt for any second completion gate) | ✅ pass | live | no-mistakes-done-mentions.txt: the only two `done:` forms in the whole generated brief are the terminal-condition line and the final `append \`done: PR {url} checks green\` to the status file` line; t… |
| The 2026-09-05 premature-done wording cannot come back in any generated brief | ✅ pass | live | rule4-and-old-wording.txt: `The task is complete only when committed on your branch`, `Firstmate will then instruct you to run /no-mistakes`, `done: {summary}` and `until a defined \`done:\` gate` are… |
| Reverting the generator to the base commit reproduces the defect and fails the new tests (regression proof) | ✅ pass | live | regression-mutation.txt: with base 0962d4a fm-dod-lib.sh in place, `not ok - no-mistakes: terminal condition must be the line after the delivery contract, got: The task is complete only when committed… |
| direct-PR and local-only keep their own terminal conditions and never learn the pipeline handoff | ✅ pass | live | generated-dod-all-modes.txt: direct-PR leads with `done: PR {url}`, local-only with `done: ready in branch fm/live-local-only` interpolated from the task id, and neither brief contains `ready for the… |
| A scout brief both names its terminal condition and tells the worker to append it to the status file | ✅ pass | live | generated-dod-all-modes.txt scout section: `Terminal condition: \`done: {one-line conclusion}\` ... then append it to the status file and stop.` |
| Rule 4&#39;s stop-gate exception renders in every ship brief so the working: handoff is not read as a forbidden turn end | ✅ pass | live | rule4-and-old-wording.txt: all three ship briefs render `continue the same stage until a stop gate the Definition of done names.` plus `The one exception: where the Definition of done names a \`workin… |
| The new nonterminal handoff still wakes firstmate rather than stranding a stopped worker | ✅ pass | live | handoff-wake.txt: `test_turn_ended_not_working_surfaced` and `test_turn_ended_provably_working_absorbed` driven from tests/fm-watch-triage.test.sh - a crew that ends its turn without positive working… |
| The downstream spawn consumer still reads the delivery contract line now that a terminal-condition line follows it | ✅ pass | live | `bash tests/fm-task-delivery.test.sh` passes, including `fm-spawn: the brief&#39;s recorded mode and the spawn&#39;s explicit mode must agree` and `fm-promote: a promoted worker receives the same mode-specifi… |
| The hardened brief tests fail loudly instead of passing green when no brief is generated (adversarial: attack the guard itself) | ✅ pass | live | test-hardening-mutation.txt: with fm-brief.sh silently emitting nothing for the brief-nohandoff ids, the pre-hardening loop still reported ok while the hardened loop reported `not ok - direct-PR: scaf… |
| A real no-mistakes worker agent reads the new brief and stops at the commit with working: instead of done: | ⏸️ untested | no | Driving an actual crewmate would need a registered project clone, a terminal backend (herdr/cmux/tmux) and authority to launch a worker, none of which this test phase holds; model interpretation of pr… |

<details>
<summary>Evidence: Generated Definition of done for all four modes (the change&#39;s end-user surface)</summary>

Source: [Generated Definition of done for all four modes (the change&#39;s end-user surface)](https://github.com/AgardnerAU/firstmate/blob/0439e137f90d4e9181c0a63fa9c0c02463008197/.no-mistakes/evidence/fm/fm-brief-dod-premature-done/generated-dod-all-modes.txt)

```text
==================== MODE: no-mistakes ====================
# Definition of done
Delivery contract: mode=no-mistakes
Terminal condition: `done: PR {url} checks green`. That is this task's ONLY legal `done:` line: a commit with no PR is not done.
Commit the finished implementation, then report `working: implemented, ready for the pipeline` and stop the turn. Do not start the pipeline yourself; firstmate owns that runtime-specific invocation and sends it to you.

You drive no-mistakes by responding to its gates, not by implementing fixes.
Follow the guidance no-mistakes itself provides for the mechanics: it loads when you invoke /no-mistakes, and `no-mistakes axi run --help` plus the `help` lines in each `axi` response are authoritative and version-matched to the installed binary.
When starting no-mistakes, pass `--intent` as only this brief's `## Captain's intent` subsection plus any later words the captain actually said.
For a legacy brief with no such subsection, include only words explicitly labeled `Captain:`, `Captain's words:`, `Captain's ask:`, or `Captain's intent:`; never copy its mixed `# Task` wholesale. If it has no provenance-marked captain words, stop and ask firstmate instead of starting no-mistakes.
Do not include `## Firstmate spec`, later Firstmate build constraints, or your own decisions and tradeoffs.
The `--intent` string you pass must be self-sufficient: that string plus the codebase must let a reader reconstruct roughly the same specification, without depending on a separate report, a PR, or context that lives only in this conversation.
When the captain's intent refers to a report, decision, or PR ("do items 1, 2, 3, and 7 of the report"), write the substance of the referenced items into `--intent` in the captain's terms, not only the pointer; that substance is the captain's ask by reference, while Firstmate's build instructions and your own decisions still stay out.
This replaces the no-mistakes skill's advice to enrich `--intent` with decisions and tradeoffs; that advice does not apply to Firstmate-dispatched work.
Do not hand-edit, commit, or fix findings yourself while a run is active - the pipeline applies every fix.

One drive call blocks until the next gate or outcome, which routinely outlives what your harness lets a single command run: Claude Code kills a command at ten minutes maximum, while one fix round is capped around thirty minutes and up to three rounds chain.
So background the drive call and poll `no-mistakes axi status` from a separate call instead of sitting in one blocking hold your harness will kill.
Where a harness's own command limit is not established, assume it bounds commands and use that same background-and-poll shape.
A killed or timed-out call is never evidence the daemon died: the daemon accepts your response immediately and runs the round in the background, so the call was only ever waiting for a read while the run kept working.
Reattach and keep going rather than reporting the pipeline blocked; rule 7 owns the checks that decide when a pipeline block is real.

Two firstmate-specific rules layer on top of that guidance:
- ask-user findings are never yours to answer: escalate to firstmate using rule 6's ask-user format and stop.
  Firstmate applies `ask-user-authority` and obtains any required captain decision.
  When the decision comes back, feed it to the gate with `no-mistakes axi respond` and let the pipeline apply it - do not route the question to "the user" or implement the fix yourself.
- NEVER pass `--yes` (or `-y`) to `no-mistakes axi run` or `no-mistakes axi respond`. It is banned fleet-wide.
  It auto-resolves every gate including ask-user findings with no escalation, and answering your own ask-user finding is a hard rule violation.

Only now is the terminal condition reachable: after /no-mistakes reports CI green (the CI-ready return point - do not wait for it to keep monitoring in the background until merge), append `done: PR {url} checks green` to the status file and stop. You are finished.

==================== MODE: direct-PR ====================
# Definition of done
Delivery contract: mode=direct-PR
Terminal condition: `done: PR {url}`. That is this task's ONLY legal `done:` line: a commit with no PR is not done.
This task ships **direct-PR**: you raise the PR yourself. Do NOT run /no-mistakes.
When the implementation is committed, push your branch and open a PR with `gh-axi`, then append `done: PR {url}` to the status file and stop.
The configured merge authority decides whether to merge the PR; firstmate relays the outcome.

==================== MODE: local-only ====================
# Definition of done
Delivery contract: mode=local-only
Terminal condition: `done: ready in branch fm/live-local-only`. That is this task's ONLY legal `done:` line.
This task ships **local-only**: no remote, no PR, no pipeline. Do NOT push, do NOT open a PR, do NOT merge.
Keep your branch a clean fast-forward onto the current default branch - if `main` has advanced, rebase onto it so the eventual merge stays a fast-forward.
When the work is implemented and committed on `fm/live-local-only`, append `done: ready in branch fm/live-local-only` to the status file and stop.
The configured merge authority approves the ready branch, then firstmate merges it into local `main` through the guarded fast-forward path.

==================== MODE: scout ====================
# Definition of done
Terminal condition: `done: {one-line conclusion}`. That is this task's ONLY legal `done:` line, and it is legal only once the report below exists and the completion gate passes; then append it to the status file and stop.
Write your findings to `/var/folders/41/64hrmnwx11q5lw3l9d7zmfgr0000gn/T/tmp.iVxeUjddu8/home/data/live-scout/report.md`.
The report must stand alone: what you did, what you found, the evidence (commands run, output, file:line references), and what you recommend.
If your deliverable is a visual artifact the captain will review and iterate on, you may host the Lavish review loop yourself (poll, revise, re-serve, staying alive) instead of handing it back to firstmate.
Before reporting done, read and follow `~/.no-mistakes/worktrees/c272d8f3fc4c/01M2G268RTQE56JAGFCF69XE8B/.agents/skills/captain-hold-lifecycle/SKILL.md` and pass its shared completion gate for the report and any visual review.
If your findings reveal work that should ship (e.g. you reproduced a bug and the fix is clear), say so in the report; firstmate may promote this task in place, and you would then receive mode-specific ship instructions as a follow-up message.
```
</details>
<details>
<summary>Evidence: Full live no-mistakes brief as a worker receives it</summary>

Source: [Full live no-mistakes brief as a worker receives it](https://github.com/AgardnerAU/firstmate/blob/0439e137f90d4e9181c0a63fa9c0c02463008197/.no-mistakes/evidence/fm/fm-brief-dod-premature-done/live-no-mistakes-brief.md)

```text
You are a crewmate: an autonomous worker agent managed by firstmate. Work on your own; do not wait for a human.

# Task
## Captain's intent
{TASK}

## Firstmate spec
{FIRSTMATE_SPEC}

# Herdr lifecycle declaration - NOT ENABLED
**HARD SAFETY GATE:** this scaffold cannot inspect the task text filled in above.
If the task will start, stop, delete, restart, profile, or otherwise drive Herdr lifecycle behavior, stop and regenerate the brief with `--herdr-lab` before dispatch.
Do not add Herdr lifecycle commands to this unguarded brief by hand.

# Setup
You are in a disposable git worktree of demo-proj, at a detached HEAD on a clean default branch.

**Verify isolation before anything else.** Run `pwd -P` and `git rev-parse --show-toplevel`; both must resolve to the disposable task worktree you were launched in, such as a treehouse pool path or an Orca-managed worktree, not the primary checkout firstmate operates from.
The path check is authoritative: `git rev-parse --git-dir` and `git rev-parse --git-common-dir` can help inspect the repo, but they do not prove you are outside the primary checkout.
If the top-level path is the primary checkout or not the worktree you were launched in, STOP - do not branch or commit here - append `blocked: launched in primary checkout, not an isolated worktree` to the status file and stop.

1. First action: create your branch: `git checkout -b fm/live-no-mistakes`
2. Run `no-mistakes doctor`; if it reports the repo is not initialized here, run `no-mistakes init`.

# Rules
1. Never push to the default branch. Never merge a PR.
2. Stay inside this worktree; modify nothing outside it.
3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.
4. Report status by appending one line:
   `echo "{state}: {one short line}" >> '/var/folders/41/64hrmnwx11q5lw3l9d7zmfgr0000gn/T/tmp.iVxeUjddu8/home/state/live-no-mistakes.status'`
   States: working, needs-decision, blocked, paused, done, failed.
   Each append wakes firstmate, so report sparingly: only phase changes a supervisor
   would act on (setup done, bug reproduced, fix implemented, validation passed) and the
   needs-decision/blocked/paused/done/failed states. No step-by-step FYI progress lines;
   firstmate reads your pane for that.
   Whenever you mention a PR anywhere - a status line, your terminal, a summary - write its full
   https:// URL exactly as the forge printed it, never a bare number such as "PR 108"; firstmate
   copies that URL from your line rather than assembling one.
   A mid-task `working:` line (including setup complete) is nonterminal: do not end the
   turn after it; continue the same stage until a stop gate the Definition of done names.
   The one exception: where the Definition of done names a `working:` line as its stop gate,
   end the turn on that line.
   Use `paused: {why}` - distinct from `blocked:` - ONLY when you are deliberately idling on a
   known external wait you expect to clear on its own (an upstream release, a rate-limit reset,
   a scheduled window): firstmate then leaves your idle pane alone and rechecks it on a long
   cadence instead of treating it as a possible wedge. Use `blocked:` when you are stuck and need help.
5. If you hit the same obstacle twice, append `blocked: {why}` and stop; firstmate will help.
6. If a decision belongs above the implementation worker (product choices, destructive actions),
   append `needs-decision: {summary of options}` and stop. Firstmate will reply with the decision.
   For a no-mistakes ask-user gate specifically, escalate all ask-user findings as one event plus one snapshot file, using that same shape even when the gate holds only a single ask-user finding: write only the ask-user findings, verbatim and unparaphrased (id, severity, file, line, description, authority), to `/var/folders/41/64hrmnwx11q5lw3l9d7zmfgr0000gn/T/tmp.iVxeUjddu8/home/data/live-no-mistakes/nm-<run>-findings.txt`, then report the gate with
   `needs-decision [key=nm-<run>-<step>]: ask-user findings=<id1>,<id2>,... file=/var/folders/41/64hrmnwx11q5lw3l9d7zmfgr0000gn/T/tmp.iVxeUjddu8/home/data/live-no-mistakes/nm-<run>-findings.txt`
   naming every ask-user finding id from that gate. The status line only points at the file; it never restates or summarizes a finding's content.
   A decision or blocker you opened stays open until a `resolved` line carrying its exact key lands; a later `done:` or `working:` line never closes it, even when the answer is what started that work.
   Firstmate's reply normally writes that closing line at answer time; when a blocker or wait clears WITHOUT a firstmate reply, append `resolved: {how it cleared}` yourself (same `[key=<slug>]` if you opened it with one) as you resume.
7. Never stop, restart, or update the shared `no-mistakes` daemon - it is one instance serving
   every lane/home, so restarting it kills other lanes' in-flight pipeline runs; only firstmate
   manages the daemon.
   Before you append `blocked:` about the pipeline, run `no-mistakes daemon status` and
   `no-mistakes axi status`. If the daemon socket refuses connections or is missing, append
   `blocked: {the daemon error}` and stop even when the local run record still says running or
   fixing, because that record can be stale after the daemon exits. A run record failed with a
   daemon error is also a real block.
   Only after ruling out socket refusal, if the run is still running or fixing, reattach and keep
   going. A drive-call error, timeout, slow read, or generic unreachability is NOT a daemon error:
   the daemon accepts `respond` immediately and runs the round in the background, so a killed or
   timed-out call was only waiting for a read while the run kept working.

# Firstmate instruction inbox
Firstmate steers you through durable message files in '/var/folders/41/64hrmnwx11q5lw3l9d7zmfgr0000gn/T/tmp.iVxeUjddu8/home/state/live-no-mistakes.inbox'.
When a terminal message says an instruction is waiting there - and at any natural checkpoint when you are unsure - list '/var/folders/41/64hrmnwx11q5lw3l9d7zmfgr0000gn/T/tmp.iVxeUjddu8/home/state/live-no-mistakes.inbox'/*.msg, read and act on each message in numeric order, then acknowledge each handled message by moving it: `mv '/var/folders/41/64hrmnwx11q5lw3l9d7zmfgr0000gn/T/tmp.iVxeUjddu8/home/state/live-no-mistakes.inbox'/NNN.msg '/var/folders/41/64hrmnwx11q5lw3l9d7zmfgr0000gn/T/tmp.iVxeUjddu8/home/state/live-no-mistakes.inbox'/handled/`.
The move IS the acknowledgement: without it firstmate rings again and eventually treats you as stuck. An empty or absent inbox needs no action.

# Project memory
If `AGENTS.md` or `CLAUDE.md` already exists, or if this task produced durable project-intrinsic knowledge, run `~/.no-mistakes/worktrees/c272d8f3fc4c/01M2G268RTQE56JAGFCF69XE8B/bin/fm-ensure-agents-md.sh .` in the worktree.
Record only project knowledge useful to almost every future session.
For anything the codebase already shows, prefer a pointer to the authoritative file, command, or doc over copying the detail.
If you touch a project `AGENTS.md`, follow `~/.no-mistakes/worktrees/c272d8f3fc4c/01M2G268RTQE56JAGFCF69XE8B/bin/fm-ensure-agents-md.sh`'s self-governance contract in the same pass.
Keep it proportionate: skip `AGENTS.md` edits for trivial tasks that produced no durable project knowledge.

# Definition of done
Delivery contract: mode=no-mistakes
Terminal condition: `done: PR {url} checks green`. That is this task's ONLY legal `done:` line: a commit with no PR is not done.
Commit the finished implementation, then report `working: implemented, ready for the pipeline` and stop the turn. Do not start the pipeline yourself; firstmate owns that runtime-specific invocation and sends it to you.

You drive no-mistakes by responding to its gates, not by implementing fixes.
Follow the guidance no-mistakes itself provides for the mechanics: it loads when you invoke /no-mistakes, and `no-mistakes axi run --help` plus the `help` lines in each `axi` response are authoritative and version-matched to the installed binary.
When starting no-mistakes, pass `--intent` as only this brief's `## Captain's intent` subsection plus any later words the captain actually said.
For a legacy brief with no such subsection, include only words explicitly labeled `Captain:`, `Captain's words:`, `Captain's ask:`, or `Captain's intent:`; never copy its mixed `# Task` wholesale. If it has no provenance-marked captain words, stop and ask firstmate instead of starting no-mistakes.
Do not include `## Firstmate spec`, later Firstmate build constraints, or your own decisions and tradeoffs.
The `--intent` string you pass must be self-sufficient: that string plus the codebase must let a reader reconstruct roughly the same specification, without depending on a separate report, a PR, or context that lives only in this conversation.
When the captain's intent refers to a report, decision, or PR ("do items 1, 2, 3, and 7 of the report"), write the substance of the referenced items into `--intent` in the captain's terms, not only the pointer; that substance is the captain's ask by reference, while Firstmate's build instructions and your own decisions still stay out.
This replaces the no-mistakes skill's advice to enrich `--intent` with decisions and tradeoffs; that advice does not apply to Firstmate-dispatched work.
Do not hand-edit, commit, or fix findings yourself while a run is active - the pipeline applies every fix.

One drive call blocks until the next gate or outcome, which routinely outlives what your harness lets a single command run: Claude Code kills a command at ten minutes maximum, while one fix round is capped around thirty minutes and up to three rounds chain.
So background the drive call and poll `no-mistakes axi status` from a separate call instead of sitting in one blocking hold your harness will kill.
Where a harness's own command limit is not established, assume it bounds commands and use that same background-and-poll shape.
A killed or timed-out call is never evidence the daemon died: the daemon accepts your response immediately and runs the round in the background, so the call was only ever waiting for a read while the run kept working.
Reattach and keep going rather than reporting the pipeline blocked; rule 7 owns the checks that decide when a pipeline block is real.

Two firstmate-specific rules layer on top of that guidance:
- ask-user findings are never yours to answer: escalate to firstmate using rule 6's ask-user format and stop.
  Firstmate applies `ask-user-authority` and obtains any required captain decision.
  When the decision comes back, feed it to the gate with `no-mistakes axi respond` and let the pipeline apply it - do not route the question to "the user" or implement the fix yourself.
- NEVER pass `--yes` (or `-y`) to `no-mistakes axi run` or `no-mistakes axi respond`. It is banned fleet-wide.
  It auto-resolves every gate including ask-user findings with no escalation, and answering your own ask-user finding is a hard rule violation.

Only now is the terminal condition reachable: after /no-mistakes reports CI green (the CI-ready return point - do not wait for it to keep monitoring in the background until merge), append `done: PR {url} checks green` to the status file and stop. You are finished.
```
</details>
<details>
<summary>Evidence: Rule 4 exception rendering and absence of the premature-done wording</summary>

Source: [Rule 4 exception rendering and absence of the premature-done wording](https://github.com/AgardnerAU/firstmate/blob/0439e137f90d4e9181c0a63fa9c0c02463008197/.no-mistakes/evidence/fm/fm-brief-dod-premature-done/rule4-and-old-wording.txt)

```text
\### Rule 4 (status protocol) as rendered, all three ship modes + scout
--- no-mistakes ---
39:   A mid-task `working:` line (including setup complete) is nonterminal: do not end the
40-   turn after it; continue the same stage until a stop gate the Definition of done names.
41-   The one exception: where the Definition of done names a `working:` line as its stop gate,
42-   end the turn on that line.
--- direct-PR ---
38:   A mid-task `working:` line (including setup complete) is nonterminal: do not end the
39-   turn after it; continue the same stage until a stop gate the Definition of done names.
40-   The one exception: where the Definition of done names a `working:` line as its stop gate,
41-   end the turn on that line.
--- local-only ---
38:   A mid-task `working:` line (including setup complete) is nonterminal: do not end the
39-   turn after it; continue the same stage until a stop gate the Definition of done names.
40-   The one exception: where the Definition of done names a `working:` line as its stop gate,
41-   end the turn on that line.
--- scout ---

\### Old premature-done wording (must be absent everywhere)
The task is complete only when committed on your branch       absent   OK
Firstmate will then instruct you to run /no-mistakes          absent   OK
done: {summary}                                               absent   OK
until a defined `done:` gate                                  absent   OK
```
</details>
<details>
<summary>Evidence: Every done: mention in the live no-mistakes brief</summary>

Source: [Every done: mention in the live no-mistakes brief](https://github.com/AgardnerAU/firstmate/blob/0439e137f90d4e9181c0a63fa9c0c02463008197/.no-mistakes/evidence/fm/fm-brief-dod-premature-done/no-mistakes-done-mentions.txt)

```text
\### Every `done:` mention in the live no-mistakes brief (adversarial: is any earlier done: gate still reachable?)
53:   A decision or blocker you opened stays open until a `resolved` line carrying its exact key lands; a later `done:` or `working:` line never closes it, even when the answer is what started that work.
82:Terminal condition: `done: PR {url} checks green`. That is this task's ONLY legal `done:` line: a commit with no PR is not done.
108:Only now is the terminal condition reachable: after /no-mistakes reports CI green (the CI-ready return point - do not wait for it to keep monitoring in the background until merge), append `done: PR {url} checks green` to the status file and stop. You are finished.
```
</details>
<details>
<summary>Evidence: Regression mutation: base wording fails both new tests</summary>

Source: [Regression mutation: base wording fails both new tests](https://github.com/AgardnerAU/firstmate/blob/0439e137f90d4e9181c0a63fa9c0c02463008197/.no-mistakes/evidence/fm/fm-brief-dod-premature-done/regression-mutation.txt)

```text
=== Regression mutation: bin/fm-dod-lib.sh reverted to the pre-fix (premature-done) wording ===
not ok - explicit no-mistakes brief did not render the pipeline definition of done
=== Pre-fix wording (base 0962d4a fm-dod-lib.sh) vs new position test ===
ok - fm-brief: scaffolds leave the worker role scope to the launch boundary and keep the secondmate contract
ok - fm-brief.sh: bash -n succeeds
not ok - no-mistakes: terminal condition must be the line after the delivery contract, got: The task is complete only when committed on your branch.

=== Pre-fix wording vs new handoff test ===
ok - fm-brief: scaffolds leave the worker role scope to the launch boundary and keep the secondmate contract
ok - fm-brief.sh: bash -n succeeds
not ok - no-mistakes DOD must commit, then hand off with the nonterminal working verb
```
</details>
<details>
<summary>Evidence: Vacuity mutation: hardened loops fail where the old ones passed on missing files</summary>

Source: [Vacuity mutation: hardened loops fail where the old ones passed on missing files](https://github.com/AgardnerAU/firstmate/blob/0439e137f90d4e9181c0a63fa9c0c02463008197/.no-mistakes/evidence/fm/fm-brief-dod-premature-done/test-hardening-mutation.txt)

```text
=== Mutation A: hardened loops are non-vacuous ===
Mutation: bin/fm-brief.sh silently produces no brief for the brief-nohandoff-* ids.
pre-hardening loop  -> ok - fm-brief.sh: no-mistakes reserves done: for the delivered PR and hands off with working:   (GREEN on files that do not exist)
hardened loop       -> not ok - direct-PR: scaffold should exit 0
```
</details>
<details>
<summary>Evidence: The nonterminal handoff still wakes firstmate</summary>

Source: [The nonterminal handoff still wakes firstmate](https://github.com/AgardnerAU/firstmate/blob/0439e137f90d4e9181c0a63fa9c0c02463008197/.no-mistakes/evidence/fm/fm-brief-dod-premature-done/handoff-wake.txt)

```text
=== The nonterminal handoff still wakes firstmate (tests/fm-watch-triage.test.sh, two turn-end cases driven) ===
ok - a bare turn-end whose crew is not provably working is surfaced (the swallowed-finish fix)
ok - a bare turn-end whose crew is provably working (busy pane) is absorbed

A no-mistakes worker that commits, appends `working: implemented, ready for the pipeline` and stops the turn is
not provably working, so fm-watch surfaces it: firstmate is woken to send the pipeline invocation.
```
</details>
<details>
<summary>Evidence: fm-brief.sh suite result</summary>

Source: [fm-brief.sh suite result](https://github.com/AgardnerAU/firstmate/blob/0439e137f90d4e9181c0a63fa9c0c02463008197/.no-mistakes/evidence/fm/fm-brief-dod-premature-done/fm-brief-test.log)

```text
ok - fm-brief: scaffolds leave the worker role scope to the launch boundary and keep the secondmate contract
ok - fm-brief.sh: bash -n succeeds
/private/var/folders/41/64hrmnwx11q5lw3l9d7zmfgr0000gn/T/fm-brief.iwkoa6/heredoc-in-substitution.sh:2
ok - fm-brief.sh: no heredoc is nested inside a command substitution (Bash 3.2 parse-safe)
ok - fm-brief.sh: --help renders the complete header
ok - fm-brief.sh: no-mistakes/direct-PR/local-only briefs generate cleanly
ok - fm-brief.sh: ship --mode is required and closed-set validated
ok - fm-brief.sh: the explicit ship mode wins over the registered posture
ok - fm-brief.sh: --yolo and scout/secondmate --mode are refused, never silently dropped
ok - fm-brief.sh: faster paths use configured authority without stacked review
ok - fm-brief.sh: no-mistakes DOD keeps its apostrophe prose and bans --yes outright
ok - fm-brief.sh: every scaffold's Definition of done leads with its mode-specific terminal condition
ok - fm-brief.sh: no-mistakes reserves done: for the delivered PR and hands off with working:
ok - fm-brief.sh: no-mistakes ask-user findings use one event plus a verbatim snapshot
ok - fm-brief.sh: ship project-memory wording carries the AGENTS.md authoring bar
ok - fm-brief.sh: --herdr-lab emits the complete hard safety contract
ok - fm-brief.sh: --herdr-lab uses its quoted Firstmate-owned helper path
ok - fm-brief.sh: ship and scout scaffolds make omitted Herdr intent fail-visible
ok - fm-brief.sh: the documented {TASK} and {FIRSTMATE_SPEC} fills cannot corrupt the Herdr safety gate
ok - fm-brief.sh: Herdr lab contract covers scouts and rejects secondmate misuse
ok - fm-brief.sh: --no-projects scaffolds a project-less charter and guards misuse
ok - fm-brief.sh: marked requests avoid generic acknowledgements and preserve material reporting
ok - fm-brief.sh: relative directory inputs ignore CDPATH, render stable absolute charter paths, or fail loudly
ok - fm-brief.sh: custom pause verb renders in every scaffold
ok - fm-brief.sh: investigation and visual-review completions load the shared decision policy
ok - fm-brief: scout and secondmate code paths still scaffold well-formed briefs
ok - fm-brief.sh: scout Lavish hosting follows the bootstrap lavish-axi floor
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"87936f0eafe30d1a1d67c605f3792d75bb1d8409","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"skipped"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>⏭️ **Rebase** - skipped</summary>

- ⚠️ `bin/fm-brief.sh` - merge conflict rebasing onto origin/main
- ⚠️ `bin/fm-dod-lib.sh` - merge conflict rebasing onto origin/main
</details>

<details>
<summary>🔧 **Review** - 5 issues found → auto-fixed (2) ✅</summary>

- ⚠️ `bin/fm-dod-lib.sh:231` - The no-mistakes DOD dropped its only commit precondition. The removed line was &#34;The task is complete only when committed on your branch&#34;; the replacement says only &#34;Report the finished implementation with `working: implemented, ready for the pipeline` and stop the turn&#34;. Nothing else a no-mistakes worker receives asks it to commit: bin/fm-brief.sh&#39;s Setup section only creates the branch (bin/fm-brief.sh:466), and bin/fm-promote.sh&#39;s ship instructions (steps 1-7, bin/fm-promote.sh:182-188) never mention committing either. Concrete sequence: a worker implements the fix, leaves it uncommitted in the worktree, appends `working: implemented, ready for the pipeline`, and stops; firstmate then sends the pipeline invocation and no-mistakes validates a HEAD that does not contain the work, or refuses. The sibling modes kept theirs (&#34;When the implementation is committed&#34; at line 211, &#34;implemented and committed on `fm/$id`&#34; at line 222), so no-mistakes is now the only mode whose brief omits it - and it is the mode where a commit is a hard precondition for the next stage. Smallest honest remedy is wording, e.g. &#34;Commit the finished implementation, then report `working: implemented, ready for the pipeline` and stop the turn&#34;; note the new test at tests/fm-brief.test.sh:448 forbids reviving the exact old sentence, so a new phrasing is needed. Classified ask-user because the generated brief text is this change&#39;s product surface and the author deliberately rewrote this paragraph.
- ⚠️ `bin/fm-brief.sh:483` - Rule 4 and the no-mistakes DOD give a worker two readings of the same moment. Rule 4 (bin/fm-brief.sh:482-483) still opens &#34;A mid-task `working:` line (including setup complete) is nonterminal: do not end the turn after it&#34;, and only the trailing clause was softened to &#34;continue the same stage until a stop gate the Definition of done names&#34;. bin/fm-dod-lib.sh:231 then instructs the worker to append a `working:` line and stop the turn. A worker resolving the conflict in rule 4&#39;s favour does not stop, and the very next DOD lines describe driving /no-mistakes itself (&#34;You drive no-mistakes by responding to its gates&#34;), so it can self-invoke the pipeline instead of waiting for the runtime-specific invocation firstmate owns per AGENTS.md:360 - the opposite of the handoff this change installs. Since the change&#39;s whole purpose is removing ambiguity from the completion contract, this residual ambiguity sits in the one paragraph pair that decides where a no-mistakes turn ends. Remedy is to make rule 4&#39;s exception explicit (the nonterminal ban applies except at a stop gate the Definition of done names) rather than leaving it to inference; classified ask-user because it is worker-facing contract wording the author deliberately chose.
- ℹ️ `bin/fm-dod-lib.sh:211` - &#34;append that terminal line to the status file&#34; (also line 222) refers back to the &#34;Terminal condition: ...&#34; sentence two lines above, which is itself a full sentence beginning with the words &#34;Terminal condition:&#34;. A literal-minded worker can append the whole sentence rather than the `done: PR {url}` form it names. The old wording spelled the line out at the point of use (&#34;append `done: PR {url}` to the status file&#34;). Repeating the bare status line at the point of use costs nothing and removes the indirection; classified ask-user as generated worker-facing wording.
- ⚠️ `bin/fm-dod-lib.sh:219` - Simplification: the change introduces the &#34;Terminal condition:&#34; lead line in four places - no-mistakes, direct-PR, local-only (line 219) and scout (bin/fm-brief.sh:419). The stated intent describes one failure mode, in one mode: three of three no-mistakes workers reporting `done:` on a local commit with nothing pushed. local-only&#39;s terminal condition genuinely is the committed branch (the new test at tests/fm-brief.test.sh:446 says so explicitly), and a scout&#39;s deliverable is a report, so neither mode can exhibit the premature-delivery defect; direct-PR at least shares the commit-is-not-delivery shape. The local-only and scout restructures are therefore not required by any intent requirement. Recommend narrowing to the modes whose terminal condition is a PR, and dropping the corresponding scout/local-only rows from the new position test. Reported as ask-user because it is the author&#39;s deliberate consistency choice across the contract family.
- ℹ️ `bin/fm-dod-lib.sh:231` - Noted tradeoff, no action needed: the implementation handoff moves from `done:` - a captain-relevant verb that always surfaces through signal_files_actionable - to `working:`, the one verb class bin/fm-watch.sh may absorb when crew_absorb_class reports working (bin/fm-classify-lib.sh:1802-1813). If the worker&#39;s pane is still rendering its final turn output when the wake is classified, that wake is absorbed. I traced this and it self-recovers: bin/fm-watch.sh:560 refuses churn-absorb for any .status file, and the absorb branch (bin/fm-watch.sh:2196) deliberately does not advance a .status signature, so the signal re-fires on the next poll and the stale-pane backbone surfaces the stopped crew regardless. The new fm-dod-lib.sh header comment describes this correctly.

🔧 Fix applied.
2 warnings still open:

- ⚠️ `tests/fm-brief.test.sh:445` - Two loops in test_no_mistakes_hands_off_the_implementation_commit_without_done assert only through assert_no_grep (lines 445-450 and 454-459). tests/lib.sh:586 implements it as `! grep -F -- &#34;$1&#34; &#34;$2&#34; &gt;/dev/null || fail`, so a missing file makes grep exit 2, the negation succeeds, and the assertion passes. Both loops invoke `FM_HOME=&#34;$home&#34; &#34;$ROOT/bin/fm-brief.sh&#34; &#34;$id&#34; some-proj --mode &#34;$mode&#34; &gt;/dev/null 2&gt;&amp;1` with no `|| fail` and no assert_present, and stderr is discarded. Concrete sequence: a future change makes fm-brief.sh reject or rename one of these modes, no brief is written, and both loops - which are the only guard that a PR-delivering brief no longer calls a bare commit complete, and that the faster paths never learn the `ready for the pipeline` handoff - report green on files that do not exist. The first brief in the same test does use assert_present (line 435) and the third loop is safe because its assert_grep fails on a missing file, so only these two are vacuous. Remedy is mechanical and does not touch product behavior: add `|| fail` to the scaffold call or an assert_present before the negative assertion in each loop.
- ⚠️ `bin/fm-brief.sh:419` - The scout Definition of done lost its only instruction to write the done line to the status file. The removed line was &#34;When the report is complete, append `done: {one-line conclusion}` to the status file and stop.&#34;; the new lead line at bin/fm-brief.sh:419 reads &#34;Terminal condition: `done: {one-line conclusion}`. That is this task&#39;s ONLY legal `done:` line, and it is legal only once the report below exists and the completion gate passes; then stop.&#34; - it names the form and the precondition but never says to append it anywhere. All three ship modes kept that verb after the fix round (bin/fm-dod-lib.sh:211 &#34;append `done: PR {url}` to the status file and stop&#34;, :222 &#34;append `done: ready in branch fm/$id` to the status file and stop&#34;, :256 &#34;append `done: PR {url} checks green` and stop&#34;), so scout is now the only mode whose brief states a terminal condition without telling the worker to emit it. Concrete sequence: a scout writes report.md, passes the captain-hold completion gate, reads &#34;then stop&#34;, and ends the turn without appending to $STATUS_FILE; since each append is what wakes firstmate (bin/fm-brief.sh:386), firstmate is not woken by the ready signal and pays exactly the supervision round trip the user intent identifies as this change&#39;s cost. Smallest honest remedy is one word at the point of use, e.g. &#34;... passes; then append it to the status file and stop.&#34; Classified ask-user because the generated brief text is this change&#39;s product surface and the author deliberately rewrote this line; note this is a different defect from the already-fixed terminal-line-back-reference finding, which only covered bin/fm-dod-lib.sh:211 and :222.

🔧 Fix applied.
✅ Re-checked - no issues remain.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- Live validation: ✅ go - 10 of 11 scenarios driven live against the product

| Scenario | Result | Live | Evidence |
| --- | --- | --- | --- |
| A no-mistakes ship brief tells the worker the only legal done: is a delivered PR, and hands the implementation commit off with working: | ✅ pass | live | generated-dod-all-modes.txt and live-no-mistakes-brief.md: the DOD opens with `Delivery contract: mode=no-mistakes` then `Terminal condition: \`done: PR {url} checks green\`. ... a commit with no PR i… |
| No earlier done: gate remains reachable in a no-mistakes brief (adversarial: hunt for any second completion gate) | ✅ pass | live | no-mistakes-done-mentions.txt: the only two `done:` forms in the whole generated brief are the terminal-condition line and the final `append \`done: PR {url} checks green\` to the status file` line; t… |
| The 2026-09-05 premature-done wording cannot come back in any generated brief | ✅ pass | live | rule4-and-old-wording.txt: `The task is complete only when committed on your branch`, `Firstmate will then instruct you to run /no-mistakes`, `done: {summary}` and `until a defined \`done:\` gate` are… |
| Reverting the generator to the base commit reproduces the defect and fails the new tests (regression proof) | ✅ pass | live | regression-mutation.txt: with base 0962d4a fm-dod-lib.sh in place, `not ok - no-mistakes: terminal condition must be the line after the delivery contract, got: The task is complete only when committed… |
| direct-PR and local-only keep their own terminal conditions and never learn the pipeline handoff | ✅ pass | live | generated-dod-all-modes.txt: direct-PR leads with `done: PR {url}`, local-only with `done: ready in branch fm/live-local-only` interpolated from the task id, and neither brief contains `ready for the… |
| A scout brief both names its terminal condition and tells the worker to append it to the status file | ✅ pass | live | generated-dod-all-modes.txt scout section: `Terminal condition: \`done: {one-line conclusion}\` ... then append it to the status file and stop.` |
| Rule 4&#39;s stop-gate exception renders in every ship brief so the working: handoff is not read as a forbidden turn end | ✅ pass | live | rule4-and-old-wording.txt: all three ship briefs render `continue the same stage until a stop gate the Definition of done names.` plus `The one exception: where the Definition of done names a \`workin… |
| The new nonterminal handoff still wakes firstmate rather than stranding a stopped worker | ✅ pass | live | handoff-wake.txt: `test_turn_ended_not_working_surfaced` and `test_turn_ended_provably_working_absorbed` driven from tests/fm-watch-triage.test.sh - a crew that ends its turn without positive working… |
| The downstream spawn consumer still reads the delivery contract line now that a terminal-condition line follows it | ✅ pass | live | `bash tests/fm-task-delivery.test.sh` passes, including `fm-spawn: the brief&#39;s recorded mode and the spawn&#39;s explicit mode must agree` and `fm-promote: a promoted worker receives the same mode-specifi… |
| The hardened brief tests fail loudly instead of passing green when no brief is generated (adversarial: attack the guard itself) | ✅ pass | live | test-hardening-mutation.txt: with fm-brief.sh silently emitting nothing for the brief-nohandoff ids, the pre-hardening loop still reported ok while the hardened loop reported `not ok - direct-PR: scaf… |
| A real no-mistakes worker agent reads the new brief and stops at the commit with working: instead of done: | ⏸️ untested | no | Driving an actual crewmate would need a registered project clone, a terminal backend (herdr/cmux/tmux) and authority to launch a worker, none of which this test phase holds; model interpretation of pr… |

- <code>`FM_HOME=&lt;isolated&gt; bin/fm-brief.sh live-&lt;mode&gt; demo-proj --mode no-mistakes|direct-PR|local-only` and `--scout`, then read each generated `# Definition of done`</code>
- <code>`bash tests/fm-brief.test.sh` (includes the two new tests: terminal-condition position across four modes, and the working: handoff)</code>
- <code>`bash tests/fm-task-delivery.test.sh` - fm-spawn still parses the `Delivery contract: mode=` line and refuses a mismatch with the terminal-condition line now following it</code>
- <code>`bash tests/fm-documentation-audiences.test.sh` - AGENTS.md section 7 prose change stays within the maintained-prose contract</code>
- <code>Regression mutation: `git show 0962d4a:bin/fm-dod-lib.sh` restored into a copied tree, then `test_definition_of_done_leads_with_its_terminal_condition` and `test_no_mistakes_hands_off_the_implementation_commit_without_done` run - both fail</code>
- <code>Vacuity mutation: fm-brief.sh made to produce no brief for the `brief-nohandoff-*` ids; pre-hardening loops pass green, hardened loops fail with `not ok - direct-PR: scaffold should exit 0`</code>
- <code>`tests/fm-watch-triage.test.sh` turn-end cases driven in isolation: `test_turn_ended_not_working_surfaced`, `test_turn_ended_provably_working_absorbed`</code>
- <code>grep of every `done:` mention in the live no-mistakes brief to confirm no earlier done: gate remains reachable</code>
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
