### PR TITLE
fix: flag unrunnable validation checks as environment faults

### DIFF
--- a/.agents/skills/ask-user-authority/SKILL.md
+++ b/.agents/skills/ask-user-authority/SKILL.md
@@ -5,6 +5,7 @@ description: >-
   Use before deciding any ask-user finding.
   This skill is the single owner of finding-decision policy: firstmate always applies judgment, decides findings that are unambiguous toward accepted intent, and escalates only genuinely ambiguous, expanding, or destructive ones.
   Finding authority is this skill's criteria, not the project's yolo posture.
+  It also owns the rule that a finding reporting a configured check could not run is an environment fault, never answered by approval.
 user-invocable: false
 metadata:
   internal: true
@@ -19,6 +20,23 @@ Firstmate always applies this judgment, decides any finding that is unambiguous 
 
 The implementation worker never decides or answers its own ask-user finding.
 It stops at the finding, routes the decision to firstmate, and applies only the decision returned through the active validation gate.
+
+## A check that could not run is not a finding
+
+A finding reporting that a configured check COULD NOT RUN - the tool was missing, the command was not found, the worktree had no installed dependencies - is an environment fault, not a code finding.
+It means nothing was checked.
+Never accept, approve, waive, or defer it: doing so records a check that never ran as a check that passed, and the pipeline's own automatic fix commits then ship unexamined by the very check meant to cover them.
+On 2026-09-08 that exact warning was raised twice in one day, and running the checks for real on the first of them found the formatter rejecting three files the pipeline's own fix commits had rewritten.
+
+Expect it rather than treating it as exceptional: the pipeline validates in a worktree it creates for each run, from its own mirror of the repository, so no project dependency is ever installed there to begin with.
+
+Firstmate decides this itself and never escalates it, because nothing about it is a product or architecture call.
+The only correct answer is Fix, framed as environment repair: install the project's dependencies from its frozen lockfile, run the configured checks for real over the changed files, fix whatever they actually report, and answer the gate with that real result.
+An honest result may be that the checks ran and cover none of the changed paths; that is a valid answer and a silent could-not-run is not.
+Repair the copy the gate is actually validating; copying the changed files into some other copy that has the tools diagnoses the fault but leaves the gate's own copy unchecked.
+
+`bin/fm-crew-state.sh` names this case in its parked-gate detail, but that classifier reads agent-authored prose and can miss an unanticipated phrasing.
+Apply this rule whenever a finding says a check did not actually run, whether or not the state line flagged it.
 
 ## Decide
 

--- a/.agents/skills/ask-user-authority/SKILL.md
+++ b/.agents/skills/ask-user-authority/SKILL.md
@@ -24,7 +24,7 @@ It stops at the finding, routes the decision to firstmate, and applies only the 
 ## A check that could not run is not a finding
 
 A finding reporting that a configured check COULD NOT RUN - the tool was missing, the command was not found, the worktree had no installed dependencies - is an environment fault, not a code finding.
-It means nothing was checked.
+A configured check did not run, so validation is incomplete.
 Never accept, approve, waive, or defer it: doing so records a check that never ran as a check that passed, and the pipeline's own automatic fix commits then ship unexamined by the very check meant to cover them.
 On 2026-09-08 that exact warning was raised twice in one day, and running the checks for real on the first of them found the formatter rejecting three files the pipeline's own fix commits had rewritten.
 

--- a/.agents/skills/ask-user-authority/SKILL.md
+++ b/.agents/skills/ask-user-authority/SKILL.md
@@ -25,10 +25,11 @@ It stops at the finding, routes the decision to firstmate, and applies only the 
 
 A finding reporting that a configured check COULD NOT RUN - the tool was missing, the command was not found, the worktree had no installed dependencies - is an environment fault, not a code finding.
 A configured check did not run, so validation is incomplete.
-Never accept, approve, waive, or defer it: doing so records a check that never ran as a check that passed, and the pipeline's own automatic fix commits then ship unexamined by the very check meant to cover them.
-On 2026-09-08 that exact warning was raised twice in one day, and running the checks for real on the first of them found the formatter rejecting three files the pipeline's own fix commits had rewritten.
+Never accept, approve, waive, or defer it: doing so permits delivery without the configured check, including coverage of the pipeline's own automatic fix commits.
+Missing project dependencies can also disable a pre-commit formatting hook that needs those same dependencies, so that hook is not an independent safety net.
 
-Expect it rather than treating it as exceptional: the pipeline validates in a worktree it creates for each run, from its own mirror of the repository, so no project dependency is ever installed there to begin with.
+Do not assume that the gate's worktree has dependencies installed merely because the worker's copy does.
+The finding must report a failure to execute validation tooling or prepare its environment; a product failure such as "Administrators cannot run exports" does not establish that a check failed to run.
 
 Firstmate decides this itself and never escalates it, because nothing about it is a product or architecture call.
 The only correct answer is Fix, framed as environment repair: install the project's dependencies from its frozen lockfile, run the configured checks for real over the changed files, fix whatever they actually report, and answer the gate with that real result.
@@ -37,6 +38,7 @@ Repair the copy the gate is actually validating; copying the changed files into 
 
 `bin/fm-crew-state.sh` names this case in its parked-gate detail, but that classifier reads agent-authored prose and can miss an unanticipated phrasing.
 Apply this rule whenever a finding says a check did not actually run, whether or not the state line flagged it.
+[`tests/fm-crew-state.test.sh`](../../../tests/fm-crew-state.test.sh) covers the recorded missing-dependency findings, mixed findings, and product failures that must not be labelled as environment faults.
 
 ## Decide
 

--- a/bin/fm-crew-state.sh
+++ b/bin/fm-crew-state.sh
@@ -664,16 +664,10 @@ if [ "$HAVE_RUN" = 1 ]; then
       if printf '%s\n' "$RUN_OUT" | grep -q 'ask-user'; then
         RUN_DETAIL="$RUN_DETAIL (ask-user: authority decision)"
       fi
-      # A gate finding that reports a configured check COULD NOT RUN is not a
-      # decision at all - it is an environment fault, and it means nothing was
-      # checked. Left as a plain ask-user finding it reads exactly like a product
-      # call and gets approved, recording an unrun check as a pass. Name it here,
-      # in the one line firstmate reads every heartbeat, so the difference is not
-      # something a tired reader has to notice in the finding prose.
       # fm_nm_unrunnable_check_finding is the ONE detector; decision policy is
       # owned by .agents/skills/ask-user-authority/SKILL.md.
       if fm_nm_unrunnable_check_finding "$RUN_OUT" >/dev/null; then
-        RUN_DETAIL="$RUN_DETAIL (environment fault: a configured check could not run - NOTHING WAS CHECKED; not approvable)"
+        RUN_DETAIL="$RUN_DETAIL (environment fault: a configured check did not run - validation is incomplete; not approvable)"
       fi
     else
       case "$status" in

--- a/bin/fm-crew-state.sh
+++ b/bin/fm-crew-state.sh
@@ -45,7 +45,9 @@
 #      round never reads as an older failed run (rule owned by
 #      fm_nm_runs_status_for_worktree in bin/fm-nm-run-lib.sh).
 #      The run-step is AUTHORITATIVE: running/fixing -> working, ci -> working,
-#      awaiting_approval/fix_review -> parked (with gate findings), terminal
+#      awaiting_approval/fix_review -> parked (with gate findings, and with a
+#      finding that reports a configured check could not run named as the
+#      environment fault it is rather than an approvable decision), terminal
 #      passed/checks-passed -> done, failed/cancelled -> failed. EXCEPT: while
 #      the active step is ci, `axi status` alone cannot tell "still waiting on
 #      checks" from "checks green, waiting on merge" (see nm_ci_checks_state) -
@@ -661,6 +663,17 @@ if [ "$HAVE_RUN" = 1 ]; then
       [ -n "$fcount" ] && RUN_DETAIL="$RUN_DETAIL: $fcount finding(s)"
       if printf '%s\n' "$RUN_OUT" | grep -q 'ask-user'; then
         RUN_DETAIL="$RUN_DETAIL (ask-user: authority decision)"
+      fi
+      # A gate finding that reports a configured check COULD NOT RUN is not a
+      # decision at all - it is an environment fault, and it means nothing was
+      # checked. Left as a plain ask-user finding it reads exactly like a product
+      # call and gets approved, recording an unrun check as a pass. Name it here,
+      # in the one line firstmate reads every heartbeat, so the difference is not
+      # something a tired reader has to notice in the finding prose.
+      # fm_nm_unrunnable_check_finding is the ONE detector; decision policy is
+      # owned by .agents/skills/ask-user-authority/SKILL.md.
+      if fm_nm_unrunnable_check_finding "$RUN_OUT" >/dev/null; then
+        RUN_DETAIL="$RUN_DETAIL (environment fault: a configured check could not run - NOTHING WAS CHECKED; not approvable)"
       fi
     else
       case "$status" in

--- a/bin/fm-nm-run-lib.sh
+++ b/bin/fm-nm-run-lib.sh
@@ -138,7 +138,7 @@ fm_nm_finding_descriptions() {  # <toon-output>
 fm_nm_unrunnable_check_finding() {  # <toon-output>
   local row
   row=$(fm_nm_finding_descriptions "$1" |
-    grep -iE '(^|[^[:alnum:]_])(checks?|lint|linter|eslint|prettier|formatter|format|tests?|test runner|vitest|jest|command|tool|toolchain|binary|executable|dependencies|node_modules|install|installed)([^[:alnum:]_]|$)' |
+    grep -iE '(^|[^[:alnum:]_])(checks?|lint|linter|eslint|prettier|formatter|test runner|vitest|jest|command not found)([^[:alnum:]_]|$)' |
     grep -iE 'could ?n[^ ]{0,3}t (be )?run|could not (be )?run|can ?n[^ ]{0,3}t (be )?run|cannot (be )?run|can not (be )?run|unable to run|did ?n[^ ]{0,3}t run|did not run|was not run|were not run|never ran|not runnable|command not found' | head -1)
   [ -n "$row" ] || return 1
   printf '%s' "$(fm_nm_trim "$row")"

--- a/bin/fm-nm-run-lib.sh
+++ b/bin/fm-nm-run-lib.sh
@@ -102,6 +102,49 @@ fm_nm_branch_sync_state() {  # <toon-output>
   fm_nm_strip_quotes "$s"
 }
 
+# Rows of the gate's `findings[N]{...}:` table in captured `axi status` TOON $1,
+# one row per line and without the header. A row is a line indented deeper than
+# the header; the first line at or left of the header's indent ends the table.
+fm_nm_finding_rows() {  # <toon-output>
+  printf '%s\n' "$1" | awk '
+    /^[[:space:]]*findings\[[0-9]+\]\{/ { hdr = match($0, /[^ \t]/) - 1; inblk = 1; next }
+    inblk {
+      if ($0 ~ /^[[:space:]]*$/) { inblk = 0; next }
+      if (match($0, /[^ \t]/) - 1 <= hdr) { inblk = 0; next }
+      print
+    }
+  '
+}
+
+# The first finding row in captured `axi status` TOON $1 that reports a
+# configured check COULD NOT RUN, printed as evidence; 1 when there is none.
+#
+# This is the ONE detector for that case. It exists because a check that could
+# not run is not a code finding at all: it is an environment fault, and it means
+# NOTHING WAS CHECKED. The pipeline validates in a worktree it creates per run
+# (`~/.no-mistakes/worktrees/<repo>/<run>/`, from its own bare mirror), which
+# carries no installed project dependencies, so a gate agent that reaches for
+# the repository's own linter, formatter, or test runner routinely finds nothing
+# there. Seen twice in one day on 2026-09-08 (runs 01M1Z60TC7SRFT0TQGH45ZPCNA
+# and 01M201A5K6A9QMZDBBGJDF6QF3), each time raised as an ask-user WARNING that
+# reads exactly like an ordinary product decision. On the first of those, running
+# the checks for real found the formatter REJECTING three files the pipeline's own
+# fix commits had rewritten, so approving the warning would have shipped exactly
+# what the check existed to catch.
+#
+# The verdict comes from agent-authored prose, so this is a backstop and not a
+# proof: the alternation is deliberately wide, and it is allowed to be wrong in
+# the direction that asks firstmate to confirm a check really ran. It can still
+# miss an unanticipated phrasing, so the decision rule in
+# .agents/skills/ask-user-authority/SKILL.md applies whether or not this fires.
+FM_NM_UNRUNNABLE_CHECK_RE=${FM_NM_UNRUNNABLE_CHECK_RE-'could ?n[^ ]{0,3}t (be )?run|could not (be )?run|can ?n[^ ]{0,3}t (be )?run|cannot (be )?run|can not (be )?run|unable to run|did ?n[^ ]{0,3}t run|did not run|was not run|were not run|never ran|not runnable|command not found|not found on( the)? path|no such file or directory|not installed|dependencies (are |were )?absent|absent dependencies|missing dependencies|no installed dependencies|dependencies not installed|no node_modules|unavailable|not available'}
+fm_nm_unrunnable_check_finding() {  # <toon-output>
+  local row
+  row=$(fm_nm_finding_rows "$1" | grep -iE "$FM_NM_UNRUNNABLE_CHECK_RE" | head -1)
+  [ -n "$row" ] || return 1
+  printf '%s' "$(fm_nm_trim "$row")"
+}
+
 # 0 if the run in captured `axi status` TOON $1 is still in flight: no
 # terminal outcome and no terminal status.
 fm_nm_run_is_active() {  # <toon-output>

--- a/bin/fm-nm-run-lib.sh
+++ b/bin/fm-nm-run-lib.sh
@@ -102,25 +102,42 @@ fm_nm_branch_sync_state() {  # <toon-output>
   fm_nm_strip_quotes "$s"
 }
 
-# Rows of the gate's `findings[N]{...}:` table in captured `axi status` TOON $1,
-# one row per line and without the header. A row is a line indented deeper than
-# the header; the first line at or left of the header's indent ends the table.
-fm_nm_finding_rows() {  # <toon-output>
+# Descriptions from the gate findings table in captured `axi status` TOON $1.
+# Read the declared column order and respect quoted commas and escaped quotes,
+# so finding IDs and file paths cannot supply classification context.
+fm_nm_finding_descriptions() {  # <toon-output>
   printf '%s\n' "$1" | awk '
-    /^[[:space:]]*findings\[[0-9]+\]\{/ { hdr = match($0, /[^ \t]/) - 1; inblk = 1; next }
+    /^[[:space:]]*findings\[[0-9]+\]\{/ {
+      hdr = match($0, /[^ \t]/) - 1; inblk = 1; description = 0
+      fields = $0; sub(/^[^{]*\{/, "", fields); sub(/\}.*/, "", fields)
+      count = split(fields, names, ",")
+      for (i = 1; i <= count; i++) if (names[i] == "description") description = i
+      next
+    }
     inblk {
       if ($0 ~ /^[[:space:]]*$/) { inblk = 0; next }
       if (match($0, /[^ \t]/) - 1 <= hdr) { inblk = 0; next }
-      print
+      field = 1; quoted = 0; value = ""
+      for (i = 1; i <= length($0); i++) {
+        c = substr($0, i, 1)
+        if (quoted && c == "\\") { c = substr($0, ++i, 1) }
+        else if (c == "\"") { quoted = !quoted; continue }
+        else if (!quoted && c == ",") {
+          if (field == description) break
+          field++; continue
+        }
+        if (field == description) value = value c
+      }
+      if (description && field == description) print value
     }
   '
 }
 
-# The first finding row in captured `axi status` TOON $1 that reports a
+# The first finding description in captured `axi status` TOON $1 that reports a
 # configured check COULD NOT RUN, printed as evidence; 1 when there is none.
 fm_nm_unrunnable_check_finding() {  # <toon-output>
   local row
-  row=$(fm_nm_finding_rows "$1" |
+  row=$(fm_nm_finding_descriptions "$1" |
     grep -iE '(^|[^[:alnum:]_])(checks?|lint|linter|eslint|prettier|formatter|format|tests?|test runner|vitest|jest|command|tool|toolchain|binary|executable|dependencies|node_modules|install|installed)([^[:alnum:]_]|$)' |
     grep -iE 'could ?n[^ ]{0,3}t (be )?run|could not (be )?run|can ?n[^ ]{0,3}t (be )?run|cannot (be )?run|can not (be )?run|unable to run|did ?n[^ ]{0,3}t run|did not run|was not run|were not run|never ran|not runnable|command not found' | head -1)
   [ -n "$row" ] || return 1

--- a/bin/fm-nm-run-lib.sh
+++ b/bin/fm-nm-run-lib.sh
@@ -120,7 +120,9 @@ fm_nm_finding_rows() {  # <toon-output>
 # configured check COULD NOT RUN, printed as evidence; 1 when there is none.
 fm_nm_unrunnable_check_finding() {  # <toon-output>
   local row
-  row=$(fm_nm_finding_rows "$1" | grep -iE 'could ?n[^ ]{0,3}t (be )?run|could not (be )?run|can ?n[^ ]{0,3}t (be )?run|cannot (be )?run|can not (be )?run|unable to run|did ?n[^ ]{0,3}t run|did not run|was not run|were not run|never ran|not runnable|command not found' | head -1)
+  row=$(fm_nm_finding_rows "$1" |
+    grep -iE '(^|[^[:alnum:]_])(checks?|lint|linter|eslint|prettier|formatter|format|tests?|test runner|vitest|jest|command|tool|toolchain|binary|executable|dependencies|node_modules|install|installed)([^[:alnum:]_]|$)' |
+    grep -iE 'could ?n[^ ]{0,3}t (be )?run|could not (be )?run|can ?n[^ ]{0,3}t (be )?run|cannot (be )?run|can not (be )?run|unable to run|did ?n[^ ]{0,3}t run|did not run|was not run|were not run|never ran|not runnable|command not found' | head -1)
   [ -n "$row" ] || return 1
   printf '%s' "$(fm_nm_trim "$row")"
 }

--- a/bin/fm-nm-run-lib.sh
+++ b/bin/fm-nm-run-lib.sh
@@ -118,29 +118,9 @@ fm_nm_finding_rows() {  # <toon-output>
 
 # The first finding row in captured `axi status` TOON $1 that reports a
 # configured check COULD NOT RUN, printed as evidence; 1 when there is none.
-#
-# This is the ONE detector for that case. It exists because a check that could
-# not run is not a code finding at all: it is an environment fault, and it means
-# NOTHING WAS CHECKED. The pipeline validates in a worktree it creates per run
-# (`~/.no-mistakes/worktrees/<repo>/<run>/`, from its own bare mirror), which
-# carries no installed project dependencies, so a gate agent that reaches for
-# the repository's own linter, formatter, or test runner routinely finds nothing
-# there. Seen twice in one day on 2026-09-08 (runs 01M1Z60TC7SRFT0TQGH45ZPCNA
-# and 01M201A5K6A9QMZDBBGJDF6QF3), each time raised as an ask-user WARNING that
-# reads exactly like an ordinary product decision. On the first of those, running
-# the checks for real found the formatter REJECTING three files the pipeline's own
-# fix commits had rewritten, so approving the warning would have shipped exactly
-# what the check existed to catch.
-#
-# The verdict comes from agent-authored prose, so this is a backstop and not a
-# proof: the alternation is deliberately wide, and it is allowed to be wrong in
-# the direction that asks firstmate to confirm a check really ran. It can still
-# miss an unanticipated phrasing, so the decision rule in
-# .agents/skills/ask-user-authority/SKILL.md applies whether or not this fires.
-FM_NM_UNRUNNABLE_CHECK_RE=${FM_NM_UNRUNNABLE_CHECK_RE-'could ?n[^ ]{0,3}t (be )?run|could not (be )?run|can ?n[^ ]{0,3}t (be )?run|cannot (be )?run|can not (be )?run|unable to run|did ?n[^ ]{0,3}t run|did not run|was not run|were not run|never ran|not runnable|command not found|not found on( the)? path|no such file or directory|not installed|dependencies (are |were )?absent|absent dependencies|missing dependencies|no installed dependencies|dependencies not installed|no node_modules|unavailable|not available'}
 fm_nm_unrunnable_check_finding() {  # <toon-output>
   local row
-  row=$(fm_nm_finding_rows "$1" | grep -iE "$FM_NM_UNRUNNABLE_CHECK_RE" | head -1)
+  row=$(fm_nm_finding_rows "$1" | grep -iE 'could ?n[^ ]{0,3}t (be )?run|could not (be )?run|can ?n[^ ]{0,3}t (be )?run|cannot (be )?run|can not (be )?run|unable to run|did ?n[^ ]{0,3}t run|did not run|was not run|were not run|never ran|not runnable|command not found' | head -1)
   [ -n "$row" ] || return 1
   printf '%s' "$(fm_nm_trim "$row")"
 }

--- a/tests/fm-crew-state.test.sh
+++ b/tests/fm-crew-state.test.sh
@@ -2442,6 +2442,48 @@ test_parked_ordinary_finding_is_not_an_environment_fault() {
   pass "an ordinary ask-user finding is not flagged as an environment fault"
 }
 
+test_finding_metadata_does_not_supply_tool_context() {
+  reset_fakes
+  local d; d=$(new_case parked-metadata-not-env)
+  make_repo_on_branch "$d/wt" fm/feat-metadata-env
+  make_fakebin "$d" >/dev/null
+  fm_write_meta "$d/state/feat-metadata-env.meta" "window=fm:fm-feat-metadata-env" \
+    "worktree=$d/wt" "kind=ship"
+  local row out
+  for row in \
+    'format,warning,b.go,,ask-user,Administrators cannot run exports' \
+    'r1,warning,src/test/exports.go,,ask-user,Administrators cannot run exports' \
+    'install,warning,"src/exports,legacy.go",,ask-user,Administrators cannot run exports' \
+    '"r1,\"test\"",warning,b.go,,ask-user,Administrators cannot run exports' \
+    'r1,warning,b.go,,ask-user,"Administrators cannot run exports, including archived records"'; do
+    FM_FAKE_AXI_STATUS="$(run_parked fm/feat-metadata-env)"
+    FM_FAKE_AXI_STATUS=${FM_FAKE_AXI_STATUS/r2,error,b.go,,ask-user,changes product behavior/$row}
+    out=$(run_crew_state "$d" feat-metadata-env)
+    assert_contains "$out" "ask-user: authority decision" "metadata case lost its decision"
+    assert_not_contains "$out" "environment fault" \
+      "$row: metadata classified a product decision as an environment fault"
+  done
+  pass "finding metadata does not supply tool context"
+
+  # The description column is selected by its header, including when a quoted
+  # metadata field contains commas or escaped quotes before it.
+  local header
+  for header in 'id,severity,file,line,action,description' 'id,description,severity,file,line,action'; do
+    if [ "$header" = 'id,severity,file,line,action,description' ]; then
+      row='"r1,\"legacy\"",warning,"src/a,b.go",,ask-user,"Checks could not run, because dependencies are absent"'
+    else
+      row='"r1,\"legacy\"","Checks could not run, because dependencies are absent",warning,b.go,,ask-user'
+    fi
+    FM_FAKE_AXI_STATUS="$(run_parked fm/feat-metadata-env)"
+    FM_FAKE_AXI_STATUS=${FM_FAKE_AXI_STATUS/id,severity,file,line,action,description/$header}
+    FM_FAKE_AXI_STATUS=${FM_FAKE_AXI_STATUS/r2,error,b.go,,ask-user,changes product behavior/$row}
+    out=$(run_crew_state "$d" feat-metadata-env)
+    assert_contains "$out" "environment fault" "a quoted finding description lost its tool context"
+  done
+  pass "finding descriptions retain tool context with quoted fields and reordered columns"
+}
+
+test_finding_metadata_does_not_supply_tool_context
 test_parked_unrunnable_check_named_as_environment_fault
 test_parked_unrunnable_check_beside_real_finding_still_named
 test_parked_ordinary_finding_is_not_an_environment_fault

--- a/tests/fm-crew-state.test.sh
+++ b/tests/fm-crew-state.test.sh
@@ -2428,6 +2428,10 @@ test_parked_ordinary_finding_is_not_an_environment_fault() {
   for description in \
     "Administrators cannot run exports" \
     "Contestants cannot run exports" \
+    "Administrators cannot run the export command" \
+    "Users cannot run the optional plugin install" \
+    "The export format cannot be run by administrators" \
+    "The customer test did not run after submitting the form" \
     "Search is unavailable to administrators" \
     "Search is not available to administrators" \
     "The optional plugin is not installed" \
@@ -2480,6 +2484,10 @@ test_finding_metadata_does_not_supply_tool_context() {
     out=$(run_crew_state "$d" feat-metadata-env)
     assert_contains "$out" "environment fault" "a quoted finding description lost its tool context"
   done
+  FM_FAKE_AXI_STATUS="$(run_parked fm/feat-metadata-env)"
+  FM_FAKE_AXI_STATUS=${FM_FAKE_AXI_STATUS/changes product behavior/command not found}
+  out=$(run_crew_state "$d" feat-metadata-env)
+  assert_contains "$out" "environment fault" "a bare command-not-found diagnostic was missed"
   pass "finding descriptions retain tool context with quoted fields and reordered columns"
 }
 

--- a/tests/fm-crew-state.test.sh
+++ b/tests/fm-crew-state.test.sh
@@ -2365,14 +2365,10 @@ test_unanchored_unfetched_active_row_does_not_match
 test_unresolved_terminal_row_is_history_not_current
 test_runs_list_continuation_found_when_axi_answers_other_branch
 
-# (c2) An ask-user finding that reports a configured check COULD NOT RUN is an
-# environment fault, not a decision. These pin the deliverable: after a run in a
-# dependency-free worktree, the one line firstmate reads every heartbeat says
-# plainly that nothing was checked and that approval is not an answer. The
-# ordinary-finding case below is what keeps the pair from going vacuous - the
-# detector must stay silent on a real product decision.
 test_parked_unrunnable_check_named_as_environment_fault() {
   local fixture branch id
+  local FM_NM_UNRUNNABLE_CHECK_RE='^$'
+  export FM_NM_UNRUNNABLE_CHECK_RE
   for fixture in run_parked_unrunnable_checks_absent_deps run_parked_unrunnable_checks_command_not_found; do
     reset_fakes
     id="feat-${fixture#run_parked_unrunnable_checks_}"
@@ -2388,8 +2384,10 @@ test_parked_unrunnable_check_named_as_environment_fault() {
     assert_contains "$out" "state: parked" "$fixture: an unrunnable-check gate is still parked"
     assert_contains "$out" "environment fault" \
       "$fixture: a check that could not run was not named as an environment fault"
-    assert_contains "$out" "NOTHING WAS CHECKED" \
-      "$fixture: the state line did not say plainly that nothing was checked"
+    assert_contains "$out" "a configured check did not run - validation is incomplete" \
+      "$fixture: the state line did not report incomplete validation"
+    assert_not_contains "$out" "NOTHING WAS CHECKED" \
+      "$fixture: the state line denied checks that passed"
     assert_contains "$out" "not approvable" \
       "$fixture: the state line left the environment fault answerable by approval"
     if [ "${FM_TEST_EVIDENCE:-0}" = 1 ]; then
@@ -2424,11 +2422,21 @@ test_parked_ordinary_finding_is_not_an_environment_fault() {
   fm_write_meta "$d/state/feat-ordinary-env.meta" "window=fm:fm-feat-ordinary-env" \
     "worktree=$d/wt" "kind=ship"
   printf 'needs-decision: review gate\n' > "$d/state/feat-ordinary-env.status"
-  FM_FAKE_AXI_STATUS="$(run_parked fm/feat-ordinary-env)"
-  local out; out=$(run_crew_state "$d" feat-ordinary-env)
-  assert_contains "$out" "ask-user: authority decision" "an ordinary parked gate lost its decision"
-  assert_not_contains "$out" "environment fault" \
-    "an ordinary product decision was misread as an environment fault"
+  local description out
+  local FM_NM_UNRUNNABLE_CHECK_RE=
+  export FM_NM_UNRUNNABLE_CHECK_RE
+  for description in \
+    "Search is unavailable to administrators" \
+    "Search is not available to administrators" \
+    "The optional plugin is not installed" \
+    "The dependency view omits missing dependencies"; do
+    FM_FAKE_AXI_STATUS="$(run_parked fm/feat-ordinary-env)"
+    FM_FAKE_AXI_STATUS=${FM_FAKE_AXI_STATUS/changes product behavior/$description}
+    out=$(run_crew_state "$d" feat-ordinary-env)
+    assert_contains "$out" "ask-user: authority decision" "an ordinary parked gate lost its decision"
+    assert_not_contains "$out" "environment fault" \
+      "$description: an ordinary product decision was misread as an environment fault"
+  done
   pass "an ordinary ask-user finding is not flagged as an environment fault"
 }
 

--- a/tests/fm-crew-state.test.sh
+++ b/tests/fm-crew-state.test.sh
@@ -2426,6 +2426,8 @@ test_parked_ordinary_finding_is_not_an_environment_fault() {
   local FM_NM_UNRUNNABLE_CHECK_RE=
   export FM_NM_UNRUNNABLE_CHECK_RE
   for description in \
+    "Administrators cannot run exports" \
+    "Contestants cannot run exports" \
     "Search is unavailable to administrators" \
     "Search is not available to administrators" \
     "The optional plugin is not installed" \

--- a/tests/fm-crew-state.test.sh
+++ b/tests/fm-crew-state.test.sh
@@ -313,6 +313,61 @@ gate: review
 EOF
 }
 
+# The 2026-09-08 dependency-free-worktree shape, twice in one day. The pipeline
+# validates in a worktree it creates per run, which carries no installed project
+# dependencies, so the gate agent could not run the repository's own checks and
+# raised that as an ask-user WARNING - indistinguishable, in the state line, from
+# a real product decision. Descriptions are the verbatim text those two runs
+# recorded, so a phrasing change in the detector is caught against real evidence
+# rather than against wording invented for the test.
+run_parked_unrunnable_checks_absent_deps() {  # <branch>
+  cat <<EOF
+run:
+  id: "01M1Z60TC7SRFT0TQGH45ZPCNA"
+  branch: $1
+  status: awaiting_approval
+  awaiting_agent: parked 2m10s
+  head: "${FM_FAKE_RUN_HEAD:-abc1234}"
+  pr: ""
+  findings[1]{id,severity,file,line,action,description}:
+    L1,warning,,,ask-user,"ESLint and Prettier checks could not run because worktree dependencies are absent. Install the project dependencies and rerun changed-file checks. Whitespace and generated agent-configuration drift checks passed."
+gate: document
+EOF
+}
+
+run_parked_unrunnable_checks_command_not_found() {  # <branch>
+  cat <<EOF
+run:
+  id: "01M201A5K6A9QMZDBBGJDF6QF3"
+  branch: $1
+  status: awaiting_approval
+  awaiting_agent: parked 1m4s
+  head: "${FM_FAKE_RUN_HEAD:-abc1234}"
+  pr: ""
+  findings[1]{id,severity,file,line,action,description}:
+    lint-tools-unavailable,warning,,,ask-user,"ESLint and Prettier checks could not run because worktree dependencies are absent; both commands returned Command not found. Restore dependencies and rerun these checks. Syntax, whitespace and configured secret checks passed."
+gate: document
+EOF
+}
+
+# An unrunnable check hiding BEHIND a genuine finding: the gate has real work to
+# decide, and the environment fault must still be named rather than absorbed into
+# the finding count.
+run_parked_unrunnable_check_beside_real_finding() {  # <branch>
+  cat <<EOF
+run:
+  id: "01RUN"
+  branch: $1
+  status: awaiting_approval
+  head: "${FM_FAKE_RUN_HEAD:-abc1234}"
+  pr: ""
+  findings[2]{id,severity,file,line,action,description}:
+    r1,error,b.go,,ask-user,changes product behavior
+    r2,warning,,,ask-user,"Vitest could not run: this worktree has no node_modules."
+gate: review
+EOF
+}
+
 run_parked_scalar_gate_running() {  # <branch>
   cat <<EOF
 run:
@@ -2309,5 +2364,76 @@ test_active_fix_round_unfetched_pipeline_head_reports_current
 test_unanchored_unfetched_active_row_does_not_match
 test_unresolved_terminal_row_is_history_not_current
 test_runs_list_continuation_found_when_axi_answers_other_branch
+
+# (c2) An ask-user finding that reports a configured check COULD NOT RUN is an
+# environment fault, not a decision. These pin the deliverable: after a run in a
+# dependency-free worktree, the one line firstmate reads every heartbeat says
+# plainly that nothing was checked and that approval is not an answer. The
+# ordinary-finding case below is what keeps the pair from going vacuous - the
+# detector must stay silent on a real product decision.
+test_parked_unrunnable_check_named_as_environment_fault() {
+  local fixture branch id
+  for fixture in run_parked_unrunnable_checks_absent_deps run_parked_unrunnable_checks_command_not_found; do
+    reset_fakes
+    id="feat-${fixture#run_parked_unrunnable_checks_}"
+    id=${id//_/-}
+    branch="fm/$id"
+    local d; d=$(new_case "$fixture")
+    make_repo_on_branch "$d/wt" "$branch"
+    make_fakebin "$d" >/dev/null
+    fm_write_meta "$d/state/$id.meta" "window=fm:fm-$id" "worktree=$d/wt" "kind=ship"
+    printf 'needs-decision: document gate\n' > "$d/state/$id.status"
+    FM_FAKE_AXI_STATUS="$($fixture "$branch")"
+    local out; out=$(run_crew_state "$d" "$id")
+    assert_contains "$out" "state: parked" "$fixture: an unrunnable-check gate is still parked"
+    assert_contains "$out" "environment fault" \
+      "$fixture: a check that could not run was not named as an environment fault"
+    assert_contains "$out" "NOTHING WAS CHECKED" \
+      "$fixture: the state line did not say plainly that nothing was checked"
+    assert_contains "$out" "not approvable" \
+      "$fixture: the state line left the environment fault answerable by approval"
+    if [ "${FM_TEST_EVIDENCE:-0}" = 1 ]; then
+      printf '# %s -> %s\n' "$fixture" "$out"
+    fi
+    pass "$fixture: an unrunnable check reads as an environment fault, not a decision"
+  done
+}
+
+test_parked_unrunnable_check_beside_real_finding_still_named() {
+  reset_fakes
+  local d; d=$(new_case parked-unrunnable-mixed)
+  make_repo_on_branch "$d/wt" fm/feat-mixed-env
+  make_fakebin "$d" >/dev/null
+  fm_write_meta "$d/state/feat-mixed-env.meta" "window=fm:fm-feat-mixed-env" \
+    "worktree=$d/wt" "kind=ship"
+  printf 'needs-decision: review gate\n' > "$d/state/feat-mixed-env.status"
+  FM_FAKE_AXI_STATUS="$(run_parked_unrunnable_check_beside_real_finding fm/feat-mixed-env)"
+  local out; out=$(run_crew_state "$d" feat-mixed-env)
+  assert_contains "$out" "2 finding(s)" "the mixed gate lost its finding count"
+  assert_contains "$out" "ask-user: authority decision" "the mixed gate lost its real decision"
+  assert_contains "$out" "environment fault" \
+    "an unrunnable check beside a real finding was absorbed into the finding count"
+  pass "an unrunnable check beside a real finding is still named"
+}
+
+test_parked_ordinary_finding_is_not_an_environment_fault() {
+  reset_fakes
+  local d; d=$(new_case parked-ordinary-not-env)
+  make_repo_on_branch "$d/wt" fm/feat-ordinary-env
+  make_fakebin "$d" >/dev/null
+  fm_write_meta "$d/state/feat-ordinary-env.meta" "window=fm:fm-feat-ordinary-env" \
+    "worktree=$d/wt" "kind=ship"
+  printf 'needs-decision: review gate\n' > "$d/state/feat-ordinary-env.status"
+  FM_FAKE_AXI_STATUS="$(run_parked fm/feat-ordinary-env)"
+  local out; out=$(run_crew_state "$d" feat-ordinary-env)
+  assert_contains "$out" "ask-user: authority decision" "an ordinary parked gate lost its decision"
+  assert_not_contains "$out" "environment fault" \
+    "an ordinary product decision was misread as an environment fault"
+  pass "an ordinary ask-user finding is not flagged as an environment fault"
+}
+
+test_parked_unrunnable_check_named_as_environment_fault
+test_parked_unrunnable_check_beside_real_finding_still_named
+test_parked_ordinary_finding_is_not_an_environment_fault
 
 echo "all fm-crew-state tests passed"


### PR DESCRIPTION
## Intent

The captain said, on 2026-09-08: "Start the three." This was the first of the three, and firstmate put it top of the list because the fleet hit it TWICE in a single day.

WHAT HAPPENS. Validation runs in a pooled task worktree that has no project dependencies installed. Its code-style step therefore reports "ESLint and Prettier checks could not run because worktree dependencies are absent" - or plainly "command not found" - as an ask-user WARNING rather than running the checks.

WHY A COULD-NOT-RUN IS NOT BENIGN HERE, established first-hand on run 01M1Z60TC7SRFT0TQGH45ZPCNA on 2026-09-08: the worker copied that run's changed files into a worktree that DID have dependencies, ran the checks itself, and found Prettier FAILING on three files - all three rewritten by the pipeline's own automatic fix commits. Approving that gate would have shipped formatting the repository's own tooling rejects, with the pipeline reporting nothing wrong.

THE COMPOUNDING PART: the repository's pre-commit hook normally runs the formatter on staged files, but that hook needs the SAME missing dependencies, so it never fired either. One missing thing disables both the check and the safety net that would have caught what the check missed.

It recurred the same day on run 01M201A5K6A9QMZDBBGJDF6QF3, reporting "command not found" for both tools.

Every change this fleet validates is exposed to it, on every project.

## What Changed

- Flag parked-gate findings about checks that could not run as environment faults, with validation marked incomplete and not approvable.
- Require dependency repair and actual check results in the gate’s worktree before resolving these findings.
- Add regression cases for missing dependencies, commands not found, mixed findings, and product failures that must not be classified as environment faults.

## Risk Assessment

✅ Low: Captain, the change is bounded to status reporting and decision guidance, and the latest fixes satisfy the requested detection constraints.

## Testing

The focused status tests and CLI replay passed, while the base-commit helper reproduced the regression. Saved transcripts show incomplete validation for both incidents and ordinary decisions for product findings. Gate responses were fixtures; no live pipeline was controlled.

<details>
<summary>Evidence: Gate inputs and real status-helper output</summary>

Source: [Gate inputs and real status-helper output](https://github.com/AgardnerAU/firstmate/blob/4e817cdb252728b74018c5addfb34f95fbcc3741/.no-mistakes/evidence/fm/fm-pipeline-worktree-missing-deps/gate-status-transcript.log)

```text
INPUT:
run:
  id: "01M1Z60TC7SRFT0TQGH45ZPCNA"
  branch: fm/feat-absent-deps
  status: awaiting_approval
  awaiting_agent: parked 2m10s
  head: "0000649b04c44672a76723626786f9bf4aa9b5b8"
  pr: ""
  findings[1]{id,severity,file,line,action,description}:
    L1,warning,,,ask-user,"ESLint and Prettier checks could not run because worktree dependencies are absent. Install the project dependencies and rerun changed-file checks. Whitespace and generated agent-configuration drift checks passed."
gate: document
OUTPUT:
state: parked · source: run-step · parked at document: 1 finding(s) (ask-user: authority decision) (environment fault: a configured check did not run - validation is incomplete; not approvable)

ok - run_parked_unrunnable_checks_absent_deps: an unrunnable check reads as an environment fault, not a decision
INPUT:
run:
  id: "01M201A5K6A9QMZDBBGJDF6QF3"
  branch: fm/feat-command-not-found
  status: awaiting_approval
  awaiting_agent: parked 1m4s
  head: "0000649b04c44672a76723626786f9bf4aa9b5b8"
  pr: ""
  findings[1]{id,severity,file,line,action,description}:
    lint-tools-unavailable,warning,,,ask-user,"ESLint and Prettier checks could not run because worktree dependencies are absent; both commands returned Command not found. Restore dependencies and rerun these checks. Syntax, whitespace and configured secret checks passed."
gate: document
OUTPUT:
state: parked · source: run-step · parked at document: 1 finding(s) (ask-user: authority decision) (environment fault: a configured check did not run - validation is incomplete; not approvable)

ok - run_parked_unrunnable_checks_command_not_found: an unrunnable check reads as an environment fault, not a decision
INPUT:
run:
  id: "01RUN"
  branch: fm/feat-mixed-env
  status: awaiting_approval
  head: "cff6e3522b2db4391b263d9a46261be668393e26"
  pr: ""
  findings[2]{id,severity,file,line,action,description}:
    r1,error,b.go,,ask-user,changes product behavior
    r2,warning,,,ask-user,"Vitest could not run: this worktree has no node_modules."
gate: review
OUTPUT:
state: parked · source: run-step · parked at review: 2 finding(s) (ask-user: authority decision) (environment fault: a configured check did not run - validation is incomplete; not approvable)

ok - an unrunnable check beside a real finding is still named
INPUT:
run:
  id: "01RUN"
  branch: fm/feat-ordinary-env
  status: awaiting_approval
  awaiting_agent: parked 2m10s
  head: "cff6e3522b2db4391b263d9a46261be668393e26"
  pr: ""
  findings[2]{id,severity,file,line,action,description}:
    r1,warning,a.go,,auto-fix,ignored error
    r2,error,b.go,,ask-user,Administrators cannot run exports
gate: review
OUTPUT:
state: parked · source: run-step · parked at review: 2 finding(s) (ask-user: authority decision)

INPUT:
run:
  id: "01RUN"
  branch: fm/feat-ordinary-env
  status: awaiting_approval
  awaiting_agent: parked 2m10s
  head: "cff6e3522b2db4391b263d9a46261be668393e26"
  pr: ""
  findings[2]{id,severity,file,line,action,description}:
    r1,warning,a.go,,auto-fix,ignored error
    r2,error,b.go,,ask-user,Contestants cannot run exports
gate: review
OUTPUT:
state: parked · source: run-step · parked at review: 2 finding(s) (ask-user: authority decision)

INPUT:
run:
  id: "01RUN"
  branch: fm/feat-ordinary-env
  status: awaiting_approval
  awaiting_agent: parked 2m10s
  head: "cff6e3522b2db4391b263d9a46261be668393e26"
  pr: ""
  findings[2]{id,severity,file,line,action,description}:
    r1,warning,a.go,,auto-fix,ignored error
    r2,error,b.go,,ask-user,Search is unavailable to administrators
gate: review
OUTPUT:
state: parked · source: run-step · parked at review: 2 finding(s) (ask-user: authority decision)

INPUT:
run:
  id: "01RUN"
  branch: fm/feat-ordinary-env
  status: awaiting_approval
  awaiting_agent: parked 2m10s
  head: "cff6e3522b2db4391b263d9a46261be668393e26"
  pr: ""
  findings[2]{id,severity,file,line,action,description}:
    r1,warning,a.go,,auto-fix,ignored error
    r2,error,b.go,,ask-user,Search is not available to administrators
gate: review
OUTPUT:
state: parked · source: run-step · parked at review: 2 finding(s) (ask-user: authority decision)

INPUT:
run:
  id: "01RUN"
  branch: fm/feat-ordinary-env
  status: awaiting_approval
  awaiting_agent: parked 2m10s
  head: "cff6e3522b2db4391b263d9a46261be668393e26"
  pr: ""
  findings[2]{id,severity,file,line,action,description}:
    r1,warning,a.go,,auto-fix,ignored error
    r2,error,b.go,,ask-user,The optional plugin is not installed
gate: review
OUTPUT:
state: parked · source: run-step · parked at review: 2 finding(s) (ask-user: authority decision)

INPUT:
run:
  id: "01RUN"
  branch: fm/feat-ordinary-env
  status: awaiting_approval
  awaiting_agent: parked 2m10s
  head: "cff6e3522b2db4391b263d9a46261be668393e26"
  pr: ""
  findings[2]{id,severity,file,line,action,description}:
    r1,warning,a.go,,auto-fix,ignored error
    r2,error,b.go,,ask-user,The dependency view omits missing dependencies
gate: review
OUTPUT:
state: parked · source: run-step · parked at review: 2 finding(s) (ask-user: authority decision)

ok - an ordinary ask-user finding is not flagged as an environment fault
```
</details>
<details>
<summary>Evidence: Base-commit regression reproduction</summary>

Source: [Base-commit regression reproduction](https://github.com/AgardnerAU/firstmate/blob/4e817cdb252728b74018c5addfb34f95fbcc3741/.no-mistakes/evidence/fm/fm-pipeline-worktree-missing-deps/baseline-regression.log)

```text
INPUT:
run:
  id: "01M1Z60TC7SRFT0TQGH45ZPCNA"
  branch: fm/feat-absent-deps
  status: awaiting_approval
  awaiting_agent: parked 2m10s
  head: "0e1ecd3465e09de0593a7094e0854ea1f192f5dc"
  pr: ""
  findings[1]{id,severity,file,line,action,description}:
    L1,warning,,,ask-user,"ESLint and Prettier checks could not run because worktree dependencies are absent. Install the project dependencies and rerun changed-file checks. Whitespace and generated agent-configuration drift checks passed."
gate: document
OUTPUT:
state: parked · source: run-step · parked at document: 1 finding(s) (ask-user: authority decision)

not ok - run_parked_unrunnable_checks_absent_deps: a check that could not run was not named as an environment fault (missing: 'environment fault')
--- output ---
state: parked · source: run-step · parked at document: 1 finding(s) (ask-user: authority decision)
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"a97b4f4da1ad486713748b7f362da0de45d9dc62","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>🔧 **Review** - 3 issues found → auto-fixed (2) ✅</summary>

- ⚠️ `bin/fm-nm-run-lib.sh:140` - The detector deliberately matches generic phrases such as &#39;unavailable&#39; anywhere in a finding row. A normal product finding such as &#39;Search is unavailable to administrators&#39; therefore becomes a non-approvable environment fault even when every check ran. This broader matching exceeds the missing-check intent. Remove the generic matching paths and restrict detection to prose reporting that validation could not execute.
- ⚠️ `bin/fm-nm-run-lib.sh:140` - The environment override FM_NM_UNRUNNABLE_CHECK_RE introduces a configuration option that the intent does not require. It also lets an inherited empty value match every finding. Remove the override and keep the detector&#39;s expression internal.
- ⚠️ `bin/fm-crew-state.sh:677` - The status claims &#39;NOTHING WAS CHECKED&#39; when only one check could not run. Both incident fixtures explicitly report other checks passing, so the new summary contradicts its input. Report that a configured check did not run and validation is incomplete; update the corresponding output assertions.

🔧 Fix: Narrow missing-check detection and report incomplete validation accurately
1 warning still open:

- ⚠️ `bin/fm-nm-run-lib.sh:123` - R1 remains partly unresolved. The requested constraint was to restrict detection to prose reporting that a check could not execute, but this expression still matches &#39;cannot run&#39; anywhere in a finding row. A product finding such as &#39;Administrators cannot run exports&#39; therefore reaches fm-crew-state.sh as a non-approvable environment fault despite completed validation. Remove these context-free matching paths and require wording that identifies validation execution; include this product-failure case in the behavioural regression coverage.

🔧 Fix: Require tooling context for missing-check detection
✅ Re-checked - no issues remain.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `TMPDIR="$PWD/.test-tmp" FM_TEST_EVIDENCE=1 bash tests/fm-crew-state.test.sh`
- `Executed the three new regression functions through the real status helper and captured gate inputs and output, including both unchanged incident descriptions, mixed findings, product findings, and inherited override values.`
- `Ran the incident regression against the base-commit status helper; it failed as expected because the environment-fault detail was absent.`
- <code>`git status --short` after fixture cleanup confirmed a clean worktree.</code>
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
