### PR TITLE
docs(bin): record the second Claude "Quick safety check" prompt

### DIFF
--- a/.agents/skills/harness-adapters/references/harness/claude.md
+++ b/.agents/skills/harness-adapters/references/harness/claude.md
@@ -24,7 +24,7 @@ That covers the first dialog only.
 A second prompt can sit behind it: a "Quick safety check" listing the tool permissions the folder pre-approves in `.claude/settings.json`, with the cursor on `No, continue without these permissions`.
 It was observed on 2026-09-07 on Claude Code 2.1.263, after the trust dialog had been pre-registered, and it wedged two workers until a human answered it in the pane.
 That project's tracked `.claude/settings.json` carried both `PreToolUse` hooks and `permissions.allow` rules, but what configuration reaches the prompt is UNESTABLISHED, so treat no settings shape as exempt.
-Nothing pre-registers that prompt today, and `hasTrustDialogHooksAccepted` is not the key that would: it appears in the measured store only as `false`, and the slots a human accepted carry only `hasTrustDialogAccepted`.
+Nothing pre-registers that prompt today, and `hasTrustDialogHooksAccepted` is NOT ESTABLISHED as the key that would: it appears in the measured store only as `false` and never as `true`, so pre-registering it `true` would write a value the vendor has never been observed writing.
 `../../../../../docs/verification/runtime-backends.md` under "Claude workspace trust" owns that observation, what it rules out, and why refreshing it needs a live spawn.
 
 Never try to answer the trust dialog with a key.

--- a/.agents/skills/harness-adapters/references/harness/claude.md
+++ b/.agents/skills/harness-adapters/references/harness/claude.md
@@ -20,9 +20,18 @@ Claude gates a folder it has never seen behind an interactive workspace-trust di
 A ship or scout spawn therefore pre-registers the worktree before launch, and the dialog does not appear.
 `../../../bin/fm-claude-trust.sh` records `hasTrustDialogAccepted` for that worktree path in `${CLAUDE_CONFIG_DIR:-$HOME}/.claude.json`, and `../../../bin/fm-spawn.sh` refuses the spawn when the write fails rather than launching a worker that would wedge.
 
+That covers the first dialog only.
+A project whose `.claude/settings.json` carries `permissions.allow` rules can have a second prompt behind it: a "Quick safety check" listing the pre-approved permissions, with the cursor on `No, continue without these permissions`.
+It was observed on 2026-09-07 on Claude Code 2.1.263, after the trust dialog had been pre-registered, and it wedged two workers until a human answered it in the pane.
+Nothing pre-registers that prompt today, and `hasTrustDialogHooksAccepted` is not the key that would: it appears in the measured store only as `false`, and the slots a human accepted carry only `hasTrustDialogAccepted`.
+`../../../docs/verification/runtime-backends.md` under "Claude workspace trust" owns that observation, what it rules out, and the reproduction.
+
 Never try to answer the trust dialog with a key.
 Firstmate's key plane carries only Enter, Escape, and C-c with no arrow navigation, so it cannot move a dialog's selection at all, and the observed rendering starts on `No, exit`, which means a sent Enter ends the session instead of accepting.
-A visible trust dialog means pre-registration did not take effect, so inspect the store and the spawn's error output rather than sending keys.
+Both prompts open with the same "Quick safety check" line, so read the next line and the options to tell them apart: the trust dialog says Claude will be able to read, edit, and execute files here and offers `No, exit`, while the second prompt says the folder pre-approves N tool permissions in `.claude/settings.json` and offers `No, continue without these permissions`.
+A visible TRUST DIALOG means pre-registration did not take effect, so inspect the store and the spawn's error output rather than sending keys; the second prompt is not pre-registered at all, so it appears even when the store is correct and the spawn reported success.
+The consequence of a sent Enter differs between the two prompts: on the trust dialog it selects `No, exit` and kills the worker, while on the second prompt it would select `No, continue without these permissions`, which by its own label leaves a live worker running without the folder's pre-approved commands.
+That second outcome is untested, and whether a worker degraded that way is an acceptable unwedge is an open decision the captain owns, so firstmate sends no key to either prompt until he rules.
 
 The once-per-machine bypass-permissions confirmation is a separate dialog, scoped to the machine rather than the path, and pre-registration does not address it.
 Never send Enter to that one either: it was observed rendering in the same shape as the trust dialog, with the selection on `No, exit` and the footer `Enter to confirm . Esc to cancel`, so Enter ends the session rather than accepting.

--- a/.agents/skills/harness-adapters/references/harness/claude.md
+++ b/.agents/skills/harness-adapters/references/harness/claude.md
@@ -25,7 +25,7 @@ A second prompt can sit behind it: a "Quick safety check" listing the tool permi
 It was observed on 2026-09-07 on Claude Code 2.1.263, after the trust dialog had been pre-registered, and it wedged two workers until a human answered it in the pane.
 That project's tracked `.claude/settings.json` carried both `PreToolUse` hooks and `permissions.allow` rules, but what configuration reaches the prompt is UNESTABLISHED, so treat no settings shape as exempt.
 Nothing pre-registers that prompt today, and `hasTrustDialogHooksAccepted` is not the key that would: it appears in the measured store only as `false`, and the slots a human accepted carry only `hasTrustDialogAccepted`.
-`../../../../../docs/verification/runtime-backends.md` under "Claude workspace trust" owns that observation, what it rules out, and the reproduction.
+`../../../../../docs/verification/runtime-backends.md` under "Claude workspace trust" owns that observation, what it rules out, and why refreshing it needs a live spawn.
 
 Never try to answer the trust dialog with a key.
 Firstmate's key plane carries only Enter, Escape, and C-c with no arrow navigation, so it cannot move a dialog's selection at all, and the observed rendering starts on `No, exit`, which means a sent Enter ends the session instead of accepting.

--- a/.agents/skills/harness-adapters/references/harness/claude.md
+++ b/.agents/skills/harness-adapters/references/harness/claude.md
@@ -21,8 +21,9 @@ A ship or scout spawn therefore pre-registers the worktree before launch, and th
 `../../../bin/fm-claude-trust.sh` records `hasTrustDialogAccepted` for that worktree path in `${CLAUDE_CONFIG_DIR:-$HOME}/.claude.json`, and `../../../bin/fm-spawn.sh` refuses the spawn when the write fails rather than launching a worker that would wedge.
 
 That covers the first dialog only.
-A project whose `.claude/settings.json` carries `permissions.allow` rules can have a second prompt behind it: a "Quick safety check" listing the pre-approved permissions, with the cursor on `No, continue without these permissions`.
+A second prompt can sit behind it: a "Quick safety check" listing the tool permissions the folder pre-approves in `.claude/settings.json`, with the cursor on `No, continue without these permissions`.
 It was observed on 2026-09-07 on Claude Code 2.1.263, after the trust dialog had been pre-registered, and it wedged two workers until a human answered it in the pane.
+That project's tracked `.claude/settings.json` carried both `PreToolUse` hooks and `permissions.allow` rules, but what configuration reaches the prompt is UNESTABLISHED, so treat no settings shape as exempt.
 Nothing pre-registers that prompt today, and `hasTrustDialogHooksAccepted` is not the key that would: it appears in the measured store only as `false`, and the slots a human accepted carry only `hasTrustDialogAccepted`.
 `../../../docs/verification/runtime-backends.md` under "Claude workspace trust" owns that observation, what it rules out, and the reproduction.
 

--- a/.agents/skills/harness-adapters/references/harness/claude.md
+++ b/.agents/skills/harness-adapters/references/harness/claude.md
@@ -45,7 +45,7 @@ Completed turns can render dim predicted text inside an empty composer, indistin
 The spawn scopes `CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false` to every Claude worker and secondmate without changing global config.
 CLI `--prompt-suggestions` affects print or SDK mode only and did not suppress interactive ghost text on v2.1.186.
 
-As defense in depth, `fm_composer_strip_ghost` in `../../../bin/fm-composer-lib.sh` removes SGR-2 runs before pending classification on styled tmux, Herdr, and Zellij readers.
+As defense in depth, `fm_composer_strip_ghost` in `../../../../../bin/fm-composer-lib.sh` removes SGR-2 runs before pending classification on styled tmux, Herdr, and Zellij readers.
 `../../../../../docs/herdr-backend.md` under "Composer and injection safety" owns dark-TRUECOLOR tradeoffs and `../../../../../docs/verification/runtime-backends.md` owns captures.
 Styled capture stays internal to the boolean detector; `fm-peek` and model-facing captures remain plain, without escapes.
 
@@ -59,25 +59,25 @@ The controls are scoped to the launched process and never modify the captain's g
 Primary behavior was verified 2026-07-04 on 2.1.201, preserved 2026-07-08 on 2.1.204, and Stop auto-arm revalidated 2026-07-24 on 2.1.219.
 This differs from the worker hook, which only touches a task marker through `.claude/settings.local.json`.
 
-Primary `.claude/settings.json` registers `../../../bin/fm-turnend-guard.sh --claude` and `../../../bin/fm-claude-stop-autoarm.sh` with `asyncRewake: true` and `timeout: 28800`.
+Primary `.claude/settings.json` registers `../../../../../bin/fm-turnend-guard.sh --claude` and `../../../../../bin/fm-claude-stop-autoarm.sh` with `asyncRewake: true` and `timeout: 28800`.
 Guard exit 2 plus stderr forces continuation.
 Stop payload `stop_hook_active=true` follows any hook-driven continuation, including async reawakening, so Claude mode ignores it and uses cooperative claim and epoch plus bounded re-block; default Codex mode keeps it as a one-block loop guard.
 
 Project `.claude/settings.json` loads only when the exact project root is the session root; Claude does not search parents, so Firstmate starts at repository root.
 Hooks still run through cwd-sensitive `/bin/sh`, so tracked commands anchor through `"$CLAUDE_PROJECT_DIR"/bin/...`.
-`../../../docs/turnend-guard.md` owns details.
+`../../../../../docs/turnend-guard.md` owns details.
 
-The Stop-owned watcher hook runs every Stop, foregrounds `../../../bin/fm-watch-arm.sh` only when eligible, and uses exit-2 async reawakening as notification.
+The Stop-owned watcher hook runs every Stop, foregrounds `../../../../../bin/fm-watch-arm.sh` only when eligible, and uses exit-2 async reawakening as notification.
 The model handles notifications but never routine re-arm.
-Claude's PreToolUse seatbelt blocks directly, and its deny is honored only with empty stdout; `../../../docs/arm-pretool-check.md` owns that contract.
+Claude's PreToolUse seatbelt blocks directly, and its deny is honored only with empty stdout; `../../../../../docs/arm-pretool-check.md` owns that contract.
 
 ### Delegation guard
 
 Claude delegation, scheduling, and worktree tools can create work without `state/<id>.meta`, making guards unable to count it.
-`../../../bin/fm-subagent-pretool-check.sh` denies delegation-shaped tool names.
+`../../../../../bin/fm-subagent-pretool-check.sh` denies delegation-shaped tool names.
 A primary should also keep an untracked home-local `permissions.deny` for known delegation tools so they disappear from the schema.
 Never track it in project `.claude/settings.json`, which is Claude-only and propagates to worker copies where it would disarm legitimate delegation.
-`../../../docs/subagent-guard.md` owns the contract, recommendation, `FM_ALLOW_SUBAGENT=1`, and applicability review.
+`../../../../../docs/subagent-guard.md` owns the contract, recommendation, `FM_ALLOW_SUBAGENT=1`, and applicability review.
 
 On Claude 2.1.217 the tool presents as `Agent`, and both `Agent` and `Task` worked as deny keys in an A/B with nonsense control.
 `permissions.allow` pre-approves rather than controls availability, so no closed positive allowlist exists.

--- a/.agents/skills/harness-adapters/references/harness/claude.md
+++ b/.agents/skills/harness-adapters/references/harness/claude.md
@@ -23,7 +23,7 @@ A ship or scout spawn therefore pre-registers the worktree before launch, and th
 That covers the first dialog only.
 A second prompt can sit behind it: a "Quick safety check" listing the tool permissions the folder pre-approves in `.claude/settings.json`, with the cursor on `No, continue without these permissions`.
 It was observed on 2026-09-07 on Claude Code 2.1.263, after the trust dialog had been pre-registered, and it wedged two workers until a human answered it in the pane.
-That project's tracked `.claude/settings.json` carried both `PreToolUse` hooks and `permissions.allow` rules, but what configuration reaches the prompt is UNESTABLISHED, so treat no settings shape as exempt.
+An allow-free tracked `.claude/settings.json` is not an open case: Firstmate's own repository has hooks and no `permissions` key, and routine worker spawns into its worktrees have never met this prompt; what remains open is the tracked `permissions.allow` dimension, and the record below owns that reasoning.
 Nothing pre-registers that prompt today, and `hasTrustDialogHooksAccepted` is NOT ESTABLISHED as the key that would: it appears in the measured store only as `false` and never as `true`, so pre-registering it `true` would write a value the vendor has never been observed writing.
 `../../../docs/verification/runtime-backends.md` under "Claude workspace trust" owns that observation, what it rules out, and why refreshing it needs a live spawn.
 

--- a/.agents/skills/harness-adapters/references/harness/claude.md
+++ b/.agents/skills/harness-adapters/references/harness/claude.md
@@ -18,14 +18,14 @@ Busy hooks verified 2026-07-28 on Claude Code 2.1.220.
 Claude gates a folder it has never seen behind an interactive workspace-trust dialog, so every fresh task worktree would hit it.
 `--dangerously-skip-permissions` does not cover that gate: `claude --help` records that the dialog is skipped only in non-interactive mode, through `-p` or a non-TTY stdout, and a crewmate pane is interactive.
 A ship or scout spawn therefore pre-registers the worktree before launch, and the dialog does not appear.
-`../../../../../bin/fm-claude-trust.sh` records `hasTrustDialogAccepted` for that worktree path in `${CLAUDE_CONFIG_DIR:-$HOME}/.claude.json`, and `../../../../../bin/fm-spawn.sh` refuses the spawn when the write fails rather than launching a worker that would wedge.
+`../../../bin/fm-claude-trust.sh` records `hasTrustDialogAccepted` for that worktree path in `${CLAUDE_CONFIG_DIR:-$HOME}/.claude.json`, and `../../../bin/fm-spawn.sh` refuses the spawn when the write fails rather than launching a worker that would wedge.
 
 That covers the first dialog only.
 A second prompt can sit behind it: a "Quick safety check" listing the tool permissions the folder pre-approves in `.claude/settings.json`, with the cursor on `No, continue without these permissions`.
 It was observed on 2026-09-07 on Claude Code 2.1.263, after the trust dialog had been pre-registered, and it wedged two workers until a human answered it in the pane.
 That project's tracked `.claude/settings.json` carried both `PreToolUse` hooks and `permissions.allow` rules, but what configuration reaches the prompt is UNESTABLISHED, so treat no settings shape as exempt.
 Nothing pre-registers that prompt today, and `hasTrustDialogHooksAccepted` is NOT ESTABLISHED as the key that would: it appears in the measured store only as `false` and never as `true`, so pre-registering it `true` would write a value the vendor has never been observed writing.
-`../../../../../docs/verification/runtime-backends.md` under "Claude workspace trust" owns that observation, what it rules out, and why refreshing it needs a live spawn.
+`../../../docs/verification/runtime-backends.md` under "Claude workspace trust" owns that observation, what it rules out, and why refreshing it needs a live spawn.
 
 Never try to answer the trust dialog with a key.
 Firstmate's key plane carries only Enter, Escape, and C-c with no arrow navigation, so it cannot move a dialog's selection at all, and the observed rendering starts on `No, exit`, which means a sent Enter ends the session instead of accepting.
@@ -45,39 +45,39 @@ Completed turns can render dim predicted text inside an empty composer, indistin
 The spawn scopes `CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false` to every Claude worker and secondmate without changing global config.
 CLI `--prompt-suggestions` affects print or SDK mode only and did not suppress interactive ghost text on v2.1.186.
 
-As defense in depth, `fm_composer_strip_ghost` in `../../../../../bin/fm-composer-lib.sh` removes SGR-2 runs before pending classification on styled tmux, Herdr, and Zellij readers.
-`../../../../../docs/herdr-backend.md` under "Composer and injection safety" owns dark-TRUECOLOR tradeoffs and `../../../../../docs/verification/runtime-backends.md` owns captures.
+As defense in depth, `fm_composer_strip_ghost` in `../../../bin/fm-composer-lib.sh` removes SGR-2 runs before pending classification on styled tmux, Herdr, and Zellij readers.
+`../../../docs/herdr-backend.md` under "Composer and injection safety" owns dark-TRUECOLOR tradeoffs and `../../../docs/verification/runtime-backends.md` owns captures.
 Styled capture stays internal to the boolean detector; `fm-peek` and model-facing captures remain plain, without escapes.
 
 ## Feedback drafts
 
 The spawn disables Claude's `/bug` and `/feedback` model-drafted feedback flow for every Claude worker and secondmate, preventing a fleet-launched agent from queuing or submitting a bug report on the captain's behalf.
-The controls are scoped to the launched process and never modify the captain's global Claude settings; `launch_template()` in `../../../../../bin/fm-spawn.sh` owns their exact mechanics and defense-in-depth rationale.
+The controls are scoped to the launched process and never modify the captain's global Claude settings; `launch_template()` in `../../../bin/fm-spawn.sh` owns their exact mechanics and defense-in-depth rationale.
 
 ## Primary integration
 
 Primary behavior was verified 2026-07-04 on 2.1.201, preserved 2026-07-08 on 2.1.204, and Stop auto-arm revalidated 2026-07-24 on 2.1.219.
 This differs from the worker hook, which only touches a task marker through `.claude/settings.local.json`.
 
-Primary `.claude/settings.json` registers `../../../../../bin/fm-turnend-guard.sh --claude` and `../../../../../bin/fm-claude-stop-autoarm.sh` with `asyncRewake: true` and `timeout: 28800`.
+Primary `.claude/settings.json` registers `../../../bin/fm-turnend-guard.sh --claude` and `../../../bin/fm-claude-stop-autoarm.sh` with `asyncRewake: true` and `timeout: 28800`.
 Guard exit 2 plus stderr forces continuation.
 Stop payload `stop_hook_active=true` follows any hook-driven continuation, including async reawakening, so Claude mode ignores it and uses cooperative claim and epoch plus bounded re-block; default Codex mode keeps it as a one-block loop guard.
 
 Project `.claude/settings.json` loads only when the exact project root is the session root; Claude does not search parents, so Firstmate starts at repository root.
 Hooks still run through cwd-sensitive `/bin/sh`, so tracked commands anchor through `"$CLAUDE_PROJECT_DIR"/bin/...`.
-`../../../../../docs/turnend-guard.md` owns details.
+`../../../docs/turnend-guard.md` owns details.
 
-The Stop-owned watcher hook runs every Stop, foregrounds `../../../../../bin/fm-watch-arm.sh` only when eligible, and uses exit-2 async reawakening as notification.
+The Stop-owned watcher hook runs every Stop, foregrounds `../../../bin/fm-watch-arm.sh` only when eligible, and uses exit-2 async reawakening as notification.
 The model handles notifications but never routine re-arm.
-Claude's PreToolUse seatbelt blocks directly, and its deny is honored only with empty stdout; `../../../../../docs/arm-pretool-check.md` owns that contract.
+Claude's PreToolUse seatbelt blocks directly, and its deny is honored only with empty stdout; `../../../docs/arm-pretool-check.md` owns that contract.
 
 ### Delegation guard
 
 Claude delegation, scheduling, and worktree tools can create work without `state/<id>.meta`, making guards unable to count it.
-`../../../../../bin/fm-subagent-pretool-check.sh` denies delegation-shaped tool names.
+`../../../bin/fm-subagent-pretool-check.sh` denies delegation-shaped tool names.
 A primary should also keep an untracked home-local `permissions.deny` for known delegation tools so they disappear from the schema.
 Never track it in project `.claude/settings.json`, which is Claude-only and propagates to worker copies where it would disarm legitimate delegation.
-`../../../../../docs/subagent-guard.md` owns the contract, recommendation, `FM_ALLOW_SUBAGENT=1`, and applicability review.
+`../../../docs/subagent-guard.md` owns the contract, recommendation, `FM_ALLOW_SUBAGENT=1`, and applicability review.
 
 On Claude 2.1.217 the tool presents as `Agent`, and both `Agent` and `Task` worked as deny keys in an A/B with nonsense control.
 `permissions.allow` pre-approves rather than controls availability, so no closed positive allowlist exists.

--- a/.agents/skills/harness-adapters/references/harness/claude.md
+++ b/.agents/skills/harness-adapters/references/harness/claude.md
@@ -18,14 +18,14 @@ Busy hooks verified 2026-07-28 on Claude Code 2.1.220.
 Claude gates a folder it has never seen behind an interactive workspace-trust dialog, so every fresh task worktree would hit it.
 `--dangerously-skip-permissions` does not cover that gate: `claude --help` records that the dialog is skipped only in non-interactive mode, through `-p` or a non-TTY stdout, and a crewmate pane is interactive.
 A ship or scout spawn therefore pre-registers the worktree before launch, and the dialog does not appear.
-`../../../bin/fm-claude-trust.sh` records `hasTrustDialogAccepted` for that worktree path in `${CLAUDE_CONFIG_DIR:-$HOME}/.claude.json`, and `../../../bin/fm-spawn.sh` refuses the spawn when the write fails rather than launching a worker that would wedge.
+`../../../../../bin/fm-claude-trust.sh` records `hasTrustDialogAccepted` for that worktree path in `${CLAUDE_CONFIG_DIR:-$HOME}/.claude.json`, and `../../../../../bin/fm-spawn.sh` refuses the spawn when the write fails rather than launching a worker that would wedge.
 
 That covers the first dialog only.
 A second prompt can sit behind it: a "Quick safety check" listing the tool permissions the folder pre-approves in `.claude/settings.json`, with the cursor on `No, continue without these permissions`.
 It was observed on 2026-09-07 on Claude Code 2.1.263, after the trust dialog had been pre-registered, and it wedged two workers until a human answered it in the pane.
 That project's tracked `.claude/settings.json` carried both `PreToolUse` hooks and `permissions.allow` rules, but what configuration reaches the prompt is UNESTABLISHED, so treat no settings shape as exempt.
 Nothing pre-registers that prompt today, and `hasTrustDialogHooksAccepted` is not the key that would: it appears in the measured store only as `false`, and the slots a human accepted carry only `hasTrustDialogAccepted`.
-`../../../docs/verification/runtime-backends.md` under "Claude workspace trust" owns that observation, what it rules out, and the reproduction.
+`../../../../../docs/verification/runtime-backends.md` under "Claude workspace trust" owns that observation, what it rules out, and the reproduction.
 
 Never try to answer the trust dialog with a key.
 Firstmate's key plane carries only Enter, Escape, and C-c with no arrow navigation, so it cannot move a dialog's selection at all, and the observed rendering starts on `No, exit`, which means a sent Enter ends the session instead of accepting.
@@ -46,7 +46,7 @@ The spawn scopes `CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false` to every Claude wo
 CLI `--prompt-suggestions` affects print or SDK mode only and did not suppress interactive ghost text on v2.1.186.
 
 As defense in depth, `fm_composer_strip_ghost` in `../../../bin/fm-composer-lib.sh` removes SGR-2 runs before pending classification on styled tmux, Herdr, and Zellij readers.
-`../../../docs/herdr-backend.md` under "Composer and injection safety" owns dark-TRUECOLOR tradeoffs and `../../../docs/verification/runtime-backends.md` owns captures.
+`../../../../../docs/herdr-backend.md` under "Composer and injection safety" owns dark-TRUECOLOR tradeoffs and `../../../../../docs/verification/runtime-backends.md` owns captures.
 Styled capture stays internal to the boolean detector; `fm-peek` and model-facing captures remain plain, without escapes.
 
 ## Feedback drafts

--- a/bin/fm-claude-trust.sh
+++ b/bin/fm-claude-trust.sh
@@ -19,6 +19,23 @@
 # it ever reads the brief. Registering the trust before launch is the only
 # control that reaches an interactive pane.
 #
+# THIS COVERS THE FIRST DIALOG ONLY. Claude Code 2.1.263 was observed on
+# 2026-09-07 to show a SECOND prompt, after this registration had already
+# suppressed the trust dialog, in a project whose .claude/settings.json carries
+# hooks and permissions.allow rules: "Quick safety check ... This folder
+# pre-approves N tool permissions in .claude/settings.json". Firstmate's key
+# plane cannot move its cursor, exactly as with the first dialog, but the
+# consequence of a sent Enter differs: the first dialog's cursor sits on "No,
+# exit" so Enter kills the worker, while this one's sits on "No, continue
+# without these permissions", which by its own label would leave a live worker
+# running without the folder's pre-approved commands. That outcome is UNTESTED,
+# and whether such a degraded worker is an acceptable unwedge is an open
+# captain decision, so no key is sent to either prompt until he rules.
+# Nothing here pre-registers that prompt, hasTrustDialogHooksAccepted is ruled
+# out as the key that would, and what persists that acceptance is unknown.
+# docs/verification/runtime-backends.md under "Claude workspace trust" owns the
+# dated measurement behind that, the observation, and its reproduction.
+#
 # THE SCOPE TEST IS THE SAFETY PROPERTY, and it is STRUCTURAL rather than a
 # path policy. <worktree> must be a LINKED git worktree - its own git dir,
 # sharing <project>'s common dir - whose top level is exactly the resolved

--- a/bin/fm-claude-trust.sh
+++ b/bin/fm-claude-trust.sh
@@ -22,12 +22,16 @@
 # THIS COVERS THE FIRST DIALOG ONLY. Claude Code 2.1.263 was observed on
 # 2026-09-07 to show a SECOND prompt, after this registration had already
 # suppressed the trust dialog: "Quick safety check ... This folder pre-approves
-# N tool permissions in .claude/settings.json". What configuration reaches that
-# prompt is UNESTABLISHED, so no settings shape is exempt. Nothing here
-# pre-registers it, and hasTrustDialogHooksAccepted is NOT ESTABLISHED as the
-# key that would. docs/verification/runtime-backends.md under "Claude workspace
-# trust" owns the figures, the settings-shape table, the sent-Enter analysis,
-# the open captain question, and why refreshing it needs a live spawn.
+# N tool permissions in .claude/settings.json". An allow-free tracked
+# .claude/settings.json is not an open case: Firstmate's own repository has
+# hooks and no permissions key, and routine worker spawns into its worktrees
+# have never met this prompt. What remains open is the tracked
+# permissions.allow dimension, and the record below owns that reasoning.
+# Nothing here pre-registers it, and hasTrustDialogHooksAccepted is NOT
+# ESTABLISHED as the key that would. docs/verification/runtime-backends.md
+# under "Claude workspace trust" owns the figures, the settings-shape table,
+# the sent-Enter analysis, the open captain question, and why refreshing it
+# needs a live spawn.
 #
 # THE SCOPE TEST IS THE SAFETY PROPERTY, and it is STRUCTURAL rather than a
 # path policy. <worktree> must be a LINKED git worktree - its own git dir,

--- a/bin/fm-claude-trust.sh
+++ b/bin/fm-claude-trust.sh
@@ -21,20 +21,15 @@
 #
 # THIS COVERS THE FIRST DIALOG ONLY. Claude Code 2.1.263 was observed on
 # 2026-09-07 to show a SECOND prompt, after this registration had already
-# suppressed the trust dialog, in a project whose .claude/settings.json carries
-# hooks and permissions.allow rules: "Quick safety check ... This folder
-# pre-approves N tool permissions in .claude/settings.json". Firstmate's key
-# plane cannot move its cursor, exactly as with the first dialog, but the
-# consequence of a sent Enter differs: the first dialog's cursor sits on "No,
-# exit" so Enter kills the worker, while this one's sits on "No, continue
-# without these permissions", which by its own label would leave a live worker
-# running without the folder's pre-approved commands. That outcome is UNTESTED,
-# and whether such a degraded worker is an acceptable unwedge is an open
-# captain decision, so no key is sent to either prompt until he rules.
-# Nothing here pre-registers that prompt, hasTrustDialogHooksAccepted is ruled
-# out as the key that would, and what persists that acceptance is unknown.
+# suppressed the trust dialog: "Quick safety check ... This folder pre-approves
+# N tool permissions in .claude/settings.json". The one project observed
+# reaching it carried both PreToolUse hooks and permissions.allow rules in its
+# tracked .claude/settings.json, but what configuration reaches that prompt is
+# UNESTABLISHED, so no settings shape is exempt. Nothing here pre-registers it,
+# and hasTrustDialogHooksAccepted is ruled out as the key that would.
 # docs/verification/runtime-backends.md under "Claude workspace trust" owns the
-# dated measurement behind that, the observation, and its reproduction.
+# figures, the settings-shape table, the sent-Enter analysis, the open captain
+# question, and the reproduction.
 #
 # THE SCOPE TEST IS THE SAFETY PROPERTY, and it is STRUCTURAL rather than a
 # path policy. <worktree> must be a LINKED git worktree - its own git dir,

--- a/bin/fm-claude-trust.sh
+++ b/bin/fm-claude-trust.sh
@@ -22,14 +22,12 @@
 # THIS COVERS THE FIRST DIALOG ONLY. Claude Code 2.1.263 was observed on
 # 2026-09-07 to show a SECOND prompt, after this registration had already
 # suppressed the trust dialog: "Quick safety check ... This folder pre-approves
-# N tool permissions in .claude/settings.json". The one project observed
-# reaching it carried both PreToolUse hooks and permissions.allow rules in its
-# tracked .claude/settings.json, but what configuration reaches that prompt is
-# UNESTABLISHED, so no settings shape is exempt. Nothing here pre-registers it,
-# and hasTrustDialogHooksAccepted is ruled out as the key that would.
-# docs/verification/runtime-backends.md under "Claude workspace trust" owns the
-# figures, the settings-shape table, the sent-Enter analysis, the open captain
-# question, and the reproduction.
+# N tool permissions in .claude/settings.json". What configuration reaches that
+# prompt is UNESTABLISHED, so no settings shape is exempt. Nothing here
+# pre-registers it, and hasTrustDialogHooksAccepted is ruled out as the key that
+# would. docs/verification/runtime-backends.md under "Claude workspace trust"
+# owns the figures, the settings-shape table, the sent-Enter analysis, the open
+# captain question, and the reproduction.
 #
 # THE SCOPE TEST IS THE SAFETY PROPERTY, and it is STRUCTURAL rather than a
 # path policy. <worktree> must be a LINKED git worktree - its own git dir,

--- a/bin/fm-claude-trust.sh
+++ b/bin/fm-claude-trust.sh
@@ -24,10 +24,10 @@
 # suppressed the trust dialog: "Quick safety check ... This folder pre-approves
 # N tool permissions in .claude/settings.json". What configuration reaches that
 # prompt is UNESTABLISHED, so no settings shape is exempt. Nothing here
-# pre-registers it, and hasTrustDialogHooksAccepted is ruled out as the key that
-# would. docs/verification/runtime-backends.md under "Claude workspace trust"
-# owns the figures, the settings-shape table, the sent-Enter analysis, the open
-# captain question, and why refreshing it needs a live spawn.
+# pre-registers it, and hasTrustDialogHooksAccepted is NOT ESTABLISHED as the
+# key that would. docs/verification/runtime-backends.md under "Claude workspace
+# trust" owns the figures, the settings-shape table, the sent-Enter analysis,
+# the open captain question, and why refreshing it needs a live spawn.
 #
 # THE SCOPE TEST IS THE SAFETY PROPERTY, and it is STRUCTURAL rather than a
 # path policy. <worktree> must be a LINKED git worktree - its own git dir,

--- a/bin/fm-claude-trust.sh
+++ b/bin/fm-claude-trust.sh
@@ -27,7 +27,7 @@
 # pre-registers it, and hasTrustDialogHooksAccepted is ruled out as the key that
 # would. docs/verification/runtime-backends.md under "Claude workspace trust"
 # owns the figures, the settings-shape table, the sent-Enter analysis, the open
-# captain question, and the reproduction.
+# captain question, and why refreshing it needs a live spawn.
 #
 # THE SCOPE TEST IS THE SAFETY PROPERTY, and it is STRUCTURAL rather than a
 # path policy. <worktree> must be a LINKED git worktree - its own git dir,

--- a/docs/verification/runtime-backends.md
+++ b/docs/verification/runtime-backends.md
@@ -343,7 +343,7 @@ So "a `PreToolUse` hook alone reaches the prompt" was never tested and remains o
 What is known: the prompt exists on 2.1.263, it appears despite a pre-registered `hasTrustDialogAccepted`, and it named the two `permissions.allow` entries from A's tracked `settings.json`.
 What is not known: which property of that project reaches it. Only A prompted, B and C did not, and one observation of each is too thin to separate tracked-versus-local settings, the hook class, the specific rules involved, or something else about the project entirely.
 
-`hasTrustDialogHooksAccepted` was the obvious candidate for the key that pre-registers this acceptance, and it is RULED OUT.
+`hasTrustDialogHooksAccepted` was the obvious candidate for the key that pre-registers this acceptance, and it is NOT ESTABLISHED as that key.
 Read-only inspection of the operator's `~/.claude.json` on 2026-09-08 (71 project entries; `hasTrustDialogAccepted: true` in 37):
 
 ```sh
@@ -358,9 +358,10 @@ grep -c 'hasTrustDialogHooksAccepted"[[:space:]]*:[[:space:]]*true' ~/.claude.js
 0
 ```
 
-The key occurs in 7 entries, is `false` in every one, and never appears as `true` anywhere in the file at any depth.
-The two project-A worktree slots where the captain answered "Yes, I trust this folder" by hand hold exactly `{"hasTrustDialogAccepted": true}` - accepting the second prompt wrote no hooks key at all.
-Whatever persists that acceptance, it is not this key, so nothing in `bin/fm-claude-trust.sh` pre-registers the second prompt and a worker that meets it still wedges.
+The key occurs in 7 entries - all of them non-treehouse slots - is `false` in every one, and never appears as `true` anywhere in the file at any depth.
+The shape of the two project-A worktree slots the captain answered by hand carries no information either way: all 8 treehouse entries in this store hold exactly one key while its 63 non-treehouse entries hold 9 to 38, so a worker session never updates its own slot's entry.
+So pre-registering this key `true` would write a value the vendor has never been observed writing, and whether it records accepting the second prompt is NOT ESTABLISHED, because the only two known acceptances happened in slots this store does not update.
+Either way, nothing in `bin/fm-claude-trust.sh` pre-registers the second prompt and a worker that meets it still wedges.
 
 Refreshing this observation needs a live spawn against a project whose settings actually trigger the prompt, compared against the same worktree without the candidate key.
 No automated guard covers that, and Firstmate holds the controlled experiment as a separate deferred scout task.

--- a/docs/verification/runtime-backends.md
+++ b/docs/verification/runtime-backends.md
@@ -300,8 +300,95 @@ That warning rendered in the same shape as the trust dialog, with the selection 
 That gate is not a production blocker, because a normal environment has already accepted it and the treatment arm above ran against the real config and saw neither dialog.
 This change does not address that warning and does not claim to.
 
-`bin/fm-spawn.sh` therefore pre-registers the task worktree through `bin/fm-claude-trust.sh` before launch, and `tests/fm-claude-trust.test.sh` pins both halves of the scope contract: a fresh worktree is trusted, and an out-of-scope path is refused.
+`bin/fm-spawn.sh` therefore pre-registers the task worktree through `bin/fm-claude-trust.sh` before launch, and `tests/fm-claude-trust.test.sh` pins what that registration writes and what it refuses: a fresh worktree is recorded with `hasTrustDialogAccepted`, and an out-of-scope path is refused.
 That automated spawn case runs against a fake claude, so it asserts the store entry and the launch command and nothing more; the live arms above are what establish that the entry actually suppresses the dialog.
+
+### A second prompt in projects with hooks or allow rules
+
+Observed 2026-09-07 on Claude Code 2.1.263, in production rather than in a built arm.
+`bin/fm-spawn.sh` launched workers into fresh treehouse worktrees with `hasTrustDialogAccepted` already pre-registered for each path, and the workspace-trust dialog above did not appear.
+Two workers in project A then wedged on a SECOND prompt the registration did not cover.
+The three projects below are the operator's own and are labelled by their settings shape rather than named; the operator's records hold the mapping.
+The prompt, with its pre-approved commands redacted:
+
+```text
+Quick safety check: Is this a project you created or one you trust? ...
+This folder pre-approves 2 tool permissions in .claude/settings.json:
+Bash(ssh root@<internal-host>:*) and Bash(ssh -o BatchMode=yes ...)
+These will apply without asking. Only proceed if you trust this configuration.
+> No, continue without these permissions
+  Yes, I trust this folder
+Enter to confirm . Esc to cancel
+```
+
+Its cursor sits on `No, continue without these permissions`, and firstmate's key plane cannot move the selection - the same reason the first dialog cannot be answered.
+Unlike the first dialog, whose Enter selects `No, exit` and kills the worker, a sent Enter here would by its own label leave a live worker running without the folder's pre-approved commands; that outcome is untested, no arm sent that key, and whether such a degraded worker is an acceptable unwedge is an open decision the captain owns.
+Both workers stayed there until the captain answered them by hand in the panes.
+
+What configuration reaches that prompt is UNESTABLISHED, and the same day's other spawns are why.
+With only `hasTrustDialogAccepted` registered:
+
+| project | tracked `.claude/settings.json` | second prompt |
+| --- | --- | --- |
+| A | `PreToolUse` hooks AND 2 `permissions.allow` entries | YES |
+| B | 8 `permissions.allow` entries, no hooks | no |
+| C | one `SessionStart` hook, no `permissions.allow` | no |
+
+That column is scoped to the repo's TRACKED `.claude/settings.json` only.
+Every arm also carried hooks Firstmate itself injects: `bin/fm-spawn.sh` writes a `.claude/settings.local.json` with `UserPromptSubmit`, `Stop`, `StopFailure`, and `SessionEnd` entries into every claude worktree before launch, so no arm was hooks-free as Claude reads the folder.
+At the file level B was therefore a hooks-and-allow worktree that did NOT prompt, which rules out "hooks plus allow rules anywhere in the folder" as the trigger on its own.
+No arm isolated a `PreToolUse` hook without allow rules: A is the only project carrying one, C's single tracked hook is `SessionStart`, and the injected hooks are `UserPromptSubmit`, `Stop`, `StopFailure`, and `SessionEnd`.
+So "a `PreToolUse` hook alone reaches the prompt" was never tested and remains open.
+
+What is known: the prompt exists on 2.1.263, it appears despite a pre-registered `hasTrustDialogAccepted`, and it named the two `permissions.allow` entries from A's tracked `settings.json`.
+What is not known: which property of that project reaches it. Only A prompted, B and C did not, and one observation of each is too thin to separate tracked-versus-local settings, the hook class, the specific rules involved, or something else about the project entirely.
+
+`hasTrustDialogHooksAccepted` was the obvious candidate for the key that pre-registers this acceptance, and it is RULED OUT.
+Read-only inspection of the operator's `~/.claude.json` on 2026-09-08 (71 project entries; `hasTrustDialogAccepted: true` in 37):
+
+```sh
+node -e 'const p=JSON.parse(require("node:fs").readFileSync(process.env.HOME+"/.claude.json","utf8")).projects;
+const c={};for(const v of Object.values(p))if("hasTrustDialogHooksAccepted" in v)c[v.hasTrustDialogHooksAccepted]=(c[v.hasTrustDialogHooksAccepted]||0)+1;
+console.log(c);'
+grep -c 'hasTrustDialogHooksAccepted"[[:space:]]*:[[:space:]]*true' ~/.claude.json
+```
+
+```text
+{ false: 7 }
+0
+```
+
+The key occurs in 7 entries, is `false` in every one, and never appears as `true` anywhere in the file at any depth.
+The two project-A worktree slots where the captain answered "Yes, I trust this folder" by hand hold exactly `{"hasTrustDialogAccepted": true}` - accepting the second prompt wrote no hooks key at all.
+Whatever persists that acceptance, it is not this key, so nothing in `bin/fm-claude-trust.sh` pre-registers the second prompt and a worker that meets it still wedges.
+
+Refreshing this observation is manual and has no live guard, because reaching the prompt needs a real project whose settings trigger it rather than a scratch repo.
+It needs both arms, because the three rows above show most projects never prompt at all: an absent prompt in the treatment arm alone would prove nothing.
+Remove the worktree's entry from `${CLAUDE_CONFIG_DIR:-$HOME}/.claude.json` before each arm.
+
+Control arm - confirm this worktree reaches the prompt at all:
+
+```sh
+bin/fm-claude-trust.sh <worktree> <project>   # registers hasTrustDialogAccepted only
+tmux new-session -d -s tp-h1 -c <worktree> \
+  "CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false claude --dangerously-skip-permissions 'reply with exactly: BRIEF-REACHED'"
+tmux capture-pane -p -t tp-h1
+```
+
+The arm is only usable if that pane shows the Quick safety check; if it does not, the project does not reproduce and no candidate can be tested on it.
+
+Treatment arm - answer the prompt by hand in that pane, then diff the store to see what the acceptance actually wrote:
+
+```sh
+cp ~/.claude.json /tmp/claude-store-before.json   # before answering
+node -e 'const a=JSON.parse(require("node:fs").readFileSync("/tmp/claude-store-before.json","utf8")).projects[process.argv[1]]||{},
+b=JSON.parse(require("node:fs").readFileSync(process.env.HOME+"/.claude.json","utf8")).projects[process.argv[1]]||{};
+for(const k of new Set([...Object.keys(a),...Object.keys(b)]))if(JSON.stringify(a[k])!==JSON.stringify(b[k]))console.log(k,JSON.stringify(a[k]),"->",JSON.stringify(b[k]));' <worktree>
+```
+
+The keys that change there are the candidates; pre-register one, clear the entry, and rerun the control arm to see whether the prompt is gone.
+Rerun this after a Claude Code upgrade rather than trusting the version above.
+
 The composer-classification record below observes the same gate from the other side, where an untrusted worktree left Claude, Grok, and Muse unverified because the guard reads a first-launch trust dialog as an unreadable composer.
 
 ## Composer classification matrix

--- a/docs/verification/runtime-backends.md
+++ b/docs/verification/runtime-backends.md
@@ -376,7 +376,9 @@ Spawn through `bin/fm-spawn.sh` where that is possible; otherwise write the file
 
 ```sh
 tmux kill-session -t tp-h1 2>/dev/null || true   # kill and entry removal come FIRST, ahead of the registration
-# now remove projects[<worktree>] from the store - never after a candidate key has been written
+node -e 'const fs=require("node:fs"),f=process.argv[1];const j=JSON.parse(fs.readFileSync(f,"utf8"));
+delete (j.projects||{})[process.argv[2]];fs.writeFileSync(f,`${JSON.stringify(j,null,2)}\n`,{mode:0o600});' \
+  "${CLAUDE_CONFIG_DIR:-$HOME}/.claude.json" <worktree> || exit 1   # never after a candidate key has been written
 bin/fm-claude-trust.sh <worktree> <project> || exit 1   # a refusal must stop the arm, not fall through to the launch
 mkdir -p <worktree>/.claude   # stand in for the hooks bin/fm-spawn.sh injects into every claude worktree
 printf '%s\n' '{"hooks":{"UserPromptSubmit":[{"hooks":[{"type":"command","command":"true"}]}],"Stop":[{"hooks":[{"type":"command","command":"true"}]}],"StopFailure":[{"hooks":[{"type":"command","command":"true"}]}],"SessionEnd":[{"hooks":[{"type":"command","command":"true"}]}]}}' \
@@ -386,7 +388,7 @@ tmux new-session -d -s tp-h1 -c <worktree> \
 pane=
 for _ in $(seq 60); do   # new-session -d returns before claude has rendered anything
   pane=$(tmux capture-pane -p -t tp-h1)
-  case $pane in *"Quick safety check"*|*BRIEF-REACHED*) break ;; esac
+  case $pane in *"Quick safety check"*|*". BRIEF-REACHED"*) break ;; esac
   sleep 1
 done
 printf '%s\n' "$pane"
@@ -395,21 +397,26 @@ printf '%s\n' "$pane"
 "Shows the Quick safety check" is NOT a usable readout: both prompts open with that byte-identical first line and both offer `Yes, I trust this folder`.
 The arm reproduces only if the pane shows the SECOND prompt, so key the readout on the discriminator - its next line is `This folder pre-approves N tool permissions in .claude/settings.json` and its first option is `No, continue without these permissions`, where the first dialog instead says Claude will be able to read, edit, and execute files here and offers `No, exit`.
 If the pane shows the FIRST dialog the registration did not take effect; fix the registration and rerun rather than answering, because answering it writes `hasTrustDialogAccepted` and the treatment arm's walk would then report the key this script already writes as a candidate.
-Apply that readout only to a pane the poll above settled: if neither prompt nor the reply ever appears the loop runs out, and only then does the project count as not reproducing.
+Apply that readout only to a pane the poll settled on one of those two prompts.
+Loop exhaustion is NOT non-reproduction: it is equally what an empty pane looks like when the session died after creation - which the `|| exit 1` on the launch cannot catch, because it only guards session creation - and what the machine-scoped Bypass Permissions warning above or any other dialog looks like, none of which reached the trust stage at all.
+Treat every one of those as an INCONCLUSIVE arm to rerun, never as a result.
+The only pane that retires this project is one that positively shows the worker past the gate with no prompt having appeared: the answered brief, which is `. BRIEF-REACHED` on its own line and not the `> reply with exactly: BRIEF-REACHED` the UI echoes back, as the capture above shows.
 
 Treatment arm - snapshot the store FIRST, then answer the second prompt by hand in the control arm's `tp-h1` pane, then diff the two snapshots to see what the acceptance actually wrote:
 
 ```sh
 STORE=${CLAUDE_CONFIG_DIR:-$HOME}/.claude.json   # the same store the control arm registered into
-cp "$STORE" /tmp/claude-store-before.json        # must run BEFORE answering
+snap=$(umask 077; mktemp "${TMPDIR:-$HOME}/claude-store-before.XXXXXX") || exit 1
+cp "$STORE" "$snap"   # must run BEFORE answering; the store is 0600 and carries account and MCP credentials,
+                      # so the snapshot gets an unpredictable name and 0600 too, never a fixed path under /tmp
 # answer "Yes, I trust this folder" by hand in tp-h1, on the prompt whose other option
 # is "No, continue without these permissions" - never on the "No, exit" trust dialog. Then:
 node -e 'const fs=require("node:fs");
 const walk=(x,y,p)=>{const o=v=>v&&typeof v==="object"&&!Array.isArray(v);
 if(o(x)&&o(y)){for(const k of new Set([...Object.keys(x),...Object.keys(y)]))walk(x[k],y[k],p.concat(k));return;}
 if(JSON.stringify(x)!==JSON.stringify(y))console.log(p.join("."),JSON.stringify(x),"->",JSON.stringify(y));};
-walk(JSON.parse(fs.readFileSync("/tmp/claude-store-before.json","utf8")),
-     JSON.parse(fs.readFileSync(process.argv[1],"utf8")),[]);' "$STORE"
+walk(JSON.parse(fs.readFileSync(process.argv[1],"utf8")),
+     JSON.parse(fs.readFileSync(process.argv[2],"utf8")),[]);' "$snap" "$STORE"
 ```
 
 Diff the WHOLE parsed store, not `projects[<worktree>]` alone.

--- a/docs/verification/runtime-backends.md
+++ b/docs/verification/runtime-backends.md
@@ -303,7 +303,7 @@ This change does not address that warning and does not claim to.
 `bin/fm-spawn.sh` therefore pre-registers the task worktree through `bin/fm-claude-trust.sh` before launch, and `tests/fm-claude-trust.test.sh` pins what that registration writes and what it refuses: a fresh worktree is recorded with `hasTrustDialogAccepted`, and an out-of-scope path is refused.
 That automated spawn case runs against a fake claude, so it asserts the store entry and the launch command and nothing more; the live arms above are what establish that the entry actually suppresses the dialog.
 
-### A second prompt in projects with hooks or allow rules
+### A second prompt the registration does not cover
 
 Observed 2026-09-07 on Claude Code 2.1.263, in production rather than in a built arm.
 `bin/fm-spawn.sh` launched workers into fresh treehouse worktrees with `hasTrustDialogAccepted` already pre-registered for each path, and the workspace-trust dialog above did not appear.
@@ -377,16 +377,24 @@ tmux capture-pane -p -t tp-h1
 
 The arm is only usable if that pane shows the Quick safety check; if it does not, the project does not reproduce and no candidate can be tested on it.
 
-Treatment arm - answer the prompt by hand in that pane, then diff the store to see what the acceptance actually wrote:
+Treatment arm - snapshot the store FIRST, then answer the prompt by hand in that pane, then diff the two snapshots to see what the acceptance actually wrote:
 
 ```sh
-cp ~/.claude.json /tmp/claude-store-before.json   # before answering
-node -e 'const a=JSON.parse(require("node:fs").readFileSync("/tmp/claude-store-before.json","utf8")).projects[process.argv[1]]||{},
-b=JSON.parse(require("node:fs").readFileSync(process.env.HOME+"/.claude.json","utf8")).projects[process.argv[1]]||{};
-for(const k of new Set([...Object.keys(a),...Object.keys(b)]))if(JSON.stringify(a[k])!==JSON.stringify(b[k]))console.log(k,JSON.stringify(a[k]),"->",JSON.stringify(b[k]));' <worktree>
+cp ~/.claude.json /tmp/claude-store-before.json   # must run BEFORE answering
+# answer "Yes, I trust this folder" by hand in the pane, then:
+node -e 'const fs=require("node:fs");
+const walk=(x,y,p)=>{const o=v=>v&&typeof v==="object"&&!Array.isArray(v);
+if(o(x)&&o(y)){for(const k of new Set([...Object.keys(x),...Object.keys(y)]))walk(x[k],y[k],p.concat(k));return;}
+if(JSON.stringify(x)!==JSON.stringify(y))console.log(p.join("."),JSON.stringify(x),"->",JSON.stringify(y));};
+walk(JSON.parse(fs.readFileSync("/tmp/claude-store-before.json","utf8")),
+     JSON.parse(fs.readFileSync(process.env.HOME+"/.claude.json","utf8")),[]);'
 ```
 
+Diff the WHOLE parsed store, not `projects[<worktree>]` alone.
+The two slots the captain answered by hand were already observed holding exactly `{"hasTrustDialogAccepted": true}` afterwards, so that per-project object is known NOT to change: a per-project diff returns nothing because of where it looked, not because the acceptance persists nothing, and reading its empty output as "no candidate keys" is the wrong conclusion.
+The whole-store walk also surfaces ordinary session bookkeeping written by any concurrent Claude session, so quiet the machine first and read the output for a newly appearing trust or permission key rather than for a single line.
 The keys that change there are the candidates; pre-register one, clear the entry, and rerun the control arm to see whether the prompt is gone.
+If nothing outside that bookkeeping changes, the acceptance is persisted somewhere other than `~/.claude.json`, or not persisted at all, and the search moves off this file.
 Rerun this after a Claude Code upgrade rather than trusting the version above.
 
 The composer-classification record below observes the same gate from the other side, where an untrusted worktree left Claude, Grok, and Muse unverified because the guard reads a first-launch trust dialog as an unreadable composer.

--- a/docs/verification/runtime-backends.md
+++ b/docs/verification/runtime-backends.md
@@ -362,85 +362,9 @@ The key occurs in 7 entries, is `false` in every one, and never appears as `true
 The two project-A worktree slots where the captain answered "Yes, I trust this folder" by hand hold exactly `{"hasTrustDialogAccepted": true}` - accepting the second prompt wrote no hooks key at all.
 Whatever persists that acceptance, it is not this key, so nothing in `bin/fm-claude-trust.sh` pre-registers the second prompt and a worker that meets it still wedges.
 
-Refreshing this observation is manual and has no live guard, because reaching the prompt needs a real project whose settings trigger it rather than a scratch repo.
-It needs both arms, because the three rows above show most projects never prompt at all: unless the control arm first shows the prompt on this worktree, an absent prompt on a later control-arm rerun would prove nothing.
-Before every control-arm launch, including the reruns below, kill any live `tp-h1` session AND remove the worktree's entry from `${CLAUDE_CONFIG_DIR:-$HOME}/.claude.json`.
-Both steps belong at the TOP of the arm: on a candidate rerun the kill and the removal precede `bin/fm-claude-trust.sh` and the candidate write, never the launch that follows them, because a removal performed after the candidate write drops the key under test.
-The kill is not optional: the treatment arm leaves `tp-h1` alive and answered, and against a live session `tmux new-session -d -s tp-h1` fails as a duplicate while `tmux capture-pane` still succeeds on that stale pane - a rerun that never launched then reads as "the prompt is gone".
-The treatment arm is not a launch of its own - it continues on the control arm's pane, with the entry left exactly as the control arm registered it, so do NOT clear it again before answering.
-
-Control arm - confirm this worktree reaches the prompt at all.
-It must carry the hooks every observed spawn carried: `bin/fm-spawn.sh` writes a `.claude/settings.local.json` into each claude worktree before launch, which is exactly what makes row B above a hooks-and-allow worktree that did not prompt.
-A bare `tmux` launch without that file differs from every row in the table along the one dimension the table leaves open, so an absent prompt there would retire the only reproducing project on a condition it was never observed under.
-Spawn through `bin/fm-spawn.sh` where that is possible; otherwise write the file yourself as below - the write is skipped when one already exists, so an existing `settings.local.json` is left in place and the arm is INCONCLUSIVE unless that file carries the four injected hooks.
-
-```sh
-cfg=${CLAUDE_CONFIG_DIR:-$HOME}                  # the worker must read the store we register into
-wt=$(cd -P -- <worktree> && pwd -P) || exit 1    # fm-claude-trust.sh keys the entry on the RESOLVED path
-tmux kill-session -t tp-h1 2>/dev/null || true   # kill and entry removal come FIRST, ahead of the registration
-node -e 'const fs=require("node:fs"),p=require("node:path"),c=require("node:crypto");
-const f=fs.realpathSync(process.argv[1]),was=fs.readFileSync(f,"utf8"),j=JSON.parse(was);
-if(!j.projects||!(process.argv[2] in j.projects))throw new Error(`no entry for ${process.argv[2]}`);
-delete j.projects[process.argv[2]];
-const t=p.join(p.dirname(f),`.claude.json.arm.${process.pid}.${c.randomBytes(8).toString("hex")}`);
-fs.writeFileSync(t,`${JSON.stringify(j,null,2)}\n`,{mode:0o600,flag:"wx"});
-if(fs.readFileSync(f,"utf8")!==was){fs.unlinkSync(t);throw new Error("store moved under us - rerun");}
-fs.renameSync(t,f);' "$cfg/.claude.json" "$wt" || exit 1   # never run after a candidate key has been written
-bin/fm-claude-trust.sh "$wt" <project> || exit 1   # a refusal must stop the arm, not fall through to the launch
-mkdir -p "$wt/.claude"   # stand in for the hooks bin/fm-spawn.sh injects into every claude worktree
-[ -e "$wt/.claude/settings.local.json" ] || printf '%s\n' '{"hooks":{"UserPromptSubmit":[{"hooks":[{"type":"command","command":"true"}]}],"Stop":[{"hooks":[{"type":"command","command":"true"}]}],"StopFailure":[{"hooks":[{"type":"command","command":"true"}]}],"SessionEnd":[{"hooks":[{"type":"command","command":"true"}]}]}}' \
-  > "$wt/.claude/settings.local.json"
-# candidate rerun only: write the candidate key into projects["$wt"] HERE, after the registration and before the launch
-tmux new-session -d -s tp-h1 -c "$wt" \
-  "${CLAUDE_CONFIG_DIR:+CLAUDE_CONFIG_DIR=$cfg }CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false claude --dangerously-skip-permissions 'reply with exactly: BRIEF-REACHED'" || exit 1
-pane=
-for _ in $(seq 60); do   # new-session -d returns before claude has rendered anything
-  pane=$(tmux capture-pane -p -t tp-h1)
-  case $pane in *"Quick safety check"*) break ;; esac
-  if printf '%s\n' "$pane" | grep -v 'exactly:' | grep -q 'BRIEF-REACHED'; then break; fi
-  sleep 1
-done
-printf '%s\n' "$pane"
-```
-
-The removal treats an ABSENT entry as an error rather than a silent success, because that is the only signal that `$wt` disagrees with the key `bin/fm-claude-trust.sh` wrote; on a worktree that was genuinely never registered there is nothing to clear, so start at the registration instead.
-It also follows that script's own writer on that store - resolve the symlink, stage beside the target with mode 0600 and an exclusive create, re-read and compare before the rename, and refuse if the store moved - because a live Claude session writes this same file and a plain truncating write would silently drop whatever the vendor flushed in between.
-
-"Shows the Quick safety check" is NOT a usable readout: both prompts open with that byte-identical first line and both offer `Yes, I trust this folder`.
-The arm reproduces only if the pane shows the SECOND prompt, so key the readout on the discriminator - its next line is `This folder pre-approves N tool permissions in .claude/settings.json` and its first option is `No, continue without these permissions`, where the first dialog instead says Claude will be able to read, edit, and execute files here and offers `No, exit`.
-If the pane shows the FIRST dialog the registration did not take effect; fix the registration and rerun rather than answering, because answering it writes `hasTrustDialogAccepted` and the treatment arm's walk would then report the key this script already writes as a candidate.
-Apply that readout only to a pane the poll settled on one of those two prompts.
-Loop exhaustion is NOT non-reproduction: it is equally what an empty pane looks like when the session died after creation - which the `|| exit 1` on the launch cannot catch, because it only guards session creation - and what the machine-scoped Bypass Permissions warning above or any other dialog looks like, none of which reached the trust stage at all.
-Treat every one of those as an INCONCLUSIVE arm to rerun, never as a result.
-The only pane that retires this project is one that positively shows the worker past the gate with no prompt having appeared: a `BRIEF-REACHED` line that is NOT the composer's echo of the brief, which is what the poll's `grep -v 'exactly:'` tests.
-Match it that way rather than on a leading glyph: the captures in this file transcribe Claude's row markers into ASCII, so the bytes on a live pane are not the bytes quoted here.
-
-Treatment arm - snapshot the store FIRST, then answer the second prompt by hand in the control arm's `tp-h1` pane, then diff the two snapshots to see what the acceptance actually wrote:
-
-```sh
-STORE=${CLAUDE_CONFIG_DIR:-$HOME}/.claude.json   # the same store the control arm registered into
-snap=$(umask 077; mktemp "${TMPDIR:-$HOME}/claude-store-before.XXXXXX") || exit 1
-cp "$STORE" "$snap"   # must run BEFORE answering; the store is 0600 and carries account and MCP credentials,
-                      # so the snapshot gets an unpredictable name and 0600 too, never a fixed path under /tmp
-# answer "Yes, I trust this folder" by hand in tp-h1, on the prompt whose other option
-# is "No, continue without these permissions" - never on the "No, exit" trust dialog. Then:
-node -e 'const fs=require("node:fs");
-const walk=(x,y,p)=>{const o=v=>v&&typeof v==="object"&&!Array.isArray(v);
-if(o(x)&&o(y)){for(const k of new Set([...Object.keys(x),...Object.keys(y)]))walk(x[k],y[k],p.concat(k));return;}
-if(JSON.stringify(x)!==JSON.stringify(y))console.log(p.join("."),JSON.stringify(x),"->",JSON.stringify(y));};
-walk(JSON.parse(fs.readFileSync(process.argv[1],"utf8")),
-     JSON.parse(fs.readFileSync(process.argv[2],"utf8")),[]);' "$snap" "$STORE"
-rm -f "$snap"   # the snapshot is a full copy of a credential-bearing store; do not leave it behind
-```
-
-Diff the WHOLE parsed store, not `projects[<worktree>]` alone.
-The two slots the captain answered by hand were already observed holding exactly `{"hasTrustDialogAccepted": true}` afterwards, so that per-project object is known NOT to change: a per-project diff returns nothing because of where it looked, not because the acceptance persists nothing, and reading its empty output as "no candidate keys" is the wrong conclusion.
-The whole-store walk also surfaces ordinary session bookkeeping written by any concurrent Claude session, so quiet the machine first and read the output for a newly appearing trust or permission key rather than for a single line.
-The keys that change there are the candidates. Test one by inserting its write into the control arm itself, at the commented step after the registration - keyed on `$wt`, the resolved path the script itself uses - and rerunning the whole arm from the top, rather than writing it before the rerun.
-Clearing after the candidate is written deletes the key under test - the entry removal drops the whole per-project object, and `bin/fm-claude-trust.sh` rebuilds it with `hasTrustDialogAccepted` alone - so the arm would launch with exactly the shape that already prompts and every candidate would read as ruled out without ever having been carried into a launch.
-The script merges into an existing entry rather than replacing it, so writing the candidate before or after the registration both work; only clearing after it does not.
-If nothing outside that bookkeeping changes, the acceptance is persisted somewhere other than that store, or not persisted at all, and the search moves off this file.
-Rerun this after a Claude Code upgrade rather than trusting the version above.
+Refreshing this observation needs a live spawn against a project whose settings actually trigger the prompt, compared against the same worktree without the candidate key.
+No automated guard covers that, and Firstmate holds the controlled experiment as a separate deferred scout task.
+Recheck this after a Claude Code upgrade rather than trusting the version above.
 
 The composer-classification record below observes the same gate from the other side, where an untrusted worktree left Claude, Grok, and Muse unverified because the guard reads a first-launch trust dialog as an unreadable composer.
 

--- a/docs/verification/runtime-backends.md
+++ b/docs/verification/runtime-backends.md
@@ -325,7 +325,7 @@ Its cursor sits on `No, continue without these permissions`, and firstmate's key
 Unlike the first dialog, whose Enter selects `No, exit` and kills the worker, a sent Enter here would by its own label leave a live worker running without the folder's pre-approved commands; that outcome is untested, no arm sent that key, and whether such a degraded worker is an acceptable unwedge is an open decision the captain owns.
 Both workers stayed there until the captain answered them by hand in the panes.
 
-What configuration reaches that prompt is UNESTABLISHED, and the same day's other spawns are why.
+Which tracked allow rules reach that prompt is UNESTABLISHED, and the same day's other spawns are why.
 With only `hasTrustDialogAccepted` registered:
 
 | project | tracked `.claude/settings.json` | second prompt |
@@ -343,7 +343,7 @@ The prompt's own text points the same way - it enumerates "This folder pre-appro
 That leaves the tracked allow rules as the dimension still open.
 
 What is known: the prompt exists on 2.1.263, it appears despite a pre-registered `hasTrustDialogAccepted`, and it named the two `permissions.allow` entries from A's tracked `settings.json`.
-What is not known: which property of A's tracked allow rules reaches it. Only A prompted, B and C did not, and one observation of each is too thin to separate the kind of rule granted, the count, tracked-versus-local settings, or something else about the project entirely.
+What is not known: which property of A's tracked allow rules reaches it. Only A prompted, B and C did not, and one observation of each is too thin to separate the kind of rule granted from the count.
 
 `hasTrustDialogHooksAccepted` was the obvious candidate for the key that pre-registers this acceptance, and it is NOT ESTABLISHED as that key.
 Read-only inspection of the operator's `~/.claude.json` on 2026-09-08 (71 project entries; `hasTrustDialogAccepted: true` in 37):
@@ -361,8 +361,8 @@ grep -c 'hasTrustDialogHooksAccepted"[[:space:]]*:[[:space:]]*true' ~/.claude.js
 ```
 
 The key occurs in 7 entries - all of them non-treehouse slots - is `false` in every one, and never appears as `true` anywhere in the file at any depth.
-The shape of the two project-A worktree slots the captain answered by hand carries no information either way: all 8 treehouse entries in this store hold exactly one key while its 63 non-treehouse entries hold 9 to 38, so a worker session never updates its own slot's entry.
-So pre-registering this key `true` would write a value the vendor has never been observed writing, and whether it records accepting the second prompt is NOT ESTABLISHED, because the only two known acceptances happened in slots this store does not update.
+Claude sessions ran in all 8 treehouse slots in this store - each has session transcripts under `~/.claude/projects` - and none of them acquired the key; those 8 hold exactly one key each, while its 63 non-treehouse entries hold 9 to 38.
+So pre-registering this key `true` would write a value the vendor has never been observed writing, and whether it records accepting the second prompt is NOT ESTABLISHED.
 Either way, nothing in `bin/fm-claude-trust.sh` pre-registers the second prompt and a worker that meets it still wedges.
 
 Refreshing this observation needs a live spawn against a project whose tracked allow rules actually trigger the prompt, compared against the same worktree without the candidate key.

--- a/docs/verification/runtime-backends.md
+++ b/docs/verification/runtime-backends.md
@@ -364,13 +364,15 @@ Whatever persists that acceptance, it is not this key, so nothing in `bin/fm-cla
 
 Refreshing this observation is manual and has no live guard, because reaching the prompt needs a real project whose settings trigger it rather than a scratch repo.
 It needs both arms, because the three rows above show most projects never prompt at all: unless the control arm first shows the prompt on this worktree, an absent prompt on a later control-arm rerun would prove nothing.
-Remove the worktree's entry from `${CLAUDE_CONFIG_DIR:-$HOME}/.claude.json` before every control-arm launch, including the reruns below.
+Before every control-arm launch, including the reruns below, kill any live `tp-h1` session AND remove the worktree's entry from `${CLAUDE_CONFIG_DIR:-$HOME}/.claude.json`.
+The kill is not optional: the treatment arm leaves `tp-h1` alive and answered, and against a live session `tmux new-session -d -s tp-h1` fails as a duplicate while `tmux capture-pane` still succeeds on that stale pane - a rerun that never launched then reads as "the prompt is gone".
 The treatment arm is not a launch of its own - it continues on the control arm's pane, with the entry left exactly as the control arm registered it, so do NOT clear it again before answering.
 
 Control arm - confirm this worktree reaches the prompt at all:
 
 ```sh
-bin/fm-claude-trust.sh <worktree> <project>   # registers hasTrustDialogAccepted only
+tmux kill-session -t tp-h1 2>/dev/null || true   # then remove the worktree's entry from the store
+bin/fm-claude-trust.sh <worktree> <project>      # registers hasTrustDialogAccepted only
 tmux new-session -d -s tp-h1 -c <worktree> \
   "CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false claude --dangerously-skip-permissions 'reply with exactly: BRIEF-REACHED'"
 tmux capture-pane -p -t tp-h1
@@ -395,7 +397,9 @@ walk(JSON.parse(fs.readFileSync("/tmp/claude-store-before.json","utf8")),
 Diff the WHOLE parsed store, not `projects[<worktree>]` alone.
 The two slots the captain answered by hand were already observed holding exactly `{"hasTrustDialogAccepted": true}` afterwards, so that per-project object is known NOT to change: a per-project diff returns nothing because of where it looked, not because the acceptance persists nothing, and reading its empty output as "no candidate keys" is the wrong conclusion.
 The whole-store walk also surfaces ordinary session bookkeeping written by any concurrent Claude session, so quiet the machine first and read the output for a newly appearing trust or permission key rather than for a single line.
-The keys that change there are the candidates; pre-register one, clear the entry, and rerun the control arm to see whether the prompt is gone.
+The keys that change there are the candidates. Test one in this order: clear the entry, run `bin/fm-claude-trust.sh`, THEN write the candidate key into that same entry, and only then rerun the control arm to see whether the prompt is gone.
+Clearing after the candidate is written deletes the key under test - the entry removal drops the whole per-project object, and `bin/fm-claude-trust.sh` rebuilds it with `hasTrustDialogAccepted` alone - so the arm would launch with exactly the shape that already prompts and every candidate would read as ruled out without ever having been carried into a launch.
+The script merges into an existing entry rather than replacing it, so writing the candidate before or after the registration both work; only clearing after it does not.
 If nothing outside that bookkeeping changes, the acceptance is persisted somewhere other than that store, or not persisted at all, and the search moves off this file.
 Rerun this after a Claude Code upgrade rather than trusting the version above.
 

--- a/docs/verification/runtime-backends.md
+++ b/docs/verification/runtime-backends.md
@@ -388,10 +388,11 @@ if(fs.readFileSync(f,"utf8")!==was){fs.unlinkSync(t);throw new Error("store move
 fs.renameSync(t,f);' "$cfg/.claude.json" "$wt" || exit 1   # never run after a candidate key has been written
 bin/fm-claude-trust.sh "$wt" <project> || exit 1   # a refusal must stop the arm, not fall through to the launch
 mkdir -p "$wt/.claude"   # stand in for the hooks bin/fm-spawn.sh injects into every claude worktree
-printf '%s\n' '{"hooks":{"UserPromptSubmit":[{"hooks":[{"type":"command","command":"true"}]}],"Stop":[{"hooks":[{"type":"command","command":"true"}]}],"StopFailure":[{"hooks":[{"type":"command","command":"true"}]}],"SessionEnd":[{"hooks":[{"type":"command","command":"true"}]}]}}' \
+[ -e "$wt/.claude/settings.local.json" ] || printf '%s\n' '{"hooks":{"UserPromptSubmit":[{"hooks":[{"type":"command","command":"true"}]}],"Stop":[{"hooks":[{"type":"command","command":"true"}]}],"StopFailure":[{"hooks":[{"type":"command","command":"true"}]}],"SessionEnd":[{"hooks":[{"type":"command","command":"true"}]}]}}' \
   > "$wt/.claude/settings.local.json"
+# candidate rerun only: write the candidate key into projects["$wt"] HERE, after the registration and before the launch
 tmux new-session -d -s tp-h1 -c "$wt" \
-  "CLAUDE_CONFIG_DIR=$cfg CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false claude --dangerously-skip-permissions 'reply with exactly: BRIEF-REACHED'" || exit 1
+  "${CLAUDE_CONFIG_DIR:+CLAUDE_CONFIG_DIR=$cfg }CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false claude --dangerously-skip-permissions 'reply with exactly: BRIEF-REACHED'" || exit 1
 pane=
 for _ in $(seq 60); do   # new-session -d returns before claude has rendered anything
   pane=$(tmux capture-pane -p -t tp-h1)
@@ -435,7 +436,7 @@ rm -f "$snap"   # the snapshot is a full copy of a credential-bearing store; do 
 Diff the WHOLE parsed store, not `projects[<worktree>]` alone.
 The two slots the captain answered by hand were already observed holding exactly `{"hasTrustDialogAccepted": true}` afterwards, so that per-project object is known NOT to change: a per-project diff returns nothing because of where it looked, not because the acceptance persists nothing, and reading its empty output as "no candidate keys" is the wrong conclusion.
 The whole-store walk also surfaces ordinary session bookkeeping written by any concurrent Claude session, so quiet the machine first and read the output for a newly appearing trust or permission key rather than for a single line.
-The keys that change there are the candidates. Test one in this order: clear the entry, run `bin/fm-claude-trust.sh`, THEN write the candidate key into that same entry - keyed on `$wt`, the resolved path the script itself uses - and only then rerun the control arm to see whether the prompt is gone.
+The keys that change there are the candidates. Test one by inserting its write into the control arm itself, at the commented step after the registration - keyed on `$wt`, the resolved path the script itself uses - and rerunning the whole arm from the top, rather than writing it before the rerun.
 Clearing after the candidate is written deletes the key under test - the entry removal drops the whole per-project object, and `bin/fm-claude-trust.sh` rebuilds it with `hasTrustDialogAccepted` alone - so the arm would launch with exactly the shape that already prompts and every candidate would read as ruled out without ever having been carried into a launch.
 The script merges into an existing entry rather than replacing it, so writing the candidate before or after the registration both work; only clearing after it does not.
 If nothing outside that bookkeeping changes, the acceptance is persisted somewhere other than that store, or not persisted at all, and the search moves off this file.

--- a/docs/verification/runtime-backends.md
+++ b/docs/verification/runtime-backends.md
@@ -365,27 +365,39 @@ Whatever persists that acceptance, it is not this key, so nothing in `bin/fm-cla
 Refreshing this observation is manual and has no live guard, because reaching the prompt needs a real project whose settings trigger it rather than a scratch repo.
 It needs both arms, because the three rows above show most projects never prompt at all: unless the control arm first shows the prompt on this worktree, an absent prompt on a later control-arm rerun would prove nothing.
 Before every control-arm launch, including the reruns below, kill any live `tp-h1` session AND remove the worktree's entry from `${CLAUDE_CONFIG_DIR:-$HOME}/.claude.json`.
+Both steps belong at the TOP of the arm: on a candidate rerun the kill and the removal precede `bin/fm-claude-trust.sh` and the candidate write, never the launch that follows them, because a removal performed after the candidate write drops the key under test.
 The kill is not optional: the treatment arm leaves `tp-h1` alive and answered, and against a live session `tmux new-session -d -s tp-h1` fails as a duplicate while `tmux capture-pane` still succeeds on that stale pane - a rerun that never launched then reads as "the prompt is gone".
 The treatment arm is not a launch of its own - it continues on the control arm's pane, with the entry left exactly as the control arm registered it, so do NOT clear it again before answering.
 
-Control arm - confirm this worktree reaches the prompt at all:
+Control arm - confirm this worktree reaches the prompt at all.
+It must carry the hooks every observed spawn carried: `bin/fm-spawn.sh` writes a `.claude/settings.local.json` into each claude worktree before launch, which is exactly what makes row B above a hooks-and-allow worktree that did not prompt.
+A bare `tmux` launch without that file differs from every row in the table along the one dimension the table leaves open, so an absent prompt there would retire the only reproducing project on a condition it was never observed under.
+Spawn through `bin/fm-spawn.sh` where that is possible; otherwise write the file yourself as below.
 
 ```sh
-tmux kill-session -t tp-h1 2>/dev/null || true   # then remove the worktree's entry from the store
-bin/fm-claude-trust.sh <worktree> <project>      # registers hasTrustDialogAccepted only
+tmux kill-session -t tp-h1 2>/dev/null || true   # kill and entry removal come FIRST, ahead of the registration
+# now remove projects[<worktree>] from the store - never after a candidate key has been written
+bin/fm-claude-trust.sh <worktree> <project> || exit 1   # a refusal must stop the arm, not fall through to the launch
+mkdir -p <worktree>/.claude   # stand in for the hooks bin/fm-spawn.sh injects into every claude worktree
+printf '%s\n' '{"hooks":{"UserPromptSubmit":[{"hooks":[{"type":"command","command":"true"}]}],"Stop":[{"hooks":[{"type":"command","command":"true"}]}],"StopFailure":[{"hooks":[{"type":"command","command":"true"}]}],"SessionEnd":[{"hooks":[{"type":"command","command":"true"}]}]}}' \
+  > <worktree>/.claude/settings.local.json
 tmux new-session -d -s tp-h1 -c <worktree> \
   "CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false claude --dangerously-skip-permissions 'reply with exactly: BRIEF-REACHED'"
 tmux capture-pane -p -t tp-h1
 ```
 
-The arm is only usable if that pane shows the Quick safety check; if it does not, the project does not reproduce and no candidate can be tested on it.
+"Shows the Quick safety check" is NOT a usable readout: both prompts open with that byte-identical first line and both offer `Yes, I trust this folder`.
+The arm reproduces only if the pane shows the SECOND prompt, so key the readout on the discriminator - its next line is `This folder pre-approves N tool permissions in .claude/settings.json` and its first option is `No, continue without these permissions`, where the first dialog instead says Claude will be able to read, edit, and execute files here and offers `No, exit`.
+If the pane shows the FIRST dialog the registration did not take effect, which is what the `|| exit 1` above catches; fix the registration and rerun rather than answering, because answering it writes `hasTrustDialogAccepted` and the treatment arm's walk would then report the key this script already writes as a candidate.
+If neither prompt appears, the project does not reproduce and no candidate can be tested on it.
 
-Treatment arm - snapshot the store FIRST, then answer the prompt by hand in the control arm's `tp-h1` pane, then diff the two snapshots to see what the acceptance actually wrote:
+Treatment arm - snapshot the store FIRST, then answer the second prompt by hand in the control arm's `tp-h1` pane, then diff the two snapshots to see what the acceptance actually wrote:
 
 ```sh
 STORE=${CLAUDE_CONFIG_DIR:-$HOME}/.claude.json   # the same store the control arm registered into
 cp "$STORE" /tmp/claude-store-before.json        # must run BEFORE answering
-# answer "Yes, I trust this folder" by hand in the tp-h1 pane, then:
+# answer "Yes, I trust this folder" by hand in tp-h1, on the prompt whose other option
+# is "No, continue without these permissions" - never on the "No, exit" trust dialog. Then:
 node -e 'const fs=require("node:fs");
 const walk=(x,y,p)=>{const o=v=>v&&typeof v==="object"&&!Array.isArray(v);
 if(o(x)&&o(y)){for(const k of new Set([...Object.keys(x),...Object.keys(y)]))walk(x[k],y[k],p.concat(k));return;}

--- a/docs/verification/runtime-backends.md
+++ b/docs/verification/runtime-backends.md
@@ -363,8 +363,9 @@ The two project-A worktree slots where the captain answered "Yes, I trust this f
 Whatever persists that acceptance, it is not this key, so nothing in `bin/fm-claude-trust.sh` pre-registers the second prompt and a worker that meets it still wedges.
 
 Refreshing this observation is manual and has no live guard, because reaching the prompt needs a real project whose settings trigger it rather than a scratch repo.
-It needs both arms, because the three rows above show most projects never prompt at all: an absent prompt in the treatment arm alone would prove nothing.
-Remove the worktree's entry from `${CLAUDE_CONFIG_DIR:-$HOME}/.claude.json` before each arm.
+It needs both arms, because the three rows above show most projects never prompt at all: unless the control arm first shows the prompt on this worktree, an absent prompt on a later control-arm rerun would prove nothing.
+Remove the worktree's entry from `${CLAUDE_CONFIG_DIR:-$HOME}/.claude.json` before every control-arm launch, including the reruns below.
+The treatment arm is not a launch of its own - it continues on the control arm's pane, with the entry left exactly as the control arm registered it, so do NOT clear it again before answering.
 
 Control arm - confirm this worktree reaches the prompt at all:
 
@@ -377,24 +378,25 @@ tmux capture-pane -p -t tp-h1
 
 The arm is only usable if that pane shows the Quick safety check; if it does not, the project does not reproduce and no candidate can be tested on it.
 
-Treatment arm - snapshot the store FIRST, then answer the prompt by hand in that pane, then diff the two snapshots to see what the acceptance actually wrote:
+Treatment arm - snapshot the store FIRST, then answer the prompt by hand in the control arm's `tp-h1` pane, then diff the two snapshots to see what the acceptance actually wrote:
 
 ```sh
-cp ~/.claude.json /tmp/claude-store-before.json   # must run BEFORE answering
-# answer "Yes, I trust this folder" by hand in the pane, then:
+STORE=${CLAUDE_CONFIG_DIR:-$HOME}/.claude.json   # the same store the control arm registered into
+cp "$STORE" /tmp/claude-store-before.json        # must run BEFORE answering
+# answer "Yes, I trust this folder" by hand in the tp-h1 pane, then:
 node -e 'const fs=require("node:fs");
 const walk=(x,y,p)=>{const o=v=>v&&typeof v==="object"&&!Array.isArray(v);
 if(o(x)&&o(y)){for(const k of new Set([...Object.keys(x),...Object.keys(y)]))walk(x[k],y[k],p.concat(k));return;}
 if(JSON.stringify(x)!==JSON.stringify(y))console.log(p.join("."),JSON.stringify(x),"->",JSON.stringify(y));};
 walk(JSON.parse(fs.readFileSync("/tmp/claude-store-before.json","utf8")),
-     JSON.parse(fs.readFileSync(process.env.HOME+"/.claude.json","utf8")),[]);'
+     JSON.parse(fs.readFileSync(process.argv[1],"utf8")),[]);' "$STORE"
 ```
 
 Diff the WHOLE parsed store, not `projects[<worktree>]` alone.
 The two slots the captain answered by hand were already observed holding exactly `{"hasTrustDialogAccepted": true}` afterwards, so that per-project object is known NOT to change: a per-project diff returns nothing because of where it looked, not because the acceptance persists nothing, and reading its empty output as "no candidate keys" is the wrong conclusion.
 The whole-store walk also surfaces ordinary session bookkeeping written by any concurrent Claude session, so quiet the machine first and read the output for a newly appearing trust or permission key rather than for a single line.
 The keys that change there are the candidates; pre-register one, clear the entry, and rerun the control arm to see whether the prompt is gone.
-If nothing outside that bookkeeping changes, the acceptance is persisted somewhere other than `~/.claude.json`, or not persisted at all, and the search moves off this file.
+If nothing outside that bookkeeping changes, the acceptance is persisted somewhere other than that store, or not persisted at all, and the search moves off this file.
 Rerun this after a Claude Code upgrade rather than trusting the version above.
 
 The composer-classification record below observes the same gate from the other side, where an untrusted worktree left Claude, Grok, and Muse unverified because the guard reads a first-launch trust dialog as an unreadable composer.

--- a/docs/verification/runtime-backends.md
+++ b/docs/verification/runtime-backends.md
@@ -382,14 +382,20 @@ mkdir -p <worktree>/.claude   # stand in for the hooks bin/fm-spawn.sh injects i
 printf '%s\n' '{"hooks":{"UserPromptSubmit":[{"hooks":[{"type":"command","command":"true"}]}],"Stop":[{"hooks":[{"type":"command","command":"true"}]}],"StopFailure":[{"hooks":[{"type":"command","command":"true"}]}],"SessionEnd":[{"hooks":[{"type":"command","command":"true"}]}]}}' \
   > <worktree>/.claude/settings.local.json
 tmux new-session -d -s tp-h1 -c <worktree> \
-  "CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false claude --dangerously-skip-permissions 'reply with exactly: BRIEF-REACHED'"
-tmux capture-pane -p -t tp-h1
+  "CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false claude --dangerously-skip-permissions 'reply with exactly: BRIEF-REACHED'" || exit 1
+pane=
+for _ in $(seq 60); do   # new-session -d returns before claude has rendered anything
+  pane=$(tmux capture-pane -p -t tp-h1)
+  case $pane in *"Quick safety check"*|*BRIEF-REACHED*) break ;; esac
+  sleep 1
+done
+printf '%s\n' "$pane"
 ```
 
 "Shows the Quick safety check" is NOT a usable readout: both prompts open with that byte-identical first line and both offer `Yes, I trust this folder`.
 The arm reproduces only if the pane shows the SECOND prompt, so key the readout on the discriminator - its next line is `This folder pre-approves N tool permissions in .claude/settings.json` and its first option is `No, continue without these permissions`, where the first dialog instead says Claude will be able to read, edit, and execute files here and offers `No, exit`.
-If the pane shows the FIRST dialog the registration did not take effect, which is what the `|| exit 1` above catches; fix the registration and rerun rather than answering, because answering it writes `hasTrustDialogAccepted` and the treatment arm's walk would then report the key this script already writes as a candidate.
-If neither prompt appears, the project does not reproduce and no candidate can be tested on it.
+If the pane shows the FIRST dialog the registration did not take effect; fix the registration and rerun rather than answering, because answering it writes `hasTrustDialogAccepted` and the treatment arm's walk would then report the key this script already writes as a candidate.
+Apply that readout only to a pane the poll above settled: if neither prompt nor the reply ever appears the loop runs out, and only then does the project count as not reproducing.
 
 Treatment arm - snapshot the store FIRST, then answer the second prompt by hand in the control arm's `tp-h1` pane, then diff the two snapshots to see what the acceptance actually wrote:
 

--- a/docs/verification/runtime-backends.md
+++ b/docs/verification/runtime-backends.md
@@ -330,18 +330,20 @@ With only `hasTrustDialogAccepted` registered:
 
 | project | tracked `.claude/settings.json` | second prompt |
 | --- | --- | --- |
-| A | `PreToolUse` hooks AND 2 `permissions.allow` entries | YES |
-| B | 8 `permissions.allow` entries, no hooks | no |
+| A | `PreToolUse` hooks AND 2 `permissions.allow` entries, both remote-root shell wildcards | YES |
+| B | 8 `permissions.allow` entries, all narrow local-CLI subcommand patterns, no hooks | no |
 | C | one `SessionStart` hook, no `permissions.allow` | no |
 
-That column is scoped to the repo's TRACKED `.claude/settings.json` only.
+Those three are the same day's non-Firstmate spawns, and that column is scoped to each repo's TRACKED `.claude/settings.json` only.
+Note the KIND of rule, not just the count: the arm that prompted is the one whose two entries grant remote shell access, while the larger eight-entry set that did not prompt is local-CLI only.
 Every arm also carried hooks Firstmate itself injects: `bin/fm-spawn.sh` writes a `.claude/settings.local.json` with `UserPromptSubmit`, `Stop`, `StopFailure`, and `SessionEnd` entries into every claude worktree before launch, so no arm was hooks-free as Claude reads the folder.
 At the file level B was therefore a hooks-and-allow worktree that did NOT prompt, which rules out "hooks plus allow rules anywhere in the folder" as the trigger on its own.
-No arm isolated a `PreToolUse` hook without allow rules: A is the only project carrying one, C's single tracked hook is `SessionStart`, and the injected hooks are `UserPromptSubmit`, `Stop`, `StopFailure`, and `SessionEnd`.
-So "a `PreToolUse` hook alone reaches the prompt" was never tested and remains open.
+A hook without allow rules is not an open case, because Firstmate itself is the standing arm for it: this repository's own tracked `.claude/settings.json` carries `SessionStart`, `PreToolUse`, and `Stop` hooks and no `permissions` key at all, it is treehouse-pooled (`bin/fm-tangle-lib.sh`), and `bin/fm-spawn.sh` launches claude workers into fresh pre-registered worktrees of it routinely without any of them wedging on this prompt.
+The prompt's own text points the same way - it enumerates "This folder pre-approves N tool permissions in `.claude/settings.json`" - so a folder with no allow entries has nothing for it to be about.
+That leaves the tracked allow rules as the dimension still open.
 
 What is known: the prompt exists on 2.1.263, it appears despite a pre-registered `hasTrustDialogAccepted`, and it named the two `permissions.allow` entries from A's tracked `settings.json`.
-What is not known: which property of that project reaches it. Only A prompted, B and C did not, and one observation of each is too thin to separate tracked-versus-local settings, the hook class, the specific rules involved, or something else about the project entirely.
+What is not known: which property of A's tracked allow rules reaches it. Only A prompted, B and C did not, and one observation of each is too thin to separate the kind of rule granted, the count, tracked-versus-local settings, or something else about the project entirely.
 
 `hasTrustDialogHooksAccepted` was the obvious candidate for the key that pre-registers this acceptance, and it is NOT ESTABLISHED as that key.
 Read-only inspection of the operator's `~/.claude.json` on 2026-09-08 (71 project entries; `hasTrustDialogAccepted: true` in 37):
@@ -363,7 +365,7 @@ The shape of the two project-A worktree slots the captain answered by hand carri
 So pre-registering this key `true` would write a value the vendor has never been observed writing, and whether it records accepting the second prompt is NOT ESTABLISHED, because the only two known acceptances happened in slots this store does not update.
 Either way, nothing in `bin/fm-claude-trust.sh` pre-registers the second prompt and a worker that meets it still wedges.
 
-Refreshing this observation needs a live spawn against a project whose settings actually trigger the prompt, compared against the same worktree without the candidate key.
+Refreshing this observation needs a live spawn against a project whose tracked allow rules actually trigger the prompt, compared against the same worktree without the candidate key.
 No automated guard covers that, and Firstmate holds the controlled experiment as a separate deferred scout task.
 Recheck this after a Claude Code upgrade rather than trusting the version above.
 

--- a/docs/verification/runtime-backends.md
+++ b/docs/verification/runtime-backends.md
@@ -372,7 +372,7 @@ The treatment arm is not a launch of its own - it continues on the control arm's
 Control arm - confirm this worktree reaches the prompt at all.
 It must carry the hooks every observed spawn carried: `bin/fm-spawn.sh` writes a `.claude/settings.local.json` into each claude worktree before launch, which is exactly what makes row B above a hooks-and-allow worktree that did not prompt.
 A bare `tmux` launch without that file differs from every row in the table along the one dimension the table leaves open, so an absent prompt there would retire the only reproducing project on a condition it was never observed under.
-Spawn through `bin/fm-spawn.sh` where that is possible; otherwise write the file yourself as below.
+Spawn through `bin/fm-spawn.sh` where that is possible; otherwise write the file yourself as below - the write is skipped when one already exists, so an existing `settings.local.json` is left in place and the arm is INCONCLUSIVE unless that file carries the four injected hooks.
 
 ```sh
 cfg=${CLAUDE_CONFIG_DIR:-$HOME}                  # the worker must read the store we register into

--- a/docs/verification/runtime-backends.md
+++ b/docs/verification/runtime-backends.md
@@ -334,7 +334,7 @@ With only `hasTrustDialogAccepted` registered:
 | B | 8 `permissions.allow` entries, all narrow local-CLI subcommand patterns, no hooks | no |
 | C | one `SessionStart` hook, no `permissions.allow` | no |
 
-Those three are the same day's non-Firstmate spawns, and that column is scoped to each repo's TRACKED `.claude/settings.json` only.
+Those three are the same day's Firstmate spawns into projects other than Firstmate itself, and that column is scoped to each repo's TRACKED `.claude/settings.json` only.
 Note the KIND of rule, not just the count: the arm that prompted is the one whose two entries grant remote shell access, while the larger eight-entry set that did not prompt is local-CLI only.
 Every arm also carried hooks Firstmate itself injects: `bin/fm-spawn.sh` writes a `.claude/settings.local.json` with `UserPromptSubmit`, `Stop`, `StopFailure`, and `SessionEnd` entries into every claude worktree before launch, so no arm was hooks-free as Claude reads the folder.
 At the file level B was therefore a hooks-and-allow worktree that did NOT prompt, which rules out "hooks plus allow rules anywhere in the folder" as the trigger on its own.

--- a/docs/verification/runtime-backends.md
+++ b/docs/verification/runtime-backends.md
@@ -375,24 +375,35 @@ A bare `tmux` launch without that file differs from every row in the table along
 Spawn through `bin/fm-spawn.sh` where that is possible; otherwise write the file yourself as below.
 
 ```sh
+cfg=${CLAUDE_CONFIG_DIR:-$HOME}                  # the worker must read the store we register into
+wt=$(cd -P -- <worktree> && pwd -P) || exit 1    # fm-claude-trust.sh keys the entry on the RESOLVED path
 tmux kill-session -t tp-h1 2>/dev/null || true   # kill and entry removal come FIRST, ahead of the registration
-node -e 'const fs=require("node:fs"),f=process.argv[1];const j=JSON.parse(fs.readFileSync(f,"utf8"));
-delete (j.projects||{})[process.argv[2]];fs.writeFileSync(f,`${JSON.stringify(j,null,2)}\n`,{mode:0o600});' \
-  "${CLAUDE_CONFIG_DIR:-$HOME}/.claude.json" <worktree> || exit 1   # never after a candidate key has been written
-bin/fm-claude-trust.sh <worktree> <project> || exit 1   # a refusal must stop the arm, not fall through to the launch
-mkdir -p <worktree>/.claude   # stand in for the hooks bin/fm-spawn.sh injects into every claude worktree
+node -e 'const fs=require("node:fs"),p=require("node:path"),c=require("node:crypto");
+const f=fs.realpathSync(process.argv[1]),was=fs.readFileSync(f,"utf8"),j=JSON.parse(was);
+if(!j.projects||!(process.argv[2] in j.projects))throw new Error(`no entry for ${process.argv[2]}`);
+delete j.projects[process.argv[2]];
+const t=p.join(p.dirname(f),`.claude.json.arm.${process.pid}.${c.randomBytes(8).toString("hex")}`);
+fs.writeFileSync(t,`${JSON.stringify(j,null,2)}\n`,{mode:0o600,flag:"wx"});
+if(fs.readFileSync(f,"utf8")!==was){fs.unlinkSync(t);throw new Error("store moved under us - rerun");}
+fs.renameSync(t,f);' "$cfg/.claude.json" "$wt" || exit 1   # never run after a candidate key has been written
+bin/fm-claude-trust.sh "$wt" <project> || exit 1   # a refusal must stop the arm, not fall through to the launch
+mkdir -p "$wt/.claude"   # stand in for the hooks bin/fm-spawn.sh injects into every claude worktree
 printf '%s\n' '{"hooks":{"UserPromptSubmit":[{"hooks":[{"type":"command","command":"true"}]}],"Stop":[{"hooks":[{"type":"command","command":"true"}]}],"StopFailure":[{"hooks":[{"type":"command","command":"true"}]}],"SessionEnd":[{"hooks":[{"type":"command","command":"true"}]}]}}' \
-  > <worktree>/.claude/settings.local.json
-tmux new-session -d -s tp-h1 -c <worktree> \
-  "CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false claude --dangerously-skip-permissions 'reply with exactly: BRIEF-REACHED'" || exit 1
+  > "$wt/.claude/settings.local.json"
+tmux new-session -d -s tp-h1 -c "$wt" \
+  "CLAUDE_CONFIG_DIR=$cfg CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false claude --dangerously-skip-permissions 'reply with exactly: BRIEF-REACHED'" || exit 1
 pane=
 for _ in $(seq 60); do   # new-session -d returns before claude has rendered anything
   pane=$(tmux capture-pane -p -t tp-h1)
-  case $pane in *"Quick safety check"*|*". BRIEF-REACHED"*) break ;; esac
+  case $pane in *"Quick safety check"*) break ;; esac
+  if printf '%s\n' "$pane" | grep -v 'exactly:' | grep -q 'BRIEF-REACHED'; then break; fi
   sleep 1
 done
 printf '%s\n' "$pane"
 ```
+
+The removal treats an ABSENT entry as an error rather than a silent success, because that is the only signal that `$wt` disagrees with the key `bin/fm-claude-trust.sh` wrote; on a worktree that was genuinely never registered there is nothing to clear, so start at the registration instead.
+It also follows that script's own writer on that store - resolve the symlink, stage beside the target with mode 0600 and an exclusive create, re-read and compare before the rename, and refuse if the store moved - because a live Claude session writes this same file and a plain truncating write would silently drop whatever the vendor flushed in between.
 
 "Shows the Quick safety check" is NOT a usable readout: both prompts open with that byte-identical first line and both offer `Yes, I trust this folder`.
 The arm reproduces only if the pane shows the SECOND prompt, so key the readout on the discriminator - its next line is `This folder pre-approves N tool permissions in .claude/settings.json` and its first option is `No, continue without these permissions`, where the first dialog instead says Claude will be able to read, edit, and execute files here and offers `No, exit`.
@@ -400,7 +411,8 @@ If the pane shows the FIRST dialog the registration did not take effect; fix the
 Apply that readout only to a pane the poll settled on one of those two prompts.
 Loop exhaustion is NOT non-reproduction: it is equally what an empty pane looks like when the session died after creation - which the `|| exit 1` on the launch cannot catch, because it only guards session creation - and what the machine-scoped Bypass Permissions warning above or any other dialog looks like, none of which reached the trust stage at all.
 Treat every one of those as an INCONCLUSIVE arm to rerun, never as a result.
-The only pane that retires this project is one that positively shows the worker past the gate with no prompt having appeared: the answered brief, which is `. BRIEF-REACHED` on its own line and not the `> reply with exactly: BRIEF-REACHED` the UI echoes back, as the capture above shows.
+The only pane that retires this project is one that positively shows the worker past the gate with no prompt having appeared: a `BRIEF-REACHED` line that is NOT the composer's echo of the brief, which is what the poll's `grep -v 'exactly:'` tests.
+Match it that way rather than on a leading glyph: the captures in this file transcribe Claude's row markers into ASCII, so the bytes on a live pane are not the bytes quoted here.
 
 Treatment arm - snapshot the store FIRST, then answer the second prompt by hand in the control arm's `tp-h1` pane, then diff the two snapshots to see what the acceptance actually wrote:
 
@@ -417,12 +429,13 @@ if(o(x)&&o(y)){for(const k of new Set([...Object.keys(x),...Object.keys(y)]))wal
 if(JSON.stringify(x)!==JSON.stringify(y))console.log(p.join("."),JSON.stringify(x),"->",JSON.stringify(y));};
 walk(JSON.parse(fs.readFileSync(process.argv[1],"utf8")),
      JSON.parse(fs.readFileSync(process.argv[2],"utf8")),[]);' "$snap" "$STORE"
+rm -f "$snap"   # the snapshot is a full copy of a credential-bearing store; do not leave it behind
 ```
 
 Diff the WHOLE parsed store, not `projects[<worktree>]` alone.
 The two slots the captain answered by hand were already observed holding exactly `{"hasTrustDialogAccepted": true}` afterwards, so that per-project object is known NOT to change: a per-project diff returns nothing because of where it looked, not because the acceptance persists nothing, and reading its empty output as "no candidate keys" is the wrong conclusion.
 The whole-store walk also surfaces ordinary session bookkeeping written by any concurrent Claude session, so quiet the machine first and read the output for a newly appearing trust or permission key rather than for a single line.
-The keys that change there are the candidates. Test one in this order: clear the entry, run `bin/fm-claude-trust.sh`, THEN write the candidate key into that same entry, and only then rerun the control arm to see whether the prompt is gone.
+The keys that change there are the candidates. Test one in this order: clear the entry, run `bin/fm-claude-trust.sh`, THEN write the candidate key into that same entry - keyed on `$wt`, the resolved path the script itself uses - and only then rerun the control arm to see whether the prompt is gone.
 Clearing after the candidate is written deletes the key under test - the entry removal drops the whole per-project object, and `bin/fm-claude-trust.sh` rebuilds it with `hasTrustDialogAccepted` alone - so the arm would launch with exactly the shape that already prompts and every candidate would read as ruled out without ever having been carried into a launch.
 The script merges into an existing entry rather than replacing it, so writing the candidate before or after the registration both work; only clearing after it does not.
 If nothing outside that bookkeeping changes, the acceptance is persisted somewhere other than that store, or not persisted at all, and the search moves off this file.


### PR DESCRIPTION
## Intent

Josh wanted Firstmate to stop its spawned Claude Code workers from wedging on a second trust prompt: on 2026-09-07, workers launched into fresh worktrees of a project whose .claude/settings.json carried PreToolUse hooks and permissions.allow entries got past the pre-registered hasTrustDialogAccepted dialog but then hit a "Quick safety check" prompt about pre-approved tool permissions, which had to be answered by hand. His ask was to have bin/fm-claude-trust.sh also pre-register hasTrustDialogHooksAccepted: true through the same atomic, scope-tested, uid-owned write path with the postcondition requiring both keys, extend tests/fm-claude-trust.test.sh to prove both keys and treat a one-key store as dropped, and record the dated 2.1.263 observation in the harness-adapters claude.md "Workspace trust" section (plus any docs page that already owned hasTrustDialogAccepted, without creating a second owner), keeping the existing refusals and safety reasoning and preserving the rule that a visible dialog means pre-registration failed and keys are never sent. He constrained it to a minimal change with no refactor, required bin/fm-lint.sh and the trust test to be run and recorded, and explicitly forbade a live spawn from the worktree. During validation the hooks-key premise was contradicted by the live ~/.claude.json store (the key appeared only as false, never true), and Josh authorized reverting the behaviour change so the branch ships as a documentation-only verification record that rules the hooks key out. He further required that the record be redacted before publication to the public repo — no internal SSH host address, private project names, or operator home paths — and that the branch be rebuilt as a single clean commit so the unredacted text never reaches branch history.

## What Changed

- `docs/verification/runtime-backends.md` gains a "second prompt the registration does not cover" record under Claude workspace trust: the 2026-09-07 / Claude Code 2.1.263 observation that a pre-approved-permissions "Quick safety check" appears after `hasTrustDialogAccepted` is pre-registered, a three-project settings-shape table scoping the trigger to tracked `permissions.allow`, and a read-only `~/.claude.json` measurement (`hasTrustDialogHooksAccepted` present as `false` in 7 entries, never `true`) that marks that key NOT ESTABLISHED as the pre-registration key.
- `bin/fm-claude-trust.sh` header comments now state that the script covers the first dialog only and point at the docs record as the owner; no code, write path, or postcondition changed.
- The harness-adapters `claude.md` "Workspace trust" section documents how to tell the two prompts apart, that a visible trust dialog still means pre-registration failed while the second prompt appears even on a correct store, and that the differing consequence of a sent Enter leaves an open captain decision — plus a fixed over-deep relative link to `bin/fm-spawn.sh`.

## Risk Assessment

✅ Low: The branch ships no executable change at all (bin/fm-claude-trust.sh is comment-only, tests are byte-identical to base), every quantitative and source claim in the new record verified exactly against the live store and repo source, and the redaction requirement is satisfied; the single remaining issue is one self-rebutting sentence in a verification record whose remedy is a clause deletion.

## Testing

Ran the three targeted suites the change touches (fm-claude-trust, fm-harness-adapter-references, fm-documentation-audiences) - all 25 assertions green - then proved the record end-to-end rather than by unit pass alone: a real fm-spawn claude launch into a fresh worktree registers hasTrustDialogAccepted and no hooks key while injecting the four hooks the record names, the record's own published reproduction command produces its documented output verbatim with all eleven other stated figures matching the live store, all 16 branch commits and every historical revision of the three touched files are free of home paths, tailnet hosts, root@host targets, IPs, tokens and private project names, all 14 reference pointers resolve, and the trust script is comment-only against base so no behavior changed. Visual evidence is a full-page render of the new documentation as a maintainer reads it, showing the redacted host placeholder and the neutral A/B/C settings-shape table.

- Evidence: [Rendered new documentation as a maintainer reads it (redacted host placeholder, neutral A/B/C table)](https://github.com/jjtylr/firstmate/blob/6fda1b70d174a7b89be754376842e75de2830a2d/.no-mistakes/evidence/fm/fm-trust-hooks-k3/record-rendered.png)

<details>
<summary>Evidence: Rendered documentation, HTML source of the screenshot above</summary>

Source: [Rendered documentation, HTML source of the screenshot above](https://github.com/jjtylr/firstmate/blob/6fda1b70d174a7b89be754376842e75de2830a2d/.no-mistakes/evidence/fm/fm-trust-hooks-k3/record-rendered.html)

```text
<!doctype html><html><head><meta charset="utf-8">
<title>Claude second trust prompt - record as a reviewer sees it</title>
<script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
<style>
:root{color-scheme:light}
body{margin:0;background:#f6f8fa;font:16px/1.6 -apple-system,BlinkMacSystemFont,"Segoe UI",Helvetica,Arial,sans-serif;color:#1f2328}
.wrap{max-width:1000px;margin:0 auto;padding:32px 24px 64px}
h1.page{font-size:20px;margin:0 0 4px}
p.sub{margin:0 0 28px;color:#59636e;font-size:14px}
.file{background:#fff;border:1px solid #d1d9e0;border-radius:8px;margin:0 0 28px;overflow:hidden}
.file>header{background:#f6f8fa;border-bottom:1px solid #d1d9e0;padding:10px 16px;font:600 13px/1.4 ui-monospace,SFMono-Regular,Menlo,monospace}
.file>header .tag{float:right;font-weight:400;color:#59636e}
.md{padding:20px 24px}
.md h2,.md h3{margin:24px 0 12px;padding-bottom:.3em;border-bottom:1px solid #d1d9e0;font-size:18px}
.md h3:first-child,.md h2:first-child{margin-top:0}
.md p{margin:0 0 14px}
.md code{background:#818b981f;padding:.2em .4em;border-radius:6px;font:85% ui-monospace,SFMono-Regular,Menlo,monospace}
.md pre{background:#f6f8fa;border:1px solid #d1d9e0;border-radius:6px;padding:14px;overflow:auto}
.md pre code{background:none;padding:0;font-size:13px;line-height:1.5}
.md table{border-collapse:collapse;margin:0 0 16px;display:block;overflow:auto}
.md th,.md td{border:1px solid #d1d9e0;padding:7px 13px}
.md th{background:#f6f8fa}
.md tr:nth-child(2n) td{background:#f6f8fa}
</style></head><body><div class="wrap">
<h1 class="page">What this branch adds, rendered as a maintainer reads it</h1>
<p class="sub">Documentation-only verification record. Redacted for the public repository: the internal host is <code>&lt;internal-host&gt;</code> and the three projects are labelled A/B/C by settings shape.</p>
<div class="file"><header>docs/verification/runtime-backends.md <span class="tag">new subsection under "Claude workspace trust"</span></header><div class="md" id="rec"></div></div>
<div class="file"><header>.agents/skills/harness-adapters/references/harness/claude.md <span class="tag">"Workspace trust" section</span></header><div class="md" id="cm"></div></div>
</div>
<script>
const D={"rec":"### A second prompt the registration does not cover\n\nObserved 2026-09-07 on Claude Code 2.1.263, in production rather than in a built arm.\n`bin/fm-spawn.sh` launched workers into fresh treehouse worktrees with `hasTrustDialogAccepted` already pre-registered for each path, and the workspace-trust dialog above did not appear.\nTwo workers in project A then wedged on a SECOND prompt the registration did not cover.\nThe three projects below are the operator's own and are labelled by their settings shape rather than named; the operator's records hold the mapping.\nThe prompt, with its pre-approved commands redacted:\n\n`` `text\nQuick safety check: Is this a project you created or one you trust? ...\nThis folder pre-approves 2 tool permissions in .claude/settings.json:\nBash(ssh root@<internal-host>:*) and Bash(ssh -o BatchMode=yes ...)\nThese will apply without asking. Only proceed if you trust this configuration.\n> No, continue without these permissions\n  Yes, I trust this folder\nEnter to confirm . Esc to cancel\n`` `\n\nIts cursor sits on `No, continue without these permissions`, and firstmate's key plane cannot move the selection - the same reason the first dialog cannot be answered.\nUnlike the first dialog, whose Enter selects `No, exit` and kills the worker, a sent Enter here would by its own label leave a live worker running without the folder's pre-approved commands; that outcome is untested, no arm sent that key, and whether such a degraded worker is an acceptable unwedge is an open decision the captain owns.\nBoth workers stayed there until the captain answered them by hand in the panes.\n\nWhich tracked allow rules reach that prompt is UNESTABLISHED, and the same day's other spawns are why.\nWith only `hasTrustDialogAccepted` registered:\n\n| project | tracked `.claude/settings.json` | second prompt |\n| --- | --- | --- |\n| A | `PreToolUse` hooks AND 2 `permissions.allow` entries, both remote-root shell wildcards | YES |\n| B | 8 `permissions.allow` entries, all narrow local-CLI subcommand patterns, no hooks | no |\n| C | one `SessionStart` hook, no `permissions.allow` | no |\n\nThose three are the same day's Firstmate spawns into projects other than Firstmate itself, and that column is scoped to each repo's TRACKED `.claude/settings.json` only.\nNote the KIND of rule, not just the count: the arm that prompted is the one whose two entries grant remote shell access, while the larger eight-entry set that did not prompt is local-CLI only.\nEvery arm also carried hooks Firstmate itself injects: `bin/fm-spawn.sh` writes a `.claude/settings.local.json` with `UserPromptSubmit`, `Stop`, `StopFailure`, and `SessionEnd` entries into every claude worktree before launch, so no arm was hooks-free as Claude reads the folder.\nAt the file level B was therefore a hooks-and-allow worktree that did NOT prompt, which rules out \"hooks plus allow rules anywhere in the folder\" as the trigger on its own.\nA hook without allow rules is not an open case, because Firstmate itself is the standing arm for it: this repository's own tracked `.claude/settings.json` carries `SessionStart`, `PreToolUse`, and `Stop` hooks and no `permissions` key at all, it is treehouse-pooled (`bin/fm-tangle-lib.sh`), and `bin/fm-spawn.sh` launches claude workers into fresh pre-registered worktrees of it routinely without any of them wedging on this prompt.\nThe prompt's own text points the same way - it enumerates \"This folder pre-approves N tool permissions in `.claude/settings.json`\" - so a folder with no allow entries has nothing for it to be about.\nThat leaves the tracked allow rules as the dimension still open.\n\nWhat is known: the prompt exists on 2.1.263, it appears despite a pre-registered `hasTrustDialogAccepted`, and it named the two `permissions.allow` entries from A's tracked `settings.json`.\nWhat is not known: which property of A's tracked allow rules reaches it. Only A prompted, B and C did not, and one observation of each is too thin to separate the kind of rule granted from the count.\n\n`hasTrustDialogHooksAccepted` was the obvious candidate for the key that pre-registers this acceptance, and it is NOT ESTABLISHED as that key.\nRead-only inspection of the operator's `~/.claude.json` on 2026-09-08 (71 project entries; `hasTrustDialogAccepted: true` in 37):\n\n`` `sh\nnode -e 'const p=JSON.parse(require(\"node:fs\").readFileSync(process.env.HOME+\"/.claude.json\",\"utf8\")).projects;\nconst c={};for(const v of Object.values(p))if(\"hasTrustDialogHooksAccepted\" in v)c[v.hasTrustDialogHooksAccepted]=(c[v.hasTrustDialogHooksAccepted]||0)+1;\nconsole.log(c);'\ngrep -c 'hasTrustDialogHooksAccepted\"[[:space:]]*:[[:space:]]*true' ~/.claude.json\n`` `\n\n`` `text\n{ false: 7 }\n0\n`` `\n\nThe key occurs in 7 entries - all of them non-treehouse slots - is `false` in every one, and never appears as `true` anywhere in the file at any depth.\nClaude sessions ran in all 8 treehouse slots in this store - each has session transcripts under `~/.claude/projects` - and none of them acquired the key; those 8 hold exactly one key each, while its 63 non-treehouse entries hold 9 to 38.\nSo pre-registering this key `true` would write a value the vendor has never been observed writing, and whether it records accepting the second prompt is NOT ESTABLISHED.\nEither way, nothing in `bin/fm-claude-trust.sh` pre-registers the second prompt and a worker that meets it still wedges.\n\nRefreshing this observation needs a live spawn against a project whose tracked allow rules actually trigger the prompt, compared against the same worktree without the candidate key.\nNo automated guard covers that, and Firstmate holds the controlled experiment as a separate deferred scout task.\nRecheck this after a Claude Code upgrade rather than trusting the version above.\n","cm":"## Workspace trust\n\nClaude gates a folder it has never seen behind an interactive workspace-trust dialog, so every fresh task worktree would hit it.\n`--dangerously-skip-permissions` does not cover that gate: `claude --help` records that the dialog is skipped only in non-interactive mode, through `-p` or a non-TTY stdout, and a crewmate pane is interactive.\nA ship or scout spawn therefore pre-registers the worktree before launch, and the dialog does not appear.\n`../../../bin/fm-claude-trust.sh` records `hasTrustDialogAccepted` for that worktree path in `${CLAUDE_CONFIG_DIR:-$HOME}/.claude.json`, and `../../../bin/fm-spawn.sh` refuses the spawn when the write fails rather than launching a worker that would wedge.\n\nThat covers the first dialog only.\nA second prompt can sit behind it: a \"Quick safety check\" listing the tool permissions the folder pre-approves in `.claude/settings.json`, with the cursor on `No, continue without these permissions`.\nIt was observed on 2026-09-07 on Claude Code 2.1.263, after the trust dialog had been pre-registered, and it wedged two workers until a human answered it in the pane.\nAn allow-free tracked `.claude/settings.json` is not an open case: Firstmate's own repository has hooks and no `permissions` key, and routine worker spawns into its worktrees have never met this prompt; what remains open is the tracked `permissions.allow` dimension, and the record below owns that reasoning.\nNothing pre-registers that prompt today, and `hasTrustDialogHooksAccepted` is NOT ESTABLISHED as the key that would: it appears in the measured store only as `false` and never as `true`, so pre-registering it `true` would write a value the vendor has never been observed writing.\n`../../../docs/verification/runtime-backends.md` under \"Claude workspace trust\" owns that observation, what it rules out, and why refreshing it needs a live spawn.\n\nNever try to answer the trust dialog with a key.\nFirstmate's key plane carries only Enter, Escape, and C-c with no arrow navigation, so it cannot move a dialog's selection at all, and the observed rendering starts on `No, exit`, which means a sent Enter ends the session instead of accepting.\nBoth prompts open with the same \"Quick safety check\" line, so read the next line and the options to tell them apart: the trust dialog says Claude will be able to read, edit, and execute files here and offers `No, exit`, while the second prompt says the folder pre-approves N tool permissions in `.claude/settings.json` and offers `No, continue without these permissions`.\nA visible TRUST DIALOG means pre-registration did not take effect, so inspect the store and the spawn's error output rather than sending keys; the second prompt is not pre-registered at all, so it appears even when the store is correct and the spawn reported success.\nThe consequence of a sent Enter differs between the two prompts: on the trust dialog it selects `No, exit` and kills the worker, while on the second prompt it would select `No, continue without these permissions`, which by its own label leaves a live worker running without the folder's pre-approved commands.\nThat second outcome is untested, and whether a worker degraded that way is an acceptable unwedge is an open decision the captain owns, so firstmate sends no key to either prompt until he rules.\n\nThe once-per-machine bypass-permissions confirmation is a separate dialog, scoped to the machine rather than the path, and pre-registration does not address it.\nNever send Enter to that one either: it was observed rendering in the same shape as the trust dialog, with the selection on `No, exit` and the footer `Enter to confirm . Esc to cancel`, so Enter ends the session rather than accepting.\nFirstmate cannot move a selection with Enter, Escape, and C-c alone, so it cannot accept this dialog at all, and an operator accepts it once per machine instead.\nInspect the pane to identify which dialog is on screen, and report it rather than answering it.\n"};
marked.setOptions({gfm:true});
document.getElementById("rec").innerHTML=marked.parse(D.rec);
document.getElementById("cm").innerHTML=marked.parse(D.cm);
document.title="rendered";
</script></body></html>
```
</details>
<details>
<summary>Evidence: Real fm-spawn claude launch: registers hasTrustDialogAccepted only, injects the four hooks the record names</summary>

Source: [Real fm-spawn claude launch: registers hasTrustDialogAccepted only, injects the four hooks the record names](https://github.com/jjtylr/firstmate/blob/6fda1b70d174a7b89be754376842e75de2830a2d/.no-mistakes/evidence/fm/fm-trust-hooks-k3/spawn-registers-first-dialog-only.txt)

<code>spawn exit: 0&#10;spawned evid harness=claude kind=ship mode=no-mistakes yolo=off window=firstmate:fm-evid worktree=&lt;tmp&gt;/spawn/wt&#10;&#10;--- 1. what the spawn pre-registered in the worker&#39;s .claude.json ---&#10;{&#10;&#34;hasTrustDialogAccepted&#34;: true&#10;}&#10;&#10;--- 2. every hasTrustDialog* key in that store ---&#10;&#34;hasTrustDialogAccepted&#34;&#10;&#10;--- 3. the .claude/settings.local.json the spawn injected into the worktree ---&#10;hook events: UserPromptSubmit, Stop, StopFailure, SessionEnd&#10;permissions key present: false&#10;&#10;--- 4. this repository&#39;s OWN tracked .claude/settings.json (the record&#39;s standing arm) ---&#10;hook events: SessionStart, PreToolUse, Stop&#10;permissions key present: false</code>

```text
A real bin/fm-spawn.sh claude spawn into a fresh linked worktree (fake claude binary,
isolated HOME and CLAUDE_CONFIG_DIR). This is the launch path the record describes.

spawn exit: 0
warning: <tmp>/spawn/home/data/evid/launch-brief.md records no delivery contract line (scaffolded before ship briefs recorded one); launching on the explicit --mode no-mistakes - confirm its definition of done matches
spawned evid harness=claude kind=ship mode=no-mistakes yolo=off window=firstmate:fm-evid worktree=<tmp>/spawn/wt

--- 1. what the spawn pre-registered in the worker's .claude.json ---
{
  "hasTrustDialogAccepted": true
}

--- 2. every hasTrustDialog* key in that store ---
"hasTrustDialogAccepted"

--- 3. the .claude/settings.local.json the spawn injected into the worktree ---
hook events: UserPromptSubmit, Stop, StopFailure, SessionEnd
permissions key present: false

--- 4. this repository's OWN tracked .claude/settings.json (the record's standing arm) ---
hook events: SessionStart, PreToolUse, Stop
permissions key present: false

=> The spawn registers hasTrustDialogAccepted and nothing else, exactly as the record states.
=> Firstmate's own repo is hooks-with-no-permissions, the shape the record names as the
   standing arm that never met the second prompt.
```
</details>
<details>
<summary>Evidence: The record&#39;s published reproduction command re-run read-only; every stated figure matches</summary>

Source: [The record&#39;s published reproduction command re-run read-only; every stated figure matches](https://github.com/jjtylr/firstmate/blob/6fda1b70d174a7b89be754376842e75de2830a2d/.no-mistakes/evidence/fm/fm-trust-hooks-k3/record-reproduction.txt)

<code>--- actual output ---&#10;{ false: 7 }&#10;0&#10;&#10;--- the record&#39;s documented output ---&#10;{ false: 7 }&#10;0&#10;&#10;measurement measured record states&#10;---------- -------- -------------&#10;project entries 71 71&#10;hasTrustDialogAccepted true 37 37&#10;entries carrying the hooks key 7 7&#10;...of those, non-treehouse 7 all 7&#10;treehouse slots 8 8&#10;keys per treehouse slot 1 exactly one each&#10;treehouse slots with hooks key 0 none acquired it&#10;non-treehouse entries 63 63&#10;keys per non-treehouse entry 9 to 38 9 to 38&#10;slots with session transcripts 8/8 all 8 ran sessions</code>

```text
The record publishes a reproduction command for its central measurement.
Running it verbatim against the live store, read-only, on 2026-09-08.

--- the command as it appears in docs/verification/runtime-backends.md ---
node -e 'const p=JSON.parse(require("node:fs").readFileSync(process.env.HOME+"/.claude.json","utf8")).projects;
const c={};for(const v of Object.values(p))if("hasTrustDialogHooksAccepted" in v)c[v.hasTrustDialogHooksAccepted]=(c[v.hasTrustDialogHooksAccepted]||0)+1;
console.log(c);'
grep -c 'hasTrustDialogHooksAccepted"[[:space:]]*:[[:space:]]*true' ~/.claude.json

--- actual output ---
{ false: 7 }
0

--- the record's documented output ---
{ false: 7 }
0

--- every other figure the record states, measured (aggregates only; no paths reproduced) ---
measurement                       measured              record states
----------                        --------              -------------
project entries                   71                    71
hasTrustDialogAccepted true       37                    37
entries carrying the hooks key    7                     7
  ...of those, non-treehouse      7                     all 7
treehouse slots                   8                     8
keys per treehouse slot           1                     exactly one each
  the key each slot holds         hasTrustDialogAccepted    hasTrustDialogAccepted
treehouse slots with hooks key    0                     none acquired it
non-treehouse entries             63                    63
keys per non-treehouse entry      9 to 38               9 to 38
slots with session transcripts    8/8                   all 8 ran sessions

=> Every figure in the record reproduces exactly, and its published command
   produces the documented output verbatim.
```
</details>
<details>
<summary>Evidence: Redaction sweep over all 16 branch commits and every historical revision of the touched files</summary>

Source: [Redaction sweep over all 16 branch commits and every historical revision of the touched files](https://github.com/jjtylr/firstmate/blob/6fda1b70d174a7b89be754376842e75de2830a2d/.no-mistakes/evidence/fm/fm-trust-hooks-k3/redaction-sweep.txt)

<code>--- 1. Every line this branch ADDS, swept for operator infrastructure ---&#10;RESULT: 0 matches. No added line carries a home path, tailnet host, root@host, IP, or token.&#10;private project names in added lines: 0&#10;&#10;--- 2. Every historical revision of the three touched files ---&#10;RESULT: 0 revisions carry a tailnet host, root@host, IP, or private project name.&#10;&#10;--- 3. Pre-existing, NOT introduced by this branch ---&#10;occurrences at base: 5&#10;occurrences added or removed by this branch: 0&#10;&#10;--- 4. What ships in place of the redacted material ---&#10;317:Bash(ssh root@&lt;internal-host&gt;:*) and Bash(ssh -o BatchMode=yes ...)&#10;311:The three projects below are the operator&#39;s own and are labelled by their settings shape rather than named</code>

```text
Redaction check for publication to the public repo (kunchenguid/firstmate).
Scope: every commit on fm/fm-trust-hooks-k3 above base b84e0e362face25f3dd8945297a3df1320d7668c, so the unredacted
text must be absent from branch HISTORY, not just from the tip.

Commits scanned: 16
Lines added by the branch: 94 across 3 files

--- 1. Every line this branch ADDS, swept for operator infrastructure ---
patterns: /Users/<name> home path | *.ts.net tailnet host | root@<host> | bare IPv4 |
          gh[pousr]_/sk-/AKIA token shapes | known private project names (case-insensitive)
RESULT: 0 matches. No added line carries a home path, tailnet host, root@host, IP, or token.
private project names in added lines: 0

--- 2. Every historical revision of the three touched files ---
(the unredacted first draft must not survive anywhere in branch history)
RESULT: 0 revisions carry a tailnet host, root@host, IP, or private project name.

--- 3. Pre-existing, NOT introduced by this branch ---
docs/verification/runtime-backends.md already carried the upstream maintainer's own
home path in unrelated sections at the base commit; unchanged by this branch:
  occurrences at base: 5
  occurrences added or removed by this branch: 0

--- 4. What ships in place of the redacted material ---
317:Bash(ssh root@<internal-host>:*) and Bash(ssh -o BatchMode=yes ...)
311:The three projects below are the operator's own and are labelled by their settings shape rather than named; the operator's records hold the mapping.

| project | tracked `.claude/settings.json` | second prompt |
| --- | --- | --- |
| A | `PreToolUse` hooks AND 2 `permissions.allow` entries, both remote-root shell wildcards | YES |
| B | 8 `permissions.allow` entries, all narrow local-CLI subcommand patterns, no hooks | no |
| C | one `SessionStart` hook, no `permissions.allow` | no |
```
</details>
<details>
<summary>Evidence: fm-claude-trust.sh run directly against a hooks+allow project: writes one key, never the hooks key</summary>

Source: [fm-claude-trust.sh run directly against a hooks+allow project: writes one key, never the hooks key](https://github.com/jjtylr/firstmate/blob/6fda1b70d174a7b89be754376842e75de2830a2d/.no-mistakes/evidence/fm/fm-trust-hooks-k3/trust-store-first-dialog-only.txt)

```text
Pre-registration a claude spawn performs, run against an isolated store.
Folder shape: tracked .claude/settings.json with PreToolUse hooks + 2 permissions.allow entries
(the shape docs/verification/runtime-backends.md records as still hitting the second prompt).

$ bin/fm-claude-trust.sh <worktree> <project>
trusted: <sandbox>/wt

$ the worktree entry the launched Claude worker reads back from .claude.json:
{
  "hasTrustDialogAccepted": true
}

$ every hasTrustDialog* key anywhere in the resulting store:
"hasTrustDialogAccepted"

=> hasTrustDialogAccepted: true is registered. hasTrustDialogHooksAccepted is never written.
=> This is the record's central claim, observed: the registration covers the first dialog only,
   and a worker in a hooks+allow folder still meets the uncovered second prompt.
```
</details>
<details>
<summary>Evidence: All 14 relative pointers in the harness-adapters claude.md reference resolve from the skill root</summary>

Source: [All 14 relative pointers in the harness-adapters claude.md reference resolve from the skill root](https://github.com/jjtylr/firstmate/blob/6fda1b70d174a7b89be754376842e75de2830a2d/.no-mistakes/evidence/fm/fm-trust-hooks-k3/reference-pointers-resolve.txt)

```text
Reference pointers in .agents/skills/harness-adapters/references/harness/claude.md resolve
against the SKILL root - the convention every other pointer in the file uses,
and the same anchor tests/fm-harness-adapter-references.test.sh enforces for
the routing targets in SKILL.md.

line   resolves  pointer
----   --------  -------
21     OK        ../../../bin/fm-claude-trust.sh
21     OK        ../../../bin/fm-spawn.sh
28     OK        ../../../docs/verification/runtime-backends.md
48     OK        ../../../bin/fm-composer-lib.sh
49     OK        ../../../docs/herdr-backend.md
49     OK        ../../../docs/verification/runtime-backends.md
55     OK        ../../../bin/fm-spawn.sh
62     OK        ../../../bin/fm-turnend-guard.sh
62     OK        ../../../bin/fm-claude-stop-autoarm.sh
68     OK        ../../../docs/turnend-guard.md
70     OK        ../../../bin/fm-watch-arm.sh
72     OK        ../../../docs/arm-pretool-check.md
77     OK        ../../../bin/fm-subagent-pretool-check.sh
80     OK        ../../../docs/subagent-guard.md

Pointers this change adds or touches:
  21:`../../../bin/fm-claude-trust.sh` records `hasTrustDialogAccepted` for that worktree path in `${CLAUDE_CONFIG_DIR:-$HOME}/.claude.json`, and `../../../bin/fm-spawn.sh` refuses the spawn when the write fails rather than launching a worker that would wedge.
  28:`../../../docs/verification/runtime-backends.md` under "Claude workspace trust" owns that observation, what it rules out, and why refreshing it needs a live spawn.
  49:`../../../docs/herdr-backend.md` under "Composer and injection safety" owns dark-TRUECOLOR tradeoffs and `../../../docs/verification/runtime-backends.md` owns captures.
  55:The controls are scoped to the launched process and never modify the captain's global Claude settings; `launch_template()` in `../../../bin/fm-spawn.sh` owns their exact mechanics and defense-in-depth rationale.

The section the new record pointer names exists in the target file:
  docs/verification/runtime-backends.md:233:## Claude workspace trust

Existing test over the routing artifact, still green:
  ok - harness adapter routing artifact is normalized and every target is readable
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"4763c105b9e856d7be6e969a82e5dfd80cb18a7e","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

_... (17 earlier update rounds omitted to keep the PR body within GitHub's 65536-char limit; full history is in the run log.)_

<details>
<summary>⚠️ **Review** - 2 issues (1 warning, 1 info)</summary>

🔧 Fix: match spawn config forwarding and fix candidate order
2 issues (1 warning, 1 info) still open:

- ⚠️ `docs/verification/runtime-backends.md:391` - The `[ -e ... ] ||` guard the last fix round added makes the arm&#39;s own stated precondition satisfiable by a file that does not satisfy it. Lines 373-374 declare the hook shape mandatory: the arm &#34;must carry the hooks every observed spawn carried&#34; and &#34;a bare tmux launch without that file differs from every row in the table along the one dimension the table leaves open, so an absent prompt there would retire the only reproducing project on a condition it was never observed under.&#34; The guard only tests existence, not content. Concrete sequence in the intended fallback path (line 375 routes non-fm-spawn worktrees here): the operator points the arm at a real project worktree that already carries a `.claude/settings.local.json` written by Claude Code itself on an &#34;allow always&#34; acceptance - that file holds `permissions.allow` and no `hooks` key. The guard skips the write, `mkdir -p` succeeds, the launch proceeds with zero hooks in the folder, no command errors, and if the pane then reaches BRIEF-REACHED line 415 says that pane &#34;retires this project&#34; - retiring the only known reproducer on exactly the hooks-free condition line 374 forbids. bin/fm-spawn.sh:3215 uses `cat &gt;` unconditionally, so an fm-spawn-created worktree is always fine; only the fallback path this line exists to serve is exposed. Remedy is one clause inside the existing arm, not a new step: say that an existing file is left in place and the arm is INCONCLUSIVE unless that file carries the four injected hooks.
- ℹ️ `.agents/skills/harness-adapters/references/harness/claude.md:28` - The single-owner pointer this change adds does not resolve. From `.agents/skills/harness-adapters/references/harness/`, `../../../` lands on `.agents/skills/`, so `../../../docs/verification/runtime-backends.md` names `.agents/skills/docs/verification/runtime-backends.md`, which does not exist (verified: the path tests MISSING, while `../../../../../bin/fm-spawn.sh` used on line 55 of the same file tests EXISTS). The intent required recording the observation here without creating a second owner, and this line is the mechanism that defers to the owner - a reader or agent following it finds nothing and is left with the summary at lines 23-27 as the de facto owner. Pre-existing lines 21 and 49 carry the same wrong depth, so fixing only line 28 leaves the file inconsistent; correcting all three to `../../../../../` is the mechanical remedy.

🔧 Fix: note hooks precondition and fix reference link depth
4 issues (2 warnings, 2 infos) still open:

- ⚠️ `docs/verification/runtime-backends.md:391` - The `[ -e ... ] ||` guard round 9 added preserves an existing `.claude/settings.local.json`, and on the arm&#39;s own intended target that file is the one `bin/fm-spawn.sh:3215` wrote, carrying live `bin/fm-busy-event.sh apply &lt;STATE_REAL&gt; &lt;ID&gt; ... --gen &lt;BUSY_GEN&gt;` commands for UserPromptSubmit, Stop, StopFailure and SessionEnd. Concrete sequence during intended usage: line 365 says reaching the prompt needs a real project rather than a scratch repo, line 375 recommends spawning through `bin/fm-spawn.sh` first, and the table&#39;s only reproducer (project A) is the two fm-spawn treehouse worktrees from 2026-09-07 - so the operator points the arm at a worktree belonging to a live fm-spawn task. The guard skips the stand-in write, the preserved file keeps the live commands, and the arm&#39;s own `tmux new-session -d -s tp-h1 -c &#34;$wt&#34;` launch (line 394) starts a SECOND claude in that folder. Its hooks pass the exact gen baked in at arm time, so `bin/fm-busy-event.sh` accepts them as the current incarnation rather than rejecting them as stale (header contract lines 16-21), and the real task&#39;s record is written busy on submit then idle on Stop, with `touch &#34;$STATE_REAL/$ID.turn-ended&#34;` firing a turn-end that `bin/fm-wake-lib.sh:2014` and `bin/fm-watch.sh:220` read as genuine - a wake for a task nobody interacted with. Even the reproducing case, where the pane wedges on the prompt and never submits, still fires SessionEnd -&gt; idle when the next rerun&#39;s `tmux kill-session` (line 380) tears the session down. Nothing in the section warns about this; round 8&#39;s finding warned about the opposite failure (truncating the file) and this guard is what makes the live hooks reachable instead. Remedy is one clause inside the existing arm, not a new step: say the target worktree&#39;s task must be retired (or carry no live Firstmate busy wiring) before the arm launches, because a preserved `settings.local.json` binds this launch to that task&#39;s incarnation.
- ⚠️ `docs/verification/runtime-backends.md:372` - Simplification. The change introduces a ~70-line two-arm reproduction procedure (lines 365-443: control arm code block 377-404, treatment arm code block 420-434, plus their readout rules). The intent&#39;s required outcome after the authorized revert is that the branch ship &#34;as a documentation-only verification record that rules the hooks key out&#34; and record the dated 2.1.263 observation - satisfied entirely by lines 306-363 (the prompt capture, the settings-shape table, the measured store figures, and the RULED OUT conclusion). No intent requirement needs an executable refresh procedure. It also carries concrete cost rather than being merely surplus: every one of this run&#39;s nine fix rounds landed inside this component (session-kill ordering, store-path resolution, atomic entry removal, poll settling, snapshot permissions, candidate-write ordering, config-dir forwarding, the settings.local.json guard), the arm has never been run, and finding `arm-fires-live-task-busy-hooks` above also lives inside it - removal of the arm is the smallest honest remedy for that finding too. The narrower form that satisfies the stated purpose: keep lines 365-366 and 443 as a one-paragraph note that refreshing this needs a live spawn against a project whose settings trigger the prompt and has no live guard, and drop the two code blocks and their readout rules. Raising this once for a decision; if the captain wants the arm kept, the finding above is the fix that matters.
- ℹ️ `.agents/skills/harness-adapters/references/harness/claude.md:48` - Round 10 corrected three links in this file to `../../../../../` (lines 21, 28, 49) but left seven at the old depth, so the file now asserts two different paths to the same repo root. From `.agents/skills/harness-adapters/references/harness/`, five levels up is the repo root, so `../../../bin/fm-composer-lib.sh` on line 48 names `.agents/skills/bin/fm-composer-lib.sh`, which does not exist - and it sits directly above the corrected line 49, where the same reader now sees both spellings one line apart. The same broken depth remains on lines 62 (`../../../bin/fm-turnend-guard.sh`, `../../../bin/fm-claude-stop-autoarm.sh`), 68 (`../../../docs/turnend-guard.md`), 70 (`../../../bin/fm-watch-arm.sh`), 72 (`../../../docs/arm-pretool-check.md`), 77 (`../../../bin/fm-subagent-pretool-check.sh`) and 80 (`../../../docs/subagent-guard.md`). Those seven are pre-existing rather than introduced here, but the partial correction is what makes the file self-contradictory; the mechanical remedy is the same one-token change on those seven lines.
- ℹ️ `docs/verification/runtime-backends.md:395` - Round 9&#39;s fix changed the launch prefix to `${CLAUDE_CONFIG_DIR:+CLAUDE_CONFIG_DIR=$cfg }` to &#34;match fm-spawn exactly&#34;, but `bin/fm-spawn.sh:3760` builds it as `CLAUDE_CONFIG_DIR=$(shell_quote &#34;$CLAUDE_CONFIG_DIR&#34;) $LAUNCH` while the arm interpolates the bare value into the string tmux hands to a shell. Concrete input: `CLAUDE_CONFIG_DIR=/Users/&lt;user&gt;/Library/Application Support/claude` - a plausible value on macOS - expands to `CLAUDE_CONFIG_DIR=/Users/&lt;user&gt;/Library/Application Support/claude CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false claude ...`, so the shell assigns a truncated config dir and tries to run `Support/claude` as the command. The session dies immediately, `tmux new-session` still returned 0 so the `|| exit 1` does not catch it, and the poll exhausts on an empty pane - which line 413 correctly classifies as INCONCLUSIVE, so no wrong conclusion is drawn, only a silently wasted arm. Remedy is to quote the value the way fm-spawn does.

🔧 Fix: drop unrun repro arm and fix reference links
3 issues (2 warnings, 1 info) still open:

- ⚠️ `bin/fm-claude-trust.sh:30` - The header block enumerates five things the record owns, and the last one no longer exists. Commit 917e6b8 deleted the entire two-arm reproduction from docs/verification/runtime-backends.md (82 lines removed, replaced by the three-line paragraph now at 365-367, which says the controlled experiment is a *deferred* scout task and that no automated guard covers it). Lines 28-30 still read &#34;docs/verification/runtime-backends.md under \&#34;Claude workspace trust\&#34; owns the figures, the settings-shape table, the sent-Enter analysis, the open captain question, and the reproduction.&#34; Concrete sequence: a maintainer hitting the second prompt reads this header, follows the pointer expecting a runnable reproduction, and finds none - the record&#39;s own text now says the opposite, that refreshing the observation has no procedure here. The other four items are still accurate (figures at 347/357-362, table at 331-335, sent-Enter at 324-325, captain question at 325). Mechanical remedy: drop &#34;and the reproduction&#34; from line 30, or replace it with what the record actually owns now (&#34;and why refreshing it needs a live spawn&#34;).
- ⚠️ `.agents/skills/harness-adapters/references/harness/claude.md:28` - Same defect, second location, introduced by the same commit. Line 28 reads &#34;`../../../../../docs/verification/runtime-backends.md` under \&#34;Claude workspace trust\&#34; owns that observation, what it rules out, and the reproduction.&#34; Commit 917e6b8 removed the reproduction from that record; what remains at runtime-backends.md:365-367 explicitly states there is no procedure and the controlled experiment is held as a separate deferred scout task. This file is the harness-adapter reference an agent consults when a worker wedges on the second prompt, so the false third clause sends it looking for a procedure that was deleted. Remedy: drop &#34;and the reproduction&#34; or replace it with &#34;and why refreshing it needs a live spawn&#34;. These are the only two dangling references - a repo-wide grep for the removed arm&#39;s session name (`tp-h1`) and for &#34;reproduction&#34; turns up nothing else pointing at this record.
- ℹ️ `docs/verification/runtime-backends.md:306` - Informational, no action needed on the safety property. The intent asks that &#34;the branch be rebuilt as a single clean commit so the unredacted text never reaches branch history.&#34; The branch is 11 commits (d934fce plus ten pipeline-authored no-mistakes(review) fix commits), so the literal single-commit shape is not met. The stated *reason* for it is fully satisfied, which is why this is not a defect: I scanned every commit in b84e0e36..HEAD for an SSH host address, bare IP, tailnet name, private project name, or operator home path and found none - the redaction was present from the first commit, and the A/B/C labelling and `&lt;internal-host&gt;` placeholder were never introduced later. The ten extra commits are this pipeline&#39;s own fix rounds, so squashing them is a delivery-phase decision rather than a source correction.

🔧 Fix: correct stale reproduction pointers after arm removal
3 issues (1 warning, 2 infos) still open:

- ⚠️ `docs/verification/runtime-backends.md:362` - The second leg of the RULED OUT argument cites an observation with no discriminating power. Line 362 reads &#34;The two project-A worktree slots where the captain answered &#39;Yes, I trust this folder&#39; by hand hold exactly {\&#34;hasTrustDialogAccepted\&#34;: true} - accepting the second prompt wrote no hooks key at all&#34;, and line 363 concludes &#34;Whatever persists that acceptance, it is not this key&#34;. Read-only re-measurement of the same store shows that shape is universal for treehouse slots: all 8 entries under /.treehouse/ carry EXACTLY one key and zero carry any additional key, while the 63 non-treehouse entries carry 9-36 keys each; all 8 of those treehouse entries have a matching ~/.claude/projects transcript directory containing at least one .jsonl session, so real Claude sessions ran in every one and none of them added a single key to its entry. The two hand-answered project-A slots are treehouse slots, so they would hold exactly {\&#34;hasTrustDialogAccepted\&#34;: true} whether or not the acceptance persists a key - the observation is consistent with both outcomes and supports neither. That also weakens the remaining leg: the 7 entries that do carry hasTrustDialogHooksAccepted: false are all non-treehouse, actively-maintained slots (9-36 keys), so Claude does write this key in slots it maintains, and &#34;never true anywhere&#34; is equally explained by &#34;the only two known acceptances happened in slots this store never receives writes for&#34;. I reproduced the record&#39;s own headline figures exactly (71 entries, 37 trusted, {false: 7}, grep count 0), so the measurement is sound; it is the inference drawn from it that is stated more strongly than the data allows. Raising this for a decision rather than as a defect to auto-correct: the RULED OUT framing is what Josh authorized the branch to ship, and the honest remedy is a wording change to that authorized conclusion (note that treehouse entries are never updated by worker sessions, so the slot shape carries no information, and scope the conclusion to the single leg that survives). This does NOT reopen the doc-only decision or ask for the hooks key to be written.
- ℹ️ `docs/verification/runtime-backends.md:365` - &#34;compared against the same worktree without the candidate key&#34; has no antecedent. The only candidate the record names, hasTrustDialogHooksAccepted, is declared RULED OUT at lines 358-363, and the two-arm procedure that defined the candidate-write step (&#34;write the candidate key into projects[$wt] HERE&#34;) was deleted in 917e6b8. The phrase is residue from that deleted arm, so a maintainer following this paragraph has no key to compare against. Remedy: drop the clause or rephrase to name it as a future candidate (&#34;compared against the same worktree without whatever candidate key is being tested&#34;).
- ℹ️ `docs/verification/runtime-backends.md:369` - The parent section&#39;s closing transition is now inside the new subsection. At base this sentence directly followed the &#34;therefore pre-registers&#34; paragraph and closed ## Claude workspace trust; the new ### heading at line 306 pushed it inside the second-prompt subsection, so &#34;the same gate&#34; most-recently refers to the second prompt while the sentence itself is about &#34;a first-launch trust dialog&#34;. This is the residue of the round-6 fix, which moved the sibling paragraph back above the ### heading (now 303-304) but left this one behind. Nothing false is asserted, since the sentence self-identifies which dialog it means, hence info rather than warning. Mechanical remedy: move line 369 up to follow line 304, before the ### heading.

🔧 Fix: weaken hooks-key claim to not-established with measured basis
3 issues (2 warnings, 1 info) still open:

- ⚠️ `.agents/skills/harness-adapters/references/harness/claude.md:21` - The round-10 fix commit (98aca8f, &#34;fix reference link depth&#34;) rewrote 12 relative links in this reference from `../../../` to `../../../../../`, which inverts them relative to the skill&#39;s own documented resolution rule. `.agents/skills/harness-adapters/SKILL.md:21-22` states the contract: &#34;The skill directory is the directory containing this `SKILL.md`. Resolve on-demand reference links and relative links to their executable, documentation, or sibling-skill owners against the skill directory, including links named by a nested reference.&#34; The skill directory is `.agents/skills/harness-adapters/`, so `../../../bin/fm-claude-trust.sh` resolves to `&lt;repo&gt;/bin/fm-claude-trust.sh` (correct), while `../../../../../bin/...` resolves two levels above the repo root and does not exist. Concrete sequence: the routing matrix loads `references/harness/claude.md` for a trust-dialog operation, the agent follows line 21 to inspect `bin/fm-claude-trust.sh`, and lands outside the repository. The rest of the skill disagrees with the new form - SKILL.md itself is 8x3-level, and `references/common/*.md` plus 8 of the 10 sibling harness references are exclusively 3-level (~90 links); only gemini.md (9 links) and one pre-existing line in this file (base line 45) used 5-level, which is most likely what the fixer normalized to. Affected lines: 21, 28, 48, 49, 62, 68, 73, 78, 82. Most of them (composer ghost, turn-end guard, delegation guard) are outside the workspace-trust section this doc-only change was scoped to, so the fix round exceeded what the change required. Smallest honest remedy is to revert those rewrites to `../../../` rather than repair them further, and to write the two genuinely new links (lines 21 and 28) in the same 3-level form; flagged ask-user because it reverses a prior review round&#39;s deliberate change.
- ⚠️ `docs/verification/runtime-backends.md:340` - The record&#39;s central open question is scoped to three arms without saying so, and the isolating configuration it calls untested is the shape firstmate itself spawns into on every crew task. Line 340 asserts &#34;No arm isolated a `PreToolUse` hook without allow rules: A is the only project carrying one&#34;, line 341 concludes that hypothesis &#34;was never tested and remains open&#34;, and lines 366-367 defer it to a scout task. But this repository&#39;s own tracked `.claude/settings.json` carries `SessionStart`, `PreToolUse`, and `Stop` hooks with an empty `permissions` object - exactly PreToolUse-without-allow - and it is treehouse-pooled (`bin/fm-tangle-lib.sh:5`), so `bin/fm-spawn.sh` launches claude workers into fresh pre-registered worktrees of it routinely. Three such worktree entries sit in the same store the record measures (each with session transcripts under `~/.claude/projects`), and a fourth pre-registered project there carries a tracked `PostToolUse` hook with zero allow entries; none are reported as wedging. The record&#39;s own quoted prompt text points the same way: it enumerates &#34;This folder pre-approves N tool permissions in .claude/settings.json&#34;, so a folder with no allow entries has nothing for that prompt to be about. Consequence: a maintainer reading 340-341 and 366-367 schedules a live scout experiment for a case the operator&#39;s routine spawns already cover. Remedy is the author&#39;s call on the record&#39;s content - either state that the arm set is scoped to the three same-day non-firstmate spawns and name firstmate&#39;s own settings as the standing PreToolUse-without-allow case, or drop the hook-alone hypothesis and narrow the open question to the tracked-allow dimension.
- ℹ️ `docs/verification/runtime-backends.md:334` - The settings-shape table separates the prompting arm from the non-prompting one by hook presence and entry count only, omitting the sharpest observable difference between A&#39;s and B&#39;s allow rules. Row A&#39;s two entries are remote-root shell wildcards (the record quotes one, redacted, at line 317); row B&#39;s eight are all narrow local-CLI subcommand patterns (`gh issue ...`, `gh pr ...`). As written, the table shows B as the strictly larger allow set that did not prompt, so a reader cannot see that the prompting arm is the one whose rules grant remote shell access - a candidate trigger at least as strong as the hook class the surrounding prose develops. Line 344 does list &#34;the specific rules involved&#34; among what cannot be separated, but the table gives no way to weigh it. A redaction-safe clause on the row descriptions (kind of rule, not command text) would carry the discriminator without naming the projects.

🔧 Fix: restore skill link depth and narrow trust-prompt question
2 issues (1 warning, 1 info) still open:

- ⚠️ `.agents/skills/harness-adapters/references/harness/claude.md:26` - The two summaries of the second-prompt finding now contradict the record they name as its owner. Commit 50d9793 narrowed docs/verification/runtime-backends.md:341-343 to say a hook without allow rules &#34;is not an open case&#34;, that a folder with no allow entries &#34;has nothing for it to be about&#34;, and that &#34;the tracked allow rules&#34; are the only dimension still open. But claude.md:26 still says &#34;what configuration reaches the prompt is UNESTABLISHED, so treat no settings shape as exempt&#34;, and bin/fm-claude-trust.sh:26 still says &#34;What configuration reaches that prompt is UNESTABLISHED, so no settings shape is exempt&#34; - both written in earlier rounds when the question was genuinely wide open, neither updated by the round that closed the allow-free shape. Concrete sequence: the routing matrix loads references/harness/claude.md for a trust-dialog operation; the agent reads line 26 and treats an allow-free project (this repository&#39;s own worktrees, or project C&#39;s shape) as a live candidate for the prompt, which is exactly the case runtime-backends.md:341 just closed with Firstmate&#39;s own routine spawns as the standing arm - and line 28 sends the reader to that record, so the two disagree on the same fact. This is the second-owner divergence the intent&#39;s &#34;without creating a second owner&#34; constraint was guarding against. Narrower remedy: in both places replace &#34;no settings shape is exempt&#34; with the record&#39;s narrowed form (an allow-free tracked settings.json is not an open case; the open dimension is the tracked permissions.allow rules), keeping the record as the owner of the reasoning. Marked ask-user because it changes agent-facing operational guidance from conservative to narrower, which is the captain&#39;s call, not a mechanical correction.
- ℹ️ `docs/verification/runtime-backends.md:337` - &#34;Those three are the same day&#39;s non-Firstmate spawns&#34; reads on its face as &#34;spawns not performed by Firstmate&#34;, which contradicts line 309 in the same subsection (&#34;`bin/fm-spawn.sh` launched workers into fresh treehouse worktrees&#34;) and line 339 (&#34;hooks Firstmate itself injects&#34; into every arm). The intended meaning, established only by the contrast drawn at line 341 (&#34;Firstmate itself is the standing arm&#34;), is spawns into projects OTHER THAN the Firstmate repository. A reader who takes the plain reading concludes the three arms were manual launches without Firstmate&#39;s injected settings.local.json hooks, which would invalidate the line 340 inference that rules out &#34;hooks plus allow rules anywhere in the folder&#34;. Mechanical wording fix, no claim changes: say &#34;Firstmate spawns into projects other than Firstmate itself&#34;.

🔧 Fix: align trust summaries with narrowed record wording
2 issues (1 warning, 1 info) still open:

- ⚠️ `docs/verification/runtime-backends.md:364` - The inference &#34;so a worker session never updates its own slot&#39;s entry&#34; (added by fix commit 8a3c4a7) contradicts line 295 in the same section, which records that &#34;a concurrent Claude session can re-add a path it visited: one entry reappeared after an earlier zero-residual check, most plausibly flushed by a session as it exited&#34;. Line 365 then uses the stronger claim to discard the record&#39;s best datum: &#34;whether it records accepting the second prompt is NOT ESTABLISHED, because the only two known acceptances happened in slots this store does not update.&#34; I verified the data read-only: all 8 treehouse slots hold exactly {hasTrustDialogAccepted}, and every one has live Claude session transcripts under ~/.claude/projects, including the two project-A slots where a human accepted the second prompt. If line 295 is right that a session flushes its slot on exit, those two slots never acquiring hasTrustDialogHooksAccepted is positive evidence the key does not record that acceptance - which is exactly what the branch concludes. Consequence: a maintainer reading 295 then 364 gets two opposite rules for whether Claude writes a pre-registered worktree slot (the fact that governs how any future trust-store measurement is interpreted), and line 368&#39;s deferred scout spawn is scheduled to re-establish something the existing measurement may already answer. The defect lives in a clause a fix round added beyond what round 13&#39;s instruction required; the smallest honest remedy is deleting that clause and stating what the data shows (sessions ran in all 8 slots, none acquired the key), not adding new reasoning. Marked ask-user because it changes an asserted epistemic claim in a verification record, which the captain owns.
- ℹ️ `docs/verification/runtime-backends.md:346` - Fix commit 8a3c4a7 narrowed line 346&#39;s subject to &#34;which property of A&#39;s tracked allow rules reaches it&#34; and line 343 states &#34;That leaves the tracked allow rules as the dimension still open&#34;, but the rest of line 346 was left from the wide version and still names &#34;tracked-versus-local settings, or something else about the project entirely&#34; as alternatives too thin to separate - neither is a property of A&#39;s tracked allow rules. Line 328 likewise still opens the paragraph with the unnarrowed &#34;What configuration reaches that prompt is UNESTABLISHED&#34;. Consequence: a maintainer designing the deferred scout experiment at line 368 reads 343 and varies only the tracked allow rules, while 346 says the project itself may be the cause, so the record states two different scopes for the same experiment. Remedy is to align the listed alternatives with the narrowed frame (kind of rule granted vs count) or widen 343 back - a content call on the record, so ask-user.

🔧 Fix: drop contradicting slot inference and align open scope
2 issues (1 warning, 1 info) still open:

- ⚠️ `docs/verification/runtime-backends.md:364` - Fix commit 4763c10 deleted the inference &#34;so a worker session never updates its own slot&#39;s entry&#34; (which contradicted line 295) but kept the datum that existed only to support it. Line 364 now reads: &#34;Claude sessions ran in all 8 treehouse slots ... and none of them acquired the key; those 8 hold exactly one key each, while its 63 non-treehouse entries hold 9 to 38.&#34; The two halves point in opposite directions and neither is resolved. The first half is evidence AGAINST the key (sessions ran, key never appeared). The trailing clause&#39;s only rhetorical function is to qualify that evidence: a slot holding 1 key while ordinary entries hold 9-38 says Claude writes nothing back to these slots, which is exactly the deleted inference and exactly the line-295 contradiction, now left for the reader to re-derive silently. Line 365&#39;s conclusion (&#34;whether it records accepting the second prompt is NOT ESTABLISHED&#34;) no longer states any basis, because its stated basis was the clause that was removed. I confirmed both measurements read-only against the live store: all 8 treehouse slots hold exactly {hasTrustDialogAccepted}, all 8 have session transcripts under ~/.claude/projects, and the 63 non-treehouse entries range 9 to 38. In a record whose whole purpose is preserving what is and is not known, and which two other files (bin/fm-claude-trust.sh:31, .agents/skills/harness-adapters/references/harness/claude.md:28) name as the sole owner of this reasoning, a sentence that carries its own unstated rebuttal is the defect. The clause exceeds what round 15&#39;s instruction required (&#34;state only the measurement that Claude sessions ran in all 8 treehouse slots and none acquired the key&#34;); the smallest honest remedy is reverting that fix round to its minimal form by deleting the trailing clause from &#34;; those 8 hold&#34; onward, not adding a new sentence to reconcile it. Marked ask-user because it is an epistemic claim in a verification record and because the deletion is what round 15&#39;s captain instruction already authorized.
- ℹ️ `.agents/skills/harness-adapters/references/harness/claude.md:55` - A fix round changed `../../../../../bin/fm-spawn.sh` to `../../../bin/fm-spawn.sh` in the &#34;Feedback drafts&#34; section, which is unrelated to this change&#39;s stated intent (recording the second trust prompt). Noting it as verified-correct rather than as a problem: these reference files anchor relative paths at the SKILL root, not the file, which is the same convention tests/fm-harness-adapter-references.test.sh enforces for SKILL.md routing targets, and `.agents/skills/harness-adapters/../../../bin/` resolves to &lt;repo&gt;/bin. The edit brings line 55 in line with the other 11 refs in the same file, all of which use `../../../`. No action needed; flagged only so the out-of-scope edit is a recorded decision rather than unnoticed drive-by churn.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`bin/fm-test-run.sh tests/fm-claude-trust.test.sh tests/fm-harness-adapter-references.test.sh tests/fm-documentation-audiences.test.sh` - 3 scripts, 25 assertions, 0 failed, 0 gate-skipped</code>
- <code>Manual end-to-end: real `bin/fm-spawn.sh ... claude --mode no-mistakes --yolo off` into a fresh linked worktree with a fake claude binary and isolated HOME/CLAUDE_CONFIG_DIR; dumped the resulting `.claude.json` entry and the injected `.claude/settings.local.json`</code>
- <code>Manual: ran `bin/fm-claude-trust.sh &lt;worktree&gt; &lt;project&gt;` directly against a sandbox project whose tracked `.claude/settings.json` carries PreToolUse hooks plus 2 permissions.allow entries, and dumped every `hasTrustDialog*` key in the resulting store</code>
- <code>Manual: ran the record&#39;s own published reproduction block (`node -e &#39;...hasTrustDialogHooksAccepted...&#39;` and `grep -c &#39;hasTrustDialogHooksAccepted&#34;[[:space:]]*:[[:space:]]*true&#39; ~/.claude.json`) read-only, plus aggregate checks of all 11 other figures the record states</code>
- <code>Manual redaction sweep across all 16 commits in `b84e0e36..HEAD` for `/Users/&lt;name&gt;`, `*.ts.net`, `root@&lt;host&gt;`, bare IPv4, `gh[pousr]_`/`sk-`/`AKIA` token shapes, and known private project names, over both added lines and every historical revision of the three touched files</code>
- <code>Manual: resolved all 14 relative pointers in `.agents/skills/harness-adapters/references/harness/claude.md` against the skill root</code>
- <code>Manual: `diff` of the comment-stripped `bin/fm-claude-trust.sh` at base vs HEAD to confirm the change is comment-only</code>
- <code>Rendered the new record subsection and the claude.md Workspace trust section to HTML and captured a full-page screenshot in headless Chrome via `chrome-devtools-axi`</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Lint** - 1 warning</summary>

- ⚠️ linter found issues (exit code 1)

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
