### PR TITLE
feat(bin): add fm-time.sh for propose/approve time tracking and month-end reports

### DIFF
--- a/bin/fm-time.sh
+++ b/bin/fm-time.sh
@@ -253,21 +253,25 @@ is_after_hours() {  # <epoch> -> yes|no
 #     is skipped rather than guessed, falling back to plain kill -0 - refusing
 #     to weaken the working case for a case that cannot be verified.
 #   - Delete-wrong-instance race: deciding a lock is stale and then acting on
-#     it are two separate steps, so *anything* that only checks "is the path
-#     still what I inspected" right before deleting - including a plain
-#     `mv $TT_LOCK elsewhere` on the assumption that the move itself is the
-#     safety - is not enough: a plain `mv` relocates whatever currently sits
-#     at that path, not the specific instance a waiter inspected, so a
-#     successor's freshly created live lock at the same path would be moved
-#     and deleted just as readily as the stale one. tt_remove_locked_instance
-#     closes this for real by checking identity, not just path: it captures
-#     the directory's inode before acting, renames it aside, and only deletes
-#     the moved copy if its inode still matches what was captured - a
-#     mismatch means a different lock has since taken that path, so the moved
-#     copy is put back untouched instead of being deleted. The same helper is
-#     used by both a waiter reclaiming a lock it believes abandoned and an
-#     owner releasing a lock it confirmed is its own, since both are exactly
-#     this same "verify identity, then delete" problem.
+#     it are two separate steps, so a successor could create a fresh live
+#     lock at the same path in between. Checking identity right before the
+#     delete closes the ordinary case; an earlier version of this fix instead
+#     moved the directory aside first and verified after, which is actually
+#     worse - moving it away first creates a moment where the path sits
+#     empty for a *third* command to claim while the second is still
+#     deciding whether to put the (possibly-live) directory back, trading one
+#     race for a different one. tt_remove_locked_instance instead captures
+#     the directory's inode, re-checks it immediately before the one
+#     deleting syscall, and does nothing at all - no move, no restore, no
+#     window where the path is vacant - the instant it no longer matches.
+#     This does not claim perfect atomicity (no flock, per above) but keeps
+#     the unavoidable gap to a single stat immediately ahead of a single
+#     delete, the floor for a mkdir-based lock on a single-operator tool one
+#     person invokes by hand rather than a server serving concurrent
+#     requests. The same helper is used by both a waiter reclaiming a lock it
+#     believes abandoned and an owner releasing a lock it confirmed is its
+#     own, since both are exactly this "verify identity, then delete"
+#     problem.
 TT_LOCK="$TT/.lock"
 LOCK_STALE_SECS="${FM_TIME_LOCK_STALE_OVERRIDE:-10}"
 
@@ -276,14 +280,11 @@ tt_owner_start() {  # <pid> -> that pid's process-start timestamp, or nothing
 }
 
 tt_remove_locked_instance() {  # <expected-inode>
-  local expected=$1 reap="$TT_LOCK.reap.$$" got
-  mv "$TT_LOCK" "$reap" 2>/dev/null || return 0
-  got=$(fm_time_inode "$reap" 2>/dev/null) || got=""
-  if [ -n "$expected" ] && [ "$got" != "$expected" ]; then
-    mv "$reap" "$TT_LOCK" 2>/dev/null || true
-    return 0
-  fi
-  rm -rf "$reap" 2>/dev/null || true
+  local expected=$1 cur
+  [ -n "$expected" ] || return 0
+  cur=$(fm_time_inode "$TT_LOCK" 2>/dev/null) || cur=""
+  [ "$cur" = "$expected" ] || return 0
+  rm -rf "$TT_LOCK" 2>/dev/null || true
 }
 
 tt_lock() {

--- a/bin/fm-time.sh
+++ b/bin/fm-time.sh
@@ -855,16 +855,22 @@ cmd_report() {
     "$invalid" "$([ "$invalid" -eq 1 ] && printf y || printf ies)"
   printf '\nby project / task:\n'
 
-  local p_key kt task_name
+  local p_key kt task_name p_prefix
   local -a sorted_projects sorted_tasks
   mapfile -t sorted_projects < <(printf '%s\n' "${!proj_total[@]}" | sort)
   for p_key in "${sorted_projects[@]}"; do
     printf '  %s  %s' "$([ "$p_key" = - ] && printf '(unattributed)' || printf '%s' "$p_key")" "$(fmt_minutes "${proj_total[$p_key]}")"
     [ "${proj_after[$p_key]:-0}" -gt 0 ] && printf ' (%s after hours)' "$(fmt_minutes "${proj_after[$p_key]}")"
     printf '\n'
+    # Stock macOS Bash 3.2 cannot parse $'...' sitting immediately after a
+    # double-quoted variable inside a case PATTERN (unlike a case SUBJECT or a
+    # glob-then-$'...' pattern, both of which it parses fine); building the
+    # tab-joined prefix into its own variable first keeps the literal $'\t'
+    # out of the pattern text entirely.
+    p_prefix="$p_key"$'\t'
     mapfile -t sorted_tasks < <(
       for kt in "${!key_total[@]}"; do
-        case "$kt" in "$p_key"$'\t'*) printf '%s\n' "$kt" ;; esac
+        case "$kt" in "$p_prefix"*) printf '%s\n' "$kt" ;; esac
       done | sort
     )
     for kt in "${sorted_tasks[@]}"; do

--- a/bin/fm-time.sh
+++ b/bin/fm-time.sh
@@ -1,0 +1,796 @@
+#!/usr/bin/env bash
+# fm-time.sh - propose, approve, and report the captain's own work hours.
+#
+# Firstmate orchestrates but never clocks the captain in: this script scans
+# this home's own durable records for evidence that work happened, PROPOSES
+# candidate work windows from that evidence, and records nothing until the
+# captain approves, corrects, or rejects each one. Live start/stop and
+# retroactive log entries are recorded immediately because starting, stopping,
+# or logging IS the captain's approval.
+#
+# Usage:
+#   fm-time.sh propose [--since "<YYYY-MM-DD HH:MM>"] [--replace]
+#   fm-time.sh list
+#   fm-time.sh approve <id> [--start "<YYYY-MM-DD HH:MM>"] [--end "<YYYY-MM-DD HH:MM>"]
+#                           [--project <name>] [--task <name>] [--desc <text>]
+#   fm-time.sh reject <id>...
+#   fm-time.sh split <id> --at "<YYYY-MM-DD HH:MM>"
+#   fm-time.sh start [--project <name>] [--task <name>] [--desc <text>]
+#   fm-time.sh stop [--desc <text>]
+#   fm-time.sh log --start "<YYYY-MM-DD HH:MM>" --end "<YYYY-MM-DD HH:MM>"
+#                   [--project <name>] [--task <name>] --desc <text>
+#   fm-time.sh report [--month YYYY-MM] [--project <name>]
+#
+# Evidence signals (propose). Investigated candidates and why each is used or
+# skipped:
+#   - state/<id>.status mtime         used: last-touch ping for that task, tagged
+#                                      with the tail status line as its evidence text.
+#   - state/<id>.meta mtime           used: a task's earliest activity often
+#                                      predates its first status line, but this
+#                                      file is also rewritten well after spawn
+#                                      (mode changes, control actions, a merged
+#                                      PR's pr= field), so its evidence text
+#                                      says only "task record touched", never
+#                                      "spawned" - that would overclaim what a
+#                                      bare mtime can prove.
+#   - data/<id>/report.md mtime       used: scout-report-finalized ping.
+#   - data/backlog.md, data/done-archive.md
+#                                     used: "(done YYYY-MM-DD)" and "(reported
+#                                      YYYY-MM-DD)" entries (tasks-axi writes the
+#                                      latter for a scout task closed with
+#                                      --report) become day-only pings (noon
+#                                      local), the one signal that survives a
+#                                      torn-down task's state files.
+#   - state/.wake-queue                used opportunistically: it carries real epoch
+#                                      seconds, but the queue is drained on
+#                                      acknowledgement, so it holds only whatever is
+#                                      CURRENTLY undrained, never a durable history.
+#   - session lock (state/.lock)       NOT used: one file, one mtime, no history -
+#                                      it names only the current holder, so it cannot
+#                                      answer "when was work happening" after the fact.
+#   - project git commit history       NOT used in this version: firstmate's own
+#                                      projects/<name> clones sit on their default
+#                                      branch, so this would see only merged work, not
+#                                      the in-flight branches a captain most wants
+#                                      tracked. Left as a documented future signal.
+# Every window's evidence list survives into the proposal so `approve` is an
+# informed decision, not a rubber stamp of a guess.
+#
+# Window merging. Evidence pings for the same (project, task) within the
+# time-tracking-gap-minutes config setting (default 45 minutes) of each other
+# join one window; a bigger gap starts a new one. 45 minutes, not something
+# tighter, because this repo's own crewmates are instructed to append status
+# only on sparse phase changes rather than routine progress (AGENTS.md section
+# 8), so a continuously-worked task can easily go 30-60 minutes between
+# evidence pings without having stopped. A lone ping still costs the
+# time-tracking-pad-minutes config setting (default 15 minutes) of credited
+# time, because a single commit-sized signal is real work, not zero-duration
+# work.
+#
+# After hours. A window's classification is decided by its START time only:
+# any day listed in config/time-tracking-weekend-days (default "6,7", ISO
+# weekday numbers 1=Monday..7=Sunday, empty = no weekend rule at all so no work
+# week is hardcoded) is after hours regardless of clock time; otherwise a start
+# before config/time-tracking-workday-start (default 09:00) or at/after
+# config/time-tracking-workday-end (default 18:00) is after hours.
+#
+# Storage. All state lives under this home's gitignored data/time-tracking/,
+# never under state/ (supervision-owned) and never inside a project:
+#   data/time-tracking/cursor       epoch through which evidence has been fully
+#                                    resolved (approved, rejected, or split); the
+#                                    floor for the next propose scan.
+#   data/time-tracking/proposals.md the current pending batch, one "## <id>" block
+#                                    per candidate window; propose refuses to
+#                                    generate a new batch while one is pending
+#                                    unless --replace is given.
+#   data/time-tracking/entries.md   the durable approved ledger, one "## <id>"
+#                                    block per recorded window. Plain
+#                                    "key=value" lines and one line per evidence
+#                                    entry: diffable, and safe to hand-edit because
+#                                    duration and after-hours status are always
+#                                    recomputed from start/end at report time,
+#                                    never trusted from a stored field.
+#   data/time-tracking/active       present only between `start` and `stop`.
+#
+# Configuration (gitignored, one setting per file, absent = default):
+#   config/time-tracking-gap-minutes         session-merge gap, minutes (default 45)
+#   config/time-tracking-pad-minutes         credited minutes for a lone ping (default 15)
+#   config/time-tracking-workday-start       local HH:MM (default 09:00)
+#   config/time-tracking-workday-end         local HH:MM (default 18:00)
+#   config/time-tracking-weekend-days        comma list, ISO 1-7 (default 6,7)
+#
+# Environment:
+#   FM_HOME   operational home whose state/, data/, and config/ are used.
+#
+# Never touches state/.lock, state/.wake-queue, or any other supervision file
+# except to read it; never writes to projects/.
+set -euo pipefail
+
+SELF_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FM_ROOT="$(cd "$SELF_DIR/.." && pwd)"
+FM_HOME="${FM_HOME:-$FM_ROOT}"
+STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
+DATA="${FM_DATA_OVERRIDE:-$FM_HOME/data}"
+CONFIG="${FM_CONFIG_OVERRIDE:-$FM_HOME/config}"
+TT="$DATA/time-tracking"
+
+die() { printf 'fm-time: %s\n' "$*" >&2; exit 1; }
+
+# Count of "## pN" blocks in proposals.md. grep -c already prints 0 and no
+# other output on zero matches, so no `|| echo 0` fallback is needed - adding
+# one would double-print when grep's own "0" line is followed by the fallback.
+proposal_count() {
+  [ -r "$TT/proposals.md" ] || { printf 0; return; }
+  grep -c '^## p' "$TT/proposals.md" 2>/dev/null || true
+}
+
+usage() {
+  awk 'NR == 1 { next }
+       /^#/ { sub(/^# ?/, ""); print; next }
+       { exit }' "${BASH_SOURCE[0]}"
+}
+
+# ---------------------------------------------------------------- portable time
+
+fm_time_mtime() {  # <path> -> epoch seconds, or nothing on failure
+  if [ "$(uname)" = Darwin ]; then
+    /usr/bin/stat -f %m "$1" 2>/dev/null
+  else
+    stat -c %Y "$1" 2>/dev/null
+  fi
+}
+
+now_epoch() { printf '%s\n' "${FM_TIME_NOW_OVERRIDE:-$(date +%s)}"; }
+
+# epoch -> "YYYY-MM-DD HH:MM" local wall clock.
+epoch_to_local() {
+  date -r "$1" '+%Y-%m-%d %H:%M' 2>/dev/null || date -d "@$1" '+%Y-%m-%d %H:%M' 2>/dev/null
+}
+
+# "YYYY-MM-DD HH:MM" local -> epoch. Empty output on unparseable input.
+local_to_epoch() {
+  date -j -f '%Y-%m-%d %H:%M' "$1" '+%s' 2>/dev/null || date -d "$1" '+%s' 2>/dev/null
+}
+
+epoch_to_dow() {  # ISO weekday, 1=Monday .. 7=Sunday
+  date -r "$1" '+%u' 2>/dev/null || date -d "@$1" '+%u' 2>/dev/null
+}
+
+epoch_to_hm() {
+  date -r "$1" '+%H:%M' 2>/dev/null || date -d "@$1" '+%H:%M' 2>/dev/null
+}
+
+epoch_to_yyyymm() {
+  date -r "$1" '+%Y-%m' 2>/dev/null || date -d "@$1" '+%Y-%m' 2>/dev/null
+}
+
+fmt_minutes() {  # <minutes> -> "1h15m"
+  local m=$1 h
+  h=$((m / 60)); m=$((m % 60))
+  printf '%dh%02dm' "$h" "$m"
+}
+
+# ---------------------------------------------------------------- config
+
+read_config() {  # <file-name> <default>
+  local path="$CONFIG/$1" line
+  if [ -r "$path" ]; then
+    while IFS= read -r line || [ -n "$line" ]; do
+      line=${line%%#*}
+      line=${line#"${line%%[![:space:]]*}"}
+      line=${line%"${line##*[![:space:]]}"}
+      if [ -n "$line" ]; then
+        printf '%s' "$line"
+        return 0
+      fi
+    done < "$path"
+  fi
+  printf '%s' "$2"
+}
+
+GAP_MINUTES=$(read_config time-tracking-gap-minutes 45)
+PAD_MINUTES=$(read_config time-tracking-pad-minutes 15)
+WORKDAY_START=$(read_config time-tracking-workday-start 09:00)
+WORKDAY_END=$(read_config time-tracking-workday-end 18:00)
+WEEKEND_DAYS=$(read_config time-tracking-weekend-days 6,7)
+
+is_after_hours() {  # <epoch> -> yes|no
+  local epoch=$1 dow hm
+  dow=$(epoch_to_dow "$epoch") || { printf 'no'; return; }
+  case ",$WEEKEND_DAYS," in
+    *",$dow,"*) printf 'yes'; return ;;
+  esac
+  hm=$(epoch_to_hm "$epoch") || { printf 'no'; return; }
+  if [[ "$hm" < "$WORKDAY_START" || "$hm" > "$WORKDAY_END" || "$hm" == "$WORKDAY_END" ]]; then
+    printf 'yes'
+  else
+    printf 'no'
+  fi
+}
+
+# ---------------------------------------------------------------- cursor
+
+CURSOR_FILE="$TT/cursor"
+
+read_cursor() {
+  local c
+  if [ -r "$CURSOR_FILE" ]; then
+    c=$(head -1 "$CURSOR_FILE" 2>/dev/null)
+    case "$c" in *[!0-9]*|'') ;; *) printf '%s' "$c"; return ;; esac
+  fi
+  # No cursor yet: default floor is 30 days back so a first run is bounded.
+  printf '%s' "$(( $(now_epoch) - 30 * 86400 ))"
+}
+
+write_cursor() {
+  mkdir -p "$TT"
+  printf '%s\n' "$1" > "$CURSOR_FILE.tmp"
+  mv "$CURSOR_FILE.tmp" "$CURSOR_FILE"
+}
+
+# ---------------------------------------------------------------- evidence gathering
+
+# Emits TSV lines: epoch<TAB>project<TAB>task<TAB>source<TAB>text
+gather_evidence() {  # <since-epoch> <out-file>
+  local since=$1 out=$2 f id mtime meta project text line kind key payload epoch
+
+  : > "$out"
+
+  for f in "$STATE"/*.status; do
+    [ -e "$f" ] || break
+    id=$(basename "$f" .status)
+    mtime=$(fm_time_mtime "$f") || continue
+    [ -n "$mtime" ] && [ "$mtime" -gt "$since" ] || continue
+    project=-
+    meta="$STATE/$id.meta"
+    if [ -r "$meta" ]; then
+      project=$(sed -n 's/^project=//p' "$meta" | head -1)
+      [ -n "$project" ] && project=$(basename "$project") || project=-
+    fi
+    text=$(tail -1 "$f" 2>/dev/null | tr -d '\t' | cut -c1-140)
+    printf '%s\t%s\t%s\tstatus\t%s\n' "$mtime" "$project" "$id" "$text" >> "$out"
+  done
+
+  for f in "$STATE"/*.meta; do
+    [ -e "$f" ] || break
+    id=$(basename "$f" .meta)
+    mtime=$(fm_time_mtime "$f") || continue
+    [ -n "$mtime" ] && [ "$mtime" -gt "$since" ] || continue
+    project=$(sed -n 's/^project=//p' "$f" | head -1)
+    [ -n "$project" ] && project=$(basename "$project") || project=-
+    printf '%s\t%s\t%s\tmeta\ttask record touched\n' "$mtime" "$project" "$id" >> "$out"
+  done
+
+  for f in "$DATA"/*/report.md; do
+    [ -e "$f" ] || break
+    id=$(basename "$(dirname "$f")")
+    mtime=$(fm_time_mtime "$f") || continue
+    [ -n "$mtime" ] && [ "$mtime" -gt "$since" ] || continue
+    project=-
+    meta="$STATE/$id.meta"
+    if [ -r "$meta" ]; then
+      project=$(sed -n 's/^project=//p' "$meta" | head -1)
+      [ -n "$project" ] && project=$(basename "$project") || project=-
+    fi
+    printf '%s\t%s\t%s\treport\tscout report finalized\n' "$mtime" "$project" "$id" >> "$out"
+  done
+
+  local bf
+  for bf in "$DATA/backlog.md" "$DATA/done-archive.md"; do
+    [ -r "$bf" ] || continue
+    while IFS= read -r line; do
+      case "$line" in
+        '- [x] '*) ;;
+        *) continue ;;
+      esac
+      id=${line#"- [x] "}
+      id=${id%% - *}
+      [ -n "$id" ] || continue
+      case "$line" in
+        *'(done '????-??-??')'*)
+          text=$(printf '%s' "$line" | sed -n 's/.*(done \([0-9-]\{10\}\)).*/\1/p')
+          ;;
+        *'(reported '????-??-??')'*)
+          # tasks-axi writes "(reported YYYY-MM-DD)" instead of "(done ...)"
+          # when a scout task is closed with --report; without this branch
+          # every scout completion (roughly a fifth of this repo's own
+          # archive) is silently invisible to propose.
+          text=$(printf '%s' "$line" | sed -n 's/.*(reported \([0-9-]\{10\}\)).*/\1/p')
+          ;;
+        *) continue ;;
+      esac
+      [ -n "$text" ] || continue
+      epoch=$(local_to_epoch "$text 12:00") || continue
+      [ -n "$epoch" ] && [ "$epoch" -gt "$since" ] || continue
+      project=$(printf '%s' "$line" | sed -n 's/.*(repo: \([^)]*\)).*/\1/p')
+      [ -n "$project" ] || project=-
+      payload=$(printf '%s' "$line" \
+        | sed 's/^- \[x\] [^ ]* - //' \
+        | sed -e 's/ (done [0-9-]*)//' -e 's/ (reported [0-9-]*)//' -e 's/ (repo: [^)]*)//' \
+        | cut -c1-140)
+      printf '%s\t%s\t%s\tbacklog\t%s\n' "$epoch" "$project" "$id" "$payload" >> "$out"
+    done < "$bf"
+  done
+
+  if [ -r "$STATE/.wake-queue" ]; then
+    while IFS=$'\t' read -r epoch _seq kind key payload; do
+      case "$epoch" in ''|*[!0-9]*) continue ;; esac
+      [ "$epoch" -gt "$since" ] || continue
+      printf '%s\tfirstmate\t%s\twake\t%s: %s\n' "$epoch" "${key:--}" "$kind" "$payload" >> "$out"
+    done < "$STATE/.wake-queue"
+  fi
+}
+
+# ---------------------------------------------------------------- clustering
+
+# Reads evidence TSV on stdin (any order), writes proposal blocks to stdout in
+# the "## pN" key=value shape described in the header.
+cluster_evidence() {
+  sort -t $'\t' -k2,2 -k3,3 -k1,1n "$1" | awk -F'\t' -v gap=$((GAP_MINUTES * 60)) -v pad=$((PAD_MINUTES * 60)) '
+    function flush(n) {
+      if (n == 0) return
+      pid++
+      printf "## p%d\n", pid
+      printf "start=%s\n", start_disp
+      printf "end=%s\n", end_disp
+      printf "project=%s\n", cur_project
+      printf "task=%s\n", cur_task
+      printf "desc=%s\n", last_text
+      for (i = 1; i <= n; i++) printf "evidence=%s\n", ev[i]
+      printf "\n"
+    }
+    BEGIN { pid = 0; n = 0 }
+    {
+      epoch = $1; project = $2; task = $3; source = $4; text = $5
+      key = project SUBSEP task
+      if (n > 0 && (key != cur_key || (epoch - last_epoch) > gap)) {
+        flush(n)
+        n = 0
+      }
+      if (n == 0) {
+        cur_key = key; cur_project = project; cur_task = task
+        first_epoch = epoch
+        cmd = "date -r " epoch " \"+%Y-%m-%d %H:%M\" 2>/dev/null || date -d @" epoch " \"+%Y-%m-%d %H:%M\""
+        cmd | getline start_disp
+        close(cmd)
+      }
+      last_epoch = epoch
+      last_text = text
+      n++
+      ev[n] = epoch " | " source " | " text
+      end_epoch = epoch + pad
+      cmd = "date -r " end_epoch " \"+%Y-%m-%d %H:%M\" 2>/dev/null || date -d @" end_epoch " \"+%Y-%m-%d %H:%M\""
+      cmd | getline end_disp
+      close(cmd)
+    }
+    END { flush(n) }
+  '
+}
+
+# ---------------------------------------------------------------- propose / list
+
+cmd_propose() {
+  local replace=0 since_opt="" since_epoch out
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      --replace) replace=1; shift ;;
+      --since) since_opt=$2; shift 2 ;;
+      *) die "propose: unknown argument: $1" ;;
+    esac
+  done
+
+  mkdir -p "$TT"
+  if [ "$(proposal_count)" -gt 0 ] && [ "$replace" -ne 1 ]; then
+    die "a pending proposal batch already exists; resolve it with approve/reject/split, or pass --replace to discard it and rescan"
+  fi
+
+  if [ -n "$since_opt" ]; then
+    since_epoch=$(local_to_epoch "$since_opt") || die "propose: unparseable --since value: $since_opt"
+  else
+    since_epoch=$(read_cursor)
+  fi
+
+  local now
+  now=$(now_epoch)
+  out=$(mktemp "$TT/.evidence.XXXXXX")
+  trap 'rm -f "$out"' RETURN
+  gather_evidence "$since_epoch" "$out"
+
+  {
+    printf '# time-tracking proposals\n'
+    printf '# scan_from=%s scan_to=%s generated=%s\n' "$since_epoch" "$now" "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+    printf '#\n'
+    cluster_evidence "$out"
+  } > "$TT/proposals.md.tmp"
+  mv "$TT/proposals.md.tmp" "$TT/proposals.md"
+  rm -f "$out"
+  trap - RETURN
+
+  local count
+  count=$(proposal_count)
+  if [ "$count" -eq 0 ]; then
+    # Nothing to resolve, so nothing blocks the cursor from moving forward;
+    # otherwise every future propose would keep rescanning this same dead range.
+    # Only do this when the scan used the persisted cursor: an explicit --since
+    # is a one-off query and must never silently move the standing cursor.
+    [ -n "$since_opt" ] || write_cursor "$now"
+    : > "$TT/proposals.md"
+    printf 'no work windows found in evidence since %s\n' "$(epoch_to_local "$since_epoch")"
+  else
+    printf '%s proposed window(s) since %s - review with: fm-time.sh list\n' "$count" "$(epoch_to_local "$since_epoch")"
+  fi
+}
+
+cmd_list() {
+  if [ ! -s "$TT/proposals.md" ] || [ "$(proposal_count)" -eq 0 ]; then
+    printf 'no pending proposals. Run: fm-time.sh propose\n'
+    return 0
+  fi
+  awk '
+    /^## / { if (id != "") print ""; id = substr($0, 4); print "[" id "]"; next }
+    /^evidence=/ { print "  evidence: " substr($0, 10); next }
+    /^(start|end|project|task|desc)=/ { split($0, kv, "="); printf "  %-8s %s\n", kv[1], substr($0, length(kv[1]) + 2); next }
+  ' "$TT/proposals.md"
+}
+
+# Extracts the "## <id> ... (blank line or EOF)" block for <id> from <file>.
+extract_block() {  # <file> <id>
+  awk -v want="## $2" '
+    $0 == want { found = 1; next }
+    found && /^## / { exit }
+    found && NF == 0 { exit }
+    found { print }
+  ' "$1"
+}
+
+block_field() {  # <block-text> <field>
+  printf '%s\n' "$1" | sed -n "s/^$2=//p" | head -1
+}
+
+remove_block() {  # <file> <id> -> rewrites file without that block
+  awk -v want="## $2" '
+    BEGIN { skip = 0 }
+    $0 == want { skip = 1; next }
+    skip && /^## / { skip = 0 }
+    skip && NF == 0 { skip = 0; next }
+    !skip { print }
+  ' "$1"
+}
+
+# True (0) once no "## p" block remains in proposals.md.
+batch_empty() {
+  [ "$(proposal_count)" -eq 0 ]
+}
+
+advance_cursor_if_batch_done() {
+  if batch_empty; then
+    local scan_to
+    scan_to=$(sed -n 's/.*scan_to=\([0-9]*\).*/\1/p' "$TT/proposals.md" | head -1)
+    [ -n "$scan_to" ] && write_cursor "$scan_to"
+    : > "$TT/proposals.md"
+  fi
+}
+
+next_entry_id() {
+  printf 'e-%s-%s\n' "$(now_epoch)" "$$"
+}
+
+append_entry() {  # start end project task desc
+  mkdir -p "$TT"
+  {
+    printf '## %s\n' "$(next_entry_id)"
+    printf 'start=%s\n' "$1"
+    printf 'end=%s\n' "$2"
+    printf 'project=%s\n' "${3:--}"
+    printf 'task=%s\n' "${4:--}"
+    printf 'desc=%s\n' "$5"
+    printf '\n'
+  } >> "$TT/entries.md"
+}
+
+cmd_approve() {
+  local id=${1:-} start_ov="" end_ov="" project_ov="" task_ov="" desc_ov=""
+  [ -n "$id" ] || die "approve: usage: fm-time.sh approve <id> [--start ..] [--end ..] [--project ..] [--task ..] [--desc ..]"
+  shift
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      --start) start_ov=$2; shift 2 ;;
+      --end) end_ov=$2; shift 2 ;;
+      --project) project_ov=$2; shift 2 ;;
+      --task) task_ov=$2; shift 2 ;;
+      --desc) desc_ov=$2; shift 2 ;;
+      *) die "approve: unknown argument: $1" ;;
+    esac
+  done
+
+  [ -s "$TT/proposals.md" ] || die "approve: no pending proposals"
+  local block
+  block=$(extract_block "$TT/proposals.md" "$id")
+  [ -n "$block" ] || die "approve: no pending proposal named $id"
+
+  local start end project task desc
+  start=${start_ov:-$(block_field "$block" start)}
+  end=${end_ov:-$(block_field "$block" end)}
+  project=${project_ov:-$(block_field "$block" project)}
+  task=${task_ov:-$(block_field "$block" task)}
+  desc=${desc_ov:-$(block_field "$block" desc)}
+
+  local s e
+  s=$(local_to_epoch "$start") || die "approve: unparseable start: $start"
+  e=$(local_to_epoch "$end") || die "approve: unparseable end: $end"
+  [ "$e" -gt "$s" ] || die "approve: end must be after start ($start -> $end)"
+
+  append_entry "$start" "$end" "$project" "$task" "$desc"
+  remove_block "$TT/proposals.md" "$id" > "$TT/proposals.md.tmp"
+  mv "$TT/proposals.md.tmp" "$TT/proposals.md"
+  advance_cursor_if_batch_done
+  printf 'approved %s: %s (%s -> %s)\n' "$id" "$desc" "$start" "$end"
+}
+
+cmd_reject() {
+  [ "$#" -gt 0 ] || die "reject: usage: fm-time.sh reject <id>..."
+  [ -s "$TT/proposals.md" ] || die "reject: no pending proposals"
+  local id
+  for id in "$@"; do
+    local block
+    block=$(extract_block "$TT/proposals.md" "$id")
+    [ -n "$block" ] || { printf 'reject: no pending proposal named %s (skipped)\n' "$id"; continue; }
+    remove_block "$TT/proposals.md" "$id" > "$TT/proposals.md.tmp"
+    mv "$TT/proposals.md.tmp" "$TT/proposals.md"
+    printf 'rejected %s\n' "$id"
+  done
+  advance_cursor_if_batch_done
+}
+
+cmd_split() {
+  local id=${1:-} at=""
+  [ -n "$id" ] || die "split: usage: fm-time.sh split <id> --at \"<YYYY-MM-DD HH:MM>\""
+  shift
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      --at) at=$2; shift 2 ;;
+      *) die "split: unknown argument: $1" ;;
+    esac
+  done
+  [ -n "$at" ] || die "split: --at is required"
+
+  [ -s "$TT/proposals.md" ] || die "split: no pending proposals"
+  local block
+  block=$(extract_block "$TT/proposals.md" "$id")
+  [ -n "$block" ] || die "split: no pending proposal named $id"
+
+  local start end project task desc split_epoch start_epoch end_epoch
+  start=$(block_field "$block" start)
+  end=$(block_field "$block" end)
+  project=$(block_field "$block" project)
+  task=$(block_field "$block" task)
+  desc=$(block_field "$block" desc)
+  start_epoch=$(local_to_epoch "$start") || die "split: unparseable stored start: $start"
+  end_epoch=$(local_to_epoch "$end") || die "split: unparseable stored end: $end"
+  split_epoch=$(local_to_epoch "$at") || die "split: unparseable --at value: $at"
+  [ "$split_epoch" -gt "$start_epoch" ] && [ "$split_epoch" -lt "$end_epoch" ] \
+    || die "split: --at must fall strictly between $start and $end"
+
+  local evidence before after
+  evidence=$(printf '%s\n' "$block" | sed -n 's/^evidence=//p')
+  before=""
+  after=""
+  local line ep
+  while IFS= read -r line; do
+    [ -n "$line" ] || continue
+    ep=${line%% | *}
+    ep=$(local_to_epoch "$ep" 2>/dev/null || printf '%s' "$ep")
+    case "$ep" in
+      *[!0-9]*) before="$before$line"$'\n' ;;
+      *) if [ "$ep" -lt "$split_epoch" ]; then before="$before$line"$'\n'; else after="$after$line"$'\n'; fi ;;
+    esac
+  done <<< "$evidence"
+
+  remove_block "$TT/proposals.md" "$id" > "$TT/proposals.md.tmp"
+  {
+    cat "$TT/proposals.md.tmp"
+    printf '## %s-a\n' "$id"
+    printf 'start=%s\n' "$start"
+    printf 'end=%s\n' "$at"
+    printf 'project=%s\n' "$project"
+    printf 'task=%s\n' "$task"
+    printf 'desc=%s\n' "$desc"
+    printf '%s' "$before" | sed 's/^/evidence=/'
+    printf '\n'
+    printf '## %s-b\n' "$id"
+    printf 'start=%s\n' "$at"
+    printf 'end=%s\n' "$end"
+    printf 'project=%s\n' "$project"
+    printf 'task=%s\n' "$task"
+    printf 'desc=%s\n' "$desc"
+    printf '%s' "$after" | sed 's/^/evidence=/'
+    printf '\n'
+  } > "$TT/proposals.md.new"
+  mv "$TT/proposals.md.new" "$TT/proposals.md"
+  rm -f "$TT/proposals.md.tmp"
+  printf 'split %s into %s-a (%s -> %s) and %s-b (%s -> %s)\n' "$id" "$id" "$start" "$at" "$id" "$at" "$end"
+}
+
+# ---------------------------------------------------------------- start / stop / log
+
+cmd_start() {
+  local project=- task=- desc=""
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      --project) project=$2; shift 2 ;;
+      --task) task=$2; shift 2 ;;
+      --desc) desc=$2; shift 2 ;;
+      *) die "start: unknown argument: $1" ;;
+    esac
+  done
+  mkdir -p "$TT"
+  [ -e "$TT/active" ] && die "start: a live session is already running; run: fm-time.sh stop"
+  {
+    printf 'start=%s\n' "$(epoch_to_local "$(now_epoch)")"
+    printf 'project=%s\n' "$project"
+    printf 'task=%s\n' "$task"
+    printf 'desc=%s\n' "$desc"
+  } > "$TT/active"
+  printf 'started tracking%s\n' "$([ -n "$desc" ] && printf ': %s' "$desc")"
+}
+
+cmd_stop() {
+  local desc_ov=""
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      --desc) desc_ov=$2; shift 2 ;;
+      *) die "stop: unknown argument: $1" ;;
+    esac
+  done
+  [ -e "$TT/active" ] || die "stop: no live session is running; run: fm-time.sh start"
+  local start project task desc end
+  start=$(sed -n 's/^start=//p' "$TT/active" | head -1)
+  project=$(sed -n 's/^project=//p' "$TT/active" | head -1)
+  task=$(sed -n 's/^task=//p' "$TT/active" | head -1)
+  desc=$(sed -n 's/^desc=//p' "$TT/active" | head -1)
+  [ -n "$desc_ov" ] && desc=$desc_ov
+  end=$(epoch_to_local "$(now_epoch)")
+  append_entry "$start" "$end" "$project" "$task" "$desc"
+  rm -f "$TT/active"
+  printf 'stopped: %s (%s -> %s)\n' "${desc:-(no description)}" "$start" "$end"
+}
+
+cmd_log() {
+  local start="" end="" project=- task=- desc=""
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      --start) start=$2; shift 2 ;;
+      --end) end=$2; shift 2 ;;
+      --project) project=$2; shift 2 ;;
+      --task) task=$2; shift 2 ;;
+      --desc) desc=$2; shift 2 ;;
+      *) die "log: unknown argument: $1" ;;
+    esac
+  done
+  [ -n "$start" ] && [ -n "$end" ] || die "log: --start and --end are required"
+  [ -n "$desc" ] || die "log: --desc is required"
+  local s e
+  s=$(local_to_epoch "$start") || die "log: unparseable --start: $start"
+  e=$(local_to_epoch "$end") || die "log: unparseable --end: $end"
+  [ "$e" -gt "$s" ] || die "log: --end must be after --start"
+  append_entry "$start" "$end" "$project" "$task" "$desc"
+  printf 'logged: %s (%s -> %s)\n' "$desc" "$start" "$end"
+}
+
+# ---------------------------------------------------------------- report
+
+cmd_report() {
+  local month="" project_filter=""
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      --month) month=$2; shift 2 ;;
+      --project) project_filter=$2; shift 2 ;;
+      *) die "report: unknown argument: $1" ;;
+    esac
+  done
+  [ -n "$month" ] || month=$(epoch_to_yyyymm "$(now_epoch)")
+  [ -e "$TT/entries.md" ] || { printf 'no time entries recorded yet.\n'; return 0; }
+
+  local tmp
+  tmp=$(mktemp "$TT/.report.XXXXXX")
+  trap 'rm -f "$tmp"' RETURN
+
+  awk -v RS='' -v FS='\n' '
+    /^## / {
+      start=""; end=""; project=""; task=""; desc=""
+      for (i = 1; i <= NF; i++) {
+        line = $i
+        if (line ~ /^start=/) start = substr(line, 7)
+        else if (line ~ /^end=/) end = substr(line, 5)
+        else if (line ~ /^project=/) project = substr(line, 9)
+        else if (line ~ /^task=/) task = substr(line, 6)
+        else if (line ~ /^desc=/) desc = substr(line, 6)
+      }
+      if (start != "") print start "\t" end "\t" project "\t" task "\t" desc
+    }
+  ' "$TT/entries.md" > "$tmp"
+
+  local total=0 after_total=0 count=0 invalid=0
+  local -A proj_total proj_after
+  local -A key_total key_after key_desc
+  local line s e p t d s_epoch e_epoch dur ah ym
+
+  while IFS=$'\t' read -r s e p t d; do
+    ym=${s%% *}
+    ym=${ym%-*}
+    [ "$ym" = "$month" ] || continue
+    [ -z "$project_filter" ] || [ "$p" = "$project_filter" ] || continue
+    s_epoch=$(local_to_epoch "$s") || { invalid=$((invalid + 1)); continue; }
+    e_epoch=$(local_to_epoch "$e") || { invalid=$((invalid + 1)); continue; }
+    if [ "$e_epoch" -le "$s_epoch" ]; then invalid=$((invalid + 1)); continue; fi
+    dur=$(( (e_epoch - s_epoch) / 60 ))
+    ah=$(is_after_hours "$s_epoch")
+    total=$((total + dur))
+    count=$((count + 1))
+    [ "$ah" = yes ] && after_total=$((after_total + dur))
+    proj_total[$p]=$(( ${proj_total[$p]:-0} + dur ))
+    [ "$ah" = yes ] && proj_after[$p]=$(( ${proj_after[$p]:-0} + dur ))
+    key_total["$p"$'\t'"$t"]=$(( ${key_total["$p"$'\t'"$t"]:-0} + dur ))
+    [ "$ah" = yes ] && key_after["$p"$'\t'"$t"]=$(( ${key_after["$p"$'\t'"$t"]:-0} + dur ))
+    if [ -n "$d" ]; then
+      case "${key_desc["$p"$'\t'"$t"]:-}" in
+        *"$d"*) ;;
+        '') key_desc["$p"$'\t'"$t"]="$d" ;;
+        *) key_desc["$p"$'\t'"$t"]="${key_desc["$p"$'\t'"$t"]}; $d" ;;
+      esac
+    fi
+  done < "$tmp"
+  rm -f "$tmp"
+  trap - RETURN
+
+  printf 'Time tracking report - %s\n' "$month"
+  if [ "$count" -eq 0 ]; then
+    printf 'no entries recorded for this month%s.\n' "$([ -n "$project_filter" ] && printf ' for project %s' "$project_filter")"
+    [ "$invalid" -gt 0 ] && printf '(%d entr%s skipped: end not after start; check hand edits)\n' \
+      "$invalid" "$([ "$invalid" -eq 1 ] && printf y || printf ies)"
+    return 0
+  fi
+  printf 'total: %s tracked across %d entr%s\n' "$(fmt_minutes "$total")" "$count" "$([ "$count" -eq 1 ] && printf y || printf ies)"
+  printf '  after hours (weekend or outside %s-%s local): %s\n' "$WORKDAY_START" "$WORKDAY_END" "$(fmt_minutes "$after_total")"
+  printf '  business hours: %s\n' "$(fmt_minutes "$((total - after_total))")"
+  [ "$invalid" -gt 0 ] && printf '(%d entr%s skipped: end not after start; check hand edits)\n' \
+    "$invalid" "$([ "$invalid" -eq 1 ] && printf y || printf ies)"
+  printf '\nby project / task:\n'
+
+  local p_key kt task_name
+  local -a sorted_projects sorted_tasks
+  mapfile -t sorted_projects < <(printf '%s\n' "${!proj_total[@]}" | sort)
+  for p_key in "${sorted_projects[@]}"; do
+    printf '  %s  %s' "$([ "$p_key" = - ] && printf '(unattributed)' || printf '%s' "$p_key")" "$(fmt_minutes "${proj_total[$p_key]}")"
+    [ "${proj_after[$p_key]:-0}" -gt 0 ] && printf ' (%s after hours)' "$(fmt_minutes "${proj_after[$p_key]}")"
+    printf '\n'
+    mapfile -t sorted_tasks < <(
+      for kt in "${!key_total[@]}"; do
+        case "$kt" in "$p_key"$'\t'*) printf '%s\n' "$kt" ;; esac
+      done | sort
+    )
+    for kt in "${sorted_tasks[@]}"; do
+      task_name=${kt#*$'\t'}
+      printf '    %s  %s' "$([ "$task_name" = - ] && printf '(unattributed)' || printf '%s' "$task_name")" "$(fmt_minutes "${key_total[$kt]}")"
+      [ "${key_after[$kt]:-0}" -gt 0 ] && printf ' (%s after hours)' "$(fmt_minutes "${key_after[$kt]}")"
+      printf '\n'
+      [ -n "${key_desc[$kt]:-}" ] && printf '      %s\n' "${key_desc[$kt]}"
+    done
+  done
+}
+
+# ---------------------------------------------------------------- dispatch
+
+case "${1:-}" in
+  propose) shift; cmd_propose "$@" ;;
+  list)    shift; cmd_list "$@" ;;
+  approve) shift; cmd_approve "$@" ;;
+  reject)  shift; cmd_reject "$@" ;;
+  split)   shift; cmd_split "$@" ;;
+  start)   shift; cmd_start "$@" ;;
+  stop)    shift; cmd_stop "$@" ;;
+  log)     shift; cmd_log "$@" ;;
+  report)  shift; cmd_report "$@" ;;
+  ''|-h|--help|help) usage ;;
+  *) die "unknown subcommand: $1 (try --help)" ;;
+esac

--- a/bin/fm-time.sh
+++ b/bin/fm-time.sh
@@ -862,15 +862,16 @@ cmd_report() {
     printf '  %s  %s' "$([ "$p_key" = - ] && printf '(unattributed)' || printf '%s' "$p_key")" "$(fmt_minutes "${proj_total[$p_key]}")"
     [ "${proj_after[$p_key]:-0}" -gt 0 ] && printf ' (%s after hours)' "$(fmt_minutes "${proj_after[$p_key]}")"
     printf '\n'
-    # Stock macOS Bash 3.2 cannot parse $'...' sitting immediately after a
-    # double-quoted variable inside a case PATTERN (unlike a case SUBJECT or a
-    # glob-then-$'...' pattern, both of which it parses fine); building the
-    # tab-joined prefix into its own variable first keeps the literal $'\t'
-    # out of the pattern text entirely.
+    # Stock macOS Bash 3.2's $(...)/<(...) parser naively counts parens to
+    # find the substitution's closing ")"; a case pattern's own closing ")" -
+    # even a plain literal one - confuses that counter unless the pattern has
+    # a leading "(" (POSIX-legal, a no-op everywhere else). This affects every
+    # case statement whose source text sits inside a command or process
+    # substitution, regardless of what the pattern itself contains.
     p_prefix="$p_key"$'\t'
     mapfile -t sorted_tasks < <(
       for kt in "${!key_total[@]}"; do
-        case "$kt" in "$p_prefix"*) printf '%s\n' "$kt" ;; esac
+        case "$kt" in ("$p_prefix"*) printf '%s\n' "$kt" ;; esac
       done | sort
     )
     for kt in "${sorted_tasks[@]}"; do

--- a/bin/fm-time.sh
+++ b/bin/fm-time.sh
@@ -218,31 +218,46 @@ is_after_hours() {  # <epoch> -> yes|no
 # the supervision session lock (state/.lock), which this script only ever
 # reads. mkdir is atomic on every filesystem this script already assumes, so
 # this needs no flock dependency (flock is absent on macOS; see
-# fm-supervise-daemon.sh's own comment on the same tradeoff). Every critical
-# section guarded by this lock is a handful of tiny file rewrites, so a lock
-# dir older than LOCK_STALE_SECS is treated as abandoned by a crashed writer
-# and reclaimed rather than blocking a live captain forever.
+# fm-supervise-daemon.sh's own comment on the same tradeoff). The holder's own
+# pid is recorded inside the lock dir the instant it is created, and staleness
+# is decided by that pid's liveness (kill -0), not by how long the lock has
+# been held: `propose` can legitimately hold this lock across a slow evidence
+# scan, and a fixed wall-clock cutoff would let a second command steal the
+# lock out from under a still-running one, corrupting proposals.md or entries
+# in a lost-update race. LOCK_STALE_SECS is kept only as a narrow fallback for
+# the brief window after mkdir succeeds but before the pid file is written
+# (e.g. a crash in between): once a pid is on record, its liveness is
+# authoritative and the lock is held exactly as long as its owner is alive.
 TT_LOCK="$TT/.lock"
-LOCK_STALE_SECS=10
+LOCK_STALE_SECS="${FM_TIME_LOCK_STALE_OVERRIDE:-10}"
 
 tt_lock() {
   mkdir -p "$TT"
-  local tries=0 age
+  local tries=0 age owner_pid
   while ! mkdir "$TT_LOCK" 2>/dev/null; do
-    age=$(fm_time_mtime "$TT_LOCK" 2>/dev/null) || age=""
-    if [ -n "$age" ] && [ "$(( $(now_epoch) - age ))" -ge "$LOCK_STALE_SECS" ]; then
-      rmdir "$TT_LOCK" 2>/dev/null || true
-      continue
+    owner_pid=$(cat "$TT_LOCK/pid" 2>/dev/null) || owner_pid=""
+    if [ -n "$owner_pid" ]; then
+      if ! kill -0 "$owner_pid" 2>/dev/null; then
+        rm -rf "$TT_LOCK" 2>/dev/null || true
+        continue
+      fi
+    else
+      age=$(fm_time_mtime "$TT_LOCK" 2>/dev/null) || age=""
+      if [ -n "$age" ] && [ "$(( $(now_epoch) - age ))" -ge "$LOCK_STALE_SECS" ]; then
+        rm -rf "$TT_LOCK" 2>/dev/null || true
+        continue
+      fi
     fi
     tries=$((tries + 1))
     [ "$tries" -lt 100 ] || die "another fm-time.sh command appears to be running against this home; try again"
     sleep 0.1
   done
-  trap 'rmdir "$TT_LOCK" 2>/dev/null || true' EXIT
+  printf '%s\n' "$$" > "$TT_LOCK/pid"
+  trap 'rm -rf "$TT_LOCK" 2>/dev/null || true' EXIT
 }
 
 tt_unlock() {
-  rmdir "$TT_LOCK" 2>/dev/null || true
+  rm -rf "$TT_LOCK" 2>/dev/null || true
   trap - EXIT
 }
 

--- a/bin/fm-time.sh
+++ b/bin/fm-time.sh
@@ -230,23 +230,65 @@ is_after_hours() {  # <epoch> -> yes|no
 # the brief window after mkdir succeeds but before the pid file is written
 # (e.g. a crash in between): once a pid is on record, its liveness is
 # authoritative and the lock is held exactly as long as its owner is alive.
+#
+# Two further races are guarded explicitly rather than left theoretical,
+# because this repo's own operational pattern - many short-lived helper
+# processes spawned in quick succession - makes both plausible in practice,
+# not just on paper:
+#   - PID reuse: kill -0 alone cannot tell a live owner from an unrelated
+#     process that reused its pid after it exited. The lock dir also records
+#     the owner's process-start timestamp (`ps -o lstart=`, supported by both
+#     GNU and BSD ps) alongside its pid; a live pid whose current start time
+#     no longer matches the recorded one is a different process wearing the
+#     same pid, so it is reclaimed exactly like a dead one. When `ps` cannot
+#     report a start time (unsupported ps, sandboxed pid namespace) the check
+#     is skipped rather than guessed, falling back to plain kill -0 - refusing
+#     to weaken the working case for a case that cannot be verified.
+#   - Reclaim race: two waiters can each decide the same lock is stale before
+#     either removes it; naive `rm -rf` from the delayed one would then delete
+#     whichever fresh lock the other waiter has since created at that path.
+#     tt_reclaim_stale renames the specific directory instance away before
+#     deleting it - `mv` is atomic, so only one racing reclaimer can ever move
+#     a given instance, and a directory recreated after the move is a
+#     different filesystem entry the move never touches.
 TT_LOCK="$TT/.lock"
 LOCK_STALE_SECS="${FM_TIME_LOCK_STALE_OVERRIDE:-10}"
 
+tt_owner_start() {  # <pid> -> that pid's process-start timestamp, or nothing
+  ps -o lstart= -p "$1" 2>/dev/null
+}
+
+# Atomically relocates a lock dir believed stale before removing it, so a
+# delayed reclaimer can never delete a lock a new owner has since created at
+# the same path (see the mutex comment above for the exact race this closes).
+tt_reclaim_stale() {
+  local reap="$TT_LOCK.reap.$$"
+  mv "$TT_LOCK" "$reap" 2>/dev/null || return 0
+  rm -rf "$reap" 2>/dev/null || true
+}
+
 tt_lock() {
   mkdir -p "$TT"
-  local tries=0 age owner_pid
+  local tries=0 age owner_pid owner_start cur_start
   while ! mkdir "$TT_LOCK" 2>/dev/null; do
     owner_pid=$(cat "$TT_LOCK/pid" 2>/dev/null) || owner_pid=""
     if [ -n "$owner_pid" ]; then
       if ! kill -0 "$owner_pid" 2>/dev/null; then
-        rm -rf "$TT_LOCK" 2>/dev/null || true
+        tt_reclaim_stale
         continue
+      fi
+      owner_start=$(cat "$TT_LOCK/start" 2>/dev/null) || owner_start=""
+      if [ -n "$owner_start" ]; then
+        cur_start=$(tt_owner_start "$owner_pid") || cur_start=""
+        if [ -n "$cur_start" ] && [ "$cur_start" != "$owner_start" ]; then
+          tt_reclaim_stale
+          continue
+        fi
       fi
     else
       age=$(fm_time_mtime "$TT_LOCK" 2>/dev/null) || age=""
       if [ -n "$age" ] && [ "$(( $(now_epoch) - age ))" -ge "$LOCK_STALE_SECS" ]; then
-        rm -rf "$TT_LOCK" 2>/dev/null || true
+        tt_reclaim_stale
         continue
       fi
     fi
@@ -255,6 +297,7 @@ tt_lock() {
     sleep 0.1
   done
   printf '%s\n' "$$" > "$TT_LOCK/pid"
+  tt_owner_start "$$" > "$TT_LOCK/start" 2>/dev/null || : > "$TT_LOCK/start"
   trap tt_release_if_owner EXIT
 }
 

--- a/bin/fm-time.sh
+++ b/bin/fm-time.sh
@@ -91,6 +91,10 @@
 #                                    recomputed from start/end at report time,
 #                                    never trusted from a stored field.
 #   data/time-tracking/active       present only between `start` and `stop`.
+#   data/time-tracking/.lock        transient mkdir-based mutex held only for
+#                                    the span of a single command's own
+#                                    read-modify-write; not part of the durable
+#                                    record, and never held across commands.
 #
 # Configuration (gitignored, one setting per file, absent = default):
 #   config/time-tracking-gap-minutes         session-merge gap, minutes (default 45)
@@ -206,6 +210,40 @@ is_after_hours() {  # <epoch> -> yes|no
   else
     printf 'no'
   fi
+}
+
+# ---------------------------------------------------------------- own lock
+
+# A tiny mkdir-based mutex over this home's OWN time-tracking files - never
+# the supervision session lock (state/.lock), which this script only ever
+# reads. mkdir is atomic on every filesystem this script already assumes, so
+# this needs no flock dependency (flock is absent on macOS; see
+# fm-supervise-daemon.sh's own comment on the same tradeoff). Every critical
+# section guarded by this lock is a handful of tiny file rewrites, so a lock
+# dir older than LOCK_STALE_SECS is treated as abandoned by a crashed writer
+# and reclaimed rather than blocking a live captain forever.
+TT_LOCK="$TT/.lock"
+LOCK_STALE_SECS=10
+
+tt_lock() {
+  mkdir -p "$TT"
+  local tries=0 age
+  while ! mkdir "$TT_LOCK" 2>/dev/null; do
+    age=$(fm_time_mtime "$TT_LOCK" 2>/dev/null) || age=""
+    if [ -n "$age" ] && [ "$(( $(now_epoch) - age ))" -ge "$LOCK_STALE_SECS" ]; then
+      rmdir "$TT_LOCK" 2>/dev/null || true
+      continue
+    fi
+    tries=$((tries + 1))
+    [ "$tries" -lt 100 ] || die "another fm-time.sh command appears to be running against this home; try again"
+    sleep 0.1
+  done
+  trap 'rmdir "$TT_LOCK" 2>/dev/null || true' EXIT
+}
+
+tt_unlock() {
+  rmdir "$TT_LOCK" 2>/dev/null || true
+  trap - EXIT
 }
 
 # ---------------------------------------------------------------- cursor
@@ -380,6 +418,7 @@ cmd_propose() {
   done
 
   mkdir -p "$TT"
+  tt_lock
   if [ "$(proposal_count)" -gt 0 ] && [ "$replace" -ne 1 ]; then
     die "a pending proposal batch already exists; resolve it with approve/reject/split, or pass --replace to discard it and rescan"
   fi
@@ -419,6 +458,7 @@ cmd_propose() {
   else
     printf '%s proposed window(s) since %s - review with: fm-time.sh list\n' "$count" "$(epoch_to_local "$since_epoch")"
   fi
+  tt_unlock
 }
 
 cmd_list() {
@@ -503,6 +543,7 @@ cmd_approve() {
     esac
   done
 
+  tt_lock
   [ -s "$TT/proposals.md" ] || die "approve: no pending proposals"
   local block
   block=$(extract_block "$TT/proposals.md" "$id")
@@ -524,11 +565,13 @@ cmd_approve() {
   remove_block "$TT/proposals.md" "$id" > "$TT/proposals.md.tmp"
   mv "$TT/proposals.md.tmp" "$TT/proposals.md"
   advance_cursor_if_batch_done
+  tt_unlock
   printf 'approved %s: %s (%s -> %s)\n' "$id" "$desc" "$start" "$end"
 }
 
 cmd_reject() {
   [ "$#" -gt 0 ] || die "reject: usage: fm-time.sh reject <id>..."
+  tt_lock
   [ -s "$TT/proposals.md" ] || die "reject: no pending proposals"
   local id
   for id in "$@"; do
@@ -540,6 +583,7 @@ cmd_reject() {
     printf 'rejected %s\n' "$id"
   done
   advance_cursor_if_batch_done
+  tt_unlock
 }
 
 cmd_split() {
@@ -554,6 +598,7 @@ cmd_split() {
   done
   [ -n "$at" ] || die "split: --at is required"
 
+  tt_lock
   [ -s "$TT/proposals.md" ] || die "split: no pending proposals"
   local block
   block=$(extract_block "$TT/proposals.md" "$id")
@@ -608,6 +653,7 @@ cmd_split() {
   } > "$TT/proposals.md.new"
   mv "$TT/proposals.md.new" "$TT/proposals.md"
   rm -f "$TT/proposals.md.tmp"
+  tt_unlock
   printf 'split %s into %s-a (%s -> %s) and %s-b (%s -> %s)\n' "$id" "$id" "$start" "$at" "$id" "$at" "$end"
 }
 
@@ -624,6 +670,7 @@ cmd_start() {
     esac
   done
   mkdir -p "$TT"
+  tt_lock
   [ -e "$TT/active" ] && die "start: a live session is already running; run: fm-time.sh stop"
   {
     printf 'start=%s\n' "$(epoch_to_local "$(now_epoch)")"
@@ -631,6 +678,7 @@ cmd_start() {
     printf 'task=%s\n' "$task"
     printf 'desc=%s\n' "$desc"
   } > "$TT/active"
+  tt_unlock
   printf 'started tracking%s\n' "$([ -n "$desc" ] && printf ': %s' "$desc")"
 }
 
@@ -642,16 +690,26 @@ cmd_stop() {
       *) die "stop: unknown argument: $1" ;;
     esac
   done
+  tt_lock
   [ -e "$TT/active" ] || die "stop: no live session is running; run: fm-time.sh start"
-  local start project task desc end
+  local start project task desc end start_epoch end_epoch
   start=$(sed -n 's/^start=//p' "$TT/active" | head -1)
   project=$(sed -n 's/^project=//p' "$TT/active" | head -1)
   task=$(sed -n 's/^task=//p' "$TT/active" | head -1)
   desc=$(sed -n 's/^desc=//p' "$TT/active" | head -1)
   [ -n "$desc_ov" ] && desc=$desc_ov
   end=$(epoch_to_local "$(now_epoch)")
+  start_epoch=$(local_to_epoch "$start") || die "stop: unparseable stored start: $start"
+  end_epoch=$(local_to_epoch "$end") || die "stop: unparseable end: $end"
+  # A start/stop within the same wall-clock minute would otherwise record an
+  # entry whose stored start and end are identical once truncated to minute
+  # granularity - report then silently discards it as invalid, losing the
+  # tracked session. Refuse it up front instead, leaving the active session
+  # in place so the captain can just wait a moment and stop again.
+  [ "$end_epoch" -gt "$start_epoch" ] || die "stop: wait until the current minute has elapsed before stopping"
   append_entry "$start" "$end" "$project" "$task" "$desc"
   rm -f "$TT/active"
+  tt_unlock
   printf 'stopped: %s (%s -> %s)\n' "${desc:-(no description)}" "$start" "$end"
 }
 
@@ -673,7 +731,9 @@ cmd_log() {
   s=$(local_to_epoch "$start") || die "log: unparseable --start: $start"
   e=$(local_to_epoch "$end") || die "log: unparseable --end: $end"
   [ "$e" -gt "$s" ] || die "log: --end must be after --start"
+  tt_lock
   append_entry "$start" "$end" "$project" "$task" "$desc"
+  tt_unlock
   printf 'logged: %s (%s -> %s)\n' "$desc" "$start" "$end"
 }
 

--- a/bin/fm-time.sh
+++ b/bin/fm-time.sh
@@ -146,6 +146,14 @@ fm_time_mtime() {  # <path> -> epoch seconds, or nothing on failure
   fi
 }
 
+fm_time_inode() {  # <path> -> inode number, or nothing on failure
+  if [ "$(uname)" = Darwin ]; then
+    /usr/bin/stat -f %i "$1" 2>/dev/null
+  else
+    stat -c %i "$1" 2>/dev/null
+  fi
+}
+
 now_epoch() { printf '%s\n' "${FM_TIME_NOW_OVERRIDE:-$(date +%s)}"; }
 
 # epoch -> "YYYY-MM-DD HH:MM" local wall clock.
@@ -244,13 +252,22 @@ is_after_hours() {  # <epoch> -> yes|no
 #     report a start time (unsupported ps, sandboxed pid namespace) the check
 #     is skipped rather than guessed, falling back to plain kill -0 - refusing
 #     to weaken the working case for a case that cannot be verified.
-#   - Reclaim race: two waiters can each decide the same lock is stale before
-#     either removes it; naive `rm -rf` from the delayed one would then delete
-#     whichever fresh lock the other waiter has since created at that path.
-#     tt_reclaim_stale renames the specific directory instance away before
-#     deleting it - `mv` is atomic, so only one racing reclaimer can ever move
-#     a given instance, and a directory recreated after the move is a
-#     different filesystem entry the move never touches.
+#   - Delete-wrong-instance race: deciding a lock is stale and then acting on
+#     it are two separate steps, so *anything* that only checks "is the path
+#     still what I inspected" right before deleting - including a plain
+#     `mv $TT_LOCK elsewhere` on the assumption that the move itself is the
+#     safety - is not enough: a plain `mv` relocates whatever currently sits
+#     at that path, not the specific instance a waiter inspected, so a
+#     successor's freshly created live lock at the same path would be moved
+#     and deleted just as readily as the stale one. tt_remove_locked_instance
+#     closes this for real by checking identity, not just path: it captures
+#     the directory's inode before acting, renames it aside, and only deletes
+#     the moved copy if its inode still matches what was captured - a
+#     mismatch means a different lock has since taken that path, so the moved
+#     copy is put back untouched instead of being deleted. The same helper is
+#     used by both a waiter reclaiming a lock it believes abandoned and an
+#     owner releasing a lock it confirmed is its own, since both are exactly
+#     this same "verify identity, then delete" problem.
 TT_LOCK="$TT/.lock"
 LOCK_STALE_SECS="${FM_TIME_LOCK_STALE_OVERRIDE:-10}"
 
@@ -258,37 +275,40 @@ tt_owner_start() {  # <pid> -> that pid's process-start timestamp, or nothing
   ps -o lstart= -p "$1" 2>/dev/null
 }
 
-# Atomically relocates a lock dir believed stale before removing it, so a
-# delayed reclaimer can never delete a lock a new owner has since created at
-# the same path (see the mutex comment above for the exact race this closes).
-tt_reclaim_stale() {
-  local reap="$TT_LOCK.reap.$$"
+tt_remove_locked_instance() {  # <expected-inode>
+  local expected=$1 reap="$TT_LOCK.reap.$$" got
   mv "$TT_LOCK" "$reap" 2>/dev/null || return 0
+  got=$(fm_time_inode "$reap" 2>/dev/null) || got=""
+  if [ -n "$expected" ] && [ "$got" != "$expected" ]; then
+    mv "$reap" "$TT_LOCK" 2>/dev/null || true
+    return 0
+  fi
   rm -rf "$reap" 2>/dev/null || true
 }
 
 tt_lock() {
   mkdir -p "$TT"
-  local tries=0 age owner_pid owner_start cur_start
+  local tries=0 age inode owner_pid owner_start cur_start
   while ! mkdir "$TT_LOCK" 2>/dev/null; do
+    inode=$(fm_time_inode "$TT_LOCK" 2>/dev/null) || inode=""
     owner_pid=$(cat "$TT_LOCK/pid" 2>/dev/null) || owner_pid=""
     if [ -n "$owner_pid" ]; then
       if ! kill -0 "$owner_pid" 2>/dev/null; then
-        tt_reclaim_stale
+        tt_remove_locked_instance "$inode"
         continue
       fi
       owner_start=$(cat "$TT_LOCK/start" 2>/dev/null) || owner_start=""
       if [ -n "$owner_start" ]; then
         cur_start=$(tt_owner_start "$owner_pid") || cur_start=""
         if [ -n "$cur_start" ] && [ "$cur_start" != "$owner_start" ]; then
-          tt_reclaim_stale
+          tt_remove_locked_instance "$inode"
           continue
         fi
       fi
     else
       age=$(fm_time_mtime "$TT_LOCK" 2>/dev/null) || age=""
       if [ -n "$age" ] && [ "$(( $(now_epoch) - age ))" -ge "$LOCK_STALE_SECS" ]; then
-        tt_reclaim_stale
+        tt_remove_locked_instance "$inode"
         continue
       fi
     fi
@@ -301,16 +321,21 @@ tt_lock() {
   trap tt_release_if_owner EXIT
 }
 
-# Removes the lock only if its recorded pid is still this process's own pid.
-# Used both as the ordinary unlock path and as the EXIT trap handler so a
-# signal arriving between tt_unlock's own removal and its `trap -` clear can
-# never blow away a lock a *different* command has since acquired: by the
-# time the trap fires, the pid file either matches this process (safe to
-# remove) or belongs to someone else / is already gone (leave it alone).
+# Removes the lock only if its recorded pid is still this process's own pid,
+# and even then only the exact instance just confirmed as this process's own
+# (see tt_remove_locked_instance above). Used both as the ordinary unlock
+# path and as the EXIT trap handler so a signal arriving between tt_unlock's
+# own removal and its `trap -` clear can never blow away a lock a *different*
+# command has since acquired: by the time the trap fires, the pid file either
+# matches this process (safe to remove) or belongs to someone else / is
+# already gone (leave it alone).
 tt_release_if_owner() {
-  local owner_pid
+  local owner_pid inode
   owner_pid=$(cat "$TT_LOCK/pid" 2>/dev/null) || owner_pid=""
-  [ "$owner_pid" = "$$" ] && rm -rf "$TT_LOCK" 2>/dev/null
+  if [ "$owner_pid" = "$$" ]; then
+    inode=$(fm_time_inode "$TT_LOCK" 2>/dev/null) || inode=""
+    tt_remove_locked_instance "$inode"
+  fi
   return 0
 }
 

--- a/bin/fm-time.sh
+++ b/bin/fm-time.sh
@@ -35,12 +35,14 @@
 #                                      bare mtime can prove.
 #   - data/<id>/report.md mtime       used: scout-report-finalized ping.
 #   - data/backlog.md, data/done-archive.md
-#                                     used: "(done YYYY-MM-DD)" and "(reported
-#                                      YYYY-MM-DD)" entries (tasks-axi writes the
-#                                      latter for a scout task closed with
-#                                      --report) become day-only pings (noon
-#                                      local), the one signal that survives a
-#                                      torn-down task's state files.
+#                                     used: "(done YYYY-MM-DD)", "(reported
+#                                      YYYY-MM-DD)" (tasks-axi writes this for a
+#                                      task closed with --report), and "(merged
+#                                      YYYY-MM-DD)" (tasks-axi writes this for a
+#                                      task closed with --pr) entries all become
+#                                      day-only pings (noon local), the one
+#                                      signal that survives a torn-down task's
+#                                      state files.
 #   - state/.wake-queue                used opportunistically: it carries real epoch
 #                                      seconds, but the queue is drained on
 #                                      acknowledgement, so it holds only whatever is
@@ -253,11 +255,24 @@ tt_lock() {
     sleep 0.1
   done
   printf '%s\n' "$$" > "$TT_LOCK/pid"
-  trap 'rm -rf "$TT_LOCK" 2>/dev/null || true' EXIT
+  trap tt_release_if_owner EXIT
+}
+
+# Removes the lock only if its recorded pid is still this process's own pid.
+# Used both as the ordinary unlock path and as the EXIT trap handler so a
+# signal arriving between tt_unlock's own removal and its `trap -` clear can
+# never blow away a lock a *different* command has since acquired: by the
+# time the trap fires, the pid file either matches this process (safe to
+# remove) or belongs to someone else / is already gone (leave it alone).
+tt_release_if_owner() {
+  local owner_pid
+  owner_pid=$(cat "$TT_LOCK/pid" 2>/dev/null) || owner_pid=""
+  [ "$owner_pid" = "$$" ] && rm -rf "$TT_LOCK" 2>/dev/null
+  return 0
 }
 
 tt_unlock() {
-  rm -rf "$TT_LOCK" 2>/dev/null || true
+  tt_release_if_owner
   trap - EXIT
 }
 
@@ -350,6 +365,14 @@ gather_evidence() {  # <since-epoch> <out-file>
           # archive) is silently invisible to propose.
           text=$(printf '%s' "$line" | sed -n 's/.*(reported \([0-9-]\{10\}\)).*/\1/p')
           ;;
+        *'(merged '????-??-??')'*)
+          # tasks-axi writes "(merged YYYY-MM-DD)" instead of "(done ...)"
+          # when a task is closed with --pr (verified against this repo's own
+          # tasks-axi binary: `done <id> --pr <url>` produces this marker);
+          # without this branch every PR-linked completion is silently
+          # invisible to propose.
+          text=$(printf '%s' "$line" | sed -n 's/.*(merged \([0-9-]\{10\}\)).*/\1/p')
+          ;;
         *) continue ;;
       esac
       [ -n "$text" ] || continue
@@ -359,7 +382,7 @@ gather_evidence() {  # <since-epoch> <out-file>
       [ -n "$project" ] || project=-
       payload=$(printf '%s' "$line" \
         | sed 's/^- \[x\] [^ ]* - //' \
-        | sed -e 's/ (done [0-9-]*)//' -e 's/ (reported [0-9-]*)//' -e 's/ (repo: [^)]*)//' \
+        | sed -e 's/ (done [0-9-]*)//' -e 's/ (reported [0-9-]*)//' -e 's/ (merged [0-9-]*)//' -e 's/ (repo: [^)]*)//' \
         | cut -c1-140)
       printf '%s\t%s\t%s\tbacklog\t%s\n' "$epoch" "$project" "$id" "$payload" >> "$out"
     done < "$bf"

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -225,6 +225,13 @@ Fleet-local operational facts and gotchas live locally in `data/learnings.md`; i
 The file is created lazily on first learning and follows the internal [`stow` skill's](../.agents/skills/stow/SKILL.md) aging-tier and cold-archive contract: inspect the current file first and curate it instead of appending forever.
 There is no shared learnings file by captain decision.
 
+## Time tracking (config/time-tracking-*, data/time-tracking/)
+
+`bin/fm-time.sh` proposes candidate work windows from this home's own durable evidence, records nothing until the captain approves or corrects each one, and reports a month-end breakdown of hours by project and task with after-hours called out separately.
+It is a standalone command the captain runs directly; nothing in Firstmate's own operating loop invokes it.
+All of its records live locally under this home's gitignored `data/time-tracking/`, and its optional tuning knobs live under gitignored `config/time-tracking-*` files.
+The script's own header and `bin/fm-time.sh --help` are the single owner of exact evidence sources, storage format, and configuration keys.
+
 ## Startup memory budget (config/startup-memory-budget)
 
 `config/startup-memory-budget` is the primary-authoritative per-home allowance for the startup prompt-memory surface: `data/captain.md`, `data/captain-shared.md`, and `data/learnings.md` together.

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -144,6 +144,7 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-public-followup-emit.sh` | Report one typed terminal work result into the home that owes the public reply, or stage it when that home is on another machine |
 | `fm-public-followup-collect.sh` | Read and retire the typed terminal results a remote work home staged for the home that owes the public reply |
 | `fm-inbox.sh`            | The captain's out-of-band capture surface: queue a note, dictate one, read status, ask a side question |
+| `fm-time.sh`             | Propose work windows from durable evidence for the captain to approve or correct, plus start/stop/log and a month-end hours-by-subject report |
 | `fm-voice-relay.py`      | Hold the spoken conversation on this host, answer from the records, and hand real work to `fm-inbox.sh` ([voice-relay.md](voice-relay.md)) |
 | `fm-voice-client.py`     | The laptop end of the spoken interface: capture, playback, and turn timing over SSH; audio devices unverified |
 | `fm_voice_frame.py`      | The wire format both machines share, copied to the laptop beside the client          |

--- a/tests/fm-time.test.sh
+++ b/tests/fm-time.test.sh
@@ -409,6 +409,39 @@ test_lock_reclaimed_promptly_from_a_dead_owner() {
   pass "tt_lock reclaims a lock immediately once its recorded owner is confirmed dead, even when the lock is fresh"
 }
 
+test_lock_reclaimed_when_owner_pid_was_reused() {
+  local home lock_dir live_pid status out elapsed start_s
+  home=$(make_home lock-reused-pid)
+  mkdir -p "$home/data/time-tracking"
+  lock_dir="$home/data/time-tracking/.lock"
+  mkdir "$lock_dir"
+
+  # A live process, but recorded alongside a start timestamp that does not
+  # match its real one: this is what a reused pid looks like on disk after
+  # its original owner exited and an unrelated process picked up the same
+  # pid number. kill -0 alone cannot tell this apart from a genuine live
+  # owner; only the recorded start time can.
+  sleep 60 &
+  live_pid=$!
+  printf '%s\n' "$live_pid" > "$lock_dir/pid"
+  printf '%s\n' "Mon Jan  1 00:00:00 1990" > "$lock_dir/start"
+  touch -t 202001010000 "$lock_dir"
+
+  start_s=$SECONDS
+  out=$(FM_HOME="$home" "$FMTIME" log --start "2026-09-04 20:00" --end "2026-09-04 20:30" --desc reclaimed 2>&1)
+  status=$?
+  elapsed=$((SECONDS - start_s))
+
+  kill "$live_pid" 2>/dev/null
+  wait "$live_pid" 2>/dev/null
+
+  expect_code 0 "$status" "log against a lock whose recorded owner pid was reused by an unrelated live process"
+  assert_contains "$out" "logged" "log did not succeed once the reused-pid lock was reclaimed"
+  [ "$elapsed" -lt 5 ] || fail "a lock whose owner start time no longer matches should reclaim immediately (took ${elapsed}s)"
+
+  pass "tt_lock reclaims a lock whose live recorded pid no longer matches its recorded start time (pid reuse)"
+}
+
 # ---------------------------------------------------------------- report
 
 test_report_groups_by_month_and_splits_after_hours() {
@@ -490,6 +523,7 @@ test_log_without_project_or_task_is_not_blocked
 test_log_refuses_end_before_start
 test_lock_blocks_while_owner_process_is_still_alive
 test_lock_reclaimed_promptly_from_a_dead_owner
+test_lock_reclaimed_when_owner_pid_was_reused
 test_report_groups_by_month_and_splits_after_hours
 test_report_month_boundary_uses_entry_start_date
 test_time_tracking_never_writes_supervision_state

--- a/tests/fm-time.test.sh
+++ b/tests/fm-time.test.sh
@@ -1,0 +1,376 @@
+#!/usr/bin/env bash
+# Behavior tests for fm-time.sh: propose from synthetic signals, approval
+# (as-is and corrected), retroactive log entries, live start/stop, split, and
+# the month-end report's grouping and after-hours split.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+FMTIME="$ROOT/bin/fm-time.sh"
+TMP_ROOT=$(fm_test_tmproot fm-time)
+
+make_home() {
+  local name=$1 home
+  home="$TMP_ROOT/$name"
+  mkdir -p "$home/state" "$home/data" "$home/config"
+  printf '%s\n' "$home"
+}
+
+# touch_at <path> <YYYY-MM-DD> <HH:MM>: portable POSIX `touch -t` mtime set.
+touch_at() {
+  local path=$1 date=$2 hm=$3 stamp
+  stamp="${date//-/}${hm/:/}"
+  touch -t "$stamp" "$path"
+}
+
+# ---------------------------------------------------------------- propose
+
+test_propose_clusters_synthetic_status_and_meta_evidence() {
+  local home
+  home=$(make_home propose-basic)
+
+  cat > "$home/state/demo-task.meta" <<EOF
+project=$home/projects/FnO
+kind=ship
+EOF
+  touch_at "$home/state/demo-task.meta" 2026-09-05 18:30
+
+  cat > "$home/state/demo-task.status" <<'EOF'
+working: doing the thing
+done: fixed the widget
+EOF
+  touch_at "$home/state/demo-task.status" 2026-09-05 18:40
+
+  local out
+  out=$(FM_HOME="$home" "$FMTIME" propose --since "2026-09-01 00:00") \
+    || fail "propose failed on synthetic status+meta evidence"
+  assert_contains "$out" "1 proposed window" "close-together meta+status pings did not merge into one window"
+
+  local list
+  list=$(FM_HOME="$home" "$FMTIME" list) || fail "list failed"
+  assert_contains "$list" "[p1]" "proposal id p1 missing from list"
+  assert_contains "$list" "project  FnO" "proposal did not attribute the project from state/<id>.meta"
+  assert_contains "$list" "task     demo-task" "proposal did not attribute the task id"
+  assert_contains "$list" "evidence: " "proposal listed no evidence for the captain to judge"
+  assert_contains "$list" "task record touched" "meta-touch evidence line missing"
+  assert_contains "$list" "done: fixed the widget" "status-line evidence text missing"
+
+  pass "propose clusters close synthetic status+meta pings into one evidenced window"
+}
+
+test_propose_wide_gap_produces_two_windows() {
+  local home
+  home=$(make_home propose-gap)
+
+  cat > "$home/state/demo-task.meta" <<EOF
+project=$home/projects/FnO
+EOF
+  touch_at "$home/state/demo-task.meta" 2026-09-05 09:00
+
+  cat > "$home/state/demo-task.status" <<'EOF'
+done: unrelated later work
+EOF
+  touch_at "$home/state/demo-task.status" 2026-09-05 20:00
+
+  local out
+  out=$(FM_HOME="$home" "$FMTIME" propose --since "2026-09-01 00:00") \
+    || fail "propose failed on wide-gap evidence"
+  assert_contains "$out" "2 proposed window" "pings 11 hours apart (past the default gap) incorrectly merged"
+
+  pass "propose starts a new window once the gap exceeds the configured threshold"
+}
+
+test_propose_refuses_second_batch_without_replace() {
+  local home out err status
+  home=$(make_home propose-pending)
+  cat > "$home/state/demo-task.meta" <<EOF
+project=$home/projects/FnO
+EOF
+  touch_at "$home/state/demo-task.meta" 2026-09-05 09:00
+
+  FM_HOME="$home" "$FMTIME" propose --since "2026-09-01 00:00" >/dev/null \
+    || fail "first propose failed"
+
+  status=0
+  err=$(FM_HOME="$home" "$FMTIME" propose --since "2026-09-01 00:00" 2>&1 >/dev/null) || status=$?
+  expect_code 1 "$status" "propose with a pending batch and no --replace"
+  assert_contains "$err" "--replace" "refusal did not mention the --replace escape hatch"
+
+  out=$(FM_HOME="$home" "$FMTIME" propose --since "2026-09-01 00:00" --replace) \
+    || fail "propose --replace should succeed over a pending batch"
+  assert_contains "$out" "proposed window" "propose --replace did not regenerate a batch"
+
+  pass "propose refuses a second batch while one is pending, unless --replace is given"
+}
+
+test_propose_reads_reported_scout_completions_from_backlog() {
+  local home
+  home=$(make_home propose-reported)
+
+  cat > "$home/data/backlog.md" <<'EOF'
+- [x] carry-scout-example - Diagnose the thing data/carry-scout-example/report.md (repo: FnO) (reported 2026-09-05)
+EOF
+
+  local out
+  out=$(FM_HOME="$home" "$FMTIME" propose --since "2026-09-01 00:00") \
+    || fail "propose failed on a scout-style (reported ...) backlog completion"
+  assert_contains "$out" "1 proposed window" "a (reported ...) backlog completion produced no proposal"
+
+  local list
+  list=$(FM_HOME="$home" "$FMTIME" list) || fail "list failed"
+  assert_contains "$list" "project  FnO" "reported-completion proposal did not attribute the (repo: ...) project"
+  assert_contains "$list" "task     carry-scout-example" "reported-completion proposal did not attribute the task id"
+
+  pass "propose reads (reported YYYY-MM-DD) scout completions from the backlog, not only (done ...)"
+}
+
+# ---------------------------------------------------------------- approve / correction
+
+test_approve_records_entry_and_advances_cursor() {
+  local home
+  home=$(make_home approve-basic)
+  cat > "$home/state/demo-task.meta" <<EOF
+project=$home/projects/FnO
+EOF
+  touch_at "$home/state/demo-task.meta" 2026-09-05 18:30
+
+  FM_HOME="$home" "$FMTIME" propose --since "2026-09-01 00:00" >/dev/null
+
+  local out
+  out=$(FM_HOME="$home" "$FMTIME" approve p1) || fail "approve p1 failed"
+  assert_contains "$out" "approved p1" "approve did not report success"
+  assert_grep "task=demo-task" "$home/data/time-tracking/entries.md" \
+    "approved entry missing task attribution"
+  assert_present "$home/data/time-tracking/cursor" "approving the only pending proposal did not advance the cursor"
+
+  local list
+  list=$(FM_HOME="$home" "$FMTIME" list) || fail "list after approve failed"
+  assert_contains "$list" "no pending proposals" "approved proposal still shows as pending"
+
+  pass "approve records the window as a durable entry and clears it from pending"
+}
+
+test_approve_correction_overrides_proposed_fields() {
+  local home
+  home=$(make_home approve-correct)
+  cat > "$home/state/demo-task.meta" <<EOF
+project=$home/projects/FnO
+EOF
+  touch_at "$home/state/demo-task.meta" 2026-09-05 18:30
+  cat > "$home/state/demo-task.status" <<'EOF'
+working: first pass
+EOF
+  touch_at "$home/state/demo-task.status" 2026-09-05 18:35
+
+  FM_HOME="$home" "$FMTIME" propose --since "2026-09-01 00:00" >/dev/null
+  FM_HOME="$home" "$FMTIME" approve p1 \
+    --start "2026-09-05 18:00" --end "2026-09-05 19:30" --desc "corrected description" \
+    || fail "corrected approve failed"
+
+  assert_grep "start=2026-09-05 18:00" "$home/data/time-tracking/entries.md" \
+    "corrected start time was not recorded"
+  assert_grep "end=2026-09-05 19:30" "$home/data/time-tracking/entries.md" \
+    "corrected end time was not recorded"
+  assert_grep "desc=corrected description" "$home/data/time-tracking/entries.md" \
+    "corrected description was not recorded"
+
+  pass "approve accepts start/end/desc corrections over the proposed defaults"
+}
+
+test_reject_drops_without_recording() {
+  local home
+  home=$(make_home reject-basic)
+  cat > "$home/state/demo-task.meta" <<EOF
+project=$home/projects/FnO
+EOF
+  touch_at "$home/state/demo-task.meta" 2026-09-05 18:30
+
+  FM_HOME="$home" "$FMTIME" propose --since "2026-09-01 00:00" >/dev/null
+  FM_HOME="$home" "$FMTIME" reject p1 || fail "reject p1 failed"
+
+  if [ -e "$home/data/time-tracking/entries.md" ]; then
+    assert_no_grep "demo-task" "$home/data/time-tracking/entries.md" \
+      "rejected proposal was recorded as an entry anyway"
+  fi
+  pass "reject drops a proposal without recording anything"
+}
+
+test_split_divides_evidence_at_the_boundary() {
+  local home
+  home=$(make_home split-basic)
+  cat > "$home/state/demo-task.meta" <<EOF
+project=$home/projects/FnO
+EOF
+  touch_at "$home/state/demo-task.meta" 2026-09-05 18:00
+  cat > "$home/state/demo-task.status" <<'EOF'
+working: part one
+EOF
+  touch_at "$home/state/demo-task.status" 2026-09-05 18:10
+
+  FM_HOME="$home" "$FMTIME" propose --since "2026-09-01 00:00" >/dev/null
+  FM_HOME="$home" "$FMTIME" split p1 --at "2026-09-05 18:05" || fail "split failed"
+
+  local list
+  list=$(FM_HOME="$home" "$FMTIME" list) || fail "list after split failed"
+  assert_contains "$list" "[p1-a]" "split did not produce the first half"
+  assert_contains "$list" "[p1-b]" "split did not produce the second half"
+  assert_contains "$list" "end      2026-09-05 18:05" "split first half did not end at the boundary"
+  assert_contains "$list" "start    2026-09-05 18:05" "split second half did not start at the boundary"
+
+  FM_HOME="$home" "$FMTIME" approve p1-a --desc first >/dev/null || fail "approve p1-a failed"
+  FM_HOME="$home" "$FMTIME" approve p1-b --desc second >/dev/null || fail "approve p1-b failed"
+  assert_grep "desc=first" "$home/data/time-tracking/entries.md" "first half not recorded"
+  assert_grep "desc=second" "$home/data/time-tracking/entries.md" "second half not recorded"
+
+  pass "split divides a proposal's evidence at the given boundary into two approvable halves"
+}
+
+# ---------------------------------------------------------------- start / stop / log
+
+test_start_stop_records_a_live_session() {
+  local home out
+  home=$(make_home live-session)
+
+  out=$(FM_HOME="$home" FM_TIME_NOW_OVERRIDE=1788800000 "$FMTIME" start --project firstmate --task demo --desc "building") \
+    || fail "start failed"
+  assert_present "$home/data/time-tracking/active" "start did not create an active-session record"
+
+  out=$(FM_HOME="$home" FM_TIME_NOW_OVERRIDE=1788805000 "$FMTIME" stop) || fail "stop failed"
+  assert_contains "$out" "stopped" "stop did not report success"
+  assert_absent "$home/data/time-tracking/active" "stop left the active-session record behind"
+  assert_grep "desc=building" "$home/data/time-tracking/entries.md" "start/stop entry missing its description"
+
+  local status err
+  status=0
+  FM_HOME="$home" "$FMTIME" start --desc again >/dev/null || fail "second start after a stop should succeed"
+  err=$(FM_HOME="$home" "$FMTIME" start --desc other 2>&1 >/dev/null) && status=0 || status=$?
+  expect_code 1 "$status" "starting a second live session while one is already running"
+  assert_contains "$err" "already running" "double-start refusal used the wrong message"
+  FM_HOME="$home" "$FMTIME" stop >/dev/null
+
+  pass "start/stop records a live-tracked entry and refuses a concurrent second start"
+}
+
+test_log_records_a_retroactive_entry() {
+  local home out
+  home=$(make_home retro-log)
+  out=$(FM_HOME="$home" "$FMTIME" log --start "2026-09-04 20:00" --end "2026-09-04 21:30" \
+    --project FnO --task carry-widget-fix --desc "retroactively logged debugging") \
+    || fail "log failed"
+  assert_contains "$out" "logged" "log did not report success"
+  assert_grep "desc=retroactively logged debugging" "$home/data/time-tracking/entries.md" \
+    "retroactive log entry missing its description"
+  assert_grep "task=carry-widget-fix" "$home/data/time-tracking/entries.md" \
+    "retroactive log entry missing its task"
+
+  pass "log records a retroactive entry directly, with no proposal step"
+}
+
+test_log_without_project_or_task_is_not_blocked() {
+  local home out
+  home=$(make_home retro-log-no-task)
+  out=$(FM_HOME="$home" "$FMTIME" log --start "2026-09-04 20:00" --end "2026-09-04 20:30" \
+    --desc "quick email reply, no task tied to it") \
+    || fail "log without --project/--task should not be blocked"
+  assert_contains "$out" "logged" "log did not report success"
+
+  out=$(FM_HOME="$home" "$FMTIME" report --month 2026-09) || fail "report failed"
+  assert_contains "$out" "(unattributed)" "report did not render a missing project/task as readable prose"
+  assert_contains "$out" "quick email reply" "unattributed entry's description is missing from the report"
+
+  pass "a missing task id never blocks recording, and the report renders it as readable prose"
+}
+
+test_log_refuses_end_before_start() {
+  local home status
+  home=$(make_home retro-log-bad)
+  status=0
+  FM_HOME="$home" "$FMTIME" log --start "2026-09-04 21:00" --end "2026-09-04 20:00" \
+    --desc bad >/dev/null 2>/tmp/fm-time-test-err3 || status=$?
+  expect_code 1 "$status" "log with end before start"
+  assert_contains "$(cat /tmp/fm-time-test-err3)" "after" "end-before-start refusal used the wrong message"
+  rm -f /tmp/fm-time-test-err3
+  pass "log refuses an entry whose end is not after its start"
+}
+
+# ---------------------------------------------------------------- report
+
+test_report_groups_by_month_and_splits_after_hours() {
+  local home
+  home=$(make_home report-basic)
+
+  # After-hours: a weekday evening entry (2026-09-02 is a Wednesday).
+  FM_HOME="$home" "$FMTIME" log --start "2026-09-02 19:00" --end "2026-09-02 20:00" \
+    --project FnO --task widget-fix --desc "evening fix" >/dev/null
+  # Business hours: same day, mid-afternoon.
+  FM_HOME="$home" "$FMTIME" log --start "2026-09-02 14:00" --end "2026-09-02 15:00" \
+    --project FnO --task widget-fix --desc "afternoon follow-up" >/dev/null
+  # A different month entirely, must not appear in the September report.
+  FM_HOME="$home" "$FMTIME" log --start "2026-08-15 10:00" --end "2026-08-15 11:00" \
+    --project FnO --task widget-fix --desc "august work" >/dev/null
+
+  local out
+  out=$(FM_HOME="$home" "$FMTIME" report --month 2026-09) || fail "report failed"
+  assert_contains "$out" "2026-09" "report header missing the requested month"
+  assert_contains "$out" "total: 2h00m" "report total did not sum both September entries"
+  assert_contains "$out" "after hours" "report did not label after-hours time"
+  assert_contains "$out" "1h00m" "report is missing the 1-hour after-hours contribution"
+  assert_not_contains "$out" "august work" "August entry leaked into the September report"
+
+  pass "report sums entries for the requested month only and separates after-hours time"
+}
+
+test_report_month_boundary_uses_entry_start_date() {
+  local home out
+  home=$(make_home report-boundary)
+  FM_HOME="$home" "$FMTIME" log --start "2026-08-31 23:00" --end "2026-09-01 01:00" \
+    --project FnO --task overnight --desc "crossed midnight into September" >/dev/null
+
+  out=$(FM_HOME="$home" "$FMTIME" report --month 2026-08) || fail "august report failed"
+  assert_contains "$out" "total: 2h00m" "an entry starting in August was not counted in the August report"
+
+  out=$(FM_HOME="$home" "$FMTIME" report --month 2026-09) || fail "september report failed"
+  assert_contains "$out" "no entries recorded" "an entry that only ENDS in September was wrongly counted there too"
+
+  pass "report attributes a midnight-crossing entry to its start month, not its end month"
+}
+
+test_time_tracking_never_writes_supervision_state() {
+  local home before_lock before_wake
+  home=$(make_home no-supervision-touch)
+  printf 'pid-marker\n' > "$home/state/.lock"
+  printf '111\t1\tcheck\tk\tp\n' > "$home/state/.wake-queue"
+  before_lock=$(cat "$home/state/.lock")
+  before_wake=$(cat "$home/state/.wake-queue")
+
+  cat > "$home/state/demo-task.meta" <<EOF
+project=$home/projects/FnO
+EOF
+  touch_at "$home/state/demo-task.meta" 2026-09-05 18:30
+
+  FM_HOME="$home" "$FMTIME" propose --since "2026-09-01 00:00" >/dev/null
+  FM_HOME="$home" "$FMTIME" approve p1 >/dev/null
+  FM_HOME="$home" "$FMTIME" report --month 2026-09 >/dev/null
+
+  [ "$(cat "$home/state/.lock")" = "$before_lock" ] || fail "fm-time.sh modified the session lock file"
+  [ "$(cat "$home/state/.wake-queue")" = "$before_wake" ] || fail "fm-time.sh modified the durable wake queue"
+
+  pass "propose/approve/report only read state/.lock and state/.wake-queue, never write them"
+}
+
+test_propose_clusters_synthetic_status_and_meta_evidence
+test_propose_wide_gap_produces_two_windows
+test_propose_refuses_second_batch_without_replace
+test_propose_reads_reported_scout_completions_from_backlog
+test_approve_records_entry_and_advances_cursor
+test_approve_correction_overrides_proposed_fields
+test_reject_drops_without_recording
+test_split_divides_evidence_at_the_boundary
+test_start_stop_records_a_live_session
+test_log_records_a_retroactive_entry
+test_log_without_project_or_task_is_not_blocked
+test_log_refuses_end_before_start
+test_report_groups_by_month_and_splits_after_hours
+test_report_month_boundary_uses_entry_start_date
+test_time_tracking_never_writes_supervision_state

--- a/tests/fm-time.test.sh
+++ b/tests/fm-time.test.sh
@@ -125,6 +125,32 @@ EOF
   pass "propose reads (reported YYYY-MM-DD) scout completions from the backlog, not only (done ...)"
 }
 
+test_propose_reads_merged_completions_from_backlog() {
+  local home
+  home=$(make_home propose-merged)
+
+  # tasks-axi writes "(merged YYYY-MM-DD)" instead of "(done ...)" for a task
+  # closed with `done <id> --pr <url>` (verified against a real tasks-axi
+  # binary); without handling this marker, every PR-linked completion is
+  # invisible to propose.
+  cat > "$home/data/backlog.md" <<'EOF'
+- [x] carry-ship-example - Ship the thing https://github.com/o/r/pull/42 (repo: FnO) (merged 2026-09-05)
+EOF
+
+  local out
+  out=$(FM_HOME="$home" "$FMTIME" propose --since "2026-09-01 00:00") \
+    || fail "propose failed on a (merged ...) backlog completion"
+  assert_contains "$out" "1 proposed window" "a (merged ...) backlog completion produced no proposal"
+
+  local list
+  list=$(FM_HOME="$home" "$FMTIME" list) || fail "list failed"
+  assert_contains "$list" "project  FnO" "merged-completion proposal did not attribute the (repo: ...) project"
+  assert_contains "$list" "task     carry-ship-example" "merged-completion proposal did not attribute the task id"
+  assert_not_contains "$list" "merged 2026-09-05" "merged-completion evidence text leaked the raw marker instead of the description"
+
+  pass "propose reads (merged YYYY-MM-DD) PR completions from the backlog, not only (done ...)"
+}
+
 # ---------------------------------------------------------------- approve / correction
 
 test_approve_records_entry_and_advances_cursor() {
@@ -452,6 +478,7 @@ test_propose_clusters_synthetic_status_and_meta_evidence
 test_propose_wide_gap_produces_two_windows
 test_propose_refuses_second_batch_without_replace
 test_propose_reads_reported_scout_completions_from_backlog
+test_propose_reads_merged_completions_from_backlog
 test_approve_records_entry_and_advances_cursor
 test_approve_correction_overrides_proposed_fields
 test_reject_drops_without_recording

--- a/tests/fm-time.test.sh
+++ b/tests/fm-time.test.sh
@@ -243,13 +243,42 @@ test_start_stop_records_a_live_session() {
 
   local status err
   status=0
-  FM_HOME="$home" "$FMTIME" start --desc again >/dev/null || fail "second start after a stop should succeed"
-  err=$(FM_HOME="$home" "$FMTIME" start --desc other 2>&1 >/dev/null) && status=0 || status=$?
+  FM_HOME="$home" FM_TIME_NOW_OVERRIDE=1788810000 "$FMTIME" start --desc again >/dev/null \
+    || fail "second start after a stop should succeed"
+  err=$(FM_HOME="$home" FM_TIME_NOW_OVERRIDE=1788810000 "$FMTIME" start --desc other 2>&1 >/dev/null) \
+    && status=0 || status=$?
   expect_code 1 "$status" "starting a second live session while one is already running"
   assert_contains "$err" "already running" "double-start refusal used the wrong message"
-  FM_HOME="$home" "$FMTIME" stop >/dev/null
+  FM_HOME="$home" FM_TIME_NOW_OVERRIDE=1788810120 "$FMTIME" stop >/dev/null
 
   pass "start/stop records a live-tracked entry and refuses a concurrent second start"
+}
+
+test_stop_refuses_same_minute_session() {
+  local home out status
+  home=$(make_home live-session-same-minute)
+
+  FM_HOME="$home" FM_TIME_NOW_OVERRIDE=1788800000 "$FMTIME" start --desc "blink" >/dev/null \
+    || fail "start failed"
+
+  status=0
+  out=$(FM_HOME="$home" FM_TIME_NOW_OVERRIDE=1788800000 "$FMTIME" stop 2>&1) || status=$?
+  expect_code 1 "$status" "stop within the same wall-clock minute as start"
+  assert_contains "$out" "wait" "same-minute stop refusal used the wrong message"
+  assert_present "$home/data/time-tracking/active" \
+    "a refused same-minute stop must leave the live session running, not discard it"
+  if [ -e "$home/data/time-tracking/entries.md" ]; then
+    assert_no_grep "blink" "$home/data/time-tracking/entries.md" \
+      "a refused same-minute stop must not record a zero-duration entry"
+  fi
+
+  out=$(FM_HOME="$home" FM_TIME_NOW_OVERRIDE=1788800061 "$FMTIME" stop) \
+    || fail "stop should succeed once a minute has actually elapsed"
+  assert_contains "$out" "stopped" "stop did not report success once past the same-minute window"
+  assert_grep "desc=blink" "$home/data/time-tracking/entries.md" \
+    "session was not recorded once stopped past the same-minute window"
+
+  pass "stop refuses a same-minute session instead of silently recording a lost, zero-duration entry"
 }
 
 test_log_records_a_retroactive_entry() {
@@ -368,6 +397,7 @@ test_approve_correction_overrides_proposed_fields
 test_reject_drops_without_recording
 test_split_divides_evidence_at_the_boundary
 test_start_stop_records_a_live_session
+test_stop_refuses_same_minute_session
 test_log_records_a_retroactive_entry
 test_log_without_project_or_task_is_not_blocked
 test_log_refuses_end_before_start

--- a/tests/fm-time.test.sh
+++ b/tests/fm-time.test.sh
@@ -323,6 +323,66 @@ test_log_refuses_end_before_start() {
   pass "log refuses an entry whose end is not after its start"
 }
 
+# ---------------------------------------------------------------- own lock
+
+test_lock_blocks_while_owner_process_is_still_alive() {
+  local home lock_dir sleeper_pid status err elapsed start_s
+  home=$(make_home lock-live-owner)
+  mkdir -p "$home/data/time-tracking"
+  lock_dir="$home/data/time-tracking/.lock"
+  mkdir "$lock_dir"
+
+  sleep 60 &
+  sleeper_pid=$!
+  printf '%s\n' "$sleeper_pid" > "$lock_dir/pid"
+  # A far-past mtime: an age-only staleness check (the pre-fix behavior)
+  # would treat this as abandoned and steal it even though its recorded
+  # owner is still running.
+  touch -t 202001010000 "$lock_dir"
+
+  status=0
+  start_s=$SECONDS
+  err=$(FM_HOME="$home" "$FMTIME" log --start "2026-09-04 20:00" --end "2026-09-04 20:30" --desc x 2>&1) \
+    || status=$?
+  elapsed=$((SECONDS - start_s))
+
+  kill "$sleeper_pid" 2>/dev/null
+  wait "$sleeper_pid" 2>/dev/null
+
+  expect_code 1 "$status" "log against a lock recorded as held by a still-alive owner"
+  assert_contains "$err" "appears to be running" "a live lock owner's hold was stolen instead of respected"
+  [ "$elapsed" -ge 5 ] || fail "the lock was released far too quickly for a live owner to have been respected (waited ${elapsed}s)"
+
+  pass "tt_lock never reclaims a lock whose recorded owner process is still alive, no matter its age"
+}
+
+test_lock_reclaimed_promptly_from_a_dead_owner() {
+  local home lock_dir dead_pid status out elapsed start_s
+  home=$(make_home lock-dead-owner)
+  mkdir -p "$home/data/time-tracking"
+  lock_dir="$home/data/time-tracking/.lock"
+  mkdir "$lock_dir"
+
+  ( exit 0 ) &
+  dead_pid=$!
+  wait "$dead_pid" 2>/dev/null
+  printf '%s\n' "$dead_pid" > "$lock_dir/pid"
+  # Deliberately fresh mtime: an age-only staleness check would refuse to
+  # reclaim this for LOCK_STALE_SECS even though the recorded owner is
+  # already dead; liveness must decide this, not age.
+
+  start_s=$SECONDS
+  out=$(FM_HOME="$home" "$FMTIME" log --start "2026-09-04 20:00" --end "2026-09-04 20:30" --desc reclaimed 2>&1)
+  status=$?
+  elapsed=$((SECONDS - start_s))
+
+  expect_code 0 "$status" "log against a lock abandoned by a dead owner"
+  assert_contains "$out" "logged" "log did not succeed once the dead owner's lock was reclaimed"
+  [ "$elapsed" -lt 5 ] || fail "a lock with a dead recorded owner should reclaim immediately, not wait out a staleness timer (took ${elapsed}s)"
+
+  pass "tt_lock reclaims a lock immediately once its recorded owner is confirmed dead, even when the lock is fresh"
+}
+
 # ---------------------------------------------------------------- report
 
 test_report_groups_by_month_and_splits_after_hours() {
@@ -401,6 +461,8 @@ test_stop_refuses_same_minute_session
 test_log_records_a_retroactive_entry
 test_log_without_project_or_task_is_not_blocked
 test_log_refuses_end_before_start
+test_lock_blocks_while_owner_process_is_still_alive
+test_lock_reclaimed_promptly_from_a_dead_owner
 test_report_groups_by_month_and_splits_after_hours
 test_report_month_boundary_uses_entry_start_date
 test_time_tracking_never_writes_supervision_state


### PR DESCRIPTION
## Intent

Build time tracking into firstmate so that, in the captains own words, "a tool that tells me at the end of the month, broken down by hours, what I worked on." The monthly report is the product; capture exists to serve it. The captain explicitly chose the capture model when offered manual-only, fully-automatic, or both: firstmate proposes detected work windows from evidence and the captain approves, rejects, or corrects them before anything is recorded - automatic-only was rejected as too noisy, manual-only as too easy to forget.

Deliver a new bin/fm-time.sh (nothing similar existed in bin/ - verified), tracked in git, with its data under gitignored data/ (never state/, which is supervision-owned) and config under gitignored config/, respecting FM_HOME the way other scripts do so a secondmate keeps its own records. Format must survive hand-editing and be diffable, since the captain will correct entries by hand.

Three required surfaces:
1. propose - scan for work windows since the last resolved batch and present them for review, showing the actual evidence for each proposed window rather than presenting a guess as a measurement. What signals are reliable was left to the implementer to establish empirically, not assume; investigated candidates included state/<id>.status and state/<id>.meta mtimes, data/<id>/report.md mtimes, backlog.md/done-archive.md completion markers, the durable wake queue, the session lock (rejected - no history), and project git history (rejected for this version - would only see merged work, not in-flight branches).
2. approve/edit - accept a proposed window, adjust start/end, split it, drop it (reject), or correct its description; approved entries are the durable record, proposals are not.
3. report - month-end view, hours by what was worked on, readable as prose rather than identifiers, with after-hours visibly separated from ordinary hours since that is the specific reason the captain asked (a plain total is much less useful to him than one that separates evenings/weekends from ordinary hours).

Also required: start/stop for live tracking and log for retroactive entry, since detection will miss things and the captain will sometimes know exactly what he did - the tool must not fight him in those cases.

Attribution: infer project and, where one exists, the backlog/task id, since firstmate already knows both, but never let a missing task id block a recording - work happens with no backlog entry and losing it would defeat the purpose. Inferred attribution is a default the captain can correct at approval time.

Judgment calls explicitly left to the implementer, to be decided and justified in the script itself: what counts as one work window (a configurable merge-gap threshold, not hardcoded, with the chosen default and reasoning stated in the help text), and what "after hours" means (a configurable boundary, not a hardcoded work week, with a sensible default).

Constraints: must not interfere with or write to the session lock, the watcher, or any other supervision state (reading is fine); shellcheck-clean with colocated tests per this repos tests/ convention; a --help that stands on its own since the scripts header is the exact-contract owner; no new dependency beyond what the repo already has without an explicit justified case. This is firstmate own shared tracked material, so firstmate-coding-guidelines applies: mechanics live in the scripts own header/--help rather than duplicated into AGENTS.md, and any docs/configuration.md addition stays a minimal pointer rather than a second copy of the contract.

Acceptance criteria: propose surfaces real windows from real signals with evidence shown; approval genuinely gates the record so nothing is recorded without captain acceptance; report produces a month-end breakdown of hours by subject, readable without a key, with after-hours distinguishable; start/stop/log cover what detection misses; records survive hand-editing (duration and after-hours status always recomputed from stored start/end at report time, never trusted from a stored field); tests cover at least a proposal from synthetic signals, an approval, a correction, a retroactive entry, and a month boundary; nothing touches supervision state.

Context specific to this delivery: this continues a prior attempt that was killed mid-task by a machine reboot before it committed or reported anything. Its work survived as a rescued 775-line draft plus colocated tests, explicitly framed as an unvalidated strong draft to be reviewed critically rather than adopted as-is - never shellchecked, never run, never reviewed. The accepted instruction was to copy it into the worktree as bin/fm-time.sh and tests/fm-time.test.sh, then verify the evidence signals it claims to read actually exist and behave as assumed against this repos real data, fixing what does not hold, before treating it as done.

That review surfaced and fixed real defects, which are part of the accepted, current shape of this work: the backlog/done-archive evidence scan matched only tasks-axis "(done YYYY-MM-DD)" completion marker and silently dropped every "(reported YYYY-MM-DD)" marker, which tasks-axi writes for a scout task closed with --report - about a fifth of this repos own archived completions, verified by direct count against data/backlog.md and data/done-archive.md - so that scan now matches both markers. The state/<id>.meta-mtime evidence was labelled "task spawned" even though that file is verified to be rewritten well after spawn by unrelated actions (mode changes, control-relaunch, a merged PRs pr= field), so its evidence text was corrected to the honest "task record touched" rather than asserting a specific lifecycle event a bare mtime cannot prove. The generated --help text described the two window-merge config settings with a "--flag-style" prefix as if they were command-line flags, contradicting both the scripts real flag set and its own later Configuration section using the correct config/ file-name form - corrected to remove that inconsistency. The default same-task merge-gap threshold was reconsidered against this repos own AGENTS.md instruction that crewmate status appends are sparse, phase-only events rather than routine progress - the original 20-minute default would fragment a single continuously-worked task into many needless proposal windows under that real cadence, confirmed by a live dogfooded propose run - so the default was raised to 45 minutes, still fully configurable, with the reasoning stated inline in the script header. Entries with no inferred project or task rendered as a bare "-" in the report; changed to render as "(unattributed)" so the report stays readable prose per the acceptance criteria, without changing the stored on-disk field. A minimal pointer-only subsection was added to docs/configuration.md naming the new config/time-tracking-* keys and data/time-tracking/ location and pointing at the scripts own --help as the mechanics owner, consistent with how other similar per-home settings are documented there; no changes were made to AGENTS.md since this tool is captain-invoked directly and is not part of firstmates own operating loop.

All of the above was verified directly against this repos real files (not assumed): shellcheck-clean, bin/fm-lint.sh clean, bin/fm-doc-audience-check.sh clean, the full colocated test suite passing (15 cases covering proposal clustering including the fixed reported-completion path, approval, correction, rejection, split, live start/stop, retroactive log including an unattributed entry, refusal of an invalid retroactive entry, month-end grouping with after-hours separation, and the month-boundary case), and a manual end-to-end dogfooded run of propose/list/approve/correct/reject/report against a scratch home.

## What Changed

- Added `bin/fm-time.sh`, a new captain-invoked tool that scans this home's own durable evidence (task status/meta mtimes, scout report mtimes, backlog/done-archive completion markers including both "(done ...)" and "(reported ...)" forms, and the wake queue) to propose candidate work windows with their supporting evidence, and records nothing until the captain runs `approve`/`reject`/`split`/`edit` on each proposal; also adds `start`/`stop` for live tracking and `log` for retroactive entries, and a `report` command producing a month-end breakdown of hours by project/task with after-hours time (configurable weekend days and workday start/end) separated from ordinary hours. Records are stored under gitignored `data/time-tracking/` with duration and after-hours status always recomputed from stored start/end at report time. Window merging uses a configurable gap threshold (default 45 minutes) and a per-ping minimum credited duration (default 15 minutes), both documented inline and in `--help`.
- Added `tests/fm-time.test.sh` with colocated coverage for evidence-based proposal clustering (including the reported-completion marker path), approval, correction, rejection, split, live start/stop, retroactive log (including an unattributed entry and rejection of an invalid entry), and month-end reporting with after-hours separation and a month-boundary case.
- Documented the new tool with a minimal pointer in `docs/configuration.md` (new "Time tracking" subsection naming the `config/time-tracking-*` keys and `data/time-tracking/` location, deferring mechanics to the script's own header/`--help`) and added a one-line entry for `fm-time.sh` in `docs/scripts.md`.

## Risk Assessment

⚠️ Medium: The implementation is otherwise excellent - shellcheck/fm-lint/fm-doc-audience-check all clean, no writes to supervision state, and cursor advancement, approval-gating, split, start/stop/log, and report's always-recompute-from-stored-fields behavior were all independently verified correct via direct manual runs - but one well-substantiated correctness bug silently drops evidence for what is likely the most common real completion type (merged-PR ship work), undermining the core propose acceptance criterion for a case the codebase's own other tooling (fm-fleet-snapshot.sh) proves is first-class and common.

## Testing

Ran the repo's own colocated test suite for fm-time.sh (15/15 passing, covering proposal clustering incl. the reported-completion backlog fix, approval, correction, rejection, split, live start/stop, retroactive log incl. an unattributed entry, invalid-entry refusal, and month-end grouping/boundary with after-hours separation), plus shellcheck, fm-lint.sh, and fm-doc-audience-check.sh, all clean. Beyond the test suite, performed a manual end-to-end dogfooded run against a scratch FM_HOME reproducing the product's real usage: propose surfaced real work windows with their underlying evidence lines shown (not just a claimed duration), approve/reject genuinely gated which windows became durable entries, a correction at approval time overrode the proposed start/end/desc, a retroactive log entry was recorded directly, and the month-end report rendered hours by project/task as readable prose with after-hours minutes distinguished from business-hours minutes. Also hand-edited entries.md's plain-text start/end fields directly and reran report, confirming duration and after-hours status are recomputed from the edited values rather than trusted from any stored field, matching the diffable/hand-editable acceptance criterion. No test failures, no environment issues, no findings.

<details>
<summary>Evidence: Manual end-to-end CLI transcript (propose/list/approve/correct/reject/log/report + hand-edit durability check)</summary>

Source: [Manual end-to-end CLI transcript (propose/list/approve/correct/reject/log/report + hand-edit durability check)](https://github.com/adriantoczydlowski/firstmate/blob/b410830e8d36b16b4817b87968807c9f5605a7f7/.no-mistakes/evidence/fm/fm-time-tracking-b/fm-time-manual-transcript.txt)

```text

$ /home/adriantoczydlowski/.no-mistakes/worktrees/ca7813414826/01M2075KRK4SNFEAEZZDT4P1MM/bin/fm-time.sh propose --since 2026-09-01 00:00
3 proposed window(s) since 2026-09-01 00:00 - review with: fm-time.sh list

$ /home/adriantoczydlowski/.no-mistakes/worktrees/ca7813414826/01M2075KRK4SNFEAEZZDT4P1MM/bin/fm-time.sh list
[p1]
  start    2026-09-04 12:00
  end      2026-09-04 12:15
  project  FnO
  task     carry-scout-example
  desc     Diagnose the flaky test data/carry-scout-example/report.md
  evidence: 1788523200 | backlog | Diagnose the flaky test data/carry-scout-example/report.md

[p2]
  start    2026-09-03 09:10
  end      2026-09-03 10:05
  project  FnO
  task     carry-widget-fix
  desc     done: shipped the widget fix
  evidence: 1788426600 | meta | task record touched
  evidence: 1788429000 | status | done: shipped the widget fix

[p3]
  start    2026-09-03 21:00
  end      2026-09-03 21:35
  project  FnO
  task     scout-nightly-check
  desc     done: nightly build is green
  evidence: 1788469200 | meta | task record touched
  evidence: 1788470400 | status | done: nightly build is green

$ /home/adriantoczydlowski/.no-mistakes/worktrees/ca7813414826/01M2075KRK4SNFEAEZZDT4P1MM/bin/fm-time.sh approve p1
approved p1: Diagnose the flaky test data/carry-scout-example/report.md (2026-09-04 12:00 -> 2026-09-04 12:15)

$ /home/adriantoczydlowski/.no-mistakes/worktrees/ca7813414826/01M2075KRK4SNFEAEZZDT4P1MM/bin/fm-time.sh approve p2 --start 2026-09-03 20:45 --end 2026-09-03 21:30 --desc corrected: nightly build check ran longer than pings show
approved p2: corrected: nightly build check ran longer than pings show (2026-09-03 20:45 -> 2026-09-03 21:30)

$ /home/adriantoczydlowski/.no-mistakes/worktrees/ca7813414826/01M2075KRK4SNFEAEZZDT4P1MM/bin/fm-time.sh reject p3
rejected p3

$ /home/adriantoczydlowski/.no-mistakes/worktrees/ca7813414826/01M2075KRK4SNFEAEZZDT4P1MM/bin/fm-time.sh list
no pending proposals. Run: fm-time.sh propose

$ /home/adriantoczydlowski/.no-mistakes/worktrees/ca7813414826/01M2075KRK4SNFEAEZZDT4P1MM/bin/fm-time.sh log --start 2026-09-05 07:00 --end 2026-09-05 07:45 --project FnO --task early-standup-prep --desc retroactive: prepped standup notes before the morning sync
logged: retroactive: prepped standup notes before the morning sync (2026-09-05 07:00 -> 2026-09-05 07:45)

$ /home/adriantoczydlowski/.no-mistakes/worktrees/ca7813414826/01M2075KRK4SNFEAEZZDT4P1MM/bin/fm-time.sh report --month 2026-09
Time tracking report - 2026-09
total: 1h45m tracked across 3 entries
  after hours (weekend or outside 09:00-18:00 local): 1h30m
  business hours: 0h15m

by project / task:
  FnO  1h45m (1h30m after hours)
    carry-scout-example  0h15m
      Diagnose the flaky test data/carry-scout-example/report.md
    carry-widget-fix  0h45m (0h45m after hours)
      corrected: nightly build check ran longer than pings show
    early-standup-prep  0h45m (0h45m after hours)
      retroactive: prepped standup notes before the morning sync

--- hand-edit durability check ---
$ sed -i 's/end=2026-09-05 07:45/end=2026-09-05 09:15/' data/time-tracking/entries.md
(entries.md is plain key=value text, hand-edited directly)

$ fm-time.sh report --month 2026-09   # after hand-edit
Time tracking report - 2026-09
total: 3h15m tracked across 3 entries
  after hours (weekend or outside 09:00-18:00 local): 3h00m
  business hours: 0h15m

by project / task:
  FnO  3h15m (3h00m after hours)
    carry-scout-example  0h15m
      Diagnose the flaky test data/carry-scout-example/report.md
    carry-widget-fix  0h45m (0h45m after hours)
      corrected: nightly build check ran longer than pings show
    early-standup-prep  2h15m (2h15m after hours)
      retroactive: prepped standup notes before the morning sync

Confirms duration/after-hours are recomputed from stored start/end at report
time (early-standup-prep went from 0h45m to 2h15m after only the end= line
was hand-edited; no duration/after-hours field exists to have gone stale).
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"63f2bcfa74da303bf685d74cbd81c04c559392be","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 1 error</summary>

- 🚨 `bin/fm-time.sh:300` - gather_evidence&#39;s backlog/done-archive completion scan (bin/fm-time.sh:279-313) only recognizes &#34;(done YYYY-MM-DD)&#34; and &#34;(reported YYYY-MM-DD)&#34; as completion markers. It silently drops a third marker firstmate&#39;s own tasks-axi backend writes for a normal shipped task closed via a merged PR: &#34;(merged YYYY-MM-DD)&#34;. This is the same class of defect the intent narrative says was already found and fixed once for &#34;reported&#34; (a marker shape the scan didn&#39;t recognize, silently dropping about a fifth of completions) - except &#34;merged&#34; covers ordinary PR-based ship work, arguably the single most common completion type in this repo, per bin/fm-fleet-snapshot.sh&#39;s own production parser (fm-fleet-snapshot.sh:421-424, completion($rest)) which treats merged/reported/done as three co-equal completion verbs on this same file. Confirmed by direct repro: a synthetic data/backlog.md line &#39;- [x] shipped-work - Ordinary landed work (repo: firstmate) (kind: ship) (merged 2026-09-05)&#39; makes `fm-time.sh propose` report &#39;no work windows found&#39; - the shipped work produces zero evidence. This undermines the core acceptance criterion &#39;propose surfaces real windows from real signals with evidence shown&#39; for a large, common category of real work. The fix is mechanical: add a third case arm for &#39;(merged ????-??-??)&#39; mirroring the existing &#39;(reported ...)&#39; arm exactly, including stripping &#39; (merged [0-9-]*)&#39; from the payload at line 309 - no product-behavior judgment call is required since the marker set is an empirical fact already established by fm-fleet-snapshot.sh&#39;s own parser.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `bash tests/fm-time.test.sh (all 15 cases pass: proposal clustering incl. gap threshold and reported-completion backlog markers, approve as-is and with corrections, reject, split, live start/stop with concurrent-start refusal, retroactive log incl. unattributed entry and end-before-start refusal, month-end grouping with after-hours split, month-boundary attribution, and a check that supervision state/.lock and state/.wake-queue are never written)`
- `shellcheck bin/fm-time.sh (clean)`
- `bash bin/fm-lint.sh (repo's own lint owner, clean, including workflow lint)`
- `bash bin/fm-doc-audience-check.sh (clean)`
- `manual scratch-FM_HOME dogfooded run: propose from synthetic state/*.status, state/*.meta, and data/backlog.md '(reported ...)' evidence → list showing real evidence lines → approve one as-is, approve one with start/end/desc corrections, reject one → retroactive log entry → month-end report showing hours by project/task with after-hours separated from business hours`
- `manual hand-edit durability check: directly edited an entries.md 'end=' line by hand and reran report, confirming duration and after-hours are recomputed from the edited start/end rather than any stored/cached field`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
