### PR TITLE
feat(bin): land WIP PR-readiness watcher, stall detector, and you.com search

### DIFF
--- a/bin/fm-pr-ready-arm.sh
+++ b/bin/fm-pr-ready-arm.sh
@@ -40,6 +40,13 @@ mkdir -p "$STATE" 2>/dev/null || { echo "error: state dir unavailable" >&2; exit
 SHIM="$STATE/$ID.check.sh"
 SIDECAR="$STATE/$ID.prs"
 
+# FM_HOME and SIDECAR are arbitrary paths (env- or override-supplied), so
+# %q-escape them before embedding: interpolating them raw into this unquoted
+# heredoc would let a $, backtick, backslash, or double quote in either path
+# reparse as shell when the generated shim runs.
+FM_HOME_Q=$(printf '%q' "$FM_HOME")
+SIDECAR_Q=$(printf '%q' "$SIDECAR")
+
 cat > "$SHIM" <<EOF
 #!/usr/bin/env bash
 # Per-task shim for the generic PR readiness check (bin/fm-pr-ready-check.sh).
@@ -53,8 +60,8 @@ cat > "$SHIM" <<EOF
 # re-registering the trust binding.
 set -u
 ID=$ID
-FM_HOME="$FM_HOME"
-SIDECAR="$SIDECAR"
+FM_HOME=$FM_HOME_Q
+SIDECAR=$SIDECAR_Q
 [ -f "\$SIDECAR" ] && [ ! -L "\$SIDECAR" ] || exit 0
 mapfile -t prs < "\$SIDECAR"
 [ "\${#prs[@]}" -ge 1 ] || exit 0

--- a/bin/fm-pr-ready-arm.sh
+++ b/bin/fm-pr-ready-arm.sh
@@ -10,10 +10,13 @@
 #
 # The PR list lives in the .prs sidecar, so editing it later needs no
 # re-registration; editing the shim itself (this template) does. The watcher
-# executes a hash-verified snapshot of the shim, possibly from a different
-# location than where it was armed, so the id and the sidecar's arm-time path
-# are both baked into the shim literally rather than recomputed relative to
-# the snapshot's own location.
+# executes a hash-verified snapshot of the shim from a temp file inside the
+# same state directory (fm_custom_check_snapshot_prepare), so deriving
+# FM_HOME from that snapshot's own path only happens to work when state is
+# exactly FM_HOME/state; under FM_STATE_OVERRIDE it resolves the wrong
+# installation and the exec below silently never runs. The id, FM_HOME, and
+# the sidecar's arm-time path are therefore all baked into the shim literally
+# rather than recomputed relative to the snapshot's own location.
 set -u
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -40,16 +43,17 @@ SIDECAR="$STATE/$ID.prs"
 cat > "$SHIM" <<EOF
 #!/usr/bin/env bash
 # Per-task shim for the generic PR readiness check (bin/fm-pr-ready-check.sh).
-# Reads the PR list from $SIDECAR, its arm-time path baked in literally (like
-# the id below) so an FM_STATE_OVERRIDE used at arm time is not lost: the
-# watcher executes a hash-verified snapshot of this file, possibly from a
-# different location, so a path recomputed from the snapshot's own location
-# would silently miss a sidecar that was written outside FM_HOME/state.
+# FM_HOME and the PR-list sidecar path are both baked in literally at arm
+# time (like the id below), never re-derived from this file's own path: the
+# watcher executes a hash-verified snapshot of this file from a temp copy
+# inside the state directory, and under FM_STATE_OVERRIDE that state
+# directory need not sit one level below FM_HOME, so a re-derived path can
+# silently resolve to the wrong installation or miss the sidecar entirely.
 # Change the PR list in the .prs sidecar only; changing this shim requires
 # re-registering the trust binding.
 set -u
 ID=$ID
-FM_HOME="\$(cd "\$(dirname "\$0")/.." && pwd)"
+FM_HOME="$FM_HOME"
 SIDECAR="$SIDECAR"
 [ -f "\$SIDECAR" ] && [ ! -L "\$SIDECAR" ] || exit 0
 mapfile -t prs < "\$SIDECAR"

--- a/bin/fm-pr-ready-arm.sh
+++ b/bin/fm-pr-ready-arm.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# Arm a watcher check that wakes firstmate when a set of PRs becomes
+# bors-ready. Writes a thin per-task shim (state/<id>.check.sh), a data
+# sidecar listing the PRs (state/<id>.prs), and binds the shim's bytes with
+# fm-check-register.sh so the watcher may execute it.
+#
+# Usage: fm-pr-ready-arm.sh <id> <pr>...
+#   <id>   task id for this watch (state/<id>.check.sh); reuse to re-arm
+#   <pr>   bare PR number (repo from FM_PR_READY_REPO) or owner/repo#number
+#
+# The PR list lives in the .prs sidecar, so editing it later needs no
+# re-registration; editing the shim itself (this template) does. The watcher
+# executes a hash-verified snapshot of the shim from the state dir, so the id
+# is baked in and paths resolve relative to the snapshot's location.
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FM_HOME="${FM_HOME:-$(cd "$SCRIPT_DIR/.." && pwd)}"
+STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
+
+# shellcheck source=bin/fm-pr-lib.sh
+. "$SCRIPT_DIR/fm-pr-lib.sh"
+
+if [ "$#" -lt 2 ]; then
+  echo "error: usage: fm-pr-ready-arm.sh <id> <pr>..." >&2
+  exit 2
+fi
+ID=$1
+shift
+fm_task_id_creation_valid "$ID" || { echo "error: invalid id: $ID" >&2; exit 2; }
+[ "$#" -ge 1 ] || { echo "error: no PRs given" >&2; exit 2; }
+
+mkdir -p "$STATE" 2>/dev/null || { echo "error: state dir unavailable" >&2; exit 1; }
+
+SHIM="$STATE/$ID.check.sh"
+SIDECAR="$STATE/$ID.prs"
+
+cat > "$SHIM" <<EOF
+#!/usr/bin/env bash
+# Per-task shim for the generic PR readiness check (bin/fm-pr-ready-check.sh).
+# Reads the PR list from state/$ID.prs; the watcher executes a hash-verified
+# snapshot of this file, so the id is baked in and paths resolve from the
+# snapshot's state-dir location. Change the PR list in the .prs sidecar only;
+# changing this shim requires re-registering the trust binding.
+set -u
+ID=$ID
+FM_HOME="\$(cd "\$(dirname "\$0")/.." && pwd)"
+SIDECAR="\$FM_HOME/state/\$ID.prs"
+[ -f "\$SIDECAR" ] && [ ! -L "\$SIDECAR" ] || exit 0
+mapfile -t prs < "\$SIDECAR"
+[ "\${#prs[@]}" -ge 1 ] || exit 0
+exec "\$FM_HOME/bin/fm-pr-ready-check.sh" "\${prs[@]}"
+EOF
+
+chmod 700 "$SHIM" || { echo "error: cannot chmod shim" >&2; exit 1; }
+
+: > "$SIDECAR" || { echo "error: cannot write sidecar" >&2; exit 1; }
+printf '%s\n' "$@" >> "$SIDECAR" || { echo "error: cannot write sidecar" >&2; exit 1; }
+
+"$SCRIPT_DIR/fm-check-register.sh" "$ID" || exit 1
+
+echo "armed: state/$ID.check.sh watching: $*"

--- a/bin/fm-pr-ready-arm.sh
+++ b/bin/fm-pr-ready-arm.sh
@@ -10,8 +10,10 @@
 #
 # The PR list lives in the .prs sidecar, so editing it later needs no
 # re-registration; editing the shim itself (this template) does. The watcher
-# executes a hash-verified snapshot of the shim from the state dir, so the id
-# is baked in and paths resolve relative to the snapshot's location.
+# executes a hash-verified snapshot of the shim, possibly from a different
+# location than where it was armed, so the id and the sidecar's arm-time path
+# are both baked into the shim literally rather than recomputed relative to
+# the snapshot's own location.
 set -u
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -38,14 +40,17 @@ SIDECAR="$STATE/$ID.prs"
 cat > "$SHIM" <<EOF
 #!/usr/bin/env bash
 # Per-task shim for the generic PR readiness check (bin/fm-pr-ready-check.sh).
-# Reads the PR list from state/$ID.prs; the watcher executes a hash-verified
-# snapshot of this file, so the id is baked in and paths resolve from the
-# snapshot's state-dir location. Change the PR list in the .prs sidecar only;
-# changing this shim requires re-registering the trust binding.
+# Reads the PR list from $SIDECAR, its arm-time path baked in literally (like
+# the id below) so an FM_STATE_OVERRIDE used at arm time is not lost: the
+# watcher executes a hash-verified snapshot of this file, possibly from a
+# different location, so a path recomputed from the snapshot's own location
+# would silently miss a sidecar that was written outside FM_HOME/state.
+# Change the PR list in the .prs sidecar only; changing this shim requires
+# re-registering the trust binding.
 set -u
 ID=$ID
 FM_HOME="\$(cd "\$(dirname "\$0")/.." && pwd)"
-SIDECAR="\$FM_HOME/state/\$ID.prs"
+SIDECAR="$SIDECAR"
 [ -f "\$SIDECAR" ] && [ ! -L "\$SIDECAR" ] || exit 0
 mapfile -t prs < "\$SIDECAR"
 [ "\${#prs[@]}" -ge 1 ] || exit 0

--- a/bin/fm-pr-ready-check.sh
+++ b/bin/fm-pr-ready-check.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# Generic bors-readiness watcher for a list of pull requests.
+# Prints one line per PR that newly became bors-ready (state OPEN, mergeable
+# MERGEABLE, no review-blocker label, all checks SUCCESS); prints nothing
+# otherwise, including on every error, so a failed lookup can never be read as
+# a ready PR. Transition-aware: each PR is reported once per distinct head
+# oid, so a re-push that turns it ready again wakes firstmate again.
+#
+# Usage: fm-pr-ready-check.sh [<pr>...]
+#   <pr>            bare PR number (repo from FM_PR_READY_REPO) or
+#                   owner/repo#number
+#
+# Env:
+#   FM_PR_READY_REPO   repo for bare PR numbers; a bare number is skipped
+#                      (silently, per the no-false-positive contract above)
+#                      when this is unset
+#   FM_PR_READY_STATE  marker dir (default FM_HOME/state)
+#
+# Watcher integration: a thin per-task shim (state/<id>.check.sh) reads its PR
+# list from a data sidecar (state/<id>.prs, one PR per line) and execs this
+# script, so the PR list can change without re-binding the check trust. Arm a
+# new watch with bin/fm-pr-ready-arm.sh <id> <pr...>.
+set -u
+
+FM_HOME="${FM_HOME:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+REPO="${FM_PR_READY_REPO:-}"
+MARK_DIR="${FM_PR_READY_STATE:-$FM_HOME/state}"
+MARK="$MARK_DIR/.pr-ready"
+
+mkdir -p "$MARK_DIR" 2>/dev/null || exit 0
+
+
+for arg in "$@"; do
+  case "$arg" in
+    *'#'*)
+      repo=${arg%#*}
+      pr=${arg##*#}
+      ;;
+    ''|*[!0-9]*)
+      continue
+      ;;
+    *)
+      [ -n "$REPO" ] || continue
+      repo=$REPO
+      pr=$arg
+      ;;
+  esac
+  case "$pr" in ''|*[!0-9]*) continue ;; esac
+
+  key="${repo//\//-}#$pr"
+  data=$(gh pr view "$pr" --repo "$repo" --json state,mergeable,headRefOid,labels 2>/dev/null) || continue
+  [ "$(printf '%s' "$data" | jq -r .state)" = OPEN ] || continue
+  [ "$(printf '%s' "$data" | jq -r .mergeable)" = MERGEABLE ] || continue
+  n=$(printf '%s' "$data" | jq -r '[.labels[].name | select(. == "review-blocker")] | length')
+  [ "$n" = 0 ] || continue
+  checks=$(gh pr checks "$pr" --repo "$repo" --json state 2>/dev/null) || continue
+  bad=$(printf '%s' "$checks" | jq -r '[.[] | select(.state != "SUCCESS")] | length')
+  [ "$bad" = 0 ] || continue
+
+  head=$(printf '%s' "$data" | jq -r .headRefOid)
+  prev=$(awk -v k="$key" '$1 == k { print $2; exit }' "$MARK" 2>/dev/null || true)
+  if [ "$prev" != "$head" ]; then
+    printf 'ready: https://github.com/%s/pull/%s (head %s)\n' "$repo" "$pr" "${head:0:10}"
+    printf '%s\t%s\n' "$key" "$head" >> "$MARK"
+  fi
+done

--- a/bin/fm-search.sh
+++ b/bin/fm-search.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# fm-search.sh - you.com web search for firstmate.
+#
+# THE PROBLEM THIS SOLVES: firstmate needs current public facts (pricing, docs,
+# APIs, news) without inventing them from memory. Tavily was the prior tool;
+# its key is absent in this home, so you.com is now the search path.
+#
+# API: you.com Web Search API, https://api.you.com/v1/search
+#   - GET works and is used here (extraction is POST-only and not implemented).
+#   - Auth: X-API-Key header. Key sources, first match wins:
+#       1. $YOUCOM_API_KEY
+#       2. ~/.pi/agent/youcom.key (mode 600; one key on one line)
+#   - Results: results.web[] with url/title/description/snippets[].
+#   - Pricing: $5.00 per 1,000 calls (up to 100 results). See you.com/docs.
+#
+# OUTPUT: one block per result, Markdown-friendly:
+#   ## <title>
+#   <url>
+#   <description>
+#   <snippet>
+#   <snippet>
+# Blank line between results. --json prints the raw API response instead.
+#
+# Usage:
+#   fm-search.sh "<query>" [--count N] [--json] [--freshness day|week|month|year]
+#       Query is required. --count default 5 (max 100).
+#       --freshness filters by recency (day/week/month/year).
+set -u
+
+usage() {
+  cat <<'EOF'
+usage: fm-search.sh "<query>" [--count N] [--freshness day|week|month|year] [--json]
+  Query is required. Results print as Markdown blocks; --json prints raw JSON.
+  Key: $YOUCOM_API_KEY or ~/.pi/agent/youcom.key (mode 600).
+EOF
+}
+
+COUNT=5
+FRESHNESS=""
+JSON_OUT=0
+QUERY=""
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    -h|--help) usage; exit 0 ;;
+    --count) COUNT="${2:-}"; shift 2 ;;
+    --freshness) FRESHNESS="${2:-}"; shift 2 ;;
+    --json) JSON_OUT=1; shift ;;
+    -*) echo "fm-search: unknown option: $1" >&2; usage >&2; exit 2 ;;
+    *) QUERY="$1"; shift ;;
+  esac
+done
+
+[ -n "$QUERY" ] || { usage >&2; exit 2; }
+case "$COUNT" in
+  ''|*[!0-9]*) echo "fm-search: --count must be a number" >&2; exit 2 ;;
+esac
+[ "$COUNT" -ge 1 ] && [ "$COUNT" -le 100 ] || { echo "fm-search: --count must be 1-100" >&2; exit 2; }
+case "$FRESHNESS" in
+  ""|day|week|month|year) ;;
+  *) echo "fm-search: --freshness must be day|week|month|year" >&2; exit 2 ;;
+esac
+
+command -v curl >/dev/null 2>&1 || { echo "fm-search: curl not found" >&2; exit 1; }
+command -v jq >/dev/null 2>&1 || { echo "fm-search: jq not found" >&2; exit 1; }
+
+KEY="${YOUCOM_API_KEY:-}"
+if [ -z "$KEY" ] && [ -f "$HOME/.pi/agent/youcom.key" ]; then
+  KEY="$(tr -d ' \n' < "$HOME/.pi/agent/youcom.key")"
+fi
+[ -n "$KEY" ] || { echo "fm-search: no API key (set YOUCOM_API_KEY or ~/.pi/agent/youcom.key)" >&2; exit 1; }
+
+URL="https://api.you.com/v1/search?query=$(printf '%s' "$QUERY" | jq -sRr @uri)&count=$COUNT"
+[ -n "$FRESHNESS" ] && URL="$URL&freshness=$FRESHNESS"
+
+RESPONSE="$(curl -sS -m 30 "$URL" -H "X-API-Key: $KEY" -H "Accept: application/json" 2>/dev/null)"
+CURL_RC=$?
+if [ $CURL_RC -ne 0 ]; then
+  echo "fm-search: curl failed (rc=$CURL_RC)" >&2
+  exit 1
+fi
+
+if [ "$JSON_OUT" -eq 1 ]; then
+  printf '%s\n' "$RESPONSE"
+  exit 0
+fi
+
+ERROR="$(printf '%s' "$RESPONSE" | jq -r '.error // ""' 2>/dev/null)"
+if [ -n "$ERROR" ]; then
+  echo "fm-search: API error: $ERROR" >&2
+  exit 1
+fi
+
+printf '%s' "$RESPONSE" | jq -r '
+  .results.web[]? |
+  "## \(.title)\n\(.url)\n\(.description // "")\n" +
+  ([.snippets[]? | "> \(.)"] | join("\n"))
+' 2>/dev/null || { echo "fm-search: could not parse response" >&2; exit 1; }

--- a/bin/fm-search.sh
+++ b/bin/fm-search.sh
@@ -5,6 +5,13 @@
 # APIs, news) without inventing them from memory. Tavily was the prior tool;
 # its key is absent in this home, so you.com is now the search path.
 #
+# Intentionally single-vendor for now: this hard-embeds you.com's endpoint,
+# auth, and response shape rather than a provider-adapter abstraction, since
+# no such adapter pattern exists elsewhere in this repo (bin/backends/ is
+# runtime spawn backends, unrelated) and a two-line key-source swap does not
+# by itself justify inventing one. Revisit if a second search provider shows
+# up.
+#
 # API: you.com Web Search API, https://api.you.com/v1/search
 #   - GET works and is used here (extraction is POST-only and not implemented).
 #   - Auth: X-API-Key header. Key sources, first match wins:

--- a/bin/fm-worker-stall-check.sh
+++ b/bin/fm-worker-stall-check.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Stall detector for conflict-fix crewmates: wakes firstmate when a worker's
+# worktree has a FROZEN HEAD with a dirty index past a stall threshold — the
+# "uncommitted merge" trap where tests run against a half-state and fabricate
+# spurious failures (learned on #5495, 2026-08-28).
+#
+# Usage: fm-worker-stall-check.sh <task-id> <worktree-path>
+#   <task-id>       task id; marker written to state/.worker-stall-<task-id>
+#   <worktree-path> the worker's git worktree to inspect
+#
+# Prints ONE line only when firstmate should wake:
+#   stalled: <task> HEAD frozen at <sha> for <n>m with <staged> staged file(s) — merge not committed
+# Silent otherwise (including every error, so a failed read can never read as a stall).
+# Once a stall fires, remove/overwrite the marker to re-arm after resolution.
+#
+# Why git state and not pane activity: token counts and busy panes climb while
+# HEAD is frozen. HEAD==unchanged + index-dirty is the single authoritative
+# signal that a merge was staged but never committed.
+set -u
+
+FM_HOME="${FM_HOME:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
+STALL_MIN=${FM_WORKER_STALL_MIN:-30}   # minutes of frozen HEAD before flagging
+WORKTREE=${2-}
+TASK=${1-}
+
+[ -n "$TASK" ] && [ -n "$WORKTREE" ] || exit 0
+[ -e "$WORKTREE/.git" ] || exit 0   # git worktrees carry a .git FILE (gitdir pointer), not a dir
+
+# Fresh HEAD? Record first-seen and exit silently; only a HEAD that stays
+# frozen across polls can stall.
+head=$(git -C "$WORKTREE" rev-parse --short HEAD 2>/dev/null) || exit 0
+marker="$STATE/.worker-stall-$TASK"
+seen=""
+[ -f "$marker" ] && [ ! -L "$marker" ] && seen=$(cat "$marker" 2>/dev/null || true)
+case "$seen" in
+  "$head"|"$head"*) ;;          # same HEAD as before — measure the freeze
+  *) printf '%s' "$head" > "$marker" 2>/dev/null || exit 0; exit 0 ;;
+esac
+
+# Frozen: how long? Marker holds "sha <epoch>" on repeat sightings.
+now=$(date +%s)
+first_seen=${seen#* }
+case "$first_seen" in
+  ''|*[!0-9]*) first_seen=$now ;;
+esac
+age=$(( (now - first_seen) / 60 ))
+[ "$age" -ge "$STALL_MIN" ] || exit 0
+
+# Frozen past threshold: is there actually an uncommitted merge (staged files)?
+staged=$(git -C "$WORKTREE" diff --cached --name-only 2>/dev/null | wc -l | tr -d ' ')
+[ "${staged:-0}" -ge 1 ] || exit 0
+dirty=$(git -C "$WORKTREE" status --porcelain 2>/dev/null | wc -l | tr -d ' ')
+[ "${dirty:-0}" -ge 1 ] || exit 0
+
+printf 'stalled: %s HEAD frozen at %s for %sm with %s staged file(s) (merge not committed) — tell worker to commit the merge, then test against the committed state\n' \
+  "$TASK" "$head" "$age" "$staged"
+exit 0

--- a/bin/fm-worker-stall-check.sh
+++ b/bin/fm-worker-stall-check.sh
@@ -28,18 +28,20 @@ TASK=${1-}
 [ -e "$WORKTREE/.git" ] || exit 0   # git worktrees carry a .git FILE (gitdir pointer), not a dir
 
 # Fresh HEAD? Record first-seen and exit silently; only a HEAD that stays
-# frozen across polls can stall.
+# frozen across polls can stall. The marker holds "sha epoch-first-seen", and
+# that epoch must be written on the FIRST sighting too, not just later ones -
+# a marker holding only the sha can never yield a nonzero age on a later poll.
 head=$(git -C "$WORKTREE" rev-parse --short HEAD 2>/dev/null) || exit 0
 marker="$STATE/.worker-stall-$TASK"
 seen=""
 [ -f "$marker" ] && [ ! -L "$marker" ] && seen=$(cat "$marker" 2>/dev/null || true)
+now=$(date +%s)
 case "$seen" in
-  "$head"|"$head"*) ;;          # same HEAD as before — measure the freeze
-  *) printf '%s' "$head" > "$marker" 2>/dev/null || exit 0; exit 0 ;;
+  "$head "*) ;;          # same HEAD as before — measure the freeze
+  *) printf '%s %s' "$head" "$now" > "$marker" 2>/dev/null || exit 0; exit 0 ;;
 esac
 
-# Frozen: how long? Marker holds "sha <epoch>" on repeat sightings.
-now=$(date +%s)
+# Frozen: how long, measured against the epoch persisted on first sighting.
 first_seen=${seen#* }
 case "$first_seen" in
   ''|*[!0-9]*) first_seen=$now ;;

--- a/tests/fm-pr-ready-arm.test.sh
+++ b/tests/fm-pr-ready-arm.test.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+# Tests for fm-pr-ready-arm.sh: writes the per-task PR-readiness shim, its
+# .prs sidecar, and binds the shim's bytes through fm-check-register.sh.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+ARM="$ROOT/bin/fm-pr-ready-arm.sh"
+
+new_home() {
+  local home="$1"
+  mkdir -p "$home/state"
+  printf '%s\n' "$home"
+}
+
+test_rejects_too_few_args() {
+  local home
+  home=$(new_home "$TMP_ROOT/too-few")
+  if out=$(FM_HOME="$home" "$ARM" only-id 2>&1); then
+    fail "arm with no PRs must exit nonzero"
+  fi
+  case "$out" in
+    *usage*) pass "missing PRs prints usage" ;;
+    *) fail "expected usage message, got: $out" ;;
+  esac
+}
+
+test_rejects_invalid_id() {
+  local home
+  home=$(new_home "$TMP_ROOT/bad-id")
+  if out=$(FM_HOME="$home" "$ARM" "../escape" 42 2>&1); then
+    fail "arm with a path-unsafe id must exit nonzero"
+  fi
+  case "$out" in
+    *"invalid id"*) pass "path-unsafe id is refused" ;;
+    *) fail "expected invalid id message, got: $out" ;;
+  esac
+}
+
+test_arms_shim_and_sidecar() {
+  local home
+  home=$(new_home "$TMP_ROOT/armed")
+  out=$(FM_HOME="$home" "$ARM" watch1 "acme/widgets#7" "acme/widgets#9" 2>&1) \
+    || fail "arm with valid id and PRs must exit zero: $out"
+
+  [ -f "$home/state/watch1.check.sh" ] || fail "shim was not written"
+  [ -f "$home/state/watch1.prs" ] || fail "sidecar was not written"
+  [ -f "$home/state/watch1.check-trust" ] || fail "check was not registered"
+
+  perm=$(stat -c '%a' "$home/state/watch1.check.sh" 2>/dev/null || stat -f '%Lp' "$home/state/watch1.check.sh")
+  if [ "$perm" = 700 ]; then
+    pass "shim is mode 700"
+  else
+    fail "shim mode was $perm, expected 700"
+  fi
+
+  content=$(cat "$home/state/watch1.prs")
+  case "$content" in
+    *"acme/widgets#7"*"acme/widgets#9"*) pass "sidecar lists both PRs" ;;
+    *) fail "sidecar missing PRs, got: $content" ;;
+  esac
+
+  case "$out" in
+    *"armed: state/watch1.check.sh watching: acme/widgets#7 acme/widgets#9"*) pass "arm confirms watched PRs" ;;
+    *) fail "expected arm confirmation, got: $out" ;;
+  esac
+}
+
+test_shim_execs_check_with_sidecar_prs() {
+  local home
+  home=$(new_home "$TMP_ROOT/exec")
+  mkdir -p "$home/bin"
+  cat > "$home/bin/fm-pr-ready-check.sh" <<'SH'
+#!/usr/bin/env bash
+printf 'called-with: %s\n' "$*"
+SH
+  chmod +x "$home/bin/fm-pr-ready-check.sh"
+  FM_HOME="$home" "$ARM" watch2 "acme/widgets#3" >/dev/null 2>&1 \
+    || fail "arm setup for shim-exec test failed"
+  out=$("$home/state/watch2.check.sh" 2>&1)
+  case "$out" in
+    *"called-with: acme/widgets#3"*) pass "shim execs fm-pr-ready-check.sh with the sidecar's PRs" ;;
+    *) fail "expected shim to forward PRs, got: $out" ;;
+  esac
+}
+
+test_rearm_replaces_sidecar() {
+  local home
+  home=$(new_home "$TMP_ROOT/rearm")
+  FM_HOME="$home" "$ARM" watch3 "acme/widgets#1" >/dev/null 2>&1 \
+    || fail "first arm failed"
+  FM_HOME="$home" "$ARM" watch3 "acme/widgets#2" >/dev/null 2>&1 \
+    || fail "re-arm failed"
+  content=$(cat "$home/state/watch3.prs")
+  case "$content" in
+    *"acme/widgets#2"*)
+      case "$content" in
+        *"acme/widgets#1"*) fail "re-arm should replace the sidecar, still has old PR: $content" ;;
+        *) pass "re-arming replaces the sidecar's PR list" ;;
+      esac
+      ;;
+    *) fail "re-armed sidecar missing new PR, got: $content" ;;
+  esac
+}
+
+TMP_ROOT=$(fm_test_tmproot fm-pr-ready-arm)
+
+test_rejects_too_few_args
+test_rejects_invalid_id
+test_arms_shim_and_sidecar
+test_shim_execs_check_with_sidecar_prs
+test_rearm_replaces_sidecar

--- a/tests/fm-pr-ready-arm.test.sh
+++ b/tests/fm-pr-ready-arm.test.sh
@@ -85,14 +85,17 @@ SH
   esac
 }
 
-# Regression for the state-override-loses-sidecar bug: when FM_STATE_OVERRIDE
-# points somewhere other than FM_HOME/state, the shim must still find the
-# sidecar it was actually written next to, not recompute a $FM_HOME/state
-# path that was never written to.
+# Regression for the state-override-loses-sidecar bug AND the follow-on
+# snapshot-loses-FM_HOME bug: when FM_STATE_OVERRIDE points somewhere that is
+# NOT one level below FM_HOME (the general case; the watcher's real snapshot
+# copy lives inside that same directory too, per
+# fm_custom_check_snapshot_prepare), the shim must still find both its own
+# sidecar and the real fm-pr-ready-check.sh, never a path re-derived from
+# where the shim happens to be running from.
 test_state_override_sidecar_resolves() {
   local home altstate
   home=$(new_home "$TMP_ROOT/override")
-  altstate="$home/altstate"
+  altstate="$TMP_ROOT/override-external-state"
   mkdir -p "$home/bin" "$altstate"
   cat > "$home/bin/fm-pr-ready-check.sh" <<'SH'
 #!/usr/bin/env bash
@@ -106,10 +109,16 @@ SH
   [ -f "$altstate/watch4.prs" ] || fail "sidecar was not written under the state override"
   [ ! -e "$home/state/watch4.prs" ] || fail "sidecar should not land under FM_HOME/state when overridden"
 
-  out=$("$altstate/watch4.check.sh" 2>&1)
+  # Exercise it as a snapshot would: copied to a temp name inside the same
+  # (externally located) state directory, same as
+  # fm_custom_check_snapshot_prepare's `mktemp "$state/.fm-custom-check.XXXXXX"`.
+  snapshot="$altstate/.fm-custom-check.snaptest"
+  cp "$altstate/watch4.check.sh" "$snapshot"
+  chmod 700 "$snapshot"
+  out=$("$snapshot" 2>&1)
   case "$out" in
     *"called-with: acme/widgets#5"*)
-      pass "shim under a state override still finds and forwards its own sidecar" ;;
+      pass "shim run as an externally-rooted snapshot still finds its sidecar and FM_HOME" ;;
     *) fail "expected shim to forward the overridden sidecar's PRs, got: $out" ;;
   esac
 }

--- a/tests/fm-pr-ready-arm.test.sh
+++ b/tests/fm-pr-ready-arm.test.sh
@@ -85,6 +85,35 @@ SH
   esac
 }
 
+# Regression for the state-override-loses-sidecar bug: when FM_STATE_OVERRIDE
+# points somewhere other than FM_HOME/state, the shim must still find the
+# sidecar it was actually written next to, not recompute a $FM_HOME/state
+# path that was never written to.
+test_state_override_sidecar_resolves() {
+  local home altstate
+  home=$(new_home "$TMP_ROOT/override")
+  altstate="$home/altstate"
+  mkdir -p "$home/bin" "$altstate"
+  cat > "$home/bin/fm-pr-ready-check.sh" <<'SH'
+#!/usr/bin/env bash
+printf 'called-with: %s\n' "$*"
+SH
+  chmod +x "$home/bin/fm-pr-ready-check.sh"
+  FM_HOME="$home" FM_STATE_OVERRIDE="$altstate" "$ARM" watch4 "acme/widgets#5" >/dev/null 2>&1 \
+    || fail "arm with a state override failed"
+
+  [ -f "$altstate/watch4.check.sh" ] || fail "shim was not written under the state override"
+  [ -f "$altstate/watch4.prs" ] || fail "sidecar was not written under the state override"
+  [ ! -e "$home/state/watch4.prs" ] || fail "sidecar should not land under FM_HOME/state when overridden"
+
+  out=$("$altstate/watch4.check.sh" 2>&1)
+  case "$out" in
+    *"called-with: acme/widgets#5"*)
+      pass "shim under a state override still finds and forwards its own sidecar" ;;
+    *) fail "expected shim to forward the overridden sidecar's PRs, got: $out" ;;
+  esac
+}
+
 test_rearm_replaces_sidecar() {
   local home
   home=$(new_home "$TMP_ROOT/rearm")
@@ -110,4 +139,5 @@ test_rejects_too_few_args
 test_rejects_invalid_id
 test_arms_shim_and_sidecar
 test_shim_execs_check_with_sidecar_prs
+test_state_override_sidecar_resolves
 test_rearm_replaces_sidecar

--- a/tests/fm-pr-ready-arm.test.sh
+++ b/tests/fm-pr-ready-arm.test.sh
@@ -123,6 +123,49 @@ SH
   esac
 }
 
+# Regression for the unquoted-heredoc-reparse bug: FM_HOME and the sidecar
+# path are baked into the generated shim through an unquoted heredoc, so a
+# raw interpolation would let a $, backtick, or double quote in either path
+# reparse as shell when the shim runs - at minimum breaking the path, at
+# worst executing an embedded command substitution. Give FM_HOME a name
+# containing those characters and prove both that the shim still runs
+# correctly and that nothing it names actually executed. (A literal
+# backslash is deliberately left out: GNU sha256sum escapes its output line
+# for a hashed path containing one, which trips fm-check-lib.sh's unrelated
+# hex-hash format check regardless of this fix - a pre-existing, out-of-scope
+# limitation of the shared custom-check hashing, not of this shim.)
+test_special_chars_in_paths_do_not_reparse() {
+  local home canary1 canary2 special
+  # shellcheck disable=SC2016  # single quotes are deliberate: this must stay
+  # a literal, unexpanded string to become a filesystem path component.
+  special='$(touch CANARY1)`touch CANARY2`"quote"'
+  home="$TMP_ROOT/weird_${special}"
+  mkdir -p "$home/bin" "$home/state"
+  cat > "$home/bin/fm-pr-ready-check.sh" <<'SH'
+#!/usr/bin/env bash
+printf 'called-with: %s\n' "$*"
+SH
+  chmod +x "$home/bin/fm-pr-ready-check.sh"
+  FM_HOME="$home" "$ARM" watch5 "acme/widgets#8" >/dev/null 2>&1 \
+    || fail "arm with a special-character FM_HOME failed"
+
+  out=$("$home/state/watch5.check.sh" 2>&1)
+  case "$out" in
+    *"called-with: acme/widgets#8"*)
+      pass "shim with special characters in FM_HOME still runs and forwards PRs" ;;
+    *) fail "expected shim to forward PRs despite special chars, got: $out" ;;
+  esac
+
+  canary1="$TMP_ROOT/CANARY1"
+  canary2="$TMP_ROOT/CANARY2"
+  if [ -e "$canary1" ] || [ -e "$canary2" ] || \
+     [ -e "$PWD/CANARY1" ] || [ -e "$PWD/CANARY2" ]; then
+    fail "a canary file was created: the shim reparsed an embedded command substitution"
+  else
+    pass "no embedded command substitution executed while arming or running the shim"
+  fi
+}
+
 test_rearm_replaces_sidecar() {
   local home
   home=$(new_home "$TMP_ROOT/rearm")
@@ -149,4 +192,5 @@ test_rejects_invalid_id
 test_arms_shim_and_sidecar
 test_shim_execs_check_with_sidecar_prs
 test_state_override_sidecar_resolves
+test_special_chars_in_paths_do_not_reparse
 test_rearm_replaces_sidecar

--- a/tests/fm-pr-ready-check.test.sh
+++ b/tests/fm-pr-ready-check.test.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+# Tests for fm-pr-ready-check.sh, the generic bors-readiness watcher.
+#
+# gh is faked on PATH so no network call happens; the script's own contract
+# (silent on every non-ready and every error path) is the thing under test,
+# so a case failing to print is as significant as one printing the wrong
+# line.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+CHECK="$ROOT/bin/fm-pr-ready-check.sh"
+TMP_ROOT=$(fm_test_tmproot fm-pr-ready-check)
+FAKEBIN=$(fm_fakebin "$TMP_ROOT")
+export PATH="$FAKEBIN:$PATH"
+
+STATE="$TMP_ROOT/state"
+mkdir -p "$STATE"
+
+assert_silent() {  # <output> <pass-message>
+  if [ -z "$1" ]; then
+    pass "$2"
+  else
+    fail "expected silence, got: $1"
+  fi
+}
+
+# Writes a gh fake that answers `pr view` with the given state/mergeable/
+# labels/head and `pr checks` with the given check states (space-separated,
+# e.g. "SUCCESS SUCCESS" or "SUCCESS FAILURE").
+write_gh() {  # <state> <mergeable> <labels-json-array> <head> <check-states...>
+  local state=$1 mergeable=$2 labels=$3 head=$4
+  shift 4
+  local checks
+  checks=$(printf '{"state":"%s"},' "$@")
+  checks="[${checks%,}]"
+  cat > "$FAKEBIN/gh" <<SH
+#!/usr/bin/env bash
+case "\$1 \$2" in
+  "pr view")
+    printf '%s\n' '{"state":"$state","mergeable":"$mergeable","headRefOid":"$head","labels":$labels}'
+    ;;
+  "pr checks")
+    printf '%s\n' '$checks'
+    ;;
+  *) exit 2 ;;
+esac
+SH
+  chmod +x "$FAKEBIN/gh"
+}
+
+test_bare_number_without_repo_is_silent() {
+  unset FM_PR_READY_REPO
+  write_gh OPEN MERGEABLE '[]' aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa SUCCESS
+  out=$(FM_PR_READY_STATE="$STATE" "$CHECK" 42 2>&1) || fail "bare PR with no repo must not error"
+  assert_silent "$out" "bare PR number with FM_PR_READY_REPO unset prints nothing"
+}
+
+test_owner_repo_hash_number_ready() {
+  write_gh OPEN MERGEABLE '[]' aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa SUCCESS SUCCESS
+  out=$(FM_PR_READY_STATE="$STATE/case-ready" "$CHECK" "acme/widgets#7" 2>&1) \
+    || fail "ready PR must exit zero"
+  case "$out" in
+    *"ready: https://github.com/acme/widgets/pull/7"*"aaaaaaaaaa"*) pass "ready PR reported once" ;;
+    *) fail "expected ready line, got: $out" ;;
+  esac
+}
+
+test_not_open_is_silent() {
+  write_gh CLOSED MERGEABLE '[]' aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa SUCCESS
+  out=$(FM_PR_READY_STATE="$STATE/case-closed" "$CHECK" "acme/widgets#8" 2>&1) \
+    || fail "closed PR check must not error"
+  assert_silent "$out" "non-OPEN PR prints nothing"
+}
+
+test_not_mergeable_is_silent() {
+  write_gh OPEN CONFLICTING '[]' aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa SUCCESS
+  out=$(FM_PR_READY_STATE="$STATE/case-conflict" "$CHECK" "acme/widgets#9" 2>&1) \
+    || fail "conflicting PR check must not error"
+  assert_silent "$out" "non-MERGEABLE PR prints nothing"
+}
+
+test_review_blocker_label_is_silent() {
+  write_gh OPEN MERGEABLE '[{"name":"review-blocker"}]' aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa SUCCESS
+  out=$(FM_PR_READY_STATE="$STATE/case-label" "$CHECK" "acme/widgets#10" 2>&1) \
+    || fail "labeled PR check must not error"
+  assert_silent "$out" "review-blocker label prints nothing"
+}
+
+test_failing_check_is_silent() {
+  write_gh OPEN MERGEABLE '[]' aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa SUCCESS FAILURE
+  out=$(FM_PR_READY_STATE="$STATE/case-failcheck" "$CHECK" "acme/widgets#11" 2>&1) \
+    || fail "failing-checks PR check must not error"
+  assert_silent "$out" "non-SUCCESS check prints nothing"
+}
+
+test_same_head_not_reported_twice() {
+  local mdir="$STATE/case-dedup"
+  write_gh OPEN MERGEABLE '[]' aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa SUCCESS
+  first=$(FM_PR_READY_STATE="$mdir" "$CHECK" "acme/widgets#12" 2>&1)
+  second=$(FM_PR_READY_STATE="$mdir" "$CHECK" "acme/widgets#12" 2>&1)
+  if [ -n "$first" ] && [ -z "$second" ]; then
+    pass "same head is reported only once"
+  else
+    fail "expected first run to report and second to be silent; first=[$first] second=[$second]"
+  fi
+}
+
+test_new_head_reported_again() {
+  local mdir="$STATE/case-repush"
+  write_gh OPEN MERGEABLE '[]' aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa SUCCESS
+  first=$(FM_PR_READY_STATE="$mdir" "$CHECK" "acme/widgets#13" 2>&1)
+  write_gh OPEN MERGEABLE '[]' bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb SUCCESS
+  second=$(FM_PR_READY_STATE="$mdir" "$CHECK" "acme/widgets#13" 2>&1)
+  case "$first$second" in
+    *aaaaaaaaaa*bbbbbbbbbb*) pass "a re-push to a new head is reported again" ;;
+    *) fail "expected both heads reported; first=[$first] second=[$second]" ;;
+  esac
+}
+
+test_bare_number_without_repo_is_silent
+test_owner_repo_hash_number_ready
+test_not_open_is_silent
+test_not_mergeable_is_silent
+test_review_blocker_label_is_silent
+test_failing_check_is_silent
+test_same_head_not_reported_twice
+test_new_head_reported_again

--- a/tests/fm-search.test.sh
+++ b/tests/fm-search.test.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+# Tests for fm-search.sh, the you.com web search wrapper.
+#
+# The network is never touched: a fake curl on PATH answers with a canned
+# you.com /v1/search response, so the cases exercise the wrapper's key
+# resolution, argument validation, and Markdown rendering without an API key
+# or an outbound call. The live API shape is verified by hand on demand
+# (you.com/docs owns the wire contract; the script header names the owner).
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+CHECK="$ROOT/bin/fm-search.sh"
+TMP_ROOT=$(fm_test_tmproot fm-search)
+FAKEBIN=$(fm_fakebin "$TMP_ROOT")
+
+# Canned /v1/search response: two web results with snippets.
+cat > "$FAKEBIN/curl" <<'SH'
+#!/usr/bin/env bash
+cat <<'JSON'
+{"results":{"web":[
+  {"url":"https://example.com/one","title":"First Result","description":"Desc one","snippets":["Snip 1a","Snip 1b"]},
+  {"url":"https://example.com/two","title":"Second Result","description":"Desc two","snippets":["Snip 2a"]}
+]}}
+JSON
+SH
+chmod +x "$FAKEBIN/curl"
+
+# A key file the wrapper reads when YOUCOM_API_KEY is unset.
+KEYDIR="$TMP_ROOT/keyhome"
+mkdir -p "$KEYDIR/.pi/agent"
+printf 'test-key-123\n' > "$KEYDIR/.pi/agent/youcom.key"
+chmod 600 "$KEYDIR/.pi/agent/youcom.key"
+
+export PATH="$FAKEBIN:$PATH"
+export HOME="$KEYDIR"
+unset YOUCOM_API_KEY
+
+test_no_query_refuses() {
+  if out=$(HOME="$KEYDIR" "$CHECK" 2>&1); then
+    fail "no query must exit nonzero"
+  fi
+  case "$out" in
+    *usage:*) pass "no query prints usage" ;;
+    *) fail "no query should print usage, got: $out" ;;
+  esac
+}
+
+test_key_file_fallback_renders_markdown() {
+  out=$(HOME="$KEYDIR" "$CHECK" "test query" --count 2) || fail "search with key-file fallback exits zero"
+  case "$out" in
+    *"## First Result"*"https://example.com/one"*"Desc one"*"> Snip 1a"*) pass "renders first result block" ;;
+    *) fail "first result block missing, got: $out" ;;
+  esac
+  case "$out" in
+    *"## Second Result"*"https://example.com/two"*"> Snip 2a"*) pass "renders second result block" ;;
+    *) fail "second result block missing, got: $out" ;;
+  esac
+}
+
+test_env_key_takes_precedence() {
+  out=$(HOME="$KEYDIR" YOUCOM_API_KEY="env-key" "$CHECK" "test query" --count 2) || fail "search with env key exits zero"
+  if [ -n "$out" ]; then
+    pass "env key path produces output"
+  else
+    fail "env key path produced no output"
+  fi
+}
+
+test_missing_key_refuses() {
+  empty_home="$TMP_ROOT/nokey"
+  mkdir -p "$empty_home"
+  if out=$(HOME="$empty_home" "$CHECK" "test query" 2>&1); then
+    fail "missing key must exit nonzero"
+  fi
+  case "$out" in
+    *"no API key"*) pass "missing key names the fix" ;;
+    *) fail "missing key should name the fix, got: $out" ;;
+  esac
+}
+
+test_invalid_count_refused() {
+  if out=$(HOME="$KEYDIR" "$CHECK" "test query" --count 999 2>&1); then
+    fail "count > 100 must be rejected"
+  fi
+  case "$out" in
+    *"--count must be 1-100"*) pass "count error message clear" ;;
+    *) fail "count error should be clear, got: $out" ;;
+  esac
+}
+
+test_api_error_surfaces() {
+  cat > "$FAKEBIN/curl" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n' '{"error":"invalid request parameter(s)"}'
+SH
+  chmod +x "$FAKEBIN/curl"
+  if out=$(HOME="$KEYDIR" "$CHECK" "test query" 2>&1); then
+    fail "API error must exit nonzero"
+  fi
+  case "$out" in
+    *"API error"*"invalid request"*) pass "API error surfaces the message" ;;
+    *) fail "API error should surface the message, got: $out" ;;
+  esac
+}
+
+test_no_query_refuses
+test_key_file_fallback_renders_markdown
+test_env_key_takes_precedence
+test_missing_key_refuses
+test_invalid_count_refused
+test_api_error_surfaces

--- a/tests/fm-worker-stall-check.test.sh
+++ b/tests/fm-worker-stall-check.test.sh
@@ -54,6 +54,28 @@ test_fresh_head_silent_and_records_marker() {
   fi
 }
 
+# Regression for the age-never-advances bug: the FIRST sighting must persist
+# an epoch alongside the sha, not just the sha. A marker holding only the sha
+# makes every later poll's `${seen#* }` extraction fall through to "now",
+# pinning the computed age at zero forever regardless of real elapsed time.
+test_fresh_marker_persists_epoch() {
+  local dir marker fields
+  dir=$(new_case epoch)
+  run_check "$dir/state" task6 "$dir/wt" >/dev/null 2>&1
+  marker=$(cat "$dir/state/.worker-stall-task6")
+  fields=$(printf '%s' "$marker" | wc -w | tr -d ' ')
+  case "$marker" in
+    *' '[0-9]*)
+      if [ "$fields" = 2 ]; then
+        pass "first-sighting marker persists sha and a numeric epoch"
+      else
+        fail "expected exactly sha+epoch, got: $marker"
+      fi
+      ;;
+    *) fail "first-sighting marker missing a numeric epoch field, got: $marker" ;;
+  esac
+}
+
 test_frozen_under_threshold_silent() {
   local dir
   dir=$(new_case underthresh)
@@ -95,6 +117,7 @@ test_frozen_past_threshold_no_staged_silent() {
 test_missing_args_silent
 test_non_worktree_silent
 test_fresh_head_silent_and_records_marker
+test_fresh_marker_persists_epoch
 test_frozen_under_threshold_silent
 test_frozen_past_threshold_with_staged_reports
 test_frozen_past_threshold_no_staged_silent

--- a/tests/fm-worker-stall-check.test.sh
+++ b/tests/fm-worker-stall-check.test.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+# Tests for fm-worker-stall-check.sh: wakes firstmate only when a worktree's
+# HEAD has stayed frozen past the threshold with a staged, uncommitted merge
+# still pending.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+CHECK="$ROOT/bin/fm-worker-stall-check.sh"
+TMP_ROOT=$(fm_test_tmproot fm-worker-stall-check)
+
+new_case() {  # <name> -> prints case dir with state/ and a one-commit worktree
+  local name=$1 dir
+  dir="$TMP_ROOT/$name"
+  mkdir -p "$dir/state"
+  fm_git_init_commit "$dir/wt"
+  printf '%s\n' "$dir"
+}
+
+run_check() {  # <state-dir> <task> <worktree>
+  FM_STATE_OVERRIDE="$1" "$CHECK" "$2" "$3"
+}
+
+assert_silent() {  # <output> <pass-message>
+  if [ -z "$1" ]; then
+    pass "$2"
+  else
+    fail "expected silence, got: $1"
+  fi
+}
+
+test_missing_args_silent() {
+  out=$("$CHECK" 2>&1) || true
+  assert_silent "$out" "no args prints nothing"
+}
+
+test_non_worktree_silent() {
+  local dir
+  dir=$(new_case notgit)
+  out=$(run_check "$dir/state" task1 "$TMP_ROOT/does-not-exist" 2>&1) || true
+  assert_silent "$out" "a non-worktree path prints nothing"
+}
+
+test_fresh_head_silent_and_records_marker() {
+  local dir
+  dir=$(new_case fresh)
+  out=$(run_check "$dir/state" task2 "$dir/wt" 2>&1)
+  [ -z "$out" ] || fail "first sighting of a HEAD must be silent, got: $out"
+  if [ -f "$dir/state/.worker-stall-task2" ]; then
+    pass "fresh HEAD records a first-seen marker"
+  else
+    fail "expected a first-seen marker to be written"
+  fi
+}
+
+test_frozen_under_threshold_silent() {
+  local dir
+  dir=$(new_case underthresh)
+  run_check "$dir/state" task3 "$dir/wt" >/dev/null 2>&1
+  head=$(git -C "$dir/wt" rev-parse --short HEAD)
+  printf '%s %s\n' "$head" "$(date +%s)" > "$dir/state/.worker-stall-task3"
+  printf 'two\n' > "$dir/wt/merge.txt"
+  git -C "$dir/wt" add merge.txt
+  out=$(FM_WORKER_STALL_MIN=30 run_check "$dir/state" task3 "$dir/wt" 2>&1)
+  assert_silent "$out" "frozen HEAD under the stall threshold stays silent"
+}
+
+test_frozen_past_threshold_with_staged_reports() {
+  local dir head
+  dir=$(new_case pastthresh)
+  run_check "$dir/state" task4 "$dir/wt" >/dev/null 2>&1
+  head=$(git -C "$dir/wt" rev-parse --short HEAD)
+  printf '%s %s\n' "$head" "$(( $(date +%s) - 3600 ))" > "$dir/state/.worker-stall-task4"
+  printf 'two\n' > "$dir/wt/merge.txt"
+  git -C "$dir/wt" add merge.txt
+  out=$(FM_WORKER_STALL_MIN=30 run_check "$dir/state" task4 "$dir/wt" 2>&1)
+  case "$out" in
+    *"stalled: task4 HEAD frozen at $head"*"1 staged file"*)
+      pass "frozen HEAD past threshold with staged files reports a stall" ;;
+    *) fail "expected a stall report, got: $out" ;;
+  esac
+}
+
+test_frozen_past_threshold_no_staged_silent() {
+  local dir head
+  dir=$(new_case cleanpast)
+  run_check "$dir/state" task5 "$dir/wt" >/dev/null 2>&1
+  head=$(git -C "$dir/wt" rev-parse --short HEAD)
+  printf '%s %s\n' "$head" "$(( $(date +%s) - 3600 ))" > "$dir/state/.worker-stall-task5"
+  out=$(FM_WORKER_STALL_MIN=30 run_check "$dir/state" task5 "$dir/wt" 2>&1)
+  assert_silent "$out" "frozen HEAD with a clean index stays silent (no stuck merge)"
+}
+
+test_missing_args_silent
+test_non_worktree_silent
+test_fresh_head_silent_and_records_marker
+test_frozen_under_threshold_silent
+test_frozen_past_threshold_with_staged_reports
+test_frozen_past_threshold_no_staged_silent

--- a/treehouse.toml
+++ b/treehouse.toml
@@ -1,0 +1,6 @@
+max_trees = 16
+root = ""
+
+# Worktree root directory (relative to repo root or absolute path).
+# Worktrees are placed under {root}/.treehouse/. Default: $HOME
+# Example: root = "./"


### PR DESCRIPTION
## Summary
- Commits six files that were written directly in the primary checkout and left uncommitted: `bin/fm-pr-ready-arm.sh` / `bin/fm-pr-ready-check.sh` (generic bors-readiness watcher pair, arming through `fm-check-register.sh`), `bin/fm-worker-stall-check.sh` (frozen-HEAD-with-dirty-index stall detector for conflict-fix crewmates), `bin/fm-search.sh` (you.com web search wrapper, replacing Tavily whose key is absent in this home), and `treehouse.toml` (this repo's own worktree-pool config, matching `treehouse init`'s defaults).
- Fixed during review: removed a hardcoded `Chamber-Hero/memberos` default repo from the PR-readiness scripts — project-specific bleed that doesn't belong in generic firstmate tooling. A bare PR number is now silently skipped unless `FM_PR_READY_REPO` is set.
- Fixed during review: replaced `fm-pr-ready-arm.sh`'s inline task-id regex with the shared `fm_task_id_creation_valid` from `fm-pr-lib.sh`, matching the convention used by `fm-procevent-when.sh` and `fm-check-register.sh` (one-owner rule).
- Added `tests/fm-pr-ready-check.test.sh`, `tests/fm-pr-ready-arm.test.sh`, and `tests/fm-worker-stall-check.test.sh` alongside the existing `tests/fm-search.test.sh`.
- Verified `fm-worker-stall-check.sh` composes with the existing custom-check contract (`state/<id>.check.sh` + `fm-check-register.sh`) already documented in `AGENTS.md`, so no watcher or `AGENTS.md` wiring was added — a caller hand-writes the shim exactly as that section already describes.
- No existing Tavily-based search wrapper or duplicate PR-readiness/stall-check scripts were found in the repo, so nothing else needed updating for the you.com switch.

## Test plan
- [x] `bin/fm-lint.sh` (shellcheck-clean, actionlint-clean)
- [x] `bin/fm-test-run.sh tests/fm-search.test.sh tests/fm-pr-ready-check.test.sh tests/fm-pr-ready-arm.test.sh tests/fm-worker-stall-check.test.sh` — all pass
- [x] `bin/fm-test-run.sh --check-coverage` — new tests picked up