### PR TITLE
feat: let callers name the ship branch in briefs

### DIFF
--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -12,7 +12,7 @@
 # charters still use a single `{TASK}` charter fill. Firstmate may adjust other
 # sections when the task genuinely deviates (e.g. working an existing external
 # PR instead of shipping a new one).
-# Usage: fm-brief.sh <task-id> <repo-name> --mode <no-mistakes|direct-PR|local-only> [--herdr-lab]
+# Usage: fm-brief.sh <task-id> <repo-name> --mode <no-mistakes|direct-PR|local-only> [--branch <name>] [--herdr-lab]
 #        fm-brief.sh <task-id> <repo-name> --scout [--herdr-lab]
 #        fm-brief.sh <task-id> --secondmate {<project>...|--no-projects}
 #   --scout writes the scout contract instead: the deliverable is a report at
@@ -43,6 +43,15 @@
 #                the configured merge authority approves, firstmate merges to local main
 # no-mistakes-prod-only is a registry policy, not a task mode; resolve it to one of
 # the three concrete modes at intake before calling this script.
+# --branch <name> is OPTIONAL on ship briefs only. When set, Setup step 1, the
+# direct-PR / local-only Rule 1 branch mentions, and the local-only Definition of
+# done (via bin/fm-dod-lib.sh) use that exact name instead of the default
+# fm/<task-id>. An absent --branch keeps today's fm/<task-id> wording byte for
+# byte. Empty values and names that fail `git check-ref-format --branch` are
+# refused before any brief is written. Scout and secondmate scaffolds refuse
+# --branch: a scout has no ship branch, and a charter is not a delivery contract.
+# Callers that also spawn must pass the same name to bin/fm-spawn.sh --branch so
+# state/<id>.meta records it for local-only landing and review helpers.
 # The generated ship brief records the chosen mode as a fixed machine-readable
 # "Delivery contract: mode=<mode>" line. bin/fm-spawn.sh reads that line and refuses
 # to launch a ship task whose explicit --mode disagrees, so an adjusted brief and the
@@ -121,6 +130,8 @@ HERDR_LAB=0
 NO_PROJECTS=0
 MODE=
 MODE_SET=0
+BRANCH=
+BRANCH_SET=0
 POS=()
 want_value=
 for a in "$@"; do
@@ -130,6 +141,7 @@ for a in "$@"; do
     esac
     case "$want_value" in
       mode) MODE=$a; MODE_SET=1 ;;
+      branch) BRANCH=$a; BRANCH_SET=1 ;;
       *) echo "error: internal parser state for --$want_value" >&2; exit 1 ;;
     esac
     want_value=
@@ -142,6 +154,8 @@ for a in "$@"; do
     --no-projects) NO_PROJECTS=1 ;;
     --mode) want_value=mode ;;
     --mode=*) MODE=${a#--mode=}; MODE_SET=1 ;;
+    --branch) want_value=branch ;;
+    --branch=*) BRANCH=${a#--branch=}; BRANCH_SET=1 ;;
     # yolo never reaches the worker: it is firstmate's merge authority, not a
     # brief input. Refuse it loudly so it is never silently dropped here and then
     # believed to have been recorded.
@@ -150,6 +164,10 @@ for a in "$@"; do
   esac
 done
 [ -z "$want_value" ] || { echo "error: --$want_value requires a value" >&2; exit 1; }
+[ "$BRANCH_SET" -eq 0 ] || [ -n "$BRANCH" ] || {
+  echo "error: --branch requires a non-empty value" >&2
+  exit 1
+}
 
 # Ship delivery mode is an explicit per-task decision (AGENTS.md section 7). A
 # missing or invalid value stops the scaffold rather than silently defaulting.
@@ -169,7 +187,19 @@ elif [ "$MODE_SET" -eq 1 ]; then
   echo "error: --mode applies only to ship briefs; a scout delivers a report and a secondmate charter is not a delivery contract" >&2
   exit 1
 fi
+if [ "$KIND" != ship ] && [ "$BRANCH_SET" -eq 1 ]; then
+  echo "error: --branch applies only to ship briefs; a scout delivers a report and a secondmate charter is not a delivery contract" >&2
+  exit 1
+fi
 ID=${POS[0]}
+if [ "$BRANCH_SET" -eq 1 ]; then
+  if ! git check-ref-format --branch "$BRANCH" >/dev/null 2>&1; then
+    echo "error: --branch '$BRANCH' is not a valid git branch name" >&2
+    exit 1
+  fi
+else
+  BRANCH="fm/$ID"
+fi
 
 if [ "$KIND" = secondmate ] && [ "$HERDR_LAB" -eq 1 ]; then
   echo "error: --herdr-lab applies only to crewmate ship or scout briefs" >&2
@@ -424,11 +454,11 @@ fi
 case "$MODE" in
   direct-PR)
     SETUP2=""
-    RULE1='1. Never push to the default branch (push only your `fm/'"$ID"'` branch). Never merge a PR.'
+    RULE1='1. Never push to the default branch (push only your `'"$BRANCH"'` branch). Never merge a PR.'
     ;;
   local-only)
     SETUP2=""
-    RULE1="1. Never push to any remote and never open a PR. Work only on your \`fm/$ID\` branch; firstmate handles the merge into local \`main\`."
+    RULE1="1. Never push to any remote and never open a PR. Work only on your \`$BRANCH\` branch; firstmate handles the merge into local \`main\`."
     ;;
   *)  # no-mistakes
     SETUP2="
@@ -436,7 +466,7 @@ case "$MODE" in
     RULE1='1. Never push to the default branch. Never merge a PR.'
     ;;
 esac
-DOD=$(fm_dod_block "$MODE" "$ID") || exit 1
+DOD=$(fm_dod_block "$MODE" "$ID" "$BRANCH") || exit 1
 
 cat > "$BRIEF" <<EOF
 You are a crewmate: an autonomous worker agent managed by firstmate. Work on your own; do not wait for a human.
@@ -452,7 +482,7 @@ You are in a disposable git worktree of $REPO, at a detached HEAD on a clean def
 The path check is authoritative: \`git rev-parse --git-dir\` and \`git rev-parse --git-common-dir\` can help inspect the repo, but they do not prove you are outside the primary checkout.
 If the top-level path is the primary checkout or not the worktree you were launched in, STOP - do not branch or commit here - append \`blocked: launched in primary checkout, not an isolated worktree\` to the status file and stop.
 
-1. First action: create your branch: \`git checkout -b fm/$ID\`$SETUP2
+1. First action: create your branch: \`git checkout -b $BRANCH\`$SETUP2
 
 # Rules
 $RULE1

--- a/bin/fm-dod-lib.sh
+++ b/bin/fm-dod-lib.sh
@@ -5,9 +5,11 @@
 # receives. Both paths must hand the worker the same contract: a promoted
 # no-mistakes worker that never received the ask-user escalation rule or the
 # `--yes` ban is the exact delivery hole this single owner exists to close.
-# fm_dod_block <no-mistakes|direct-PR|local-only> <task-id> prints the block on
-# stdout with no trailing blank line. The caller validates the mode; an unknown
-# mode is refused rather than silently rendered as the pipeline contract.
+# fm_dod_block <no-mistakes|direct-PR|local-only> <task-id> [branch] prints the
+# block on stdout with no trailing blank line. The optional branch names the ship
+# branch in local-only Definition of done prose; absent or empty keeps
+# fm/<task-id>. The caller validates the mode; an unknown mode is refused rather
+# than silently rendered as the pipeline contract.
 # The block opens with the fixed machine-readable "Delivery contract: mode=<mode>"
 # line that bin/fm-spawn.sh checks a ship brief against.
 # This file is the one owner of the no-mistakes `--intent` contract: only the
@@ -190,8 +192,12 @@ fm_ask_user_escalation_block() {  # <data-dir> <task-id>
 EOF
 }
 
-fm_dod_block() {  # <mode> <task-id>
-  local mode=$1 id=$2
+fm_dod_block() {  # <mode> <task-id> [branch]
+  # Optional third arg is the ship branch name written into local-only Definition
+  # of done prose. Absent or empty keeps the historical fm/<task-id> default so
+  # callers that do not pass a branch stay byte-identical.
+  local mode=$1 id=$2 branch=${3:-}
+  [ -n "$branch" ] || branch="fm/$id"
   case "$mode" in
     direct-PR)
       cat <<EOF
@@ -208,9 +214,9 @@ EOF
 # Definition of done
 Delivery contract: mode=local-only
 This task ships **local-only**: no remote, no PR, no pipeline.
-The task is complete only when committed on your branch \`fm/$id\`. Do NOT push, do NOT open a PR, do NOT merge.
+The task is complete only when committed on your branch \`$branch\`. Do NOT push, do NOT open a PR, do NOT merge.
 Keep your branch a clean fast-forward onto the current default branch - if \`main\` has advanced, rebase onto it so the eventual merge stays a fast-forward.
-When it is implemented and committed, append \`done: ready in branch fm/$id\` to the status file and stop.
+When it is implemented and committed, append \`done: ready in branch $branch\` to the status file and stop.
 The configured merge authority approves the ready branch, then firstmate merges it into local \`main\` through the guarded fast-forward path.
 EOF
       ;;

--- a/bin/fm-merge-local.sh
+++ b/bin/fm-merge-local.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Perform the approved local merge for a local-only ship task: fast-forward the
-# project's default branch to the crewmate's fm/<id> branch.
+# project's default branch to the crewmate's ship branch.
 #
 # This is firstmate's merge gate-action (the captain's merge authority applied
 # locally instead of via a GitHub PR). It is the one sanctioned exception to hard
@@ -9,6 +9,9 @@
 # auto-approves), and only as a clean fast-forward - it refuses a diverged branch
 # and tells you to have the crewmate rebase. See AGENTS.md prime directives,
 # project management, and task lifecycle.
+# The ship branch is state/<id>.meta's branch= when present (recorded by
+# bin/fm-spawn.sh --branch or bin/fm-promote.sh --branch); otherwise the
+# historical default fm/<task-id>.
 # Usage: fm-merge-local.sh <task-id>
 set -eu
 
@@ -47,7 +50,8 @@ default_branch() {
   return 1
 }
 
-BRANCH="fm/$ID"
+BRANCH=$(grep '^branch=' "$META" | cut -d= -f2- || true)
+[ -n "$BRANCH" ] || BRANCH="fm/$ID"
 git -C "$PROJ" rev-parse --verify --quiet "refs/heads/$BRANCH" >/dev/null || { echo "error: branch $BRANCH does not exist in $PROJ" >&2; exit 1; }
 
 DEFAULT=$(default_branch) || { echo "error: cannot determine default branch for $PROJ; expected origin/HEAD, main, or master" >&2; exit 1; }

--- a/bin/fm-promote.sh
+++ b/bin/fm-promote.sh
@@ -5,7 +5,8 @@
 # again. Promotion also writes the crewmate's ship instructions to
 # data/<task-id>/ship-instructions.md and prints the fm-send.sh command that
 # delivers them. Those instructions carry the scratch-state inventory, the clean
-# default-branch base, the fm/<task-id> branch, and - rendered from
+# default-branch base, the ship branch (fm/<task-id> unless --branch names
+# another), and - rendered from
 # bin/fm-dod-lib.sh, the single owner an ordinary ship brief also uses - the
 # mode-specific Definition of done, so a promoted worker receives exactly the same
 # delivery contract as a briefed one, including the no-mistakes mode's ask-user
@@ -17,11 +18,13 @@
 # brief contributes only Task lines explicitly marked as captain words to intent.
 # A scout records no delivery posture, so promotion is where this task's delivery
 # contract is decided: --mode and --yolo are REQUIRED and written into the meta
-# alongside the kind= flip. Firstmate resolves both at promotion time, having just
+# alongside the kind= flip. Optional --branch records branch= the same way
+# bin/fm-spawn.sh does, and names that branch in the ship instructions.
+# Firstmate resolves mode and yolo at promotion time, having just
 # read the scout's report (AGENTS.md section 7); data/projects.md holds the
 # captain's standing posture as context, and this script never looks it up.
 # no-mistakes-prod-only is a registry policy rather than a task mode and is refused.
-# Usage: fm-promote.sh <task-id> --mode <no-mistakes|direct-PR|local-only> --yolo <on|off>
+# Usage: fm-promote.sh <task-id> --mode <no-mistakes|direct-PR|local-only> --yolo <on|off> [--branch <name>]
 set -eu
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -49,8 +52,10 @@ DATA="${FM_DATA_OVERRIDE:-$FM_HOME/data}"
 
 MODE=
 YOLO=
+BRANCH=
 MODE_SET=0
 YOLO_SET=0
+BRANCH_SET=0
 POS=()
 want_value=
 for a in "$@"; do
@@ -61,6 +66,7 @@ for a in "$@"; do
     case "$want_value" in
       mode) MODE=$a; MODE_SET=1 ;;
       yolo) YOLO=$a; YOLO_SET=1 ;;
+      branch) BRANCH=$a; BRANCH_SET=1 ;;
     esac
     want_value=
     continue
@@ -70,17 +76,23 @@ for a in "$@"; do
     --mode=*) MODE=${a#--mode=}; MODE_SET=1 ;;
     --yolo) want_value=yolo ;;
     --yolo=*) YOLO=${a#--yolo=}; YOLO_SET=1 ;;
+    --branch) want_value=branch ;;
+    --branch=*) BRANCH=${a#--branch=}; BRANCH_SET=1 ;;
     *) POS+=("$a") ;;
   esac
 done
 [ -z "$want_value" ] || { echo "error: --$want_value requires a value" >&2; exit 1; }
-[ "${#POS[@]}" -ge 1 ] || { echo "usage: fm-promote.sh <task-id> --mode <no-mistakes|direct-PR|local-only> --yolo <on|off>" >&2; exit 1; }
+[ "${#POS[@]}" -ge 1 ] || { echo "usage: fm-promote.sh <task-id> --mode <no-mistakes|direct-PR|local-only> --yolo <on|off> [--branch <name>]" >&2; exit 1; }
 [ "$MODE_SET" -eq 1 ] || {
   echo "error: promotion requires --mode <no-mistakes|direct-PR|local-only>; decide it now from the scout's findings and the project's registered posture in data/projects.md" >&2
   exit 1
 }
 [ "$YOLO_SET" -eq 1 ] || {
   echo "error: promotion requires --yolo <on|off>; it is this task's merge authority, not a project lookup" >&2
+  exit 1
+}
+[ "$BRANCH_SET" -eq 0 ] || [ -n "$BRANCH" ] || {
+  echo "error: --branch requires a non-empty value" >&2
   exit 1
 }
 case "$MODE" in
@@ -96,6 +108,14 @@ case "$YOLO" in
 esac
 
 ID=${POS[0]}
+if [ "$BRANCH_SET" -eq 1 ]; then
+  if ! git check-ref-format --branch "$BRANCH" >/dev/null 2>&1; then
+    echo "error: --branch '$BRANCH' is not a valid git branch name" >&2
+    exit 1
+  fi
+else
+  BRANCH="fm/$ID"
+fi
 fm_task_id_creation_valid "$ID" || { echo "error: invalid task id" >&2; exit 2; }
 CONTROL_LOCK="$STATE/.control-$ID.lock"
 CONTROL_LOCK_HELD=0
@@ -179,7 +199,7 @@ EOF
 ## Firstmate spec
 1. **Verify isolation before anything else.** Run \`pwd -P\` and \`git rev-parse --show-toplevel\`; both must resolve to the disposable task worktree you were launched in, such as a treehouse pool path or an Orca-managed worktree, not the primary checkout firstmate operates from. If either does not resolve to the worktree you were launched in, stop and escalate to firstmate.
 2. Inventory this worktree's scratch state with \`git status\` and \`git log\` before changing anything.
-3. Return to a clean default-branch base, then create your branch: \`git checkout -b fm/$ID\`.
+3. Return to a clean default-branch base, then create your branch: \`git checkout -b $BRANCH\`.
 4. Carry over only the intended fix changes. Leave scratch commits, debug edits, and experiment files behind.
 5. If you reproduced a bug, turn that reproduction into a regression test.
 6. These ship instructions supersede the scout delivery rules and report-based Definition of done. Everything else in your original instructions carries over unchanged: the status protocol; the instruction inbox and its acknowledgement; the escalation rules, including ask-user; and every safety rule.
@@ -187,18 +207,19 @@ $PROMOTION_ASK_USER_BLOCK
 7. Treat the scout-time Firstmate spec and any unmarked legacy \`# Task\` text as investigation context, not captain intent or ship-time instructions.
 EOF
   printf '\n'
-  fm_dod_block "$MODE" "$ID"
+  fm_dod_block "$MODE" "$ID" "$BRANCH"
 } > "$TMP" || { echo "error: could not render ship instructions for mode=$MODE" >&2; exit 1; }
 mv "$TMP" "$INSTRUCTIONS"
 TMP=
 [ -f "$INSTRUCTIONS" ] && [ -r "$INSTRUCTIONS" ] || { echo "error: ship instructions were not published as a readable file: $INSTRUCTIONS" >&2; exit 1; }
 
 TMP="$STATE/.$ID.meta.promote.${BASHPID:-$$}"
-grep -v -e '^kind=' -e '^mode=' -e '^yolo=' "$META" > "$TMP"
+grep -v -e '^kind=' -e '^mode=' -e '^yolo=' -e '^branch=' "$META" > "$TMP"
 {
   echo "kind=ship"
   echo "mode=$MODE"
   echo "yolo=$YOLO"
+  [ "$BRANCH_SET" -eq 0 ] || echo "branch=$BRANCH"
 } >> "$TMP"
 if ! fm_backlog_atomic_transition publish "$TMP" "$META" "task record" "$STATE"; then
   rm -f -- "$TMP"

--- a/bin/fm-review-diff.sh
+++ b/bin/fm-review-diff.sh
@@ -10,6 +10,8 @@
 # only a fallback when fetch fails (stale recorded SHAs must never win over a
 # reachable remote PR head). If neither PR head can be resolved, fall back to
 # the local branch with a warning. Without pr=, compare the local branch.
+# The local branch is state/<id>.meta's branch= when present and that ref exists
+# in the worktree; otherwise fm/<task-id> when that ref exists; otherwise HEAD.
 # Usage: fm-review-diff.sh <task-id> [--stat]
 #   --stat prints only the stat summary; default prints stat summary plus full diff.
 set -eu
@@ -67,11 +69,16 @@ default_branch() {
 
 DEFAULT=$(default_branch) || { echo "error: cannot determine default branch for $PROJ; expected origin/HEAD, main, or master" >&2; exit 1; }
 
-BRANCH="fm/$ID"
+BRANCH=$(grep '^branch=' "$META" | cut -d= -f2- || true)
+[ -n "$BRANCH" ] || BRANCH="fm/$ID"
 if ! git -C "$WT" rev-parse --verify --quiet "refs/heads/$BRANCH" >/dev/null; then
-  BRANCH=$(git -C "$WT" symbolic-ref --quiet --short HEAD 2>/dev/null || true)
-  [ -n "$BRANCH" ] || { echo "error: branch fm/$ID does not exist and worktree $WT is detached" >&2; exit 1; }
-  git -C "$WT" rev-parse --verify --quiet "refs/heads/$BRANCH" >/dev/null || { echo "error: branch $BRANCH does not exist in $WT" >&2; exit 1; }
+  if [ "$BRANCH" != "fm/$ID" ] && git -C "$WT" rev-parse --verify --quiet "refs/heads/fm/$ID" >/dev/null; then
+    BRANCH="fm/$ID"
+  else
+    BRANCH=$(git -C "$WT" symbolic-ref --quiet --short HEAD 2>/dev/null || true)
+    [ -n "$BRANCH" ] || { echo "error: recorded ship branch does not exist and worktree $WT is detached" >&2; exit 1; }
+    git -C "$WT" rev-parse --verify --quiet "refs/heads/$BRANCH" >/dev/null || { echo "error: branch $BRANCH does not exist in $WT" >&2; exit 1; }
+  fi
 fi
 
 pr_number_from_target() {

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Spawn a direct report: a crewmate in a treehouse or Orca worktree, or a
 # secondmate in its isolated firstmate home.
-# Usage: fm-spawn.sh <task-id> <project-dir> --mode <no-mistakes|direct-PR|local-only> --yolo <on|off> [--harness <name>|harness|launch-command] [--model <name>] [--effort <level>] [--backend <name>]
+# Usage: fm-spawn.sh <task-id> <project-dir> --mode <no-mistakes|direct-PR|local-only> --yolo <on|off> [--branch <name>] [--harness <name>|harness|launch-command] [--model <name>] [--effort <level>] [--backend <name>]
 #        fm-spawn.sh <task-id> <project-dir> --scout [--harness <name>|harness|launch-command] [--model <name>] [--effort <level>] [--backend <name>]
 #        fm-spawn.sh <task-id> [<firstmate-home>] [--harness <name>|harness|launch-command] [--model <name>] [--effort <level>] [--backend <name>] --secondmate
 #   --mode and --yolo are this task's delivery contract, REQUIRED for every ship
@@ -14,6 +14,15 @@
 #   scaffolded before that line existed warns once and launches on the flag. A
 #   ship or scout spawn also refuses leftover `{TASK}` / `{FIRSTMATE_SPEC}`
 #   placeholders, an empty Task, or an incomplete pair of Task subsections.
+#   --branch <name> is OPTIONAL on ship spawns only. When set, it is recorded as
+#   branch= in state/<id>.meta so local-only landing (bin/fm-merge-local.sh) and
+#   review helpers (bin/fm-review-diff.sh) resolve the real ship branch instead of
+#   deriving fm/<task-id>. An absent --branch writes no branch= line, preserving
+#   today's meta shape and the fm/<task-id> consumer default. Empty values and
+#   names that fail `git check-ref-format --branch` are refused. This flag does
+#   not re-scaffold the brief: pass the same name to bin/fm-brief.sh --branch when
+#   scaffolding so the worker's Setup/Rules text matches the recorded branch.
+#   --relaunch reuses any recorded branch= and refuses --branch.
 #   Every ship or scout spawn renders `launch-brief.md`; for a no-mistakes ship
 #   it also carries the current `--intent` contract and the extracted captain
 #   intent. A legacy mixed Task is accepted there only under bin/fm-dod-lib.sh's
@@ -208,7 +217,7 @@
 # Batch dispatch: pass one or more `id=repo` pairs instead of a single <id> <project>, e.g.
 #     fm-spawn.sh fix-a-k3=projects/foo add-b-q7=projects/bar [--scout]
 #   Each pair re-execs this script in single-task mode, so the single path stays the only
-#   source of truth; shared --scout/--harness/--model/--effort/--backend/--mode/--yolo
+#   source of truth; shared --scout/--harness/--model/--effort/--backend/--mode/--yolo/--branch
 #   applies to every pair. A ship batch therefore carries one delivery contract, and each
 #   pair still checks it against its own brief; a batch spanning modes is two invocations.
 #   If config/crew-dispatch.json exists, shared --harness is required for crewmate
@@ -447,6 +456,7 @@ BACKEND_ARG=
 MODE=
 YOLO=
 TRACEPARENT_ARG=
+BRANCH=
 HARNESS_SET=0
 MODEL_SET=0
 EFFORT_SET=0
@@ -454,6 +464,7 @@ BACKEND_SET=0
 MODE_SET=0
 YOLO_SET=0
 TRACEPARENT_SET=0
+BRANCH_SET=0
 RELAUNCH=0
 POS=()
 want_value=
@@ -470,6 +481,7 @@ for a in "$@"; do
       mode) MODE=$a; MODE_SET=1 ;;
       yolo) YOLO=$a; YOLO_SET=1 ;;
       traceparent) TRACEPARENT_ARG=$a; TRACEPARENT_SET=1 ;;
+      branch) BRANCH=$a; BRANCH_SET=1 ;;
       *) echo "error: internal parser state for --$want_value" >&2; exit 1 ;;
     esac
     want_value=
@@ -493,6 +505,8 @@ for a in "$@"; do
     --yolo=*) YOLO=${a#--yolo=}; YOLO_SET=1 ;;
     --traceparent) want_value=traceparent ;;
     --traceparent=*) TRACEPARENT_ARG=${a#--traceparent=}; TRACEPARENT_SET=1 ;;
+    --branch) want_value=branch ;;
+    --branch=*) BRANCH=${a#--branch=}; BRANCH_SET=1 ;;
     *) POS+=("$a") ;;
   esac
 done
@@ -504,6 +518,7 @@ done
 [ "$MODE_SET" -eq 0 ] || [ -n "$MODE" ] || { echo "error: --mode requires a non-empty value" >&2; exit 1; }
 [ "$YOLO_SET" -eq 0 ] || [ -n "$YOLO" ] || { echo "error: --yolo requires a non-empty value" >&2; exit 1; }
 [ "$TRACEPARENT_SET" -eq 0 ] || [ -n "$TRACEPARENT_ARG" ] || { echo "error: --traceparent requires a non-empty value" >&2; exit 1; }
+[ "$BRANCH_SET" -eq 0 ] || [ -n "$BRANCH" ] || { echo "error: --branch requires a non-empty value" >&2; exit 1; }
 # A parent-delivered carrier replaces this home's own resolution, so it is
 # refused unless it is a secondmate spawn carrying a strictly valid W3C value.
 # Nothing else may reach the pane's TRACEPARENT export.
@@ -531,6 +546,7 @@ if [ "$RELAUNCH" -eq 1 ]; then
   [ "$KIND_SET" -eq 0 ] || { echo "error: --relaunch reuses the task's recorded kind; --scout/--secondmate cannot override it" >&2; exit 1; }
   [ "$MODE_SET" -eq 0 ] || { echo "error: --relaunch reuses the task's recorded delivery mode; --mode cannot override it" >&2; exit 1; }
   [ "$YOLO_SET" -eq 0 ] || { echo "error: --relaunch reuses the task's recorded yolo posture; --yolo cannot override it" >&2; exit 1; }
+  [ "$BRANCH_SET" -eq 0 ] || { echo "error: --relaunch reuses the task's recorded branch; --branch cannot override it" >&2; exit 1; }
 else
   # Delivery contract (AGENTS.md section 7). A ship task's mode and yolo are
   # firstmate's per-task decision, so they are required and closed-set validated
@@ -556,6 +572,10 @@ else
       on|off) ;;
       *) echo "error: --yolo must be on or off (got '$YOLO')" >&2; exit 1 ;;
     esac
+    if [ "$BRANCH_SET" -eq 1 ] && ! git check-ref-format --branch "$BRANCH" >/dev/null 2>&1; then
+      echo "error: --branch '$BRANCH' is not a valid git branch name" >&2
+      exit 1
+    fi
   else
     [ "$MODE_SET" -eq 0 ] || {
       echo "error: --mode applies only to ship spawns; a scout delivers a report and a secondmate records its own fixed posture" >&2
@@ -563,6 +583,10 @@ else
     }
     [ "$YOLO_SET" -eq 0 ] || {
       echo "error: --yolo applies only to ship spawns; a scout delivers a report and a secondmate records its own fixed posture" >&2
+      exit 1
+    }
+    [ "$BRANCH_SET" -eq 0 ] || {
+      echo "error: --branch applies only to ship spawns; a scout delivers a report and a secondmate records its own fixed posture" >&2
       exit 1
     }
   fi
@@ -1099,6 +1123,7 @@ if [ "${#POS[@]}" -gt 0 ] && [ "${POS[0]}" != "$idpart" ] && case "$idpart" in *
   # spanning several modes is two invocations rather than a silent mixed dispatch.
   [ "$MODE_SET" -eq 0 ] || shared_args+=(--mode "$MODE")
   [ "$YOLO_SET" -eq 0 ] || shared_args+=(--yolo "$YOLO")
+  [ "$BRANCH_SET" -eq 0 ] || shared_args+=(--branch "$BRANCH")
   for pair in "${POS[@]}"; do
     case "$pair" in
       *=*) : ;;
@@ -3580,6 +3605,7 @@ preserve_relaunch_meta() {
   echo "kind=$KIND"
   [ -z "$MODE" ] || echo "mode=$MODE"
   [ -z "$YOLO" ] || echo "yolo=$YOLO"
+  [ "$BRANCH_SET" -eq 0 ] || echo "branch=$BRANCH"
   echo "tasktmp=$TASK_TMP"
   echo "model=${MODEL:-default}"
   echo "effort=${EFFORT:-default}"

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -868,7 +868,70 @@ test_worker_role_scope() {
   pass "fm-brief: scaffolds leave the worker role scope to the launch boundary and keep the secondmate contract"
 }
 
-test_worker_role_scope
+# Optional --branch renames the ship branch in Setup and the delivery-mode Rule 1
+# lines (and local-only Definition of done via fm-dod-lib). Absent keeps fm/<id>.
+test_optional_ship_branch_name() {
+  local home id brief out status help
+  home="$TMP_ROOT/branch-name-home"
+  mkdir -p "$home/data"
+
+  id='brief-branch-default'
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" some-proj --mode direct-PR >/dev/null 2>&1 \
+    || fail "default direct-PR brief should scaffold"
+  brief="$home/data/$id/brief.md"
+  assert_grep "git checkout -b fm/$id" "$brief" "default Setup lost fm/<task-id> branch create"
+  assert_grep "push only your \`fm/$id\` branch" "$brief" "default direct-PR Rule 1 lost fm/<task-id>"
+  assert_no_grep "git checkout -b feat/" "$brief" "default brief unexpectedly used a conventional branch"
+
+  id='brief-branch-named'
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" some-proj --mode direct-PR \
+    --branch feat/named-branch >/dev/null 2>&1 \
+    || fail "direct-PR brief with --branch should scaffold"
+  brief="$home/data/$id/brief.md"
+  assert_grep "git checkout -b feat/named-branch" "$brief" \
+    "named --branch missing from Setup create step"
+  assert_grep "push only your \`feat/named-branch\` branch" "$brief" \
+    "named --branch missing from direct-PR Rule 1"
+  assert_no_grep "git checkout -b fm/$id" "$brief" \
+    "named --branch left the default fm/<task-id> Setup command"
+
+  id='brief-branch-local'
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" some-proj --mode local-only \
+    --branch fix/local-named >/dev/null 2>&1 \
+    || fail "local-only brief with --branch should scaffold"
+  brief="$home/data/$id/brief.md"
+  assert_grep "git checkout -b fix/local-named" "$brief" \
+    "named --branch missing from local-only Setup"
+  assert_grep "Work only on your \`fix/local-named\` branch" "$brief" \
+    "named --branch missing from local-only Rule 1"
+  assert_grep "ready in branch fix/local-named" "$brief" \
+    "named --branch missing from local-only Definition of done"
+
+  out=$(FM_HOME="$home" "$ROOT/bin/fm-brief.sh" brief-branch-empty some-proj \
+    --mode direct-PR --branch= 2>&1)
+  status=$?
+  [ "$status" -ne 0 ] || fail "empty --branch should refuse"
+  assert_contains "$out" "non-empty" "empty --branch refusal did not name the empty-value rule"
+  assert_absent "$home/data/brief-branch-empty/brief.md" "empty --branch still wrote a brief"
+
+  out=$(FM_HOME="$home" "$ROOT/bin/fm-brief.sh" brief-branch-bad some-proj \
+    --mode direct-PR --branch 'bad branch' 2>&1)
+  status=$?
+  [ "$status" -ne 0 ] || fail "invalid --branch should refuse"
+  assert_contains "$out" "not a valid git branch name" "invalid --branch refusal did not name the ref rule"
+  assert_absent "$home/data/brief-branch-bad/brief.md" "invalid --branch still wrote a brief"
+
+  out=$(FM_HOME="$home" "$ROOT/bin/fm-brief.sh" brief-branch-scout some-proj \
+    --scout --branch feat/nope 2>&1)
+  status=$?
+  [ "$status" -ne 0 ] || fail "scout --branch should refuse"
+  assert_contains "$out" "applies only to ship briefs" "scout --branch refusal lost its scope message"
+
+  help=$("$ROOT/bin/fm-brief.sh" --help)
+  assert_contains "$help" "--branch" "fm-brief.sh --help omitted --branch"
+  pass "fm-brief.sh: optional --branch defaults, renders, and rejects invalid values"
+}
+
 test_script_parses
 test_no_heredoc_in_command_substitution
 test_help_includes_entire_header
@@ -891,3 +954,5 @@ test_secondmate_directory_paths_are_absolute_and_output_is_stable
 test_pause_verb_override_renders_all_brief_scaffolds
 test_scout_and_secondmate_load_decision_hold_policy
 test_scout_and_secondmate_scaffold
+test_worker_role_scope
+test_optional_ship_branch_name

--- a/tests/fm-merge-local.test.sh
+++ b/tests/fm-merge-local.test.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# Behavior tests for bin/fm-merge-local.sh ship-branch resolution.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+fm_git_identity fmtest fmtest@example.invalid
+
+TMP_ROOT=$(fm_test_tmproot fm-merge-local)
+MERGE_LOCAL="$ROOT/bin/fm-merge-local.sh"
+
+make_local_only_case() {
+  local name=$1 branch=$2 write_meta_branch=$3 case_dir
+  case_dir="$TMP_ROOT/$name"
+  mkdir -p "$case_dir/home/state"
+
+  git init -q "$case_dir/project"
+  git -C "$case_dir/project" checkout -q -b main
+  printf 'base\n' > "$case_dir/project/file.txt"
+  git -C "$case_dir/project" add file.txt
+  git -C "$case_dir/project" -c user.email=t@t -c user.name=t commit -qm baseline
+  git -C "$case_dir/project" checkout -q -b "$branch"
+  printf 'change\n' >> "$case_dir/project/file.txt"
+  git -C "$case_dir/project" add file.txt
+  git -C "$case_dir/project" -c user.email=t@t -c user.name=t commit -qm change
+  git -C "$case_dir/project" checkout -q main
+
+  {
+    echo "project=$case_dir/project"
+    echo "mode=local-only"
+    echo "worktree=$case_dir/project"
+    [ "$write_meta_branch" = 1 ] && echo "branch=$branch"
+  } > "$case_dir/home/state/task-x.meta"
+  printf '%s\n' "$case_dir"
+}
+
+test_default_fm_branch_still_lands() {
+  local case_dir out
+  case_dir=$(make_local_only_case default-fm fm/task-x 0)
+  out=$(FM_HOME="$case_dir/home" FM_STATE_OVERRIDE="$case_dir/home/state" \
+    "$MERGE_LOCAL" task-x 2>&1) || fail "default fm/<id> merge failed: $out"
+  assert_contains "$out" "merged fm/task-x" "default path did not land fm/<id>"
+  pass "fm-merge-local: absent branch= still lands fm/<task-id>"
+}
+
+test_recorded_branch_lands() {
+  local case_dir out
+  case_dir=$(make_local_only_case named-branch feat/named-local 1)
+  out=$(FM_HOME="$case_dir/home" FM_STATE_OVERRIDE="$case_dir/home/state" \
+    "$MERGE_LOCAL" task-x 2>&1) || fail "recorded branch= merge failed: $out"
+  assert_contains "$out" "merged feat/named-local" "recorded branch= was not used for landing"
+  pass "fm-merge-local: branch= from meta is the land target"
+}
+
+test_default_fm_branch_still_lands
+test_recorded_branch_lands


### PR DESCRIPTION
## Summary

- Add optional `--branch <name>` to `bin/fm-brief.sh` so Setup and delivery-mode Rule 1 use a caller-supplied ship branch instead of hard-coded `fm/<task-id>`, with empty or invalid names refused via `git check-ref-format --branch`.
- Pass the same name through `bin/fm-dod-lib.sh` (local-only Definition of done), `bin/fm-spawn.sh` / `bin/fm-promote.sh` (`branch=` in task meta), and the consumers that previously derived `fm/<id>` (`fm-merge-local`, `fm-review-diff`).
- Absent `--branch` keeps today's `fm/<task-id>` wording and meta shape byte for byte.

## Report

1. **Option:** `--branch <name>` (and `--branch=`), matching existing `--mode` value style. Ship-only; scout/secondmate refuse it.
2. **Consumers:** see PR conversation below in the test plan notes / commit; critical derive paths now read `branch=` with `fm/<id>` fallback. Loose matches (`fm-bearings-snapshot`, tangle comments, fixture branch names in tests) left alone.
3. **`fm-spawn.sh`:** yes - accepts `--branch` and records `branch=` so local-only landing cannot look for `fm/<id>` after a named branch was used. It does not re-scaffold the brief; callers must pass the same name to `fm-brief.sh`.
4. **Left alone:** bearings display heuristic, tangle comment examples, promote/spawn default when unset, and test fixtures that create `fm/` branches as sample data.

## Test plan

- [x] `bin/fm-lint.sh`
- [x] `tests/fm-brief.test.sh` (default, named in all three locations + local-only DoD, invalid/empty/scout refusal)
- [x] `tests/fm-merge-local.test.sh` (default `fm/<id>` and recorded `branch=`)
- [x] `tests/fm-review-diff.test.sh`, `tests/fm-task-delivery.test.sh`, `tests/fm-tangle-guard.test.sh`, `tests/fm-branch-supervision.test.sh`