### PR TITLE
fix(quota): rank fm-quota-choose by spendPriority instead of argument order

### DIFF
--- a/.agents/skills/quota-array-dispatch/SKILL.md
+++ b/.agents/skills/quota-array-dispatch/SKILL.md
@@ -29,7 +29,7 @@ The helper maps each harness to its primary provider family and applies the prov
 An `exhausted_now` runway vetoes the candidate.
 The helper selects a candidate only when its applicable quota has a known `effectivePercentRemaining` greater than zero.
 An exact tie among the top known scalars exits 3 naming every tied candidate instead of breaking it, which you escalate the same way you would a tie you found by hand.
-A candidate with no known scalar stays eligible and ranks below every known value; the helper's header owns the remaining mechanics.
+A candidate with no known scalar stays eligible and ranks below every known value, and when two or more candidates are eligible but none has a known scalar the helper exits 3 naming every eligible candidate instead of choosing by argument order, while a single eligible candidate is still printed alone with exit 0.
 This is an optional narrow helper with a known limitation: it maps each harness to one primary provider family only, so a candidate whose established provider differs from that primary family is checked against the wrong quota row.
 omp has no primary family, so the helper keys an `omp:` candidate on its model prefix, mapping only `openai-codex/` and `claude-bridge/` and refusing every other prefix; the helper's header owns that mapping.
 Authoritative multi-provider routing - including provider discovery from the harness catalog and quota matching by that explicit provider - stays owned by this skill's intake procedure above and AGENTS.md section 4, not by the helper.

--- a/.agents/skills/quota-array-dispatch/SKILL.md
+++ b/.agents/skills/quota-array-dispatch/SKILL.md
@@ -21,16 +21,19 @@ Deterministic shell owns only schema, configuration, and version validation plus
 
 ## Worker-side quota helper
 
-The canonical shell helper for a worker that has already performed its model-selection reasoning and now needs to pick the first viable candidate is `bin/fm-quota-choose.sh`.
+The canonical shell helper for a worker that has already performed its model-selection reasoning and now needs to pick among the viable candidates is `bin/fm-quota-choose.sh`.
 Pass it the intake's already-captured default TOON or permitted JSON fallback through stdin or `--snapshot`; it never takes another quota snapshot, so it selects from the same quota state as the intake.
-Pass each candidate as `harness:model`, with earlier candidates preferred.
+Pass each candidate as `harness:model`; by default the helper ranks the eligible candidates by this skill's "Rank by spendPriority" rule, taking the highest known `spendPriority` from the tightest applicable scope.
+`--ordered` is the exception, restoring first-eligible selection in argument order for a caller whose candidate order is itself a deliberate preference rather than an array to rank.
 The helper maps each harness to its primary provider family and applies the provider-wide scopes plus the exact model or product scopes for the model.
 An `exhausted_now` runway vetoes the candidate.
 The helper selects a candidate only when its applicable quota has a known `effectivePercentRemaining` greater than zero.
+An exact tie among the top known scalars exits 3 naming every tied candidate instead of breaking it, which you escalate the same way you would a tie you found by hand.
+A candidate with no known scalar stays eligible and ranks below every known value; the helper's header owns the remaining mechanics.
 This is an optional narrow helper with a known limitation: it maps each harness to one primary provider family only, so a candidate whose established provider differs from that primary family is checked against the wrong quota row.
 omp has no primary family, so the helper keys an `omp:` candidate on its model prefix, mapping only `openai-codex/` and `claude-bridge/` and refusing every other prefix; the helper's header owns that mapping.
 Authoritative multi-provider routing - including provider discovery from the harness catalog and quota matching by that explicit provider - stays owned by this skill's intake procedure above and AGENTS.md section 4, not by the helper.
-Use it only when the brief already fixed the candidate order and every candidate's provider is the harness's primary family.
+Use it only when every candidate's provider is the harness's primary family.
 It does not replace the reasoning-class, runway-feasibility, or authentication gates above.
 Firstmate can optionally arm `bin/fm-procevent-quota.sh` for a recurring mid-task check that wakes when the tracked provider drops below its configured threshold or its runway becomes `exhausted_now`.
 

--- a/bin/fm-quota-choose.sh
+++ b/bin/fm-quota-choose.sh
@@ -7,9 +7,13 @@
 # Reads one already-captured quota-axi default TOON or JSON snapshot from the
 # provided file, or from stdin when --snapshot is omitted. For each --candidate
 # it maps <harness> to its primary provider family, then applies the
-# provider-wide scopes and exact model or product scopes for <model>. A candidate
-# is eligible only when no applicable runway is `exhausted_now` and its known
-# effective percent remaining is greater than zero.
+# provider-wide scopes and exact model or product scopes for <model>. The <model>
+# token is matched exactly against the `model:` and `product:` scope suffixes,
+# so pass the token the snapshot actually uses when quota-axi names a model
+# window differently from the dispatch id - for example claude:fable rather
+# than claude:claude-fable-5-1. A candidate is eligible only when no applicable
+# runway is `exhausted_now` and its known effective percent remaining is
+# greater than zero.
 #
 # Among the eligible candidates the helper ranks by known `spendPriority`, read
 # from the tightest applicable scope: the exact model or product row when one
@@ -25,10 +29,13 @@
 # script exits 0. When two or more candidates share the highest known scalar the
 # helper refuses to break the tie: it prints "tie <harness> <model>" for each
 # tied candidate, one per line, and exits 3, and the caller escalates that choice
-# rather than resolving it by order. When no eligible candidate has a known
-# scalar there is nothing comparable to rank on, so the first eligible candidate
-# in argument order is printed. If no candidate is quota-eligible, it prints
-# "none" and exits 1.
+# rather than resolving it by order. When two or more candidates are eligible
+# and none has a known scalar there is nothing comparable to rank on, so the
+# helper escalates exactly like an exact tie: "tie <harness> <model>" for every
+# eligible candidate and exit 3, never a pick by argument order. A single
+# eligible candidate is printed as "<harness> <model>" with exit 0 whether or
+# not its scalar is known. If no candidate is quota-eligible, it prints "none"
+# and exits 1.
 #
 # --ordered restores first-eligible selection in argument order, for a caller
 # whose candidate order is a deliberate preference rather than an array to rank.
@@ -498,12 +505,9 @@ best=$(
   '
 )
 
-# No comparable scalar anywhere: there is nothing to rank on, so fall back to
-# argument order rather than escalating a tie that has no known values in it.
-if [ -z "$best" ]; then
-  printf '%s\n' "${ELIGIBLE_LABEL[0]}"
-  exit 0
-fi
+# No comparable scalar anywhere: there is nothing to rank on, so every eligible
+# candidate is escalated as a tie rather than picked by argument order.
+[ -n "$best" ] || best="${!ELIGIBLE_LABEL[*]}"
 
 read -r -a BEST_INDEXES <<< "$best"
 if [ "${#BEST_INDEXES[@]}" -gt 1 ]; then

--- a/bin/fm-quota-choose.sh
+++ b/bin/fm-quota-choose.sh
@@ -1,27 +1,47 @@
 #!/usr/bin/env bash
-# Choose the first quota-eligible candidate from a ranked list.
+# Choose the quota-eligible candidate with the highest known spendPriority.
 #
 # Usage:
-#   fm-quota-choose.sh [--snapshot <path>] [--candidate <harness:model>]...
+#   fm-quota-choose.sh [--snapshot <path>] [--ordered] [--candidate <harness:model>]...
 #
 # Reads one already-captured quota-axi default TOON or JSON snapshot from the
 # provided file, or from stdin when --snapshot is omitted. For each --candidate
-# in order, it maps <harness> to its primary provider family, then applies the
+# it maps <harness> to its primary provider family, then applies the
 # provider-wide scopes and exact model or product scopes for <model>. A candidate
 # is eligible only when no applicable runway is `exhausted_now` and its known
-# effective percent remaining is greater than zero. The first eligible
-# candidate is printed as "<harness> <model>" and the script exits 0.
-# If no candidate is quota-eligible, it prints "none" and exits 1.
+# effective percent remaining is greater than zero.
+#
+# Among the eligible candidates the helper ranks by known `spendPriority`, read
+# from the tightest applicable scope: the exact model or product row when one
+# applies, otherwise the provider-wide row. A higher known scalar is better.
+# Where several rows share that tightest scope, the lowest known scalar is used.
+# A candidate whose tightest scope publishes no known scalar - absent, `unknown`,
+# or unmeasurable - stays eligible but ranks below every known value and never
+# breaks a tie. A present-but-unknown model or product row is never backfilled
+# from the provider-wide row, because quota-axi reports that tighter scope as
+# unmeasurable rather than healthy.
+#
+# The single highest-ranked candidate is printed as "<harness> <model>" and the
+# script exits 0. When two or more candidates share the highest known scalar the
+# helper refuses to break the tie: it prints "tie <harness> <model>" for each
+# tied candidate, one per line, and exits 3, and the caller escalates that choice
+# rather than resolving it by order. When no eligible candidate has a known
+# scalar there is nothing comparable to rank on, so the first eligible candidate
+# in argument order is printed. If no candidate is quota-eligible, it prints
+# "none" and exits 1.
+#
+# --ordered restores first-eligible selection in argument order, for a caller
+# whose candidate order is a deliberate preference rather than an array to rank.
 #
 # Candidates are accepted as `--candidate <harness:model>` or as positional
-# colon-separated arguments, with earlier candidates preferred.
+# colon-separated arguments.
 # This script is deterministic and safe: it performs no side effects and exits
 # nonzero when the environment would lead to an unsafe dispatch.
 #
 # The helper is the canonical worker-side selection used after the agent has
 # already run `quota-axi` for its model selection. It never replaces the agent's
-# reasoning-class or runway-feasibility gates; it only answers which ordered
-# candidate remains eligible under the captured quota evidence.
+# reasoning-class or runway-feasibility gates; it only answers which candidate
+# the captured quota evidence selects among those the agent already accepted.
 #
 # Multi-provider limitation: this helper maps each harness to ONE primary
 # provider family (see provider_for_harness below) and checks quota for that
@@ -32,8 +52,8 @@
 # optional helper. Authoritative multi-provider routing - including provider
 # discovery from the harness catalog and quota matching by that explicit
 # provider - is owned by AGENTS.md section 4 and the quota-array-dispatch skill,
-# not by this helper. Use this helper only when the brief already fixed the
-# candidate order and every candidate's provider is the harness's primary family.
+# not by this helper. Use this helper only when every candidate's provider is
+# the harness's primary family.
 #
 # omp (Oh My Pi) has no single primary family, so its candidate model prefix
 # selects the family: openai-codex/<id> checks the codex row and
@@ -65,6 +85,7 @@ usage() {
 
 CANDIDATES=()
 SNAPSHOT_SOURCE=
+ORDERED=0
 
 while [ "$#" -gt 0 ]; do
   case "$1" in
@@ -72,6 +93,10 @@ while [ "$#" -gt 0 ]; do
       [ -n "${2-}" ] || die "--snapshot needs a path"
       SNAPSHOT_SOURCE=$2
       shift 2
+      ;;
+    --ordered)
+      ORDERED=1
+      shift
       ;;
     --candidate)
       [ -n "${2-}" ] || die "--candidate needs a value"
@@ -282,7 +307,14 @@ else
                     scope: .[1],
                     status: "known",
                     effectivePercentRemaining: (.[2] | tonumber),
-                    runway: {status: .[4]}
+                    runway: {status: .[4]},
+                    selection: (
+                      .[3] as $spend_priority |
+                      if ($spend_priority | test("^-?[0-9]+(\\.[0-9]+)?$")) then
+                        {status: "known", spendPriority: ($spend_priority | tonumber)}
+                      else {status: "unknown"}
+                      end
+                    )
                   }
                 })) +
                 ($attention_entries | map(. as $entry | {
@@ -377,7 +409,40 @@ for c in "${CANDIDATES[@]}"; do
   esac
 done
 
-chosen="none"
+# spend_priority_for_provider_model <provider> <model>
+# Print the ranking scalar for the tightest applicable scope, or `unknown` when
+# that scope publishes no comparable number. The tightest scope is the exact
+# model or product row when one applies, otherwise the provider-wide row; a
+# present-but-unknown tighter row is never backfilled from the wider one. Where
+# several rows share the tightest scope, the lowest known scalar is printed.
+spend_priority_for_provider_model() {
+  local provider=$1 model=${2:-default}
+  printf '%s\n' "$QUOTA_JSON" | jq -r --arg provider "$provider" --arg model "$model" '
+    ($model | sub("^model:"; "")) as $model_token |
+    ([.providers[]? | select(.provider == $provider)] | first) as $p |
+    if ($p // null) == null then "unknown"
+    else ($p.quotaSemantics.effectiveAvailability // []) |
+    map(select(.scope as $scope |
+      $scope == "all_models" or $scope == "all_products" or
+      ($model_token != "" and $model_token != "default" and
+       (($scope | startswith("model:")) or ($scope | startswith("product:"))) and
+       ($model_token == ($scope | sub("^(model|product):"; ""))))
+    )) as $applicable |
+    ($applicable | map(select(
+      (.scope | startswith("model:")) or (.scope | startswith("product:"))
+    ))) as $named |
+    (if ($named | length) > 0 then $named else $applicable end) as $tightest |
+    ($tightest | map(
+      select(.selection.status == "known" and (.selection.spendPriority | type) == "number") |
+      .selection.spendPriority
+    )) as $known |
+    if ($known | length) == 0 then "unknown" else ($known | min | tostring) end
+    end
+  ' 2>/dev/null
+}
+
+ELIGIBLE_LABEL=()
+ELIGIBLE_PRIORITY=()
 for c in "${CANDIDATES[@]}"; do
   harness=${c%%:*}
   model=${c#*:}
@@ -399,10 +464,54 @@ for c in "${CANDIDATES[@]}"; do
       ((.runway.status // "") != "exhausted_now")
     end
   ' >/dev/null 2>&1; then
-    chosen="$harness $model"
-    break
+    ELIGIBLE_LABEL+=("$harness $model")
+    # --ordered keeps the caller's own preference, so the first eligible
+    # candidate wins and no ranking scalar is read.
+    [ "$ORDERED" = 0 ] || break
+    priority=$(spend_priority_for_provider_model "$provider" "$scope_model")
+    [ -n "$priority" ] || priority=unknown
+    ELIGIBLE_PRIORITY+=("$priority")
   fi
 done
 
-printf '%s\n' "$chosen"
-[ "$chosen" != "none" ]
+if [ "${#ELIGIBLE_LABEL[@]}" -eq 0 ]; then
+  printf 'none\n'
+  exit 1
+fi
+
+if [ "$ORDERED" = 1 ]; then
+  printf '%s\n' "${ELIGIBLE_LABEL[0]}"
+  exit 0
+fi
+
+# Rank the eligible candidates by highest known spendPriority. Candidates whose
+# tightest scope has no known scalar are excluded from the comparison entirely,
+# so they can neither win against a known value nor create a tie.
+best=$(
+  for i in "${!ELIGIBLE_PRIORITY[@]}"; do
+    [ "${ELIGIBLE_PRIORITY[$i]}" = unknown ] ||
+      printf '%s %s\n' "$i" "${ELIGIBLE_PRIORITY[$i]}"
+  done | awk '
+    NR == 1 || $2 > top { top = $2; list = $1; next }
+    $2 == top { list = list " " $1 }
+    END { if (NR > 0) print list }
+  '
+)
+
+# No comparable scalar anywhere: there is nothing to rank on, so fall back to
+# argument order rather than escalating a tie that has no known values in it.
+if [ -z "$best" ]; then
+  printf '%s\n' "${ELIGIBLE_LABEL[0]}"
+  exit 0
+fi
+
+read -r -a BEST_INDEXES <<< "$best"
+if [ "${#BEST_INDEXES[@]}" -gt 1 ]; then
+  for i in "${BEST_INDEXES[@]}"; do
+    printf 'tie %s\n' "${ELIGIBLE_LABEL[$i]}"
+  done
+  exit 3
+fi
+
+printf '%s\n' "${ELIGIBLE_LABEL[${BEST_INDEXES[0]}]}"
+exit 0

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -102,7 +102,7 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-tasks-axi-lib.sh`    | Shared backlog-backend selector and `tasks-axi` compatibility probe                  |
 | `fm-backlog-transition-lib.sh` | Pair task-record changes with their backlog transitions and replay interrupted closes |
 | `fm-quota-axi-lib.sh`    | Shared `quota-axi` compatibility floor and quota snapshot schema validation           |
-| `fm-quota-choose.sh`     | Choose the first candidate with known positive quota from an ordered harness:model list |
+| `fm-quota-choose.sh`     | Choose the quota-eligible harness:model candidate with the highest known spendPriority |
 | `fm-vendor-auth-probe.sh`| Run one hard-bounded, non-destructive authentication probe of a named vendor CLI and report the fact |
 | `fm-wake-drain.sh`       | Present and acknowledge the current actor's claimed wake rows alongside status, outcome-backstop, decision, divergence, recovery, and supervision checks |
 | `fm-wake-grant.sh`       | Serialize Pi supervision-branch wake-row claim activation, publication, release, and deactivation |

--- a/tests/fm-quota-choose.test.sh
+++ b/tests/fm-quota-choose.test.sh
@@ -741,13 +741,21 @@ out=$(call_choose --snapshot "$UNMEASURABLE_SCOPE_TOON" codex:default claude:def
 [ "$out" = "codex default" ] || fail "provider-wide codex ranking: expected 'codex default', got '$out'"
 ok "an unmeasurable model scope is not backfilled from the provider-wide row"
 
-# With no known scalar anywhere there is nothing comparable to rank on, so
-# argument order still decides rather than escalating an empty tie.
-out=$(call_choose --snapshot "$LAB/captured.json" --candidate pi:default --candidate claude:claude-3-5-sonnet)
-[ "$out" = "pi default" ] || fail "all-unknown ranking: expected 'pi default', got '$out'"
-out=$(call_choose --snapshot "$LAB/captured.json" --candidate claude:claude-3-5-sonnet --candidate pi:default)
-[ "$out" = "claude claude-3-5-sonnet" ] || fail "all-unknown ranking: expected 'claude claude-3-5-sonnet', got '$out'"
-ok "candidates with no known scalar fall back to argument order"
+# With no known scalar anywhere there is nothing comparable to rank on, so two
+# or more eligible candidates are escalated as a tie rather than picked by order.
+out=$(call_choose --snapshot "$LAB/captured.json" --candidate pi:default --candidate claude:claude-3-5-sonnet 2>/dev/null) && rc=0 || rc=$?
+[ "$rc" = 3 ] || fail "all-unknown ranking exited $rc with '$out'"
+[ "$out" = "tie pi default
+tie claude claude-3-5-sonnet" ] || fail "all-unknown ranking named: '$out'"
+out=$(call_choose --snapshot "$LAB/captured.json" --candidate claude:claude-3-5-sonnet --candidate pi:default 2>/dev/null) && rc=0 || rc=$?
+[ "$rc" = 3 ] || fail "reversed all-unknown ranking exited $rc with '$out'"
+[ "$out" = "tie claude claude-3-5-sonnet
+tie pi default" ] || fail "reversed all-unknown ranking named: '$out'"
+out=$(call_choose --snapshot "$LAB/captured.json" --candidate pi:default)
+[ "$out" = "pi default" ] || fail "single all-unknown candidate: expected 'pi default', got '$out'"
+out=$(call_choose --ordered --snapshot "$LAB/captured.json" --candidate pi:default --candidate claude:claude-3-5-sonnet)
+[ "$out" = "pi default" ] || fail "--ordered all-unknown: expected 'pi default', got '$out'"
+ok "candidates with no known scalar escalate as a tie instead of falling back to argument order"
 
 # The JSON snapshot path carries the same selection evidence.
 jq '(.providers[] | select(.provider == "claude").quotaSemantics.effectiveAvailability[0].selection) =

--- a/tests/fm-quota-choose.test.sh
+++ b/tests/fm-quota-choose.test.sh
@@ -43,6 +43,11 @@ MALFORMED_COUNTED_TOON="$LAB/malformed-counted-quota.toon"
 UNKNOWN_EXHAUSTED_TOON="$LAB/unknown-exhausted-quota.toon"
 TRAILING_EMPTY_TOON="$LAB/trailing-empty-quota.toon"
 QUOTED_TOON="$LAB/quoted-quota.toon"
+RANK_TOON="$LAB/rank-quota.toon"
+TIE_TOON="$LAB/tie-quota.toon"
+SCOPE_RANK_TOON="$LAB/scope-rank-quota.toon"
+UNMEASURABLE_SCOPE_TOON="$LAB/unmeasurable-scope-quota.toon"
+RANK_JSON="$LAB/rank-quota.json"
 FAKEBIN="$LAB/fakebin"
 CALLS="$LAB/calls"
 
@@ -179,8 +184,11 @@ if help=$("$BIN/fm-quota-choose.sh" --help 2>&1); then
   fail "help unexpectedly exited zero"
 fi
 printf '%s\n' "$help" | grep -Fq \
-  "candidate order and every candidate's provider is the harness's primary family." \
+  "Use this helper only when every candidate's provider is" \
   || fail "help omitted the multi-provider usage restriction"
+printf '%s\n' "$help" | grep -Fq \
+  -e "--ordered restores first-eligible selection in argument order" \
+  || fail "help omitted the --ordered exception"
 if printf '%s\n' "$help" | grep -Fq 'set -u'; then
   fail "help leaked executable source"
 fi
@@ -640,5 +648,117 @@ ok "invalid availability status fails closed"
 
 [ "$(wc -l < "$CALLS" | tr -d '[:space:]')" = 1 ] || fail "helper took an additional quota snapshot"
 ok "helper reuses the captured quota snapshot"
+
+
+# Ranking by spendPriority. The first eligible candidate in argument order is
+# deliberately not the highest-ranked one, so order alone cannot pass these.
+cat > "$RANK_TOON" <<'TOON'
+bin: quota-axi
+generatedAt: "2030-01-01T00:00:00Z"
+quota[3]{provider,scope,effectivePercentRemaining,spendPriority,runway,confidence,limitedBy,resetsAt}:
+  codex,all_models,60,-2.0035,through_reset,established,weekly,"2030-01-02T00:00:00Z"
+  claude,all_models,50,0.5,through_reset,established,seven_day,"2030-01-02T00:00:00Z"
+  grok,all_products,90,2.5655,through_reset,established,credits,"2030-01-02T00:00:00Z"
+exhaustion[0]:
+attention[0]:
+TOON
+out=$(call_choose --snapshot "$RANK_TOON" codex:default claude:default grok:default)
+[ "$out" = "grok default" ] || fail "ranked pick: expected 'grok default', got '$out'"
+out=$(call_choose --snapshot "$RANK_TOON" grok:default claude:default codex:default)
+[ "$out" = "grok default" ] || fail "ranked pick is order-independent, got '$out'"
+ok "highest known spendPriority beats the first eligible candidate"
+
+out=$(call_choose --ordered --snapshot "$RANK_TOON" codex:default claude:default grok:default)
+[ "$out" = "codex default" ] || fail "--ordered: expected 'codex default', got '$out'"
+out=$(call_choose --ordered --snapshot "$RANK_TOON" claude:default grok:default)
+[ "$out" = "claude default" ] || fail "--ordered: expected 'claude default', got '$out'"
+ok "--ordered restores first-eligible selection"
+
+# An exact tie among the top known scalars is escalated, never broken by order.
+cat > "$TIE_TOON" <<'TOON'
+bin: quota-axi
+generatedAt: "2030-01-01T00:00:00Z"
+quota[3]{provider,scope,effectivePercentRemaining,spendPriority,runway,confidence,limitedBy,resetsAt}:
+  claude,all_models,50,1.25,through_reset,established,seven_day,"2030-01-02T00:00:00Z"
+  codex,all_models,60,1.25,through_reset,established,weekly,"2030-01-02T00:00:00Z"
+  grok,all_products,99,unknown,through_reset,unknown,credits,"2030-01-02T00:00:00Z"
+exhaustion[0]:
+attention[0]:
+TOON
+out=$(call_choose --snapshot "$TIE_TOON" claude:default codex:default 2>/dev/null) && rc=0 || rc=$?
+[ "$rc" = 3 ] || fail "exact tie exited $rc with '$out'"
+[ "$out" = "tie claude default
+tie codex default" ] || fail "exact tie named: '$out'"
+out=$(call_choose --snapshot "$TIE_TOON" codex:default claude:default 2>/dev/null) && rc=0 || rc=$?
+[ "$rc" = 3 ] || fail "reversed tie exited $rc with '$out'"
+[ "$out" = "tie codex default
+tie claude default" ] || fail "reversed tie named: '$out'"
+ok "an exact tie among the top known scalars exits 3 naming every tied candidate"
+
+out=$(call_choose --snapshot "$TIE_TOON" grok:default claude:default)
+[ "$out" = "claude default" ] || fail "unknown spendPriority outranked a known one: '$out'"
+out=$(call_choose --snapshot "$TIE_TOON" grok:default claude:default codex:default 2>/dev/null) && rc=0 || rc=$?
+[ "$rc" = 3 ] || fail "tie beside an unknown candidate exited $rc with '$out'"
+[ "$out" = "tie claude default
+tie codex default" ] || fail "unknown candidate entered the tie: '$out'"
+out=$(call_choose --ordered --snapshot "$TIE_TOON" grok:default claude:default)
+[ "$out" = "grok default" ] || fail "--ordered ignored the caller's order under a tie: '$out'"
+ok "unknown spendPriority never wins and never joins a tie"
+
+# The tightest applicable scope supplies the ranking scalar, so the same
+# provider ranks differently for a model with its own row.
+cat > "$SCOPE_RANK_TOON" <<'TOON'
+bin: quota-axi
+generatedAt: "2030-01-01T00:00:00Z"
+quota[3]{provider,scope,effectivePercentRemaining,spendPriority,runway,confidence,limitedBy,resetsAt}:
+  claude,all_models,50,0.5,through_reset,established,seven_day,"2030-01-02T00:00:00Z"
+  claude,"model:fable",40,3.0,through_reset,established,"model:fable","2030-01-02T00:00:00Z"
+  grok,all_products,90,2.0,through_reset,established,credits,"2030-01-02T00:00:00Z"
+exhaustion[0]:
+attention[0]:
+TOON
+out=$(call_choose --snapshot "$SCOPE_RANK_TOON" grok:default claude:default)
+[ "$out" = "grok default" ] || fail "provider-wide ranking: expected 'grok default', got '$out'"
+out=$(call_choose --snapshot "$SCOPE_RANK_TOON" grok:default claude:fable)
+[ "$out" = "claude fable" ] || fail "model-scope ranking: expected 'claude fable', got '$out'"
+ok "a model-scope row overrides the provider row for ranking"
+
+# A present-but-unmeasurable model scope is not backfilled from the healthier
+# provider-wide row, so that candidate ranks as unknown.
+cat > "$UNMEASURABLE_SCOPE_TOON" <<'TOON'
+bin: quota-axi
+generatedAt: "2030-01-01T00:00:00Z"
+quota[3]{provider,scope,effectivePercentRemaining,spendPriority,runway,confidence,limitedBy,resetsAt}:
+  codex,all_models,65,1.9,through_reset,established,weekly,"2030-01-02T00:00:00Z"
+  codex,"model:codex_bengalfox",65,unknown,unknown,unknown,weekly,"2030-01-02T00:00:00Z"
+  claude,all_models,50,0.5,through_reset,established,seven_day,"2030-01-02T00:00:00Z"
+exhaustion[0]:
+attention[0]:
+TOON
+out=$(call_choose --snapshot "$UNMEASURABLE_SCOPE_TOON" codex:model:codex_bengalfox claude:default)
+[ "$out" = "claude default" ] || fail "unmeasurable model scope was backfilled from the provider row: '$out'"
+out=$(call_choose --snapshot "$UNMEASURABLE_SCOPE_TOON" codex:default claude:default)
+[ "$out" = "codex default" ] || fail "provider-wide codex ranking: expected 'codex default', got '$out'"
+ok "an unmeasurable model scope is not backfilled from the provider-wide row"
+
+# With no known scalar anywhere there is nothing comparable to rank on, so
+# argument order still decides rather than escalating an empty tie.
+out=$(call_choose --snapshot "$LAB/captured.json" --candidate pi:default --candidate claude:claude-3-5-sonnet)
+[ "$out" = "pi default" ] || fail "all-unknown ranking: expected 'pi default', got '$out'"
+out=$(call_choose --snapshot "$LAB/captured.json" --candidate claude:claude-3-5-sonnet --candidate pi:default)
+[ "$out" = "claude claude-3-5-sonnet" ] || fail "all-unknown ranking: expected 'claude claude-3-5-sonnet', got '$out'"
+ok "candidates with no known scalar fall back to argument order"
+
+# The JSON snapshot path carries the same selection evidence.
+jq '(.providers[] | select(.provider == "claude").quotaSemantics.effectiveAvailability[0].selection) =
+      {"status":"known","spendPriority":0.1} |
+    (.providers[] | select(.provider == "pi").quotaSemantics.effectiveAvailability[0].selection) =
+      {"status":"known","spendPriority":2.0}' \
+  "$LAB/captured.json" > "$RANK_JSON"
+out=$(call_choose --snapshot "$RANK_JSON" --candidate claude:claude-3-5-sonnet --candidate pi:default)
+[ "$out" = "pi default" ] || fail "JSON ranking: expected 'pi default', got '$out'"
+out=$(call_choose --ordered --snapshot "$RANK_JSON" --candidate claude:claude-3-5-sonnet --candidate pi:default)
+[ "$out" = "claude claude-3-5-sonnet" ] || fail "JSON --ordered: expected 'claude claude-3-5-sonnet', got '$out'"
+ok "JSON snapshots rank on their selection evidence"
 
 printf '# all fm-quota-choose tests passed\n'


### PR DESCRIPTION
## Intent

Captain: "Proceed." on the firstmate code follow-up in the crew-dispatch ladder plan, Part B, where the helper script and the dispatch skill disagree on ordering. The captain earlier confirmed this item is in scope: "the firstmate code follow-up where the helper script and the dispatch skill disagree on ordering ... are all in scope".

The problem the captain approved fixing: bin/fm-quota-choose.sh returns the first quota-eligible candidate in argument order and never reads spendPriority (its header said "with earlier candidates preferred"), while .agents/skills/quota-array-dispatch/SKILL.md requires ranking eligible candidates by highest known spendPriority, requires escalating exact ties, and forbids selecting by array order. On the 2026-09-07 quota snapshot the two paths chose different models for the same dispatch tier (adversarial review finding F2; also the constructive review's finding 1). The skill already scopes the helper to "candidate order already fixed by the brief", but nothing enforced that, and the helper is the only executable in the repo, so it is what a hurried firstmate reaches for.

The approved change, keeping the helper small:
1. Add ranking to bin/fm-quota-choose.sh: after computing eligibility exactly as today, choose among eligible candidates by highest known spendPriority taken from the tightest applicable scope (the named model or product row when one exists, else the provider-wide row). Candidates with unknown or unmeasurable spendPriority remain eligible but rank below every known value and never break a tie.
2. Exact tie among the top known values: print "tie <harness> <model>" for each tied candidate on its own line and exit 3. Callers must escalate; never resolve by order.
3. Add --ordered to keep today's first-eligible behavior for briefs that intentionally fix the order. Default is ranked.
4. Print the chosen candidate exactly as today on success so existing callers keep parsing; "none" and exit 1 are unchanged.
5. Update the header comment, the helper's --help output, and the "Worker-side quota helper" section of .agents/skills/quota-array-dispatch/SKILL.md so the skill says the helper ranks by spendPriority by default and --ordered is the exception.
6. Tests: extend tests/fm-quota-choose.test.sh with fixtures for ranked pick beats first-eligible; tie exits 3 with both names; unknown never wins a tie; --ordered restores first-eligible; model-scope row overrides provider row for ranking. Behavior through the executable, no source-byte assertions, shellcheck clean, bin/fm-lint.sh passes.

Explicitly out of scope, by the captain's decision: no daemon, no composite score, no provider mapping changes; the helper's single-primary-family limitation stays documented as-is.

Acceptance the captain set: bin/fm-test-run.sh tests/fm-quota-choose.test.sh green, bin/fm-lint.sh green, and the live selection check returning "claude claude-opus-5" on a snapshot where Opus has the highest known spendPriority even when Fable is listed first.

Delivery: the captain does not have push access to upstream kunchenguid/firstmate, so this ships through the fork lobel-dev/firstmate as push target per CONTRIBUTING.md; the PR opens against upstream. The captain's standing rules: explicit model ids never aliases, tools install only inside the firstmate home and never globally, and no PR merge and no local landing without the captain's word.

## What Changed

- `bin/fm-quota-choose.sh` now ranks quota-eligible candidates by the highest known `spendPriority` from the tightest applicable scope (exact model/product row, else provider-wide row) instead of returning the first eligible candidate; eligibility checks are unchanged. Unknown or unmeasurable scalars stay eligible but rank below every known value and never break a tie. An exact tie among the top known values, or an all-unknown set of two or more eligible candidates, prints `tie <harness> <model>` per candidate and exits 3; the success line and the `none`/exit 1 path are unchanged. A new `--ordered` flag restores first-eligible selection in argument order.
- The header comment, `--help` usage, `docs/scripts.md` entry, and the "Worker-side quota helper" section of `.agents/skills/quota-array-dispatch/SKILL.md` now describe ranked selection as the default, `--ordered` as the exception, the tie/exit-3 escalation, and exact model-token matching against snapshot scope suffixes.
- `tests/fm-quota-choose.test.sh` gains fixtures covering ranked pick beating first-eligible, tie exit 3 naming both candidates, unknown never winning a tie, `--ordered` restoring first-eligible, model-scope row overriding the provider row, no backfill of an unmeasurable model row, all-unknown escalation, and the JSON snapshot path.

## Risk Assessment

✅ Low: The change is bounded to one helper, its tests, and its documentation; every required intent item (ranking by tightest-scope spendPriority, tie exit 3, --ordered, unchanged success/none output, header/help/SKILL updates, the six fixtures) is present and traces correctly, the all-unknown escalation matches the captain's recorded decision, and unknown-scalar handling fails toward escalation rather than a silent wrong pick.

## Testing

Ran the targeted test file through the repo runner (green), then reproduced the captain's acceptance scenario as an end user: on both a fixture mirroring the real Claude row shapes and a live quota-axi 0.1.29 snapshot, the target helper returns "claude claude-opus-5" with Fable listed first while the base-commit helper returns "claude fable"; --ordered, tie exit 3, all-unknown escalation, and none/exit 1 all behave as specified. The globally installed quota-axi 0.1.7 is below the repo floor and could not be used, so the live check used an isolated ephemeral 0.1.29 install under /tmp that was removed afterwards; account quota values were kept out of the published evidence.

<details>
<summary>Evidence: Acceptance transcript: ranked pick vs base commit, --ordered, tie, none (fixture)</summary>

Source: [Acceptance transcript: ranked pick vs base commit, --ordered, tie, none (fixture)](https://github.com/lobel-dev/firstmate/blob/63839c24bf7a72a48259f2ab045d6ee91224662c/.no-mistakes/evidence/fm/fm-quota-choose-rank-r1/fm-quota-choose-acceptance-transcript.txt)

```text
# Acceptance: "claude claude-opus-5" when Fable is listed first and Opus has the highest known spendPriority
# Fixture mirrors the recorded real Claude row shapes (all_models + model:fable); Opus reads the all_models row.
$ cat opus-first.toon
bin: quota-axi
generatedAt: "2026-09-07T00:00:00Z"
quota[3]{provider,scope,effectivePercentRemaining,spendPriority,runway,confidence,limitedBy,resetsAt}:
  claude,all_models,10,1.4,through_reset,established,seven_day,"2026-09-14T00:00:00Z"
  claude,"model:fable",4,0.3,through_reset,established,"model:fable","2026-09-14T00:00:00Z"
  codex,all_models,64,1.1,through_reset,established,weekly,"2026-09-14T00:00:00Z"
exhaustion[0]:
attention[0]:

$ bin/fm-quota-choose.sh --snapshot opus-first.toon claude:fable claude:claude-opus-5   # target b9cbde6
claude claude-opus-5
exit=0

$ <base 72bfdd0>/bin/fm-quota-choose.sh --snapshot opus-first.toon claude:fable claude:claude-opus-5   # before the fix: first-eligible wins
claude fable
exit=0

$ bin/fm-quota-choose.sh --ordered --snapshot opus-first.toon claude:fable claude:claude-opus-5   # --ordered keeps the old behavior
claude fable
exit=0

$ bin/fm-quota-choose.sh --snapshot opus-first.toon claude:claude-fable-5-1 claude:claude-opus-5   # explicit id does not match model:fable, both read all_models -> tie, exit 3
tie claude claude-fable-5-1
tie claude claude-opus-5
exit=3

$ bin/fm-quota-choose.sh --snapshot opus-first.toon codex:default claude:claude-opus-5   # cross-provider rank, codex first in argv
claude claude-opus-5
exit=0

$ bin/fm-quota-choose.sh --snapshot opus-first.toon grok:default   # no eligible candidate unchanged
none
exit=1

$ bin/fm-quota-choose.sh --help | sed -n 1,45p
Choose the quota-eligible candidate with the highest known spendPriority.

Usage:
  fm-quota-choose.sh [--snapshot <path>] [--ordered] [--candidate <harness:model>]...

Reads one already-captured quota-axi default TOON or JSON snapshot from the
provided file, or from stdin when --snapshot is omitted. For each --candidate
it maps <harness> to its primary provider family, then applies the
provider-wide scopes and exact model or product scopes for <model>. The <model>
token is matched exactly against the `model:` and `product:` scope suffixes,
so pass the token the snapshot actually uses when quota-axi names a model
window differently from the dispatch id - for example claude:fable rather
than claude:claude-fable-5-1. A candidate is eligible only when no applicable
runway is `exhausted_now` and its known effective percent remaining is
greater than zero.

Among the eligible candidates the helper ranks by known `spendPriority`, read
from the tightest applicable scope: the exact model or product row when one
applies, otherwise the provider-wide row. A higher known scalar is better.
Where several rows share that tightest scope, the lowest known scalar is used.
A candidate whose tightest scope publishes no known scalar - absent, `unknown`,
or unmeasurable - stays eligible but ranks below every known value and never
breaks a tie. A present-but-unknown model or product row is never backfilled
from the provider-wide row, because quota-axi reports that tighter scope as
unmeasurable rather than healthy.

The single highest-ranked candidate is printed as "<harness> <model>" and the
script exits 0. When two or more candidates share the highest known scalar the
helper refuses to break the tie: it prints "tie <harness> <model>" for each
tied candidate, one per line, and exits 3, and the caller escalates that choice
rather than resolving it by order. When two or more candidates are eligible
and none has a known scalar there is nothing comparable to rank on, so the
helper escalates exactly like an exact tie: "tie <harness> <model>" for every
eligible candidate and exit 3, never a pick by argument order. A single
eligible candidate is printed as "<harness> <model>" with exit 0 whether or
not its scalar is known. If no candidate is quota-eligible, it prints "none"
and exits 1.

--ordered restores first-eligible selection in argument order, for a caller
whose candidate order is a deliberate preference rather than an array to rank.

Candidates are accepted as `--candidate <harness:model>` or as positional
colon-separated arguments.
This script is deterministic and safe: it performs no side effects and exits
nonzero when the environment would lead to an unsafe dispatch.
```
</details>
<details>
<summary>Evidence: Live selection check on real quota-axi 0.1.29 snapshot: Opus chosen over first-listed Fable</summary>

Source: [Live selection check on real quota-axi 0.1.29 snapshot: Opus chosen over first-listed Fable](https://github.com/lobel-dev/firstmate/blob/63839c24bf7a72a48259f2ab045d6ee91224662c/.no-mistakes/evidence/fm/fm-quota-choose-rank-r1/fm-quota-choose-live-check.txt)

<code>$ bin/fm-quota-choose.sh --snapshot live.toon claude:fable claude:claude-opus-5&#10;claude claude-opus-5&#10;exit=0&#10;&#10;$ &lt;base 72bfdd0&gt;/bin/fm-quota-choose.sh --snapshot live.toon claude:fable claude:claude-opus-5&#10;claude fable&#10;exit=0&#10;&#10;$ bin/fm-quota-choose.sh --ordered --snapshot live.toon claude:fable claude:claude-opus-5&#10;claude fable&#10;exit=0&#10;&#10;$ bin/fm-quota-choose.sh --snapshot live.toon claude:claude-fable-5-1 claude:claude-opus-5&#10;tie claude claude-fable-5-1&#10;tie claude claude-opus-5&#10;exit=3</code>

```text
# Live check 2026-09-08T00:26:19Z: quota-axi 0.1.29 (isolated ephemeral install under /tmp, floor FM_QUOTA_AXI_MIN=0.1.29) default TOON captured once and reused below.
# Account quota values are not persisted (docs/verification/dispatch-auth.md norm); only scope names, the rank relation, and helper output.
$ awk '/^quota\[/{q=1;next} /^exhaustion\[/{q=0} q && /^  claude,/' live.toon | cut -d, -f1,2   # Claude quota rows in the live snapshot
  claude,all_models
  claude,"model:fable"
# In this snapshot the claude all_models spendPriority (which claude-opus-5 reads) is higher than the model:fable spendPriority.

$ bin/fm-quota-choose.sh --snapshot live.toon claude:fable claude:claude-opus-5   # target: Fable listed first, Opus ranks higher
claude claude-opus-5
exit=0

$ <base 72bfdd0>/bin/fm-quota-choose.sh --snapshot live.toon claude:fable claude:claude-opus-5   # before the fix
claude fable
exit=0

$ bin/fm-quota-choose.sh --ordered --snapshot live.toon claude:fable claude:claude-opus-5
claude fable
exit=0

$ bin/fm-quota-choose.sh --snapshot live.toon claude:claude-fable-5-1 claude:claude-opus-5   # explicit dispatch id: no model:claude-fable-5-1 row, both read all_models -> tie
tie claude claude-fable-5-1
tie claude claude-opus-5
exit=3

$ bin/fm-quota-choose.sh --snapshot live.toon codex:default claude:claude-opus-5   # codex quota unavailable in this snapshot
claude claude-opus-5
exit=0
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"b9cbde6b70f68256d9aa1b9cd0c350b9ce0553eb","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"skipped"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>⚠️ **Review** - 2 infos</summary>

- ℹ️ `bin/fm-quota-choose.sh:425` - Simplification only: the applicable-scope selection jq (provider lookup plus the all_models/all_products/exact model:/product: filter into $applicable) is duplicated byte-for-byte between effective_for_provider_model (lines 381-393) and the new spend_priority_for_provider_model (lines 425-437). A shared jq def string sourced by both would remove the copy and keep the eligibility scope and the ranking scope from drifting. Optional; the copy is correct today and both functions are read-only, so leaving it is acceptable.
- ℹ️ `bin/fm-quota-choose.sh:497` - Ranking traced and verified against the fixtures: RANK_TOON (codex -2.0035, claude 0.5, grok 2.5655) ranks grok in either argument order; TIE_TOON emits index/scalar pairs only for known scalars so grok (unknown) never enters the awk comparison and claude/codex tie at 1.25 with exit 3 in argument order; SCOPE_RANK_TOON picks the model:fable row (3.0) over all_models (0.5) because $named is non-empty; UNMEASURABLE_SCOPE_TOON returns unknown for codex:model:codex_bengalfox because a present-but-unknown named row is not backfilled; captured.json with two candidates and no selection field yields an empty $best, falls back to every eligible index, and exits 3, while a single candidate prints with exit 0. --ordered breaks before the ranking read and exits 0 on the first label, so the label and priority arrays stay aligned in ranked mode. The TOON-to-JSON conversion only classifies a spendPriority matching ^-?[0-9]+(\.[0-9]+)?$ as known; the recorded real values (-2.0035, 2.5655, 0.5) fit that, and anything else fails toward unknown rather than a wrong pick. All six intent-listed fixtures are present and exercised through the executable; the only help assertion greps the --help output, which is the executable&#39;s public output, consistent with the pre-existing help test. The intent&#39;s declined review-2 concern about explicit-id scope matching is unchanged and is documented in the header as instructed, not re-raised here.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`bin/fm-test-run.sh tests/fm-quota-choose.test.sh` (all cases pass, including the 8 new ranking/tie/--ordered/scope/all-unknown/JSON fixtures)</code>
- <code>Fixture acceptance run: `bin/fm-quota-choose.sh --snapshot opus-first.toon claude:fable claude:claude-opus-5` -&gt; `claude claude-opus-5` exit 0; same command against base-commit script (git archive 72bfdd0 bin/) -&gt; `claude fable` exit 0</code>
- <code>Fixture: `--ordered` -&gt; `claude fable`; `claude:claude-fable-5-1 claude:claude-opus-5` -&gt; two `tie` lines exit 3; `codex:default claude:claude-opus-5` -&gt; Opus despite codex first; `grok:default` -&gt; `none` exit 1; `--help` shows the new ranking contract and --ordered</code>
- <code>Live check: isolated ephemeral install of quota-axi@0.1.29 under /tmp (global 0.1.7 is below FM_QUOTA_AXI_MIN=0.1.29 and its TOON is rejected as invalid by both base and target), one default TOON capture, then `bin/fm-quota-choose.sh --snapshot live.toon claude:fable claude:claude-opus-5` -&gt; `claude claude-opus-5` exit 0 vs base -&gt; `claude fable`; `--ordered` -&gt; `claude fable`; explicit-id pair -&gt; tie exit 3</code>
- <code>Cleanup: removed /tmp install and snapshots; `git status --porcelain` clean</code>
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>⏭️ **Lint** - skipped</summary>

- ⚠️ linter found issues (exit code 1)
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
