### PR TITLE
fix(spawn): verify and retry on a post-acquisition Treehouse slot collision

### DIFF
--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -2366,9 +2366,22 @@ validate_spawn_worktree() {  # <source> <inspect-target>
 # re-spawn of an existing id (not --relaunch) reaches here with its own prior
 # meta still on disk, and that prior record naming this same worktree is
 # expected reuse, never a foreign collision.
+#
+# A worktree= match alone is not proof of a LIVE collision: fm-teardown.sh
+# returns a task's Treehouse slot to the pool well before it removes that
+# task's .meta record, and several of its steps in between deliberately retain
+# the record on failure so a rerun can retry delivery. A worktree can
+# therefore be legitimately back in the pool, freshly reused by this spawn,
+# while its former owner's meta still names it. Only a positive liveness
+# signal for the other task's recorded endpoint - the same
+# fm_backend_agent_alive classifier fm-crew-state.sh and this file's own
+# duplicate-launch guard already trust - proves it is still owned; a
+# confirmed-dead or missing endpoint is a stale record, not a collision. A
+# target that cannot be resolved at all is treated the same as unknown
+# (conservative), matching fm-spawn.sh's other endpoint-liveness guard above.
 SPAWN_WT_COLLISION_TASK=
 spawn_worktree_claimed_elsewhere() {  # <worktree>
-  local wt=$1 wt_real self_meta other_meta other_wt
+  local wt=$1 wt_real self_meta other_meta other_wt other_backend other_target other_state
   SPAWN_WT_COLLISION_TASK=
   wt_real=$(real_path_or_raw "$wt")
   self_meta="$STATE/$ID.meta"
@@ -2378,6 +2391,14 @@ spawn_worktree_claimed_elsewhere() {  # <worktree>
     other_wt=$(fm_meta_get "$other_meta" worktree)
     [ -n "$other_wt" ] || continue
     [ "$(real_path_or_raw "$other_wt")" = "$wt_real" ] || continue
+    other_backend=$(fm_backend_of_meta "$other_meta")
+    other_target=$(fm_backend_target_of_meta "$other_meta")
+    if [ -n "$other_target" ]; then
+      other_state=$(fm_backend_agent_alive "$other_backend" "$other_target" 2>/dev/null || printf unknown)
+    else
+      other_state=unknown
+    fi
+    [ "$other_state" = dead ] && continue
     SPAWN_WT_COLLISION_TASK=$(basename "$other_meta" .meta)
     return 0
   done
@@ -3146,6 +3167,29 @@ elif [ "$KIND" != secondmate ] && [ "$BACKEND" != orca ]; then
     fi
     if [ "$SPAWN_WT_ATTEMPT" -ge "$SPAWN_WT_COLLISION_RETRIES" ]; then
       echo "error: treehouse repeatedly handed spawn $ID a worktree another live task already owns (last: $WT, held by $SPAWN_WT_COLLISION_TASK) after $SPAWN_WT_COLLISION_RETRIES attempts; refusing to launch onto a possibly double-owned worktree" >&2
+      exit 1
+    fi
+    # `treehouse get` opens a foreground subshell in whatever shell currently
+    # occupies the pane - every other call site invokes it exactly once, from
+    # the pane's original top-level shell at $PROJ_ABS. The pane is still
+    # sitting in that first subshell (the external `treehouse return --force`
+    # above ran in an unrelated subprocess and never touched it), so resending
+    # `treehouse get` without first leaving it would nest a second subshell
+    # inside the colliding one instead of issuing a clean acquisition from
+    # $PROJ_ABS. Exit that subshell and confirm the pane is back at the
+    # project directory before retrying.
+    spawn_send_text_line "$WT_TARGET" 'exit'
+    wt_exited=0
+    for _ in $(seq 1 20); do
+      p=$(spawn_current_path "$WT_TARGET" || true)
+      if [ -n "$p" ] && [ "$(real_path_or_raw "$p")" = "$PROJ_ABS_REAL" ]; then
+        wt_exited=1
+        break
+      fi
+      sleep 0.5
+    done
+    if [ "$wt_exited" -ne 1 ]; then
+      echo "error: window $T did not return to the project directory after returning the colliding worktree slot $WT; refusing to resend treehouse get into a possibly nested subshell; inspect window $T" >&2
       exit 1
     fi
     sleep 1

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -2354,6 +2354,36 @@ validate_spawn_worktree() {  # <source> <inspect-target>
   fi
 }
 
+# True when some OTHER task's published record already names <worktree>: proof
+# that Treehouse handed this spawn a slot a live task already owns, regardless
+# of what Treehouse's own pool state believes. Treehouse's `get` is meant to
+# never repeat a leased slot, but its liveness tracking is keyed off whichever
+# process last touched the pane, which can be a short-lived intermediate shell
+# that has already exited by the time the long-lived agent is running - so a
+# later, fully sequential `get` can still be handed a path another task's
+# state/<id>.meta already recorded (AGENTS.md section 1's fm-spawn.sh scope).
+# This task's own $ID.meta is excluded by path, not by absence: a plain
+# re-spawn of an existing id (not --relaunch) reaches here with its own prior
+# meta still on disk, and that prior record naming this same worktree is
+# expected reuse, never a foreign collision.
+SPAWN_WT_COLLISION_TASK=
+spawn_worktree_claimed_elsewhere() {  # <worktree>
+  local wt=$1 wt_real self_meta other_meta other_wt
+  SPAWN_WT_COLLISION_TASK=
+  wt_real=$(real_path_or_raw "$wt")
+  self_meta="$STATE/$ID.meta"
+  for other_meta in "$STATE"/*.meta; do
+    [ -e "$other_meta" ] || continue
+    [ "$other_meta" != "$self_meta" ] || continue
+    other_wt=$(fm_meta_get "$other_meta" worktree)
+    [ -n "$other_wt" ] || continue
+    [ "$(real_path_or_raw "$other_wt")" = "$wt_real" ] || continue
+    SPAWN_WT_COLLISION_TASK=$(basename "$other_meta" .meta)
+    return 0
+  done
+  return 1
+}
+
 # A pooled slot whose only deviation is a submodule gitlink is stale, not dirty:
 # an earlier refresh moved the superproject and left the submodule checkout on
 # the pin the previous base recorded. The refusal still stands and this gate
@@ -3023,6 +3053,21 @@ if [ "$RELAUNCH" -eq 1 ]; then
   fi
   [ "$KIND" = secondmate ] || validate_spawn_worktree "relaunch" "$T"
 elif [ "$KIND" != secondmate ] && [ "$BACKEND" != orca ]; then
+  # Bounded retry on a post-acquisition collision: Treehouse's own pool state
+  # is not trusted to keep one slot from being handed to two tasks (see
+  # spawn_worktree_claimed_elsewhere above). FM_TREEHOUSE_SLOT_COLLISION_RETRIES
+  # overrides the default for testing; an invalid value falls back to it.
+  SPAWN_WT_COLLISION_RETRIES=${FM_TREEHOUSE_SLOT_COLLISION_RETRIES:-3}
+  case "$SPAWN_WT_COLLISION_RETRIES" in
+    ''|*[!0-9]*)
+      echo "warning: invalid FM_TREEHOUSE_SLOT_COLLISION_RETRIES '$SPAWN_WT_COLLISION_RETRIES'; using 3" >&2
+      SPAWN_WT_COLLISION_RETRIES=3
+      ;;
+  esac
+  SPAWN_WT_ATTEMPT=0
+  while :; do
+  SPAWN_WT_ATTEMPT=$((SPAWN_WT_ATTEMPT + 1))
+  WT=""
   spawn_send_text_line "$WT_TARGET" 'treehouse get'
 
   # Wait for the treehouse subshell: the pane's cwd moves from the project to the worktree.
@@ -3083,6 +3128,31 @@ elif [ "$KIND" != secondmate ] && [ "$BACKEND" != orca ]; then
   fi
 
   validate_spawn_worktree "treehouse get" "$T"
+
+  if spawn_worktree_claimed_elsewhere "$WT"; then
+    echo "warning: treehouse handed spawn $ID the worktree '$WT', already recorded by task $SPAWN_WT_COLLISION_TASK; returning the colliding slot and retrying acquisition (attempt $SPAWN_WT_ATTEMPT/$SPAWN_WT_COLLISION_RETRIES)" >&2
+    if ! command -v treehouse >/dev/null 2>&1; then
+      echo "error: treehouse command not found; cannot return the colliding worktree slot $WT" >&2
+      exit 1
+    fi
+    # Treehouse's own return tracks the lease by its pool-state owner_pid, not
+    # by scanning the worktree for live processes, so this does not reach for
+    # task $SPAWN_WT_COLLISION_TASK's actual running agent - the stale
+    # owner_pid this clears is exactly the already-exited intermediate shell
+    # the bug report traced the collision to.
+    if ! ( cd "$PROJ_ABS" && treehouse return --force "$WT" ) >/dev/null 2>&1; then
+      echo "error: could not return the colliding worktree slot $WT (already recorded by task $SPAWN_WT_COLLISION_TASK); refusing to launch onto a possibly double-owned worktree; inspect window $T and the pool state manually" >&2
+      exit 1
+    fi
+    if [ "$SPAWN_WT_ATTEMPT" -ge "$SPAWN_WT_COLLISION_RETRIES" ]; then
+      echo "error: treehouse repeatedly handed spawn $ID a worktree another live task already owns (last: $WT, held by $SPAWN_WT_COLLISION_TASK) after $SPAWN_WT_COLLISION_RETRIES attempts; refusing to launch onto a possibly double-owned worktree" >&2
+      exit 1
+    fi
+    sleep 1
+    continue
+  fi
+  break
+  done
 fi
 if [ "$RELAUNCH" -eq 0 ] && [ "$KIND" != secondmate ]; then
   freshen_spawn_worktree_base "$WT" || exit 1

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -947,6 +947,7 @@ FM_STALE_WORKTREE_LOCK_AGE_SECS=30       # min mtime age before fm-teardown.sh t
 FM_TREEHOUSE_RETURN_LOCK_RETRIES=3        # retries after a treehouse return fails on the transient git index.lock signature
 FM_TREEHOUSE_RETURN_LOCK_RETRY_WAIT_SECS=1 # seconds fm-teardown.sh waits before each retry after that signature
 FM_STALE_WORKTREE_LOCK_RETRY_WAIT_SECS=   # legacy alias for FM_TREEHOUSE_RETURN_LOCK_RETRY_WAIT_SECS when the new variable is unset
+FM_TREEHOUSE_SLOT_COLLISION_RETRIES=3     # fm-spawn.sh retries after `treehouse get` hands back a worktree another live task's state/<id>.meta already names
 FM_FLEET_SYNC_PACKED_REFS_LOCK_RETRIES=3        # fetch retries after fm-fleet-sync.sh hits the orphaned .git/packed-refs.lock signature
 FM_FLEET_SYNC_PACKED_REFS_LOCK_RETRY_WAIT_SECS=1 # seconds fm-fleet-sync.sh waits before each of those retries
 FM_FLEET_SYNC_PACKED_REFS_LOCK_AGE_SECS=30       # min mtime age before fm-fleet-sync.sh treats a leftover packed-refs.lock as provably stale
@@ -1005,3 +1006,6 @@ Only after those retries exhaust does it remove the lock, and only when it is pr
 A live lock, a missing `lsof`, any failed check, or any other fetch failure keeps today's behavior.
 Every wait, retry, and removal is printed to stderr, and a successful recovery also prints one `recovered:` summary line to stdout so a session-start refresh - which discards fleet-sync stderr and relays only stdout - still surfaces it.
 The shared staleness proof lives in `bin/fm-lock-lib.sh`, which both `fm-teardown.sh` and `fm-fleet-sync.sh` use.
+
+`fm-spawn.sh` distrusts Treehouse's own pool-slot liveness tracking and independently verifies each acquired worktree against every other live task's `state/<id>.meta` before branching onto it.
+On a collision it returns the slot with `treehouse return --force`, retries acquisition up to `FM_TREEHOUSE_SLOT_COLLISION_RETRIES` times (nonnegative integer; unset, blank, or invalid uses the default of 3), and fails loudly rather than checking out onto a worktree another live task may already own.

--- a/tests/fm-spawn-pool-base-freshen.test.sh
+++ b/tests/fm-spawn-pool-base-freshen.test.sh
@@ -183,12 +183,14 @@ test_stale_pool_base_refreshes_before_branching() {
       "$branch_head" "$current" "$(cat "$POOL_DIR/advanced-main.txt")"
   fi
 
-  # Simulate the first task's slot having been genuinely returned to the pool
-  # (as teardown would do) before this second task reuses the same physical
-  # worktree - otherwise the reused path would still be a live collision by
-  # fm-spawn's own record-based guard, not the idempotent-refresh case this
-  # test means to exercise.
-  rm -f "$HOME_DIR/state/pool-current-base-r1.meta"
+  # The first task's .meta is deliberately left in place, still naming
+  # $POOL_DIR: real teardown returns a Treehouse slot to the pool well before
+  # it removes the task's .meta record, so a genuinely-returned slot can be
+  # reused while a stale record still names it. The fake tmux here never
+  # reports the first task's window as present, so fm-spawn's collision guard
+  # reads its recorded endpoint as dead and does not treat this reuse as a
+  # live collision - exactly the idempotent-refresh case this test means to
+  # exercise.
   id='pool-current-base-repeat-r1'
   fm_test_spawn_brief "$HOME_DIR" "$id"
   out=$(run_spawn "$id" --mode no-mistakes --yolo off)
@@ -534,11 +536,12 @@ strand_submodule_pin_via_spawn() {  # <seed-id>
     || fail "the first spawn did not move the pooled base across the moved submodule pin"
   [ "$(git -C "$POOL_DIR/ui" rev-parse HEAD)" = "$SUBPIN1" ] \
     || fail "the first spawn did not strand the submodule on the pin the old base recorded"
-  # Simulate this seed task's slot having been genuinely returned to the pool
-  # (as teardown would do) before the case's own spawn reuses the same
-  # physical worktree - otherwise the reused path would still be a live
-  # collision by fm-spawn's own record-based guard.
-  rm -f "$HOME_DIR/state/$id.meta"
+  # The seed task's .meta is deliberately left in place, still naming
+  # $POOL_DIR: real teardown returns a Treehouse slot to the pool well before
+  # it removes the task's .meta record. The fake tmux here never reports the
+  # seed task's window as present, so fm-spawn's collision guard reads its
+  # recorded endpoint as dead and does not block the case's own spawn from
+  # reusing the same physical worktree.
 }
 
 test_stale_submodule_pin_explains_itself() {

--- a/tests/fm-spawn-pool-base-freshen.test.sh
+++ b/tests/fm-spawn-pool-base-freshen.test.sh
@@ -183,6 +183,12 @@ test_stale_pool_base_refreshes_before_branching() {
       "$branch_head" "$current" "$(cat "$POOL_DIR/advanced-main.txt")"
   fi
 
+  # Simulate the first task's slot having been genuinely returned to the pool
+  # (as teardown would do) before this second task reuses the same physical
+  # worktree - otherwise the reused path would still be a live collision by
+  # fm-spawn's own record-based guard, not the idempotent-refresh case this
+  # test means to exercise.
+  rm -f "$HOME_DIR/state/pool-current-base-r1.meta"
   id='pool-current-base-repeat-r1'
   fm_test_spawn_brief "$HOME_DIR" "$id"
   out=$(run_spawn "$id" --mode no-mistakes --yolo off)
@@ -528,6 +534,11 @@ strand_submodule_pin_via_spawn() {  # <seed-id>
     || fail "the first spawn did not move the pooled base across the moved submodule pin"
   [ "$(git -C "$POOL_DIR/ui" rev-parse HEAD)" = "$SUBPIN1" ] \
     || fail "the first spawn did not strand the submodule on the pin the old base recorded"
+  # Simulate this seed task's slot having been genuinely returned to the pool
+  # (as teardown would do) before the case's own spawn reuses the same
+  # physical worktree - otherwise the reused path would still be a live
+  # collision by fm-spawn's own record-based guard.
+  rm -f "$HOME_DIR/state/$id.meta"
 }
 
 test_stale_submodule_pin_explains_itself() {

--- a/tests/fm-spawn-treehouse-slot-collision.test.sh
+++ b/tests/fm-spawn-treehouse-slot-collision.test.sh
@@ -1,0 +1,173 @@
+#!/usr/bin/env bash
+# Regression test for fm-spawn.sh's post-acquisition Treehouse slot-collision
+# guard (bin/fm-spawn.sh, spawn_worktree_claimed_elsewhere and the retry loop
+# around `treehouse get`).
+#
+# Reproduced live: rapid-fire fm-spawn.sh calls against the same Treehouse pool
+# handed two different tasks the identical worktree path, because Treehouse's
+# own pool-state liveness tracking loses track of a slot once the interactive
+# agent replaces the short-lived intermediate shell that `treehouse get`
+# originally opened. Firstmate cannot fix Treehouse's own bookkeeping, so
+# fm-spawn.sh verifies independently: after every `treehouse get`, it greps
+# every OTHER task's state/*.meta for the same worktree=, and on a match
+# returns the colliding slot and retries acquisition (bounded, then fails
+# loudly) rather than proceeding to launch onto a worktree another live task
+# may already own.
+#
+# This test fakes both tmux (to control what pane_current_path reports after
+# each `treehouse get`) and treehouse itself (to observe and succeed the
+# `return --force` call the guard issues on a detected collision).
+set -u
+
+# shellcheck source=tests/fixtures.sh
+. "$(dirname "${BASH_SOURCE[0]}")/fixtures.sh"
+
+SPAWN="$ROOT/bin/fm-spawn.sh"
+TMP_ROOT=$(fm_test_tmproot fm-spawn-treehouse-slot-collision)
+
+# make_collision_fakebin <dir> <return-log> builds a fake tmux whose
+# `#{pane_current_path}` query reports FM_FAKE_PANE_WT1 after the first
+# `treehouse get` is sent and FM_FAKE_PANE_WT2 after every `get` sent after
+# that - one worktree per acquisition attempt, not per pane read - plus a fake
+# treehouse that exits 0 and appends every `return` invocation's arguments to
+# <return-log>.
+make_collision_fakebin() {
+  local dir=$1 return_log=$2 fakebin
+  fakebin=$(fm_fakebin "$dir")
+  cat > "$fakebin/tmux" <<SH
+#!/usr/bin/env bash
+set -u
+case "\$*" in
+  *"treehouse get"*)
+    n=0
+    [ -f "\${FM_FAKE_GET_COUNTFILE:?unset}" ] && n=\$(cat "\$FM_FAKE_GET_COUNTFILE")
+    n=\$((n + 1))
+    printf '%s\n' "\$n" > "\$FM_FAKE_GET_COUNTFILE"
+    exit 0
+    ;;
+esac
+case "\$*" in
+  *"#{pane_current_path}"*)
+    n=0
+    [ -f "\${FM_FAKE_GET_COUNTFILE:?unset}" ] && n=\$(cat "\$FM_FAKE_GET_COUNTFILE")
+    if [ "\$n" -le 1 ]; then
+      printf '%s\n' "\${FM_FAKE_PANE_WT1:?unset}"
+    else
+      printf '%s\n' "\${FM_FAKE_PANE_WT2:?unset}"
+    fi
+    exit 0
+    ;;
+esac
+case "\${1:-}" in
+  display-message) printf 'firstmate\n'; exit 0 ;;
+  list-windows) exit 0 ;;
+  has-session|new-session|new-window|kill-window|send-keys) exit 0 ;;
+esac
+exit 0
+SH
+  chmod +x "$fakebin/tmux"
+  cat > "$fakebin/treehouse" <<SH
+#!/usr/bin/env bash
+if [ "\${1:-}" = return ]; then
+  printf '%s\n' "\$*" >> "$return_log"
+fi
+exit 0
+SH
+  chmod +x "$fakebin/treehouse"
+  printf '%s\n' "$fakebin"
+}
+
+# make_collision_case <name> <id>: a home, a project with two real, isolated
+# worktrees (WT1 the slot Treehouse will collide on, WT2 the clean slot a
+# retry lands on), and an unrelated other task's state/<id>.meta already
+# recording WT1 as its own worktree - simulating the live incident's second
+# task landing on a slot the first task's record already claims.
+make_collision_case() {
+  local name=$1 id=$2 case_dir home proj wt1 wt2 return_log countfile fakebin
+  case_dir="$TMP_ROOT/$name"
+  home="$case_dir/home"
+  proj="$case_dir/project"
+  wt1="$case_dir/wt1"
+  wt2="$case_dir/wt2"
+  return_log="$case_dir/treehouse-return.log"
+  countfile="$case_dir/get-call-count"
+  mkdir -p "$case_dir"
+  : > "$return_log"
+  fakebin=$(make_collision_fakebin "$case_dir/fake" "$return_log")
+  fm_test_spawn_home "$home" codex
+  fm_git_worktree "$proj" "$wt1" "wt1-$name"
+  git -C "$proj" worktree add --quiet -b "wt2-$name" "$wt2"
+  fm_test_spawn_brief "$home" "$id" "Exercise the Treehouse slot-collision guard for $id."
+  fm_write_meta "$home/state/other-holder-$name.meta" "worktree=$wt1"
+  printf '%s\n' "$case_dir|$home|$proj|$wt1|$wt2|$fakebin|$countfile|$return_log|other-holder-$name"
+}
+
+read_collision_record() {
+  IFS='|' read -r _ HOME_DIR PROJ_DIR WT1_DIR WT2_DIR FAKEBIN_DIR COUNTFILE RETURN_LOG HOLDER_ID <<EOF
+$1
+EOF
+}
+
+run_collision_spawn() {
+  local id=$1
+  FM_ROOT_OVERRIDE='' FM_HOME="$HOME_DIR" \
+    FM_STATE_OVERRIDE="$HOME_DIR/state" FM_DATA_OVERRIDE="$HOME_DIR/data" \
+    FM_PROJECTS_OVERRIDE="$HOME_DIR/projects" FM_CONFIG_OVERRIDE="$HOME_DIR/config" \
+    FM_SPAWN_NO_GUARD=1 TMUX="fake,1,0" \
+    FM_FAKE_PANE_WT1="$WT1_DIR" FM_FAKE_PANE_WT2="$WT2_DIR" \
+    FM_FAKE_GET_COUNTFILE="$COUNTFILE" \
+    PATH="$FAKEBIN_DIR:$PATH" \
+    "$SPAWN" "$id" "$PROJ_DIR" --mode no-mistakes --yolo off 2>&1
+}
+
+# A collision on the first acquired slot is returned and retried; the spawn
+# lands on the clean second slot and the colliding one is never recorded.
+test_collision_is_returned_and_retried_onto_a_clean_slot() {
+  local rec id out status
+  id=collision-recovers-z1
+  rec=$(make_collision_case collision-recovers "$id")
+  read_collision_record "$rec"
+
+  out=$(run_collision_spawn "$id")
+  status=$?
+  expect_code 0 "$status" "spawn should succeed once a retry lands on an unclaimed slot"$'\n'"$out"
+  assert_contains "$out" "spawned $id" "spawn did not report success"
+  assert_contains "$out" "$HOLDER_ID" "the collision warning did not name the task already holding the slot"
+  assert_grep "worktree=$WT2_DIR" "$HOME_DIR/state/$id.meta" \
+    "meta did not record the clean second slot"
+  assert_no_grep "worktree=$WT1_DIR" "$HOME_DIR/state/$id.meta" \
+    "meta wrongly recorded the slot task $HOLDER_ID already owns"
+  assert_grep "return" "$RETURN_LOG" "the colliding slot was never returned to the pool"
+  assert_grep "--force" "$RETURN_LOG" "the colliding slot was not force-returned"
+  assert_grep "$WT1_DIR" "$RETURN_LOG" "the return call did not name the colliding worktree"
+  [ "$(wc -l < "$RETURN_LOG")" -eq 1 ] || fail "expected exactly one treehouse return call, got $(wc -l < "$RETURN_LOG")"
+  pass "a detected slot collision is returned and retried onto a clean slot, never recording the collided path"
+}
+
+# A pane stuck handing back the same claimed slot on every attempt exhausts
+# the bounded retry budget and fails loudly instead of launching onto a
+# worktree another live task's record already claims.
+test_persistent_collision_fails_loudly_after_retries_exhausted() {
+  local rec id out status
+  id=collision-persists-z2
+  rec=$(make_collision_case collision-persists "$id")
+  read_collision_record "$rec"
+  # Force every attempt to land on WT1 by keeping WT2 identical to WT1, so the
+  # collision guard can never see a clean slot regardless of attempt count.
+  WT2_DIR=$WT1_DIR
+
+  out=$(FM_TREEHOUSE_SLOT_COLLISION_RETRIES=2 run_collision_spawn "$id")
+  status=$?
+  [ "$status" -ne 0 ] || fail "spawn succeeded despite every attempt colliding with task $HOLDER_ID's slot"$'\n'"$out"
+  assert_contains "$out" "repeatedly handed" "the failure did not explain the retry budget was exhausted"
+  assert_contains "$out" "$HOLDER_ID" "the failure did not name the task holding the colliding slot"
+  assert_contains "$out" "2" "the failure did not cite the configured retry budget"
+  [ "$(wc -l < "$RETURN_LOG")" -eq 2 ] || fail "expected exactly 2 treehouse return calls (one per exhausted retry), got $(wc -l < "$RETURN_LOG")"
+  [ ! -e "$HOME_DIR/state/$id.meta" ] || fail "a spawn that never resolved the collision published task metadata"
+  pass "a persistent slot collision exhausts the retry budget and fails loudly without publishing metadata"
+}
+
+test_collision_is_returned_and_retried_onto_a_clean_slot
+test_persistent_collision_fails_loudly_after_retries_exhausted
+
+echo "# all fm-spawn-treehouse-slot-collision tests passed"

--- a/tests/fm-spawn-treehouse-slot-collision.test.sh
+++ b/tests/fm-spawn-treehouse-slot-collision.test.sh
@@ -9,14 +9,14 @@
 # agent replaces the short-lived intermediate shell that `treehouse get`
 # originally opened. Firstmate cannot fix Treehouse's own bookkeeping, so
 # fm-spawn.sh verifies independently: after every `treehouse get`, it greps
-# every OTHER task's state/*.meta for the same worktree=, and on a match
-# returns the colliding slot and retries acquisition (bounded, then fails
-# loudly) rather than proceeding to launch onto a worktree another live task
-# may already own.
+# every OTHER task's state/*.meta for the same worktree=, and on a match whose
+# recorded endpoint is not confirmed dead, returns the colliding slot and
+# retries acquisition (bounded, then fails loudly) rather than proceeding to
+# launch onto a worktree another live task may already own.
 #
-# This test fakes both tmux (to control what pane_current_path reports after
-# each `treehouse get`) and treehouse itself (to observe and succeed the
-# `return --force` call the guard issues on a detected collision).
+# This test fakes both tmux (to control what pane_current_path reports across
+# `treehouse get` and 'exit' sends) and treehouse itself (to observe and
+# succeed the `return --force` call the guard issues on a detected collision).
 set -u
 
 # shellcheck source=tests/fixtures.sh
@@ -25,12 +25,19 @@ set -u
 SPAWN="$ROOT/bin/fm-spawn.sh"
 TMP_ROOT=$(fm_test_tmproot fm-spawn-treehouse-slot-collision)
 
-# make_collision_fakebin <dir> <return-log> builds a fake tmux whose
-# `#{pane_current_path}` query reports FM_FAKE_PANE_WT1 after the first
-# `treehouse get` is sent and FM_FAKE_PANE_WT2 after every `get` sent after
-# that - one worktree per acquisition attempt, not per pane read - plus a fake
-# treehouse that exits 0 and appends every `return` invocation's arguments to
-# <return-log>.
+# make_collision_fakebin <dir> <return-log> builds a fake tmux that tracks
+# which foreground subshell currently occupies the pane via a phase file
+# (FM_FAKE_PHASE_FILE): the first `treehouse get` moves the phase to "wt1"
+# (pane reports FM_FAKE_PANE_WT1); a literal 'exit' send - the only way any
+# call site leaves the subshell `treehouse get` opens - moves it back to
+# "project" (pane reports FM_FAKE_PANE_PROJ); a `treehouse get` sent while the
+# phase is "project" moves it to "wt2" (pane reports FM_FAKE_PANE_WT2). A
+# `treehouse get` sent WITHOUT an intervening 'exit' (i.e. while already past
+# "wt1") stays on "wt1", modeling a second `get` typed into the still-open
+# first subshell rather than a clean acquisition. Every `treehouse get` and
+# every literal 'exit' send is appended, in order, to FM_FAKE_SEND_LOG when
+# set. The fake treehouse exits 0 and appends every `return` invocation's
+# arguments to <return-log>.
 make_collision_fakebin() {
   local dir=$1 return_log=$2 fakebin
   fakebin=$(fm_fakebin "$dir")
@@ -39,22 +46,31 @@ make_collision_fakebin() {
 set -u
 case "\$*" in
   *"treehouse get"*)
-    n=0
-    [ -f "\${FM_FAKE_GET_COUNTFILE:?unset}" ] && n=\$(cat "\$FM_FAKE_GET_COUNTFILE")
-    n=\$((n + 1))
-    printf '%s\n' "\$n" > "\$FM_FAKE_GET_COUNTFILE"
+    printf 'get\n' >> "\${FM_FAKE_SEND_LOG:-/dev/null}"
+    phase=start
+    [ -f "\${FM_FAKE_PHASE_FILE:?unset}" ] && phase=\$(cat "\$FM_FAKE_PHASE_FILE")
+    if [ "\$phase" = project ]; then
+      printf 'wt2\n' > "\$FM_FAKE_PHASE_FILE"
+    else
+      printf 'wt1\n' > "\$FM_FAKE_PHASE_FILE"
+    fi
+    exit 0
+    ;;
+  *"send-keys"*"exit Enter"*)
+    printf 'exit\n' >> "\${FM_FAKE_SEND_LOG:-/dev/null}"
+    printf 'project\n' > "\${FM_FAKE_PHASE_FILE:?unset}"
     exit 0
     ;;
 esac
 case "\$*" in
   *"#{pane_current_path}"*)
-    n=0
-    [ -f "\${FM_FAKE_GET_COUNTFILE:?unset}" ] && n=\$(cat "\$FM_FAKE_GET_COUNTFILE")
-    if [ "\$n" -le 1 ]; then
-      printf '%s\n' "\${FM_FAKE_PANE_WT1:?unset}"
-    else
-      printf '%s\n' "\${FM_FAKE_PANE_WT2:?unset}"
-    fi
+    phase=project
+    [ -f "\${FM_FAKE_PHASE_FILE:?unset}" ] && phase=\$(cat "\$FM_FAKE_PHASE_FILE")
+    case "\$phase" in
+      wt1) printf '%s\n' "\${FM_FAKE_PANE_WT1:?unset}" ;;
+      wt2) printf '%s\n' "\${FM_FAKE_PANE_WT2:?unset}" ;;
+      *) printf '%s\n' "\${FM_FAKE_PANE_PROJ:?unset}" ;;
+    esac
     exit 0
     ;;
 esac
@@ -83,14 +99,14 @@ SH
 # recording WT1 as its own worktree - simulating the live incident's second
 # task landing on a slot the first task's record already claims.
 make_collision_case() {
-  local name=$1 id=$2 case_dir home proj wt1 wt2 return_log countfile fakebin
+  local name=$1 id=$2 case_dir home proj wt1 wt2 return_log phase_file fakebin
   case_dir="$TMP_ROOT/$name"
   home="$case_dir/home"
   proj="$case_dir/project"
   wt1="$case_dir/wt1"
   wt2="$case_dir/wt2"
   return_log="$case_dir/treehouse-return.log"
-  countfile="$case_dir/get-call-count"
+  phase_file="$case_dir/phase"
   mkdir -p "$case_dir"
   : > "$return_log"
   fakebin=$(make_collision_fakebin "$case_dir/fake" "$return_log")
@@ -99,11 +115,11 @@ make_collision_case() {
   git -C "$proj" worktree add --quiet -b "wt2-$name" "$wt2"
   fm_test_spawn_brief "$home" "$id" "Exercise the Treehouse slot-collision guard for $id."
   fm_write_meta "$home/state/other-holder-$name.meta" "worktree=$wt1"
-  printf '%s\n' "$case_dir|$home|$proj|$wt1|$wt2|$fakebin|$countfile|$return_log|other-holder-$name"
+  printf '%s\n' "$case_dir|$home|$proj|$wt1|$wt2|$fakebin|$phase_file|$return_log|other-holder-$name"
 }
 
 read_collision_record() {
-  IFS='|' read -r _ HOME_DIR PROJ_DIR WT1_DIR WT2_DIR FAKEBIN_DIR COUNTFILE RETURN_LOG HOLDER_ID <<EOF
+  IFS='|' read -r _ HOME_DIR PROJ_DIR WT1_DIR WT2_DIR FAKEBIN_DIR PHASE_FILE RETURN_LOG HOLDER_ID <<EOF
 $1
 EOF
 }
@@ -114,8 +130,8 @@ run_collision_spawn() {
     FM_STATE_OVERRIDE="$HOME_DIR/state" FM_DATA_OVERRIDE="$HOME_DIR/data" \
     FM_PROJECTS_OVERRIDE="$HOME_DIR/projects" FM_CONFIG_OVERRIDE="$HOME_DIR/config" \
     FM_SPAWN_NO_GUARD=1 TMUX="fake,1,0" \
-    FM_FAKE_PANE_WT1="$WT1_DIR" FM_FAKE_PANE_WT2="$WT2_DIR" \
-    FM_FAKE_GET_COUNTFILE="$COUNTFILE" \
+    FM_FAKE_PANE_WT1="$WT1_DIR" FM_FAKE_PANE_WT2="$WT2_DIR" FM_FAKE_PANE_PROJ="$PROJ_DIR" \
+    FM_FAKE_PHASE_FILE="$PHASE_FILE" FM_FAKE_SEND_LOG="${FM_FAKE_SEND_LOG:-/dev/null}" \
     PATH="$FAKEBIN_DIR:$PATH" \
     "$SPAWN" "$id" "$PROJ_DIR" --mode no-mistakes --yolo off 2>&1
 }
@@ -167,7 +183,70 @@ test_persistent_collision_fails_loudly_after_retries_exhausted() {
   pass "a persistent slot collision exhausts the retry budget and fails loudly without publishing metadata"
 }
 
+# A torn-down task's state/<id>.meta can still name a worktree well after its
+# Treehouse slot was genuinely returned to the pool: fm-teardown.sh returns the
+# slot long before it removes the .meta record, and several of its steps
+# deliberately retain that record on failure so a rerun can retry delivery.
+# That is a stale record, not a live collision, and must not block or retry a
+# new spawn reusing the same physical worktree.
+test_stale_meta_of_a_returned_slot_does_not_block_reuse() {
+  local rec id out status
+  id=stale-meta-reuse-z3
+  rec=$(make_collision_case stale-meta-reuse "$id")
+  read_collision_record "$rec"
+  # Overwrite the holder's record with a real endpoint the fake tmux never
+  # reports as present (list-windows never lists it) - exactly what a
+  # genuinely torn-down task's retained .meta looks like: a dead endpoint, not
+  # a live owner.
+  fm_write_meta "$HOME_DIR/state/$HOLDER_ID.meta" "worktree=$WT1_DIR" "window=firstmate:@stale-holder"
+
+  out=$(run_collision_spawn "$id")
+  status=$?
+  expect_code 0 "$status" \
+    "spawn should reuse a worktree whose only claimant record has a confirmed-dead endpoint"$'\n'"$out"
+  assert_contains "$out" "spawned $id" "spawn did not report success"
+  assert_not_contains "$out" "already recorded by task" \
+    "a confirmed-dead stale record was wrongly treated as a live collision"
+  assert_grep "worktree=$WT1_DIR" "$HOME_DIR/state/$id.meta" \
+    "spawn did not reuse the worktree the dead endpoint's stale record names"
+  [ ! -s "$RETURN_LOG" ] || fail "a non-colliding stale record still triggered a treehouse return"
+  pass "a torn-down task's stale-but-present meta record does not block or retry reuse of its worktree"
+}
+
+# On a detected collision, the retry must return the pane to its project
+# directory (exiting the first `treehouse get`'s foreground subshell) before
+# resending `treehouse get`, not type a second `treehouse get` straight into
+# the pane left inside the first subshell - the fake tmux's phase model only
+# advances from "wt1" to "wt2" across an intervening 'exit' send, so a retry
+# that skipped the exit would keep landing on WT1 and this test would time out
+# the same way it did before the fix.
+test_retry_returns_pane_to_project_before_resending_get() {
+  local rec id out status send_log
+  id=exit-order-z4
+  rec=$(make_collision_case exit-order "$id")
+  read_collision_record "$rec"
+
+  send_log="${PHASE_FILE%/phase}/send.log"
+  : > "$send_log"
+  out=$(FM_FAKE_SEND_LOG="$send_log" run_collision_spawn "$id")
+  status=$?
+  expect_code 0 "$status" "spawn should succeed once the retry lands on the clean slot"$'\n'"$out"
+  assert_contains "$out" "spawned $id" "spawn did not report success"
+  assert_grep "worktree=$WT2_DIR" "$HOME_DIR/state/$id.meta" "meta did not record the clean second slot"
+
+  [ -s "$send_log" ] || fail "no tmux sends were recorded"
+  # Exactly: first `treehouse get`, then the retry's 'exit', then the second
+  # `treehouse get` - proving the pane is returned to the project directory
+  # before it is resent, not typed into the still-open first subshell.
+  expected=$'get\nexit\nget'
+  actual=$(cat "$send_log")
+  [ "$actual" = "$expected" ] || fail "unexpected send order: got '$actual', want '$expected'"
+  pass "a collision retry exits the pane's subshell before resending treehouse get"
+}
+
 test_collision_is_returned_and_retried_onto_a_clean_slot
 test_persistent_collision_fails_loudly_after_retries_exhausted
+test_stale_meta_of_a_returned_slot_does_not_block_reuse
+test_retry_returns_pane_to_project_before_resending_get
 
 echo "# all fm-spawn-treehouse-slot-collision tests passed"


### PR DESCRIPTION
## Intent

Fix a real, reproduced race in fm-spawn.sh: rapid-fire spawns against the same Treehouse pool can receive the identical worktree path (confirmed 3 times via each task's state/<id>.meta worktree= field), because Treehouse's own pool-slot liveness tracking (owner_pid/owner_started_at) does not reliably reflect a slot as occupied once fm-spawn hands the pane to the long-lived interactive agent (the tracked owner_pid may belong to a short-lived intermediate shell that already exited). A second task's git checkout -b then silently switches the shared directory's branch out from under the first task's still-running agent - a live risk of cross-task work corruption. Decided approach (not a lock-file design): fm-spawn.sh itself verifies and retries on a post-spawn collision, independent of Treehouse's own internal liveness tracking. After Treehouse hands back a worktree path, it greps every other live task's state/*.meta worktree= field for that same path; on a collision it releases/rejects the just-acquired slot (treehouse return --force) and retries acquisition, bounded by FM_TREEHOUSE_SLOT_COLLISION_RETRIES (default 3), then fails loudly rather than proceeding to git checkout -b on a path another task may already own. Added a regression test (tests/fm-spawn-treehouse-slot-collision.test.sh) that fakes tmux and treehouse to reproduce both the recovered-collision and exhausted-retries-fails-loudly cases, and adjusted two pre-existing fm-spawn-pool-base-freshen.test.sh cases whose slot reuse would otherwise now be flagged as a live collision by this new guard. Separately investigated, lower priority and left unresolved: projects/MemberOS/.git had core.bare flipped to true on 2026-09-07 around session bootstrap time despite having a full working-tree checkout, breaking treehouse get until manually corrected; grepped bin/*.sh for any core.bare-setting logic and found none, so the root cause remains unknown - flagging as a still-open, not-fixed item rather than spending further time on it.

## What Changed

- Added `spawn_worktree_claimed_elsewhere()` to `bin/fm-spawn.sh`, which after each `treehouse get` greps every other live task's `state/<id>.meta` for the same `worktree=` path and uses the existing `fm_backend_agent_alive` classifier to distinguish a genuinely live collision from a stale record left behind by teardown (which returns a slot to the pool before removing its meta file).
- On a detected live collision, the acquisition loop now returns the colliding slot with `treehouse return --force`, exits the pane's `treehouse get` subshell back to the project directory, and retries acquisition up to `FM_TREEHOUSE_SLOT_COLLISION_RETRIES` (default 3) attempts before failing loudly instead of proceeding to `git checkout -b` on a possibly double-owned worktree.
- Documented `FM_TREEHOUSE_SLOT_COLLISION_RETRIES` in `docs/configuration.md`, added `tests/fm-spawn-treehouse-slot-collision.test.sh` covering both the recovered-collision and exhausted-retries-fails-loudly cases with faked `tmux`/`treehouse`, and adjusted two existing scenarios in `tests/fm-spawn-pool-base-freshen.test.sh` whose legitimate slot reuse would otherwise now be flagged as a live collision by the new guard.

## Risk Assessment

✅ Low: The fix round adds a positive liveness check (fm_backend_agent_alive, reusing the same classifier already trusted by fm-crew-state.sh and fm-spawn's own duplicate-launch guard) to spawn_worktree_claimed_elsewhere so a stale-but-present .meta from a genuinely torn-down task no longer blocks legitimate worktree reuse, and it makes the collision retry exit the pane's existing treehouse-get subshell (and verifies it settled back at $PROJ_ABS_REAL) before resending 'treehouse get', closing the nested-subshell resend risk. Both changes are narrowly scoped to the collision guard and retry loop as instructed, traced through the code against concrete failure sequences (dead/missing endpoint vs. live/unknown endpoint; pane still in a nested subshell vs. returned to project root), and are backed by new regression tests that exercise the real spawn path and assert observable behavior (meta contents, return-log emptiness, and the exact tmux send order) rather than matching source text.

## Testing

Ran the two smallest relevant test files (fm-spawn-treehouse-slot-collision.test.sh and fm-spawn-pool-base-freshen.test.sh) against the target commit: all pass, including the two new regression tests added specifically for the two review-round-1 decisions (liveness-based collision check instead of mere meta-presence, and exiting the pane's subshell before resending `treehouse get`). To confirm these weren't tautological, I temporarily reverted bin/fm-spawn.sh to the pre-review-fix commit (06b3479) and reran the collision test suite — it failed as expected, then restored the target file (working tree is clean, no diff). This is scripted, deterministic shell-level testing that exercises fm-spawn.sh's actual collision-guard logic via faked tmux/treehouse binaries, directly demonstrating the fixed behavior described in the user intent; no further manual or UI verification is applicable since this is a CLI/bash orchestration script with no user-facing rendered surface.

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"ffbfa9b0cf506cbb4b0987ebcb3074b72e8a7abd","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>🔧 **Review** - 2 issues found → auto-fixed ✅</summary>

- ⚠️ `bin/fm-spawn.sh:2370` - spawn_worktree_claimed_elsewhere() treats the mere presence of another task&#39;s state/&lt;id&gt;.meta naming the same worktree= as proof that a live task owns it, but fm-teardown.sh returns the Treehouse slot to the pool (teardown_treehouse_return, bin/fm-teardown.sh:3223-3226) well before it removes that task&#39;s .meta record (the final fm_backlog_atomic_transition remove / rm -f state/$ID.meta happen ~130 lines later, bin/fm-teardown.sh:3359+). Several steps in between are explicitly designed to fail and *retain* the durable record for a later retry (e.g. &#39;retaining every durable task record so a rerun can retry the delivery&#39; at the inactive-reconcile check, and the herdr endpoint-confirmation check) - i.e. a worktree can be legitimately back in the pool, available for reuse, while its former owner&#39;s meta still names it, for an indefinite, by-design window (not just a crash). A new spawn that acquires that now-free slot will hit spawn_worktree_claimed_elsewhere&#39;s guard, treat it as a foreign collision, force-return the slot it legitimately just got, and retry - degrading to spurious warnings in larger pools, or exhausting FM_TREEHOUSE_SLOT_COLLISION_RETRIES and failing the spawn outright in a small pool, even though nothing is actually double-owned. The two adjusted tests in fm-spawn-pool-base-freshen.test.sh paper over exactly this by manually `rm -f`&#39;ing the prior task&#39;s .meta to simulate &#39;as teardown would do&#39; - but real teardown does not delete it atomically with the treehouse return; it can (by design) leave it behind for a retryable window. The guard has no liveness check (the codebase already has fm_pid_alive and per-backend pane/session liveness helpers used elsewhere for exactly this kind of stale-record problem) to distinguish a truly-live owner from a retained-for-retry record of an already-returned slot.
- ⚠️ `bin/fm-spawn.sh:3071` - On a detected collision, the retry loop resends the literal text &#39;treehouse get&#39; to the same pane (spawn_send_text_line &#34;$WT_TARGET&#34; &#39;treehouse get&#39;) without first returning that pane to its top-level shell. Per this codebase&#39;s own documentation (docs/cmux-backend.md:90, docs/zellij-backend.md:69, bin/backends/herdr.sh:2528-2532, bin/backends/cmux.sh:39), &#39;treehouse get&#39; works by opening a foreground subshell in the pane&#39;s current shell - every other call site in the codebase invokes it exactly once, from the pane&#39;s original top-level shell at $PROJ_ABS. After a collision, the pane&#39;s foreground process is still the subshell the FIRST &#39;treehouse get&#39; opened, sitting in the colliding worktree - the external `treehouse return --force` call runs in an unrelated subprocess ( cd &#34;$PROJ_ABS&#34; &amp;&amp; ... ) and has no effect on that pane. Resending &#39;treehouse get&#39; therefore runs the command a second time from inside an already-open worktree subshell rather than from the clean project-root shell every other caller assumes, which is untested against the real treehouse binary (the new regression test fakes both tmux&#39;s pane_current_path and treehouse itself, so it never exercises whether a real, nested second invocation behaves the same as a first one from $PROJ_ABS).

🔧 Fix: Fix collision guard false positives and exit stale subshell before retry
✅ Re-checked - no issues remain.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`bash tests/fm-spawn-treehouse-slot-collision.test.sh` against target commit 3a967b2 — all 4 tests pass, including the two new regression tests (test_stale_meta_of_a_returned_slot_does_not_block_reuse, test_retry_returns_pane_to_project_before_resending_get)</code>
- <code>`bash tests/fm-spawn-pool-base-freshen.test.sh` against target commit 3a967b2 — all cases pass, including the two adjusted cases whose .meta is now deliberately left in place (relying on the new liveness check) instead of being manually rm -f&#39;d</code>
- `Manually swapped bin/fm-spawn.sh to the pre-review-fix content (git show 06b3479:bin/fm-spawn.sh) and reran tests/fm-spawn-treehouse-slot-collision.test.sh — confirmed it fails (missing liveness/exit-before-retry logic causes the collision guard to misbehave against the new fake-tmux subshell model), proving the new tests are genuine regressions tied to the fix, not vacuous. Restored bin/fm-spawn.sh to the target commit's content afterward (git diff clean).`
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
