### PR TITLE
test(tests): measure bounded outcome length with jq instead of bash

### DIFF
--- a/tests/fm-public-followup.test.sh
+++ b/tests/fm-public-followup.test.sh
@@ -274,7 +274,7 @@ expect_failure() {
 # non-ASCII characters, and control characters must never survive into the typed
 # event or the thread.
 test_outcome_text_is_bounded_without_corrupting_characters() {
-  local home event text long
+  local home event text long text_length
   home=$(make_home outcome-text)
   seed_commitment "$home" pf-text req-text discord main work-text
 
@@ -300,7 +300,9 @@ test_outcome_text_is_bounded_without_corrupting_characters() {
   event=$(find "$home/state/public-followup/events" -name '*.json' | head -1)
   text=$(jq -r '.public_safe_outcome' "$event") \
     || fail "an over-long outcome must still produce valid JSON"
-  [ "${#text}" -le 600 ] || fail "the outcome text was not bounded, got ${#text} characters"
+  text_length=$(printf '%s' "$text" | jq -Rr 'length') \
+    || fail "the bounded outcome text length could not be measured"
+  [ "$text_length" -le 600 ] || fail "the outcome text was not bounded, got $text_length characters"
   case "$text" in
     *[!é]*) fail "codepoint bounding split a multi-byte character" ;;
   esac


### PR DESCRIPTION
## Intent

Established 2026-09-06 by running the six failing suites on unmodified main (51d2e8c9) in this container, serially: total=6 failed=6. Every one fails on main, so none was caused by the change that surfaced them.

The consequence is larger than six tests. The pipeline test gate fails for EVERY task run in this container, so every future change here starts from red and its author has to re-derive this same baseline to know which failures are theirs. That cost repeats on every task until these are fixed.

Three distinct causes, and only one is a missing tool:

1. `fm-test-run` - ruby is absent from this container and the suite needs it to parse `.github/workflows/ci.yml` as YAML. A container gap, same family as the Chrome, git-lfs, poppler and unixODBC gaps found earlier this week. It belongs in the container definition, not worked around in the test.

2. `fm-session-start` and `fm-bootstrap` - both assert a "MISSING: node" diagnostic while a real node lives at `/usr/bin/node` which their fixture PATH keeps. This is a TEST DEFECT, not an environment one: the fixture fails to isolate PATH, so the test only passes on a machine that happens to lack node.

3. `fm-public-followup` - outcome text was not bounded; it got 1200 characters.

Note the shape of cause 2, because it is the interesting one: a test that passes only because the machine lacks a tool is green for a reason unrelated to the code, and would go red the moment someone installed that tool. It asserts the environment while appearing to assert behaviour.

## What Changed

- In `tests/fm-public-followup.test.sh`, the outcome-bounding test now measures the extracted `public_safe_outcome` length with `jq -Rr 'length'` instead of bash `${#text}`, so the 600-character bound is checked consistently regardless of the shell's locale (bash counts bytes in byte-oriented locales, which overcounts multi-byte characters).

- The measured length is kept in a new `text_length` variable and reused in the failure message, and a measurement failure now fails the test explicitly.

## Risk Assessment

✅ Low: A two-line, locale-independent measurement fix that aligns the test with the emitter's documented codepoint bound, with no silent-failure path reachable and full conformance to the stated intent.

## Testing

Reproduced the reported baseline failure of the 600-codepoint bounding assertion at commit b84e0e3 under the container's POSIX locale (bash counted 1200 bytes for 600 é codepoints), then verified the target commit's jq-based codepoint measurement makes the same focused test pass and the full fm-public-followup suite (73 assertions) green; the still-red fm-test-run suite is the documented ruby container gap outside this change's scope. No UI surface is involved, so no visual artifact applies.

<details>
<summary>Evidence: Baseline (b84e0e3): bounding test fails with &#39;got 1200 characters&#39;</summary>

Source: [Baseline (b84e0e3): bounding test fails with &#39;got 1200 characters&#39;](https://github.com/hajekt2/firstmate/blob/9d58ec8f23a676688c090045f39d122e9c655e11/.no-mistakes/evidence/fm/fm-six-suites-red-on-main-in-agent-container/baseline-bounding-test-fails.txt)

<code>not ok - the outcome text was not bounded, got 1200 characters&#10;exit=1</code>

```text
# Baseline: commit b84e0e3 (before the fix), host locale LC_CTYPE=POSIX so bash ${#} counts bytes
$ FM_TEST_ONLY=test_outcome_text_is_bounded_without_corrupting_characters bash tests/fm-public-followup.test.sh
not ok - the outcome text was not bounded, got 1200 characters
exit=1
```
</details>
<details>
<summary>Evidence: Target (05204f3): bounding test passes with jq codepoint count</summary>

Source: [Target (05204f3): bounding test passes with jq codepoint count](https://github.com/hajekt2/firstmate/blob/9d58ec8f23a676688c090045f39d122e9c655e11/.no-mistakes/evidence/fm/fm-six-suites-red-on-main-in-agent-container/fixed-bounding-test-passes.txt)

```text
# Fixed: commit 05204f3 (target), same host locale
$ FM_TEST_ONLY=test_outcome_text_is_bounded_without_corrupting_characters bash tests/fm-public-followup.test.sh
ok - outcome text is collapsed to one line, bounded by codepoint, and never corrupts characters
exit=0
```
</details>
<details>
<summary>Evidence: Full fm-public-followup suite output at target commit (73/73 ok, exit 0)</summary>

Source: [Full fm-public-followup suite output at target commit (73/73 ok, exit 0)](https://github.com/hajekt2/firstmate/blob/9d58ec8f23a676688c090045f39d122e9c655e11/.no-mistakes/evidence/fm/fm-six-suites-red-on-main-in-agent-container/full-public-followup-suite-passes.txt)

```text
ok - outcome text is collapsed to one line, bounded by codepoint, and never corrupts characters
ok - restart end-to-end: typed result reconciles from disk and delivers one reply to the original thread
ok - duplicate terminal results, restart replay, and repeated delivery are all no-ops
ok - wrong source, wrong work id, stale generation, malformed, unsupported deliverable, and forged identity are all refused
ok - a relay transport failure is held as retryable with no false completion, and the retry posts once
ok - a dry-run records no public delivery and leaves the commitment retryable
ok - a late success receipt closes the exact attempt with no second post, and a mismatched attempt is refused
ok - typed terminal cleanup clears the legacy link without posting
ok - a delivery interrupted between post and receipt refuses to repost
ok - a child home reports typed results but can never become the outward-post owner
ok - typed delivery refuses to post when its cleanup registration is missing
ok - marked secondmate teardown resolves its parent and fails closed when unavailable
ok - local seeding publishes durable parent state before its identity marker
ok - a lost launch-time parent binding is recovered from the durable local record
ok - a durable local parent record does not bypass a genuinely missing parent-side registration
ok - unknown durable parent fields remain forward-compatible
ok - conflicting live and durable parent bindings fail closed
ok - unsafe durable parent records fail closed before cleanup
ok - a NUL-bearing durable parent record fails closed before cleanup
ok - relay-disabled unmarked teardown runs no public-followup work
ok - a marked child proceeds without tasks-axi when its parent relay is disabled
ok - secondmate parent resolution matches the durable registry id literally
ok - traversal-shaped registrations are rejected before path construction or posting
ok - pending keeps registrations when tasks-axi returns malformed JSON
ok - the retained private request context keeps the original thread deliverable after inbox cleanup
ok - cleanup refuses while a public reply is owed and proceeds once it has landed
ok - a relay-disabled home runs no tasks-axi call, prints nothing, and gains no artifact
ok - a relay-enabled home with no commitments makes no backlog call and stays silent
ok - a relay-exhausted follow-up binding is escalated rather than retried into the thread
ok - the relay poll stays inert without a token, silent with no commitments, and surfaces a new result once
ok - startup surfaces unresolved public commitments only in a relay home that owes one
ok - typed public-followup records carry only public-safe summaries and deliverables
ok - dropped-baton regression: delivery retains the loop and pending prints open-loop
ok - CONTROL: the identical teardown REFUSES the moment a commitment is registered
ok - rechain posts the shipped follow-on into the same thread
ok - rechain resumes the same obligation after an interrupted bind
ok - concurrent rechains cannot fork one delivered source
ok - failed rechain retirement keeps the source claimed by one resumable destination
ok - first register succeeds with an empty lock list under /bin/bash
ok - registration replay preserves delivered and retired loop states
ok - redelivery does not report a retired loop as open
ok - retire closes delivered loops after secondmate home removal
ok - retire fails closed for an unbound existing secondmate
ok - retire fails closed when a secondmate ID is reassigned
ok - rechain refuses an unrelated existing destination
ok - pending skips a registration retired during settlement
ok - retire --reason closes the loop and drops the open-loop line
ok - retention creates no false teardown refusal and pending no longer prunes
ok - expiry escalation is pinned by FMX_NOW_OVERRIDE
ok - brief fails explicitly when typed deliverable keys are unavailable
ok - pre-change registrations are open loops and un-rechainable, never a crash
ok - teardown reports an unreconciled legacy Relay link
ok - secondmate promotion matches teardown parent resolution
ok - a public loop bound to a remote secondmate home delivers and retires
ok - delivered remote registrations skip offline collection routes
ok - --force still covers only the unresolved obligation, not the link clear
ok - retire fails closed when a remote route is reassigned
ok - retire fails closed when remote state is unreadable
ok - retire fails closed when remote state is non-writable
ok - retire accepts link absence in non-writable remote state
ok - the guarded remote clear refuses a lock it cannot acquire instead of hanging
ok - an unconfirmed remote clear is unknown completion, never a silent close
ok - a typed terminal result emitted in a remote work home reaches the owning home
ok - an unreachable remote work home fails loudly instead of reporting an empty inbox
ok - an unreadable remote outbox fails collection without losing its result
ok - invalid registration fails collection without dropping the staged result
ok - unsafe registration entries fail collection without dropping staged results
ok - route loss fails brief and consume without dropping the staged result
ok - empty reachable remote collection remains a healthy no-op
ok - remote brief rejects traversal and empty route path components
ok - a local work home's emit path is unchanged
ok - a duplicate report from a remote work home stays a no-op
ok - staging requires the matching secondmate firstmate home
suite exit=0
```
</details>
- Outcome: ⚠️ 1 info across 1 run (17m9s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"05204f3bfbdf0b7fad85e770bd4e39a20a0e7655","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>⚠️ **Test** - 1 info</summary>

- ℹ️ tests/fm-test-run.test.sh still fails in this container with &#39;ruby is required to parse .github/workflows/ci.yml as YAML&#39; because ruby is absent. Per the stated intent this is a container-definition gap, not a defect in this change, and must be fixed in the container image rather than worked around in the test; it remains outstanding after this commit and keeps the pipeline gate red for that suite until the container definition adds ruby.
- <code>`FM_TEST_ONLY=test_outcome_text_is_bounded_without_corrupting_characters bash tests/fm-public-followup.test.sh` at base commit b84e0e3 — reproduces the exact reported failure: `not ok - the outcome text was not bounded, got 1200 characters` (exit 1)</code>
- <code>`FM_TEST_ONLY=test_outcome_text_is_bounded_without_corrupting_characters bash tests/fm-public-followup.test.sh` at target commit 05204f3 — `ok - outcome text is collapsed to one line, bounded by codepoint, and never corrupts characters` (exit 0)</code>
- <code>`bash tests/fm-public-followup.test.sh` — full changed suite, 73 assertions all pass (exit 0), including the non-ASCII collapse, control-character refusal, and multibyte-split guards</code>
- <code>Context checks named in the intent: `bash tests/fm-session-start.test.sh` and `bash tests/fm-bootstrap.test.sh` both pass in this container (their baseline causes appear already resolved); `bash tests/fm-test-run.test.sh` still fails solely on the missing ruby container dependency</code>
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>