### PR TITLE
fix(tests): retire polling processes during fixture teardown

### DIFF
--- a/tests/fm-bearings-board-lavish-live-e2e.test.sh
+++ b/tests/fm-bearings-board-lavish-live-e2e.test.sh
@@ -34,21 +34,27 @@ pass() { printf 'ok - %s\n' "$1"; }
 note() { printf '# %s\n' "$1"; }
 
 LAB=''
+# The guard's board build arms a real listener on the lab board. Ending the
+# session is this file's own business; retiring that listener and removing the
+# lab belong to tests/lib.sh, which is why the lab is a registered fixture root
+# and why every exit path - a passing run, a failed assertion, and a terminating
+# signal - lands here rather than only the happy path.
 cleanup() {
-  [ -z "$LAB" ] || {
-    [ ! -f "$LAB/.lavish/bearings-board.html" ] \
-      || lavish-axi end "$LAB/.lavish/bearings-board.html" >/dev/null 2>&1 || true
-    rm -rf "$LAB"
-  }
+  [ -z "$LAB" ] || [ ! -f "$LAB/.lavish/bearings-board.html" ] \
+    || lavish-axi end "$LAB/.lavish/bearings-board.html" >/dev/null 2>&1 || true
+  fm_test_cleanup
 }
-fail() { printf 'not ok - %s\n' "$1" >&2; cleanup; exit 1; }
+fail() { printf 'not ok - %s\n' "$1" >&2; exit 1; }
 trap cleanup EXIT
+trap 'cleanup; exit 130' INT
+trap 'cleanup; exit 143' TERM
+trap 'cleanup; exit 129' HUP
+trap 'cleanup; exit 131' QUIT
 
 VERSION=$(lavish-axi --version 2>/dev/null | tr -d '[:space:]')
 note "lavish-axi ${VERSION:-version-unknown}"
 
-LAB=$(mktemp -d "${TMPDIR:-/tmp}/fm-bearings-lavish-live.XXXXXX") || fail "cannot create the guard lab"
-LAB=$(cd -P -- "$LAB" && pwd -P)
+LAB=$(fm_test_tmproot fm-bearings-lavish-live) || fail "cannot create the guard lab"
 mkdir -p "$LAB/state" "$LAB/data"
 
 cat > "$LAB/payload.json" <<'JSON'

--- a/tests/fm-bearings-board-lavish-live-e2e.test.sh
+++ b/tests/fm-bearings-board-lavish-live-e2e.test.sh
@@ -55,6 +55,10 @@ VERSION=$(lavish-axi --version 2>/dev/null | tr -d '[:space:]')
 note "lavish-axi ${VERSION:-version-unknown}"
 
 LAB=$(fm_test_tmproot fm-bearings-lavish-live) || fail "cannot create the guard lab"
+# Declared with the exact claim root run_board uses, so teardown retires the
+# listener the board arms even on the paths where the board never reached the
+# point of taking a claim.
+fm_test_track_procevent_home "$LAB" "$LAB/procevent-claims"
 mkdir -p "$LAB/state" "$LAB/data"
 
 cat > "$LAB/payload.json" <<'JSON'

--- a/tests/fm-captain-hold-lifecycle.test.sh
+++ b/tests/fm-captain-hold-lifecycle.test.sh
@@ -19,6 +19,10 @@ command -v tasks-axi >/dev/null 2>&1 || { echo "skip: tasks-axi not found"; exit
 
 make_home() {  # <name>
   local home="$TMP_ROOT/$1" fakebin
+  # Registered with tests/lib.sh, not with a shell array: make_home is called
+  # inside a command substitution, so an array append here never reaches the
+  # caller and every listener run_lavish arms would survive the run.
+  fm_test_track_procevent_home "$home" "$home/procevent-claims"
   mkdir -p "$home/data" "$home/state" "$home/config" "$home/projects"
   cp "$ROOT/.tasks.toml" "$home/.tasks.toml"
   cat > "$home/data/backlog.md" <<'EOF'

--- a/tests/fm-extension-binding.test.sh
+++ b/tests/fm-extension-binding.test.sh
@@ -128,6 +128,7 @@ mkdir -p "$PACKAGES" "$HOMES"
 
 new_home() {
   mkdir -p "$1"
+  fm_test_track_procevent_home "$1" "$FM_PROCEVENT_CLAIM_ROOT"
 }
 
 make_package() {  # <dir> <id> <adapter> [fixed-scenario] [required-consent]

--- a/tests/fm-remote-reply.test.sh
+++ b/tests/fm-remote-reply.test.sh
@@ -14,6 +14,10 @@ REMOTE="$TMP_ROOT/remote"
 FAKEBIN=$(fm_fakebin "$TMP_ROOT/fake")
 CLAIMS="$TMP_ROOT/claims"
 mkdir -p "$PARENT/data" "$PARENT/state" "$REMOTE/state" "$REMOTE/data/reply" "$CLAIMS"
+# The reply relay arms a listener in the parent home. The EXIT path below sweeps
+# it; declaring the home is what retires it when the run is interrupted instead,
+# because that path runs tests/lib.sh's own signal teardown.
+fm_test_track_procevent_home "$PARENT" "$CLAIMS"
 # shellcheck source=bin/fm-remote-job-lib.sh
 . "$ROOT/bin/fm-remote-job-lib.sh"
 # The recorded worker pid is the serving child, not its restart supervisor, so

--- a/tests/fm-remote-secondmate-lifecycle-e2e.test.sh
+++ b/tests/fm-remote-secondmate-lifecycle-e2e.test.sh
@@ -25,6 +25,10 @@ TMUX_LOG="$TMP_ROOT/remote-tmux.log"
 TMUX_STATE="$TMP_ROOT/remote-tmux.state"
 CLAIMS="$TMP_ROOT/claims"
 mkdir -p "$PARENT/data" "$PARENT/state" "$PARENT/config" "$PARENT/projects" "$REMOTE_ROOT" "$CLAIMS"
+# The lifecycle arms a reply listener in the parent home. The EXIT path below
+# sweeps it; declaring the home is what retires it when the run is interrupted
+# instead, because that path runs tests/lib.sh's own signal teardown.
+fm_test_track_procevent_home "$PARENT" "$CLAIMS"
 cleanup() {
   local worker_pid='' wait_attempt=0
   touch "$TMP_ROOT/provision.release" "$TMP_ROOT/seed.release" "$TMP_ROOT/handoff.release" \

--- a/tests/fm-remote-secondmate-parent-binding.test.sh
+++ b/tests/fm-remote-secondmate-parent-binding.test.sh
@@ -48,6 +48,11 @@ HERDR_LOG="$TMP_ROOT/remote-herdr.log"
 CLAIMS="$TMP_ROOT/claims"
 PUBLISH_PID=
 mkdir -p "$PARENT/data" "$PARENT/state" "$PARENT/config" "$PARENT/projects" "$REMOTE_ROOT" "$CLAIMS"
+# Parent binding arms a listener in the parent home. The EXIT trap below sweeps
+# it; declaring the home is what retires it when the run is interrupted
+# instead, because that path runs tests/lib.sh's own signal teardown before the
+# fixture root is removed.
+fm_test_track_procevent_home "$PARENT" "$CLAIMS"
 
 cleanup() {
   local worker_pid=''

--- a/tests/fm-remote-secondmate-trace-context.test.sh
+++ b/tests/fm-remote-secondmate-trace-context.test.sh
@@ -33,6 +33,11 @@ TMUX_LOG="$TMP_ROOT/remote-tmux.log"
 TMUX_STATE="$TMP_ROOT/remote-tmux.state"
 CLAIMS="$TMP_ROOT/claims"
 mkdir -p "$PARENT/data" "$PARENT/state" "$PARENT/config" "$PARENT/projects" "$REMOTE_ROOT" "$CLAIMS"
+# The trace-context relay arms a listener in the parent home. The EXIT trap
+# below sweeps it; declaring the home is what retires it when the run is
+# interrupted instead, because that path runs tests/lib.sh's own signal
+# teardown before the fixture root is removed.
+fm_test_track_procevent_home "$PARENT" "$CLAIMS"
 trap 'FM_HOME="$PARENT" FM_PROCEVENT_CLAIM_ROOT="$CLAIMS" "$ROOT/bin/fm-procevent.sh" sweep-home >/dev/null 2>&1 || true; if [ -f "$TMP_ROOT/remote-jobs/worker.pid" ]; then kill "$(cat "$TMP_ROOT/remote-jobs/worker.pid")" 2>/dev/null || true; fi; rm -rf -- "$TMP_ROOT"' EXIT
 
 # The remote host's tracked code root is this branch, as a real git repository:

--- a/tests/fm-secondmate-safety.test.sh
+++ b/tests/fm-secondmate-safety.test.sh
@@ -2520,6 +2520,7 @@ SH
   PATH="$fakebin:$PATH" FM_HOME="$home" FM_FAKE_TMUX_LOG="$log" \
     FM_FAKE_TMUX_CAPTURE="$TMP_ROOT/taskset-state-absent-fake/pane.txt" \
     XDG_STATE_HOME="$TMP_ROOT/taskset-state-absent-xdg" \
+    FM_PROCEVENT_CLAIM_ROOT="$claim_root" \
     FM_TASK_SET_TEST_READY="$ready" FM_TASK_SET_TEST_RELEASE="$release" \
     "$ROOT/bin/fm-teardown.sh" domain --force >/dev/null 2>"$err" &
   # shellcheck disable=SC2031 # The background PID is captured immediately in this shell.

--- a/tests/fm-test-fixture-cleanup.test.sh
+++ b/tests/fm-test-fixture-cleanup.test.sh
@@ -29,6 +29,28 @@ set -u
 
 LIB="$ROOT/tests/lib.sh"
 
+# The interrupted-run case below holds a live child test process while it waits.
+# That child owns an armed listener, so teardown has to stop it BEFORE the
+# fixture roots go: signalled while its own home still exists, it retires the
+# listener through its own traps. Only this exact pid is ever signalled, and it
+# is cleared the moment the case has waited for it, so a pid the OS has since
+# recycled onto an unrelated process can never be reached from here.
+HELD_LISTENER_CHILD=
+
+cleanup() {
+  if [ -n "$HELD_LISTENER_CHILD" ]; then
+    kill -TERM "$HELD_LISTENER_CHILD" 2>/dev/null || true
+    wait "$HELD_LISTENER_CHILD" 2>/dev/null || true
+    HELD_LISTENER_CHILD=
+  fi
+  fm_test_cleanup
+}
+trap cleanup EXIT
+trap 'cleanup; exit 130' INT
+trap 'cleanup; exit 143' TERM
+trap 'cleanup; exit 129' HUP
+trap 'cleanup; exit 131' QUIT
+
 wait_for_file() {  # <path> [tries]
   local tries=${2:-200}
   while [ "$tries" -gt 0 ]; do
@@ -134,19 +156,20 @@ test_armed_listener_retired_after_failing_exit() {
 }
 
 test_armed_listener_retired_after_sigterm() {
-  local harness pid child_pid child_root
+  local harness pid child_root
   harness=$(fm_test_tmproot fm-test-cleanup-listener-term-harness)
   write_listener_child "$harness"
   run_listener_child "$harness" hold >/dev/null 2>&1 &
-  child_pid=$!
+  HELD_LISTENER_CHILD=$!
   wait_for_file "$harness/child-root" \
     || fail "the child never armed its listener before the wait timed out"
   pid=$(cat "$harness/listener.pid")
   child_root=$(cat "$harness/child-root")
   listener_alive "$pid" "$harness/blocker.sh" \
     || fail "the child's listener was not running before it was interrupted"
-  kill -TERM "$child_pid"
-  wait "$child_pid" 2>/dev/null
+  kill -TERM "$HELD_LISTENER_CHILD"
+  wait "$HELD_LISTENER_CHILD" 2>/dev/null
+  HELD_LISTENER_CHILD=
   assert_absent "$child_root" "an interrupted run left its fixture root behind"
   wait_for_listener_exit "$pid" "$harness/blocker.sh" \
     || fail "an interrupted run left its listener polling a target it had already removed"

--- a/tests/fm-test-fixture-cleanup.test.sh
+++ b/tests/fm-test-fixture-cleanup.test.sh
@@ -8,14 +8,147 @@
 # that exact pattern and assert the fixture root is actually gone once the
 # owning process's guarded teardown has run - on a normal exit and on a
 # terminating signal - plus that a stale marked fixture from a killed prior
-# run gets reaped on the next source. Nothing here inspects tests/lib.sh's
-# source text; it only observes filesystem state around the real helper.
+# run gets reaped on the next source.
+#
+# The last two cases cover the other half of that teardown: a fixture home that
+# armed a real process-event listener. A runner is detached and reparents, so
+# removing the fixture root does not stop it, and a run that ends by failing or
+# by being signalled is exactly the one that used to leave a listener polling a
+# target that no longer existed. Those cases arm a real runner and assert the
+# process is gone, identified by the unique blocker path the case registered.
+#
+# Nothing here inspects tests/lib.sh's source text; it only observes filesystem
+# and process state around the real helper.
 set -u
 
 # shellcheck source=tests/lib.sh
 . "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
 
 LIB="$ROOT/tests/lib.sh"
+
+wait_for_file() {  # <path> [tries]
+  local tries=${2:-200}
+  while [ "$tries" -gt 0 ]; do
+    [ -s "$1" ] && return 0
+    sleep 0.05
+    tries=$((tries - 1))
+  done
+  return 1
+}
+
+# Is the armed listener still running? Identified by the unique blocker path
+# THIS case registered, never by a script or process name: an orphan left by
+# this test has to be distinguishable from any other listener on the machine,
+# including a live one that has nothing to do with the suite.
+listener_alive() {  # <pid> <blocker-path>
+  local args
+  args=$(ps -o args= -p "$1" 2>/dev/null) || return 1
+  case "$args" in *"$2"*) return 0 ;; esac
+  return 1
+}
+
+wait_for_listener_exit() {  # <pid> <blocker-path> [tries]
+  local tries=${3:-200}
+  while [ "$tries" -gt 0 ]; do
+    listener_alive "$1" "$2" || return 0
+    sleep 0.05
+    tries=$((tries - 1))
+  done
+  return 1
+}
+
+# Build a child test process that arms a real detached process-event runner in
+# its own fixture root - the shape every suite that opens a listener uses - and
+# then ends the way its argument names. Two details make the assertion real:
+# the blocker records its pid OUTSIDE the fixture root, so the check survives
+# the root's removal, and the child does not declare its home for reaping, so a
+# suite that forgets that call is exactly what is under test.
+write_listener_child() {  # <harness>
+  local harness=$1
+  cat > "$harness/blocker.sh" <<'SH'
+#!/usr/bin/env bash
+# Records its own pid, then blocks the way a real poll does. The wait is bounded
+# so a stub that escapes its test stops on its own instead of polling forever.
+printf '%s\n' "$$" > "$1"
+while [ "$SECONDS" -lt "${FM_TEST_STUB_MAX_BLOCK_SECONDS:-120}" ]; do sleep 0.2; done
+exit 75
+SH
+  chmod +x "$harness/blocker.sh"
+  cat > "$harness/child.sh" <<'SH'
+#!/usr/bin/env bash
+set -u
+# shellcheck source=tests/lib.sh
+# shellcheck disable=SC1090
+. "$FM_TEST_CHILD_LIB"
+root=$(fm_test_tmproot fm-test-cleanup-listener)
+home="$root/home"
+mkdir -p "$home/state"
+FM_HOME="$home" FM_PROCEVENT_CLAIM_ROOT="$home/procevent-claims" \
+  "$ROOT/bin/fm-procevent.sh" register lavish leaked-src \
+  -- "$FM_TEST_CHILD_BLOCKER" "$FM_TEST_CHILD_PIDFILE" >/dev/null
+FM_HOME="$home" FM_PROCEVENT_CLAIM_ROOT="$home/procevent-claims" \
+  "$ROOT/bin/fm-procevent.sh" reconcile >/dev/null
+tries=200
+while [ ! -s "$FM_TEST_CHILD_PIDFILE" ]; do
+  [ "$tries" -gt 0 ] || { printf 'the listener never started\n' >&2; exit 3; }
+  sleep 0.05
+  tries=$((tries - 1))
+done
+printf '%s\n' "$root" > "$FM_TEST_CHILD_ROOTFILE"
+case "${1-}" in
+  fail) fail "deliberate failure while a listener is armed" ;;
+  hold) while :; do sleep 0.1; done ;;
+esac
+SH
+  chmod +x "$harness/child.sh"
+}
+
+# Replaces the calling shell, so backgrounding this function makes $! the child
+# test process itself. Signalling a wrapper subshell instead would leave the
+# child running and prove nothing about its teardown.
+run_listener_child() {  # <harness> <mode>
+  exec env FM_TEST_CHILD_LIB="$LIB" \
+    FM_TEST_CHILD_BLOCKER="$1/blocker.sh" \
+    FM_TEST_CHILD_PIDFILE="$1/listener.pid" \
+    FM_TEST_CHILD_ROOTFILE="$1/child-root" \
+    bash "$1/child.sh" "$2"
+}
+
+test_armed_listener_retired_after_failing_exit() {
+  local harness rc=0 pid child_root
+  harness=$(fm_test_tmproot fm-test-cleanup-listener-fail-harness)
+  write_listener_child "$harness"
+  ( run_listener_child "$harness" fail ) >/dev/null 2>&1 || rc=$?
+  [ "$rc" -eq 1 ] \
+    || fail "the child never reached its deliberate failure with a listener armed (exit $rc)"
+  wait_for_file "$harness/listener.pid" || fail "the child never recorded its listener"
+  pid=$(cat "$harness/listener.pid")
+  child_root=$(cat "$harness/child-root")
+  assert_absent "$child_root" "a failed test left its fixture root behind"
+  wait_for_listener_exit "$pid" "$harness/blocker.sh" \
+    || fail "a failed test left its listener polling a target it had already removed"
+  pass "a failed test retires the listener it armed"
+}
+
+test_armed_listener_retired_after_sigterm() {
+  local harness pid child_pid child_root
+  harness=$(fm_test_tmproot fm-test-cleanup-listener-term-harness)
+  write_listener_child "$harness"
+  run_listener_child "$harness" hold >/dev/null 2>&1 &
+  child_pid=$!
+  wait_for_file "$harness/child-root" \
+    || fail "the child never armed its listener before the wait timed out"
+  pid=$(cat "$harness/listener.pid")
+  child_root=$(cat "$harness/child-root")
+  listener_alive "$pid" "$harness/blocker.sh" \
+    || fail "the child's listener was not running before it was interrupted"
+  kill -TERM "$child_pid"
+  wait "$child_pid" 2>/dev/null
+  assert_absent "$child_root" "an interrupted run left its fixture root behind"
+  wait_for_listener_exit "$pid" "$harness/blocker.sh" \
+    || fail "an interrupted run left its listener polling a target it had already removed"
+  pass "an interrupted run retires the listener it armed"
+}
 
 test_fixture_root_gone_after_normal_exit() {
   local child_out child_dir
@@ -166,6 +299,8 @@ test_orphan_sweep_reaps_read_only_package_tree() {
 
 test_fixture_root_gone_after_normal_exit
 test_fixture_root_gone_after_sigterm
+test_armed_listener_retired_after_failing_exit
+test_armed_listener_retired_after_sigterm
 test_cleanup_registry_resists_precreation
 test_fixture_registration_failure_rolls_back_root
 test_orphan_sweep_respects_fixture_ownership

--- a/tests/fm-test-fixture-cleanup.test.sh
+++ b/tests/fm-test-fixture-cleanup.test.sh
@@ -16,9 +16,8 @@
 # by being signalled is exactly the one that used to leave a listener polling a
 # target that no longer existed. Those two arm a real runner in a declared home
 # and assert the process is gone, identified by the unique blocker path the case
-# registered. The third pins the containment default that bounds a home nobody
-# declared: with no claim root of its own, a source's claim has to land in the
-# suite-owned root rather than under the running user's own state directory.
+# registered. The third exercises tests/lib.sh's containment default without a
+# per-home claim-root override; its home is declared for teardown.
 #
 # Nothing here inspects tests/lib.sh's source text; it only observes filesystem
 # and process state around the real helper.

--- a/tests/fm-test-fixture-cleanup.test.sh
+++ b/tests/fm-test-fixture-cleanup.test.sh
@@ -32,15 +32,30 @@ LIB="$ROOT/tests/lib.sh"
 # The interrupted-run case below holds a live child test process while it waits.
 # That child owns an armed listener, so teardown has to stop it BEFORE the
 # fixture roots go: signalled while its own home still exists, it retires the
-# listener through its own traps. Only this exact pid is ever signalled, and it
-# is cleared the moment the case has waited for it, so a pid the OS has since
-# recycled onto an unrelated process can never be reached from here.
+# listener through its own traps.
+#
+# The recorded pid alone does not authorize a signal. A child that dies during
+# its own startup can be reaped before this suite ever waits for it, which frees
+# its pid for the operating system to hand to an unrelated process, and killing
+# a stranger from teardown would be a worse defect than the leak. So the pid is
+# signalled only while the kernel still reports it as a child of THIS shell -
+# ownership of that exact recorded identifier, never a process or script name -
+# and it is dropped as soon as the case has waited for it.
 HELD_LISTENER_CHILD=
+
+held_listener_child_is_ours() {
+  local parent
+  [ -n "$HELD_LISTENER_CHILD" ] || return 1
+  parent=$(ps -o ppid= -p "$HELD_LISTENER_CHILD" 2>/dev/null | tr -d '[:space:]')
+  [ -n "$parent" ] && [ "$parent" = "$$" ]
+}
 
 cleanup() {
   if [ -n "$HELD_LISTENER_CHILD" ]; then
-    kill -TERM "$HELD_LISTENER_CHILD" 2>/dev/null || true
-    wait "$HELD_LISTENER_CHILD" 2>/dev/null || true
+    if held_listener_child_is_ours; then
+      kill -TERM "$HELD_LISTENER_CHILD" 2>/dev/null || true
+      wait "$HELD_LISTENER_CHILD" 2>/dev/null || true
+    fi
     HELD_LISTENER_CHILD=
   fi
   fm_test_cleanup

--- a/tests/fm-test-fixture-cleanup.test.sh
+++ b/tests/fm-test-fixture-cleanup.test.sh
@@ -10,12 +10,15 @@
 # terminating signal - plus that a stale marked fixture from a killed prior
 # run gets reaped on the next source.
 #
-# The last two cases cover the other half of that teardown: a fixture home that
+# Three more cases cover the other half of that teardown: a fixture home that
 # armed a real process-event listener. A runner is detached and reparents, so
 # removing the fixture root does not stop it, and a run that ends by failing or
 # by being signalled is exactly the one that used to leave a listener polling a
-# target that no longer existed. Those cases arm a real runner and assert the
-# process is gone, identified by the unique blocker path the case registered.
+# target that no longer existed. Those two arm a real runner in a declared home
+# and assert the process is gone, identified by the unique blocker path the case
+# registered. The third pins the containment default that bounds a home nobody
+# declared: with no claim root of its own, a source's claim has to land in the
+# suite-owned root rather than under the running user's own state directory.
 #
 # Nothing here inspects tests/lib.sh's source text; it only observes filesystem
 # and process state around the real helper.
@@ -58,11 +61,10 @@ wait_for_listener_exit() {  # <pid> <blocker-path> [tries]
 }
 
 # Build a child test process that arms a real detached process-event runner in
-# its own fixture root - the shape every suite that opens a listener uses - and
-# then ends the way its argument names. Two details make the assertion real:
-# the blocker records its pid OUTSIDE the fixture root, so the check survives
-# the root's removal, and the child does not declare its home for reaping, so a
-# suite that forgets that call is exactly what is under test.
+# its own fixture root, declared for reaping the way every suite that opens a
+# listener declares one, and then ends the way its argument names. The blocker
+# records its pid OUTSIDE the fixture root, so the check survives the root's
+# removal and can still name the process after its target is gone.
 write_listener_child() {  # <harness>
   local harness=$1
   cat > "$harness/blocker.sh" <<'SH'
@@ -82,6 +84,7 @@ set -u
 . "$FM_TEST_CHILD_LIB"
 root=$(fm_test_tmproot fm-test-cleanup-listener)
 home="$root/home"
+fm_test_track_procevent_home "$home" "$home/procevent-claims"
 mkdir -p "$home/state"
 FM_HOME="$home" FM_PROCEVENT_CLAIM_ROOT="$home/procevent-claims" \
   "$ROOT/bin/fm-procevent.sh" register lavish leaked-src \
@@ -148,6 +151,43 @@ test_armed_listener_retired_after_sigterm() {
   wait_for_listener_exit "$pid" "$harness/blocker.sh" \
     || fail "an interrupted run left its listener polling a target it had already removed"
   pass "an interrupted run retires the listener it armed"
+}
+
+# A home that names no claim root of its own must still not reach the running
+# user's real claim store. HOME and XDG_STATE_HOME are pointed at a scratch
+# directory, so the pre-fix fallback would resolve there and is observable:
+# either the claim lands under the suite-owned root, or it lands under the
+# scratch state directory this case owns.
+test_undeclared_home_claims_stay_in_the_suite_owned_root() {
+  local root home scratch tries=200
+  root=$(fm_test_tmproot fm-test-cleanup-claim-root)
+  home="$root/home"
+  scratch="$root/scratch"
+  fm_test_track_procevent_home "$home"
+  mkdir -p "$home/state" "$scratch"
+  cat > "$root/blocker.sh" <<'SH'
+#!/usr/bin/env bash
+while [ "$SECONDS" -lt "${FM_TEST_STUB_MAX_BLOCK_SECONDS:-120}" ]; do sleep 0.2; done
+exit 75
+SH
+  chmod +x "$root/blocker.sh"
+  HOME="$scratch" XDG_STATE_HOME="$scratch/state" FM_HOME="$home" \
+    "$ROOT/bin/fm-procevent.sh" register lavish contained-src -- "$root/blocker.sh" >/dev/null \
+    || fail "the undeclared home could not register its source"
+  HOME="$scratch" XDG_STATE_HOME="$scratch/state" FM_HOME="$home" \
+    "$ROOT/bin/fm-procevent.sh" reconcile >/dev/null \
+    || fail "the undeclared home could not start its source"
+  while [ ! -e "$FM_PROCEVENT_CLAIM_ROOT/contained-src.claim" ] && [ "$tries" -gt 0 ]; do
+    sleep 0.05
+    tries=$((tries - 1))
+  done
+  assert_present "$FM_PROCEVENT_CLAIM_ROOT/contained-src.claim" \
+    "an undeclared home's claim did not land in the suite-owned claim root"
+  assert_absent "$scratch/state/firstmate/procevent-claims" \
+    "an undeclared home reached the running user's own procevent claim store"
+  FM_HOME="$home" FM_STATE_OVERRIDE="$home/state" \
+    "$ROOT/bin/fm-procevent.sh" sweep-home >/dev/null 2>&1 || true
+  pass "an undeclared home's claims stay inside the suite-owned claim root"
 }
 
 test_fixture_root_gone_after_normal_exit() {
@@ -301,6 +341,7 @@ test_fixture_root_gone_after_normal_exit
 test_fixture_root_gone_after_sigterm
 test_armed_listener_retired_after_failing_exit
 test_armed_listener_retired_after_sigterm
+test_undeclared_home_claims_stay_in_the_suite_owned_root
 test_cleanup_registry_resists_precreation
 test_fixture_registration_failure_rolls_back_root
 test_orphan_sweep_respects_fixture_ownership

--- a/tests/lib.sh
+++ b/tests/lib.sh
@@ -122,17 +122,21 @@ FM_TEST_OWNER_IDENTITY=$(fm_test_pid_identity "$$") || {
 # ${XDG_STATE_HOME:-$HOME/.local/state}/firstmate/procevent-claims, where they
 # would write into and contend with live runners that have nothing to do with
 # this suite. A suite that sets its own claim root - and a child that inherits
-# one from its parent test process - keeps that value, and only the directory
-# this library created is removed at teardown.
+# one from its parent test process - keeps that value. Teardown removes the
+# exact directory this library created, held in FM_TEST_OWNED_CLAIM_ROOT, and
+# never whatever FM_PROCEVENT_CLAIM_ROOT points at by then: a suite is free to
+# repoint that variable after sourcing, and the path it repoints to is its own
+# to remove.
 
 FM_TEST_PROCEVENT_REGISTRY=$(mktemp "${TMPDIR:-/tmp}/.fm-test-procevent.$$.XXXXXX") || return 1
 
-FM_TEST_OWNS_CLAIM_ROOT=
-[ -n "${FM_PROCEVENT_CLAIM_ROOT:-}" ] || FM_TEST_OWNS_CLAIM_ROOT=1
-: "${FM_PROCEVENT_CLAIM_ROOT:=$(mktemp -d "${TMPDIR:-/tmp}/.fm-test-procevent-claims.$$.XXXXXX")}"
-if [ -z "$FM_PROCEVENT_CLAIM_ROOT" ]; then
-  rm -f "$FM_TEST_CLEANUP_REGISTRY" "$FM_TEST_PROCEVENT_REGISTRY"
-  return 1
+FM_TEST_OWNED_CLAIM_ROOT=
+if [ -z "${FM_PROCEVENT_CLAIM_ROOT:-}" ]; then
+  FM_TEST_OWNED_CLAIM_ROOT=$(mktemp -d "${TMPDIR:-/tmp}/.fm-test-procevent-claims.$$.XXXXXX") || {
+    rm -f "$FM_TEST_CLEANUP_REGISTRY" "$FM_TEST_PROCEVENT_REGISTRY"
+    return 1
+  }
+  FM_PROCEVENT_CLAIM_ROOT=$FM_TEST_OWNED_CLAIM_ROOT
 fi
 export FM_PROCEVENT_CLAIM_ROOT
 
@@ -182,7 +186,7 @@ fm_test_cleanup() {
     done < "$FM_TEST_CLEANUP_REGISTRY"
     rm -f "$FM_TEST_CLEANUP_REGISTRY"
   fi
-  [ -z "${FM_TEST_OWNS_CLAIM_ROOT:-}" ] || rm -rf "$FM_PROCEVENT_CLAIM_ROOT"
+  [ -z "${FM_TEST_OWNED_CLAIM_ROOT:-}" ] || rm -rf "$FM_TEST_OWNED_CLAIM_ROOT"
 }
 
 fm_test_tmproot() {

--- a/tests/lib.sh
+++ b/tests/lib.sh
@@ -67,9 +67,10 @@ pass() {
 # --- self-cleaning temp root ------------------------------------------------
 #
 # fm_test_tmproot <prefix> echoes a fresh temp dir and registers it for removal
-# on EXIT/INT/TERM. A test file that needs extra teardown (e.g. killing a
-# daemon) should define its own EXIT trap and call fm_test_cleanup from inside
-# it so registered dirs are still removed.
+# on EXIT/INT/TERM/HUP/QUIT. A test file that needs extra teardown (e.g. stopping
+# an owned child before its fixture disappears) should route EXIT and those
+# signal traps through that teardown, then call fm_test_cleanup before deleting
+# fixture directories. See tests/fm-test-fixture-cleanup.test.sh.
 #
 # The call site is almost always `TMP_ROOT=$(fm_test_tmproot prefix)`, which
 # forks a subshell to capture stdout. Anything that function does to the
@@ -106,8 +107,9 @@ FM_TEST_OWNER_IDENTITY=$(fm_test_pid_identity "$$") || {
 # survives to poll a target that no longer exists.
 #
 # Reaping is declaration-driven and opt-in: a home is swept only when the suite
-# named it through fm_test_track_procevent_home, and only against the claim root
-# that declaration named. Nothing is discovered, and nothing matches on a script
+# named it through fm_test_track_procevent_home. Pass the claim root used to arm
+# that home's sources; omitting it uses the FM_PROCEVENT_CLAIM_ROOT environment
+# value at cleanup time. Nothing is discovered, and nothing matches on a script
 # or process name, which would reach into another home's live runners.
 # Registration goes through a `$$`-keyed registry file for the same reason the
 # temp roots do - a fixture home is almost always built inside a command
@@ -191,8 +193,8 @@ fm_test_tmproot() {
 # it from fm_test_tmproot keeps one owner for it: it is registered for teardown
 # like every other fixture root, carries the marker identifying this shell, and
 # is reaped as a stale orphan by a later run if this one is killed outright.
-# A value the suite sets, and one a child inherits from its parent test process,
-# is neither created nor removed here.
+# A value already set when this library is sourced, including one inherited
+# from a parent test process, is used without registering its path for removal.
 if [ -z "${FM_PROCEVENT_CLAIM_ROOT:-}" ]; then
   FM_PROCEVENT_CLAIM_ROOT=$(fm_test_tmproot fm-test-procevent-claims) || {
     rm -f "$FM_TEST_CLEANUP_REGISTRY" "$FM_TEST_PROCEVENT_REGISTRY"

--- a/tests/lib.sh
+++ b/tests/lib.sh
@@ -221,6 +221,8 @@ fm_test_reap_orphans() {
   now=$(date +%s)
   for marker in "${TMPDIR:-/tmp}"/fm-*/.fm-test-fixture; do
     [ -e "$marker" ] || continue
+    mtime=$(stat -c %Y "$marker" 2>/dev/null || stat -f %m "$marker" 2>/dev/null) || continue
+    [ $((now - mtime)) -ge "$FM_TEST_ORPHAN_MAX_AGE_SECONDS" ] || continue
     owner_pid=$(sed -n '1p' "$marker" 2>/dev/null) || owner_pid=
     owner_identity=$(sed -n '2,$p' "$marker" 2>/dev/null) || owner_identity=
     case "$owner_pid" in
@@ -232,8 +234,6 @@ fm_test_reap_orphans() {
         fi
         ;;
     esac
-    mtime=$(stat -c %Y "$marker" 2>/dev/null || stat -f %m "$marker" 2>/dev/null) || continue
-    [ $((now - mtime)) -ge "$FM_TEST_ORPHAN_MAX_AGE_SECONDS" ] || continue
     dir=$(dirname "$marker")
     if [ -d "$dir" ] && [ ! -L "$dir" ]; then
       find "$dir" -type d -exec chmod u+rwx {} + 2>/dev/null || true

--- a/tests/lib.sh
+++ b/tests/lib.sh
@@ -105,98 +105,59 @@ FM_TEST_OWNER_IDENTITY=$(fm_test_pid_identity "$$") || {
 # fails, or by a run that is signalled part way through, is exactly the one that
 # survives to poll a target that no longer exists.
 #
-# Teardown finds a home two ways, and needs both:
+# Reaping is declaration-driven and opt-in: a home is swept only when the suite
+# named it through fm_test_track_procevent_home, and only against the claim root
+# that declaration named. Nothing is discovered, and nothing matches on a script
+# or process name, which would reach into another home's live runners.
+# Registration goes through a `$$`-keyed registry file for the same reason the
+# temp roots do - a fixture home is almost always built inside a command
+# substitution (`home=$(make_home x)`), and an array append there never reaches
+# the caller, so a suite that tracked its homes in a shell array was silently
+# tracking nothing and left every runner it started behind.
 #
-#   - Discovery. Every fixture root fm_test_tmproot created for this run is
-#     searched for the state/procevent directory an armed source leaves behind.
-#     A suite therefore cannot leak a listener by forgetting to declare its home,
-#     which is how the leak this guards kept coming back.
-#   - Declaration, through fm_test_track_procevent_home, for a home that is NOT
-#     inside one of those roots, or that needs a claim root discovery cannot
-#     infer. It goes through a `$$`-keyed registry file for the same reason the
-#     temp roots do - a fixture home is almost always built inside a command
-#     substitution (`home=$(make_home x)`), and an array append there never
-#     reaches the caller, so a suite that tracked its homes in a shell array was
-#     silently tracking nothing.
-#
-# Both paths sweep the exact home (and its claim root when the suite uses a
-# private one), and discovery never leaves the fixture roots this run created.
-# Nothing here matches on a script or process name, which would reach into
-# another home's live runners.
+# A suite that forgets to declare still leaks its runner. What bounds that leak
+# is the claim root: FM_PROCEVENT_CLAIM_ROOT defaults here to a private per-run
+# directory this library owns, so an undeclared home's claims and locks land in
+# a fixture directory instead of the developer's real
+# ${XDG_STATE_HOME:-$HOME/.local/state}/firstmate/procevent-claims, where they
+# would write into and contend with live runners that have nothing to do with
+# this suite. A suite that sets its own claim root - and a child that inherits
+# one from its parent test process - keeps that value, and only the directory
+# this library created is removed at teardown.
 
 FM_TEST_PROCEVENT_REGISTRY=$(mktemp "${TMPDIR:-/tmp}/.fm-test-procevent.$$.XXXXXX") || return 1
+
+FM_TEST_OWNS_CLAIM_ROOT=
+[ -n "${FM_PROCEVENT_CLAIM_ROOT:-}" ] || FM_TEST_OWNS_CLAIM_ROOT=1
+: "${FM_PROCEVENT_CLAIM_ROOT:=$(mktemp -d "${TMPDIR:-/tmp}/.fm-test-procevent-claims.$$.XXXXXX")}"
+if [ -z "$FM_PROCEVENT_CLAIM_ROOT" ]; then
+  rm -f "$FM_TEST_CLEANUP_REGISTRY" "$FM_TEST_PROCEVENT_REGISTRY"
+  return 1
+fi
+export FM_PROCEVENT_CLAIM_ROOT
 
 fm_test_track_procevent_home() {  # <home> [claim-root]
   [ -n "${1:-}" ] || return 1
   printf '%s\t%s\n' "$1" "${2-}" >> "$FM_TEST_PROCEVENT_REGISTRY"
 }
 
-# Retire one fixture home's registered sources and stop the runners it owns.
-# A private claim root is used when the caller names one, and otherwise when the
-# home carries the `procevent-claims` directory this suite's fixtures put beside
-# their state; anything else keeps whatever claim root the suite exported.
-fm_test_sweep_procevent_home() {  # <home> [claim-root]
-  local home=$1 claim_root=${2-}
-  [ -n "$home" ] && [ -d "$home/state/procevent" ] || return 0
-  if [ -z "$claim_root" ] && [ -d "$home/procevent-claims" ]; then
-    claim_root="$home/procevent-claims"
-  fi
-  if [ -n "$claim_root" ]; then
-    FM_HOME="$home" FM_STATE_OVERRIDE="$home/state" FM_PROCEVENT_CLAIM_ROOT="$claim_root" \
-      "$ROOT/bin/fm-procevent.sh" sweep-home >/dev/null 2>&1 || true
-  else
-    FM_HOME="$home" FM_STATE_OVERRIDE="$home/state" \
-      "$ROOT/bin/fm-procevent.sh" sweep-home >/dev/null 2>&1 || true
-  fi
-}
-
-# Print every process-event home inside one fixture root. Bounded to that root
-# and to a shallow depth, and it never follows a symlink out of it, so the scan
-# stays proportionate and can only reach homes this run created. Repository
-# checkouts and package trees a fixture copies in are pruned rather than walked.
-fm_test_procevent_homes_under() {  # <fixture-root>
-  local root=$1 dir
-  [ -n "$root" ] && [ -d "$root" ] || return 0
-  while IFS= read -r dir; do
-    [ -n "$dir" ] || continue
-    printf '%s\n' "${dir%/state/procevent}"
-  done < <(find "$root" -maxdepth 6 \
-    \( -name .git -o -name node_modules \) -prune -o \
-    -type d -path '*/state/procevent' -print 2>/dev/null)
-}
-
-# Sweep every process-event home discovered inside one fixture root. Reads and
-# extends its caller's `seen` list so a home reached twice - declared and then
-# discovered, or held in both root registries - is swept once.
-fm_test_sweep_discovered_procevent_homes() {  # <fixture-root>
-  local home
-  while IFS= read -r home; do
+fm_test_reap_procevent_homes() {
+  local home claim_root seen=$'\n'
+  [ -f "$FM_TEST_PROCEVENT_REGISTRY" ] || return 0
+  while IFS=$'\t' read -r home claim_root; do
+    [ -n "$home" ] || continue
     case "$seen" in *$'\n'"$home"$'\n'*) continue ;; esac
     seen+="$home"$'\n'
-    fm_test_sweep_procevent_home "$home"
-  done < <(fm_test_procevent_homes_under "$1")
-}
-
-fm_test_reap_procevent_homes() {
-  local home claim_root root seen=$'\n'
-  if [ -f "$FM_TEST_PROCEVENT_REGISTRY" ]; then
-    while IFS=$'\t' read -r home claim_root; do
-      [ -n "$home" ] || continue
-      case "$seen" in *$'\n'"$home"$'\n'*) continue ;; esac
-      seen+="$home"$'\n'
-      fm_test_sweep_procevent_home "$home" "$claim_root"
-    done < "$FM_TEST_PROCEVENT_REGISTRY"
-    rm -f "$FM_TEST_PROCEVENT_REGISTRY"
-  fi
-  for root in "${FM_TEST_CLEANUP_DIRS[@]:-}"; do
-    [ -n "$root" ] || continue
-    fm_test_sweep_discovered_procevent_homes "$root"
-  done
-  [ -f "$FM_TEST_CLEANUP_REGISTRY" ] || return 0
-  while IFS= read -r root; do
-    [ -n "$root" ] || continue
-    fm_test_sweep_discovered_procevent_homes "$root"
-  done < "$FM_TEST_CLEANUP_REGISTRY"
+    [ -d "$home/state/procevent" ] || continue
+    if [ -n "$claim_root" ]; then
+      FM_HOME="$home" FM_STATE_OVERRIDE="$home/state" FM_PROCEVENT_CLAIM_ROOT="$claim_root" \
+        "$ROOT/bin/fm-procevent.sh" sweep-home >/dev/null 2>&1 || true
+    else
+      FM_HOME="$home" FM_STATE_OVERRIDE="$home/state" \
+        "$ROOT/bin/fm-procevent.sh" sweep-home >/dev/null 2>&1 || true
+    fi
+  done < "$FM_TEST_PROCEVENT_REGISTRY"
+  rm -f "$FM_TEST_PROCEVENT_REGISTRY"
 }
 
 # Ceiling on how long a fixture's blocking stub may keep polling. A stub that
@@ -221,6 +182,7 @@ fm_test_cleanup() {
     done < "$FM_TEST_CLEANUP_REGISTRY"
     rm -f "$FM_TEST_CLEANUP_REGISTRY"
   fi
+  [ -z "${FM_TEST_OWNS_CLAIM_ROOT:-}" ] || rm -rf "$FM_PROCEVENT_CLAIM_ROOT"
 }
 
 fm_test_tmproot() {

--- a/tests/lib.sh
+++ b/tests/lib.sh
@@ -100,15 +100,29 @@ FM_TEST_OWNER_IDENTITY=$(fm_test_pid_identity "$$") || {
 #
 # A process-event runner is detached into its own process group and reparents to
 # init, so removing a fixture directory does not stop one: only sweeping the home
-# that owns it does. Registration goes through a `$$`-keyed registry file for the
-# same reason the temp roots do - a fixture home is almost always built inside a
-# command substitution (`home=$(make_home x)`), and an array append there never
-# reaches the caller, so a suite that tracked its homes in a shell array was
-# silently tracking nothing and left every runner it started behind.
+# that owns it does. That is why the sweep runs from every teardown path here
+# rather than from a suite's happy path - a listener armed by a case that then
+# fails, or by a run that is signalled part way through, is exactly the one that
+# survives to poll a target that no longer exists.
 #
-# The sweep is scoped to the exact home (and its claim root when the suite uses a
-# private one). It never matches on a script or process name, which would reach
-# into another home's live runners.
+# Teardown finds a home two ways, and needs both:
+#
+#   - Discovery. Every fixture root fm_test_tmproot created for this run is
+#     searched for the state/procevent directory an armed source leaves behind.
+#     A suite therefore cannot leak a listener by forgetting to declare its home,
+#     which is how the leak this guards kept coming back.
+#   - Declaration, through fm_test_track_procevent_home, for a home that is NOT
+#     inside one of those roots, or that needs a claim root discovery cannot
+#     infer. It goes through a `$$`-keyed registry file for the same reason the
+#     temp roots do - a fixture home is almost always built inside a command
+#     substitution (`home=$(make_home x)`), and an array append there never
+#     reaches the caller, so a suite that tracked its homes in a shell array was
+#     silently tracking nothing.
+#
+# Both paths sweep the exact home (and its claim root when the suite uses a
+# private one), and discovery never leaves the fixture roots this run created.
+# Nothing here matches on a script or process name, which would reach into
+# another home's live runners.
 
 FM_TEST_PROCEVENT_REGISTRY=$(mktemp "${TMPDIR:-/tmp}/.fm-test-procevent.$$.XXXXXX") || return 1
 
@@ -117,23 +131,72 @@ fm_test_track_procevent_home() {  # <home> [claim-root]
   printf '%s\t%s\n' "$1" "${2-}" >> "$FM_TEST_PROCEVENT_REGISTRY"
 }
 
-fm_test_reap_procevent_homes() {
-  local home claim_root seen=$'\n'
-  [ -f "$FM_TEST_PROCEVENT_REGISTRY" ] || return 0
-  while IFS=$'\t' read -r home claim_root; do
-    [ -n "$home" ] || continue
+# Retire one fixture home's registered sources and stop the runners it owns.
+# A private claim root is used when the caller names one, and otherwise when the
+# home carries the `procevent-claims` directory this suite's fixtures put beside
+# their state; anything else keeps whatever claim root the suite exported.
+fm_test_sweep_procevent_home() {  # <home> [claim-root]
+  local home=$1 claim_root=${2-}
+  [ -n "$home" ] && [ -d "$home/state/procevent" ] || return 0
+  if [ -z "$claim_root" ] && [ -d "$home/procevent-claims" ]; then
+    claim_root="$home/procevent-claims"
+  fi
+  if [ -n "$claim_root" ]; then
+    FM_HOME="$home" FM_STATE_OVERRIDE="$home/state" FM_PROCEVENT_CLAIM_ROOT="$claim_root" \
+      "$ROOT/bin/fm-procevent.sh" sweep-home >/dev/null 2>&1 || true
+  else
+    FM_HOME="$home" FM_STATE_OVERRIDE="$home/state" \
+      "$ROOT/bin/fm-procevent.sh" sweep-home >/dev/null 2>&1 || true
+  fi
+}
+
+# Print every process-event home inside one fixture root. Bounded to that root
+# and to a shallow depth, and it never follows a symlink out of it, so the scan
+# stays proportionate and can only reach homes this run created. Repository
+# checkouts and package trees a fixture copies in are pruned rather than walked.
+fm_test_procevent_homes_under() {  # <fixture-root>
+  local root=$1 dir
+  [ -n "$root" ] && [ -d "$root" ] || return 0
+  while IFS= read -r dir; do
+    [ -n "$dir" ] || continue
+    printf '%s\n' "${dir%/state/procevent}"
+  done < <(find "$root" -maxdepth 6 \
+    \( -name .git -o -name node_modules \) -prune -o \
+    -type d -path '*/state/procevent' -print 2>/dev/null)
+}
+
+# Sweep every process-event home discovered inside one fixture root. Reads and
+# extends its caller's `seen` list so a home reached twice - declared and then
+# discovered, or held in both root registries - is swept once.
+fm_test_sweep_discovered_procevent_homes() {  # <fixture-root>
+  local home
+  while IFS= read -r home; do
     case "$seen" in *$'\n'"$home"$'\n'*) continue ;; esac
     seen+="$home"$'\n'
-    [ -d "$home/state/procevent" ] || continue
-    if [ -n "$claim_root" ]; then
-      FM_HOME="$home" FM_STATE_OVERRIDE="$home/state" FM_PROCEVENT_CLAIM_ROOT="$claim_root" \
-        "$ROOT/bin/fm-procevent.sh" sweep-home >/dev/null 2>&1 || true
-    else
-      FM_HOME="$home" FM_STATE_OVERRIDE="$home/state" \
-        "$ROOT/bin/fm-procevent.sh" sweep-home >/dev/null 2>&1 || true
-    fi
-  done < "$FM_TEST_PROCEVENT_REGISTRY"
-  rm -f "$FM_TEST_PROCEVENT_REGISTRY"
+    fm_test_sweep_procevent_home "$home"
+  done < <(fm_test_procevent_homes_under "$1")
+}
+
+fm_test_reap_procevent_homes() {
+  local home claim_root root seen=$'\n'
+  if [ -f "$FM_TEST_PROCEVENT_REGISTRY" ]; then
+    while IFS=$'\t' read -r home claim_root; do
+      [ -n "$home" ] || continue
+      case "$seen" in *$'\n'"$home"$'\n'*) continue ;; esac
+      seen+="$home"$'\n'
+      fm_test_sweep_procevent_home "$home" "$claim_root"
+    done < "$FM_TEST_PROCEVENT_REGISTRY"
+    rm -f "$FM_TEST_PROCEVENT_REGISTRY"
+  fi
+  for root in "${FM_TEST_CLEANUP_DIRS[@]:-}"; do
+    [ -n "$root" ] || continue
+    fm_test_sweep_discovered_procevent_homes "$root"
+  done
+  [ -f "$FM_TEST_CLEANUP_REGISTRY" ] || return 0
+  while IFS= read -r root; do
+    [ -n "$root" ] || continue
+    fm_test_sweep_discovered_procevent_homes "$root"
+  done < "$FM_TEST_CLEANUP_REGISTRY"
 }
 
 # Ceiling on how long a fixture's blocking stub may keep polling. A stub that

--- a/tests/lib.sh
+++ b/tests/lib.sh
@@ -116,29 +116,10 @@ FM_TEST_OWNER_IDENTITY=$(fm_test_pid_identity "$$") || {
 # tracking nothing and left every runner it started behind.
 #
 # A suite that forgets to declare still leaks its runner. What bounds that leak
-# is the claim root: FM_PROCEVENT_CLAIM_ROOT defaults here to a private per-run
-# directory this library owns, so an undeclared home's claims and locks land in
-# a fixture directory instead of the developer's real
-# ${XDG_STATE_HOME:-$HOME/.local/state}/firstmate/procevent-claims, where they
-# would write into and contend with live runners that have nothing to do with
-# this suite. A suite that sets its own claim root - and a child that inherits
-# one from its parent test process - keeps that value. Teardown removes the
-# exact directory this library created, held in FM_TEST_OWNED_CLAIM_ROOT, and
-# never whatever FM_PROCEVENT_CLAIM_ROOT points at by then: a suite is free to
-# repoint that variable after sourcing, and the path it repoints to is its own
-# to remove.
+# is the claim root this library defaults FM_PROCEVENT_CLAIM_ROOT to, below,
+# once fm_test_tmproot is defined.
 
 FM_TEST_PROCEVENT_REGISTRY=$(mktemp "${TMPDIR:-/tmp}/.fm-test-procevent.$$.XXXXXX") || return 1
-
-FM_TEST_OWNED_CLAIM_ROOT=
-if [ -z "${FM_PROCEVENT_CLAIM_ROOT:-}" ]; then
-  FM_TEST_OWNED_CLAIM_ROOT=$(mktemp -d "${TMPDIR:-/tmp}/.fm-test-procevent-claims.$$.XXXXXX") || {
-    rm -f "$FM_TEST_CLEANUP_REGISTRY" "$FM_TEST_PROCEVENT_REGISTRY"
-    return 1
-  }
-  FM_PROCEVENT_CLAIM_ROOT=$FM_TEST_OWNED_CLAIM_ROOT
-fi
-export FM_PROCEVENT_CLAIM_ROOT
 
 fm_test_track_procevent_home() {  # <home> [claim-root]
   [ -n "${1:-}" ] || return 1
@@ -186,7 +167,6 @@ fm_test_cleanup() {
     done < "$FM_TEST_CLEANUP_REGISTRY"
     rm -f "$FM_TEST_CLEANUP_REGISTRY"
   fi
-  [ -z "${FM_TEST_OWNED_CLAIM_ROOT:-}" ] || rm -rf "$FM_TEST_OWNED_CLAIM_ROOT"
 }
 
 fm_test_tmproot() {
@@ -202,6 +182,24 @@ fm_test_tmproot() {
   fi
   printf '%s\n' "$root"
 }
+
+# The machine-wide claim root, defaulted into a fixture root this run owns. A
+# suite that neither declares its home nor names its own claim root would
+# otherwise resolve to the developer's real
+# ${XDG_STATE_HOME:-$HOME/.local/state}/firstmate/procevent-claims and write
+# claims into, and take locks in, the store the live boards' runners use. Taking
+# it from fm_test_tmproot keeps one owner for it: it is registered for teardown
+# like every other fixture root, carries the marker identifying this shell, and
+# is reaped as a stale orphan by a later run if this one is killed outright.
+# A value the suite sets, and one a child inherits from its parent test process,
+# is neither created nor removed here.
+if [ -z "${FM_PROCEVENT_CLAIM_ROOT:-}" ]; then
+  FM_PROCEVENT_CLAIM_ROOT=$(fm_test_tmproot fm-test-procevent-claims) || {
+    rm -f "$FM_TEST_CLEANUP_REGISTRY" "$FM_TEST_PROCEVENT_REGISTRY"
+    return 1
+  }
+fi
+export FM_PROCEVENT_CLAIM_ROOT
 
 trap fm_test_cleanup EXIT
 trap 'fm_test_cleanup; exit 130' INT


### PR DESCRIPTION
## Intent

Test runs leave behind polling processes that never die. Noticed on 2026-09-08 by the second mate while measuring machine load during the CI ceiling investigation, then verified in the main home.

MEASUREMENT: 194 resident `bin/fm-procevent-lavish.sh poll` processes.
- 190 are polling a target that NO LONGER EXISTS - temporary test-fixture directories of the form /private/var/folders/.../T/fm-bearings-board-render.XXXX/ - so they are purely orphaned.
- Only 4 are legitimate: our two live Lavish boards.
- Origin, by working copy: 98 from .treehouse/firstmate-7bab20/2/firstmate, 52 from /4, 20 from /3. These are firstmate task copies, not sibling homes.
- The oldest in that sample date from 2026-09-07 18:28; the second mate saw some from 2026-08-21, so the leak has been running for at least three weeks.

THE REAL CONSEQUENCE, and this is not cosmetic: that load makes local timing unusable. It distorts every duration measurement taken on this machine - including the ones used to diagnose CI timeouts in the first place.

WHAT MUST BE DELIVERED: tests that arm a polling source must retire it on the way out, including when the test FAILS or is INTERRUPTED. The cleanup belongs in the test's teardown, not on its happy path.

DO NOT simply kill the existing processes: that is the symptom. The leak recreates them.

ACCEPTANCE CRITERION: after a complete run of the affected suite, no `fm-procevent-lavish.sh poll` process survives whose target no longer exists.

LATER ADDITION FROM THE CAPTAIN: when you write the pull request, state the consequence explicitly and not only the process count. That resident load makes local timing unusable, which means this leak has been quietly corrupting the very duration measurements we use to diagnose slow tests - it was found during exactly such a measurement. That is why this is a real defect rather than untidiness. Also confirmed: the 190 live orphans are being cleared separately and are not yours - do not mass-kill them, and do not write any broad process sweep, which is a shape this fleet forbids because it can reach sibling homes.

## What Changed

- Register polling fixture homes for teardown and route live Lavish cleanup through exit and signal traps, retiring listeners before deleting fixtures. Leaked pollers create resident load that makes local timing unusable and corrupts duration measurements used to diagnose slow tests.
- Default process-event claims to a suite-owned temporary directory while preserving explicit overrides, and align secondmate teardown with its fixture claim root.
- Add regression coverage for listener retirement after failure and SIGTERM, plus claim-root isolation, using bounded polling stubs and ownership-checked child cleanup.

## Risk Assessment

✅ Low: The changes are bounded to test teardown and fixture containment, preserve scoped process ownership checks, and match the explicitly accepted declaration-only cleanup design.

## Testing

Three focused suites and live process probes passed after resolving isolated Lavish setup. CLI, PID and filesystem evidence covers normal, failed and interrupted teardown, foreign-PID refusal, claim containment and fixture ownership; temporary processes and files were cleaned up.

- Live validation: ✅ go - 7 of 7 scenarios driven live against the product

| Scenario | Result | Live | Evidence |
| --- | --- | --- | --- |
| Complete the real Lavish suite and leave no polling process behind after fixture removal | ✅ pass | live | Successful live-suite-retry.log and Completed-suite orphan check: no surviving polls or board fixture roots. |
| Fail an assertion while real Lavish polling is armed and retire every associated poll | ✅ pass | live | Real Lavish failure and SIGTERM process records: failure exited 1; PIDs 3183, 3759 and 3762 were absent afterward, with the target removed. |
| Interrupt the live board suite with SIGTERM and retire its polling processes | ✅ pass | live | Real Lavish failure and SIGTERM process records: SIGTERM produced exit 143; PIDs 69527, 72160 and 72167 were absent afterward, with the target removed. |
| Run suite teardown with its genuine live child and terminate that child | ✅ pass | live | Child ownership guard: suite 40625 owned PID 49693; teardown permitted termination, and both child and fixture were gone afterward. |
| Substitute a foreign process identifier and prove teardown refuses to signal it | ✅ pass | live | Child ownership guard: suite 54747 refused PID 40604, owned by probe parent 32621. Fixture cleanup ran while the foreign sleep remained alive; the probe subsequently reaped it. |
| Arm a source without a custom claim root and keep its claims inside the suite-owned store | ✅ pass | live | Claim and fixture ownership boundaries: a real runner claimed the suite-owned store; no fallback XDG store appeared, and child cleanup preserved the inherited claim root. |
| Reap stale fixtures while preserving fresh fixtures and live owners | ✅ pass | live | Claim and fixture ownership boundaries: old live-owned and fresh unowned fixtures survived; the old fixture with mismatched ownership was removed. |

<details>
<summary>Evidence: Validation report</summary>

Source: [Validation report](https://github.com/mremond/firstmate/blob/09720a4a354cec2231c63ad2f6d0ff6cfcd67c24/.no-mistakes/evidence/fm/fm-tests-leak-poll-processes/validation-report.md)

```text
# Test-phase evidence

Target: `3cea357284a5419aeacb0ad823b6e48091a4f826` (tree `3314fc6b5b81264c03689aa011cc25ba5ba2d6f9`).

The change prevents orphaned test polling from adding resident load that corrupts local duration measurements. Validation used only this worktree and run-owned processes; no existing fleet process was signalled.

## Observed behavior

| Scenario | Observations |
|---|---|
| Complete affected suites | Fixture cleanup, bearings renderer, and real Lavish 0.1.62 suites completed successfully. The subsequent process check found zero poll processes and zero board fixture roots in their isolated directories. |
| Real Lavish failure | Suite PID 80939; observed poll PIDs 3183, 3759, 3762. Suite exited 1; all recorded PIDs were absent, no target-matching poll remained, and the fixture home and target were removed. |
| Real Lavish sigterm | Suite PID 85201; observed poll PIDs 69527, 72160, 72167. Suite exited 143; all recorded PIDs were absent, no target-matching poll remained, and the fixture home and target were removed. |
| Own child accepted | Suite PID 40625 owned sleep PID 49693. The guard permitted teardown; PID 49693 was absent and its fixture was removed. |
| Foreign child refused | Suite PID 54747 recorded sleep PID 40604, owned by probe parent 32621. The guard refused; fixture cleanup ran and PID 40604 remained alive. The probe then terminated and reaped its own sleep. |
| Claim and marker boundaries | A real registered command source took its claim under the suite-owned root; no fallback XDG claim store appeared. Inherited claims survived child cleanup. Old live-owned and fresh unowned fixtures survived; old mismatched ownership was removed. |

## Execution

- `TMPDIR="$PWD/.test-phase/tmp" bin/fm-test-run.sh --jobs 1 tests/fm-test-fixture-cleanup.test.sh tests/fm-bearings-board-render.test.sh`
- With the isolated Lavish environment in `run-environment.json`: `TMPDIR="$PWD/.test-phase/tmp-live" bin/fm-test-run.sh --jobs 1 tests/fm-bearings-board-lavish-live-e2e.test.sh`
- `python3 guard-probe.py` (run from the worktree using the evidence script path).
- `python3 live-teardown-probe.py` (run from the worktree using the evidence script path).
- `TMPDIR="$PWD/.test-phase/storage-tmp" bash storage-boundary-probe.sh` (evidence script path).
- `python3 final-process-check.py` plus exact recorded-PID/process-group inspection and isolated-server shutdown.

The first live-suite attempt failed during board setup. The same suite passed after the isolated server was started explicitly and checked through `/health`. A scratch keeper session kept that test-only server available across subsequent probes. No repository changes were needed.

The ownership probes use Bash DEBUG instrumentation to pause the unchanged suite after it installs its actual EXIT trap. The live probes pause the unchanged live suite after the real board build, observe real `lavish-axi poll` processes, then inject a failure or SIGTERM. They do not replace teardown, mock the poll command, or assert implementation-source text. Round 5's injected failure/interruption proofs were not rerun.

No linter, formatter, static analysis, full repository suite, publication, or other gate phase ran. No UI content changed, so process and filesystem transcripts are the evidence for this change.

## Evidence

- [Live failure and interruption process records](live-teardown-probe.jsonl)
- [Child ownership guard](guard-probe.log)
- [Claim and marker state](storage-boundary-probe.log)
- [Completed-suite orphan check](completed-suite-process-check.json)
- [Final exact PID and group check](final-process-check.json)
- [Targeted suites](targeted-suites.log)
- [Successful live suite](live-suite-retry.log)
- [Initial live setup attempt](live-suite.log)
- [Environment cleanup](environment-cleanup.log)
```
</details>
<details>
<summary>Evidence: Real Lavish failure and SIGTERM process records</summary>

Source: [Real Lavish failure and SIGTERM process records](https://github.com/mremond/firstmate/blob/09720a4a354cec2231c63ad2f6d0ff6cfcd67c24/.no-mistakes/evidence/fm/fm-tests-leak-poll-processes/live-teardown-probe.jsonl)

```text
{"mode": "failure", "event": "start", "suite_pid": 80939}
{"mode": "failure", "event": "armed", "suite_pid": 80939, "target": "~/.no-mistakes/worktrees/acf4a767348a/01M2082V2RRVRBS459RBJ4K0BY/.test-phase/live-probes/failure/tmp/fm-bearings-lavish-live.WvKekB/.lavish/bearings-board.html", "target_exists": true, "polls": [{"pid": 3183, "ppid": 91497, "pgid": 91497, "args": "bash ~/.no-mistakes/worktrees/acf4a767348a/01M2082V2RRVRBS459RBJ4K0BY/bin/fm-procevent-lavish.sh poll ~/.no-mistakes/worktrees/acf4a767348a/01M2082V2RRVRBS459RBJ4K0BY/.test-phase/live-probes/failure/tmp/fm-bearings-lavish-live.WvKekB/.lavish/bearings-board.html"}, {"pid": 3759, "ppid": 3183, "pgid": 91497, "args": "node /opt/homebrew/bin/lavish-axi poll ~/.no-mistakes/worktrees/acf4a767348a/01M2082V2RRVRBS459RBJ4K0BY/.test-phase/live-probes/failure/tmp/fm-bearings-lavish-live.WvKekB/.lavish/bearings-board.html"}, {"pid": 3762, "ppid": 3183, "pgid": 91497, "args": "bash ~/.no-mistakes/worktrees/acf4a767348a/01M2082V2RRVRBS459RBJ4K0BY/bin/fm-procevent-lavish.sh poll ~/.no-mistakes/worktrees/acf4a767348a/01M2082V2RRVRBS459RBJ4K0BY/.test-phase/live-probes/failure/tmp/fm-bearings-lavish-live.WvKekB/.lavish/bearings-board.html"}]}
{"mode": "failure", "event": "after_teardown", "suite_exit": 1, "target_exists": false, "home_exists": false, "surviving_polls": [], "recorded_pid_postconditions": [{"pid": 3183, "ps_exit": 1, "current": ""}, {"pid": 3759, "ps_exit": 1, "current": ""}, {"pid": 3762, "ps_exit": 1, "current": ""}]}
{"mode": "sigterm", "event": "start", "suite_pid": 85201}
{"mode": "sigterm", "event": "armed", "suite_pid": 85201, "target": "~/.no-mistakes/worktrees/acf4a767348a/01M2082V2RRVRBS459RBJ4K0BY/.test-phase/live-probes/sigterm/tmp/fm-bearings-lavish-live.jeQodq/.lavish/bearings-board.html", "target_exists": true, "polls": [{"pid": 69527, "ppid": 53637, "pgid": 53637, "args": "bash ~/.no-mistakes/worktrees/acf4a767348a/01M2082V2RRVRBS459RBJ4K0BY/bin/fm-procevent-lavish.sh poll ~/.no-mistakes/worktrees/acf4a767348a/01M2082V2RRVRBS459RBJ4K0BY/.test-phase/live-probes/sigterm/tmp/fm-bearings-lavish-live.jeQodq/.lavish/bearings-board.html"}, {"pid": 72160, "ppid": 69527, "pgid": 53637, "args": "node /opt/homebrew/bin/lavish-axi poll ~/.no-mistakes/worktrees/acf4a767348a/01M2082V2RRVRBS459RBJ4K0BY/.test-phase/live-probes/sigterm/tmp/fm-bearings-lavish-live.jeQodq/.lavish/bearings-board.html"}, {"pid": 72167, "ppid": 69527, "pgid": 53637, "args": "bash ~/.no-mistakes/worktrees/acf4a767348a/01M2082V2RRVRBS459RBJ4K0BY/bin/fm-procevent-lavish.sh poll ~/.no-mistakes/worktrees/acf4a767348a/01M2082V2RRVRBS459RBJ4K0BY/.test-phase/live-probes/sigterm/tmp/fm-bearings-lavish-live.jeQodq/.lavish/bearings-board.html"}]}
{"mode": "sigterm", "event": "after_teardown", "suite_exit": 143, "target_exists": false, "home_exists": false, "surviving_polls": [], "recorded_pid_postconditions": [{"pid": 69527, "ps_exit": 1, "current": ""}, {"pid": 72160, "ps_exit": 1, "current": ""}, {"pid": 72167, "ps_exit": 1, "current": ""}]}
```
</details>
<details>
<summary>Evidence: Child ownership guard</summary>

Source: [Child ownership guard](https://github.com/mremond/firstmate/blob/09720a4a354cec2231c63ad2f6d0ff6cfcd67c24/.no-mistakes/evidence/fm/fm-tests-leak-poll-processes/guard-probe.log)

```text
target=3cea357284a5419aeacb0ad823b6e48091a4f826
suite_sha256=2da181c8692f5e1559c429c2c7d7222c049b25314c628748d2c07d5f914749c8
probe_parent=32621 foreign_sleep_pid=40604
suite_pid=40625 tracked_pid=49693 observed_parent=40625 guard_permits=true fixture=~/.no-mistakes/worktrees/acf4a767348a/01M2082V2RRVRBS459RBJ4K0BY/.test-phase/guard/own-tmp/fm-guard-probe.cHsBJf
mode=own suite_exit=0 tracked_pid=49693 alive_after_teardown=false fixture_exists_after_teardown=False
suite_pid=54747 tracked_pid=40604 observed_parent=32621 guard_permits=false fixture=~/.no-mistakes/worktrees/acf4a767348a/01M2082V2RRVRBS459RBJ4K0BY/.test-phase/guard/foreign-tmp/fm-guard-probe.dgBZna
mode=foreign suite_exit=0 tracked_pid=40604 alive_after_teardown=true fixture_exists_after_teardown=False
probe_cleanup foreign_sleep_pid=40604 reaped=true
```
</details>
<details>
<summary>Evidence: Claim and fixture ownership boundaries</summary>

Source: [Claim and fixture ownership boundaries](https://github.com/mremond/firstmate/blob/09720a4a354cec2231c63ad2f6d0ff6cfcd67c24/.no-mistakes/evidence/fm/fm-tests-leak-poll-processes/storage-boundary-probe.log)

```text
owner_pid=53256 old_live_owner_preserved=true fresh_unowned_preserved=true old_reused_identity_removed=true
inherited_claim_root=~/.no-mistakes/worktrees/acf4a767348a/01M2082V2RRVRBS459RBJ4K0BY/.test-phase/storage-tmp/fm-test-procevent-claims.37jUL3 child_cleanup_preserved_parent_root=true
registered: claim-store-probe (lavish)
reconciled: published=0 started=1 stopped=0 uncertain=0
claim_path=~/.no-mistakes/worktrees/acf4a767348a/01M2082V2RRVRBS459RBJ4K0BY/.test-phase/storage-tmp/fm-test-procevent-claims.37jUL3/claim-store-probe.claim fallback_claim_store_exists=false
~/.no-mistakes/worktrees/acf4a767348a/01M2082V2RRVRBS459RBJ4K0BY/.test-phase/storage-tmp/fm-probe-claim-store.JQTMf4/home
14115
.claim.LjkgFH-14115
Tue Sep  8 15:29:01 2026     bash ~/.no-mistakes/worktrees/acf4a767348a/01M2082V2RRVRBS459RBJ4K0BY/bin/fm-procevent.sh _start claim-store-probe
~/.no-mistakes/worktrees/acf4a767348a/01M2082V2RRVRBS459RBJ4K0BY/.test-phase/storage-tmp/fm-probe-claim-store.JQTMf4/home/state/procevent
16777234:48758370
active
~/.no-mistakes/worktrees/acf4a767348a/01M2082V2RRVRBS459RBJ4K0BY/.test-phase/storage-tmp/fm-probe-claim-store.JQTMf4/home/state
16777234
48757744
501
755
after_cleanup fixture_exists=false claim_root_exists=false
```
</details>
<details>
<summary>Evidence: Completed-suite orphan check</summary>

Source: [Completed-suite orphan check](https://github.com/mremond/firstmate/blob/09720a4a354cec2231c63ad2f6d0ff6cfcd67c24/.no-mistakes/evidence/fm/fm-tests-leak-poll-processes/completed-suite-process-check.json)

```text
{
  "at": "2026-09-08T13:29:41.615333+00:00",
  "completed_suites": [
    "fm-test-fixture-cleanup",
    "fm-bearings-board-render",
    "fm-bearings-board-lavish-live-e2e"
  ],
  "surviving_polls": [],
  "surviving_board_fixture_roots": []
}
```
</details>
<details>
<summary>Evidence: Final process check</summary>

Source: [Final process check](https://github.com/mremond/firstmate/blob/09720a4a354cec2231c63ad2f6d0ff6cfcd67c24/.no-mistakes/evidence/fm/fm-tests-leak-poll-processes/final-process-check.json)

```text
{
  "at": "2026-09-08T13:32:03.328190+00:00",
  "target": "3cea357284a5419aeacb0ad823b6e48091a4f826",
  "remaining_run_scoped_processes": [],
  "remaining_recorded_pids_or_groups": []
}
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"5b7e41c4b0e6df17c5f64b81566f5d0e3805729a","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>🔧 **Review** - 3 issues found → auto-fixed (5) → no changes applied ✅</summary>

- ⚠️ `tests/lib.sh:176` - The new discovery pass calls fm_test_sweep_procevent_home &#34;$home&#34; with no claim root. When the discovered home has no $home/procevent-claims directory and the suite never exported FM_PROCEVENT_CLAIM_ROOT, fm_procevent_claim_root (bin/fm-procevent-lib.sh:35) falls back to the developer&#39;s real ${XDG_STATE_HOME:-$HOME/.local/state}/firstmate/procevent-claims. Concrete path: tests/fm-turnend-guard.test.sh:94 and :313 create $TMP_ROOT/pred-source/state/procevent and $TMP_ROOT/hook-source-only/state/procevent inside a registered fixture root and never set FM_PROCEVENT_CLAIM_ROOT. At that suite&#39;s teardown, discovery finds both homes and runs bin/fm-procevent.sh sweep-home with FM_HOME/FM_STATE_OVERRIDE pointed at the fixture but the REAL claim root; cmd_sweep_home (bin/fm-procevent.sh:1555) then iterates every real *.claim, and for each one fm_procevent_source_lock_acquire (bin/fm-procevent-lib.sh:315-322) does mkdir -p on the real claim root, creates a &lt;real-source-id&gt;.lock directory there via the unbounded fm_lock_acquire_wait, and fm_procevent_claim_load_locked reads the live claim. The ownership check (fm_procevent_claim_owned_by_state) does prevent retiring the two live boards&#39; sources, so nothing is killed, but ordinary test teardown now writes into and takes locks in the user&#39;s live firstmate state and briefly contends with the live board runners. That is the cross-home reach this change&#39;s own comment claims it avoids (&#34;discovery never leaves the fixture roots this run created&#34;) and that the intent forbids (&#34;do not write any broad process sweep, which is a shape this fleet forbids because it can reach sibling homes&#34;). The remedy, not the defect, needs authorization: the smallest honest fix is to drop the discovery pass entirely (see the discovery-component finding) and keep the declaration path, since a home that genuinely armed a runner without a private claim root can only be swept BY touching the real claim root - so any narrower guard (skip discovery unless a private claim root is inferable or exported) deliberately narrows the coverage the author designed discovery for.
- ⚠️ `tests/lib.sh:157` - Simplification: the change introduces a whole discovery mechanism - fm_test_procevent_homes_under (tests/lib.sh:157), fm_test_sweep_discovered_procevent_homes (tests/lib.sh:171), the find-based scan with its -maxdepth 6 bound and .git/node_modules prune list, and the $home/procevent-claims directory-name inference at tests/lib.sh:141 - that no requirement in the intent needs. The intent requires only that &#34;tests that arm a polling source must retire it on the way out, including when the test FAILS or is INTERRUPTED. The cleanup belongs in the test&#39;s teardown, not on its happy path.&#34; The declaration registry (fm_test_track_procevent_home + fm_test_reap_procevent_homes) already existed as of the base commit and already ran from EXIT/INT/TERM/HUP/QUIT. What actually leaked in this branch was the live e2e guard, whose cleanup() never called fm_test_cleanup and which had no signal traps at all - and both of those are fixed directly in this diff. The name inference at :141 is also a second definition of a fact every other suite already states explicitly as the second argument to fm_test_track_procevent_home. Recommended remedy: remove the discovery pass and the inference, and have the e2e guard declare its home (fm_test_track_procevent_home &#34;$LAB&#34; &#34;$LAB/procevent-claims&#34;), which satisfies the acceptance criterion with the mechanism the repo already has. The claim-root defect reported above lives inside this component, so removing it also removes that defect.
- ⚠️ `tests/fm-bearings-board-lavish-live-e2e.test.sh:57` - LAB is registered as a fixture root but its process-event home is never declared with fm_test_track_procevent_home &#34;$LAB&#34; &#34;$LAB/procevent-claims&#34;, unlike every other suite that arms a listener (tests/fm-bearings-board-render.test.sh:25, tests/fm-bearings-board.test.sh, tests/fm-captain-hold-lifecycle.test.sh). Teardown therefore depends entirely on discovery inferring the claim root from the existence of $LAB/procevent-claims. That directory is created only once a claim/lock is actually taken (bin/fm-procevent-lib.sh:319). If `run_board build` at line 88 registers the source into $LAB/state/procevent but dies before reconcile claims it - the exact failure path the guard&#39;s `|| fail` handles - then $LAB/state/procevent exists while $LAB/procevent-claims does not, and teardown sweeps $LAB against the real user claim root instead (same mechanism as the tests/lib.sh:176 finding). One declaration line beside the LAB creation makes the claim root exact on every path and removes the dependency on inference.

🔧 Fix applied.
3 issues (2 warnings, 1 info) still open:

- ⚠️ `tests/fm-remote-secondmate-trace-context.test.sh:36` - Two suites that arm a real process-event listener still leak it when the run is INTERRUPTED, which the intent marks required: &#34;tests that arm a polling source must retire it on the way out, including when the test FAILS or is INTERRUPTED.&#34; tests/fm-remote-secondmate-trace-context.test.sh:36 and tests/fm-remote-secondmate-parent-binding.test.sh:60 (trap at :67) are structurally identical to tests/fm-remote-reply.test.sh, which this change DID declare (tests/fm-remote-reply.test.sh:20): each takes a fixture root from fm_test_tmproot, arms sources in $PARENT, keeps a private $CLAIMS=&#34;$TMP_ROOT/claims&#34;, and installs an EXIT-only trap whose cleanup calls `FM_HOME=&#34;$PARENT&#34; FM_PROCEVENT_CLAIM_ROOT=&#34;$CLAIMS&#34; fm-procevent.sh sweep-home`. Neither calls fm_test_track_procevent_home. Concrete sequence on SIGINT/SIGTERM: tests/lib.sh&#39;s own signal trap (tests/lib.sh:205-209) fires first, runs fm_test_cleanup, which reaps the procevent registry (empty - nothing declared, so no sweep) and then rm -rf&#39;s the registered TMP_ROOT; `exit 130` then fires the suite&#39;s EXIT trap, whose sweep-home now runs with $PARENT/state/procevent and $CLAIMS already deleted, so it retires nothing. The detached runner reparents and keeps polling a fixture path that no longer exists - exactly the 190-orphan shape the intent measured. The remedy is the same one-line declaration already applied to the five sibling suites (fm_test_track_procevent_home &#34;$PARENT&#34; &#34;$CLAIMS&#34; beside the mkdir at trace-context:35 / parent-binding:51), which makes the reap run before the fixture is removed. Marked ask-user because the prior round&#39;s instructions enumerated an explicit five-suite list and this extends that list.
- ⚠️ `tests/lib.sh:185` - fm_test_cleanup gates removal on FM_TEST_OWNS_CLAIM_ROOT (&#34;did this library create one?&#34;) but then removes the CURRENT value of $FM_PROCEVENT_CLAIM_ROOT, not the directory it actually created at tests/lib.sh:132. Three suites reassign the variable after sourcing lib.sh - tests/fm-extension-binding.test.sh:124, tests/fm-procevent.test.sh:21, tests/fm-procevent-when.test.sh:19 (`export FM_PROCEVENT_CLAIM_ROOT=&#34;$TMP_ROOT/claims&#34;`). Concrete trace for fm-extension-binding: at source time the variable is unset, so FM_TEST_OWNS_CLAIM_ROOT=1 and mktemp -d creates $TMPDIR/.fm-test-procevent-claims.$$.XXXXXX; line 124 then overwrites the variable; at teardown extension_test_cleanup -&gt; fm_test_cleanup rm -rf&#39;s $TMP_ROOT/claims (a path the library never created, and already removed with the fixture root moments earlier) while the library&#39;s own directory is never touched. It survives the run permanently: fm_test_reap_orphans only globs &#34;${TMPDIR}&#34;/fm-*/.fm-test-fixture (tests/lib.sh:222), which the dotted name cannot match and which carries no fixture marker. The same directory also survives in the ~49 suites that replace lib.sh&#39;s EXIT trap without calling fm_test_cleanup (e.g. tests/fm-remote-reply.test.sh:35, tests/fm-procevent.test.sh), so a full run leaves roughly one uncollected directory per such suite in TMPDIR - new residue introduced by a change whose purpose is to stop test runs leaving residue. Fix is mechanical and behavior-preserving: capture the created path in its own variable (e.g. FM_TEST_OWNED_CLAIM_ROOT=$FM_PROCEVENT_CLAIM_ROOT right after line 132) and rm -rf that variable at line 185.
- ℹ️ `tests/fm-test-fixture-cleanup.test.sh:108` - Informational, no action needed on its own. test_armed_listener_retired_after_failing_exit (:108) and test_armed_listener_retired_after_sigterm (:124) both have their child declare its home explicitly (fm_test_track_procevent_home &#34;$home&#34; &#34;$home/procevent-claims&#34; at :87) and drive the declaration registry, which existed unchanged as of base commit b84e0e3 (git show b84e0e3:tests/lib.sh - fm_test_track_procevent_home, fm_test_reap_procevent_homes, and the EXIT/INT/TERM/HUP/QUIT traps are all present, and fm_test_reap_procevent_homes is byte-identical to the version on this branch). Both cases therefore pass at the base commit and would still pass with this branch&#39;s lib.sh change reverted; they pin an existing invariant rather than reproducing this branch&#39;s failure. Only test_undeclared_home_claims_stay_in_the_suite_owned_root (:163) discriminates - at base FM_PROCEVENT_CLAIM_ROOT is unbound under set -u and the XDG fallback would create $scratch/state/firstmate/procevent-claims. Worth knowing when judging how much of this branch is regression-covered: the e2e guard&#39;s teardown routing and the five added declarations are not exercised by any test here.

🔧 Fix applied.
1 warning still open:

- ⚠️ `tests/lib.sh:135` - The claim-root containment component introduced by a prior fix round (tests/lib.sh:133-141, removed at :189) is not required by the User intent and leaves new, uncollectable residue.

WHY IT EXCEEDS THE INTENT. The intent requires &#34;tests that arm a polling source must retire it on the way out, including when the test FAILS or is INTERRUPTED&#34;, with the acceptance criterion &#34;no fm-procevent-lavish.sh poll process survives whose target no longer exists.&#34; This component retires nothing - it only relocates where claim files are written. tests/lib.sh:118-119 concedes exactly that: &#34;A suite that forgets to declare still leaks its runner. What bounds that leak is the claim root.&#34; Every listener that this branch actually retires is retired by the declaration registry (fm_test_track_procevent_home + fm_test_reap_procevent_homes), which existed at base commit b84e0e3 and is untouched here.

THE CONCRETE DEFECT INSIDE IT. Sourcing tests/lib.sh unconditionally creates $TMPDIR/.fm-test-procevent-claims.$$.XXXXXX (:135), and only fm_test_cleanup removes it (:189). 44 suites install a top-level EXIT trap and never call fm_test_cleanup - tests/fm-remote-reply.test.sh:36, tests/fm-remote-secondmate-trace-context.test.sh:41, tests/fm-control.test.sh, tests/fm-on.test.sh, tests/fm-gotmp.test.sh, tests/fm-remote-job.test.sh among them - so on their NORMAL exit the directory is never removed. Reproduced: sourcing tests/lib.sh in a scratch TMPDIR, taking a fixture root, then replacing the EXIT trap with a bare `rm -rf &#34;$TMP_ROOT&#34;` left `.fm-test-procevent-claims.18370.5xiCbd` behind. It is also permanently uncollectable: fm_test_reap_orphans globs &#34;${TMPDIR}&#34;/fm-*/.fm-test-fixture (tests/lib.sh:224), which a dotted name cannot match and which carries no fixture marker. A full suite run therefore adds roughly twenty directories that accumulate on every subsequent run - new residue from a change whose stated purpose is to stop test runs leaving residue behind. (The two registry FILES leaked by the same 44 suites are pre-existing at base; the directory is not.)

TWO FURTHER COSTS. (1) `export FM_PROCEVENT_CLAIM_ROOT` (:141) globally overrides the ${XDG_STATE_HOME:-$HOME/.local/state}/firstmate/procevent-claims fallback for every child process of every suite, which forced the compensating override at tests/fm-secondmate-safety.test.sh:2523 and, as a side effect, removed the only coverage of bin/fm-teardown.sh:2389&#39;s XDG claim-root fallback. (2) test_undeclared_home_claims_stay_in_the_suite_owned_root (tests/fm-test-fixture-cleanup.test.sh:163) exists solely to pin this component.

REMEDY - the remedy, not the defect, is what needs authorization. The smallest honest fix is to REMOVE the component (drop :133-141 and :189, plus its dedicated test and the fm-secondmate-safety.test.sh:2523 override), leaving declaration-driven reaping, which is what satisfies the intent. If you want to keep it - its real value is that an undeclared fixture home&#39;s runner would otherwise write claims and locks into the developer&#39;s live procevent store alongside the four legitimate board runners - then the narrower form is to make it collectable: name it fm-test-procevent-claims.$$.XXXXXX (no leading dot) and write the .fm-test-fixture marker into it, so fm_test_reap_orphans bounds the growth. Please do not have this repaired by hardening without that decision.

🔧 Fix applied.
2 warnings still open:

- ⚠️ `tests/lib.sh:197` - The claim root created at source time is a marked fixture root, so every suite that replaces lib.sh&#39;s EXIT trap without calling fm_test_cleanup leaks one marked directory per run, and each leaked marker then costs a bash+ps identity probe at the start of every later suite.

REPRODUCED. Sourcing tests/lib.sh in a scratch TMPDIR, taking a fixture root, then replacing the EXIT trap with a bare `rm -rf &#34;$TMP_ROOT&#34;` and exiting NORMALLY left `&lt;scratch&gt;/fm-test-procevent-claims.IsX6YC/.fm-test-fixture` behind. 44 suites use exactly that shape (tests/fm-remote-reply.test.sh:35, tests/fm-control.test.sh, tests/fm-on.test.sh, tests/fm-gotmp.test.sh, tests/fm-remote-job.test.sh, tests/fm-pi-watch-extension.test.sh among them). At base b84e0e3 those suites leaked no marker at all - each removed its own TMP_ROOT - so this residue is new.

THE AMPLIFICATION. fm_test_reap_orphans (tests/lib.sh:219-243) runs at source time in every suite and, for each marker, spends two `sed` calls plus fm_test_pid_identity - which forks a bash that sources bin/fm-wake-lib.sh - BEFORE it ever looks at the marker&#39;s age (the mtime/max-age check is at :235-236, after the identity probe at :229). Measured on this machine: sourcing tests/lib.sh in a TMPDIR holding 20 dead-owner markers took 5.09s versus 0.48s in an empty TMPDIR, i.e. ~0.23s per marker. Since a leaked claim root is only collected once it is FM_TEST_ORPHAN_MAX_AGE_SECONDS (3600s) old, one full local run leaves ~44 markers that every suite of the next run inside that hour pays for, and repeated runs stack. This lands squarely on the defect the intent is about (&#34;that load makes local timing unusable… corrupting the very duration measurements we use to diagnose slow tests&#34;).

REMEDY (minimal, behavior-preserving, correction not extension). Hoist the age check to the top of the loop body in fm_test_reap_orphans so a marker younger than FM_TEST_ORPHAN_MAX_AGE_SECONDS is skipped after one `stat`, and only an already-old marker pays the identity probe. The removal condition is unchanged either way - a directory is removed iff its owner is not live AND its marker is at least max-age old - so test_orphan_sweep_respects_fixture_ownership and test_orphan_sweep_reaps_read_only_package_tree still pin the same outcomes (the backdated live-owned dir is still kept via the identity branch, the reused-identity stale dir is still removed, the fresh unowned dir is still kept). Measured cost of the cheap path: 20 `stat` calls took 0.40s versus 4.6s for 20 identity probes. Do not fix this by removing the containment default - that decision was already made in a prior round.
- ⚠️ `tests/lib.sh:110` - The branch&#39;s own commit history describes a teardown mechanism the delivered code does not contain, and the property the author&#39;s commit claims is no longer delivered.

EVIDENCE. The author&#39;s commit f5895d3 states: &#34;Teardown now discovers process-event homes inside the fixture roots the run created and sweeps each of them, so declaration supplements discovery instead of being the only path. Declaration is kept for a home outside those roots or one whose claim root cannot be inferred.&#34; and &#34;A suite therefore cannot leak a listener by forgetting to declare its home, which is how the leak this guards kept coming back.&#34; Its lib.sh hunk added fm_test_procevent_homes_under and fm_test_sweep_discovered_procevent_homes.

HEAD contradicts both. The pipeline fix commit 6f7b589 (&#34;drop procevent discovery&#34;) deleted those two functions; tests/lib.sh:110 now reads &#34;Nothing is discovered&#34; and :118 reads &#34;A suite that forgets to declare still leaks its runner.&#34; `git show HEAD:tests/lib.sh | grep -c homes_under` is 0. So the branch ships declaration-only reaping while its history advertises discovery-plus-declaration, and the PR this run will open from these commits would state a mechanism that is not in the diff.

WHY IT NEEDS YOUR CALL, NOT MINE. This is a reversal of the author&#39;s deliberate design made by the pipeline&#39;s fixer, not by the author. I could not find a present-day violation of the acceptance criterion under declaration-only: I swept every suite touching procevent and each one that arms a real detached runner is either declared or sweeps in its own EXIT trap (fm-watch-triage.test.sh:3940 registers a command that exits immediately and then retires the source; fm-secondmate-safety, fm-turnend-guard and fm-pi-watch-extension only stub or stage procevent state). So the regime is currently sufficient - but it is the forget-to-declare regime the author explicitly designed against, and the code and the commit message now disagree.

Decide one of two things: restore discovery as the author wrote it, or keep declaration-only and correct f5895d3&#39;s message (and the PR narrative built from it) so the branch does not claim a mechanism it does not have.

🔧 No changes applied.
1 error still open:

- 🚨 `tests/fm-test-fixture-cleanup.test.sh:140` - The requirement says cleanup must run “including when the test FAILS or is INTERRUPTED,” but this new background child is terminated only on the happy path at line 148. If SIGTERM reaches the suite while it waits for child-root, or an assertion before that kill fails, fm_test_cleanup removes the parent harness without stopping child_pid. The child has its own cleanup registry and continues the unbounded sleep loop at line 103; its armed listener is left to timeout safeguards. Track this exact child in suite teardown, terminate and wait for it before removing fixtures, and clear the tracked PID after the normal wait.

🔧 Fix applied.
1 error still open:

- 🚨 `tests/fm-test-fixture-cleanup.test.sh:42` - The approved remedy requires signalling the tracked PID “only while it is still this suite&#39;s own child,” but this new teardown checks only that HELD_LISTENER_CHILD is nonempty before killing it. If the child terminates during startup while the suite waits for child-root, Bash can reap it before the explicit wait. If that PID is reused before the assertion times out, cleanup sends SIGTERM to an unrelated process. Clearing the identifier after the happy-path wait does not protect this failure path. Verify current child ownership and identity before signalling, while preserving the wait-before-fixture-removal order and the explicitly limited scope.

🔧 Fix applied.
✅ Re-checked - no issues remain.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- Live validation: ✅ go - 7 of 7 scenarios driven live against the product

| Scenario | Result | Live | Evidence |
| --- | --- | --- | --- |
| Complete the real Lavish suite and leave no polling process behind after fixture removal | ✅ pass | live | Successful live-suite-retry.log and Completed-suite orphan check: no surviving polls or board fixture roots. |
| Fail an assertion while real Lavish polling is armed and retire every associated poll | ✅ pass | live | Real Lavish failure and SIGTERM process records: failure exited 1; PIDs 3183, 3759 and 3762 were absent afterward, with the target removed. |
| Interrupt the live board suite with SIGTERM and retire its polling processes | ✅ pass | live | Real Lavish failure and SIGTERM process records: SIGTERM produced exit 143; PIDs 69527, 72160 and 72167 were absent afterward, with the target removed. |
| Run suite teardown with its genuine live child and terminate that child | ✅ pass | live | Child ownership guard: suite 40625 owned PID 49693; teardown permitted termination, and both child and fixture were gone afterward. |
| Substitute a foreign process identifier and prove teardown refuses to signal it | ✅ pass | live | Child ownership guard: suite 54747 refused PID 40604, owned by probe parent 32621. Fixture cleanup ran while the foreign sleep remained alive; the probe subsequently reaped it. |
| Arm a source without a custom claim root and keep its claims inside the suite-owned store | ✅ pass | live | Claim and fixture ownership boundaries: a real runner claimed the suite-owned store; no fallback XDG store appeared, and child cleanup preserved the inherited claim root. |
| Reap stale fixtures while preserving fresh fixtures and live owners | ✅ pass | live | Claim and fixture ownership boundaries: old live-owned and fresh unowned fixtures survived; the old fixture with mismatched ownership was removed. |

- `TMPDIR="$PWD/.test-phase/tmp" bin/fm-test-run.sh --jobs 1 tests/fm-test-fixture-cleanup.test.sh tests/fm-bearings-board-render.test.sh`
- <code>`bin/fm-test-run.sh --jobs 1 tests/fm-bearings-board-lavish-live-e2e.test.sh` with isolated TMPDIR and Lavish settings; initial setup failure followed by a successful rerun</code>
- `python3 ~/.no-mistakes/evidence/01M2082V2RRVRBS459RBJ4K0BY/guard-probe.py`
- `python3 ~/.no-mistakes/evidence/01M2082V2RRVRBS459RBJ4K0BY/live-teardown-probe.py`
- `TMPDIR="$PWD/.test-phase/storage-tmp" bash ~/.no-mistakes/evidence/01M2082V2RRVRBS459RBJ4K0BY/storage-boundary-probe.sh`
- `python3 ~/.no-mistakes/evidence/01M2082V2RRVRBS459RBJ4K0BY/final-process-check.py`
- <code>Ended the isolated Lavish server, verified its port closed, removed scratch files, and confirmed unchanged HEAD and clean `git status --short`</code>
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
