### PR TITLE
Apply the honey token-efficiency skill to every ship crewmate

### DIFF
--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -67,6 +67,9 @@
 # Scaffolds carry no role scope: fm-spawn.sh supplies fm_brief_worker_role from
 # fm-dod-lib.sh to every ship/scout launch brief, so this file never becomes a
 # second owner of a contract that must stay current across relaunches.
+# Ship (not scout, not the secondmate charter) carries a fixed Rules entry
+# telling the worker to apply the `honey` token-efficiency skill; a scout's
+# deliverable is a report, so it stays exempt to keep findings complete.
 # Refuses to overwrite an existing brief.
 set -eu
 
@@ -492,6 +495,9 @@ $ASK_USER_BLOCK
    going. A drive-call error, timeout, slow read, or generic unreachability is NOT a daemon error:
    the daemon accepts \`respond\` immediately and runs the round in the background, so a killed or
    timed-out call was only waiting for a read while the run kept working.
+8. Apply the \`honey\` skill to all code and prose you produce: invoke it with \`/honey\` on claude, grok, kimi, and cursor, \`\$honey\` on codex, or by asking for it in plain words on opencode and pi.
+   If the skill is not available in this runtime, continue without it and say so in one status line.
+   Status appends, the PR description, and any report you write stay complete; Honey trims narration, never evidence.
 
 $INBOX_SECTION
 

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -221,6 +221,39 @@ test_ship_modes_generate_clean_briefs() {
   pass "fm-brief.sh: no-mistakes/direct-PR/local-only briefs generate cleanly"
 }
 
+# The honey token-efficiency skill applies to every ship worker (all three
+# delivery modes) but a scout's deliverable is a report, so it stays exempt to
+# keep findings complete; a secondmate charter is not a delivery contract at
+# all and carries neither ship nor scout Rules.
+test_honey_rule_ship_only() {
+  local home id mode brief
+  home="$TMP_ROOT/honey-home"
+  write_registry "$home"
+
+  for id_mode in "brief-honey-nomistakes:no-mistakes" "brief-honey-directpr:direct-PR" "brief-honey-localonly:local-only"; do
+    id=${id_mode%%:*}
+    mode=${id_mode##*:}
+    FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" some-proj --mode "$mode" >/dev/null 2>&1 \
+      || fail "fm-brief.sh $id --mode $mode exited non-zero"
+    brief="$home/data/$id/brief.md"
+    assert_grep 'Apply the `honey` skill' "$brief" "$id: ship brief missing the honey rule"
+    assert_grep 'Honey trims narration, never evidence' "$brief" "$id: ship brief honey rule dropped the evidence-stays-complete clause"
+  done
+
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" brief-honey-scout some-proj --scout >/dev/null 2>&1 \
+    || fail "fm-brief.sh scout scaffold exited non-zero"
+  brief="$home/data/brief-honey-scout/brief.md"
+  assert_no_grep 'Apply the `honey` skill' "$brief" "scout brief must stay exempt from the honey rule"
+
+  FM_SECONDMATE_CHARTER='Supervise the some-proj domain.' \
+    FM_HOME="$home" "$ROOT/bin/fm-brief.sh" brief-honey-sm some-proj --secondmate some-proj >/dev/null 2>&1 \
+    || fail "fm-brief.sh secondmate scaffold exited non-zero"
+  brief="$home/data/brief-honey-sm/brief.md"
+  assert_no_grep 'Apply the `honey` skill' "$brief" "secondmate charter must stay exempt from the honey rule"
+
+  pass "fm-brief.sh: honey rule appears in every ship mode only, never in scout or secondmate"
+}
+
 # A ship task's delivery mode is firstmate's per-task decision, so a missing or
 # unusable value must stop the scaffold instead of silently defaulting. The
 # no-mistakes-prod-only row is the conditional registry policy: it is never a task
@@ -873,6 +906,7 @@ test_script_parses
 test_no_heredoc_in_command_substitution
 test_help_includes_entire_header
 test_ship_modes_generate_clean_briefs
+test_honey_rule_ship_only
 test_ship_mode_is_required_and_closed_set
 test_ship_mode_is_explicit_not_registry
 test_delivery_flags_are_refused_where_they_do_not_apply


### PR DESCRIPTION
## Summary
- Adds a fixed rule to the ship brief scaffold (all three delivery modes: no-mistakes, direct-PR, local-only) in `bin/fm-brief.sh` instructing the worker to invoke the `honey` token-efficiency skill (`/honey` on claude/grok/kimi/cursor, `$honey` on codex, plain-language ask on opencode/pi), fall back gracefully with a one-line status note if unavailable, and keep status appends, PR descriptions, and reports complete since Honey trims narration, never evidence.
- Scout and secondmate scaffolds are explicitly exempt (a scout's deliverable is a complete report, so the "less prose" lever must not thin findings).
- Updated the script's header comment to document the new rule and its scout exemption.
- Left `AGENTS.md`, `docs/configuration.md`, and the skills directory untouched per task scope (a separate task is slimming AGENTS.md concurrently).

## Test plan
- [x] `bin/fm-lint.sh` (shellcheck-clean)
- [x] `tests/fm-brief.test.sh` — extended with `test_honey_rule_ship_only`, asserting the honey rule appears in all three ship modes and is absent from scout and secondmate briefs; full suite passes
- [x] `tests/fm-task-delivery.test.sh`, `tests/fm-ask-user-authority.test.sh`, `tests/fm-secondmate-safety.test.sh`, `tests/fm-tangle-guard.test.sh`, `tests/fm-spawn-dispatch-profile.test.sh` — all pass, no regressions

Note: this host's `no-mistakes` binary is an unrelated static-analysis CLI (no `axi`/`doctor`/`init` subcommands), so this PR was opened directly per firstmate's `direct-PR` delivery mode instead of through the no-mistakes pipeline.