### PR TITLE
fix(bin): treat missing endpoints as agent-free in exit and relaunch

### DIFF
--- a/bin/fm-control.sh
+++ b/bin/fm-control.sh
@@ -451,12 +451,11 @@ do_exit() {
   require_state_verified_backend exit
   state=$(agent_state)
   case "$state" in
-    dead)
+    dead|missing)
       printf 'already-stopped'
       return 0
       ;;
     alive) ;;
-    missing) die "task $ID's recorded endpoint is gone, so there is no agent to stop; reconcile the task before any further control action" ;;
     *) die "task $ID's endpoint reads '$state' rather than a positively classified state; refusing to send a lifecycle command into an unattributed endpoint" ;;
   esac
   # A busy agent is interrupted first before the exit command is submitted.

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -1274,10 +1274,13 @@ if [ "$RELAUNCH" -eq 1 ]; then
     exit 1
   }
   RELAUNCH_STATE=$(fm_backend_agent_state "$BACKEND" "$RELAUNCH_TARGET")
-  [ "$RELAUNCH_STATE" = dead ] || {
-    echo "error: task $ID's endpoint reads '$RELAUNCH_STATE'; a relaunch requires a positively agent-free endpoint (stop the agent first with bin/fm-control.sh $ID exit)" >&2
-    exit 1
-  }
+  case "$RELAUNCH_STATE" in
+    dead|missing) ;;
+    *)
+      echo "error: task $ID's endpoint reads '$RELAUNCH_STATE'; a relaunch requires a positively agent-free endpoint (stop the agent first with bin/fm-control.sh $ID exit)" >&2
+      exit 1
+      ;;
+  esac
   RELAUNCH_PRIOR_HARNESS=$(fm_meta_get "$RELAUNCH_META" harness)
   KIND=$(fm_meta_get "$RELAUNCH_META" kind)
   [ -n "$KIND" ] || KIND=ship

--- a/tests/fm-control-relaunch.test.sh
+++ b/tests/fm-control-relaunch.test.sh
@@ -16,7 +16,8 @@
 #      reports the concrete state, and preserves the work.
 #   6. fm-spawn --relaunch refuses on its own: a live agent, a contradicting
 #      flag, an extra positional, or a backend that cannot prove the previous
-#      agent exited.
+#      agent exited. A dead or a vanished (missing) endpoint are equally
+#      agent-free and both license the relaunch.
 set -u
 
 # shellcheck source=tests/lib.sh
@@ -322,6 +323,19 @@ test_same_harness_relaunch_keeps_identity_and_reuses_the_endpoint() {
   assert_grep "/exit" "$dir/fake/literal" "the previous agent should have been exited"
   assert_grep "encode launch-brief" "$dir/fake/literal" "the replacement should have been launched"
   pass "fm-control relaunch: a same-harness relaunch replaces the agent in the same endpoint and worktree"
+}
+
+test_relaunch_succeeds_from_a_missing_endpoint() {
+  local dir out rc
+  dir=$(new_case gone rl41)
+  add_ship_task "$dir" rl41 claude
+  : > "$dir/fake/windows"
+  out=$(run_control "$dir" rl41 relaunch --note "endpoint vanished, resuming"); rc=$?
+  expect_code 0 "$rc" "relaunching a task whose endpoint vanished should succeed"$'\n'"$out"
+  assert_contains "$out" "relaunched rl41 harness=claude from=claude" "the outcome should name the transition"
+  [ "$(journal_field "$dir" rl41 phase)" = complete ] \
+    || fail "the transaction journal should end complete"
+  pass "fm-control relaunch: a vanished endpoint is recovered exactly like a positively dead one"
 }
 
 test_relaunch_from_linked_home_preserves_recorded_worktree() {
@@ -1375,6 +1389,17 @@ test_spawn_relaunch_refuses_a_live_agent() {
   pass "fm-spawn --relaunch: refuses to launch a second agent into a live endpoint"
 }
 
+test_spawn_relaunch_succeeds_from_a_missing_endpoint() {
+  local dir out rc
+  dir=$(new_case gone-spawn rl40)
+  add_ship_task "$dir" rl40 claude
+  : > "$dir/fake/windows"
+  out=$(run_spawn "$dir" rl40 --relaunch --harness claude); rc=$?
+  expect_code 0 "$rc" "relaunching from a vanished endpoint should succeed"$'\n'"$out"
+  assert_contains "$out" "spawned rl40 harness=claude" "the launch should report the new agent"
+  pass "fm-spawn --relaunch: a vanished endpoint is as agent-free as a positively dead one"
+}
+
 test_spawn_relaunch_refuses_a_symlinked_task_record_before_inspection() {
   local dir meta target out rc
   dir=$(new_case symlink-meta rl37)
@@ -1533,6 +1558,7 @@ test_relaunch_moves_a_drifted_item_back_in_flight() {
 }
 
 test_same_harness_relaunch_keeps_identity_and_reuses_the_endpoint
+test_relaunch_succeeds_from_a_missing_endpoint
 test_relaunch_from_linked_home_preserves_recorded_worktree
 test_relaunch_preserves_durable_task_metadata
 test_relaunch_serializes_concurrent_durable_metadata_publication
@@ -1576,6 +1602,7 @@ test_concurrent_relaunch_is_refused
 test_direct_spawn_relaunch_participates_in_the_lifecycle_lock
 test_promotion_participates_in_the_lifecycle_lock_before_metadata_resolution
 test_spawn_relaunch_refuses_a_live_agent
+test_spawn_relaunch_succeeds_from_a_missing_endpoint
 test_spawn_relaunch_refuses_a_symlinked_task_record_before_inspection
 test_spawn_relaunch_keeps_its_early_meta_lock_continuous
 test_spawn_relaunch_refuses_a_pending_authoritative_close

--- a/tests/fm-control-relaunch.test.sh
+++ b/tests/fm-control-relaunch.test.sh
@@ -347,7 +347,9 @@ test_relaunch_reaches_the_launch_attempt_from_a_missing_endpoint() {
     "an unconfirmed replacement must still report where the work lives"
   [ "$(journal_field "$dir" rl41 phase)" = "failed:launching" ] \
     || fail "the transaction journal should record the launch phase, got '$(journal_field "$dir" rl41 phase)'"
-  assert_grep "/exit" "$dir/fake/literal" "the previous agent should have been exited"
+  # A vanished endpoint is already agent-free, so exit is idempotent and sends
+  # no bytes (test_missing_endpoint_exit_is_idempotent pins that directly);
+  # what proves the launch was actually attempted is the launch-brief literal.
   assert_grep "encode launch-brief" "$dir/fake/literal" "the replacement launch should have been attempted"
   pass "fm-control relaunch: a vanished endpoint reaches the launch attempt instead of the old dead-end refusal"
 }

--- a/tests/fm-control-relaunch.test.sh
+++ b/tests/fm-control-relaunch.test.sh
@@ -325,17 +325,31 @@ test_same_harness_relaunch_keeps_identity_and_reuses_the_endpoint() {
   pass "fm-control relaunch: a same-harness relaunch replaces the agent in the same endpoint and worktree"
 }
 
-test_relaunch_succeeds_from_a_missing_endpoint() {
+test_relaunch_reaches_the_launch_attempt_from_a_missing_endpoint() {
   local dir out rc
   dir=$(new_case gone rl41)
   add_ship_task "$dir" rl41 claude
   : > "$dir/fake/windows"
   out=$(run_control "$dir" rl41 relaunch --note "endpoint vanished, resuming"); rc=$?
-  expect_code 0 "$rc" "relaunching a task whose endpoint vanished should succeed"$'\n'"$out"
-  assert_contains "$out" "relaunched rl41 harness=claude from=claude" "the outcome should name the transition"
-  [ "$(journal_field "$dir" rl41 phase)" = complete ] \
-    || fail "the transaction journal should end complete"
-  pass "fm-control relaunch: a vanished endpoint is recovered exactly like a positively dead one"
+  # The fixture's fake tmux never repopulates its window list once emptied, so
+  # a launch into a target list-windows still reports absent cannot be
+  # confirmed alive here - that confirmation is the untouched postcondition
+  # this fix deliberately leaves alone. What this pins is the actual bug: the
+  # OLD code dead-ended at do_exit with "recorded endpoint is gone... reconcile
+  # the task" before ever attempting a launch. The fix must reach the launch
+  # attempt instead, landing on the pipeline's existing graceful outcome for
+  # an unconfirmed replacement rather than refusing outright.
+  assert_not_contains "$out" "recorded endpoint is gone" \
+    "a vanished endpoint must not hit the old dead-end refusal"
+  assert_contains "$out" "no running agent could be confirmed" \
+    "the relaunch should reach the launch attempt rather than refusing before it"
+  assert_contains "$out" "its work is preserved" \
+    "an unconfirmed replacement must still report where the work lives"
+  [ "$(journal_field "$dir" rl41 phase)" = "failed:launching" ] \
+    || fail "the transaction journal should record the launch phase, got '$(journal_field "$dir" rl41 phase)'"
+  assert_grep "/exit" "$dir/fake/literal" "the previous agent should have been exited"
+  assert_grep "encode launch-brief" "$dir/fake/literal" "the replacement launch should have been attempted"
+  pass "fm-control relaunch: a vanished endpoint reaches the launch attempt instead of the old dead-end refusal"
 }
 
 test_relaunch_from_linked_home_preserves_recorded_worktree() {
@@ -1558,7 +1572,7 @@ test_relaunch_moves_a_drifted_item_back_in_flight() {
 }
 
 test_same_harness_relaunch_keeps_identity_and_reuses_the_endpoint
-test_relaunch_succeeds_from_a_missing_endpoint
+test_relaunch_reaches_the_launch_attempt_from_a_missing_endpoint
 test_relaunch_from_linked_home_preserves_recorded_worktree
 test_relaunch_preserves_durable_task_metadata
 test_relaunch_serializes_concurrent_durable_metadata_publication

--- a/tests/fm-control.test.sh
+++ b/tests/fm-control.test.sh
@@ -13,7 +13,8 @@
 #      and a record bound to another task are all refused.
 #   4. Verb allowlist: no arbitrary text, no raw keys, no resume.
 #   5. Lifecycle states: busy interrupts first, idle does not, already-stopped
-#      is idempotent success, and an agent that does not stop fails closed.
+#      and a vanished endpoint are both idempotent exit success, and an agent
+#      that does not stop fails closed.
 #   6. Marker non-regression: a control command to a kind=secondmate task
 #      carries NO from-firstmate marker and opens no pending-reply expectation,
 #      while fm-send's marking of the same task is untouched.
@@ -634,15 +635,28 @@ test_already_stopped_exit_is_idempotent() {
   pass "fm-control exit: an already-stopped agent is idempotent success with no bytes sent"
 }
 
-test_missing_endpoint_refuses() {
+test_missing_endpoint_exit_is_idempotent() {
   local dir out rc
   dir=$(new_case gone)
   add_task "$dir" t1 claude
   : > "$dir/fake/windows"
   out=$(run_control "$dir" t1 exit); rc=$?
-  expect_code 1 "$rc" "a missing endpoint should refuse"
-  assert_contains "$out" "recorded endpoint is gone" "the refusal should name the missing endpoint"
-  pass "fm-control exit: a vanished endpoint refuses instead of silently succeeding"
+  expect_code 0 "$rc" "exiting a vanished endpoint should succeed"
+  assert_contains "$out" "already-stopped t1" "the outcome should say it was already stopped"
+  [ -z "$(literals "$dir")" ] || fail "a vanished endpoint must not be sent an exit command"
+  pass "fm-control exit: a vanished endpoint is idempotent success with no bytes sent"
+}
+
+test_missing_endpoint_interrupt_refuses() {
+  local dir out rc
+  dir=$(new_case gone-interrupt)
+  add_task "$dir" t1 claude
+  : > "$dir/fake/windows"
+  out=$(run_control "$dir" t1 interrupt); rc=$?
+  expect_code 1 "$rc" "interrupting a vanished endpoint should refuse"
+  assert_contains "$out" "nothing to interrupt" "the refusal should say there is no agent"
+  [ -z "$(keys_sent "$dir")" ] || fail "no key should reach a vanished endpoint"
+  pass "fm-control interrupt: a vanished endpoint still refuses rather than keying a shell"
 }
 
 test_interrupt_refuses_when_no_agent_runs() {
@@ -900,7 +914,8 @@ test_verb_allowlist_is_closed
 test_resume_is_refused_with_its_reason
 test_relaunch_only_flags_are_rejected_on_other_verbs
 test_already_stopped_exit_is_idempotent
-test_missing_endpoint_refuses
+test_missing_endpoint_exit_is_idempotent
+test_missing_endpoint_interrupt_refuses
 test_interrupt_refuses_when_no_agent_runs
 test_ambiguous_endpoint_refuses
 test_busy_agent_is_interrupted_before_the_exit_command


### PR DESCRIPTION
## Intent

Fix an asymmetry in firstmate's agent lifecycle control plane: bin/fm-spawn.sh's --relaunch gate and bin/fm-control.sh's do_exit() only treated a backend endpoint state of 'dead' as license to recover an agent, but refused a state of 'missing' (e.g. a closed pane), even though fm_backend_agent_state's contract says both dead and missing license recovery. This caused a real fleet-wide recovery blocker when session-lock outages left endpoints reading 'missing' and neither relaunch nor exit could recover them. Widen both gates to accept 'missing' alongside 'dead' (do_exit treats it as idempotent already-stopped, matching the existing dead-state behavior; the relaunch gate no longer refuses it), without weakening refusal for any other state (alive/unknown must keep refusing exactly as before). Add regression coverage for both verbs against a synthesized missing state.

## What Changed

- `bin/fm-control.sh`'s `do_exit()` now treats a `missing` endpoint the same as `dead`, returning idempotent `already-stopped` instead of dying with "recorded endpoint is gone... reconcile the task"; `alive` and unrecognized states still refuse exactly as before.
- `bin/fm-spawn.sh`'s `--relaunch` gate now accepts `RELAUNCH_STATE` of either `dead` or `missing` as agent-free (via a `case` instead of a single `[ = dead ]` check), so a relaunch against a vanished endpoint reaches the launch attempt instead of being refused.
- Added regression coverage: `tests/fm-control.test.sh` renames/splits the old `test_missing_endpoint_refuses` into `test_missing_endpoint_exit_is_idempotent` (asserts no bytes sent) and a new `test_missing_endpoint_interrupt_refuses` (interrupt still refuses on a missing endpoint); `tests/fm-control-relaunch.test.sh` adds `test_relaunch_reaches_the_launch_attempt_from_a_missing_endpoint` and `test_spawn_relaunch_succeeds_from_a_missing_endpoint`.

## Risk Assessment

✅ Low: The change is a narrow, symmetric widening of two state-check gates that exactly matches the documented fm_backend_agent_state contract (only dead and missing license recovery), leaves all other states' refusals untouched, and ships with direct regression tests for both verbs plus a confirming test that interrupt still refuses on missing.

## Testing

The do_exit and --relaunch missing-state gate widening matches the fm_backend_agent_state contract and the new regression tests for do_exit/interrupt against a synthesized missing endpoint passed in a full run of tests/fm-control.test.sh; the corresponding relaunch-side regression tests in tests/fm-control-relaunch.test.sh could not be confirmed to pass within the session, and an unrelated pre-existing muse-harness interrupt test failed in the same run but touches no code changed by this diff.

- Outcome: ⚠️ 2 issues (1 warning, 1 info) across 1 run (9m51s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"3fc6937c34e4cd0deb163c8567e759b2ca6f5355","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"skipped"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>⚠️ **Test** - 2 issues (1 warning, 1 info)</summary>

- ℹ️ tests/fm-control.test.sh:737 test_muse_interrupt_confirms_adapter_acknowledgement failed (&#39;not ok - the result should report muse&#39;s cancelled terminal acknowledgement&#39;, got cancel=unconfirmed instead of cancel=confirmed). This test exercises the muse harness&#39;s session-log cancellation-ack path, which this branch&#39;s diff does not touch at all (the diff only changes bin/fm-control.sh&#39;s do_exit state-gate case statement and bin/fm-spawn.sh&#39;s --relaunch state gate). It ran and failed both before and unrelated to the code under test, so it looks like a pre-existing environment-sensitive flake (session-log/workspace-root path matching) rather than a regression from this change. Root cause was not fully diagnosed given time constraints; flagging for awareness rather than as a blocker on this intent.
- ⚠️ tests/fm-control-relaunch.test.sh contains the other half of the required regression coverage for this intent (test_relaunch_reaches_the_launch_attempt_from_a_missing_endpoint and test_spawn_relaunch_succeeds_from_a_missing_endpoint, confirmed present via diff review), but a full run of that file did not finish within the available session time, so its pass/fail could not be automatically confirmed. Re-run `bash tests/fm-control-relaunch.test.sh` directly (this suite is slow under the Windows/cygwin bash environment) to get confirmed evidence for the fm-spawn.sh side of the fix.
- <code>`bash tests/fm-control.test.sh` (full run, completed) — confirmed &#39;ok&#39; for test_missing_endpoint_exit_is_idempotent and test_missing_endpoint_interrupt_refuses</code>
- `git diff 891dc51..3fc6937 -- bin/fm-control.sh bin/fm-spawn.sh (manual code review against the fm_backend_agent_state contract in bin/fm-backend.sh:878-901)`
- `git diff 891dc51..3fc6937 -- tests/fm-control.test.sh tests/fm-control-relaunch.test.sh (manual review confirming the required missing-state regression tests for both do_exit and --relaunch were added)`
- <code>`bash tests/fm-control-relaunch.test.sh` (launched, did not complete within session time)</code>
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>⏭️ **Lint** - skipped</summary>

- ⚠️ linter found issues (exit code 1)
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
