### PR TITLE
fix(bin): make the PR the finish line in the no-mistakes and direct-PR definitions of done

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -350,7 +350,7 @@ After an autonomous merge, give the captain a one-line full-URL or local-main ou
 
 ### Validate
 
-For a no-mistakes ship, trigger validation on the same worker after its implementation commit, using the harness invocation owned by `harness-adapters`.
+For a no-mistakes ship, the worker starts validation itself immediately after its implementation commit, per its brief's Definition of done (`bin/fm-dod-lib.sh`); if a worker stalls before that step, steer it there using the harness invocation owned by `harness-adapters`.
 The task worker that starts a no-mistakes run drives the pipeline and owns every `no-mistakes axi run` and `no-mistakes axi respond` call through the next gate or outcome.
 Firstmate never invokes `no-mistakes axi respond` for a crew-owned run.
 When the captain adds or changes an ask mid-task, append the captain's words to that brief's `## Captain's intent` and steer the worker; Firstmate build constraints stay in `## Firstmate spec` or the steer.

--- a/bin/fm-dod-lib.sh
+++ b/bin/fm-dod-lib.sh
@@ -14,12 +14,14 @@
 # pipeline or PR step as a numbered action to perform, not a condition that
 # is already satisfied, and it states outright that `done:` requires that
 # mode's PR URL: a worker that finished implementing and committing is told
-# to report `working:` and go do the next numbered step, never `done:`. This
-# closes the finish-line ambiguity by construction instead of by a louder
-# reminder, because emphasis alone did not stop repeated premature `done:`
-# lines describing a finished implementation with no PR (see PR history for
-# the evidence). local-only and scout keep their own `done:` semantics with
-# no PR, unaffected by that rule.
+# to report `working:` and go do the next numbered step, never `done:`. The
+# wording is restructured so the pipeline run, or opening the PR, reads as a
+# numbered action still owed inside the work sequence rather than a condition
+# tacked on at the end; nothing in the code rejects a premature `done:`, so
+# this is a clearer contract, not a guarantee. Emphasis alone did not stop
+# repeated premature `done:` lines describing a finished implementation with
+# no PR (see PR history for the evidence). local-only and scout keep their
+# own `done:` semantics with no PR, unaffected by that rule.
 # This file is the one owner of the no-mistakes `--intent` contract: only the
 # brief's `## Captain's intent` subsection plus later captain words, never
 # `## Firstmate spec` and never the worker's own tradeoffs.
@@ -239,7 +241,7 @@ Work through these steps in order; do not stop after step 1 believing the task i
 4. After /no-mistakes reports CI green (the CI-ready return point - do not wait for it to keep monitoring in the background until merge), append \`done: PR {url} checks green\` and stop. You are finished.
 
 \`done:\` on this task means exactly step 4, never anything earlier: never append \`done:\` on a status line that does not carry that PR URL.
-If the implementation is finished but you have not yet driven /no-mistakes to a green CI, the correct word is \`working:\` (for example \`working: implemented, starting /no-mistakes\`), and the exact next action is step 2 above.
+If the implementation is finished but you have not started /no-mistakes yet, the correct word is \`working:\` (for example \`working: implemented, starting /no-mistakes\`), and the exact next action is step 2 above.
 
 You drive no-mistakes by responding to its gates, not by implementing fixes.
 Follow the guidance no-mistakes itself provides for the mechanics: it loads when you invoke /no-mistakes, and \`no-mistakes axi run --help\` plus the \`help\` lines in each \`axi\` response are authoritative and version-matched to the installed binary.

--- a/bin/fm-dod-lib.sh
+++ b/bin/fm-dod-lib.sh
@@ -10,18 +10,18 @@
 # mode is refused rather than silently rendered as the pipeline contract.
 # The block opens with the fixed machine-readable "Delivery contract: mode=<mode>"
 # line that bin/fm-spawn.sh checks a ship brief against.
-# For every PR-ending mode (no-mistakes, direct-PR), the block sequences the
-# pipeline or PR step as a numbered action to perform, not a condition that
-# is already satisfied, and it states outright that `done:` requires that
-# mode's PR URL: a worker that finished implementing and committing is told
-# to report `working:` and go do the next numbered step, never `done:`. The
-# wording is restructured so the pipeline run, or opening the PR, reads as a
-# numbered action still owed inside the work sequence rather than a condition
-# tacked on at the end; nothing in the code rejects a premature `done:`, so
-# this is a clearer contract, not a guarantee. Emphasis alone did not stop
-# repeated premature `done:` lines describing a finished implementation with
-# no PR (see PR history for the evidence). local-only and scout keep their
-# own `done:` semantics with no PR, unaffected by that rule.
+# For every PR-ending mode (no-mistakes, direct-PR), the block words the
+# pipeline run, or opening the PR, as a numbered action still owed inside the
+# work sequence rather than a condition tacked on at the end, and it states
+# outright that `done:` requires that mode's PR URL. A worker that has
+# committed but has not yet started the pipeline (or, in direct-PR, has no PR
+# yet) is told to report `working:` and go do that numbered step, never
+# `done:`; a worker already inside a live run follows the escalation rules
+# below instead. Nothing in the code rejects a premature `done:`, so this is a
+# clearer contract, not a guarantee: emphasis alone did not stop repeated
+# premature `done:` lines describing a finished implementation with no PR.
+# local-only and scout keep their own `done:` semantics with no PR, unaffected
+# by that rule.
 # This file is the one owner of the no-mistakes `--intent` contract: only the
 # brief's `## Captain's intent` subsection plus later captain words, never
 # `## Firstmate spec` and never the worker's own tradeoffs.

--- a/bin/fm-dod-lib.sh
+++ b/bin/fm-dod-lib.sh
@@ -10,6 +10,16 @@
 # mode is refused rather than silently rendered as the pipeline contract.
 # The block opens with the fixed machine-readable "Delivery contract: mode=<mode>"
 # line that bin/fm-spawn.sh checks a ship brief against.
+# For every PR-ending mode (no-mistakes, direct-PR), the block sequences the
+# pipeline or PR step as a numbered action to perform, not a condition that
+# is already satisfied, and it states outright that `done:` requires that
+# mode's PR URL: a worker that finished implementing and committing is told
+# to report `working:` and go do the next numbered step, never `done:`. This
+# closes the finish-line ambiguity by construction instead of by a louder
+# reminder, because emphasis alone did not stop repeated premature `done:`
+# lines describing a finished implementation with no PR (see PR history for
+# the evidence). local-only and scout keep their own `done:` semantics with
+# no PR, unaffected by that rule.
 # This file is the one owner of the no-mistakes `--intent` contract: only the
 # brief's `## Captain's intent` subsection plus later captain words, never
 # `## Firstmate spec` and never the worker's own tradeoffs.
@@ -197,9 +207,12 @@ fm_dod_block() {  # <mode> <task-id>
       cat <<EOF
 # Definition of done
 Delivery contract: mode=direct-PR
-This task ships **direct-PR**: you raise the PR yourself, without the no-mistakes pipeline.
-The task is complete only when committed on your branch.
-When it is implemented and committed, push your branch and open a PR with \`gh-axi\`, then append \`done: PR {url}\` to the status file and stop.
+This task ships **direct-PR**: the PR is the finish line, not the commit.
+Work through these steps in order; do not stop after step 1 believing the task is finished.
+1. Implement and commit on your branch.
+2. Push your branch and open a PR with \`gh-axi\`.
+3. Append \`done: PR {url}\` to the status file and stop.
+Never append \`done:\` on a status line that does not carry that PR URL: if the implementation is finished but no PR exists yet, the correct word is \`working:\`, and the exact next action is step 2 above.
 Do NOT run /no-mistakes. The configured merge authority decides whether to merge the PR; firstmate relays the outcome.
 EOF
       ;;
@@ -218,9 +231,15 @@ EOF
       cat <<EOF
 # Definition of done
 Delivery contract: mode=no-mistakes
-The task is complete only when committed on your branch.
-When you believe it is complete, append \`done: {summary}\` to the status file and stop.
-Firstmate will then instruct you to run /no-mistakes to validate and ship a PR.
+This task ships **no-mistakes**: a validated PR is the finish line, not the commit.
+Work through these steps in order; do not stop after step 1 believing the task is finished.
+1. Implement, test, and commit on your branch.
+2. Immediately start /no-mistakes yourself; do not wait for firstmate to tell you to.
+3. Drive every no-mistakes gate to completion, following the guidance below.
+4. After /no-mistakes reports CI green (the CI-ready return point - do not wait for it to keep monitoring in the background until merge), append \`done: PR {url} checks green\` and stop. You are finished.
+
+\`done:\` on this task means exactly step 4, never anything earlier: never append \`done:\` on a status line that does not carry that PR URL.
+If the implementation is finished but you have not yet driven /no-mistakes to a green CI, the correct word is \`working:\` (for example \`working: implemented, starting /no-mistakes\`), and the exact next action is step 2 above.
 
 You drive no-mistakes by responding to its gates, not by implementing fixes.
 Follow the guidance no-mistakes itself provides for the mechanics: it loads when you invoke /no-mistakes, and \`no-mistakes axi run --help\` plus the \`help\` lines in each \`axi\` response are authoritative and version-matched to the installed binary.
@@ -244,8 +263,6 @@ Two firstmate-specific rules layer on top of that guidance:
   When the decision comes back, feed it to the gate with \`no-mistakes axi respond\` and let the pipeline apply it - do not route the question to "the user" or implement the fix yourself.
 - NEVER pass \`--yes\` (or \`-y\`) to \`no-mistakes axi run\` or \`no-mistakes axi respond\`. It is banned fleet-wide.
   It auto-resolves every gate including ask-user findings with no escalation, and answering your own ask-user finding is a hard rule violation.
-
-After /no-mistakes reports CI green (the CI-ready return point - do not wait for it to keep monitoring in the background until merge), append \`done: PR {url} checks green\` and stop. You are finished.
 EOF
       ;;
     *)

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -334,8 +334,8 @@ test_no_mistakes_dod_wording() {
   brief="$home/data/$id/brief.md"
   assert_present "$brief" "brief was not scaffolded"
   # The pipeline invocation is a numbered step to perform, not a condition
-  # already satisfied by finishing the implementation - this is the closes-by-
-  # construction fix for workers reporting `done:` right after their commit.
+  # already satisfied by finishing the implementation - this is the wording fix
+  # for workers reporting `done:` right after their commit.
   assert_grep "2. Immediately start /no-mistakes yourself; do not wait for firstmate to tell you to." "$brief" \
     "no-mistakes DOD must sequence starting the pipeline as a numbered step, not a condition"
   assert_grep "never append \`done:\` on a status line that does not carry that PR URL" "$brief" \

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -340,7 +340,7 @@ test_no_mistakes_dod_wording() {
     "no-mistakes DOD must sequence starting the pipeline as a numbered step, not a condition"
   assert_grep "never append \`done:\` on a status line that does not carry that PR URL" "$brief" \
     "no-mistakes DOD must forbid a done: line with no PR URL"
-  assert_grep "the correct word is \`working:\` (for example \`working: implemented, starting /no-mistakes\`), and the exact next action is step 2 above" "$brief" \
+  assert_grep "you have not started /no-mistakes yet, the correct word is \`working:\` (for example \`working: implemented, starting /no-mistakes\`), and the exact next action is step 2 above" "$brief" \
     "no-mistakes DOD must name working: plus the exact next command in place of a premature done:"
   assert_no_grep "Firstmate will then instruct you to run /no-mistakes" "$brief" \
     "no-mistakes DOD must not leave the old wait-for-firstmate-to-tell-you-to handshake behind"

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -260,7 +260,7 @@ test_ship_mode_is_explicit_not_registry() {
   brief="$home/data/brief-explicit-a5/brief.md"
   grep -qx "Delivery contract: mode=no-mistakes" "$brief" \
     || fail "registered direct-PR posture overrode the explicit --mode"
-  assert_grep "Firstmate will then instruct you to run /no-mistakes" "$brief" \
+  assert_grep "a validated PR is the finish line, not the commit" "$brief" \
     "explicit no-mistakes brief did not render the pipeline definition of done"
 
   # An unregistered project is not a blocker either, because nothing is looked up.
@@ -333,6 +333,17 @@ test_no_mistakes_dod_wording() {
   FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" some-proj --mode no-mistakes >/dev/null 2>&1
   brief="$home/data/$id/brief.md"
   assert_present "$brief" "brief was not scaffolded"
+  # The pipeline invocation is a numbered step to perform, not a condition
+  # already satisfied by finishing the implementation - this is the closes-by-
+  # construction fix for workers reporting `done:` right after their commit.
+  assert_grep "2. Immediately start /no-mistakes yourself; do not wait for firstmate to tell you to." "$brief" \
+    "no-mistakes DOD must sequence starting the pipeline as a numbered step, not a condition"
+  assert_grep "never append \`done:\` on a status line that does not carry that PR URL" "$brief" \
+    "no-mistakes DOD must forbid a done: line with no PR URL"
+  assert_grep "the correct word is \`working:\` (for example \`working: implemented, starting /no-mistakes\`), and the exact next action is step 2 above" "$brief" \
+    "no-mistakes DOD must name working: plus the exact next command in place of a premature done:"
+  assert_no_grep "Firstmate will then instruct you to run /no-mistakes" "$brief" \
+    "no-mistakes DOD must not leave the old wait-for-firstmate-to-tell-you-to handshake behind"
   assert_grep "no-mistakes itself provides for the mechanics" "$brief" \
     "no-mistakes DOD lost its guidance-reference sentence"
   # shellcheck disable=SC2016  # single quotes are deliberate: the backticks must stay literal
@@ -370,6 +381,47 @@ test_no_mistakes_dod_wording() {
   assert_no_grep "no-mistakes refuses" "$brief" \
     "no-mistakes DOD must not claim the tool itself refuses --yes"
   pass "fm-brief.sh: no-mistakes DOD keeps its apostrophe prose and bans --yes outright"
+}
+
+# A worker that finished implementing and committing must never be told to
+# say `done:` before a PR-ending mode's PR actually exists, and the fix must
+# not spread that PR-only "done:" restriction onto a mode or kind whose
+# contract legitimately has no PR.
+test_done_requires_pr_url_only_where_a_pr_ends_the_task() {
+  local home id brief
+  home="$TMP_ROOT/done-pr-guard-home"
+  mkdir -p "$home/data"
+
+  for id in brief-guard-nm brief-guard-direct; do
+    case "$id" in
+      brief-guard-nm) FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" some-proj --mode no-mistakes >/dev/null 2>&1 ;;
+      *) FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" some-proj --mode direct-PR >/dev/null 2>&1 ;;
+    esac
+    brief="$home/data/$id/brief.md"
+    assert_grep "does not carry that PR URL" "$brief" \
+      "$id: PR-ending mode must forbid a done: line with no PR URL"
+    assert_grep "1. Implement" "$brief" \
+      "$id: PR-ending mode must sequence implementation as a numbered step"
+  done
+
+  id="brief-guard-local"
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" some-proj --mode local-only >/dev/null 2>&1
+  brief="$home/data/$id/brief.md"
+  assert_grep "done: ready in branch fm/$id" "$brief" \
+    "local-only brief lost its no-PR done: line"
+  assert_no_grep "does not carry that PR URL" "$brief" \
+    "local-only brief must not receive the PR-ending done: guard; it has no PR by design"
+
+  id="brief-guard-scout"
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" some-proj --scout >/dev/null 2>&1
+  brief="$home/data/$id/brief.md"
+  # shellcheck disable=SC2016  # single quotes are deliberate: the backticks must stay literal
+  assert_grep 'append `done: {one-line conclusion}`' "$brief" \
+    "scout brief lost its report-based done: line"
+  assert_no_grep "does not carry that PR URL" "$brief" \
+    "scout brief must not receive the PR-ending done: guard; a scout never has a PR"
+
+  pass "fm-brief.sh: the done:-requires-a-PR-URL guard lands only on PR-ending modes"
 }
 
 test_ask_user_escalation_format() {
@@ -878,6 +930,7 @@ test_ship_mode_is_explicit_not_registry
 test_delivery_flags_are_refused_where_they_do_not_apply
 test_faster_paths_use_configured_authority_without_stacked_review
 test_no_mistakes_dod_wording
+test_done_requires_pr_url_only_where_a_pr_ends_the_task
 test_ask_user_escalation_format
 test_ship_project_memory_wording
 test_herdr_lab_contract_is_explicit_and_complete


### PR DESCRIPTION
## Intent

Firstmate spent one evening steering six different workers past the same line, and the sixth time made it obvious the workers were not the problem.

Each of them finished implementing, testing and browser-proving its work, then appended a `done:` status describing all of that - with no pipeline run and no PR. One wrote "ready for /no-mistakes" as its done line. Every one needed the supervisor to send the same sentence again: your contract ends at the PR, not at a commit.

Six workers, six tasks, two different model families, one behaviour. The generated brief states the contract correctly and emphatically, and it still does not land at the moment a worker believes it has finished.

## What Changed

- `bin/fm-dod-lib.sh` rewrites the no-mistakes and direct-PR Definition-of-done blocks as ordered numbered steps that end at the PR: the no-mistakes worker now starts `/no-mistakes` itself right after its commit instead of waiting for firstmate to tell it to, and the previously trailing "after CI green, append `done: PR {url} checks green`" sentence becomes step 4 of that list. Both blocks now state that a `done:` status line must carry that mode's PR URL, and that a finished-but-unshipped implementation reports `working:` plus the exact next step. The local-only and scout blocks keep their own no-PR `done:` semantics, and a new header comment records that nothing in the code rejects a premature `done:` - this is a clearer contract, not a guarantee.
- `AGENTS.md` updates the Validate section to match: for a no-mistakes ship the worker starts validation itself per its brief's Definition of done, and firstmate steers it there with the `harness-adapters` invocation only if the worker stalls before that step.
- `tests/fm-brief.test.sh` replaces the assertion on the removed "Firstmate will then instruct you to run /no-mistakes" handshake, asserts the numbered pipeline step and the `done:`-requires-a-PR-URL wording in the no-mistakes brief, and adds `test_done_requires_pr_url_only_where_a_pr_ends_the_task`, which checks the new guard renders for no-mistakes and direct-PR but is absent from local-only and scout briefs.

## Risk Assessment

✅ Low: Todos os hunks são prosa de brief gerado, uma frase de documentação e testes sobre esse artefacto; nenhum caminho de execução mudou e o estreitamento do `working:` foi verificado contra a regra absoluta que continua a cobrir o caso de run activa.

## Testing

Conduzi o produto real, bin/fm-brief.sh, contra um FM_HOME temporário e li os briefs gerados, que são a superfície entregue ao worker. Os dois modos que terminam em PR mostram agora os passos numerados, a regra de que `done:` exige o URL do PR, e o `working:` limitado a quem ainda não iniciou o pipeline. Local-only e scout continuam com o seu `done:` sem PR e sem a nova guarda. No cenário adversarial do worker já dentro de uma run e parado num gate ask-user, a condição do `working:` não se aplica e a regra de escalação continua a mandar `needs-decision:` e parar, que era exactamente o risco levantado na revisão. Os testes dirigidos de brief e de delivery passam. Não há evidência visual porque a mudança não tem superfície gráfica; o artefacto equivalente é o brief markdown gerado, guardado na pasta de evidência.

- Live validation: ✅ go - 6 of 7 scenarios driven live against the product

| Scenario | Result | Live | Evidence |
| --- | --- | --- | --- |
| Um brief no-mistakes gerado apresenta o arranque do pipeline como passo numerado e o PR validado como meta | ✅ pass | live | brief-dod-nm.md gerado por bin/fm-brief.sh; passos 1 a 4 presentes, sem a antiga frase de espera por firstmate |
| Um brief no-mistakes proíbe uma linha done: sem URL de PR e nomeia working: como substituto | ✅ pass | live | brief-dod-nm.md, linhas do bloco `done:` e `working:` após o passo 4 |
| Adversarial: worker já dentro de uma run e parado num gate ask-user não é mandado emitir working: nem reiniciar /no-mistakes | ✅ pass | live | grep de todas as ocorrências de working:, done: e needs-decision: no brief gerado; a condição do working: exige não ter iniciado o pipeline, e a regra 6 manda needs-decision: e parar |
| Um brief direct-PR apresenta o PR como passo numerado com a mesma guarda de URL | ✅ pass | live | brief-dod-direct.md gerado por bin/fm-brief.sh |
| Local-only e scout mantêm o done: sem PR e não recebem a guarda de URL | ✅ pass | live | brief-dod-local.md e brief-dod-scout.md; ambos mantêm o done: próprio e não contêm a frase da guarda |
| A linha mecânica Delivery contract: mode= continua a ser lida pelo spawn a partir de um brief real | ✅ pass | live | ./tests/fm-task-delivery.test.sh, incluindo o caso do acordo entre o modo gravado no brief e o modo explícito do spawn |
| Um worker LLM real que acabou de fazer commit inicia /no-mistakes em vez de escrever done: | ⏸️ untested | no | Exige avaliação com modelos vivos a executar o brief num worker real, o que sai da validação determinística e não está disponível aqui. Para o cobrir seria preciso autoridade para lançar workers de av… |

<details>
<summary>Evidence: Definition of done gerada, modo no-mistakes</summary>

Source: [Definition of done gerada, modo no-mistakes](https://github.com/tpeixinho/firstmate/blob/b79f9d4de5d63f1d72015394f75b6ff985d96c59/.no-mistakes/evidence/fm/land-the-ship-brief-fix-make-the-pipelin-02/brief-dod-nm.md)

```text
# Definition of done
Delivery contract: mode=no-mistakes
This task ships **no-mistakes**: a validated PR is the finish line, not the commit.
Work through these steps in order; do not stop after step 1 believing the task is finished.
1. Implement, test, and commit on your branch.
2. Immediately start /no-mistakes yourself; do not wait for firstmate to tell you to.
3. Drive every no-mistakes gate to completion, following the guidance below.
4. After /no-mistakes reports CI green (the CI-ready return point - do not wait for it to keep monitoring in the background until merge), append `done: PR {url} checks green` and stop. You are finished.

`done:` on this task means exactly step 4, never anything earlier: never append `done:` on a status line that does not carry that PR URL.
If the implementation is finished but you have not started /no-mistakes yet, the correct word is `working:` (for example `working: implemented, starting /no-mistakes`), and the exact next action is step 2 above.

You drive no-mistakes by responding to its gates, not by implementing fixes.
Follow the guidance no-mistakes itself provides for the mechanics: it loads when you invoke /no-mistakes, and `no-mistakes axi run --help` plus the `help` lines in each `axi` response are authoritative and version-matched to the installed binary.
When starting no-mistakes, pass `--intent` as only this brief's `## Captain's intent` subsection plus any later words the captain actually said.
For a legacy brief with no such subsection, include only words explicitly labeled `Captain:`, `Captain's words:`, `Captain's ask:`, or `Captain's intent:`; never copy its mixed `# Task` wholesale. If it has no provenance-marked captain words, stop and ask firstmate instead of starting no-mistakes.
Do not include `## Firstmate spec`, later Firstmate build constraints, or your own decisions and tradeoffs.
The `--intent` string you pass must be self-sufficient: that string plus the codebase must let a reader reconstruct roughly the same specification, without depending on a separate report, a PR, or context that lives only in this conversation.
When the captain's intent refers to a report, decision, or PR ("do items 1, 2, 3, and 7 of the report"), write the substance of the referenced items into `--intent` in the captain's terms, not only the pointer; that substance is the captain's ask by reference, while Firstmate's build instructions and your own decisions still stay out.
This replaces the no-mistakes skill's advice to enrich `--intent` with decisions and tradeoffs; that advice does not apply to Firstmate-dispatched work.
Do not hand-edit, commit, or fix findings yourself while a run is active - the pipeline applies every fix.

One drive call blocks until the next gate or outcome, which routinely outlives what your harness lets a single command run: Claude Code kills a command at ten minutes maximum, while one fix round is capped around thirty minutes and up to three rounds chain.
So background the drive call and poll `no-mistakes axi status` from a separate call instead of sitting in one blocking hold your harness will kill.
Where a harness's own command limit is not established, assume it bounds commands and use that same background-and-poll shape.
A killed or timed-out call is never evidence the daemon died: the daemon accepts your response immediately and runs the round in the background, so the call was only ever waiting for a read while the run kept working.
Reattach and keep going rather than reporting the pipeline blocked; rule 7 owns the checks that decide when a pipeline block is real.

Two firstmate-specific rules layer on top of that guidance:
- ask-user findings are never yours to answer: escalate to firstmate using rule 6's ask-user format and stop.
  Firstmate applies `ask-user-authority` and obtains any required captain decision.
  When the decision comes back, feed it to the gate with `no-mistakes axi respond` and let the pipeline apply it - do not route the question to "the user" or implement the fix yourself.
- NEVER pass `--yes` (or `-y`) to `no-mistakes axi run` or `no-mistakes axi respond`. It is banned fleet-wide.
  It auto-resolves every gate including ask-user findings with no escalation, and answering your own ask-user finding is a hard rule violation.
```
</details>
<details>
<summary>Evidence: Definition of done gerada, modo direct-PR</summary>

Source: [Definition of done gerada, modo direct-PR](https://github.com/tpeixinho/firstmate/blob/b79f9d4de5d63f1d72015394f75b6ff985d96c59/.no-mistakes/evidence/fm/land-the-ship-brief-fix-make-the-pipelin-02/brief-dod-direct.md)

```text
# Definition of done
Delivery contract: mode=direct-PR
This task ships **direct-PR**: the PR is the finish line, not the commit.
Work through these steps in order; do not stop after step 1 believing the task is finished.
1. Implement and commit on your branch.
2. Push your branch and open a PR with `gh-axi`.
3. Append `done: PR {url}` to the status file and stop.
Never append `done:` on a status line that does not carry that PR URL: if the implementation is finished but no PR exists yet, the correct word is `working:`, and the exact next action is step 2 above.
Do NOT run /no-mistakes. The configured merge authority decides whether to merge the PR; firstmate relays the outcome.
```
</details>
<details>
<summary>Evidence: Definition of done gerada, modo local-only</summary>

Source: [Definition of done gerada, modo local-only](https://github.com/tpeixinho/firstmate/blob/b79f9d4de5d63f1d72015394f75b6ff985d96c59/.no-mistakes/evidence/fm/land-the-ship-brief-fix-make-the-pipelin-02/brief-dod-local.md)

```text
# Definition of done
Delivery contract: mode=local-only
This task ships **local-only**: no remote, no PR, no pipeline.
The task is complete only when committed on your branch `fm/live-local`. Do NOT push, do NOT open a PR, do NOT merge.
Keep your branch a clean fast-forward onto the current default branch - if `main` has advanced, rebase onto it so the eventual merge stays a fast-forward.
When it is implemented and committed, append `done: ready in branch fm/live-local` to the status file and stop.
The configured merge authority approves the ready branch, then firstmate merges it into local `main` through the guarded fast-forward path.
```
</details>
<details>
<summary>Evidence: Definition of done gerada, scout</summary>

Source: [Definition of done gerada, scout](https://github.com/tpeixinho/firstmate/blob/b79f9d4de5d63f1d72015394f75b6ff985d96c59/.no-mistakes/evidence/fm/land-the-ship-brief-fix-make-the-pipelin-02/brief-dod-scout.md)

```text
# Definition of done
Write your findings to `/var/folders/3r/6cq6fg_x461_vvfymrdp2npw0000gn/T/tmp.Dmlykxz7UG/fmhome/data/live-scout/report.md`.
The report must stand alone: what you did, what you found, the evidence (commands run, output, file:line references), and what you recommend.
If your deliverable is a visual artifact the captain will review and iterate on, you may host the Lavish review loop yourself (poll, revise, re-serve, staying alive) instead of handing it back to firstmate.
Before reporting done, read and follow `~/.no-mistakes/worktrees/bae792236fae/01M200VYHME4322487WPEW6SCV/.agents/skills/captain-hold-lifecycle/SKILL.md` and pass its shared completion gate for the report and any visual review.
When the report is complete, append `done: {one-line conclusion}` to the status file and stop.
If your findings reveal work that should ship (e.g. you reproduced a bug and the fix is clear), say so in the report; firstmate may promote this task in place, and you would then receive mode-specific ship instructions as a follow-up message.
```
</details>
<details>
<summary>Evidence: Brief no-mistakes completo tal como o worker o recebe</summary>

Source: [Brief no-mistakes completo tal como o worker o recebe](https://github.com/tpeixinho/firstmate/blob/b79f9d4de5d63f1d72015394f75b6ff985d96c59/.no-mistakes/evidence/fm/land-the-ship-brief-fix-make-the-pipelin-02/brief-no-mistakes-full.md)

```text
You are a crewmate: an autonomous worker agent managed by firstmate. Work on your own; do not wait for a human.

# Task
## Captain's intent
{TASK}

## Firstmate spec
{FIRSTMATE_SPEC}

# Herdr lifecycle declaration - NOT ENABLED
**HARD SAFETY GATE:** this scaffold cannot inspect the task text filled in above.
If the task will start, stop, delete, restart, profile, or otherwise drive Herdr lifecycle behavior, stop and regenerate the brief with `--herdr-lab` before dispatch.
Do not add Herdr lifecycle commands to this unguarded brief by hand.

# Setup
You are in a disposable git worktree of some-proj, at a detached HEAD on a clean default branch.

**Verify isolation before anything else.** Run `pwd -P` and `git rev-parse --show-toplevel`; both must resolve to the disposable task worktree you were launched in, such as a treehouse pool path or an Orca-managed worktree, not the primary checkout firstmate operates from.
The path check is authoritative: `git rev-parse --git-dir` and `git rev-parse --git-common-dir` can help inspect the repo, but they do not prove you are outside the primary checkout.
If the top-level path is the primary checkout or not the worktree you were launched in, STOP - do not branch or commit here - append `blocked: launched in primary checkout, not an isolated worktree` to the status file and stop.

1. First action: create your branch: `git checkout -b fm/live-nm`
2. Run `no-mistakes doctor`; if it reports the repo is not initialized here, run `no-mistakes init`.

# Rules
1. Never push to the default branch. Never merge a PR.
2. Stay inside this worktree; modify nothing outside it.
3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.
4. Report status by appending one line:
   `echo "{state}: {one short line}" >> '/var/folders/3r/6cq6fg_x461_vvfymrdp2npw0000gn/T/tmp.Dmlykxz7UG/fmhome/state/live-nm.status'`
   States: working, needs-decision, blocked, paused, done, failed.
   Each append wakes firstmate, so report sparingly: only phase changes a supervisor
   would act on (setup done, bug reproduced, fix implemented, validation passed) and the
   needs-decision/blocked/paused/done/failed states. No step-by-step FYI progress lines;
   firstmate reads your pane for that.
   Whenever you mention a PR anywhere - a status line, your terminal, a summary - write its full
   https:// URL exactly as the forge printed it, never a bare number such as "PR 108"; firstmate
   copies that URL from your line rather than assembling one.
   A mid-task `working:` line (including setup complete) is nonterminal: do not end the
   turn after it; continue the same stage until a defined `done:` gate under Definition of done.
   Use `paused: {why}` - distinct from `blocked:` - ONLY when you are deliberately idling on a
   known external wait you expect to clear on its own (an upstream release, a rate-limit reset,
   a scheduled window): firstmate then leaves your idle pane alone and rechecks it on a long
   cadence instead of treating it as a possible wedge. Use `blocked:` when you are stuck and need help.
5. If you hit the same obstacle twice, append `blocked: {why}` and stop; firstmate will help.
6. If a decision belongs above the implementation worker (product choices, destructive actions),
   append `needs-decision: {summary of options}` and stop. Firstmate will reply with the decision.
   For a no-mistakes ask-user gate specifically, escalate all ask-user findings as one event plus one snapshot file, using that same shape even when the gate holds only a single ask-user finding: write only the ask-user findings, verbatim and unparaphrased (id, severity, file, line, description, authority), to `/var/folders/3r/6cq6fg_x461_vvfymrdp2npw0000gn/T/tmp.Dmlykxz7UG/fmhome/data/live-nm/nm-<run>-findings.txt`, then report the gate with
   `needs-decision [key=nm-<run>-<step>]: ask-user findings=<id1>,<id2>,... file=/var/folders/3r/6cq6fg_x461_vvfymrdp2npw0000gn/T/tmp.Dmlykxz7UG/fmhome/data/live-nm/nm-<run>-findings.txt`
   naming every ask-user finding id from that gate. The status line only points at the file; it never restates or summarizes a finding's content.
   A decision or blocker you opened stays open until a `resolved` line carrying its exact key lands; a later `done:` or `working:` line never closes it, even when the answer is what started that work.
   Firstmate's reply normally writes that closing line at answer time; when a blocker or wait clears WITHOUT a firstmate reply, append `resolved: {how it cleared}` yourself (same `[key=<slug>]` if you opened it with one) as you resume.
7. Never stop, restart, or update the shared `no-mistakes` daemon - it is one instance serving
   every lane/home, so restarting it kills other lanes' in-flight pipeline runs; only firstmate
   manages the daemon.
   Before you append `blocked:` about the pipeline, run `no-mistakes daemon status` and
   `no-mistakes axi status`. If the daemon socket refuses connections or is missing, append
   `blocked: {the daemon error}` and stop even when the local run record still says running or
   fixing, because that record can be stale after the daemon exits. A run record failed with a
   daemon error is also a real block.
   Only after ruling out socket refusal, if the run is still running or fixing, reattach and keep
   going. A drive-call error, timeout, slow read, or generic unreachability is NOT a daemon error:
   the daemon accepts `respond` immediately and runs the round in the background, so a killed or
   timed-out call was only waiting for a read while the run kept working.

# Firstmate instruction inbox
Firstmate steers you through durable message files in '/var/folders/3r/6cq6fg_x461_vvfymrdp2npw0000gn/T/tmp.Dmlykxz7UG/fmhome/state/live-nm.inbox'.
When a terminal message says an instruction is waiting there - and at any natural checkpoint when you are unsure - list '/var/folders/3r/6cq6fg_x461_vvfymrdp2npw0000gn/T/tmp.Dmlykxz7UG/fmhome/state/live-nm.inbox'/*.msg, read and act on each message in numeric order, then acknowledge each handled message by moving it: `mv '/var/folders/3r/6cq6fg_x461_vvfymrdp2npw0000gn/T/tmp.Dmlykxz7UG/fmhome/state/live-nm.inbox'/NNN.msg '/var/folders/3r/6cq6fg_x461_vvfymrdp2npw0000gn/T/tmp.Dmlykxz7UG/fmhome/state/live-nm.inbox'/handled/`.
The move IS the acknowledgement: without it firstmate rings again and eventually treats you as stuck. An empty or absent inbox needs no action.

# Project memory
If `AGENTS.md` or `CLAUDE.md` already exists, or if this task produced durable project-intrinsic knowledge, run `~/.no-mistakes/worktrees/bae792236fae/01M200VYHME4322487WPEW6SCV/bin/fm-ensure-agents-md.sh .` in the worktree.
Record only project knowledge useful to almost every future session.
For anything the codebase already shows, prefer a pointer to the authoritative file, command, or doc over copying the detail.
If you touch a project `AGENTS.md`, follow `~/.no-mistakes/worktrees/bae792236fae/01M200VYHME4322487WPEW6SCV/bin/fm-ensure-agents-md.sh`'s self-governance contract in the same pass.
Keep it proportionate: skip `AGENTS.md` edits for trivial tasks that produced no durable project knowledge.

# Definition of done
Delivery contract: mode=no-mistakes
This task ships **no-mistakes**: a validated PR is the finish line, not the commit.
Work through these steps in order; do not stop after step 1 believing the task is finished.
1. Implement, test, and commit on your branch.
2. Immediately start /no-mistakes yourself; do not wait for firstmate to tell you to.
3. Drive every no-mistakes gate to completion, following the guidance below.
4. After /no-mistakes reports CI green (the CI-ready return point - do not wait for it to keep monitoring in the background until merge), append `done: PR {url} checks green` and stop. You are finished.

`done:` on this task means exactly step 4, never anything earlier: never append `done:` on a status line that does not carry that PR URL.
If the implementation is finished but you have not started /no-mistakes yet, the correct word is `working:` (for example `working: implemented, starting /no-mistakes`), and the exact next action is step 2 above.

You drive no-mistakes by responding to its gates, not by implementing fixes.
Follow the guidance no-mistakes itself provides for the mechanics: it loads when you invoke /no-mistakes, and `no-mistakes axi run --help` plus the `help` lines in each `axi` response are authoritative and version-matched to the installed binary.
When starting no-mistakes, pass `--intent` as only this brief's `## Captain's intent` subsection plus any later words the captain actually said.
For a legacy brief with no such subsection, include only words explicitly labeled `Captain:`, `Captain's words:`, `Captain's ask:`, or `Captain's intent:`; never copy its mixed `# Task` wholesale. If it has no provenance-marked captain words, stop and ask firstmate instead of starting no-mistakes.
Do not include `## Firstmate spec`, later Firstmate build constraints, or your own decisions and tradeoffs.
The `--intent` string you pass must be self-sufficient: that string plus the codebase must let a reader reconstruct roughly the same specification, without depending on a separate report, a PR, or context that lives only in this conversation.
When the captain's intent refers to a report, decision, or PR ("do items 1, 2, 3, and 7 of the report"), write the substance of the referenced items into `--intent` in the captain's terms, not only the pointer; that substance is the captain's ask by reference, while Firstmate's build instructions and your own decisions still stay out.
This replaces the no-mistakes skill's advice to enrich `--intent` with decisions and tradeoffs; that advice does not apply to Firstmate-dispatched work.
Do not hand-edit, commit, or fix findings yourself while a run is active - the pipeline applies every fix.

One drive call blocks until the next gate or outcome, which routinely outlives what your harness lets a single command run: Claude Code kills a command at ten minutes maximum, while one fix round is capped around thirty minutes and up to three rounds chain.
So background the drive call and poll `no-mistakes axi status` from a separate call instead of sitting in one blocking hold your harness will kill.
Where a harness's own command limit is not established, assume it bounds commands and use that same background-and-poll shape.
A killed or timed-out call is never evidence the daemon died: the daemon accepts your response immediately and runs the round in the background, so the call was only ever waiting for a read while the run kept working.
Reattach and keep going rather than reporting the pipeline blocked; rule 7 owns the checks that decide when a pipeline block is real.

Two firstmate-specific rules layer on top of that guidance:
- ask-user findings are never yours to answer: escalate to firstmate using rule 6's ask-user format and stop.
  Firstmate applies `ask-user-authority` and obtains any required captain decision.
  When the decision comes back, feed it to the gate with `no-mistakes axi respond` and let the pipeline apply it - do not route the question to "the user" or implement the fix yourself.
- NEVER pass `--yes` (or `-y`) to `no-mistakes axi run` or `no-mistakes axi respond`. It is banned fleet-wide.
  It auto-resolves every gate including ask-user findings with no escalation, and answering your own ask-user finding is a hard rule violation.
```
</details>
<details>
<summary>Evidence: tests/fm-brief.test.sh</summary>

Source: [tests/fm-brief.test.sh](https://github.com/tpeixinho/firstmate/blob/b79f9d4de5d63f1d72015394f75b6ff985d96c59/.no-mistakes/evidence/fm/land-the-ship-brief-fix-make-the-pipelin-02/tests-fm-brief.log)

```text
ok - fm-brief: scaffolds leave the worker role scope to the launch boundary and keep the secondmate contract
ok - fm-brief.sh: bash -n succeeds
/private/var/folders/3r/6cq6fg_x461_vvfymrdp2npw0000gn/T/fm-brief.S6Ykyf/heredoc-in-substitution.sh:2
ok - fm-brief.sh: no heredoc is nested inside a command substitution (Bash 3.2 parse-safe)
ok - fm-brief.sh: --help renders the complete header
ok - fm-brief.sh: no-mistakes/direct-PR/local-only briefs generate cleanly
ok - fm-brief.sh: ship --mode is required and closed-set validated
ok - fm-brief.sh: the explicit ship mode wins over the registered posture
ok - fm-brief.sh: --yolo and scout/secondmate --mode are refused, never silently dropped
ok - fm-brief.sh: faster paths use configured authority without stacked review
ok - fm-brief.sh: no-mistakes DOD keeps its apostrophe prose and bans --yes outright
ok - fm-brief.sh: the done:-requires-a-PR-URL guard lands only on PR-ending modes
ok - fm-brief.sh: no-mistakes ask-user findings use one event plus a verbatim snapshot
ok - fm-brief.sh: ship project-memory wording carries the AGENTS.md authoring bar
ok - fm-brief.sh: --herdr-lab emits the complete hard safety contract
ok - fm-brief.sh: --herdr-lab uses its quoted Firstmate-owned helper path
ok - fm-brief.sh: ship and scout scaffolds make omitted Herdr intent fail-visible
ok - fm-brief.sh: the documented {TASK} and {FIRSTMATE_SPEC} fills cannot corrupt the Herdr safety gate
ok - fm-brief.sh: Herdr lab contract covers scouts and rejects secondmate misuse
ok - fm-brief.sh: --no-projects scaffolds a project-less charter and guards misuse
ok - fm-brief.sh: marked requests avoid generic acknowledgements and preserve material reporting
ok - fm-brief.sh: relative directory inputs ignore CDPATH, render stable absolute charter paths, or fail loudly
ok - fm-brief.sh: custom pause verb renders in every scaffold
ok - fm-brief.sh: investigation and visual-review completions load the shared decision policy
ok - fm-brief: scout and secondmate code paths still scaffold well-formed briefs
```
</details>
<details>
<summary>Evidence: tests/fm-task-delivery.test.sh</summary>

Source: [tests/fm-task-delivery.test.sh](https://github.com/tpeixinho/firstmate/blob/b79f9d4de5d63f1d72015394f75b6ff985d96c59/.no-mistakes/evidence/fm/land-the-ship-brief-fix-make-the-pipelin-02/tests-fm-task-delivery.log)

```text
ok - fm-spawn: every legacy worker receives scoped role instructions without changing project or primary instructions
ok - fm-spawn: a ship spawn requires a valid explicit mode and yolo before anything is created
ok - fm-spawn: scout and secondmate spawns refuse ship delivery flags
ok - fm-spawn: the brief's recorded mode and the spawn's explicit mode must agree
ok - fm-spawn: a rigor downgrade against the registered posture is announced, never blocked
ok - fm-spawn: a scout spawn resolves no delivery posture from the registry
ok - fm-promote: promotion requires the delivery contract and records it exactly once
ok - fm-promote: a symlinked task record is refused and its target is left untouched
ok - fm-promote: a promoted worker receives the same mode-specific delivery contract a briefed one does
ok - fm-project-mode: the conditional policy is accepted, mapped for mechanical callers, and readable raw
ok - fm-spawn/fm-promote: leftover Task placeholders are refused until both subsections are filled
# all fm-task-delivery tests passed
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"63f45b50b4dba0545530d015e0a8acb6e6a7599a","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>⚠️ **Review** - 1 info</summary>

- ⚠️ `bin/fm-dod-lib.sh:242` - No bloco no-mistakes, a frase &#34;If the implementation is finished but you have not yet driven /no-mistakes to a green CI, the correct word is `working:` ... and the exact next action is step 2 above&#34; cobre todos os estados intermédios do pipeline, não apenas o de &#34;ainda não iniciei&#34;. Caso concreto: worker parado num gate ask-user. A regra 6 e o bloco de escalação mandam escrever `needs-decision:` e parar, mas esta frase manda `working:` e aponta como próxima acção o passo 2, isto é iniciar /no-mistakes outra vez com uma run activa, algo que o AGENTS.md proíbe expressamente (&#34;do not ... start a second validation run&#34;). A frase equivalente do direct-PR usa a condição precisa &#34;no PR exists yet&#34;. Correcção mínima: restringir a condição a &#34;you have not yet started /no-mistakes&#34;.
- ⚠️ `bin/fm-dod-lib.sh:17` - O comentário de cabeçalho afirma que a mudança &#34;closes the finish-line ambiguity by construction instead of by a louder reminder&#34;, mas a alteração é inteiramente texto do brief entregue ao worker. Sequência que continua acessível: o worker faz commit e acrescenta `done: implemented, ready for /no-mistakes`; não existe registo de run, bin/fm-crew-state.sh é conduzido pelo registo da run e cai para o `done` do status log, log_reports_ci_ready devolve 1 por faltar o URL do PR combinado com &#34;checks green&#34;, e nada rejeita nem reclassifica a linha, pelo que o supervisor tem de a apanhar manualmente tal como antes. O intent regista que o texto já era emfático e falhou seis vezes. Não classifico como erro porque o intent não proíbe uma correcção textual; fica para decisão porque o remédio que tornaria a invariante verdadeira (guarda ciente do modo sobre uma linha `done:` sem URL de PR nos modos que terminam em PR, em bin/fm-classify-lib.sh ou bin/fm-crew-state.sh) alarga o âmbito da mudança, e é o remédio, não o defeito, que precisa de autorização.
- ⚠️ `bin/fm-dod-lib.sh:211` - A reestruturação do bloco direct-PR em lista numerada mais a nova frase de guarda do `done:` é uma cópia paralela da regra para um modo que a evidência do intent não cobre: o relato descreve apenas workers no-mistakes que apenderam `done:` sem pipeline nem PR. O bloco direct-PR tinha, isso sim, uma contradição própria (&#34;The task is complete only when committed on your branch&#34; seguido de &#34;push ... open a PR ... then append `done: PR {url}`&#34;), pelo que a forma estritamente mais estreita é apagar essa única frase contraditória e manter o resto do bloco como estava, em vez de replicar o padrão de passos numerados e a guarda do URL. Remédio recomendado: reduzir a alteração do direct-PR a essa supressão.

🔧 Fix applied.
1 info still open:

- ℹ️ `tests/fm-brief.test.sh:337` - O comentário do teste ainda diz &#34;this is the closes-by-construction fix for workers reporting `done:` right after their commit&#34;, a mesma alegação de garantia que a ronda de correcção retirou do cabeçalho de bin/fm-dod-lib.sh. O cabeçalho passou a dizer explicitamente &#34;nothing in the code rejects a premature `done:`, so this is a clearer contract, not a guarantee&#34;, pelo que a mudança deixa duas descrições contraditórias do mesmo efeito. Remédio: reescrever o comentário para &#34;numbered action, not a condition&#34;, sem afirmar garantia.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- Live validation: ✅ go - 6 of 7 scenarios driven live against the product

| Scenario | Result | Live | Evidence |
| --- | --- | --- | --- |
| Um brief no-mistakes gerado apresenta o arranque do pipeline como passo numerado e o PR validado como meta | ✅ pass | live | brief-dod-nm.md gerado por bin/fm-brief.sh; passos 1 a 4 presentes, sem a antiga frase de espera por firstmate |
| Um brief no-mistakes proíbe uma linha done: sem URL de PR e nomeia working: como substituto | ✅ pass | live | brief-dod-nm.md, linhas do bloco `done:` e `working:` após o passo 4 |
| Adversarial: worker já dentro de uma run e parado num gate ask-user não é mandado emitir working: nem reiniciar /no-mistakes | ✅ pass | live | grep de todas as ocorrências de working:, done: e needs-decision: no brief gerado; a condição do working: exige não ter iniciado o pipeline, e a regra 6 manda needs-decision: e parar |
| Um brief direct-PR apresenta o PR como passo numerado com a mesma guarda de URL | ✅ pass | live | brief-dod-direct.md gerado por bin/fm-brief.sh |
| Local-only e scout mantêm o done: sem PR e não recebem a guarda de URL | ✅ pass | live | brief-dod-local.md e brief-dod-scout.md; ambos mantêm o done: próprio e não contêm a frase da guarda |
| A linha mecânica Delivery contract: mode= continua a ser lida pelo spawn a partir de um brief real | ✅ pass | live | ./tests/fm-task-delivery.test.sh, incluindo o caso do acordo entre o modo gravado no brief e o modo explícito do spawn |
| Um worker LLM real que acabou de fazer commit inicia /no-mistakes em vez de escrever done: | ⏸️ untested | no | Exige avaliação com modelos vivos a executar o brief num worker real, o que sai da validação determinística e não está disponível aqui. Para o cobrir seria preciso autoridade para lançar workers de av… |

- <code>`FM_HOME=&lt;tmp&gt; ./bin/fm-brief.sh live-nm some-proj --mode no-mistakes` e inspecção do brief.md gerado</code>
- `FM_HOME=<tmp> ./bin/fm-brief.sh live-direct some-proj --mode direct-PR`
- `FM_HOME=<tmp> ./bin/fm-brief.sh live-local some-proj --mode local-only`
- `FM_HOME=<tmp> ./bin/fm-brief.sh live-scout some-proj --scout`
- <code>`grep -n &#39;working:|done:|needs-decision&#39; brief.md` no brief no-mistakes gerado (cenário adversarial ask-user)</code>
- <code>`grep -c &#39;After /no-mistakes reports CI green&#39; brief.md` = 1 (sem duplicação após a frase ter sido movida para o passo 4)</code>
- `./tests/fm-brief.test.sh`
- <code>`./tests/fm-task-delivery.test.sh` (acordo entre o modo gravado no brief e o modo do spawn)</code>
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
