### PR TITLE
fix(inbox): recover doorbells when Enter is swallowed

### DIFF
--- a/bin/fm-send.sh
+++ b/bin/fm-send.sh
@@ -48,11 +48,11 @@
 # available, escalates after the bounded ladder, and instead routes a positively
 # dead or missing endpoint directly to recovery without typing. An explicit
 # fire-and-forget record is excluded from that ladder.
-# bin/fm-task-inbox-lib.sh owns the record format, the doorbell line, and the
-# re-ring ladder. The composer pre-check before the ring is ADVISORY only: when
-# the composer visibly holds pending text the ring is skipped with a notice and
-# the watcher re-rings an ordinary record later; no composer verdict is
-# delivery proof on this plane, and a failed ring never fails the send.
+# bin/fm-task-inbox-lib.sh owns the record format, the doorbell line, the
+# composer-safe exact-doorbell recovery, and the re-ring ladder. A pending
+# composer not positively identified as this record's doorbell is skipped, no
+# composer verdict is delivery proof on this plane, and a failed ring never
+# fails the send.
 #
 # TYPED - the LOCAL text that must reach the terminal itself: a harness-native
 # invocation (a leading "/", or a leading "$" to a codex target) must reach
@@ -137,10 +137,11 @@
 # seconds (default 30, and any override must be a positive integer): a bound
 # hit is completion-unknown and exits through this same unconfirmed contract
 # instead of waiting out a busy remote queue.
-# The remote host runs no re-ring ladder of its own: a swallowed ordinary
-# doorbell surfaces through the parent's pending-reply recovery and escalation,
-# whose recovery request re-rings the remote doorbell when it is enqueued;
-# fire-and-forget delivery deliberately arms neither mechanism. Internal
+# The remote host runs no re-ring ladder of its own. The host-local ring uses
+# the composer-safe recovery owned by bin/fm-task-inbox-lib.sh; if the record
+# remains unhandled, the parent's pending-reply recovery and escalation can ring
+# it again, while fire-and-forget delivery deliberately arms no such backstop.
+# Internal
 # semantic callers may set FM_SEND_EXPECTED_SPAWN_GEN or
 # FM_SEND_EXPECTED_REMOTE_HOST to require that sampled identity to still match
 # during the final locked remote-route validation; unset or empty guards do not

--- a/bin/fm-task-inbox-lib.sh
+++ b/bin/fm-task-inbox-lib.sh
@@ -389,6 +389,11 @@ fm_task_inbox_ring() {  # <backend> <target> <record-path> [expected-label]
     send-failed)
       if ! fm_task_inbox_composer_holds_doorbell "$backend" "$target" "$rec" "$label"; then
         cstate=$(fm_backend_composer_state "$backend" "$target" "$label" 2>/dev/null) || cstate=unknown
+        # send-failed cannot distinguish an Enter that landed from a literal
+        # send that never typed anything without widening the backend contract.
+        # Report failure in both cases so an empty composer cannot falsely mark
+        # an unsent doorbell delivered. The durable record makes the resulting
+        # re-ring safe, and a duplicate doorbell is a no-op after handling.
         [ "$cstate" = empty ] && return 2
         return 1
       fi

--- a/bin/fm-task-inbox-lib.sh
+++ b/bin/fm-task-inbox-lib.sh
@@ -87,11 +87,9 @@ FM_TASK_INBOX_SCHEMA='fm-task-inbox.v1'
 FM_TASK_INBOX_GRACE_DEFAULT=90
 FM_TASK_INBOX_RING_MAX_DEFAULT=3
 FM_TASK_INBOX_LOCK_WAIT_DEFAULT=5
-# Enter-only retries (and spacing) used to commit a doorbell that is already
-# sitting unsubmitted in the composer. Never retypes; see
-# fm_task_inbox_commit_pending_doorbell.
-FM_TASK_INBOX_COMMIT_RETRIES=${FM_TASK_INBOX_COMMIT_RETRIES:-3}
-FM_TASK_INBOX_COMMIT_SLEEP=${FM_TASK_INBOX_COMMIT_SLEEP:-0.4}
+# A doorbell gets at most three Enter attempts, spaced 0.4 seconds apart.
+_FM_TASK_INBOX_COMMIT_RETRIES=3
+_FM_TASK_INBOX_COMMIT_SLEEP=0.4
 
 fm_task_inbox_grace_secs() {
   local g=${FM_TASK_INBOX_GRACE_SECS:-$FM_TASK_INBOX_GRACE_DEFAULT}
@@ -317,24 +315,24 @@ fm_task_inbox_composer_holds_doorbell() {  # <backend> <target> <record-path> [e
 # the composer, with a bounded Enter-only retry. Retyping is never correct
 # here - the text is already there, and a second copy would be delivered as
 # well as the first. True when the composer is proven empty.
-fm_task_inbox_commit_pending_doorbell() {  # <backend> <target> <record-path> [expected-label] [attempts]
-  local backend=$1 target=$2 rec=$3 label=${4:-} retries=${5:-$FM_TASK_INBOX_COMMIT_RETRIES} state i=0
-  case "$retries" in ''|*[!0-9]*|0) retries=3 ;; esac
-  while [ "$i" -lt "$retries" ]; do
+fm_task_inbox_commit_pending_doorbell() {  # <backend> <target> <record-path> [expected-label] [attempts-spent]
+  local backend=$1 target=$2 rec=$3 label=${4:-} state i=${5:-0}
+  case "$i" in 0|1) ;; *) i=0 ;; esac
+  while [ "$i" -lt "$_FM_TASK_INBOX_COMMIT_RETRIES" ]; do
     if ! fm_task_inbox_composer_holds_doorbell "$backend" "$target" "$rec" "$label"; then
       state=$(fm_backend_composer_state "$backend" "$target" "$label" 2>/dev/null) || state=unknown
       [ "$state" = empty ] && return 0
       return 1
     fi
-    fm_backend_send_key "$backend" "$target" Enter "$label" || return 1
-    sleep "$FM_TASK_INBOX_COMMIT_SLEEP"
-    state=$(fm_backend_composer_state "$backend" "$target" "$label" 2>/dev/null) || state=unknown
-    case "$state" in
-      empty) return 0 ;;
-      pending|pending-unproven) ;;
-      *) return 1 ;;
-    esac
+    fm_backend_send_key "$backend" "$target" Enter "$label" || true
     i=$((i + 1))
+    sleep "$_FM_TASK_INBOX_COMMIT_SLEEP"
+    if fm_task_inbox_composer_holds_doorbell "$backend" "$target" "$rec" "$label"; then
+      continue
+    fi
+    state=$(fm_backend_composer_state "$backend" "$target" "$label" 2>/dev/null) || state=unknown
+    [ "$state" = empty ] && return 0
+    return 1
   done
   return 1
 }
@@ -359,7 +357,7 @@ fm_task_inbox_commit_pending_doorbell() {  # <backend> <target> <record-path> [e
 # verdicts would starve a harness whose idle screen the classifier cannot
 # positively identify (that classifier is advisory here by design).
 fm_task_inbox_ring() {  # <backend> <target> <record-path> [expected-label]
-  local backend=$1 target=$2 rec=$3 label=${4:-} line cstate verdict retries
+  local backend=$1 target=$2 rec=$3 label=${4:-} line cstate verdict
   case "$(fm_backend_agent_state "$backend" "$target" 2>/dev/null || true)" in
     dead|missing) return 3 ;;
   esac
@@ -398,10 +396,7 @@ fm_task_inbox_ring() {  # <backend> <target> <record-path> [expected-label]
     pending|pending-unproven|unknown) ;;
     *) return 0 ;;
   esac
-  retries=$FM_TASK_INBOX_COMMIT_RETRIES
-  case "$retries" in ''|*[!0-9]*|0) retries=3 ;; esac
-  [ "$retries" -gt 1 ] || return 1
-  fm_task_inbox_commit_pending_doorbell "$backend" "$target" "$rec" "$label" "$((retries - 1))" || return 1
+  fm_task_inbox_commit_pending_doorbell "$backend" "$target" "$rec" "$label" 1 || return 1
   return 0
 }
 

--- a/bin/fm-task-inbox-lib.sh
+++ b/bin/fm-task-inbox-lib.sh
@@ -316,26 +316,27 @@ fm_task_inbox_composer_holds_doorbell() {  # <backend> <target> <record-path> [e
 # fm_task_inbox_commit_pending_doorbell: submit a doorbell already sitting in
 # the composer, with a bounded Enter-only retry. Retyping is never correct
 # here - the text is already there, and a second copy would be delivered as
-# well as the first - so this reuses the shared Enter-only ladder rather than
-# going back through the type-and-submit path.
-# True when the composer no longer holds pending text.
-_FM_TASK_INBOX_COMMIT_BACKEND=''
-_fm_task_inbox_commit_send_key() {  # <target> <key> [expected-label]
-  fm_backend_send_key "$_FM_TASK_INBOX_COMMIT_BACKEND" "$1" "$2" "${3:-}"
-}
-_fm_task_inbox_commit_state() {  # <target> [expected-label]
-  fm_backend_composer_state "$_FM_TASK_INBOX_COMMIT_BACKEND" "$1" "${2:-}" 2>/dev/null || printf 'unknown'
-}
-fm_task_inbox_commit_pending_doorbell() {  # <backend> <target> [expected-label]
-  local backend=$1 target=$2 label=${3:-} state
-  _FM_TASK_INBOX_COMMIT_BACKEND=$backend
-  state=$(fm_composer_submit_retry_core _fm_task_inbox_commit_send_key _fm_task_inbox_commit_state \
-    "$target" "$FM_TASK_INBOX_COMMIT_RETRIES" "$FM_TASK_INBOX_COMMIT_SLEEP" "$label")
-  _FM_TASK_INBOX_COMMIT_BACKEND=''
-  case "$state" in
-    pending|pending-unproven) return 1 ;;
-  esac
-  return 0
+# well as the first. True when the composer is proven empty.
+fm_task_inbox_commit_pending_doorbell() {  # <backend> <target> <record-path> [expected-label] [attempts]
+  local backend=$1 target=$2 rec=$3 label=${4:-} retries=${5:-$FM_TASK_INBOX_COMMIT_RETRIES} state i=0
+  case "$retries" in ''|*[!0-9]*|0) retries=3 ;; esac
+  while [ "$i" -lt "$retries" ]; do
+    if ! fm_task_inbox_composer_holds_doorbell "$backend" "$target" "$rec" "$label"; then
+      state=$(fm_backend_composer_state "$backend" "$target" "$label" 2>/dev/null) || state=unknown
+      [ "$state" = empty ] && return 0
+      return 1
+    fi
+    fm_backend_send_key "$backend" "$target" Enter "$label" || return 1
+    sleep "$FM_TASK_INBOX_COMMIT_SLEEP"
+    state=$(fm_backend_composer_state "$backend" "$target" "$label" 2>/dev/null) || state=unknown
+    case "$state" in
+      empty) return 0 ;;
+      pending|pending-unproven) ;;
+      *) return 1 ;;
+    esac
+    i=$((i + 1))
+  done
+  return 1
 }
 
 # Ring the doorbell, best-effort: one endpoint-liveness pre-check, one advisory
@@ -358,7 +359,7 @@ fm_task_inbox_commit_pending_doorbell() {  # <backend> <target> [expected-label]
 # verdicts would starve a harness whose idle screen the classifier cannot
 # positively identify (that classifier is advisory here by design).
 fm_task_inbox_ring() {  # <backend> <target> <record-path> [expected-label]
-  local backend=$1 target=$2 rec=$3 label=${4:-} line cstate verdict
+  local backend=$1 target=$2 rec=$3 label=${4:-} line cstate verdict retries
   case "$(fm_backend_agent_state "$backend" "$target" 2>/dev/null || true)" in
     dead|missing) return 3 ;;
   esac
@@ -373,7 +374,7 @@ fm_task_inbox_ring() {  # <backend> <target> <record-path> [expected-label]
       # to a re-ring that would defer again on the same text. Anything we
       # cannot positively identify as this record's doorbell still defers.
       if fm_task_inbox_composer_holds_doorbell "$backend" "$target" "$rec" "$label"; then
-        fm_task_inbox_commit_pending_doorbell "$backend" "$target" "$label" || return 1
+        fm_task_inbox_commit_pending_doorbell "$backend" "$target" "$rec" "$label" || return 1
         return 0
       fi
       return 1
@@ -383,12 +384,18 @@ fm_task_inbox_ring() {  # <backend> <target> <record-path> [expected-label]
   # steps, so an agent exiting after the liveness check could leave a bare
   # shell only a suffix; the `: ` prefix protects complete lines only. Do not
   # add process-bound atomic delivery here unless an incident reopens this.
-  if ! verdict=$(fm_backend_send_text_submit "$backend" "$target" "$line" 3 0.4 0.3 "$label" 2>/dev/null); then
+  if ! verdict=$(fm_backend_send_text_submit "$backend" "$target" "$line" 1 0.4 0.3 "$label" 2>/dev/null); then
     return 2
   fi
-  # The verdict is read only to report a failed keystroke; every other value
-  # (empty, pending, unknown, ...) is deliberately ignored, never proof.
   [ "$verdict" != send-failed ] || return 2
+  case "$verdict" in
+    pending|pending-unproven)
+      retries=$FM_TASK_INBOX_COMMIT_RETRIES
+      case "$retries" in ''|*[!0-9]*|0) retries=3 ;; esac
+      [ "$retries" -gt 1 ] || return 1
+      fm_task_inbox_commit_pending_doorbell "$backend" "$target" "$rec" "$label" "$((retries - 1))" || return 1
+      ;;
+  esac
   return 0
 }
 

--- a/bin/fm-task-inbox-lib.sh
+++ b/bin/fm-task-inbox-lib.sh
@@ -77,11 +77,21 @@ _FM_TASK_INBOX_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 . "$_FM_TASK_INBOX_LIB_DIR/fm-wake-lib.sh"
 # shellcheck source=/dev/null
 . "$_FM_TASK_INBOX_LIB_DIR/fm-backend.sh"
+# The composer extractor below identifies a swallowed doorbell still sitting in
+# the composer. Sourced explicitly rather than relying on a backend adapter
+# having pulled it in first.
+# shellcheck source=/dev/null
+. "$_FM_TASK_INBOX_LIB_DIR/fm-composer-lib.sh"
 
 FM_TASK_INBOX_SCHEMA='fm-task-inbox.v1'
 FM_TASK_INBOX_GRACE_DEFAULT=90
 FM_TASK_INBOX_RING_MAX_DEFAULT=3
 FM_TASK_INBOX_LOCK_WAIT_DEFAULT=5
+# Enter-only retries (and spacing) used to commit a doorbell that is already
+# sitting unsubmitted in the composer. Never retypes; see
+# fm_task_inbox_commit_pending_doorbell.
+FM_TASK_INBOX_COMMIT_RETRIES=${FM_TASK_INBOX_COMMIT_RETRIES:-3}
+FM_TASK_INBOX_COMMIT_SLEEP=${FM_TASK_INBOX_COMMIT_SLEEP:-0.4}
 
 fm_task_inbox_grace_secs() {
   local g=${FM_TASK_INBOX_GRACE_SECS:-$FM_TASK_INBOX_GRACE_DEFAULT}
@@ -268,6 +278,69 @@ fm_task_inbox_doorbell_line() {  # <record-path>
     "$quoted" "$quoted"
 }
 
+# fm_task_inbox_composer_holds_doorbell: true only when the composer's OWN
+# content carries THIS record's complete doorbell line - the signature of an
+# Enter that was swallowed after the line was typed.
+#
+# Why identity matters: fm_task_inbox_ring defers on a `pending` composer so
+# our Enter can never submit someone's real half-typed content. That guard has
+# no way to tell foreign text from firstmate's own undelivered doorbell, so a
+# single swallowed Enter makes the doorbell itself the thing that blocks every
+# later re-ring, and the steer sits unsubmitted until a human presses Enter.
+# Identifying our own line is what makes the deferral recoverable without
+# weakening the guarantee for text we did not type.
+#
+# Only the composer REGION is consulted (fm_composer_extract_selected_content),
+# never the whole capture: an already-submitted doorbell stays visible in the
+# transcript above, and matching that history would let a human's half-typed
+# text be committed. Both sides are compared with every whitespace byte
+# removed, because a composer wraps a long line across rows mid-token.
+#
+# Every failure - unreadable capture, unidentifiable composer, no match -
+# returns false, so the caller keeps today's conservative skip.
+fm_task_inbox_composer_holds_doorbell() {  # <backend> <target> <record-path> [expected-label]
+  local backend=$1 target=$2 rec=$3 label=${4:-} line cap caps content
+  line=$(fm_task_inbox_doorbell_line "$rec") || return 1
+  cap=$(fm_backend_capture "$backend" "$target" "$FM_COMPOSER_CAPTURE_LINES" "$label" 2>/dev/null) || return 1
+  [ -n "$cap" ] || return 1
+  # styled=0: a plain capture cannot strip ghost/placeholder text, which can
+  # only ever cost a match (a placeholder never carries this record's path).
+  caps=$(printf 'styled=0\ncursor=0\nidentity=0\nrows=%s' "$FM_COMPOSER_CAPTURE_LINES")
+  content=$(fm_composer_extract_selected_content "$caps" "$cap" 2>/dev/null) || return 1
+  content=${content//[$' \t\r\n\v\f']/}
+  line=${line//[$' \t\r\n\v\f']/}
+  [ -n "$line" ] || return 1
+  case "$content" in
+    *"$line"*) return 0 ;;
+  esac
+  return 1
+}
+
+# fm_task_inbox_commit_pending_doorbell: submit a doorbell already sitting in
+# the composer, with a bounded Enter-only retry. Retyping is never correct
+# here - the text is already there, and a second copy would be delivered as
+# well as the first - so this reuses the shared Enter-only ladder rather than
+# going back through the type-and-submit path.
+# True when the composer no longer holds pending text.
+_FM_TASK_INBOX_COMMIT_BACKEND=''
+_fm_task_inbox_commit_send_key() {  # <target> <key> [expected-label]
+  fm_backend_send_key "$_FM_TASK_INBOX_COMMIT_BACKEND" "$1" "$2" "${3:-}"
+}
+_fm_task_inbox_commit_state() {  # <target> [expected-label]
+  fm_backend_composer_state "$_FM_TASK_INBOX_COMMIT_BACKEND" "$1" "${2:-}" 2>/dev/null || printf 'unknown'
+}
+fm_task_inbox_commit_pending_doorbell() {  # <backend> <target> [expected-label]
+  local backend=$1 target=$2 label=${3:-} state
+  _FM_TASK_INBOX_COMMIT_BACKEND=$backend
+  state=$(fm_composer_submit_retry_core _fm_task_inbox_commit_send_key _fm_task_inbox_commit_state \
+    "$target" "$FM_TASK_INBOX_COMMIT_RETRIES" "$FM_TASK_INBOX_COMMIT_SLEEP" "$label")
+  _FM_TASK_INBOX_COMMIT_BACKEND=''
+  case "$state" in
+    pending|pending-unproven) return 1 ;;
+  esac
+  return 0
+}
+
 # Ring the doorbell, best-effort: one endpoint-liveness pre-check, one advisory
 # composer pre-check, then the backend's submit machinery with a minimal retry
 # budget, verdict discarded.
@@ -277,7 +350,12 @@ fm_task_inbox_doorbell_line() {  # <record-path>
 # record). No return value is delivery proof; the acknowledgement move is the
 # only delivery signal.
 # The skip is deliberately narrow: only an exact `pending` verdict defers,
-# because there our Enter could submit someone's real half-typed content.
+# because there our Enter could submit someone's real half-typed content. A
+# pending composer that positively holds THIS record's own doorbell is the one
+# exception - that text is ours and already typed, so it is committed with an
+# Enter-only retry rather than deferred forever (see
+# fm_task_inbox_composer_holds_doorbell for why the deferral is otherwise
+# self-sustaining, and why every unidentified case still defers).
 # `pending-unproven` and `unknown` still ring - the worst outcome is a garbled
 # CONSTANT line the worker recovers semantically, while skipping on ambiguous
 # verdicts would starve a harness whose idle screen the classifier cannot
@@ -292,7 +370,17 @@ fm_task_inbox_ring() {  # <backend> <target> <record-path> [expected-label]
   fi
   cstate=$(fm_backend_composer_state "$backend" "$target" "$label" 2>/dev/null) || cstate=unknown
   case "$cstate" in
-    pending) return 1 ;;
+    pending)
+      # Our own doorbell sitting here is a swallowed Enter, not someone's
+      # half-typed content: commit what is already typed instead of deferring
+      # to a re-ring that would defer again on the same text. Anything we
+      # cannot positively identify as this record's doorbell still defers.
+      if fm_task_inbox_composer_holds_doorbell "$backend" "$target" "$rec" "$label"; then
+        fm_task_inbox_commit_pending_doorbell "$backend" "$target" "$label" || return 1
+        return 0
+      fi
+      return 1
+      ;;
   esac
   # Accepted residual race: terminal input and Enter are separate delivery
   # steps, so an agent exiting after the liveness check could leave a bare

--- a/bin/fm-task-inbox-lib.sh
+++ b/bin/fm-task-inbox-lib.sh
@@ -301,7 +301,7 @@ fm_task_inbox_doorbell_line() {  # <record-path>
 # returns false, so the caller keeps today's conservative skip.
 fm_task_inbox_composer_holds_doorbell() {  # <backend> <target> <record-path> [expected-label]
   local backend=$1 target=$2 rec=$3 label=${4:-} line cap caps row raw content glyph
-  local joined='' prompt_seen=0
+  local remaining framed left right prompt_seen=0 width
   line=$(fm_task_inbox_doorbell_line "$rec") || return 1
   cap=$(fm_backend_capture "$backend" "$target" "$FM_COMPOSER_CAPTURE_LINES" "$label" 2>/dev/null) || return 1
   [ -n "$cap" ] || return 1
@@ -309,36 +309,74 @@ fm_task_inbox_composer_holds_doorbell() {  # <backend> <target> <record-path> [e
   # only ever cost a match (a placeholder never carries this record's path).
   caps=$(printf 'styled=0\ncursor=0\nidentity=0\nrows=%s' "$FM_COMPOSER_CAPTURE_LINES")
   # Run the shared selector in this shell so its selected composer bounds remain
-  # available. Its ordinary output collapses whitespace, so reconstruct from
-  # the selected rows instead and preserve visible whitespace within each row.
+  # available. Its ordinary output trims every row, so compare the visible row
+  # cells ourselves. Only proven UI furniture is removed; editable whitespace
+  # at the start or at a wrap boundary remains part of the identity check.
   fm_composer_extract_selected_content "$caps" "$cap" >/dev/null 2>&1 || return 1
+  remaining=$line
   row=$FM_COMPOSER_SELECTED_FIRST
   while [ "$row" -le "$FM_COMPOSER_SELECTED_LAST" ]; do
     raw=$(_fm_composer_screen_row "$row" "$cap")
-    content=$(_fm_composer_row_content "$raw" 0)
+    content=$(printf '%s\n' "$raw" | fm_composer_strip_ansi)
+    fm_composer_normalize_spaces_var content
     case "$FM_COMPOSER_SELECTED_KIND" in
-      bare)
-        if [ "$row" -eq "$FM_COMPOSER_SELECTED_FIRST" ] \
-          && fm_composer_leading_agent_glyph_var glyph "$content"; then
-          content=${content#*"$glyph"}
-        fi
-        ;;
-      leftbar) case "$content" in '┃'*) content=${content#┃} ;; esac ;;
       box)
+        # Whitespace outside the paired border and one cell just inside each
+        # edge are box geometry. Every other cell is composer content.
+        framed=$content
+        fm_composer_normalize_trim_var framed
+        left=${framed:0:1}; right=${framed: -1}
+        case "$left$right" in '││'|'┃┃'|'║║'|'||') ;; *) return 1 ;; esac
+        content=${framed:1:${#framed}-2}
+        case "$content" in ' '*) content=${content:1} ;; *) return 1 ;; esac
+        case "$content" in *' ') content=${content:0:${#content}-1} ;; *) return 1 ;; esac
         if [ "$prompt_seen" = 0 ] \
           && fm_composer_leading_prompt_glyph_var glyph "$content"; then
           content=${content#*"$glyph"}
+          case "$content" in ' '*) content=${content:1} ;; esac
           prompt_seen=1
         fi
         ;;
+      leftbar)
+        framed=$content
+        fm_composer_normalize_trim_var framed
+        case "$framed" in '┃'*) content=${framed#┃} ;; *) return 1 ;; esac
+        case "$content" in ' '*) content=${content:1} ;; esac
+        ;;
+      bare)
+        if [ "$row" -eq "$FM_COMPOSER_SELECTED_FIRST" ]; then
+          framed=$content
+          framed=${framed#"${framed%%[![:space:]]*}"}
+          fm_composer_leading_agent_glyph_var glyph "$framed" || return 1
+          content=${framed#*"$glyph"}
+          case "$content" in ' '*) content=${content:1} ;; esac
+        fi
+        ;;
+      pi) ;;
+      *) return 1 ;;
     esac
-    fm_composer_normalize_spaces_var content
-    fm_composer_normalize_trim_var content
-    joined+=$content
+
+    width=${#content}
+    if [ "${#remaining}" -ge "$width" ]; then
+      [ "$content" = "${remaining:0:$width}" ] || return 1
+      remaining=${remaining:$width}
+    else
+      [ "${content:0:${#remaining}}" = "$remaining" ] || return 1
+      content=${content:${#remaining}}
+      # A bordered box paints blank cells through its right edge. Unbordered
+      # shapes do not provide that geometry, so any trailing cell is editable
+      # composer content and must prevent an identity match.
+      if [ "$FM_COMPOSER_SELECTED_KIND" = box ]; then
+        [ -z "${content// /}" ] || return 1
+      else
+        [ -z "$content" ] || return 1
+      fi
+      remaining=
+    fi
     row=$((row + 1))
   done
   [ -n "$line" ] || return 1
-  [ "$joined" = "$line" ]
+  [ -z "$remaining" ]
 }
 
 # fm_task_inbox_commit_pending_doorbell: submit a doorbell already sitting in

--- a/bin/fm-task-inbox-lib.sh
+++ b/bin/fm-task-inbox-lib.sh
@@ -291,27 +291,54 @@ fm_task_inbox_doorbell_line() {  # <record-path>
 # Identifying our own line is what makes the deferral recoverable without
 # weakening the guarantee for text we did not type.
 #
-# Only the composer REGION is consulted (fm_composer_extract_selected_content),
-# never the whole capture: an already-submitted doorbell stays visible in the
-# transcript above, and matching that history would let a human's half-typed
-# text be committed. Both sides are compared with every whitespace byte
-# removed, because a composer wraps a long line across rows mid-token.
+# Only the composer REGION is consulted, never the whole capture: an
+# already-submitted doorbell stays visible in the transcript above, and
+# matching that history would let a human's half-typed text be committed.
+# Wrapped rows are rejoined without adding whitespace. Removing all whitespace
+# would make a user-edited line look unchanged and could submit their draft.
 #
-# Every failure - unreadable capture, unidentifiable composer, no match -
+# Every failure - unreadable capture, unidentifiable composer, no exact match -
 # returns false, so the caller keeps today's conservative skip.
 fm_task_inbox_composer_holds_doorbell() {  # <backend> <target> <record-path> [expected-label]
-  local backend=$1 target=$2 rec=$3 label=${4:-} line cap caps content
+  local backend=$1 target=$2 rec=$3 label=${4:-} line cap caps row raw content glyph
+  local joined='' prompt_seen=0
   line=$(fm_task_inbox_doorbell_line "$rec") || return 1
   cap=$(fm_backend_capture "$backend" "$target" "$FM_COMPOSER_CAPTURE_LINES" "$label" 2>/dev/null) || return 1
   [ -n "$cap" ] || return 1
   # styled=0: a plain capture cannot strip ghost/placeholder text, which can
   # only ever cost a match (a placeholder never carries this record's path).
   caps=$(printf 'styled=0\ncursor=0\nidentity=0\nrows=%s' "$FM_COMPOSER_CAPTURE_LINES")
-  content=$(fm_composer_extract_selected_content "$caps" "$cap" 2>/dev/null) || return 1
-  content=${content//[$' \t\r\n\v\f']/}
-  line=${line//[$' \t\r\n\v\f']/}
+  # Run the shared selector in this shell so its selected composer bounds remain
+  # available. Its ordinary output collapses whitespace, so reconstruct from
+  # the selected rows instead and preserve visible whitespace within each row.
+  fm_composer_extract_selected_content "$caps" "$cap" >/dev/null 2>&1 || return 1
+  row=$FM_COMPOSER_SELECTED_FIRST
+  while [ "$row" -le "$FM_COMPOSER_SELECTED_LAST" ]; do
+    raw=$(_fm_composer_screen_row "$row" "$cap")
+    content=$(_fm_composer_row_content "$raw" 0)
+    case "$FM_COMPOSER_SELECTED_KIND" in
+      bare)
+        if [ "$row" -eq "$FM_COMPOSER_SELECTED_FIRST" ] \
+          && fm_composer_leading_agent_glyph_var glyph "$content"; then
+          content=${content#*"$glyph"}
+        fi
+        ;;
+      leftbar) case "$content" in '┃'*) content=${content#┃} ;; esac ;;
+      box)
+        if [ "$prompt_seen" = 0 ] \
+          && fm_composer_leading_prompt_glyph_var glyph "$content"; then
+          content=${content#*"$glyph"}
+          prompt_seen=1
+        fi
+        ;;
+    esac
+    fm_composer_normalize_spaces_var content
+    fm_composer_normalize_trim_var content
+    joined+=$content
+    row=$((row + 1))
+  done
   [ -n "$line" ] || return 1
-  [ "$content" = "$line" ]
+  [ "$joined" = "$line" ]
 }
 
 # fm_task_inbox_commit_pending_doorbell: submit a doorbell already sitting in

--- a/bin/fm-task-inbox-lib.sh
+++ b/bin/fm-task-inbox-lib.sh
@@ -387,15 +387,21 @@ fm_task_inbox_ring() {  # <backend> <target> <record-path> [expected-label]
   if ! verdict=$(fm_backend_send_text_submit "$backend" "$target" "$line" 1 0.4 0.3 "$label" 2>/dev/null); then
     return 2
   fi
-  [ "$verdict" != send-failed ] || return 2
   case "$verdict" in
-    pending|pending-unproven)
-      retries=$FM_TASK_INBOX_COMMIT_RETRIES
-      case "$retries" in ''|*[!0-9]*|0) retries=3 ;; esac
-      [ "$retries" -gt 1 ] || return 1
-      fm_task_inbox_commit_pending_doorbell "$backend" "$target" "$rec" "$label" "$((retries - 1))" || return 1
+    send-failed)
+      if ! fm_task_inbox_composer_holds_doorbell "$backend" "$target" "$rec" "$label"; then
+        cstate=$(fm_backend_composer_state "$backend" "$target" "$label" 2>/dev/null) || cstate=unknown
+        [ "$cstate" = empty ] && return 2
+        return 1
+      fi
       ;;
+    pending|pending-unproven|unknown) ;;
+    *) return 0 ;;
   esac
+  retries=$FM_TASK_INBOX_COMMIT_RETRIES
+  case "$retries" in ''|*[!0-9]*|0) retries=3 ;; esac
+  [ "$retries" -gt 1 ] || return 1
+  fm_task_inbox_commit_pending_doorbell "$backend" "$target" "$rec" "$label" "$((retries - 1))" || return 1
   return 0
 }
 

--- a/bin/fm-task-inbox-lib.sh
+++ b/bin/fm-task-inbox-lib.sh
@@ -13,12 +13,15 @@
 #
 # Design (captain-adopted, data/fm-send-reliability-reframe-s1/report.md): the
 # payload moves to the filesystem, which is reliable; the terminal carries only
-# a short constant doorbell line. While the endpoint remains available, that
-# line does not need to be reliable because ringing it again is free. A
-# duplicated doorbell is a no-op by construction (the worker finds the inbox
-# empty or already handled), and a swallowed doorbell is detected by the
-# absence of the worker's acknowledgement and re-rung on a bounded schedule.
-# A positively dead or missing endpoint bypasses that schedule without being
+# a short constant doorbell line. The ring verifies an inconclusive submit and
+# retries Enter only while the composer positively holds this record's exact
+# doorbell, stops on proven emptiness, and otherwise sends no further key. An
+# initial send-failed verdict with an empty composer still reports failure
+# because the backend cannot distinguish a landed Enter from text never typed.
+# A duplicated doorbell is a no-op by construction (the worker finds the
+# inbox empty or already handled), so the absence of acknowledgement still
+# drives the bounded watcher re-ring schedule as a backstop. A positively dead
+# or missing endpoint bypasses that schedule without being
 # typed into, and its unhandled record surfaces through the ordinary stale wake
 # into stuck-crewmate-recovery.
 #

--- a/bin/fm-task-inbox-lib.sh
+++ b/bin/fm-task-inbox-lib.sh
@@ -310,10 +310,7 @@ fm_task_inbox_composer_holds_doorbell() {  # <backend> <target> <record-path> [e
   content=${content//[$' \t\r\n\v\f']/}
   line=${line//[$' \t\r\n\v\f']/}
   [ -n "$line" ] || return 1
-  case "$content" in
-    *"$line"*) return 0 ;;
-  esac
-  return 1
+  [ "$content" = "$line" ]
 }
 
 # fm_task_inbox_commit_pending_doorbell: submit a doorbell already sitting in
@@ -386,7 +383,7 @@ fm_task_inbox_ring() {  # <backend> <target> <record-path> [expected-label]
   # steps, so an agent exiting after the liveness check could leave a bare
   # shell only a suffix; the `: ` prefix protects complete lines only. Do not
   # add process-bound atomic delivery here unless an incident reopens this.
-  if ! verdict=$(fm_backend_send_text_submit "$backend" "$target" "$line" 1 0.4 0.3 "$label" 2>/dev/null); then
+  if ! verdict=$(fm_backend_send_text_submit "$backend" "$target" "$line" 3 0.4 0.3 "$label" 2>/dev/null); then
     return 2
   fi
   # The verdict is read only to report a failed keystroke; every other value

--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -331,6 +331,7 @@ family_for_basename() {
     fm-sessionstart-hook-live-e2e.test.sh|fm-sessionstart-instruction-refresh-live-e2e.test.sh|\
     fm-quota-array-dispatch-live-e2e.test.sh|fm-send-secondmate-marker-herdr-e2e.test.sh|\
     fm-send-inbox-doorbell-live-e2e.test.sh|\
+    fm-send-inbox-doorbell-herdr-live-e2e.test.sh|\
     fm-herdr-submit-confirm-live-e2e.test.sh)
       printf '%s\n' live-harness-optin
       ;;

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -154,6 +154,7 @@ Unsupported supervisor backends refuse at daemon startup.
 Stalled escalation delivery writes `state/.subsuper-inject-wedged` and attempts a configured backend-independent active alert after `FM_MAX_DEFER_SECS` instead of silently deferring forever.
 On an unmarked return, `bin/fm-afk-return.sh` owns ordered shutdown, durable catch-up evidence, and the fail-closed gate that keeps ordinary work behind every live firstmate-actionable blocker.
 `fm-send.sh` delivers every remote text steer and ordinary local text steer as a durable steering-inbox record plus a best-effort constant doorbell line (`bin/fm-task-inbox-lib.sh`).
+Doorbell-specific composer identity, guarded Enter recovery, and the watcher re-ring ladder remain inside that inbox owner rather than the generic backend submit cores.
 The doorbell line is a shell no-op and is never typed into an endpoint classified as dead or missing; that record surfaces once for recovery instead of walking the re-ring ladder (`bin/fm-task-inbox-lib.sh` header).
 Its local-only typed plane - harness-native invocations and explicit backend targets - selects a pre-Enter popup-settle for slash commands and for codex `$...` skill invocations using metadata-routed target `harness=` values, then adds its own `FM_SEND_SETTLE` pause after successful typed sends so immediate peeks catch the receiving turn starting; the sub-supervisor uses only the shared submit core and does not pay that post-submit pause.
 

--- a/docs/herdr-backend.md
+++ b/docs/herdr-backend.md
@@ -211,6 +211,7 @@ An already-running server is reused without restart or environment changes.
 Explicit named-session routing and unrelated launch environment remain intact.
 
 Literal text and Enter are separate operations on `fm-send.sh`'s typed plane; ordinary local text steers instead use the durable steering inbox and send only its best-effort constant doorbell through this adapter.
+Doorbell-specific identity verification and guarded Enter recovery belong to `bin/fm-task-inbox-lib.sh`, not this generic backend submit path; [runtime backend verification](verification/runtime-backends.md#swallowed-enter-recovery) owns the cross-version evidence.
 Spawn-time fixed commands may use Herdr's atomic run primitive.
 Enter, Escape, and Ctrl-C are supported.
 Typed-plane slash input, and dollar-prefixed skill input for Codex, uses the shared harness-aware settle before the first Enter so a completion popup cannot consume it.
@@ -332,6 +333,7 @@ Tests use thin compatibility wrappers in `tests/herdr-test-safety.sh` and never 
 tests/fm-backend-herdr.test.sh
 tests/fm-composer-lib.test.sh
 tests/fm-herdr-submit-confirm-live-e2e.test.sh
+tests/fm-send-inbox-doorbell-herdr-live-e2e.test.sh
 tests/fm-backend-herdr-smoke.test.sh
 tests/fm-backend-herdr-prune-safety-e2e.test.sh
 tests/fm-backend-herdr-respawn-idem-e2e.test.sh

--- a/docs/remote-secondmates.md
+++ b/docs/remote-secondmates.md
@@ -179,7 +179,8 @@ Every remote transport attempt is bounded by `FM_SEND_REMOTE_BUDGET`; that heade
 An unconfirmed SSH transport (exit 255) is retried identically once, while a budget expiry is not retried because completion is unknown; either outcome preserves this ordinary reply-bearing request's pending-reply expectation for the record that may have landed.
 If delivery remains unconfirmed, only the exact `FM_PENDING_REPLY_EXISTING_CORR=<id>` resend command printed by `fm-send` is safe to run later because it preserves the request body and lets the remote enqueue deduplicate onto the same record; a plain rerun mints a different correlation and is not idempotent.
 When deduplication finds that the worker already moved the matching record into `handled/`, the resend exits successfully without ringing the doorbell again.
-The remote host runs no doorbell re-ring ladder of its own; a swallowed doorbell for an ordinary reply-bearing request surfaces through the parent's pending-reply recovery and escalation, whose recovery request rings the doorbell again when it is enqueued.
+The remote host runs no doorbell re-ring ladder of its own, but its host-local ring uses the composer-safe exact-doorbell recovery owned by [`bin/fm-task-inbox-lib.sh`](../bin/fm-task-inbox-lib.sh).
+If the record remains unhandled, the parent's pending-reply recovery and escalation remain the backstop and ring the doorbell again with the recovery request.
 `fm-peek.sh` and `fm-crew-state.sh` route remote-secondmate reads to the endpoint's host instead of consulting local worktree or backend state.
 An unreachable or unreadable remote read is unknown, not evidence that the endpoint is dead.
 

--- a/docs/verification/runtime-backends.md
+++ b/docs/verification/runtime-backends.md
@@ -366,13 +366,14 @@ This guard is the refresh command after any harness upgrade; it spends a small n
 
 ### Swallowed-Enter recovery
 
-The same guard also proves the recovery half: a doorbell whose Enter is lost leaves firstmate's own line sitting in the composer, which reads `pending` - the exact verdict the ring defers on to protect a human's half-typed text.
+The general live guard now checks the recovery half too: a doorbell whose Enter is lost leaves firstmate's own line sitting in the composer, which reads `pending` - the exact verdict the ring defers on to protect a human's half-typed text.
 Identifying that line as firstmate's own is what keeps the deferral recoverable, because a ring that cannot tell its own undelivered doorbell from foreign text defers again on the text the previous ring left behind and the steer waits for a human keypress.
 Verified on 2026-09-08 against Herdr 0.9.0 (protocol 22) and Herdr 0.8.2 (protocol 20), each in its own isolated named-session lab with its own short `XDG_CONFIG_HOME`, `XDG_STATE_HOME`, and `XDG_DATA_HOME`, driving `fm_task_inbox_ring` against real Claude Code 2.1.236.
 Both versions behaved identically: before the change every re-ring returned the deferral status and left the composer `pending`; after it the first re-ring committed the line, the worker acted, and the worker acknowledged the durable record by moving it into `handled/`.
 A composer holding text firstmate did not type was deferred untouched and visibly remained unsent on both versions, while its durable record remained in place.
 
-The self-contained guard downloads checksum-pinned official release binaries when needed, uses only non-default `fm-lab-` sessions, and tears down each isolated universe on exit. It is the command that refreshes this cross-version record:
+The self-contained guard downloads checksum-pinned official release binaries when needed, uses only non-default `fm-lab-` sessions, and tears down each isolated universe on exit.
+It is the command that refreshes this cross-version record:
 
 ```sh
 FM_SEND_INBOX_HERDR_LIVE_E2E=1 tests/fm-send-inbox-doorbell-herdr-live-e2e.test.sh
@@ -390,7 +391,6 @@ ok - cross-version Herdr doorbell guard: 2 version(s) passed, 0 unavailable
 
 The same run recorded why the transport itself is not the variable: with a raw-mode reader in the pane, `pane send-text` followed by `pane send-keys enter` delivers byte-identical input on both releases (the literal text, then the Enter encoding the application asked for - `\r`, or `\e[13u` under the Kitty keyboard protocol), in the same order, at the caller's settle interval.
 `pane run` is not an equivalent substitute for a composer: it emits the text bracketed-paste wrapped with the Enter appended in one zero-delay write (`\e[200~` ... `\e[201~\e[13u`), which a real Claude composer intermittently fails to commit - 2 of 3 and 4 of 5 submitted across two runs on 0.9.0, failing on the first message each time - against 5 of 5 for the settled two-step on both releases.
-
 
 ## Gemini
 

--- a/docs/verification/runtime-backends.md
+++ b/docs/verification/runtime-backends.md
@@ -364,6 +364,26 @@ Two findings from the run shaped the shipped behavior: an OpenCode vendor update
 Kimi was not installed on the verification machine; its receive path is the same one-line-plus-shell contract, and the portable ladder and enqueue regressions in `tests/fm-task-inbox.test.sh` and `tests/fm-send-inbox.test.sh` cover every harness-independent half.
 This guard is the refresh command after any harness upgrade; it spends a small number of real tokens per installed harness, reports an absent harness explicitly, and refuses a run that verified nothing.
 
+### Swallowed-Enter recovery
+
+The same guard also proves the recovery half: a doorbell whose Enter is lost leaves firstmate's own line sitting in the composer, which reads `pending` - the exact verdict the ring defers on to protect a human's half-typed text.
+Identifying that line as firstmate's own is what keeps the deferral recoverable, because a ring that cannot tell its own undelivered doorbell from foreign text defers again on the text the previous ring left behind and the steer waits for a human keypress.
+Verified on 2026-09-08 against Herdr 0.9.0 (protocol 22) and Herdr 0.8.2 (protocol 20), each in its own isolated named-session lab with its own `XDG_CONFIG_HOME`, driving `fm_task_inbox_ring` against real Claude Code 2.1.236.
+Both versions behaved identically: before the change every re-ring returned the deferral status and left the composer `pending`; after it the first re-ring committed the line and the composer returned to `empty` with the turn started.
+A composer holding text firstmate did not type is still deferred untouched on both versions, with no key sent.
+
+The guard itself was run on 2026-09-08 on tmux 3.6a, macOS arm64, and both halves passed for the installed harness:
+
+```text
+ok - claude (2.1.236 (Claude Code)): the doorbell reached a real worker, which acted and acked with the mv
+ok - claude (2.1.236 (Claude Code)): a swallowed doorbell was committed by one re-ring, and the worker acted and acked
+ok - live steering-inbox doorbell guard: 2 check(s) honored the doorbell contract
+```
+
+The same run recorded why the transport itself is not the variable: with a raw-mode reader in the pane, `pane send-text` followed by `pane send-keys enter` delivers byte-identical input on both releases (the literal text, then the Enter encoding the application asked for - `\r`, or `\e[13u` under the Kitty keyboard protocol), in the same order, at the caller's settle interval.
+`pane run` is not an equivalent substitute for a composer: it emits the text bracketed-paste wrapped with the Enter appended in one zero-delay write (`\e[200~` ... `\e[201~\e[13u`), which a real Claude composer intermittently fails to commit - 2 of 3 and 4 of 5 submitted across two runs on 0.9.0, failing on the first message each time - against 5 of 5 for the settled two-step on both releases.
+
+
 ## Gemini
 
 The Gemini crewmate adapter was verified on 2026-09-04 with gemini-cli 0.58.0 on Linux, Node v24.20.0, tmux 3.4.

--- a/docs/verification/runtime-backends.md
+++ b/docs/verification/runtime-backends.md
@@ -368,16 +368,24 @@ This guard is the refresh command after any harness upgrade; it spends a small n
 
 The same guard also proves the recovery half: a doorbell whose Enter is lost leaves firstmate's own line sitting in the composer, which reads `pending` - the exact verdict the ring defers on to protect a human's half-typed text.
 Identifying that line as firstmate's own is what keeps the deferral recoverable, because a ring that cannot tell its own undelivered doorbell from foreign text defers again on the text the previous ring left behind and the steer waits for a human keypress.
-Verified on 2026-09-08 against Herdr 0.9.0 (protocol 22) and Herdr 0.8.2 (protocol 20), each in its own isolated named-session lab with its own `XDG_CONFIG_HOME`, driving `fm_task_inbox_ring` against real Claude Code 2.1.236.
-Both versions behaved identically: before the change every re-ring returned the deferral status and left the composer `pending`; after it the first re-ring committed the line and the composer returned to `empty` with the turn started.
-A composer holding text firstmate did not type is still deferred untouched on both versions, with no key sent.
+Verified on 2026-09-08 against Herdr 0.9.0 (protocol 22) and Herdr 0.8.2 (protocol 20), each in its own isolated named-session lab with its own short `XDG_CONFIG_HOME`, `XDG_STATE_HOME`, and `XDG_DATA_HOME`, driving `fm_task_inbox_ring` against real Claude Code 2.1.236.
+Both versions behaved identically: before the change every re-ring returned the deferral status and left the composer `pending`; after it the first re-ring committed the line, the worker acted, and the worker acknowledged the durable record by moving it into `handled/`.
+A composer holding text firstmate did not type was deferred untouched and visibly remained unsent on both versions, while its durable record remained in place.
 
-The guard itself was run on 2026-09-08 on tmux 3.6a, macOS arm64, and both halves passed for the installed harness:
+The self-contained guard downloads checksum-pinned official release binaries when needed, uses only non-default `fm-lab-` sessions, and tears down each isolated universe on exit. It is the command that refreshes this cross-version record:
+
+```sh
+FM_SEND_INBOX_HERDR_LIVE_E2E=1 tests/fm-send-inbox-doorbell-herdr-live-e2e.test.sh
+```
+
+Observed output on 2026-09-08, macOS arm64:
 
 ```text
-ok - claude (2.1.236 (Claude Code)): the doorbell reached a real worker, which acted and acked with the mv
-ok - claude (2.1.236 (Claude Code)): a swallowed doorbell was committed by one re-ring, and the worker acted and acked
-ok - live steering-inbox doorbell guard: 2 check(s) honored the doorbell contract
+ok - Herdr 0.8.2: swallowed doorbell recovered through real fm_task_inbox_ring
+ok - Herdr 0.8.2: foreign draft stayed unchanged and unsubmitted
+ok - Herdr 0.9.0: swallowed doorbell recovered through real fm_task_inbox_ring
+ok - Herdr 0.9.0: foreign draft stayed unchanged and unsubmitted
+ok - cross-version Herdr doorbell guard: 2 version(s) passed, 0 unavailable
 ```
 
 The same run recorded why the transport itself is not the variable: with a raw-mode reader in the pane, `pane send-text` followed by `pane send-keys enter` delivers byte-identical input on both releases (the literal text, then the Enter encoding the application asked for - `\r`, or `\e[13u` under the Kitty keyboard protocol), in the same order, at the caller's settle interval.

--- a/tests/fm-send-inbox-doorbell-herdr-live-e2e.test.sh
+++ b/tests/fm-send-inbox-doorbell-herdr-live-e2e.test.sh
@@ -1,0 +1,209 @@
+#!/usr/bin/env bash
+# Self-contained cross-version Herdr doorbell guard (live-harness-optin family).
+#
+# Run with FM_SEND_INBOX_HERDR_LIVE_E2E=1. Each version gets a short, private
+# XDG universe and a non-default named session. Herdr 0.8.2 may use the already
+# installed exact-version binary; otherwise the pinned official asset is
+# downloaded. Herdr 0.9.0 is downloaded into its scratch prefix. Downloads are
+# size-bounded and SHA-256 verified. No system binary or default session is
+# changed.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+fm_live_gate opt-in FM_SEND_INBOX_HERDR_LIVE_E2E curl jq claude
+
+unset NO_MISTAKES_GATE
+unset HERDR_ENV HERDR_PANE_ID HERDR_TAB_ID HERDR_WORKSPACE_ID HERDR_SOCKET_PATH HERDR_SESSION
+
+TIMEOUT=${FM_SEND_INBOX_HERDR_LIVE_TIMEOUT:-180}
+CHECKED=0
+UNAVAILABLE=0
+ASSET=
+SHA256=
+
+release_asset() { # <version>
+  local version=$1
+  case "$(uname -s)-$(uname -m)-$version" in
+    Darwin-arm64-0.8.2) ASSET=herdr-macos-aarch64; SHA256=a5d4f4d504d8b309c91f811050559300faba31258425f53c50852fc96f6ae574 ;;
+    Darwin-x86_64-0.8.2) ASSET=herdr-macos-x86_64; SHA256=ab50262c8190cd7aa9056d249d255c08c328c3e8716de9cfa29db4f131b8e2c1 ;;
+    Linux-aarch64-0.8.2|Linux-arm64-0.8.2) ASSET=herdr-linux-aarch64; SHA256=f55610658e1c2e0d2aaef730b4b2ab885f7f8ba00285ab372bfb14f2e3d5b40d ;;
+    Linux-x86_64-0.8.2) ASSET=herdr-linux-x86_64; SHA256=976150a14d490c94b243ea2e1a7eb2dfb67f12e36b182db90936f6728e6aecf4 ;;
+    Darwin-arm64-0.9.0) ASSET=herdr-macos-aarch64; SHA256=32b53df09872628059c789a69f02a6b8e29e14ddf26711421f3463f70c1aef17 ;;
+    Darwin-x86_64-0.9.0) ASSET=herdr-macos-x86_64; SHA256=d0c920b2a126a74809fa1491411c9a097a44786cac9c2ca51b818a995581cf16 ;;
+    Linux-aarch64-0.9.0|Linux-arm64-0.9.0) ASSET=herdr-linux-aarch64; SHA256=9c8db20fb7e7427b138d5367113f1621ffd319f2f65d6f009e2594029115f0d2 ;;
+    Linux-x86_64-0.9.0) ASSET=herdr-linux-x86_64; SHA256=4fa1a01158dd8043da92d31b270780b0dcc10603038d9b61cac4d81ab63fb71f ;;
+    *) return 1 ;;
+  esac
+}
+
+file_sha256() { # <path>
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$1" | awk '{print $1}'
+  elif command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 "$1" | awk '{print $1}'
+  else
+    return 1
+  fi
+}
+
+obtain_version() { # <version> <prefix>
+  local version=$1 prefix=$2 installed actual url
+  mkdir -p "$prefix/bin"
+  installed=$(command -v herdr 2>/dev/null || true)
+  if [ "$version" = 0.8.2 ] && [ -n "$installed" ] && [ "$("$installed" --version 2>/dev/null | awk '{print $2; exit}')" = "$version" ]; then
+    cp "$installed" "$prefix/bin/herdr" || return 1
+    chmod 0755 "$prefix/bin/herdr"
+    return 0
+  fi
+  release_asset "$version" || return 1
+  url="https://github.com/ogulcancelik/herdr/releases/download/v${version}/${ASSET}"
+  if ! curl -fsSL --max-filesize 30000000 "$url" -o "$prefix/bin/herdr.download"; then
+    return 1
+  fi
+  actual=$(file_sha256 "$prefix/bin/herdr.download") || return 1
+  [ "$actual" = "$SHA256" ] || {
+    printf 'not ok - Herdr %s asset checksum mismatch (expected %s, got %s)\n' "$version" "$SHA256" "$actual" >&2
+    return 1
+  }
+  mv "$prefix/bin/herdr.download" "$prefix/bin/herdr"
+  chmod 0755 "$prefix/bin/herdr"
+  [ "$("$prefix/bin/herdr" --version 2>/dev/null | awk '{print $2; exit}')" = "$version" ] || return 1
+}
+
+composer_content() { # <target>
+  local cap caps
+  cap=$(fm_backend_capture herdr "$1" "$FM_COMPOSER_CAPTURE_LINES" claude 2>/dev/null) || return 1
+  caps=$(printf 'styled=0\ncursor=0\nidentity=0\nrows=%s' "$FM_COMPOSER_CAPTURE_LINES")
+  fm_composer_extract_selected_content "$caps" "$cap" 2>/dev/null
+}
+
+wait_for_idle_composer() { # <target> <pane>
+  local target=$1 pane=$2 i=0 state agent
+  while [ "$i" -lt 60 ]; do
+    state=$(fm_backend_composer_state herdr "$target" claude 2>/dev/null || true)
+    agent=$(herdr agent get "$pane" --session "$HERDR_SESSION" 2>/dev/null | jq -r '.result.agent.agent_status // empty' 2>/dev/null || true)
+    case "$agent:$state" in idle:empty|done:empty|blocked:empty) return 0 ;; esac
+    sleep 1
+    i=$((i + 1))
+  done
+  return 1
+}
+
+run_version() ( # <version> <prefix>
+  local version=$1 prefix=$2 session pane ws target home rec handled line acted i rc
+  local foreign foreign_before foreign_after safety_rec safety_handled server_pid=
+  export XDG_CONFIG_HOME="$prefix/c"
+  export XDG_STATE_HOME="$prefix/s"
+  export XDG_DATA_HOME="$prefix/d"
+  export PATH="$prefix/bin:$PATH"
+  export HERDR_SESSION="fm-lab-doorbell-${version//./}-$$"
+  session=$HERDR_SESSION
+  mkdir -p "$XDG_CONFIG_HOME" "$XDG_STATE_HOME" "$XDG_DATA_HOME"
+
+  cleanup_version() {
+    local cleanup_rc=$?
+    trap - EXIT
+    herdr server stop --session "$session" >/dev/null 2>&1 || cleanup_rc=1
+    [ -z "$server_pid" ] || wait "$server_pid" 2>/dev/null || true
+    rm -rf "$prefix"
+    exit "$cleanup_rc"
+  }
+  trap cleanup_version EXIT
+
+  herdr server --session "$session" >"$prefix/server.log" 2>&1 &
+  server_pid=$!
+  i=0
+  while [ "$i" -lt 60 ]; do
+    [ "$(herdr status --json --session "$session" 2>/dev/null | jq -r '.server.running // false' 2>/dev/null)" = true ] && break
+    sleep 1
+    i=$((i + 1))
+  done
+  [ "$i" -lt 60 ] || fail "Herdr $version: isolated server did not start"
+
+  ws=$(herdr workspace create --cwd "$ROOT" --label "doorbell-$version" --no-focus --session "$session") \
+    || fail "Herdr $version: could not create isolated workspace"
+  pane=$(printf '%s' "$ws" | jq -er '.result.root_pane.pane_id') \
+    || fail "Herdr $version: workspace create returned no pane"
+  target="$session:$pane"
+  herdr pane run "$pane" "CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false CLAUDE_CODE_SEND_FEEDBACK=0 claude --dangerously-skip-permissions --settings '{\"feedbackDrafts\":\"off\"}'" --session "$session" >/dev/null \
+    || fail "Herdr $version: could not launch real Claude"
+  wait_for_idle_composer "$target" "$pane" || fail "Herdr $version: Claude did not reach an empty idle composer"
+
+  home="$prefix/home"
+  mkdir -p "$home/state"
+  acted="$prefix/recovery-acted"
+  rec=$(FM_STATE_OVERRIDE="$home/state" fm_task_inbox_write "$home/state" "herdr-$version" \
+    "Firstmate live check: run exactly this shell command now: touch $acted - then follow the mv instruction you were given for this message. Reply with one short line.") \
+    || fail "Herdr $version: could not write recovery record"
+  handled="$home/state/herdr-$version.inbox/handled/${rec##*/}"
+  line=$(fm_task_inbox_doorbell_line "$rec") || fail "Herdr $version: could not form doorbell"
+
+  herdr pane send-text "$pane" "$line" --session "$session" >/dev/null \
+    || fail "Herdr $version: could not stage swallowed doorbell"
+  sleep 2
+  [ "$(fm_backend_composer_state herdr "$target" claude 2>/dev/null || true)" = pending ] \
+    || fail "Herdr $version: staged doorbell was not visibly pending"
+  fm_task_inbox_composer_holds_doorbell herdr "$target" "$rec" claude \
+    || fail "Herdr $version: pending composer did not hold the exact doorbell"
+  fm_task_inbox_ring herdr "$target" "$rec" claude \
+    || fail "Herdr $version: fm_task_inbox_ring did not recover the swallowed Enter"
+
+  i=0
+  while [ "$i" -lt "$TIMEOUT" ]; do
+    [ -f "$handled" ] && [ -e "$acted" ] && break
+    sleep 1
+    i=$((i + 1))
+  done
+  [ -f "$handled" ] && [ -e "$acted" ] \
+    || fail "Herdr $version: worker did not act and acknowledge recovered doorbell within ${TIMEOUT}s"
+  pass "Herdr $version: swallowed doorbell recovered through real fm_task_inbox_ring"
+
+  wait_for_idle_composer "$target" "$pane" || fail "Herdr $version: Claude did not return idle before draft-safety check"
+  foreign="Human draft must stay unsent $version $$"
+  safety_rec=$(FM_STATE_OVERRIDE="$home/state" fm_task_inbox_write "$home/state" "draft-$version" \
+    "touch $prefix/unsafe-acted") || fail "Herdr $version: could not write draft-safety record"
+  safety_handled="$home/state/draft-$version.inbox/handled/${safety_rec##*/}"
+  herdr pane send-text "$pane" "$foreign" --session "$session" >/dev/null \
+    || fail "Herdr $version: could not stage foreign draft"
+  sleep 2
+  [ "$(fm_backend_composer_state herdr "$target" claude 2>/dev/null || true)" = pending ] \
+    || fail "Herdr $version: foreign draft was not visibly pending"
+  foreign_before=$(composer_content "$target") || fail "Herdr $version: could not read staged foreign draft"
+  [ "$foreign_before" = "$foreign" ] || fail "Herdr $version: staged foreign draft content was not exact"
+
+  fm_task_inbox_ring herdr "$target" "$safety_rec" claude >/dev/null 2>&1
+  rc=$?
+  [ "$rc" -eq 1 ] || fail "Herdr $version: ring did not defer on foreign draft (status $rc)"
+  sleep 2
+  foreign_after=$(composer_content "$target") || fail "Herdr $version: could not re-read foreign draft"
+  [ "$foreign_after" = "$foreign_before" ] || fail "Herdr $version: ring changed or submitted foreign draft"
+  [ -f "$safety_rec" ] && [ ! -f "$safety_handled" ] && [ ! -e "$prefix/unsafe-acted" ] \
+    || fail "Herdr $version: foreign draft was submitted or durable record was consumed"
+  pass "Herdr $version: foreign draft stayed unchanged and unsubmitted"
+)
+
+# The portable behavior suite demonstrates that the historical implementation
+# fails the swallowed-doorbell case. This live guard owns only real-product
+# evidence for the two affected Herdr releases.
+# shellcheck source=/dev/null
+. "$ROOT/bin/fm-task-inbox-lib.sh"
+
+for version in 0.8.2 0.9.0; do
+  prefix=$(mktemp -d "/tmp/fmh${version//./}.XXXXXX") || fail "Herdr $version: could not allocate short scratch prefix"
+  if ! obtain_version "$version" "$prefix"; then
+    printf '# unavailable: Herdr %s pinned official binary could not be obtained\n' "$version" >&2
+    rm -rf "$prefix"
+    UNAVAILABLE=$((UNAVAILABLE + 1))
+    continue
+  fi
+  if run_version "$version" "$prefix"; then
+    CHECKED=$((CHECKED + 1))
+  else
+    fail "Herdr $version: live doorbell scenarios failed"
+  fi
+done
+
+[ "$CHECKED" -gt 0 ] || fail "cross-version Herdr doorbell guard verified no version"
+pass "cross-version Herdr doorbell guard: $CHECKED version(s) passed, $UNAVAILABLE unavailable"

--- a/tests/fm-send-inbox-doorbell-live-e2e.test.sh
+++ b/tests/fm-send-inbox-doorbell-live-e2e.test.sh
@@ -51,7 +51,8 @@ SESSION="inboxlive"
 LAB=$(mktemp -d "${TMPDIR:-/tmp}/fm-inbox-live.XXXXXX")
 LAB=$(cd "$LAB" && pwd)
 TIMEOUT=${FM_SEND_INBOX_LIVE_TIMEOUT:-240}
-CHECKED=0
+DELIVERY_CHECKED=0
+RECOVERY_CHECKED=0
 FAILED=0
 
 pass() { printf 'ok - %s\n' "$1"; }
@@ -182,7 +183,7 @@ check_harness_doorbell() {  # <name>
     i=$((i + 1))
   done
   if [ -f "$handled" ] && [ -e "$acted" ]; then
-    CHECKED=$((CHECKED + 1))
+    DELIVERY_CHECKED=$((DELIVERY_CHECKED + 1))
     pass "$name ($version): the doorbell reached a real worker, which acted and acked with the mv"
   else
     FAILED=1
@@ -217,7 +218,8 @@ check_harness_swallowed_recovery() {  # <name>
     || { FAILED=1; printf 'not ok - %s (%s): could not launch for the swallowed-doorbell check\n' "$name" "$version" >&2; return 0; }
   wait_ready "$win"; ready_rc=$?
   if [ "$ready_rc" -eq 1 ]; then
-    note "$name ($version): composer already pending before the swallow check; not verified here"
+    FAILED=1
+    printf 'not ok - %s (%s): composer already pending before the swallowed-doorbell check\n' "$name" "$version" >&2
     tmux -L "$SOCKET" kill-window -t "$SESSION:$win" 2>/dev/null || true
     return 0
   fi
@@ -234,7 +236,8 @@ check_harness_swallowed_recovery() {  # <name>
   tmux -L "$SOCKET" send-keys -t "$SESSION:$win" -l "$line" 2>/dev/null || true
   sleep 2
   if [ "$(fm_tmux_composer_state "$SESSION:$win")" != pending ]; then
-    note "$name ($version): the typed doorbell did not read as pending text; swallow not reproduced, not verified here"
+    FAILED=1
+    printf 'not ok - %s (%s): typed doorbell did not read as pending; swallowed-doorbell recovery was not verified\n' "$name" "$version" >&2
     tmux -L "$SOCKET" kill-window -t "$SESSION:$win" 2>/dev/null || true
     return 0
   fi
@@ -254,7 +257,7 @@ check_harness_swallowed_recovery() {  # <name>
     i=$((i + 1))
   done
   if [ -f "$handled" ] && [ -e "$acted" ]; then
-    CHECKED=$((CHECKED + 1))
+    RECOVERY_CHECKED=$((RECOVERY_CHECKED + 1))
     pass "$name ($version): a swallowed doorbell was committed by one re-ring, and the worker acted and acked"
   else
     FAILED=1
@@ -280,8 +283,12 @@ if [ "$FAILED" -ne 0 ]; then
   printf 'not ok - live steering-inbox doorbell guard found failures above\n' >&2
   exit 1
 fi
-if [ "$CHECKED" -eq 0 ]; then
-  printf 'not ok - live steering-inbox doorbell guard verified nothing (no harness installed?)\n' >&2
+if [ "$DELIVERY_CHECKED" -eq 0 ]; then
+  printf 'not ok - live steering-inbox doorbell guard verified no delivery checks (no harness installed?)\n' >&2
   exit 1
 fi
-pass "live steering-inbox doorbell guard: $CHECKED check(s) honored the doorbell contract"
+if [ "$RECOVERY_CHECKED" -eq 0 ]; then
+  printf 'not ok - live steering-inbox doorbell guard verified no swallowed-doorbell recovery checks\n' >&2
+  exit 1
+fi
+pass "live steering-inbox doorbell guard: $DELIVERY_CHECKED delivery check(s), $RECOVERY_CHECKED recovery check(s) passed"

--- a/tests/fm-send-inbox-doorbell-live-e2e.test.sh
+++ b/tests/fm-send-inbox-doorbell-live-e2e.test.sh
@@ -13,6 +13,14 @@
 # file) and ACKNOWLEDGE it (the mv into handled/), failing loudly with the
 # harness name and version.
 #
+# Each harness is checked twice, because the two halves fail for different
+# reasons. The delivery check above proves a doorbell that lands is honored.
+# The swallowed-Enter check proves the recovery: a doorbell typed without its
+# Enter leaves firstmate's own line in the composer, which reads `pending` -
+# the same verdict the ring defers on to protect a human's half-typed text -
+# and one ordinary re-ring must commit it rather than defer on it forever.
+# Only a real harness renders the composer that read depends on.
+#
 # Run explicitly with FM_SEND_INBOX_LIVE_E2E=1. This test spends a small
 # number of real model tokens per installed harness (one short turn each) -
 # authorized by the harness-dependent-checks rule. An absent harness is
@@ -21,7 +29,8 @@
 # FM_SEND_INBOX_LIVE_HARNESSES="claude codex ..." when needed, and tune the
 # per-harness wait with FM_SEND_INBOX_LIVE_TIMEOUT (seconds, default 240).
 # Record the dated per-harness result in
-# docs/verification/runtime-backends.md ("Steering-inbox doorbell").
+# docs/verification/runtime-backends.md ("Steering-inbox doorbell", whose
+# "Swallowed-Enter recovery" subsection owns the recovery evidence).
 #
 # Folder trust: harnesses launch with the repo root as cwd, which the
 # operator's machine has normally already trusted; a trust dialog is a real
@@ -185,10 +194,83 @@ check_harness_doorbell() {  # <name>
   tmux -L "$SOCKET" kill-window -t "$SESSION:$win" 2>/dev/null || true
 }
 
+# The swallowed-Enter recovery, proven against a real composer.
+#
+# A doorbell whose Enter is lost leaves firstmate's OWN line sitting in the
+# composer. That makes the composer read `pending`, which is exactly the state
+# the ring defers on to protect a human's half-typed text - so without
+# identifying its own line the ring defers forever and the steer waits for a
+# human keypress. Only a real harness renders the composer this reads, so a
+# stub cannot prove the recovery: it would only replay the shape written into
+# the stub. Types the doorbell with NO Enter, then requires one ordinary
+# re-ring to commit it and the worker to act and acknowledge.
+check_harness_swallowed_recovery() {  # <name>
+  local name=$1 version cmd win="hs-$1" home task acted rec handled line i ready_rc
+  version=$(harness_version "$name")
+  cmd=$(launch_cmd "$name") || return 0
+  home="$LAB/$name-swallow-home"
+  mkdir -p "$home/state"
+  task="swallow-$name"
+  acted="$LAB/acted-swallow-$name"
+  tmux -L "$SOCKET" new-window -d -t "$SESSION:" -n "$win" -c "$ROOT" \
+    -- bash -lc "$cmd" \
+    || { FAILED=1; printf 'not ok - %s (%s): could not launch for the swallowed-doorbell check\n' "$name" "$version" >&2; return 0; }
+  wait_ready "$win"; ready_rc=$?
+  if [ "$ready_rc" -eq 1 ]; then
+    note "$name ($version): composer already pending before the swallow check; not verified here"
+    tmux -L "$SOCKET" kill-window -t "$SESSION:$win" 2>/dev/null || true
+    return 0
+  fi
+  printf 'window=%s:%s\nkind=ship\nharness=%s\n' "$SESSION" "$win" "$name" > "$home/state/$task.meta"
+  rec=$(FM_STATE_OVERRIDE="$home/state" fm_task_inbox_write "$home/state" "$task" \
+    "Firstmate live check: run exactly this shell command now: touch $acted - then follow the mv instruction you were given for this message. Reply with one short line.") \
+    || { FAILED=1; printf 'not ok - %s (%s): could not write the durable record\n' "$name" "$version" >&2; return 0; }
+  handled="$home/state/$task.inbox/handled/${rec##*/}"
+  line=$(fm_task_inbox_doorbell_line "$rec")
+
+  # The swallow: the line is typed, the Enter never lands. Typed the same way
+  # the tmux adapter types it (send-keys -l), so the composer sees exactly what
+  # a real doorbell leaves behind when its Enter is lost.
+  tmux -L "$SOCKET" send-keys -t "$SESSION:$win" -l "$line" 2>/dev/null || true
+  sleep 2
+  if [ "$(fm_tmux_composer_state "$SESSION:$win")" != pending ]; then
+    note "$name ($version): the typed doorbell did not read as pending text; swallow not reproduced, not verified here"
+    tmux -L "$SOCKET" kill-window -t "$SESSION:$win" 2>/dev/null || true
+    return 0
+  fi
+
+  # One ordinary re-ring must recover it rather than deferring on our own text.
+  if ! fm_task_inbox_ring tmux "$SESSION:$win" "$rec" "$name"; then
+    FAILED=1
+    printf 'not ok - %s (%s): the re-ring deferred on firstmate own swallowed doorbell instead of committing it\n' "$name" "$version" >&2
+    tmux -L "$SOCKET" capture-pane -p -t "$SESSION:$win" 2>/dev/null | grep '[^[:space:]]' | tail -8 | sed 's/^/#   /' >&2
+    tmux -L "$SOCKET" kill-window -t "$SESSION:$win" 2>/dev/null || true
+    return 0
+  fi
+  i=0
+  while [ "$i" -lt "$TIMEOUT" ]; do
+    [ -f "$handled" ] && [ -e "$acted" ] && break
+    sleep 1
+    i=$((i + 1))
+  done
+  if [ -f "$handled" ] && [ -e "$acted" ]; then
+    CHECKED=$((CHECKED + 1))
+    pass "$name ($version): a swallowed doorbell was committed by one re-ring, and the worker acted and acked"
+  else
+    FAILED=1
+    printf 'not ok - %s (%s): swallowed doorbell not honored within %ss (acted=%s acked=%s)\n' \
+      "$name" "$version" "$TIMEOUT" "$([ -e "$acted" ] && echo yes || echo no)" \
+      "$([ -f "$handled" ] && echo yes || echo no)" >&2
+    tmux -L "$SOCKET" capture-pane -p -t "$SESSION:$win" 2>/dev/null | grep '[^[:space:]]' | tail -10 | sed 's/^/#   /' >&2
+  fi
+  tmux -L "$SOCKET" kill-window -t "$SESSION:$win" 2>/dev/null || true
+}
+
 HARNESSES=${FM_SEND_INBOX_LIVE_HARNESSES:-'claude codex opencode pi grok kimi muse'}
 for h in $HARNESSES; do
   if command -v "$h" >/dev/null 2>&1; then
     check_harness_doorbell "$h"
+    check_harness_swallowed_recovery "$h"
   else
     note "harness absent, not verified here: $h"
   fi
@@ -202,4 +284,4 @@ if [ "$CHECKED" -eq 0 ]; then
   printf 'not ok - live steering-inbox doorbell guard verified nothing (no harness installed?)\n' >&2
   exit 1
 fi
-pass "live steering-inbox doorbell guard: $CHECKED harness(es) honored the doorbell contract"
+pass "live steering-inbox doorbell guard: $CHECKED check(s) honored the doorbell contract"

--- a/tests/fm-task-inbox.test.sh
+++ b/tests/fm-task-inbox.test.sh
@@ -79,6 +79,13 @@ case "${1:-}" in
       if [ -n "${FM_ACK_RECORD:-}" ] && [ -f "$FM_ACK_RECORD" ]; then
         mv "$FM_ACK_RECORD" "${FM_ACK_RECORD%/*}/handled/"
       fi
+    else
+      printf '%s\n' "${1:-}" >> "${FM_KEY_LOG:-/dev/null}"
+      # A committed Enter clears the composer, exactly as a real one does.
+      if [ "${1:-}" = Enter ] && [ -n "${FM_FAKE_TMUX_CAPTURE_AFTER_ENTER:-}" ] \
+        && [ -n "${FM_FAKE_TMUX_CAPTURE:-}" ]; then
+        cp "$FM_FAKE_TMUX_CAPTURE_AFTER_ENTER" "$FM_FAKE_TMUX_CAPTURE"
+      fi
     fi
     exit 0 ;;
   display-message)
@@ -104,6 +111,25 @@ SH
   chmod +x "$fb/tmux"
   make_fake_crew_state "$fb" >/dev/null
   printf '%s\n' "$fb"
+}
+
+# make_composer_capture: a bordered composer pane holding <text>, wrapped across
+# rows the way a terminal wraps a long line. Border and content rows are the
+# same width on purpose: mismatched box geometry is what the shared classifier
+# calls ambiguous, and an ambiguous box downgrades pending to pending-unproven,
+# which is a different branch from the proven pending these cases exercise.
+# The fake tmux reports cursor row 1, so row 1 is the first content row.
+make_composer_capture() {  # <path> <text>
+  local path=$1 text=$2 width=60 rest=$2 i
+  {
+    printf '╭'; for ((i=0;i<width+2;i++)); do printf '─'; done; printf '╮\n'
+    [ -n "$rest" ] || printf '│ %-*s │\n' "$width" ''
+    while [ -n "$rest" ]; do
+      printf '│ %-*s │\n' "$width" "${rest:0:$width}"
+      rest=${rest:$width}
+    done
+    printf '╰'; for ((i=0;i<width+2;i++)); do printf '─'; done; printf '╯\n'
+  } > "$path"
 }
 
 watch_bg() {  # <state> <fakebin> <out> [extra env assignments...]
@@ -277,6 +303,72 @@ test_ring_skips_dead_agent() {
   [ "$rc" = 0 ] || fail "an endpoint the classifier cannot see should still be rung, got $rc"
   grep -qF 'Firstmate instruction waiting' "$log" || fail "an unclassifiable endpoint did not receive the doorbell"
   pass "inbox: the ring skips dead or missing endpoints and still rings live or unclassifiable endpoints"
+}
+
+# A doorbell whose Enter was swallowed leaves firstmate's OWN line sitting in
+# the composer. The `pending` deferral that protects a human's half-typed text
+# cannot tell the two apart on its own, so without identification the steer sits
+# unsubmitted until a human presses Enter, and every re-ring defers again on the
+# text the previous ring left behind. The ring must commit its own doorbell with
+# Enter alone - never retyping, which would deliver the line twice.
+test_ring_commits_its_own_swallowed_doorbell() {
+  local dir state rec doorbell log keylog rc
+  dir="$TMP_ROOT/ring-swallowed"
+  state="$dir/state"
+  mkdir -p "$state"
+  make_watch_stubs "$dir" >/dev/null
+  rec=$(inbox_lib "$state" fm_task_inbox_write "$state" t1 "please continue")
+  doorbell=$(inbox_lib "$state" fm_task_inbox_doorbell_line "$rec")
+  make_composer_capture "$dir/capture.txt" "$doorbell"
+  make_composer_capture "$dir/capture-empty.txt" ""
+  log="$dir/send.log"; : > "$log"
+  keylog="$dir/key.log"; : > "$keylog"
+  rc=0
+  PATH="$dir/fakebin:$PATH" FM_SEND_LOG="$log" FM_KEY_LOG="$keylog" \
+    FM_FAKE_TMUX_AGENT=claude FM_FAKE_TMUX_CAPTURE="$dir/capture.txt" \
+    FM_FAKE_TMUX_CAPTURE_AFTER_ENTER="$dir/capture-empty.txt" \
+    inbox_lib "$state" fm_task_inbox_ring tmux sess:fm-t1 "$rec" fm-t1 || rc=$?
+  [ "$rc" = 0 ] || fail "a swallowed doorbell should be committed and report rang, got $rc"
+  grep -qx 'Enter' "$keylog" || fail "committing a swallowed doorbell must send Enter:"$'\n'"$(cat "$keylog")"
+  [ ! -s "$log" ] || fail "committing a swallowed doorbell must not retype it:"$'\n'"$(cat "$log")"
+  [ -f "$rec" ] || fail "committing a swallowed doorbell must leave the durable record"
+  pass "inbox: the ring commits its own swallowed doorbell without retyping it"
+}
+
+# The other direction, and the one that must never regress: a composer holding
+# text firstmate did not type is someone's real half-typed content. It is
+# deferred untouched - no Enter, nothing typed - however long it sits there.
+test_ring_never_submits_foreign_composer_text() {
+  local dir state rec other other_doorbell log keylog rc
+  dir="$TMP_ROOT/ring-foreign"
+  state="$dir/state"
+  mkdir -p "$state"
+  make_watch_stubs "$dir" >/dev/null
+  rec=$(inbox_lib "$state" fm_task_inbox_write "$state" t1 "please continue")
+  make_composer_capture "$dir/capture.txt" "rm -rf the production database"
+  log="$dir/send.log"; : > "$log"
+  keylog="$dir/key.log"; : > "$keylog"
+  rc=0
+  PATH="$dir/fakebin:$PATH" FM_SEND_LOG="$log" FM_KEY_LOG="$keylog" \
+    FM_FAKE_TMUX_AGENT=claude FM_FAKE_TMUX_CAPTURE="$dir/capture.txt" \
+    inbox_lib "$state" fm_task_inbox_ring tmux sess:fm-t1 "$rec" fm-t1 || rc=$?
+  [ "$rc" = 1 ] || fail "foreign composer text should defer the ring, got $rc"
+  [ ! -s "$keylog" ] || fail "foreign composer text must never receive a key:"$'\n'"$(cat "$keylog")"
+  [ ! -s "$log" ] || fail "foreign composer text must not be typed over:"$'\n'"$(cat "$log")"
+  [ -f "$rec" ] || fail "deferring the ring must leave the durable record"
+
+  # Another record's doorbell is not this record's doorbell either.
+  other=$(inbox_lib "$state" fm_task_inbox_write "$state" t2 "another steer")
+  other_doorbell=$(inbox_lib "$state" fm_task_inbox_doorbell_line "$other")
+  make_composer_capture "$dir/capture.txt" "$other_doorbell"
+  : > "$keylog"
+  rc=0
+  PATH="$dir/fakebin:$PATH" FM_SEND_LOG="$log" FM_KEY_LOG="$keylog" \
+    FM_FAKE_TMUX_AGENT=claude FM_FAKE_TMUX_CAPTURE="$dir/capture.txt" \
+    inbox_lib "$state" fm_task_inbox_ring tmux sess:fm-t1 "$rec" fm-t1 || rc=$?
+  [ "$rc" = 1 ] || fail "another record's doorbell should defer this ring, got $rc"
+  [ ! -s "$keylog" ] || fail "another record's doorbell must not be committed by this ring:"$'\n'"$(cat "$keylog")"
+  pass "inbox: the ring never submits composer text it did not type"
 }
 
 test_idempotent_write_dedups_exact_body() {
@@ -696,6 +788,8 @@ test_write_is_durable_and_exact
 test_doorbell_is_a_shell_noop
 test_doorbell_rejects_terminal_controls
 test_ring_skips_dead_agent
+test_ring_commits_its_own_swallowed_doorbell
+test_ring_never_submits_foreign_composer_text
 test_idempotent_write_dedups_exact_body
 test_idempotent_write_follows_concurrent_ack
 test_handled_mv_dedups_by_sequence

--- a/tests/fm-task-inbox.test.sh
+++ b/tests/fm-task-inbox.test.sh
@@ -339,7 +339,7 @@ test_ring_commits_its_own_swallowed_doorbell() {
 # text firstmate did not type is someone's real half-typed content. It is
 # deferred untouched - no Enter, nothing typed - however long it sits there.
 test_ring_never_submits_foreign_composer_text() {
-  local dir state rec other other_doorbell log keylog rc
+  local dir state rec doorbell other other_doorbell log keylog rc
   dir="$TMP_ROOT/ring-foreign"
   state="$dir/state"
   mkdir -p "$state"
@@ -356,6 +356,18 @@ test_ring_never_submits_foreign_composer_text() {
   [ ! -s "$keylog" ] || fail "foreign composer text must never receive a key:"$'\n'"$(cat "$keylog")"
   [ ! -s "$log" ] || fail "foreign composer text must not be typed over:"$'\n'"$(cat "$log")"
   [ -f "$rec" ] || fail "deferring the ring must leave the durable record"
+
+  doorbell=$(inbox_lib "$state" fm_task_inbox_doorbell_line "$rec")
+  make_composer_capture "$dir/capture.txt" "$doorbell finish the release notes"
+  : > "$keylog"
+  : > "$log"
+  rc=0
+  PATH="$dir/fakebin:$PATH" FM_SEND_LOG="$log" FM_KEY_LOG="$keylog" \
+    FM_FAKE_TMUX_AGENT=claude FM_FAKE_TMUX_CAPTURE="$dir/capture.txt" \
+    inbox_lib "$state" fm_task_inbox_ring tmux sess:fm-t1 "$rec" fm-t1 || rc=$?
+  [ "$rc" = 1 ] || fail "a doorbell mixed with human draft text should defer the ring, got $rc"
+  [ ! -s "$keylog" ] || fail "mixed doorbell and human draft text must never receive a key:"$'\n'"$(cat "$keylog")"
+  [ ! -s "$log" ] || fail "mixed doorbell and human draft text must not be typed over:"$'\n'"$(cat "$log")"
 
   # Another record's doorbell is not this record's doorbell either.
   other=$(inbox_lib "$state" fm_task_inbox_write "$state" t2 "another steer")

--- a/tests/fm-task-inbox.test.sh
+++ b/tests/fm-task-inbox.test.sh
@@ -161,6 +161,20 @@ make_composer_capture() {  # <path> <text>
   } > "$path"
 }
 
+make_bare_composer_capture() {  # <path> <text>
+  local path=$1 rest=$2 width=60 first=1
+  : > "$path"
+  while [ -n "$rest" ]; do
+    if [ "$first" = 1 ]; then
+      printf '❯ %s\n' "${rest:0:$width}" >> "$path"
+      first=0
+    else
+      printf '%s\n' "${rest:0:$width}" >> "$path"
+    fi
+    rest=${rest:$width}
+  done
+}
+
 watch_bg() {  # <state> <fakebin> <out> [extra env assignments...]
   local state=$1 fakebin=$2 out=$3
   shift 3
@@ -538,6 +552,39 @@ test_ring_never_submits_foreign_composer_text() {
     inbox_lib "$state" fm_task_inbox_ring tmux sess:fm-t1 "$rec" fm-t1 || rc=$?
   [ "$rc" = 1 ] || fail "a whitespace-edited doorbell should defer the ring, got $rc"
   [ ! -s "$keylog" ] || fail "a whitespace-edited doorbell must never receive a key:"$'\n'"$(cat "$keylog")"
+
+  # Leading whitespace is composer content, not box padding. It must remain
+  # visible to the identity check rather than being trimmed with the UI cell.
+  make_composer_capture "$dir/capture.txt" " $doorbell"
+  : > "$keylog"
+  rc=0
+  PATH="$dir/fakebin:$PATH" FM_SEND_LOG="$log" FM_KEY_LOG="$keylog" \
+    FM_FAKE_TMUX_AGENT=claude FM_FAKE_TMUX_CAPTURE="$dir/capture.txt" \
+    inbox_lib "$state" fm_task_inbox_ring tmux sess:fm-t1 "$rec" fm-t1 || rc=$?
+  [ "$rc" = 1 ] || fail "a leading-whitespace-edited doorbell should defer the ring, got $rc"
+  [ ! -s "$keylog" ] || fail "a leading-whitespace-edited doorbell must never receive a key:"$'\n'"$(cat "$keylog")"
+
+  # An inserted space that becomes the first cell of a continuation row used
+  # to disappear when every wrapped row was trimmed independently.
+  make_composer_capture "$dir/capture.txt" "${doorbell:0:60} ${doorbell:60}"
+  : > "$keylog"
+  rc=0
+  PATH="$dir/fakebin:$PATH" FM_SEND_LOG="$log" FM_KEY_LOG="$keylog" \
+    FM_FAKE_TMUX_AGENT=claude FM_FAKE_TMUX_CAPTURE="$dir/capture.txt" \
+    inbox_lib "$state" fm_task_inbox_ring tmux sess:fm-t1 "$rec" fm-t1 || rc=$?
+  [ "$rc" = 1 ] || fail "a wrap-boundary whitespace edit should defer the ring, got $rc"
+  [ ! -s "$keylog" ] || fail "a wrap-boundary whitespace edit must never receive a key:"$'\n'"$(cat "$keylog")"
+
+  # A bare composer has no right-edge padding. Its trailing whitespace is
+  # therefore editable content and must not be normalized away.
+  make_bare_composer_capture "$dir/capture.txt" "$doorbell "
+  : > "$keylog"
+  rc=0
+  PATH="$dir/fakebin:$PATH" FM_SEND_LOG="$log" FM_KEY_LOG="$keylog" \
+    FM_FAKE_TMUX_AGENT=claude FM_FAKE_TMUX_CAPTURE="$dir/capture.txt" \
+    inbox_lib "$state" fm_task_inbox_ring tmux sess:fm-t1 "$rec" fm-t1 || rc=$?
+  [ "$rc" = 1 ] || fail "a trailing-whitespace-edited doorbell should defer the ring, got $rc"
+  [ ! -s "$keylog" ] || fail "a trailing-whitespace-edited doorbell must never receive a key:"$'\n'"$(cat "$keylog")"
 
   # Another record's doorbell is not this record's doorbell either.
   other=$(inbox_lib "$state" fm_task_inbox_write "$state" t2 "another steer")

--- a/tests/fm-task-inbox.test.sh
+++ b/tests/fm-task-inbox.test.sh
@@ -45,6 +45,16 @@ inbox_lib() {  # <state> <function> [args...]
   shift
   FM_STATE_OVERRIDE="$state" bash -c '
     . "$1"
+    if [ -n "${FM_FAKE_SUBMIT_VERDICT:-}" ]; then
+      fm_backend_send_text_submit() {
+        local backend=$1 target=$2 text=$3 settle=$6 label=${7:-}
+        fm_backend_source "$backend" || { printf send-failed; return 0; }
+        fm_backend_tmux_send_literal "$target" "$text" "$label" || { printf send-failed; return 0; }
+        sleep "$settle"
+        fm_backend_send_key "$backend" "$target" Enter "$label" || true
+        printf %s "$FM_FAKE_SUBMIT_VERDICT"
+      }
+    fi
     fn=$2
     shift 2
     "$fn" "$@"
@@ -79,12 +89,31 @@ case "${1:-}" in
       if [ -n "${FM_ACK_RECORD:-}" ] && [ -f "$FM_ACK_RECORD" ]; then
         mv "$FM_ACK_RECORD" "${FM_ACK_RECORD%/*}/handled/"
       fi
+      if [ -n "${FM_FAKE_TMUX_CAPTURE_AFTER_LITERAL:-}" ] && [ -n "${FM_FAKE_TMUX_CAPTURE:-}" ]; then
+        cp "$FM_FAKE_TMUX_CAPTURE_AFTER_LITERAL" "$FM_FAKE_TMUX_CAPTURE"
+      fi
     else
       printf '%s\n' "${1:-}" >> "${FM_KEY_LOG:-/dev/null}"
+      if [ "${1:-}" = Enter ] && [ -n "${FM_FAKE_TMUX_FAIL_FIRST_ENTER_FILE:-}" ] \
+        && [ ! -e "$FM_FAKE_TMUX_FAIL_FIRST_ENTER_FILE" ]; then
+        : > "$FM_FAKE_TMUX_FAIL_FIRST_ENTER_FILE"
+        if [ -n "${FM_FAKE_TMUX_CAPTURE_AFTER_FAILED_ENTER:-}" ] && [ -n "${FM_FAKE_TMUX_CAPTURE:-}" ]; then
+          cp "$FM_FAKE_TMUX_CAPTURE_AFTER_FAILED_ENTER" "$FM_FAKE_TMUX_CAPTURE"
+        fi
+        exit 1
+      fi
       # A committed Enter clears the composer, exactly as a real one does.
       if [ "${1:-}" = Enter ] && [ -n "${FM_FAKE_TMUX_CAPTURE_AFTER_ENTER:-}" ] \
         && [ -n "${FM_FAKE_TMUX_CAPTURE:-}" ]; then
-        cp "$FM_FAKE_TMUX_CAPTURE_AFTER_ENTER" "$FM_FAKE_TMUX_CAPTURE"
+        if [ -n "${FM_FAKE_TMUX_ENTER_COUNT_FILE:-}" ]; then
+          count=$(cat "$FM_FAKE_TMUX_ENTER_COUNT_FILE" 2>/dev/null || printf 0)
+          count=$((count + 1))
+          printf '%s\n' "$count" > "$FM_FAKE_TMUX_ENTER_COUNT_FILE"
+          [ "$count" = "${FM_FAKE_TMUX_CAPTURE_AFTER_ENTER_AT:-1}" ] \
+            && cp "$FM_FAKE_TMUX_CAPTURE_AFTER_ENTER" "$FM_FAKE_TMUX_CAPTURE"
+        else
+          cp "$FM_FAKE_TMUX_CAPTURE_AFTER_ENTER" "$FM_FAKE_TMUX_CAPTURE"
+        fi
       fi
     fi
     exit 0 ;;
@@ -370,6 +399,76 @@ test_ring_stops_enter_retries_when_composer_changes() {
   [ "$(grep -c '^Enter$' "$keylog")" = 1 ] || fail "initial submission must not retry Enter after draft text appears:"$'\n'"$(cat "$keylog")"
   [ "$(wc -l < "$log" | tr -d ' ')" = 1 ] || fail "initial submission must type the doorbell exactly once:"$'\n'"$(cat "$log")"
   pass "inbox: Enter retries stop when the composer content changes"
+}
+
+test_ring_guards_unknown_and_failed_enter_retries() {
+  local dir state rec doorbell log keylog rc
+  dir="$TMP_ROOT/ring-submit-verdicts"
+  state="$dir/state"
+  mkdir -p "$state"
+  make_watch_stubs "$dir" >/dev/null
+  rec=$(inbox_lib "$state" fm_task_inbox_write "$state" t1 "please continue")
+  doorbell=$(inbox_lib "$state" fm_task_inbox_doorbell_line "$rec")
+  make_composer_capture "$dir/capture-empty.txt" ""
+  make_composer_capture "$dir/capture-doorbell.txt" "$doorbell"
+  make_composer_capture "$dir/capture-mixed.txt" "$doorbell finish the release notes"
+  log="$dir/send.log"
+  keylog="$dir/key.log"
+
+  cp "$dir/capture-empty.txt" "$dir/capture.txt"
+  : > "$log"; : > "$keylog"; : > "$dir/enter-count"
+  rc=0
+  PATH="$dir/fakebin:$PATH" FM_SEND_LOG="$log" FM_KEY_LOG="$keylog" \
+    FM_FAKE_TMUX_AGENT=claude FM_FAKE_TMUX_CAPTURE="$dir/capture.txt" \
+    FM_FAKE_TMUX_CAPTURE_AFTER_LITERAL="$dir/capture-doorbell.txt" \
+    FM_FAKE_TMUX_CAPTURE_AFTER_ENTER="$dir/capture-empty.txt" \
+    FM_FAKE_TMUX_ENTER_COUNT_FILE="$dir/enter-count" FM_FAKE_TMUX_CAPTURE_AFTER_ENTER_AT=2 \
+    FM_FAKE_SUBMIT_VERDICT=unknown FM_TASK_INBOX_COMMIT_SLEEP=0 \
+    inbox_lib "$state" fm_task_inbox_ring tmux sess:fm-t1 "$rec" fm-t1 || rc=$?
+  [ "$rc" = 0 ] || fail "an unknown verdict with the exact doorbell should retry safely, got $rc"
+  [ "$(grep -c '^Enter$' "$keylog")" = 2 ] || fail "an unknown verdict should get one guarded retry:"$'\n'"$(cat "$keylog")"
+  [ "$(wc -l < "$log" | tr -d ' ')" = 1 ] || fail "an unknown verdict retry must not retype the doorbell"
+
+  cp "$dir/capture-empty.txt" "$dir/capture.txt"
+  : > "$log"; : > "$keylog"; : > "$dir/enter-count"
+  rc=0
+  PATH="$dir/fakebin:$PATH" FM_SEND_LOG="$log" FM_KEY_LOG="$keylog" \
+    FM_FAKE_TMUX_AGENT=claude FM_FAKE_TMUX_CAPTURE="$dir/capture.txt" \
+    FM_FAKE_TMUX_CAPTURE_AFTER_LITERAL="$dir/capture-doorbell.txt" \
+    FM_FAKE_TMUX_CAPTURE_AFTER_ENTER="$dir/capture-mixed.txt" \
+    FM_FAKE_TMUX_ENTER_COUNT_FILE="$dir/enter-count" FM_FAKE_TMUX_CAPTURE_AFTER_ENTER_AT=1 \
+    FM_FAKE_SUBMIT_VERDICT=unknown FM_TASK_INBOX_COMMIT_SLEEP=0 \
+    inbox_lib "$state" fm_task_inbox_ring tmux sess:fm-t1 "$rec" fm-t1 || rc=$?
+  [ "$rc" = 1 ] || fail "an unknown verdict with changed composer text should remain undelivered, got $rc"
+  [ "$(grep -c '^Enter$' "$keylog")" = 1 ] || fail "an unknown verdict must not retry Enter over changed text:"$'\n'"$(cat "$keylog")"
+
+  cp "$dir/capture-empty.txt" "$dir/capture.txt"
+  : > "$log"; : > "$keylog"; rm -f "$dir/failed-enter"
+  rc=0
+  PATH="$dir/fakebin:$PATH" FM_SEND_LOG="$log" FM_KEY_LOG="$keylog" \
+    FM_FAKE_TMUX_AGENT=claude FM_FAKE_TMUX_CAPTURE="$dir/capture.txt" \
+    FM_FAKE_TMUX_CAPTURE_AFTER_LITERAL="$dir/capture-doorbell.txt" \
+    FM_FAKE_TMUX_CAPTURE_AFTER_ENTER="$dir/capture-empty.txt" \
+    FM_FAKE_TMUX_FAIL_FIRST_ENTER_FILE="$dir/failed-enter" \
+    FM_FAKE_SUBMIT_VERDICT=send-failed FM_TASK_INBOX_COMMIT_SLEEP=0 \
+    inbox_lib "$state" fm_task_inbox_ring tmux sess:fm-t1 "$rec" fm-t1 || rc=$?
+  [ "$rc" = 0 ] || fail "a failed first Enter with the exact doorbell should retry safely, got $rc"
+  [ "$(grep -c '^Enter$' "$keylog")" = 2 ] || fail "a failed first Enter should get one guarded retry:"$'\n'"$(cat "$keylog")"
+  [ "$(wc -l < "$log" | tr -d ' ')" = 1 ] || fail "a failed Enter retry must not retype the doorbell"
+
+  cp "$dir/capture-empty.txt" "$dir/capture.txt"
+  : > "$log"; : > "$keylog"; rm -f "$dir/failed-enter"
+  rc=0
+  PATH="$dir/fakebin:$PATH" FM_SEND_LOG="$log" FM_KEY_LOG="$keylog" \
+    FM_FAKE_TMUX_AGENT=claude FM_FAKE_TMUX_CAPTURE="$dir/capture.txt" \
+    FM_FAKE_TMUX_CAPTURE_AFTER_LITERAL="$dir/capture-doorbell.txt" \
+    FM_FAKE_TMUX_CAPTURE_AFTER_FAILED_ENTER="$dir/capture-mixed.txt" \
+    FM_FAKE_TMUX_FAIL_FIRST_ENTER_FILE="$dir/failed-enter" \
+    FM_FAKE_SUBMIT_VERDICT=send-failed FM_TASK_INBOX_COMMIT_SLEEP=0 \
+    inbox_lib "$state" fm_task_inbox_ring tmux sess:fm-t1 "$rec" fm-t1 || rc=$?
+  [ "$rc" = 1 ] || fail "a failed first Enter with changed composer text should remain undelivered, got $rc"
+  [ "$(grep -c '^Enter$' "$keylog")" = 1 ] || fail "a failed first Enter must not retry over changed text:"$'\n'"$(cat "$keylog")"
+  pass "inbox: unknown and failed first Enter retries preserve composer text"
 }
 
 # The other direction, and the one that must never regress: a composer holding
@@ -839,6 +938,7 @@ test_doorbell_rejects_terminal_controls
 test_ring_skips_dead_agent
 test_ring_commits_its_own_swallowed_doorbell
 test_ring_stops_enter_retries_when_composer_changes
+test_ring_guards_unknown_and_failed_enter_retries
 test_ring_never_submits_foreign_composer_text
 test_idempotent_write_dedups_exact_body
 test_idempotent_write_follows_concurrent_ack

--- a/tests/fm-task-inbox.test.sh
+++ b/tests/fm-task-inbox.test.sh
@@ -527,6 +527,18 @@ test_ring_never_submits_foreign_composer_text() {
   [ ! -s "$keylog" ] || fail "mixed doorbell and human draft text must never receive a key:"$'\n'"$(cat "$keylog")"
   [ ! -s "$log" ] || fail "mixed doorbell and human draft text must not be typed over:"$'\n'"$(cat "$log")"
 
+  # Whitespace is editable content too. A space inserted into the quoted inbox
+  # path makes this a different, malformed instruction and must not authorize
+  # Enter.
+  make_composer_capture "$dir/capture.txt" "${doorbell//"$state"/"$state x"}"
+  : > "$keylog"
+  rc=0
+  PATH="$dir/fakebin:$PATH" FM_SEND_LOG="$log" FM_KEY_LOG="$keylog" \
+    FM_FAKE_TMUX_AGENT=claude FM_FAKE_TMUX_CAPTURE="$dir/capture.txt" \
+    inbox_lib "$state" fm_task_inbox_ring tmux sess:fm-t1 "$rec" fm-t1 || rc=$?
+  [ "$rc" = 1 ] || fail "a whitespace-edited doorbell should defer the ring, got $rc"
+  [ ! -s "$keylog" ] || fail "a whitespace-edited doorbell must never receive a key:"$'\n'"$(cat "$keylog")"
+
   # Another record's doorbell is not this record's doorbell either.
   other=$(inbox_lib "$state" fm_task_inbox_write "$state" t2 "another steer")
   other_doorbell=$(inbox_lib "$state" fm_task_inbox_doorbell_line "$other")

--- a/tests/fm-task-inbox.test.sh
+++ b/tests/fm-task-inbox.test.sh
@@ -381,7 +381,7 @@ test_ring_stops_enter_retries_when_composer_changes() {
   rc=0
   PATH="$dir/fakebin:$PATH" FM_SEND_LOG="$log" FM_KEY_LOG="$keylog" \
     FM_FAKE_TMUX_AGENT=claude FM_FAKE_TMUX_CAPTURE="$dir/capture.txt" \
-    FM_FAKE_TMUX_CAPTURE_AFTER_ENTER="$dir/capture-mixed.txt" FM_TASK_INBOX_COMMIT_SLEEP=0 \
+    FM_FAKE_TMUX_CAPTURE_AFTER_ENTER="$dir/capture-mixed.txt" \
     inbox_lib "$state" fm_task_inbox_ring tmux sess:fm-t1 "$rec" fm-t1 || rc=$?
   [ "$rc" = 1 ] || fail "recovery should stop when human draft text appears, got $rc"
   [ "$(grep -c '^Enter$' "$keylog")" = 1 ] || fail "recovery must not retry Enter after draft text appears:"$'\n'"$(cat "$keylog")"
@@ -393,7 +393,7 @@ test_ring_stops_enter_retries_when_composer_changes() {
   rc=0
   PATH="$dir/fakebin:$PATH" FM_SEND_LOG="$log" FM_KEY_LOG="$keylog" \
     FM_FAKE_TMUX_AGENT=claude FM_FAKE_TMUX_CAPTURE="$dir/capture.txt" \
-    FM_FAKE_TMUX_CAPTURE_AFTER_ENTER="$dir/capture-mixed.txt" FM_TASK_INBOX_COMMIT_SLEEP=0 \
+    FM_FAKE_TMUX_CAPTURE_AFTER_ENTER="$dir/capture-mixed.txt" \
     inbox_lib "$state" fm_task_inbox_ring tmux sess:fm-t1 "$rec" fm-t1 || rc=$?
   [ "$rc" = 1 ] || fail "initial submission should stop when human draft text appears, got $rc"
   [ "$(grep -c '^Enter$' "$keylog")" = 1 ] || fail "initial submission must not retry Enter after draft text appears:"$'\n'"$(cat "$keylog")"
@@ -423,7 +423,7 @@ test_ring_guards_unknown_and_failed_enter_retries() {
     FM_FAKE_TMUX_CAPTURE_AFTER_LITERAL="$dir/capture-doorbell.txt" \
     FM_FAKE_TMUX_CAPTURE_AFTER_ENTER="$dir/capture-empty.txt" \
     FM_FAKE_TMUX_ENTER_COUNT_FILE="$dir/enter-count" FM_FAKE_TMUX_CAPTURE_AFTER_ENTER_AT=2 \
-    FM_FAKE_SUBMIT_VERDICT=unknown FM_TASK_INBOX_COMMIT_SLEEP=0 \
+    FM_FAKE_SUBMIT_VERDICT=unknown \
     inbox_lib "$state" fm_task_inbox_ring tmux sess:fm-t1 "$rec" fm-t1 || rc=$?
   [ "$rc" = 0 ] || fail "an unknown verdict with the exact doorbell should retry safely, got $rc"
   [ "$(grep -c '^Enter$' "$keylog")" = 2 ] || fail "an unknown verdict should get one guarded retry:"$'\n'"$(cat "$keylog")"
@@ -437,7 +437,7 @@ test_ring_guards_unknown_and_failed_enter_retries() {
     FM_FAKE_TMUX_CAPTURE_AFTER_LITERAL="$dir/capture-doorbell.txt" \
     FM_FAKE_TMUX_CAPTURE_AFTER_ENTER="$dir/capture-mixed.txt" \
     FM_FAKE_TMUX_ENTER_COUNT_FILE="$dir/enter-count" FM_FAKE_TMUX_CAPTURE_AFTER_ENTER_AT=1 \
-    FM_FAKE_SUBMIT_VERDICT=unknown FM_TASK_INBOX_COMMIT_SLEEP=0 \
+    FM_FAKE_SUBMIT_VERDICT=unknown \
     inbox_lib "$state" fm_task_inbox_ring tmux sess:fm-t1 "$rec" fm-t1 || rc=$?
   [ "$rc" = 1 ] || fail "an unknown verdict with changed composer text should remain undelivered, got $rc"
   [ "$(grep -c '^Enter$' "$keylog")" = 1 ] || fail "an unknown verdict must not retry Enter over changed text:"$'\n'"$(cat "$keylog")"
@@ -450,7 +450,7 @@ test_ring_guards_unknown_and_failed_enter_retries() {
     FM_FAKE_TMUX_CAPTURE_AFTER_LITERAL="$dir/capture-doorbell.txt" \
     FM_FAKE_TMUX_CAPTURE_AFTER_ENTER="$dir/capture-empty.txt" \
     FM_FAKE_TMUX_FAIL_FIRST_ENTER_FILE="$dir/failed-enter" \
-    FM_FAKE_SUBMIT_VERDICT=send-failed FM_TASK_INBOX_COMMIT_SLEEP=0 \
+    FM_FAKE_SUBMIT_VERDICT=send-failed \
     inbox_lib "$state" fm_task_inbox_ring tmux sess:fm-t1 "$rec" fm-t1 || rc=$?
   [ "$rc" = 0 ] || fail "a failed first Enter with the exact doorbell should retry safely, got $rc"
   [ "$(grep -c '^Enter$' "$keylog")" = 2 ] || fail "a failed first Enter should get one guarded retry:"$'\n'"$(cat "$keylog")"
@@ -464,11 +464,33 @@ test_ring_guards_unknown_and_failed_enter_retries() {
     FM_FAKE_TMUX_CAPTURE_AFTER_LITERAL="$dir/capture-doorbell.txt" \
     FM_FAKE_TMUX_CAPTURE_AFTER_FAILED_ENTER="$dir/capture-mixed.txt" \
     FM_FAKE_TMUX_FAIL_FIRST_ENTER_FILE="$dir/failed-enter" \
-    FM_FAKE_SUBMIT_VERDICT=send-failed FM_TASK_INBOX_COMMIT_SLEEP=0 \
+    FM_FAKE_SUBMIT_VERDICT=send-failed \
     inbox_lib "$state" fm_task_inbox_ring tmux sess:fm-t1 "$rec" fm-t1 || rc=$?
   [ "$rc" = 1 ] || fail "a failed first Enter with changed composer text should remain undelivered, got $rc"
   [ "$(grep -c '^Enter$' "$keylog")" = 1 ] || fail "a failed first Enter must not retry over changed text:"$'\n'"$(cat "$keylog")"
-  pass "inbox: unknown and failed first Enter retries preserve composer text"
+
+  cp "$dir/capture-doorbell.txt" "$dir/capture.txt"
+  : > "$keylog"; rm -f "$dir/failed-enter"
+  rc=0
+  PATH="$dir/fakebin:$PATH" FM_SEND_LOG="$log" FM_KEY_LOG="$keylog" \
+    FM_FAKE_TMUX_AGENT=claude FM_FAKE_TMUX_CAPTURE="$dir/capture.txt" \
+    FM_FAKE_TMUX_CAPTURE_AFTER_ENTER="$dir/capture-empty.txt" \
+    FM_FAKE_TMUX_FAIL_FIRST_ENTER_FILE="$dir/failed-enter" \
+    inbox_lib "$state" fm_task_inbox_ring tmux sess:fm-t1 "$rec" fm-t1 || rc=$?
+  [ "$rc" = 0 ] || fail "a transient recovery Enter failure should use the remaining retry budget, got $rc"
+  [ "$(grep -c '^Enter$' "$keylog")" = 2 ] || fail "recovery should retry after a transient Enter failure:"$'\n'"$(cat "$keylog")"
+
+  cp "$dir/capture-doorbell.txt" "$dir/capture.txt"
+  : > "$keylog"; rm -f "$dir/failed-enter"
+  rc=0
+  PATH="$dir/fakebin:$PATH" FM_SEND_LOG="$log" FM_KEY_LOG="$keylog" \
+    FM_FAKE_TMUX_AGENT=claude FM_FAKE_TMUX_CAPTURE="$dir/capture.txt" \
+    FM_FAKE_TMUX_CAPTURE_AFTER_FAILED_ENTER="$dir/capture-empty.txt" \
+    FM_FAKE_TMUX_FAIL_FIRST_ENTER_FILE="$dir/failed-enter" \
+    inbox_lib "$state" fm_task_inbox_ring tmux sess:fm-t1 "$rec" fm-t1 || rc=$?
+  [ "$rc" = 0 ] || fail "a failed recovery key that landed should report delivery, got $rc"
+  [ "$(grep -c '^Enter$' "$keylog")" = 1 ] || fail "recovery should stop after a failed key lands:"$'\n'"$(cat "$keylog")"
+  pass "inbox: unknown and failed Enter retries preserve composer text"
 }
 
 # The other direction, and the one that must never regress: a composer holding

--- a/tests/fm-task-inbox.test.sh
+++ b/tests/fm-task-inbox.test.sh
@@ -335,6 +335,43 @@ test_ring_commits_its_own_swallowed_doorbell() {
   pass "inbox: the ring commits its own swallowed doorbell without retyping it"
 }
 
+test_ring_stops_enter_retries_when_composer_changes() {
+  local dir state rec doorbell log keylog rc
+  dir="$TMP_ROOT/ring-retry-draft"
+  state="$dir/state"
+  mkdir -p "$state"
+  make_watch_stubs "$dir" >/dev/null
+  rec=$(inbox_lib "$state" fm_task_inbox_write "$state" t1 "please continue")
+  doorbell=$(inbox_lib "$state" fm_task_inbox_doorbell_line "$rec")
+  make_composer_capture "$dir/capture-doorbell.txt" "$doorbell"
+  make_composer_capture "$dir/capture-empty.txt" ""
+  make_composer_capture "$dir/capture-mixed.txt" "$doorbell finish the release notes"
+  cp "$dir/capture-doorbell.txt" "$dir/capture.txt"
+  log="$dir/send.log"; : > "$log"
+  keylog="$dir/key.log"; : > "$keylog"
+  rc=0
+  PATH="$dir/fakebin:$PATH" FM_SEND_LOG="$log" FM_KEY_LOG="$keylog" \
+    FM_FAKE_TMUX_AGENT=claude FM_FAKE_TMUX_CAPTURE="$dir/capture.txt" \
+    FM_FAKE_TMUX_CAPTURE_AFTER_ENTER="$dir/capture-mixed.txt" FM_TASK_INBOX_COMMIT_SLEEP=0 \
+    inbox_lib "$state" fm_task_inbox_ring tmux sess:fm-t1 "$rec" fm-t1 || rc=$?
+  [ "$rc" = 1 ] || fail "recovery should stop when human draft text appears, got $rc"
+  [ "$(grep -c '^Enter$' "$keylog")" = 1 ] || fail "recovery must not retry Enter after draft text appears:"$'\n'"$(cat "$keylog")"
+  [ ! -s "$log" ] || fail "recovery must not retype a swallowed doorbell:"$'\n'"$(cat "$log")"
+
+  cp "$dir/capture-empty.txt" "$dir/capture.txt"
+  : > "$log"
+  : > "$keylog"
+  rc=0
+  PATH="$dir/fakebin:$PATH" FM_SEND_LOG="$log" FM_KEY_LOG="$keylog" \
+    FM_FAKE_TMUX_AGENT=claude FM_FAKE_TMUX_CAPTURE="$dir/capture.txt" \
+    FM_FAKE_TMUX_CAPTURE_AFTER_ENTER="$dir/capture-mixed.txt" FM_TASK_INBOX_COMMIT_SLEEP=0 \
+    inbox_lib "$state" fm_task_inbox_ring tmux sess:fm-t1 "$rec" fm-t1 || rc=$?
+  [ "$rc" = 1 ] || fail "initial submission should stop when human draft text appears, got $rc"
+  [ "$(grep -c '^Enter$' "$keylog")" = 1 ] || fail "initial submission must not retry Enter after draft text appears:"$'\n'"$(cat "$keylog")"
+  [ "$(wc -l < "$log" | tr -d ' ')" = 1 ] || fail "initial submission must type the doorbell exactly once:"$'\n'"$(cat "$log")"
+  pass "inbox: Enter retries stop when the composer content changes"
+}
+
 # The other direction, and the one that must never regress: a composer holding
 # text firstmate did not type is someone's real half-typed content. It is
 # deferred untouched - no Enter, nothing typed - however long it sits there.
@@ -801,6 +838,7 @@ test_doorbell_is_a_shell_noop
 test_doorbell_rejects_terminal_controls
 test_ring_skips_dead_agent
 test_ring_commits_its_own_swallowed_doorbell
+test_ring_stops_enter_retries_when_composer_changes
 test_ring_never_submits_foreign_composer_text
 test_idempotent_write_dedups_exact_body
 test_idempotent_write_follows_concurrent_ack


### PR DESCRIPTION
## Intent

Fix the herdr-backend doorbell input flakiness. SYMPTOM (observed repeatedly today steering the remote secondmate "bluefin"): when the main firstmate rings a remote herdr-backed agent via fm-send, the durable inbox message is delivered reliably, but the DOORBELL frequently fails to wake the agent - the doorbell instruction lands in the agent's Claude composer but is NOT submitted, so it sits as unsent/queued text until a manual Enter keystroke forces it. Intermittent; requires manual nudging; degrades remote-secondmate steering.
ROOT CAUSE (REVISED per the worker's E2E investigation, 2026-09-08 - this SUPERSEDES firstmate's original hypothesis, which was empirically wrong): the original hypothesis that this was a herdr 0.8.2-vs-0.9.0 version difference is REFUTED - the worker reproduced the failure on isolated 0.9.0 AND 0.8.2 labs with real Claude and found them byte-identical in transport. The real defect is version-independent: firstmate types the doorbell literal then sends a SEPARATE Enter, and when that Enter is swallowed the code never verifies or retries, so the doorbell sits unsubmitted and never self-heals. The atomic `pane run` helper is REJECTED as the fix and MUST NOT be required or reverted to: the worker proved it is WORSE for the interactive Claude composer (bracketed-paste+Enter burst, fails 1-in-3). AUTHORIZED APPROACH (the brief's own "send-and-verify with bounded retry" alternative, now the accepted design): a robust send-and-verify-bounded-retry recovery that re-verifies the composer holds EXACTLY the pending doorbell before every Enter and never submits human draft text, with the watcher re-ring recovery as backstop. GOAL: reliably wake the agent on both herdr versions with no manual Enter, without regressing 0.8.2 or any other backend, and without ever submitting a human's unfinished composer text. This removes the need to pin/downgrade herdr.

## What Changed

- Detect an exact pending inbox doorbell and retry Enter with bounded, composer-safe verification without retyping the message.
- Stop recovery when the composer is empty, unknown, or contains changed/foreign text, preserving unfinished human drafts.
- Add regression and opt-in cross-version Herdr live coverage, plus documentation for the recovery behavior.

## Risk Assessment

✅ Low: The change is bounded to identity-checked, finite Enter retries, preserves conservative failure handling, and adds behavior-focused regression coverage without introducing unsupported paths.

## Testing

Exercised guarded retry behavior with targeted process-backed tests, then drove swallowed-doorbell recovery and foreign-draft protection through real Claude sessions on isolated Herdr 0.8.2 and 0.9.0 plus tmux; all driven scenarios passed. No screenshot was captured because this is terminal transport behavior, so live CLI transcripts record the observable act-and-ack results.

- Live validation: ✅ go - 4 of 5 scenarios driven live against the product

| Scenario | Result | Live | Evidence |
| --- | --- | --- | --- |
| A swallowed doorbell on Herdr 0.8.2 is submitted by one re-ring, acted on by Claude, and moved into handled/ | ✅ pass | live | Herdr 0.8.2 live result in `herdr-cross-version-live.log`. |
| A swallowed doorbell on Herdr 0.9.0 is submitted by one re-ring, acted on by Claude, and moved into handled/ | ✅ pass | live | Herdr 0.9.0 live result in `herdr-cross-version-live.log`. |
| A foreign human draft remains visibly unchanged and unsubmitted when rung on both supported Herdr versions | ✅ pass | live | Foreign-draft safety results for Herdr 0.8.2 and 0.9.0 in `herdr-cross-version-live.log`. |
| The existing tmux backend still delivers an ordinary doorbell and recovers a swallowed Enter through a real Claude worker | ✅ pass | live | Real worker act-and-ack and swallowed-doorbell recovery in `tmux-claude-doorbell-live.log`. |
| Unknown and failed-Enter verdicts retry only while the composer exactly matches the doorbell and stop when its content changes | ⏸️ untested | no | Real Herdr provides no deterministic fault-injection control for forcing an unknown verdict or transient send-key failure. A Herdr test build or runtime fault-injection facility capable of forcing tho… |

<details>
<summary>Evidence: Herdr 0.8.2 and 0.9.0 live doorbell transcript</summary>

Source: [Herdr 0.8.2 and 0.9.0 live doorbell transcript](https://github.com/d1on/firstmate/blob/5ee60c0fd5837c016ccaae15b24506cf1b5ee621/.no-mistakes/evidence/fm/firstmate-herdr-doorbell-submit-fix/herdr-cross-version-live.log)

```text
ok - Herdr 0.8.2: swallowed doorbell recovered through real fm_task_inbox_ring
ok - Herdr 0.8.2: foreign draft stayed unchanged and unsubmitted
ok - Herdr 0.9.0: swallowed doorbell recovered through real fm_task_inbox_ring
ok - Herdr 0.9.0: foreign draft stayed unchanged and unsubmitted
ok - cross-version Herdr doorbell guard: 2 version(s) passed, 0 unavailable
```
</details>
<details>
<summary>Evidence: tmux and Claude live doorbell transcript</summary>

Source: [tmux and Claude live doorbell transcript](https://github.com/d1on/firstmate/blob/5ee60c0fd5837c016ccaae15b24506cf1b5ee621/.no-mistakes/evidence/fm/firstmate-herdr-doorbell-submit-fix/tmux-claude-doorbell-live.log)

```text
ok - claude (2.1.236 (Claude Code)): the doorbell reached a real worker, which acted and acked with the mv
ok - claude (2.1.236 (Claude Code)): a swallowed doorbell was committed by one re-ring, and the worker acted and acked
ok - live steering-inbox doorbell guard: 1 delivery check(s), 1 recovery check(s) passed
```
</details>
<details>
<summary>Evidence: Targeted inbox retry and safety transcript</summary>

Source: [Targeted inbox retry and safety transcript](https://github.com/d1on/firstmate/blob/5ee60c0fd5837c016ccaae15b24506cf1b5ee621/.no-mistakes/evidence/fm/firstmate-herdr-doorbell-submit-fix/fm-task-inbox-targeted.log)

```text
ok - inbox: a steer is written durably and round-trips byte-exact with a self-describing doorbell
ok - inbox: a hostile-path doorbell executes as a no-op in bare shells
ok - inbox: terminal-control paths are rejected without typing
ok - inbox: the ring skips dead or missing endpoints and still rings live or unclassifiable endpoints
ok - inbox: the ring commits its own swallowed doorbell without retyping it
ok - inbox: Enter retries stop when the composer content changes
ok - inbox: unknown and failed Enter retries preserve composer text
ok - inbox: the ring never submits composer text it did not type
ok - inbox: the idempotent enqueue dedups an exact re-run onto the same record, handled or not
ok - inbox: idempotent enqueue follows a record concurrently moved to handled
ok - inbox: the handled mv is the idempotent ack and sequences are never reissued
ok - inbox: concurrent writers serialize on the sequence lock and lose nothing
ok - inbox: a writer retries when a competing lock vanishes after its failed claim
ok - inbox: ladder bookkeeping ignores a concurrently removed inbox
ok - inbox: fire-and-forget records stay durable and outside the ladder
ok - inbox: the re-ring ladder paces by grace, escalates once, and resets on ack
ok - watcher: an unhandled aged message on an idle pane re-rings without waking firstmate, and the ack silences it
ok - watcher: a busy pane just waits - the record is durable and no doorbell is typed
ok - watcher: a healthy or empty inbox stays completely silent
ok - watcher: acknowledgement silences an unwritable ladder without a stale wake
ok - watcher: unwritable ladder bookkeeping surfaces a stale wake after the doorbell
ok - watcher: a spent ring budget emits exactly one ordinary stale wake for recovery
ok - watcher: a positively dead pane is never typed into and surfaces exactly one stale wake
ok - watcher: dead-pane recovery overrides stale busy state
```
</details>
- Outcome: 🔧 2 issues found → auto-fixed ✅ across 2 runs (30m22s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"4ecd818e3fc203aa019e869cf1ba7cd6077c6c1d","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>🔧 **Test** - 2 issues found → auto-fixed ✅</summary>

- ⚠️ The required Herdr 0.8.2 and 0.9.0 product scenarios could not be driven in this run. Herdr 0.8.2 is installed, but this process is not inside a Herdr-managed pane (HERDR_ENV is unset), so Herdr&#39;s control contract prohibits operating a session; 0.9.0 is also unavailable. Re-run inside a Herdr-managed pane with isolated 0.8.2 and 0.9.0 sessions to complete acceptance evidence.
- ⚠️ live validation verdict: inconclusive (3 of 5 scenarios were driven live against the product); untested: Recover a swallowed doorbell through the real Herdr 0.8.2 backend, Recover a swallowed doorbell through the real Herdr 0.9.0 backend
- Live validation: ⚠️ inconclusive - 3 of 5 scenarios driven live against the product

| Scenario | Result | Live | Evidence |
| --- | --- | --- | --- |
| Send a normal durable inbox message to a real Claude worker and observe it act and acknowledge the record | ✅ pass | live | Real Claude doorbell delivery and swallowed-Enter recovery log |
| Leave the exact doorbell unsent in a real Claude composer, re-ring once, and observe the worker act and acknowledge without manual Enter | ✅ pass | live | Real Claude doorbell delivery and swallowed-Enter recovery log |
| Ring while a real Claude composer contains a human draft and observe that the draft remains pending and is never submitted | ✅ pass | live | Real Claude foreign-draft composer before and after guarded ring |
| Recover a swallowed doorbell through the real Herdr 0.8.2 backend | ⏸️ untested | no | This process is not running in a Herdr-managed pane, and Herdr&#39;s control contract forbids session control when HERDR_ENV is not 1. Run this phase from a Herdr-managed pane with an isolated 0.8.2 sessi… |
| Recover a swallowed doorbell through the real Herdr 0.9.0 backend | ⏸️ untested | no | Herdr 0.9.0 is not available, and this process also lacks HERDR_ENV=1. Provide an isolated 0.9.0 executable/session and run the phase from a Herdr-managed pane. |

- `bash tests/fm-task-inbox.test.sh`
- `FM_SEND_INBOX_LIVE_E2E=1 FM_SEND_INBOX_LIVE_HARNESSES=claude FM_SEND_INBOX_LIVE_TIMEOUT=180 bash tests/fm-send-inbox-doorbell-live-e2e.test.sh`
- `~/.no-mistakes/evidence/01M20JNC7Q0Y38V3GS2XWJ25E4/foreign-draft-live-check.sh`
- `test "${HERDR_ENV:-}" = 1; herdr --version; claude --version`

🔧 Fix applied.
✅ Re-checked - no issues remain.
- Live validation: ✅ go - 4 of 5 scenarios driven live against the product

| Scenario | Result | Live | Evidence |
| --- | --- | --- | --- |
| A swallowed doorbell on Herdr 0.8.2 is submitted by one re-ring, acted on by Claude, and moved into handled/ | ✅ pass | live | Herdr 0.8.2 live result in `herdr-cross-version-live.log`. |
| A swallowed doorbell on Herdr 0.9.0 is submitted by one re-ring, acted on by Claude, and moved into handled/ | ✅ pass | live | Herdr 0.9.0 live result in `herdr-cross-version-live.log`. |
| A foreign human draft remains visibly unchanged and unsubmitted when rung on both supported Herdr versions | ✅ pass | live | Foreign-draft safety results for Herdr 0.8.2 and 0.9.0 in `herdr-cross-version-live.log`. |
| The existing tmux backend still delivers an ordinary doorbell and recovers a swallowed Enter through a real Claude worker | ✅ pass | live | Real worker act-and-ack and swallowed-doorbell recovery in `tmux-claude-doorbell-live.log`. |
| Unknown and failed-Enter verdicts retry only while the composer exactly matches the doorbell and stop when its content changes | ⏸️ untested | no | Real Herdr provides no deterministic fault-injection control for forcing an unknown verdict or transient send-key failure. A Herdr test build or runtime fault-injection facility capable of forcing tho… |

- `bash tests/fm-task-inbox.test.sh`
- `FM_SEND_INBOX_HERDR_LIVE_E2E=1 FM_SEND_INBOX_HERDR_LIVE_TIMEOUT=180 bash tests/fm-send-inbox-doorbell-herdr-live-e2e.test.sh`
- `FM_SEND_INBOX_LIVE_E2E=1 FM_SEND_INBOX_LIVE_HARNESSES=claude FM_SEND_INBOX_LIVE_TIMEOUT=180 bash tests/fm-send-inbox-doorbell-live-e2e.test.sh`
- <code>Verified isolated Herdr and tmux test sessions terminated and `git status --short` remained clean.</code>
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
