### PR TITLE
docs: consolidate agent instruction routing pointers

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,7 +35,7 @@ See the [no-mistakes quick start](https://kunchenguid.github.io/no-mistakes/star
 ## Repo conventions
 
 - This repo is a template for running a firstmate orchestrator agent.
-  [`AGENTS.md`](AGENTS.md) owns the supervisor contract, role boundary, and bundled firstmate skill triggers; `CLAUDE.md` is a real `@AGENTS.md` pointer to it, and `.claude/skills` is a symlink to `.agents/skills`.
+  [`AGENTS.md`](AGENTS.md) owns the supervisor contract; [`docs/agents-routing.md`](docs/agents-routing.md) maps compatibility pointers to their owners.
 - Only shared material is tracked: `AGENTS.md`, `README.md`, `CONTRIBUTING.md`, `.tasks.toml`, `.github/workflows/`, `bin/`, `.agents/skills/`, and `skills/`.
   `.agents/skills/` holds agent-loaded skills that assume a live firstmate home and carry `metadata.internal: true` so installers such as [skills.sh](https://skills.sh) hide them from discovery; `skills/` holds standalone, installer-facing public skills with no firstmate dependency (see the README's "Two-tier skill layout").
   Everything personal to one captain's fleet (`.env`, `data/`, `state/`, `config/`, `projects/`, `.no-mistakes/`) is gitignored; never commit it.

--- a/README.md
+++ b/README.md
@@ -230,7 +230,7 @@ Firstmate's skills live in two separate places with different audiences:
 - [docs/supervision-protocols/](docs/supervision-protocols/) - rendered primary-harness watcher protocols for Claude, Codex, OpenCode, Pi and `pi-signed`, omp, Grok, Cursor, and unknown harness fallback.
 - [docs/scripts.md](docs/scripts.md) - the `bin/` toolbelt reference.
 - [docs/documentation-audiences.md](docs/documentation-audiences.md) - documentation audiences and the machine-checked placement boundary.
-- [`AGENTS.md`](AGENTS.md) - the supervisor contract, role boundary, and routing index for conditional procedures.
+- [Agent-instruction routing](docs/agents-routing.md) - canonical ownership, compatibility, and the bounded surface inventory.
 - [CONTRIBUTING.md](CONTRIBUTING.md) - how to contribute, including the dev/test commands.
 
 ## Contributing

--- a/docs/agents-routing.md
+++ b/docs/agents-routing.md
@@ -1,0 +1,48 @@
+# Agent-instruction routing
+
+`AGENTS.md` is the sole canonical supervisor contract for this repository.
+`CLAUDE.md` is a real two-line `@AGENTS.md` import pointer and must not carry independent instructions.
+The tracked `.claude/skills` link points Claude at `.agents/skills`; the skill files remain the conditional-procedure owners.
+
+## Ownership map
+
+The consolidation changes discovery, not ownership.
+The always-loaded role, safety, startup, routing, delivery, and skill-trigger obligations remain in `AGENTS.md`.
+`docs/configuration.md` remains the owner of top-level operational-home schemas, while each producing script's header and help remain the owner of exact mechanics and mutations.
+`docs/sessionstart-nudge.md`, `docs/subagent-guard.md`, `docs/turnend-guard.md`, and `docs/secondmate-parent-channel.md` retain their native session-start, delegation-boundary, turn-end-backstop, and parent-channel contracts respectively.
+Harness-specific supervision text remains under `docs/supervision-protocols/`, and project instruction migration remains owned by `bin/fm-ensure-agents-md.sh`.
+The public, contributor, and architecture pages below now route readers to this map instead of repeating the `CLAUDE.md` and skill-link compatibility details.
+
+## Bounded inventory
+
+This inventory covers the 13 tracked Markdown routing surfaces that mention the agent-instruction convention.
+It is deliberately finite: it does not treat arbitrary project clones, private homes, generated files, or test fixtures as repository instruction surfaces.
+
+| Surface | Role |
+| --- | --- |
+| `AGENTS.md` | Canonical always-loaded supervisor contract |
+| `CLAUDE.md` | Compatibility pointer to `AGENTS.md` |
+| `CONTRIBUTING.md` | Contributor-facing setup and maintenance pointer |
+| `README.md` | Public setup pointer |
+| `docs/architecture.md` | Maintainer architecture pointer |
+| `docs/configuration.md` | Operator configuration pointer |
+| `docs/scripts.md` | Script ownership pointer |
+| `docs/secondmate-parent-channel.md` | Secondmate return-channel pointer |
+| `docs/sessionstart-nudge.md` | Session-start contract pointer |
+| `docs/subagent-guard.md` | Subagent boundary pointer |
+| `docs/supervision-protocols/grok.md` | Grok-specific supervision pointer |
+| `docs/supervision-protocols/unknown.md` | Fallback supervision pointer |
+| `docs/turnend-guard.md` | Turn-end backstop pointer |
+
+Each row is a pointer or compatibility statement, not a second owner.
+Operational detail belongs to the named script, skill, or documentation owner.
+
+## Compatibility and migration
+
+Existing clones that have a real `CLAUDE.md` pointer continue to resolve `AGENTS.md` without migration.
+`bin/fm-ensure-agents-md.sh` owns creation and migration of project-level `AGENTS.md` and `CLAUDE.md` files; its exact pointer bytes and conflict behavior are the compatibility contract.
+A repository-root `CLAUDE.md` remains a regular file matching the pointer emitted by that public helper.
+A project-level `AGENTS.md` is project-intrinsic memory and is distinct from this repository's supervisor contract.
+No repository instruction is moved, deleted, or inferred from a project-level file by this inventory.
+
+Run `tests/fm-agents-routing.test.sh` to check the inventory, pointer shape, symlink target, and discoverability of the canonical owner.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -4,7 +4,7 @@ How firstmate works, in depth.
 
 The [README](../README.md) carries the high-level diagram and a short synopsis.
 This document expands every part of it.
-firstmate's supervisor contract and routing index for conditional procedures is [`AGENTS.md`](../AGENTS.md); this is the human-facing companion.
+[`agents-routing.md`](agents-routing.md) maps instruction surfaces to canonical owners.
 
 ## Event-driven supervision
 

--- a/docs/documentation-audiences.json
+++ b/docs/documentation-audiences.json
@@ -285,6 +285,10 @@
       "audience": "maintainer-architecture"
     },
     {
+      "path": "docs/agents-routing.md",
+      "audience": "maintainer-architecture"
+    },
+    {
       "path": "docs/arm-pretool-check.md",
       "audience": "maintainer-architecture"
     },

--- a/tests/fm-agents-routing.test.sh
+++ b/tests/fm-agents-routing.test.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# Behavior tests for the repository agent-instruction routing contract.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+DOC="$ROOT/docs/agents-routing.md"
+TMP_ROOT=$(fm_test_tmproot fm-agents-routing)
+
+assert_inventory() {
+  local count
+  count=$(awk 'BEGIN { in_table=0; count=0 }
+    /^\| Surface \| Role \|$/ { in_table=1; next }
+    in_table && /^\| ---/ { next }
+    in_table && /^\|/ { count++; next }
+    in_table && !/^\|/ { exit }
+    END { print count }' "$DOC")
+  [ "$count" -eq 13 ] || fail "routing inventory contains $count surfaces, expected 13"
+  for path in \
+    AGENTS.md CLAUDE.md CONTRIBUTING.md README.md docs/architecture.md \
+    docs/configuration.md docs/scripts.md docs/secondmate-parent-channel.md \
+    docs/sessionstart-nudge.md docs/subagent-guard.md \
+    docs/supervision-protocols/grok.md docs/supervision-protocols/unknown.md \
+    docs/turnend-guard.md; do
+    assert_grep "| \`$path\` |" "$DOC" "routing inventory omitted $path"
+    assert_present "$ROOT/$path" "$path is missing"
+  done
+}
+
+test_inventory_and_canonical_pointer() {
+  local fixture
+  assert_present "$DOC" "routing inventory is missing"
+  assert_inventory
+  [ ! -L "$ROOT/CLAUDE.md" ] || fail "root CLAUDE.md must be a regular pointer file"
+  fixture="$TMP_ROOT/pointer-owner"
+  mkdir -p "$fixture"
+  "$ROOT/bin/fm-ensure-agents-md.sh" "$fixture" >/dev/null 2>&1 || \
+    fail "public migration helper could not create a pointer fixture"
+  cmp -s "$ROOT/CLAUDE.md" "$fixture/CLAUDE.md" || \
+    fail "root CLAUDE.md disagrees with the public migration owner"
+  [ -L "$ROOT/.claude/skills" ] || fail ".claude/skills must remain a symlink"
+  [ "$(readlink "$ROOT/.claude/skills")" = "../.agents/skills" ] || \
+    fail ".claude/skills points at the wrong skill tree"
+  pass "fm-agents-routing: inventory and canonical pointer are valid"
+}
+
+test_discoverability_and_owner_language() {
+  local count
+  assert_grep 'docs/agents-routing.md' "$ROOT/README.md" \
+    "README does not make the routing inventory discoverable"
+  assert_grep 'agents-routing.md' "$ROOT/docs/architecture.md" \
+    "architecture docs do not point at the routing inventory"
+  assert_grep 'sole canonical supervisor contract' "$DOC" \
+    "inventory does not name AGENTS.md as the canonical owner"
+  assert_grep 'bin/fm-ensure-agents-md.sh' "$DOC" \
+    "inventory does not identify the migration owner"
+  for source in "$ROOT/README.md" "$ROOT/CONTRIBUTING.md" "$ROOT/docs/architecture.md"; do
+    count=$(grep -F -c 'agents-routing.md' "$source")
+    [ "$count" -eq 1 ] || fail "${source#"$ROOT/"} has $count routing-inventory pointers, expected one"
+  done
+  assert_grep 'firstmate-coding-guidelines' "$ROOT/AGENTS.md" \
+    "always-loaded contract lost the shared-material skill trigger"
+  assert_grep 'docs/sessionstart-nudge.md' "$ROOT/AGENTS.md" \
+    "always-loaded contract lost the native session-start route"
+  assert_grep 'docs/turnend-guard.md' "$ROOT/AGENTS.md" \
+    "always-loaded contract lost the turn-end backstop route"
+  assert_grep 'docs/secondmate-parent-channel.md' "$ROOT/AGENTS.md" \
+    "always-loaded contract lost the secondmate parent-channel route"
+  pass "fm-agents-routing: canonical ownership and migration remain discoverable"
+}
+
+test_inventory_and_canonical_pointer
+test_discoverability_and_owner_language


### PR DESCRIPTION
Summary
- Consolidate redundant instruction-routing pointers into the canonical ownership map.
- Preserve AGENTS.md as the always-loaded supervisor contract and retain CLAUDE.md/migration compatibility.

Scope
- Add the maintainer-facing 13-surface routing inventory and classify it as maintainer architecture.
- Add public regression coverage for inventory completeness, canonical pointer compatibility, migration behavior, and trigger discoverability.
- No runtime behavior, operational state, or project-memory contract changes.

Validation
- `bash tests/fm-agents-routing.test.sh`
- `bash tests/fm-ensure-agents-md.test.sh`
- `bin/fm-doc-audience-check.sh` (98 surfaces, 357 local links)
- `bin/fm-lint.sh` (ShellCheck 0.11.0, actionlint 1.7.12)
- Fixed consumed-output proxy: 110860 -> 110753 bytes (-107) across README.md, CONTRIBUTING.md, and docs/architecture.md; excludes the new map/test and is not runtime/token savings.

The exact reviewed head is f8c54d67ae6234768ede27f482adc8e4d1072531. Independent review approved that exact head against main with no blocking findings.