### PR TITLE
docs: document FM_KIMI_* spawn env-var family in configuration reference

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -965,7 +965,7 @@ FM_KIMI_DELIVERY_POLLS=40   # kimi-only: pane-capture polls confirming brief-poi
 FM_KIMI_POLL_INTERVAL=0.5   # kimi-only: seconds between readiness and delivery polls; also the default FM_KIMI_SUBMIT_SLEEP
 FM_KIMI_SUBMIT_RETRIES=3   # kimi-only: Enter-retry attempts for the brief-pointer submit after typing it once, never retyping
 FM_KIMI_SUBMIT_SLEEP=0.5   # kimi-only: seconds between submit checks; defaults to FM_KIMI_POLL_INTERVAL
-FM_KIMI_SUBMIT_SETTLE=0   # kimi-only: seconds to settle after a confirmed brief-pointer submit before delivery polling; 0 disables
+FM_KIMI_SUBMIT_SETTLE=0   # kimi-only: pre-Enter settle seconds after typing the brief pointer so completion popups clear before Enter; 0 disables
 FM_PENDING_REPLY_GRACE_SECS=120   # seconds after marked-request delivery before a completed turn without a correlated parent report is eligible for its one recovery repost
 # sub-supervisor (bin/fm-supervise-daemon.sh); presence-gated via /afk
 FM_SUPERVISOR_BACKEND=             # optional supervisor pane backend override; tmux/herdr only, otherwise detects $TMUX_PANE then HERDR_ENV/HERDR_PANE_ID before tmux fallback

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -959,6 +959,13 @@ GROK_HOME=              # optional Grok config home for firstmate's global grok 
 FM_SEND_RETRIES=3       # fm-send typed-plane Enter-retry attempts after typing the line once
 FM_SEND_SLEEP=0.4       # seconds between fm-send typed-plane submit checks
 FM_SEND_SETTLE=1        # seconds fm-send waits after a successful typed-plane submit; 0 disables
+# kimi spawn readiness, submit, and delivery tuning (bin/fm-spawn.sh owns the mechanics)
+FM_KIMI_READY_POLLS=60   # kimi-only: pane-capture polls for the launch-readiness signal (welcome banner or empty composer) before brief delivery
+FM_KIMI_DELIVERY_POLLS=40   # kimi-only: pane-capture polls confirming brief-pointer delivery before the spawn fails
+FM_KIMI_POLL_INTERVAL=0.5   # kimi-only: seconds between readiness and delivery polls; also the default FM_KIMI_SUBMIT_SLEEP
+FM_KIMI_SUBMIT_RETRIES=3   # kimi-only: Enter-retry attempts for the brief-pointer submit after typing it once, never retyping
+FM_KIMI_SUBMIT_SLEEP=0.5   # kimi-only: seconds between submit checks; defaults to FM_KIMI_POLL_INTERVAL
+FM_KIMI_SUBMIT_SETTLE=0   # kimi-only: seconds to settle after a confirmed brief-pointer submit before delivery polling; 0 disables
 FM_PENDING_REPLY_GRACE_SECS=120   # seconds after marked-request delivery before a completed turn without a correlated parent report is eligible for its one recovery repost
 # sub-supervisor (bin/fm-supervise-daemon.sh); presence-gated via /afk
 FM_SUPERVISOR_BACKEND=             # optional supervisor pane backend override; tmux/herdr only, otherwise detects $TMUX_PANE then HERDR_ENV/HERDR_PANE_ID before tmux fallback


### PR DESCRIPTION
## Intent

Document the whole FM_KIMI_* spawn env-var family in the firstmate repo's docs/configuration.md. The environment-variable list there lacks the entire kimi spawn-tuning family: FM_KIMI_SUBMIT_RETRIES, FM_KIMI_READY_POLLS, FM_KIMI_DELIVERY_POLLS, FM_KIMI_POLL_INTERVAL, FM_KIMI_SUBMIT_SLEEP, FM_KIMI_SUBMIT_SETTLE. This is a documentation-consistency pass discovered as finding kimi-env-family-undocumented (approved 2026-09-04) from the KW-SPAWN-GATE-FIX-1 document gate; it is not a behavior change. The mechanics of each variable are owned by bin/fm-spawn.sh's header and comments - read them for exact defaults and semantics, and keep docs/configuration.md consistent with that authoritative source rather than inventing detail.

## What Changed

- Added the six `FM_KIMI_*` spawn-tuning variables (`FM_KIMI_SUBMIT_RETRIES`, `FM_KIMI_READY_POLLS`, `FM_KIMI_DELIVERY_POLLS`, `FM_KIMI_POLL_INTERVAL`, `FM_KIMI_SUBMIT_SLEEP`, `FM_KIMI_SUBMIT_SETTLE`) to the environment-variable list in `docs/configuration.md`.
- Each entry documents its default value and kimi-only semantics, consistent with the authoritative mechanics owned by `bin/fm-spawn.sh`.
- No behavior change; documentation consistency only.

## Risk Assessment

✅ Low: Documentation-only addition of seven lines whose defaults and semantics exactly match the authoritative source in bin/fm-spawn.sh; no behavior change and no ambiguity.

## Testing

Ran a targeted executable consistency check plus manual source cross-verification: the real kimi readiness/delivery/submit functions extracted from bin/fm-spawn.sh and bin/fm-tmux-lib.sh were executed with stubbed captures and a fake timestamping tmux to prove the documented poll/interval/failure and pre-Enter-settle semantics and all six defaults; the resulting transcript is saved as evidence. All checks pass, the previously-fixed FM_KIMI_SUBMIT_SETTLE line is behaviorally accurate, and the worktree is clean.

<details>
<summary>Evidence: Executable verification transcript (PASS)</summary>

Source: [Executable verification transcript (PASS)](https://github.com/dmeiser/firstmate/blob/3e665491d6c64681338a5b2d1f62520fd3d8fd23/.no-mistakes/evidence/fm/KW-KIMI-ENV-DOCS/verify-kimi-env-docs.transcript.txt)

<code>== 1. defaults actually resolve to the documented values ==&#10;resolved defaults: ready=60 delivery=40 interval=0.5 retries=3 sleep=0.5 settle=0&#10;== 2. FM_KIMI_READY_POLLS + FM_KIMI_POLL_INTERVAL govern the readiness loop ==&#10;never-ready, polls=3 interval=0.2 =&gt; VERDICT=fail in 425ms (expect VERDICT=fail, ~400-700ms)&#10;banner on first capture =&gt; VERDICT=pass (expect VERDICT=pass)&#10;== 3. FM_KIMI_DELIVERY_POLLS governs delivery confirmation ==&#10;never-deliver =&gt; VERDICT=fail (expect VERDICT=fail; spawn would fail per doc)&#10;context-usage line present =&gt; VERDICT=pass (expect VERDICT=pass)&#10;== 3b. FM_KIMI_SUBMIT_SETTLE is a pre-Enter settle after typing (never retyping) ==&#10;settle=0.3 =&gt; verdict=submitted; typed-&gt;enter gap=308ms (expect ~300ms, typed before enter)&#10;settle=0 =&gt; verdict=submitted in 18ms (expect fast; doc: 0 disables)&#10;== 4. doc lines exist and carry the documented defaults ==&#10;all six FM_KIMI_* lines present with documented defaults&#10;RESULT: PASS</code>

```text
== 1. defaults actually resolve to the documented values ==
  resolved defaults: ready=60 delivery=40 interval=0.5 retries=3 sleep=0.5 settle=0
== 2. FM_KIMI_READY_POLLS + FM_KIMI_POLL_INTERVAL govern the readiness loop ==
  never-ready, polls=3 interval=0.2 => VERDICT=fail in 425ms (expect VERDICT=fail, ~400-700ms)
  banner on first capture => VERDICT=pass (expect VERDICT=pass)
== 3. FM_KIMI_DELIVERY_POLLS governs delivery confirmation ==
  never-deliver => VERDICT=fail (expect VERDICT=fail; spawn would fail per doc)
  context-usage line present => VERDICT=pass (expect VERDICT=pass)
== 3b. FM_KIMI_SUBMIT_SETTLE is a pre-Enter settle after typing (never retyping) ==
  settle=0.3 => verdict=submitted; typed->enter gap=308ms (expect ~300ms, typed before enter)
  settle=0 => verdict=submitted in 18ms (expect fast; doc: 0 disables)
== 4. doc lines exist and carry the documented defaults ==
  all six FM_KIMI_* lines present with documented defaults
RESULT: PASS
```
</details>
<details>
<summary>Evidence: Executable verification script (extracts and runs the real kimi spawn functions)</summary>

Source: [Executable verification script (extracts and runs the real kimi spawn functions)](https://github.com/dmeiser/firstmate/blob/3e665491d6c64681338a5b2d1f62520fd3d8fd23/.no-mistakes/evidence/fm/KW-KIMI-ENV-DOCS/verify-kimi-env-docs.sh)

```text
#!/bin/sh
# Executable consistency check: docs/configuration.md FM_KIMI_* lines vs the
# actual behavior of the kimi spawn functions in bin/fm-spawn.sh.
# Contract under test (from the approved intent kimi-env-family-undocumented):
# docs/configuration.md must accurately document the FM_KIMI_* family whose
# mechanics are owned by bin/fm-spawn.sh. We verify that by EXECUTING the real
# functions extracted from bin/fm-spawn.sh with stubbed captures and asserting
# the documented poll/interval/failure semantics and defaults.
set -u
ROOT=${1:-/home/dm/.no-mistakes/worktrees/ce3ac3a0e863/01M1Z8RRM2CG2FQX7FRZEJJGKC}
FM_SPAWN=$ROOT/bin/fm-spawn.sh
DOC=$ROOT/docs/configuration.md
fails=0
note() { printf '%s\n' "$*"; }
fail() { printf 'FAIL: %s\n' "$*"; fails=$((fails+1)); }

[ -f "$FM_SPAWN" ] && [ -f "$DOC" ] || { echo "missing inputs"; exit 2; }

extract_fn() { # extract a function definition (simple awk brace matching)
  awk -v name="$1" '$0 ~ "^"name"\\(\\) \\{" {p=1} p {print} p && /^}/ {exit}' "$FM_SPAWN"
}

for fn in kimi_wait_for_ready kimi_wait_for_delivery kimi_delivery_is_confirmed kimi_composer_is_empty; do
  extract_fn "$fn" > "/tmp/$$.$fn" || true
  grep -q "^}" "/tmp/$$.$fn" || { echo "could not extract $fn"; exit 2; }
done

stub_body() { # <mode>
  case "$1" in
    never-ready|never-deliver) printf 'kimi_capture() { printf "junk pane\\n"; }\n' ;;
    ready-banner)  printf 'kimi_capture() { printf "Welcome to Kimi Code!\\n"; }\n' ;;
    delivered)     printf 'kimi_capture() { echo "context: 42.0%%"; }\nkimi_composer_is_empty() { return 0; }\n' ;;
  esac
}

run_stubbed() { # <fn-name> <stub-mode> [env assignments...]
  fn=$1; mode=$2; shift 2
  lib=/tmp/$$.lib.sh
  cat /tmp/$$.kimi_wait_for_ready /tmp/$$.kimi_wait_for_delivery \
      /tmp/$$.kimi_delivery_is_confirmed /tmp/$$.kimi_composer_is_empty > "$lib"
  stub_body "$mode" >> "$lib"
  env "$@" BACKEND=kimi T=t1 W=w1 sh -c ". '$lib'; if $fn; then echo VERDICT=pass; else echo VERDICT=fail; fi"
}

note "== 1. defaults actually resolve to the documented values =="
out=$(env -i PATH="$PATH" sh -c '
  FM_KIMI_READY_POLLS=${FM_KIMI_READY_POLLS:-60}
  FM_KIMI_DELIVERY_POLLS=${FM_KIMI_DELIVERY_POLLS:-40}
  FM_KIMI_POLL_INTERVAL=${FM_KIMI_POLL_INTERVAL:-0.5}
  FM_KIMI_SUBMIT_RETRIES=${FM_KIMI_SUBMIT_RETRIES:-3}
  FM_KIMI_SUBMIT_SLEEP=${FM_KIMI_SUBMIT_SLEEP:-${FM_KIMI_POLL_INTERVAL:-0.5}}
  FM_KIMI_SUBMIT_SETTLE=${FM_KIMI_SUBMIT_SETTLE:-0}
  printf "ready=%s delivery=%s interval=%s retries=%s sleep=%s settle=%s\n" \
    "$FM_KIMI_READY_POLLS" "$FM_KIMI_DELIVERY_POLLS" "$FM_KIMI_POLL_INTERVAL" \
    "$FM_KIMI_SUBMIT_RETRIES" "$FM_KIMI_SUBMIT_SLEEP" "$FM_KIMI_SUBMIT_SETTLE"
')
note "  resolved defaults: $out"
echo "$out" | grep -q 'ready=60 delivery=40 interval=0.5 retries=3 sleep=0.5 settle=0' \
  || fail "resolved defaults do not match docs table"

note "== 2. FM_KIMI_READY_POLLS + FM_KIMI_POLL_INTERVAL govern the readiness loop =="
# Documented: "pane-capture polls for the launch-readiness signal ... before brief
# delivery". 3 polls at 0.2s => ~0.4s elapsed, exit 1; a ready banner exits 0 fast.
t0=$(date +%s%N)
v=$(run_stubbed kimi_wait_for_ready never-ready FM_KIMI_READY_POLLS=3 FM_KIMI_POLL_INTERVAL=0.2)
t1=$(date +%s%N)
ms=$(( (t1-t0)/1000000 ))
note "  never-ready, polls=3 interval=0.2 => $v in ${ms}ms (expect VERDICT=fail, ~400-700ms)"
[ "$v" = VERDICT=fail ] || fail "readiness should fail when signal never appears"
[ "$ms" -ge 350 ] && [ "$ms" -le 1500 ] || fail "elapsed ${ms}ms outside expected poll-window (polls*interval not honored)"
v=$(run_stubbed kimi_wait_for_ready ready-banner FM_KIMI_READY_POLLS=3 FM_KIMI_POLL_INTERVAL=0.2)
note "  banner on first capture => $v (expect VERDICT=pass)"
[ "$v" = VERDICT=pass ] || fail "readiness should pass on welcome banner"

note "== 3. FM_KIMI_DELIVERY_POLLS governs delivery confirmation =="
v=$(run_stubbed kimi_wait_for_delivery never-deliver FM_KIMI_DELIVERY_POLLS=2 FM_KIMI_POLL_INTERVAL=0.1)
note "  never-deliver => $v (expect VERDICT=fail; spawn would fail per doc)"
[ "$v" = VERDICT=fail ] || fail "delivery should fail when never confirmed"
v=$(run_stubbed kimi_wait_for_delivery delivered FM_KIMI_DELIVERY_POLLS=5 FM_KIMI_POLL_INTERVAL=0.1)
note "  context-usage line present => $v (expect VERDICT=pass)"
[ "$v" = VERDICT=pass ] || fail "delivery should pass on context-usage echo"

note "== 3b. FM_KIMI_SUBMIT_SETTLE is a pre-Enter settle after typing (never retyping) =="
# Documented: "pre-Enter settle seconds after typing the brief pointer so
# completion popups clear before Enter; 0 disables". Execute the real
# fm_tmux_submit_core with a timestamping fake tmux and a recording
# enter-core stub; assert the typed literal lands BEFORE the settle sleep and
# the Enter retry core starts AFTER it.
extract_fn2() { awk -v name="$1" '$0 ~ "^"name"\\(\\) \\{" {p=1} p {print} p && /^}/ {exit}' "$2"; }
extract_fn2 fm_tmux_submit_core "$ROOT/bin/fm-tmux-lib.sh" | grep -q '^}' || { echo "could not extract fm_tmux_submit_core"; exit 2; }
SUBMIT_HARNESS=/tmp/$$.submit.sh
LOG=/tmp/$$.submit.log
: > "$LOG"
mkdir -p /tmp/$$.fakebin
printf '#!/bin/sh\necho "tmux $(date +%%s%%N) $*" >> "%s"\n' "$LOG" > /tmp/$$.fakebin/tmux
chmod +x /tmp/$$.fakebin/tmux
{
  extract_fn2 fm_tmux_submit_core "$ROOT/bin/fm-tmux-lib.sh"
  printf 'fm_pane_busy_state() { echo idle; }\n'
  printf 'fm_tmux_submit_enter_core() { echo "enter-core $(date +%%s%%N) retries=$2 sleep=$3 baseline=$4" >> "%s"; echo submitted; }\n' "$LOG"
} > "$SUBMIT_HARNESS"
submit_run() { # <settle>
  : > "$LOG"
  env PATH="/tmp/$$.fakebin:$PATH" sh -c ". '$SUBMIT_HARNESS'; fm_tmux_submit_core t1 'Read the brief at /tmp/x and follow it exactly.' 2 0.1 $1"
}
t0=$(date +%s%N); out=$(submit_run 0.3); t1=$(date +%s%N)
ms=$(( (t1-t0)/100000000 ))
typed_ts=$(awk '/send-keys/{print $2; exit}' "$LOG")
enter_ts=$(awk  '/enter-core/{print $2; exit}' "$LOG")
gap_ms=$(( (enter_ts - typed_ts)/1000000 ))
note "  settle=0.3 => verdict=$out; typed->enter gap=${gap_ms}ms (expect ~300ms, typed before enter)"
[ "$out" = submitted ] || fail "submit core did not report submitted"
[ "$gap_ms" -ge 250 ] && [ "$gap_ms" -le 700 ] || fail "settle gap ${gap_ms}ms not ~300ms (settle not slept between typing and Enter)"
grep -q 'send-keys -t t1 -l Read the brief at /tmp/x and follow it exactly.' "$LOG" || fail "typed literal not sent exactly once via send-keys -l"
[ "$(grep -c 'send-keys' "$LOG")" -eq 1 ] || fail "text was retyped (doc: never retyping)"
awk '/enter-core/{print}' "$LOG" | grep -q 'retries=2 sleep=0.1' || fail "retries/sleep not threaded to enter core"
t0=$(date +%s%N); out=$(submit_run 0); t1=$(date +%s%N)
zero_ms=$(( (t1-t0)/1000000 ))
note "  settle=0 => verdict=$out in ${zero_ms}ms (expect fast; doc: 0 disables)"
[ "$zero_ms" -lt 100 ] || fail "settle=0 should disable the wait"

note "== 4. doc lines exist and carry the documented defaults =="
grep -q '^FM_KIMI_READY_POLLS=60' "$DOC" || fail "FM_KIMI_READY_POLLS=60 line missing"
grep -q '^FM_KIMI_DELIVERY_POLLS=40' "$DOC" || fail "FM_KIMI_DELIVERY_POLLS=40 line missing"
grep -q '^FM_KIMI_POLL_INTERVAL=0.5' "$DOC" || fail "FM_KIMI_POLL_INTERVAL=0.5 line missing"
grep -q '^FM_KIMI_SUBMIT_RETRIES=3' "$DOC" || fail "FM_KIMI_SUBMIT_RETRIES=3 line missing"
grep -q '^FM_KIMI_SUBMIT_SLEEP=0.5' "$DOC" || fail "FM_KIMI_SUBMIT_SLEEP=0.5 line missing"
grep -q '^FM_KIMI_SUBMIT_SETTLE=0' "$DOC" || fail "FM_KIMI_SUBMIT_SETTLE=0 line missing"
note "  all six FM_KIMI_* lines present with documented defaults"

rm -rf /tmp/$$.kimi_* /tmp/$$.lib.sh /tmp/$$.fakebin /tmp/$$.submit.sh /tmp/$$.submit.log
if [ "$fails" -eq 0 ]; then echo "RESULT: PASS"; else echo "RESULT: FAIL ($fails)"; exit 1; fi
```
</details>
- Outcome: 🔧 1 issue found → auto-fixed ✅ across 2 runs (14m44s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"c58125f0a0fbaaa6d45e7d5a4dddfe4c91ad1ece","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>🔧 **Test** - 1 issue found → auto-fixed ✅</summary>

- 🚨 `docs/configuration.md:968` - The new FM_KIMI_SUBMIT_SETTLE doc line described it as &#39;seconds to settle after a confirmed brief-pointer submit before delivery polling; 0 disables&#39; — semantics that belong to FM_SEND_SETTLE (fm-send.sh:1107-1109 implements that post-submit pause separately). In the kimi spawn path the variable is only threaded as the `settle` argument to fm_backend_send_text_submit -&gt; fm_tmux_submit_core (bin/fm-tmux-lib.sh:281), where it is slept immediately AFTER typing the brief pointer and BEFORE the Enter retry loop (a pre-Enter settle so completion popups clear), and delivery polling (kimi_wait_for_delivery) starts immediately after the submit verdict with no post-submit wait. The line contradicted the intent&#39;s requirement to stay consistent with bin/fm-spawn.sh&#39;s authoritative mechanics rather than invent detail. Fixed in place to: &#39;kimi-only: pre-Enter settle seconds after typing the brief pointer so completion popups clear before Enter; 0 disables&#39;. All other five lines (defaults 60/40/0.5/3/0.5-via-FM_KIMI_POLL_INTERVAL/0 and poll/retry semantics) were verified against fm-spawn.sh lines 2885, 2911, 3878-3880 and fm-backend.sh&#39;s send_text_submit contract and are accurate.
- `Traced each of the six FM_KIMI_* defaults and semantics from bin/fm-spawn.sh:2885 (kimi_wait_for_ready), :2911 (kimi_wait_for_delivery), :3878-3880 (submit retries/sleep/settle) through fm_backend_send_text_submit (bin/fm-backend.sh:732) into fm_tmux_submit_core (bin/fm-tmux-lib.sh:281-291) and compared against the new docs/configuration.md lines`
- `Compared FM_KIMI_SUBMIT_SETTLE against the fm-send.sh settle implementation (bin/fm-send.sh:1107-1109) to confirm the doc's original wording described different (FM_SEND_SETTLE) semantics`
- `bash tests/fm-kimi-harness.test.sh (full file: behavior tests that run bin/fm-spawn.sh with FM_KIMI_READY_POLLS=2 FM_KIMI_DELIVERY_POLLS=2 FM_KIMI_POLL_INTERVAL=0 through the kimi launch-readiness, brief-pointer submit, and delivery-confirmation path) - all cases ok`
- `git status --porcelain to confirm only docs/configuration.md is modified and no transient test artifacts remain in the worktree`

🔧 Fix: Fix FM_KIMI_SUBMIT_SETTLE doc line to pre-Enter settle semantics
✅ Re-checked - no issues remain.
- <code>`sh ~/.no-mistakes/evidence/01M1Z8RRM2CG2FQX7FRZEJJGKC/verify-kimi-env-docs.sh .` — executable consistency check: resolves all six FM_KIMI_* default expressions and asserts they equal the documented values (60/40/0.5/3/0.5/0)</code>
- <code>Extracted the real `kimi_wait_for_ready` from bin/fm-spawn.sh and drove it with stubbed pane captures: 3 polls × 0.2s interval fails in ~425ms when no readiness signal appears, passes immediately on the &#39;Welcome to Kimi Code!&#39; banner — confirming the FM_KIMI_READY_POLLS/FM_KIMI_POLL_INTERVAL doc semantics</code>
- <code>Extracted the real `kimi_wait_for_delivery` and `kimi_delivery_is_confirmed`: fails when delivery is never confirmed, passes on the &#39;context: 42.0%&#39; echo — confirming the FM_KIMI_DELIVERY_POLLS doc semantics</code>
- <code>Extracted the real `fm_tmux_submit_core` from bin/fm-tmux-lib.sh with a timestamping fake `tmux`: settle=0.3 produced a 308ms typed→Enter-core gap after exactly one `send-keys -l` of the literal, with retries=2/sleep=0.1 threaded into the Enter-retry core; settle=0 completed in 18ms — confirming the corrected FM_KIMI_SUBMIT_SETTLE pre-Enter semantics, &#39;never retyping&#39;, and &#39;0 disables&#39;</code>
- <code>`grep -n &#39;FM_KIMI_&#39; bin/fm-spawn.sh` plus reading fm-spawn.sh:2885,2911,3878-3880 and fm-tmux-lib.sh:281-288 to cross-check every doc line against the authoritative source</code>
- <code>`git status --short` — worktree clean, no transient artifacts left behind</code>
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
