### PR TITLE
fix: prevent automated Lavish reviews from opening browsers

### DIFF
--- a/.agents/skills/bearings/SKILL.md
+++ b/.agents/skills/bearings/SKILL.md
@@ -104,7 +104,7 @@ Compose the payload from the same snapshot with the same ranking judgment as the
 - Every Captain's Call item and every Underway, Recently Landed, and Charted Next row carries an explicit `repo` field. Fill it from the snapshot and task records wherever known; use null or an empty string only as the deliberate genuinely-no-repo marker, in which case the template may show the internal id. Ids otherwise stay in the payload only as the routing channel, and composed reasons name blockers in plain words.
 
 Run `build` once after composing the payload.
-Its serve-first sequence publishes the board, establishes and verifies its Lavish session with `lavish-axi`, reopens an ended session when necessary, and only then binds the answer source and proves a live polling listener; use the session URL it prints in the chat digest.
+Its serve-first sequence publishes the board, establishes and verifies its Lavish session with `lavish-axi` without opening a browser, reopens an ended session when necessary without opening a browser, and only then binds the answer source and proves a live polling listener; use the session URL it prints in the chat digest and open it explicitly when you want to review it.
 Never bind or arm the board before its session is listed open.
 Never run `lavish-axi poll` for the board yourself: the armed source's supervised runner owns the blocking poll, and both the build and the watcher's ordinary reconcile repair a missing listener, so no conversational turn ever blocks on the board.
 

--- a/bin/fm-bearings-board.sh
+++ b/bin/fm-bearings-board.sh
@@ -15,9 +15,10 @@
 #            already landed, give every surviving decision card the standard
 #            reconcile choice, and inject the result into a fresh copy of the
 #            shipped template at the stable board path. Establish the Lavish
-#            session on that board and PROVE it is live BEFORE binding and
-#            arming its answer source, so a registered poll can never race a
-#            session that does not exist or attach to one that has ended.
+#            session on that board without opening a browser, then PROVE it is
+#            live BEFORE binding and arming its answer source, so a registered
+#            poll can never race a session that does not exist or attach to one
+#            that has ended.
 #            Bind to the keyed-answer intake (bin/fm-captain-hold.sh) ALWAYS
 #            precedes arm, so the board can never produce an answer that has
 #            nowhere to go (captain-hold-lifecycle's ordering rule, enforced
@@ -221,22 +222,22 @@ lavish_board_live() {  # <establish output> <canonical-board-path>
   lavish_session_listed_open "$2"
 }
 
-# Establish the board session and PROVE it is live before anything arms a poll
-# on it. A session the captain ended is reopened once - the captain asked for
-# this board, which is exactly the attention `--reopen` exists for - and a
-# session that is still not live after that refuses the build rather than
-# arming a poll that can never attach.
+# Establish the board session without opening a browser and PROVE it is live
+# before anything arms a poll on it. A session the captain ended is reopened
+# once without opening a browser; the returned URL remains available for the
+# captain to open explicitly. A session that is still not live after that
+# refuses the build rather than arming a poll that can never attach.
 establish_board_session() {  # <board>
   local board=$1 real out status version
   BOARD_SESSION_REOPENED=0
   real=$(board_realpath "$board") || fail "cannot resolve the board path: $board"
-  out=$(lavish-axi "$board") || fail "cannot establish the board Lavish session"
+  out=$(lavish-axi "$board" --no-open) || fail "cannot establish the board Lavish session"
   printf '%s\n' "$out"
   if lavish_board_live "$out" "$real"; then
     printf 'session: live\n'
     return 0
   fi
-  out=$(lavish-axi "$board" --reopen) || fail "cannot reopen the ended board Lavish session"
+  out=$(lavish-axi "$board" --no-open --reopen) || fail "cannot reopen the ended board Lavish session"
   printf '%s\n' "$out"
   if lavish_board_live "$out" "$real"; then
     BOARD_SESSION_REOPENED=1

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -371,6 +371,7 @@ The report is the only thing that survives, so anything worth keeping must be in
 1. Never push to any remote and never open a PR.
 2. Stay inside this worktree; the only files you may write outside it are the report and the status file below.
 3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.
+When preparing or serving a Lavish artifact without a current explicit captain request to open it, pass \`--no-open\` and return the review URL without opening a browser. Use plain \`lavish-axi <html-file>\` or \`--reopen\` only when the captain explicitly asks to open or reopen that review.
 4. Report status by appending one line:
    \`echo "{state}: {one short line}" >> $STATUS_FILE\`
    States: working, needs-decision, blocked, $PAUSED_VERB, done, failed.
@@ -458,6 +459,7 @@ If the top-level path is the primary checkout or not the worktree you were launc
 $RULE1
 2. Stay inside this worktree; modify nothing outside it.
 3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.
+When preparing or serving a Lavish artifact without a current explicit captain request to open it, pass \`--no-open\` and return the review URL without opening a browser. Use plain \`lavish-axi <html-file>\` or \`--reopen\` only when the captain explicitly asks to open or reopen that review.
 4. Report status by appending one line:
    \`echo "{state}: {one short line}" >> $STATUS_FILE\`
    States: working, needs-decision, blocked, $PAUSED_VERB, done, failed.

--- a/tests/fm-bearings-board-lavish-live-e2e.test.sh
+++ b/tests/fm-bearings-board-lavish-live-e2e.test.sh
@@ -14,8 +14,10 @@
 #
 # The captain-ended state is reached through the same server route the browser's
 # End session button calls, so no browser is needed and nothing here depends on
-# a human. The artifact is a scratch page in a temporary directory, and the
-# session it opens is ended again before the guard returns.
+# a human. Every artifact-serving call uses --no-open because this guard needs
+# session state and URLs, not browser focus. The artifact is a scratch page in
+# a temporary directory, and the session it opens is ended again before the
+# guard returns.
 #
 # Standard CI has no lavish-axi, so this reports a capability skip there. The
 # portable counterpart in tests/fm-bearings-board.test.sh pins the build's logic
@@ -74,7 +76,7 @@ JSON
 
 run_board() {
   FM_HOME="$LAB" FM_STATE_OVERRIDE="$LAB/state" FM_DATA_OVERRIDE="$LAB/data" \
-    FM_PROCEVENT_CLAIM_ROOT="$LAB/procevent-claims" \
+    FM_PROCEVENT_CLAIM_ROOT="$LAB/procevent-claims" LAVISH_AXI_NO_OPEN=1 \
     "$ROOT/bin/fm-bearings-board.sh" "$@"
 }
 
@@ -82,7 +84,7 @@ BOARD="$LAB/.lavish/bearings-board.html"
 run_board build "$LAB/payload.json" >/dev/null 2>&1 || fail "the guard board did not build"
 [ -f "$BOARD" ] || fail "the guard board was not published"
 
-url=$(lavish-axi "$BOARD" | sed -n 's/^[[:space:]]*url:[[:space:]]*//p' | head -1 | tr -d '"')
+url=$(lavish-axi "$BOARD" --no-open | sed -n 's/^[[:space:]]*url:[[:space:]]*//p' | head -1 | tr -d '"')
 case "$url" in
   http://*/session/*) ;;
   *) fail "could not read the guard board session url: $url" ;;
@@ -96,7 +98,7 @@ curl -fsS -X POST "$base/api/$key/end" >/dev/null 2>&1 \
 
 # ASSUMPTION UNDER GUARD: this exits 0 while reporting the session is not live.
 set +e
-ended_out=$(lavish-axi "$BOARD" 2>&1)
+ended_out=$(lavish-axi "$BOARD" --no-open 2>&1)
 ended_rc=$?
 set -e
 [ "$ended_rc" -eq 0 ] \

--- a/tests/fm-bearings-board.test.sh
+++ b/tests/fm-bearings-board.test.sh
@@ -79,7 +79,12 @@ esac
 file=$1
 shift
 reopen=0
-for arg in "$@"; do [ "$arg" != --reopen ] || reopen=1; done
+no_open=0
+for arg in "$@"; do
+  [ "$arg" != --reopen ] || reopen=1
+  [ "$arg" != --no-open ] || no_open=1
+done
+[ "$no_open" = 1 ] || { printf 'automated artifact establishment must pass --no-open\n' >&2; exit 97; }
 real=$(cd "$(dirname "$file")" && pwd -P)/$(basename "$file")
 if [ -e "$state/user-ended" ] && [ "$reopen" = 0 ]; then
   emit "$real" user-ended

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -214,6 +214,8 @@ test_ship_modes_generate_clean_briefs() {
     assert_grep "## Captain's intent" "$brief" "$id: brief missing Captain's intent subsection"
     assert_grep "## Firstmate spec" "$brief" "$id: brief missing Firstmate spec subsection"
     assert_grep 'never a bare number such as "PR 108"' "$brief" "$id: brief missing the full-PR-URL rule"
+    assert_grep 'pass `--no-open`' "$brief" "$id: brief missing the automated Lavish no-open rule"
+    assert_grep 'captain explicitly asks to open or reopen' "$brief" "$id: brief missing the explicit Lavish open exception"
     assert_grep "mid-task \`working:\` line (including setup complete) is nonterminal" "$brief" \
       "$id: brief missing nonterminal working:/setup-complete gate protection"
     assert_no_grep "EOF" "$brief" "$id: brief leaked a heredoc EOF marker (unterminated heredoc)"
@@ -828,6 +830,10 @@ test_scout_and_secondmate_scaffold() {
   assert_grep "report.md" "$brief" "scout brief must point at the report deliverable"
   assert_grep "you may host the Lavish review loop yourself" "$brief" \
     "scout brief must mention the option to host a Lavish review loop"
+  assert_grep 'pass `--no-open`' "$brief" \
+    "scout brief must require automated Lavish serving without browser open"
+  assert_grep 'captain explicitly asks to open or reopen' "$brief" \
+    "scout brief must preserve explicit Lavish open behavior"
   assert_grep "## Captain's intent" "$brief" "scout brief missing Captain's intent subsection"
   assert_grep "## Firstmate spec" "$brief" "scout brief missing Firstmate spec subsection"
   assert_grep "{FIRSTMATE_SPEC}" "$brief" "scout brief missing the spec placeholder"

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -214,7 +214,7 @@ test_ship_modes_generate_clean_briefs() {
     assert_grep "## Captain's intent" "$brief" "$id: brief missing Captain's intent subsection"
     assert_grep "## Firstmate spec" "$brief" "$id: brief missing Firstmate spec subsection"
     assert_grep 'never a bare number such as "PR 108"' "$brief" "$id: brief missing the full-PR-URL rule"
-    assert_grep 'pass `--no-open`' "$brief" "$id: brief missing the automated Lavish no-open rule"
+    assert_grep "pass \`--no-open\`" "$brief" "$id: brief missing the automated Lavish no-open rule"
     assert_grep 'captain explicitly asks to open or reopen' "$brief" "$id: brief missing the explicit Lavish open exception"
     assert_grep "mid-task \`working:\` line (including setup complete) is nonterminal" "$brief" \
       "$id: brief missing nonterminal working:/setup-complete gate protection"
@@ -830,7 +830,7 @@ test_scout_and_secondmate_scaffold() {
   assert_grep "report.md" "$brief" "scout brief must point at the report deliverable"
   assert_grep "you may host the Lavish review loop yourself" "$brief" \
     "scout brief must mention the option to host a Lavish review loop"
-  assert_grep 'pass `--no-open`' "$brief" \
+  assert_grep "pass \`--no-open\`" "$brief" \
     "scout brief must require automated Lavish serving without browser open"
   assert_grep 'captain explicitly asks to open or reopen' "$brief" \
     "scout brief must preserve explicit Lavish open behavior"


### PR DESCRIPTION
## Intent

Captain: "i dont like that lavish autoopens a tab without me opening it." Desired behavior: preparing or serving a Lavish artifact should not launch a browser tab automatically. Firstmate should return the review URL, and the captain chooses when to open it. Explicit human requests to open or reopen a review may still open it. Determine which current component owns the auto-open behavior and establish the smallest robust fix path. The completed diagnosis established that automated Firstmate Bearings board serving omits Lavish's supported `--no-open` flag in initial establishment and ended-session recovery. The captain's preference is sufficient implementation authority: update those automated call sites and tests so reviews return a URL without opening a browser, while explicit captain open/reopen behavior remains available.

## What Changed
- Updated automated Bearings board establishment and ended-session recovery to use Lavish `--no-open` while retaining the review URL.
- Documented no-open behavior for automated Lavish artifacts and preserved explicit captain open/reopen requests.
- Updated board and brief tests to enforce the behavior.

## Risk Assessment

✅ Low: The change is narrowly scoped and covers both automated Lavish establishment paths while preserving explicit captain opening behavior.

## Testing

Targeted tests and real Lavish end-to-end verification passed. No screenshot was captured because the required behavior is deliberately not opening a browser; the transcript records returned URLs, recovery, and explicit-open behavior.

<details>
<summary>Evidence: Lavish no-auto-open and explicit-open transcript</summary>

Source: [Lavish no-auto-open and explicit-open transcript](https://github.com/reneleogp/firstmate/blob/e4e5c1b27b5182de47ed5e1fd53bfabd42bdebf0/.no-mistakes/evidence/fm/lavish-no-autoopen-l1/lavish-no-auto-open-transcript.txt)

```text
Firstmate Bearings board no-auto-open evidence
The fake macOS open command fails if invoked.
Initial automated build:
board: /var/folders/gk/2vqhl8hj213dqcsd4t3726wm0000gn/T//fm-lavish-no-open-evidence.nBd0GT/.lavish/bearings-board.html
session:
  file: /private/var/folders/gk/2vqhl8hj213dqcsd4t3726wm0000gn/T/fm-lavish-no-open-evidence.nBd0GT/.lavish/bearings-board.html
  url: "http://127.0.0.1:4387/session/ca08249b416500f2"
  status: opened
next_step: "Do not respond to the user just yet. Now you must run `lavish-axi poll /private/var/folders/gk/2vqhl8hj213dqcsd4t3726wm0000gn/T/fm-lavish-no-open-evidence.nBd0GT/.lavish/bearings-board.html`. This command long-polls until the user sends feedback or ends the session, and it stays silent the whole time - that is normal, never kill it. Layout issues the browser detects do not return this poll; they wait in the user's Layout issues inbox until the user queues them, then arrive as an ordinary tag \"layout-warnings\" prompt. Do not pass --timeout-ms during normal agent use. Keep the poll in the foreground by default and let it return the feedback directly to the agent. A background poll is allowed only through a harness-native tracked background-job facility whose completion result is guaranteed to resume or notify the same agent. Never use `nohup`, shell `&`, `disown`, redirected fire-and-forget processes, or a detached terminal without an explicit verified callback merely to keep polling alive. If the harness has no completion-aware background facility, use the foreground poll or first wire a verified wake callback into the surrounding supervisor. Do not tell the user the artifact is being monitored until that wake path is live. If the poll gets killed or times out before feedback arrives, re-run it - feedback remains queued until delivery. Poll delivery consumes the response, so read it completely. After applying feedback, run `lavish-axi poll /private/var/folders/gk/2vqhl8hj213dqcsd4t3726wm0000gn/T/fm-lavish-no-open-evidence.nBd0GT/.lavish/bearings-board.html --agent-reply \"<message for the user>\"` without --timeout-ms to show your response in Lavish Editor and wait for more feedback. If the user ends the session, stop polling and do not reopen it by re-running `lavish-axi /private/var/folders/gk/2vqhl8hj213dqcsd4t3726wm0000gn/T/fm-lavish-no-open-evidence.nBd0GT/.lavish/bearings-board.html` unless the user asks for further review or something genuinely important needs their visual attention - deliver routine updates directly in this conversation instead. When reopening is warranted, run `lavish-axi /private/var/folders/gk/2vqhl8hj213dqcsd4t3726wm0000gn/T/fm-lavish-no-open-evidence.nBd0GT/.lavish/bearings-board.html --reopen`."
session: live
served: /var/folders/gk/2vqhl8hj213dqcsd4t3726wm0000gn/T//fm-lavish-no-open-evidence.nBd0GT/.lavish/bearings-board.html
bound: lavish-ca08249b416500f2
armed: lavish-ca08249b416500f2
listening: live
Recovery after captain-ended session:
board: /var/folders/gk/2vqhl8hj213dqcsd4t3726wm0000gn/T//fm-lavish-no-open-evidence.nBd0GT/.lavish/bearings-board.html
session:
  file: /private/var/folders/gk/2vqhl8hj213dqcsd4t3726wm0000gn/T/fm-lavish-no-open-evidence.nBd0GT/.lavish/bearings-board.html
  url: "http://127.0.0.1:4387/session/ca08249b416500f2"
  status: user-ended
next_step: "The user explicitly ended this Lavish Editor session from the browser, so `lavish-axi /private/var/folders/gk/2vqhl8hj213dqcsd4t3726wm0000gn/T/fm-lavish-no-open-evidence.nBd0GT/.lavish/bearings-board.html` did not reopen it. Do not reopen unless the user asks for further review or something genuinely important needs their visual attention - deliver routine updates directly in this conversation instead. When reopening is warranted, run `lavish-axi /private/var/folders/gk/2vqhl8hj213dqcsd4t3726wm0000gn/T/fm-lavish-no-open-evidence.nBd0GT/.lavish/bearings-board.html --reopen`."
session:
  file: /private/var/folders/gk/2vqhl8hj213dqcsd4t3726wm0000gn/T/fm-lavish-no-open-evidence.nBd0GT/.lavish/bearings-board.html
  url: "http://127.0.0.1:4387/session/ca08249b416500f2"
  status: opened
next_step: "Do not respond to the user just yet. Now you must run `lavish-axi poll /private/var/folders/gk/2vqhl8hj213dqcsd4t3726wm0000gn/T/fm-lavish-no-open-evidence.nBd0GT/.lavish/bearings-board.html`. This command long-polls until the user sends feedback or ends the session, and it stays silent the whole time - that is normal, never kill it. Layout issues the browser detects do not return this poll; they wait in the user's Layout issues inbox until the user queues them, then arrive as an ordinary tag \"layout-warnings\" prompt. Do not pass --timeout-ms during normal agent use. Keep the poll in the foreground by default and let it return the feedback directly to the agent. A background poll is allowed only through a harness-native tracked background-job facility whose completion result is guaranteed to resume or notify the same agent. Never use `nohup`, shell `&`, `disown`, redirected fire-and-forget processes, or a detached terminal without an explicit verified callback merely to keep polling alive. If the harness has no completion-aware background facility, use the foreground poll or first wire a verified wake callback into the surrounding supervisor. Do not tell the user the artifact is being monitored until that wake path is live. If the poll gets killed or times out before feedback arrives, re-run it - feedback remains queued until delivery. Poll delivery consumes the response, so read it completely. After applying feedback, run `lavish-axi poll /private/var/folders/gk/2vqhl8hj213dqcsd4t3726wm0000gn/T/fm-lavish-no-open-evidence.nBd0GT/.lavish/bearings-board.html --agent-reply \"<message for the user>\"` without --timeout-ms to show your response in Lavish Editor and wait for more feedback. If the user ends the session, stop polling and do not reopen it by re-running `lavish-axi /private/var/folders/gk/2vqhl8hj213dqcsd4t3726wm0000gn/T/fm-lavish-no-open-evidence.nBd0GT/.lavish/bearings-board.html` unless the user asks for further review or something genuinely important needs their visual attention - deliver routine updates directly in this conversation instead. When reopening is warranted, run `lavish-axi /private/var/folders/gk/2vqhl8hj213dqcsd4t3726wm0000gn/T/fm-lavish-no-open-evidence.nBd0GT/.lavish/bearings-board.html --reopen`."
session: reopened
served: /var/folders/gk/2vqhl8hj213dqcsd4t3726wm0000gn/T//fm-lavish-no-open-evidence.nBd0GT/.lavish/bearings-board.html
bound: lavish-ca08249b416500f2
armed: lavish-ca08249b416500f2
listening: live
RESULT: no browser launch; review URL returned and recovery reopened without browser

Explicit captain-open capability check (browser launcher shim records the request):
session:
  file: /private/var/folders/gk/2vqhl8hj213dqcsd4t3726wm0000gn/T/fm-lavish-explicit-open-evidence.4gn7Nq/page.html
  url: "http://127.0.0.1:4387/session/0246c9b384c27da3"
  status: opened
self_paint_warning: "This artifact never paints its own page surface: no background on html/body/:root, no bg-* class or data-theme on html/body, and no stylesheet that could set one. Lavish injects no design system, so text that assumes a dark or light host surface can render invisible. Set an explicit background and readable text."
next_step: "First fix the unpainted page surface flagged in self_paint_warning and save - Lavish live-reloads the artifact automatically, so you do not need to re-run `lavish-axi /private/var/folders/gk/2vqhl8hj213dqcsd4t3726wm0000gn/T/fm-lavish-explicit-open-evidence.4gn7Nq/page.html`. Do not respond to the user just yet. Now you must run `lavish-axi poll /private/var/folders/gk/2vqhl8hj213dqcsd4t3726wm0000gn/T/fm-lavish-explicit-open-evidence.4gn7Nq/page.html`. This command long-polls until the user sends feedback or ends the session, and it stays silent the whole time - that is normal, never kill it. Layout issues the browser detects do not return this poll; they wait in the user's Layout issues inbox until the user queues them, then arrive as an ordinary tag \"layout-warnings\" prompt. Do not pass --timeout-ms during normal agent use. Keep the poll in the foreground by default and let it return the feedback directly to the agent. A background poll is allowed only through a harness-native tracked background-job facility whose completion result is guaranteed to resume or notify the same agent. Never use `nohup`, shell `&`, `disown`, redirected fire-and-forget processes, or a detached terminal without an explicit verified callback merely to keep polling alive. If the harness has no completion-aware background facility, use the foreground poll or first wire a verified wake callback into the surrounding supervisor. Do not tell the user the artifact is being monitored until that wake path is live. If the poll gets killed or times out before feedback arrives, re-run it - feedback remains queued until delivery. Poll delivery consumes the response, so read it completely. After applying feedback, run `lavish-axi poll /private/var/folders/gk/2vqhl8hj213dqcsd4t3726wm0000gn/T/fm-lavish-explicit-open-evidence.4gn7Nq/page.html --agent-reply \"<message for the user>\"` without --timeout-ms to show your response in Lavish Editor and wait for more feedback. If the user ends the session, stop polling and do not reopen it by re-running `lavish-axi /private/var/folders/gk/2vqhl8hj213dqcsd4t3726wm0000gn/T/fm-lavish-explicit-open-evidence.4gn7Nq/page.html` unless the user asks for further review or something genuinely important needs their visual attention - deliver routine updates directly in this conversation instead. When reopening is warranted, run `lavish-axi /private/var/folders/gk/2vqhl8hj213dqcsd4t3726wm0000gn/T/fm-lavish-explicit-open-evidence.4gn7Nq/page.html --reopen`."
RESULT: explicit plain lavish-axi invocation still requested browser open
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"2ce108d05d4c7a8d1781e0f4ca91fd72671678bd","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `bash tests/fm-bearings-board.test.sh`
- `bash tests/fm-brief.test.sh`
- `bash tests/fm-bearings-board-lavish-live-e2e.test.sh`
- `Real Lavish build/recovery with a browser-launch shim and explicit-open verification`
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
