### PR TITLE
ci: rebalance portable serial shards and guard runtime headroom

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -371,13 +371,11 @@ jobs:
             echo "::warning::no portable serial timing JSON found; shard balance unchecked"
             exit 0
           fi
-          # The tests-portable-serial job cap above, handed back so the guard
-          # measures headroom against the cap this workflow actually sets.
-          # bin/fm-test-run.sh refuses a value that disagrees with its own
-          # record, and the suite parses this workflow and refuses when either
-          # disagrees with that job's real timeout-minutes key, so the cap
-          # cannot move in one place only.
-          bin/fm-test-run.sh --check-shard-balance --job-timeout-minutes 20 "${serial[@]}"
+          # The guard owns the cap it measures against; the suite parses this
+          # workflow and refuses when that record and the tests-portable-serial
+          # timeout-minutes above disagree, so the cap cannot move in one place
+          # only.
+          bin/fm-test-run.sh --check-shard-balance "${serial[@]}"
       - name: Upload aggregate timing artifact
         if: always()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,15 +135,17 @@ jobs:
   tests-portable-serial:
     name: Behavior portable serial ${{ matrix.shard }}
     runs-on: ubuntu-latest
-    # Measured whole remainder is ~63 min of serial work; the balanced shards
-    # are ~12.7 min each. Cap is a hang tripwire with roughly 1.6x margin, not
-    # the expected healthy end of the lane.
+    # Measured whole remainder is ~77 min of serial work across six shards, whose
+    # worst measured shard is ~13.4 min. Cap is a hang tripwire with roughly 1.5x
+    # margin, not the expected healthy end of the lane. The timing aggregate job
+    # below checks that margin against every run rather than leaving this comment
+    # to go stale again.
     timeout-minutes: 20
     strategy:
       # Every shard reports so one failure never hides another shard's result.
       fail-fast: false
       matrix:
-        shard: [1, 2, 3, 4, 5]
+        shard: [1, 2, 3, 4, 5, 6]
     steps:
       - uses: actions/checkout@v6
         with:
@@ -356,6 +358,23 @@ jobs:
           bin/fm-test-run.sh --aggregate-json \
             "$RUNNER_TEMP/fm-test/fm-test-timing-aggregate.json" \
             "${inputs[@]}"
+      # The measured counterpart to the coverage guard's unhinted-share bound:
+      # that one catches a hint that is missing, this one catches a hint that is
+      # wrong, and reports which scripts to re-measure before a shard reaches
+      # the cap above (docs/fm-test-portable-shards.md).
+      - name: Check portable serial shard balance
+        run: |
+          set -eu
+          shopt -s nullglob
+          serial=("$RUNNER_TEMP"/fm-test-aggregate/fm-test-timing-portable-serial-*.json)
+          if [ "${#serial[@]}" -eq 0 ]; then
+            echo "::warning::no portable serial timing JSON found; shard balance unchecked"
+            exit 0
+          fi
+          # Same literal as the tests-portable-serial job cap above:
+          # bin/fm-test-run.sh refuses when the two disagree rather than
+          # measuring headroom against a cap that has since moved.
+          bin/fm-test-run.sh --check-shard-balance --job-timeout-minutes 20 "${serial[@]}"
       - name: Upload aggregate timing artifact
         if: always()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -371,9 +371,12 @@ jobs:
             echo "::warning::no portable serial timing JSON found; shard balance unchecked"
             exit 0
           fi
-          # Same literal as the tests-portable-serial job cap above:
-          # bin/fm-test-run.sh refuses when the two disagree rather than
-          # measuring headroom against a cap that has since moved.
+          # The tests-portable-serial job cap above, handed back so the guard
+          # measures headroom against the cap this workflow actually sets.
+          # bin/fm-test-run.sh refuses a value that disagrees with its own
+          # record, and the suite parses this workflow and refuses when either
+          # disagrees with that job's real timeout-minutes key, so the cap
+          # cannot move in one place only.
           bin/fm-test-run.sh --check-shard-balance --job-timeout-minutes 20 "${serial[@]}"
       - name: Upload aggregate timing artifact
         if: always()

--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -201,12 +201,14 @@ PORTABLE_SERIAL_MAX_UNHINTED_PERCENT=15
 # Drift: a shard runs further over its hint weight than this. The hints are what
 # the packer balances on, so once they read low the packer keeps reporting a
 # perfect split while one runner carries the excess. The remedy is a hint
-# refresh, and the guard names the scripts that drifted most.
+# refresh, and the guard names the scripts that drifted most. Only scripts that
+# actually carry a hint are compared: a missing hint is not a stale one, and the
+# unhinted share above already owns those.
 PORTABLE_SERIAL_MAX_HINT_DRIFT_PERCENT=15
 
-# Headroom: the worst shard's measured duration against a share of the job cap.
-# This is the property actually being protected, and it degrades gracefully as
-# the suite grows. Two shares, because the guard has to speak long before the
+# Headroom: the worst shard's own recorded wall time against a share of the job
+# cap, since the wall clock is what that cap bounds. This is the property
+# actually being protected, and it degrades gracefully as the suite grows. Two shares, because the guard has to speak long before the
 # badge goes red and still not redden a suite that is merely unlucky.
 #
 # Warn: loud, non-fatal, and low enough that a lane growing at a few minutes a
@@ -1072,7 +1074,7 @@ check_portable_serial_balance() {
     "$PORTABLE_SERIAL_WARN_SHARD_BUDGET_PERCENT" \
     "$PORTABLE_SERIAL_MAX_SHARD_BUDGET_PERCENT" \
     "$PORTABLE_SERIAL_SHARDS" "$@" <<'PY' || rc=$?
-import json, sys
+import json, os, re, sys
 from pathlib import Path
 
 hints_path, bound_s, default_s, drift_s, warn_budget_s, budget_s, shards_s = sys.argv[1:8]
@@ -1086,6 +1088,17 @@ expected_shards = int(shards_s)
 
 # Below this a percentage says more about rounding than about balance.
 MIN_HINTED_MS = 60000
+
+# A numbered serial shard lane. The count may differ from this runner's own, so
+# an artifact from an earlier partition stays readable; what cannot be mixed is
+# two partitions in one invocation, because a shard number means different work
+# in each.
+LANE_RE = re.compile(r"^portable-serial-([0-9]+)of([0-9]+)$")
+
+# The warning is the signal that has to arrive before the badge goes red, so
+# under Actions it is raised as an annotation instead of a line only someone who
+# opens the step log would ever read.
+ANNOTATE = os.environ.get("GITHUB_ACTIONS") == "true"
 
 hints = {}
 for line in Path(hints_path).read_text().splitlines():
@@ -1107,13 +1120,33 @@ def minutes(ms):
     return "%.2f min" % (ms / 60000.0)
 
 
-shards = []
+# What the job cap actually bounds is the shard's wall clock, and the runner
+# records exactly that. The per-script sum only stands in for an artifact that
+# carries no usable one.
+def wall_ms_of(data, fallback):
+    summary = data.get("summary")
+    value = summary.get("duration_ms") if isinstance(summary, dict) else None
+    try:
+        wall = int(value)
+    except (TypeError, ValueError):
+        return fallback
+    return wall if wall > 0 else fallback
+
+
+by_index = {}
+partitions = {}
+ignored = 0
+deduped = 0
 for path in inputs:
     if not path.exists():
         continue
     data = json.loads(path.read_text())
     lane = lane_of(data)
     if not lane.startswith("portable-serial-"):
+        continue
+    match = LANE_RE.match(lane)
+    if match is None:
+        ignored += 1
         continue
     scripts = [s for s in data.get("scripts", []) if s.get("path")]
     if not scripts:
@@ -1123,15 +1156,53 @@ for path in inputs:
         real = int(s["duration_ms"])
         hint = hints.get(s["path"], default_ms)
         rows.append((real - hint, s["path"], real, hint, s["path"] not in hints))
-    shards.append(
-        {
-            "lane": lane,
-            "measured": sum(r[2] for r in rows),
-            "hinted": sum(r[3] for r in rows),
-            "rows": rows,
-        }
+    # A script with no hint is not a stale hint, so it is excluded from the
+    # drift comparison on both sides; the coverage guard's unhinted share owns
+    # those. It still counts in full toward the wall time below.
+    hinted = [r for r in rows if not r[4]]
+    partitions.setdefault(int(match.group(2)), lane)
+    shard = {
+        "lane": lane,
+        "wall": wall_ms_of(data, sum(r[2] for r in rows)),
+        "hinted_measured": sum(r[2] for r in hinted),
+        "hinted": sum(r[3] for r in hinted),
+        "hinted_count": len(hinted),
+        "unhinted_count": len(rows) - len(hinted),
+        "rows": rows,
+    }
+    index = int(match.group(1))
+    previous = by_index.get(index)
+    if previous is not None:
+        # Several runs globbed together supply the same shard more than once.
+        # Keep the slowest copy, the same worst-case rule the hint table itself
+        # is refreshed on, so a repeat can never inflate the lane total.
+        deduped += 1
+        if previous["wall"] >= shard["wall"]:
+            continue
+    by_index[index] = shard
+
+if len(partitions) > 1:
+    print(
+        "shard balance guard: inputs mix %d serial partitions (%s), whose shard "
+        "numbers cover different work; check one partition at a time "
+        "(docs/fm-test-portable-shards.md)"
+        % (len(partitions), ", ".join(sorted(partitions.values()))),
+        file=sys.stderr,
+    )
+    sys.exit(2)
+
+if ignored:
+    print(
+        "FM_TEST_SHARD_BALANCE ignored %d artifact(s) that name no numbered "
+        "portable serial shard" % ignored
+    )
+if deduped:
+    print(
+        "FM_TEST_SHARD_BALANCE deduped %d repeated shard artifact(s); the "
+        "slowest copy of each shard was kept" % deduped
     )
 
+shards = [by_index[index] for index in sorted(by_index)]
 if not shards:
     print(
         "FM_TEST_SHARD_BALANCE skipped no portable serial timing artifacts "
@@ -1139,7 +1210,6 @@ if not shards:
     )
     sys.exit(0)
 
-shards.sort(key=lambda s: s["lane"])
 complete = len(shards) >= expected_shards
 if not complete:
     print(
@@ -1149,21 +1219,24 @@ if not complete:
     )
 
 for s in shards:
-    s["share"] = s["measured"] * 100.0 / bound_ms
+    s["share"] = s["wall"] * 100.0 / bound_ms
     s["drift"] = (
-        (s["measured"] - s["hinted"]) * 100.0 / s["hinted"] if s["hinted"] else 0.0
+        (s["hinted_measured"] - s["hinted"]) * 100.0 / s["hinted"]
+        if s["hinted"]
+        else 0.0
     )
     s["drifted"] = s["hinted"] >= MIN_HINTED_MS and s["drift"] > max_drift
 
 # What an even repack of the reported work would put on each shard. Only that
 # answers whether the lane has outgrown its shard count, so the headroom report
 # never asserts that remedy without it.
-even_ms = sum(s["measured"] for s in shards) / expected_shards if complete else None
+even_ms = sum(s["wall"] for s in shards) / expected_shards if complete else None
 
 
-def drifted_rows(s):
+def drifted_rows(s, hinted_only=False):
+    rows = [r for r in s["rows"] if not r[4]] if hinted_only else s["rows"]
     lines = []
-    for delta, path, real, hint, unhinted in sorted(s["rows"], reverse=True)[:5]:
+    for delta, path, real, hint, unhinted in sorted(rows, reverse=True)[:5]:
         if delta <= 0:
             continue
         lines.append(
@@ -1181,8 +1254,8 @@ def drifted_rows(s):
 
 # A shard can be heavy with every hint accurate, so the header is only printed
 # when there is something under it to read.
-def labelled_rows(s, header):
-    rows = drifted_rows(s)
+def labelled_rows(s, header, hinted_only=False):
+    rows = drifted_rows(s, hinted_only)
     return [header] + rows if rows else []
 
 
@@ -1191,15 +1264,15 @@ def labelled_rows(s, header):
 # lane needs another runner.
 def headroom_report(s, limit, label):
     lines = [
-        "shard balance guard %s: %s measured %s, %.0f%% of the %s min job cap "
+        "shard balance guard %s: %s ran %s, %.0f%% of the %s min job cap "
         "(over %d%%)"
-        % (label, s["lane"], minutes(s["measured"]), s["share"], bound_s, limit)
+        % (label, s["lane"], minutes(s["wall"]), s["share"], bound_s, limit)
     ]
     if s["drifted"]:
         lines.append(
-            "  it also ran %.0f%% over its own hint weight, so refresh the hints "
-            "and repack before adding a shard; the drift report below names the "
-            "scripts to re-measure" % s["drift"]
+            "  its hinted scripts also ran %.0f%% over their hint weight, so "
+            "refresh the hints and repack before adding a shard; the drift "
+            "report below names the scripts to re-measure" % s["drift"]
         )
     elif even_ms is None:
         lines.append(
@@ -1236,24 +1309,35 @@ for s in shards:
     elif s["share"] > warn_budget:
         warnings.append(headroom_report(s, warn_budget, "warning"))
     if s["drifted"]:
+        excluded = (
+            "; %d unhinted script(s) excluded, the coverage guard owns those"
+            % s["unhinted_count"]
+            if s["unhinted_count"]
+            else ""
+        )
         lines = [
-            "shard balance guard failed: %s measured %s against %s of hint weight "
-            "(+%.0f%%, max +%s%%)\n"
+            "shard balance guard failed: %s ran %s against %s of hint weight "
+            "over its %d hinted scripts (+%.0f%%, max +%s%%%s)\n"
             "  the hint table is stale; re-measure these scripts "
             "(docs/fm-test-portable-shards.md):"
             % (
                 s["lane"],
-                minutes(s["measured"]),
+                minutes(s["hinted_measured"]),
                 minutes(s["hinted"]),
+                s["hinted_count"],
                 s["drift"],
                 max_drift,
+                excluded,
             )
         ]
-        lines += drifted_rows(s)
+        lines += drifted_rows(s, hinted_only=True)
         failures.append("\n".join(lines))
 
 for w in warnings:
-    print(w, file=sys.stderr)
+    if ANNOTATE:
+        print("::warning::" + w.replace("\n", "%0A"))
+    else:
+        print(w, file=sys.stderr)
 if failures:
     for f in failures:
         print(f, file=sys.stderr)

--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -1099,8 +1099,6 @@ for path in inputs:
         continue
     data = json.loads(path.read_text())
     match = LANE_RE.match(lane_of(data))
-    if match is None:
-        continue
     scripts = [s for s in data.get("scripts", []) if s.get("path")]
     if not scripts:
         continue

--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -1095,15 +1095,10 @@ def minutes(ms):
 shards = []
 declared_shards = 0
 for path in inputs:
-    if not path.exists():
-        continue
     data = json.loads(path.read_text())
     match = LANE_RE.match(lane_of(data))
-    scripts = [s for s in data.get("scripts", []) if s.get("path")]
-    if not scripts:
-        continue
     rows = []
-    for s in scripts:
+    for s in data["scripts"]:
         real = int(s["duration_ms"])
         hint = hints.get(s["path"], default_ms)
         rows.append((real - hint, s["path"], real, hint, s["path"] not in hints))
@@ -1117,12 +1112,6 @@ for path in inputs:
     )
 
 shards.sort(key=lambda s: s["lane"])
-if not shards:
-    print(
-        "FM_TEST_SHARD_BALANCE skipped no portable serial timing artifacts "
-        "(a cancelled shard uploads none)"
-    )
-    sys.exit(0)
 
 # The artifacts declare the partition they ran as, so coverage is counted
 # against that rather than against whatever this runner is configured for now.

--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -1092,19 +1092,6 @@ def minutes(ms):
     return "%.2f min" % (ms / 60000.0)
 
 
-# What the job cap bounds is the shard's wall clock, and the runner records
-# exactly that. The per-script sum only stands in for an artifact that carries
-# no usable one.
-def wall_ms_of(data, fallback):
-    summary = data.get("summary")
-    value = summary.get("duration_ms") if isinstance(summary, dict) else None
-    try:
-        wall = int(value)
-    except (TypeError, ValueError):
-        return fallback
-    return wall if wall > 0 else fallback
-
-
 shards = []
 declared_shards = 0
 for path in inputs:
@@ -1126,7 +1113,7 @@ for path in inputs:
     shards.append(
         {
             "lane": match.group(0),
-            "wall": wall_ms_of(data, sum(r[2] for r in rows)),
+            "wall": int(data["summary"]["duration_ms"]),
             "rows": rows,
         }
     )

--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -1067,11 +1067,10 @@ bound_ms = int(bound_s) * 60000
 default_ms = int(default_s)
 max_budget = int(budget_s)
 
-# A numbered serial shard lane. The count may differ from this runner's own, so
-# an artifact from an earlier partition stays readable; what cannot be mixed is
-# two partitions in one invocation, because a shard number means different work
-# in each.
-LANE_RE = re.compile(r"^portable-serial-([0-9]+)of([0-9]+)$")
+# A numbered serial shard lane, capturing the shard count it declares. That
+# count may differ from this runner's own, so an artifact from an earlier
+# partition stays readable and is still counted against its own lane.
+LANE_RE = re.compile(r"^portable-serial-[0-9]+of([0-9]+)$")
 
 hints = {}
 for line in Path(hints_path).read_text().splitlines():
@@ -1106,9 +1105,8 @@ def wall_ms_of(data, fallback):
     return wall if wall > 0 else fallback
 
 
-by_index = {}
-partitions = {}
-deduped = 0
+shards = []
+declared_shards = 0
 for path in inputs:
     if not path.exists():
         continue
@@ -1124,41 +1122,16 @@ for path in inputs:
         real = int(s["duration_ms"])
         hint = hints.get(s["path"], default_ms)
         rows.append((real - hint, s["path"], real, hint, s["path"] not in hints))
-    lane = match.group(0)
-    partitions.setdefault(int(match.group(2)), lane)
-    shard = {
-        "lane": lane,
-        "wall": wall_ms_of(data, sum(r[2] for r in rows)),
-        "rows": rows,
-    }
-    index = int(match.group(1))
-    previous = by_index.get(index)
-    if previous is not None:
-        # Several runs globbed together supply the same shard more than once.
-        # Keep the slowest copy, the same worst-case rule the hint table itself
-        # is refreshed on, so a repeat can never be counted as extra coverage.
-        deduped += 1
-        if previous["wall"] >= shard["wall"]:
-            continue
-    by_index[index] = shard
-
-if len(partitions) > 1:
-    print(
-        "shard balance guard: inputs mix %d serial partitions (%s), whose shard "
-        "numbers cover different work; check one partition at a time "
-        "(docs/fm-test-portable-shards.md)"
-        % (len(partitions), ", ".join(sorted(partitions.values()))),
-        file=sys.stderr,
-    )
-    sys.exit(2)
-
-if deduped:
-    print(
-        "FM_TEST_SHARD_BALANCE deduped %d repeated shard artifact(s); the "
-        "slowest copy of each shard was kept" % deduped
+    declared_shards = max(declared_shards, int(match.group(1)))
+    shards.append(
+        {
+            "lane": match.group(0),
+            "wall": wall_ms_of(data, sum(r[2] for r in rows)),
+            "rows": rows,
+        }
     )
 
-shards = [by_index[index] for index in sorted(by_index)]
+shards.sort(key=lambda s: s["lane"])
 if not shards:
     print(
         "FM_TEST_SHARD_BALANCE skipped no portable serial timing artifacts "
@@ -1168,7 +1141,6 @@ if not shards:
 
 # The artifacts declare the partition they ran as, so coverage is counted
 # against that rather than against whatever this runner is configured for now.
-declared_shards = next(iter(partitions))
 if len(shards) < declared_shards:
     print(
         "FM_TEST_SHARD_BALANCE partial %d of %d portable serial shards reported "
@@ -1183,7 +1155,7 @@ for s in shards:
     if share <= max_budget:
         continue
     lines = [
-        "shard balance guard failed: %s ran %s, %.0f%% of the %s min job cap "
+        "shard balance guard failed: %s ran %s, %.1f%% of the %s min job cap "
         "(max %d%%); repack the lane (docs/fm-test-portable-shards.md)"
         % (s["lane"], minutes(s["wall"]), share, bound_s, max_budget)
     ]
@@ -1213,7 +1185,7 @@ if failures:
 
 worst = max(shards, key=lambda s: s["share"])
 print(
-    "FM_TEST_SHARD_BALANCE ok shards=%d worst_share=%s@%.0f%% bound=%smin"
+    "FM_TEST_SHARD_BALANCE ok shards=%d worst_share=%s@%.1f%% bound=%smin"
     % (len(shards), worst["lane"], worst["share"], bound_s)
 )
 PY

--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -24,8 +24,7 @@
 #   fm-test-run.sh --list-lanes
 #   fm-test-run.sh --check-coverage
 #
-#   fm-test-run.sh --check-shard-balance [--job-timeout-minutes <n>] \
-#                    <serial-lane.json> [more serial-lane.json...]
+#   fm-test-run.sh --check-shard-balance <serial-lane.json> [more serial-lane.json...]
 #
 # Aggregation (no suite execution):
 #   fm-test-run.sh --aggregate-json <out.json> <lane.json> [more lane.json...]
@@ -153,7 +152,6 @@ LIST_CONCURRENT_SAFE_FAMILIES=0
 LIST_LANES=0
 CHECK_COVERAGE=0
 AGGREGATE_OUT=
-JOB_TIMEOUT_MINUTES=
 FAMILY=
 LANE=
 BASE_REF=origin/main
@@ -194,35 +192,24 @@ PORTABLE_SERIAL_DEFAULT_WEIGHT_MS=27000
 # instead of silently. docs/fm-test-portable-shards.md owns the refresh.
 PORTABLE_SERIAL_MAX_UNHINTED_PERCENT=15
 
-# The two ways a balanced-looking partition still reaches its CI job cap, each
-# with its own remedy, checked by --check-shard-balance against the measured
-# durations the lanes already upload.
+# How close a shard may run to its CI job cap before --check-shard-balance
+# fails, as a share of that cap taken against the shard's own recorded wall
+# time. This is the property actually being protected: it degrades gracefully as
+# the suite grows, and it fires while the shard still finishes rather than after
+# it is cancelled. The failure names the scripts furthest over their hints, so
+# it still says what to re-measure.
 #
-# Drift: a shard runs further over its hint weight than this. The hints are what
-# the packer balances on, so once they read low the packer keeps reporting a
-# perfect split while one runner carries the excess. The remedy is a hint
-# refresh, and the guard names the scripts that drifted most. Only scripts that
-# actually carry a hint are compared: a missing hint is not a stale one, and the
-# unhinted share above already owns those.
-PORTABLE_SERIAL_MAX_HINT_DRIFT_PERCENT=15
-
-# Headroom: the worst shard's own recorded wall time against a share of the job
-# cap, since the wall clock is what that cap bounds. This is the property
-# actually being protected, and it degrades gracefully as the suite grows. Two shares, because the guard has to speak long before the
-# badge goes red and still not redden a suite that is merely unlucky.
-#
-# Warn: loud, non-fatal, and low enough that a lane growing at a few minutes a
-# day is told about it with days of margin left to add a shard in.
-PORTABLE_SERIAL_WARN_SHARD_BUDGET_PERCENT=75
-# Fail: far enough above the warning that ordinary hosted-runner spread cannot
-# turn an otherwise green suite red. Per-script noise on this lane reaches 3x,
-# and a guard that cries wolf gets switched off.
+# A richer diagnosis was built here and deliberately reduced away: a second
+# pass/fail bound on hint drift, a non-failing warning share below this one, and
+# a branch that told "the estimates are wrong" apart from "the lane has outgrown
+# its shard count". Both properties that are actually required survive in this
+# single check, so do not re-derive that split and add it back.
 PORTABLE_SERIAL_MAX_SHARD_BUDGET_PERCENT=90
 
-# The tests-portable-serial job cap the headroom share is taken against, in
-# minutes. .github/workflows/ci.yml owns that job's timeout-minutes and passes
-# it back through --job-timeout-minutes, which is refused when the two disagree
-# rather than left to drift silently.
+# The tests-portable-serial job cap that share is taken against, in minutes.
+# .github/workflows/ci.yml owns that job's timeout-minutes; tests/fm-test-run.test.sh
+# parses the workflow and refuses when the two disagree rather than leaving them
+# to drift silently.
 PORTABLE_SERIAL_JOB_TIMEOUT_MINUTES=20
 
 usage() {
@@ -1070,35 +1057,21 @@ check_portable_serial_balance() {
   tmp=$(mktemp -d "${TMPDIR:-/tmp}/fm-shard-balance.XXXXXX") || die "mktemp failed"
   portable_serial_weight_hints >"$tmp/hints"
   python3 - "$tmp/hints" "$bound_minutes" "$PORTABLE_SERIAL_DEFAULT_WEIGHT_MS" \
-    "$PORTABLE_SERIAL_MAX_HINT_DRIFT_PERCENT" \
-    "$PORTABLE_SERIAL_WARN_SHARD_BUDGET_PERCENT" \
-    "$PORTABLE_SERIAL_MAX_SHARD_BUDGET_PERCENT" \
-    "$PORTABLE_SERIAL_SHARDS" "$@" <<'PY' || rc=$?
-import json, os, re, sys
+    "$PORTABLE_SERIAL_MAX_SHARD_BUDGET_PERCENT" "$@" <<'PY' || rc=$?
+import json, re, sys
 from pathlib import Path
 
-hints_path, bound_s, default_s, drift_s, warn_budget_s, budget_s, shards_s = sys.argv[1:8]
-inputs = [Path(p) for p in sys.argv[8:]]
+hints_path, bound_s, default_s, budget_s = sys.argv[1:5]
+inputs = [Path(p) for p in sys.argv[5:]]
 bound_ms = int(bound_s) * 60000
 default_ms = int(default_s)
-max_drift = int(drift_s)
-warn_budget = int(warn_budget_s)
 max_budget = int(budget_s)
-expected_shards = int(shards_s)
-
-# Below this a percentage says more about rounding than about balance.
-MIN_HINTED_MS = 60000
 
 # A numbered serial shard lane. The count may differ from this runner's own, so
 # an artifact from an earlier partition stays readable; what cannot be mixed is
 # two partitions in one invocation, because a shard number means different work
 # in each.
 LANE_RE = re.compile(r"^portable-serial-([0-9]+)of([0-9]+)$")
-
-# The warning is the signal that has to arrive before the badge goes red, so
-# under Actions it is raised as an annotation instead of a line only someone who
-# opens the step log would ever read.
-ANNOTATE = os.environ.get("GITHUB_ACTIONS") == "true"
 
 hints = {}
 for line in Path(hints_path).read_text().splitlines():
@@ -1120,9 +1093,9 @@ def minutes(ms):
     return "%.2f min" % (ms / 60000.0)
 
 
-# What the job cap actually bounds is the shard's wall clock, and the runner
-# records exactly that. The per-script sum only stands in for an artifact that
-# carries no usable one.
+# What the job cap bounds is the shard's wall clock, and the runner records
+# exactly that. The per-script sum only stands in for an artifact that carries
+# no usable one.
 def wall_ms_of(data, fallback):
     summary = data.get("summary")
     value = summary.get("duration_ms") if isinstance(summary, dict) else None
@@ -1135,18 +1108,13 @@ def wall_ms_of(data, fallback):
 
 by_index = {}
 partitions = {}
-ignored = 0
 deduped = 0
 for path in inputs:
     if not path.exists():
         continue
     data = json.loads(path.read_text())
-    lane = lane_of(data)
-    if not lane.startswith("portable-serial-"):
-        continue
-    match = LANE_RE.match(lane)
+    match = LANE_RE.match(lane_of(data))
     if match is None:
-        ignored += 1
         continue
     scripts = [s for s in data.get("scripts", []) if s.get("path")]
     if not scripts:
@@ -1156,18 +1124,11 @@ for path in inputs:
         real = int(s["duration_ms"])
         hint = hints.get(s["path"], default_ms)
         rows.append((real - hint, s["path"], real, hint, s["path"] not in hints))
-    # A script with no hint is not a stale hint, so it is excluded from the
-    # drift comparison on both sides; the coverage guard's unhinted share owns
-    # those. It still counts in full toward the wall time below.
-    hinted = [r for r in rows if not r[4]]
+    lane = match.group(0)
     partitions.setdefault(int(match.group(2)), lane)
     shard = {
         "lane": lane,
         "wall": wall_ms_of(data, sum(r[2] for r in rows)),
-        "hinted_measured": sum(r[2] for r in hinted),
-        "hinted": sum(r[3] for r in hinted),
-        "hinted_count": len(hinted),
-        "unhinted_count": len(rows) - len(hinted),
         "rows": rows,
     }
     index = int(match.group(1))
@@ -1175,7 +1136,7 @@ for path in inputs:
     if previous is not None:
         # Several runs globbed together supply the same shard more than once.
         # Keep the slowest copy, the same worst-case rule the hint table itself
-        # is refreshed on, so a repeat can never inflate the lane total.
+        # is refreshed on, so a repeat can never be counted as extra coverage.
         deduped += 1
         if previous["wall"] >= shard["wall"]:
             continue
@@ -1191,11 +1152,6 @@ if len(partitions) > 1:
     )
     sys.exit(2)
 
-if ignored:
-    print(
-        "FM_TEST_SHARD_BALANCE ignored %d artifact(s) that name no numbered "
-        "portable serial shard" % ignored
-    )
 if deduped:
     print(
         "FM_TEST_SHARD_BALANCE deduped %d repeated shard artifact(s); the "
@@ -1210,36 +1166,32 @@ if not shards:
     )
     sys.exit(0)
 
-complete = len(shards) >= expected_shards
-if not complete:
+# The artifacts declare the partition they ran as, so coverage is counted
+# against that rather than against whatever this runner is configured for now.
+declared_shards = next(iter(partitions))
+if len(shards) < declared_shards:
     print(
         "FM_TEST_SHARD_BALANCE partial %d of %d portable serial shards reported "
         "a timing artifact; a cancelled shard uploads none, so the rest are "
-        "unchecked" % (len(shards), expected_shards)
+        "unchecked" % (len(shards), declared_shards)
     )
 
+failures = []
 for s in shards:
-    s["share"] = s["wall"] * 100.0 / bound_ms
-    s["drift"] = (
-        (s["hinted_measured"] - s["hinted"]) * 100.0 / s["hinted"]
-        if s["hinted"]
-        else 0.0
-    )
-    s["drifted"] = s["hinted"] >= MIN_HINTED_MS and s["drift"] > max_drift
-
-# What an even repack of the reported work would put on each shard. Only that
-# answers whether the lane has outgrown its shard count, so the headroom report
-# never asserts that remedy without it.
-even_ms = sum(s["wall"] for s in shards) / expected_shards if complete else None
-
-
-def drifted_rows(s, hinted_only=False):
-    rows = [r for r in s["rows"] if not r[4]] if hinted_only else s["rows"]
-    lines = []
-    for delta, path, real, hint, unhinted in sorted(rows, reverse=True)[:5]:
+    share = s["wall"] * 100.0 / bound_ms
+    s["share"] = share
+    if share <= max_budget:
+        continue
+    lines = [
+        "shard balance guard failed: %s ran %s, %.0f%% of the %s min job cap "
+        "(max %d%%); repack the lane (docs/fm-test-portable-shards.md)"
+        % (s["lane"], minutes(s["wall"]), share, bound_s, max_budget)
+    ]
+    over = []
+    for delta, path, real, hint, unhinted in sorted(s["rows"], reverse=True)[:5]:
         if delta <= 0:
             continue
-        lines.append(
+        over.append(
             "    %s measured %.1fs hint %.1fs (%+.1fs)%s"
             % (
                 path,
@@ -1249,114 +1201,20 @@ def drifted_rows(s, hinted_only=False):
                 " [no hint, default weight]" if unhinted else "",
             )
         )
-    return lines
+    if over:
+        lines.append("  re-measure the scripts furthest over their hints:")
+        lines += over
+    failures.append("\n".join(lines))
 
-
-# A shard can be heavy with every hint accurate, so the header is only printed
-# when there is something under it to read.
-def labelled_rows(s, header, hinted_only=False):
-    rows = drifted_rows(s, hinted_only)
-    return [header] + rows if rows else []
-
-
-# States what was measured against the cap, then the cause the guard could
-# actually establish: a shard over its budget is not by itself evidence that the
-# lane needs another runner.
-def headroom_report(s, limit, label):
-    lines = [
-        "shard balance guard %s: %s ran %s, %.0f%% of the %s min job cap "
-        "(over %d%%)"
-        % (label, s["lane"], minutes(s["wall"]), s["share"], bound_s, limit)
-    ]
-    if s["drifted"]:
-        lines.append(
-            "  its hinted scripts also ran %.0f%% over their hint weight, so "
-            "refresh the hints and repack before adding a shard; the drift "
-            "report below names the scripts to re-measure" % s["drift"]
-        )
-    elif even_ms is None:
-        lines.append(
-            "  only %d of %d shards reported, so whether an even repack would fit "
-            "could not be determined (docs/fm-test-portable-shards.md)"
-            % (len(shards), expected_shards)
-        )
-        lines += labelled_rows(s, "  the scripts furthest over their hints:")
-    elif even_ms * 100.0 / bound_ms > limit:
-        lines.append(
-            "  an even repack across %d shards still gives %s each, so the lane has "
-            "outgrown its shard count: raise PORTABLE_SERIAL_SHARDS and the ci.yml "
-            "matrix (docs/fm-test-portable-shards.md)"
-            % (expected_shards, minutes(even_ms))
-        )
-    else:
-        lines.append(
-            "  an even repack across %d shards gives %s each, which fits, so this "
-            "shard is packed heavy rather than the lane having outgrown its shard "
-            "count (docs/fm-test-portable-shards.md)"
-            % (expected_shards, minutes(even_ms))
-        )
-        lines += labelled_rows(s, "  re-measure these scripts:")
-    return "\n".join(lines)
-
-
-warnings = []
-failures = []
-for s in shards:
-    # Warn well below the cap so the guard speaks before the badge goes red, and
-    # fail only where hosted-runner spread can no longer explain the shard.
-    if s["share"] > max_budget:
-        failures.append(headroom_report(s, max_budget, "failed"))
-    elif s["share"] > warn_budget:
-        warnings.append(headroom_report(s, warn_budget, "warning"))
-    if s["drifted"]:
-        excluded = (
-            "; %d unhinted script(s) excluded, the coverage guard owns those"
-            % s["unhinted_count"]
-            if s["unhinted_count"]
-            else ""
-        )
-        lines = [
-            "shard balance guard failed: %s ran %s against %s of hint weight "
-            "over its %d hinted scripts (+%.0f%%, max +%s%%%s)\n"
-            "  the hint table is stale; re-measure these scripts "
-            "(docs/fm-test-portable-shards.md):"
-            % (
-                s["lane"],
-                minutes(s["hinted_measured"]),
-                minutes(s["hinted"]),
-                s["hinted_count"],
-                s["drift"],
-                max_drift,
-                excluded,
-            )
-        ]
-        lines += drifted_rows(s, hinted_only=True)
-        failures.append("\n".join(lines))
-
-for w in warnings:
-    if ANNOTATE:
-        print("::warning::" + w.replace("\n", "%0A"))
-    else:
-        print(w, file=sys.stderr)
 if failures:
     for f in failures:
         print(f, file=sys.stderr)
     sys.exit(1)
 
-worst_share = max(shards, key=lambda s: s["share"])
-worst_drift = max(shards, key=lambda s: s["drift"])
+worst = max(shards, key=lambda s: s["share"])
 print(
-    "FM_TEST_SHARD_BALANCE %s shards=%d worst_share=%s@%.0f%% "
-    "worst_drift=%s@%+.0f%% bound=%smin"
-    % (
-        "warn" if warnings else "ok",
-        len(shards),
-        worst_share["lane"],
-        worst_share["share"],
-        worst_drift["lane"],
-        worst_drift["drift"],
-        bound_s,
-    )
+    "FM_TEST_SHARD_BALANCE ok shards=%d worst_share=%s@%.0f%% bound=%smin"
+    % (len(shards), worst["lane"], worst["share"], bound_s)
 )
 PY
   rm -rf "$tmp"
@@ -2130,15 +1988,6 @@ while [ "$#" -gt 0 ]; do
       MODE='shard-balance'
       shift
       ;;
-    --job-timeout-minutes)
-      [ "$#" -gt 1 ] || die "--job-timeout-minutes requires a value"
-      JOB_TIMEOUT_MINUTES=$2
-      shift 2
-      ;;
-    --job-timeout-minutes=*)
-      JOB_TIMEOUT_MINUTES=${1#--job-timeout-minutes=}
-      shift
-      ;;
     --aggregate-json)
       [ "$#" -gt 1 ] || die "--aggregate-json requires an output path"
       AGGREGATE_OUT=$2
@@ -2214,17 +2063,6 @@ if [ "$CHECK_COVERAGE" -eq 1 ]; then
 fi
 
 if [ "${MODE:-}" = "shard-balance" ]; then
-  if [ -n "$JOB_TIMEOUT_MINUTES" ]; then
-    case "$JOB_TIMEOUT_MINUTES" in
-      ''|*[!0-9]*) die "--job-timeout-minutes must be a positive integer" ;;
-    esac
-    # One owner, cross-checked: ci.yml passes back the cap it actually sets on
-    # the tests-portable-serial job, so changing it in either place without the
-    # other fails loudly instead of leaving this guard measuring headroom
-    # against a cap that no longer exists.
-    [ "$JOB_TIMEOUT_MINUTES" -eq "$PORTABLE_SERIAL_JOB_TIMEOUT_MINUTES" ] ||
-      die "--job-timeout-minutes $JOB_TIMEOUT_MINUTES disagrees with this runner's recorded portable serial job cap of $PORTABLE_SERIAL_JOB_TIMEOUT_MINUTES minutes (see PORTABLE_SERIAL_JOB_TIMEOUT_MINUTES)"
-  fi
   [ "${#SCRIPTS[@]}" -gt 0 ] || die "--check-shard-balance requires at least one timing JSON"
   for s in "${SCRIPTS[@]}"; do
     [ -f "$s" ] || die "shard balance input not found: $s"

--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -24,6 +24,9 @@
 #   fm-test-run.sh --list-lanes
 #   fm-test-run.sh --check-coverage
 #
+#   fm-test-run.sh --check-shard-balance [--job-timeout-minutes <n>] \
+#                    <serial-lane.json> [more serial-lane.json...]
+#
 # Aggregation (no suite execution):
 #   fm-test-run.sh --aggregate-json <out.json> <lane.json> [more lane.json...]
 #
@@ -150,6 +153,7 @@ LIST_CONCURRENT_SAFE_FAMILIES=0
 LIST_LANES=0
 CHECK_COVERAGE=0
 AGGREGATE_OUT=
+JOB_TIMEOUT_MINUTES=
 FAMILY=
 LANE=
 BASE_REF=origin/main
@@ -175,7 +179,7 @@ CHANGED_DEFAULT_TIMEOUT_SECS=900
 
 # How many separate-runner shards the portable serial remainder splits into.
 # One owner: CI lane names carry this count and are refused when they disagree.
-PORTABLE_SERIAL_SHARDS=5
+PORTABLE_SERIAL_SHARDS=6
 
 # Balance hint for a portable-serial script with no measured duration, close to
 # the measured per-script mean so a newly added test neither starves nor
@@ -189,6 +193,28 @@ PORTABLE_SERIAL_DEFAULT_WEIGHT_MS=27000
 # leaves room for newly added tests while making a stale hint table fail loudly
 # instead of silently. docs/fm-test-portable-shards.md owns the refresh.
 PORTABLE_SERIAL_MAX_UNHINTED_PERCENT=15
+
+# The two ways a balanced-looking partition still reaches its CI job cap, each
+# with its own remedy, checked by --check-shard-balance against the measured
+# durations the lanes already upload.
+#
+# Drift: a shard runs further over its hint weight than this. The hints are what
+# the packer balances on, so once they read low the packer keeps reporting a
+# perfect split while one runner carries the excess. The remedy is a hint
+# refresh, and the guard names the scripts that drifted most.
+PORTABLE_SERIAL_MAX_HINT_DRIFT_PERCENT=15
+
+# Headroom: the worst shard's measured duration against this share of the job
+# cap. Accurate hints cannot fix a lane that has simply outgrown its shard
+# count, so this is the property actually being protected and the remedy is
+# another shard. It degrades gracefully as the suite grows.
+PORTABLE_SERIAL_MAX_SHARD_BUDGET_PERCENT=75
+
+# The tests-portable-serial job cap the headroom share is taken against, in
+# minutes. .github/workflows/ci.yml owns that job's timeout-minutes and passes
+# it back through --job-timeout-minutes, which is refused when the two disagree
+# rather than left to drift silently.
+PORTABLE_SERIAL_JOB_TIMEOUT_MINUTES=20
 
 usage() {
   awk '
@@ -585,148 +611,158 @@ list_portable_serial() {
 # balance rather than coverage. That doc owns the refresh procedure.
 portable_serial_weight_hints() {
   cat <<'EOF'
-tests/fm-afk-inject-e2e.test.sh 35792
-tests/fm-afk-pi-herdr-return-e2e.test.sh 100
-tests/fm-afk-return.test.sh 1837
-tests/fm-ask-user-authority.test.sh 128
-tests/fm-backend-cmux-smoke.test.sh 33
-tests/fm-backend-cmux.test.sh 3657
-tests/fm-backend-orca.test.sh 19253
-tests/fm-backend-tmux-smoke.test.sh 393
+tests/fm-afk-inject-e2e.test.sh 34966
+tests/fm-afk-pi-herdr-return-e2e.test.sh 76
+tests/fm-afk-return.test.sh 1931
+tests/fm-ask-user-authority.test.sh 289
+tests/fm-backend-cmux-smoke.test.sh 93
+tests/fm-backend-cmux.test.sh 3617
+tests/fm-backend-orca.test.sh 19996
+tests/fm-backend-tmux-smoke.test.sh 297
 tests/fm-backend-zellij-smoke.test.sh 23
-tests/fm-backend-zellij.test.sh 9418
-tests/fm-backend.test.sh 20061
-tests/fm-backlog-atomicity.test.sh 122256
-tests/fm-backlog-handoff.test.sh 52291
-tests/fm-bearings-board-render.test.sh 1528
-tests/fm-bearings-board.test.sh 4195
-tests/fm-bearings-snapshot.test.sh 79954
-tests/fm-bootstrap-network-parallel.test.sh 8214
-tests/fm-bootstrap.test.sh 25208
-tests/fm-branch-supervision.test.sh 5729
-tests/fm-busy-adapter-wiring.test.sh 17873
-tests/fm-busy-state.test.sh 2926
-tests/fm-calm-pi-extension.test.sh 256
-tests/fm-check-unregister.test.sh 481
-tests/fm-classify-corr-token.test.sh 38742
-tests/fm-classify-decision-key.test.sh 1167
-tests/fm-claude-stop-autoarm-live-e2e.test.sh 21
-tests/fm-claude-stop-autoarm.test.sh 60709
-tests/fm-cmux-claude-composer-live-e2e.test.sh 23
-tests/fm-codex-continuity-live-e2e.test.sh 21
-tests/fm-composer-matrix-live-e2e.test.sh 23
-tests/fm-control-relaunch.test.sh 48210
-tests/fm-control.test.sh 37798
-tests/fm-cursor-harness.test.sh 30103
-tests/fm-cursor-primary-live-e2e.test.sh 21
-tests/fm-cursor-primary.test.sh 54947
-tests/fm-daemon.test.sh 26870
-tests/fm-documentation-audiences.test.sh 732
-tests/fm-extension-binding.test.sh 7398
-tests/fm-fleet-snapshot-view.test.sh 8547
-tests/fm-fleet-sync.test.sh 37749
-tests/fm-gate-refuse.test.sh 4977
-tests/fm-gitignore-config.test.sh 62
-tests/fm-gotmp.test.sh 1310
-tests/fm-grok-continuity-live-e2e.test.sh 20
-tests/fm-grok-stop-live-e2e.test.sh 21
-tests/fm-guard-stale-banner.test.sh 11218
-tests/fm-harness-adapter-instructions-live-e2e.test.sh 20
-tests/fm-harness-adapter-references.test.sh 55
-tests/fm-harness-liveness-drift-live-e2e.test.sh 21
-tests/fm-herdr-session-cleanup.test.sh 6704
-tests/fm-herdr-submit-confirm-live-e2e.test.sh 23
-tests/fm-herdr-version-floor-live-e2e.test.sh 23
-tests/fm-home-summary-refresh.test.sh 34793
-tests/fm-inactive-reconcile.test.sh 41826
-tests/fm-kimi-harness.test.sh 18015
-tests/fm-lint-workflows.test.sh 855
-tests/fm-live-gate.test.sh 6000
-tests/fm-muse-harness.test.sh 55572
-tests/fm-muse-signals-live-e2e.test.sh 23
-tests/fm-no-mistakes-required.test.sh 370
-tests/fm-on.test.sh 11692
-tests/fm-opencode-primary-live-e2e.test.sh 21
-tests/fm-operational-input.test.sh 231
-tests/fm-peek-remote.test.sh 1018
-tests/fm-pending-reply.test.sh 24679
-tests/fm-pi-branch-extension.test.sh 22239
-tests/fm-pi-branch-live-e2e.test.sh 56
-tests/fm-pi-branch-responsiveness-live-e2e.test.sh 21
-tests/fm-pi-primary-live-e2e.test.sh 20
-tests/fm-pi-watch-extension.test.sh 42970
+tests/fm-backend-zellij.test.sh 8707
+tests/fm-backend.test.sh 36848
+tests/fm-backlog-atomicity.test.sh 155409
+tests/fm-backlog-handoff.test.sh 53404
+tests/fm-bearings-board-lavish-live-e2e.test.sh 124
+tests/fm-bearings-board-render.test.sh 4724
+tests/fm-bearings-board.test.sh 36757
+tests/fm-bearings-snapshot.test.sh 111794
+tests/fm-bootstrap-network-parallel.test.sh 18238
+tests/fm-bootstrap.test.sh 42689
+tests/fm-branch-supervision.test.sh 9826
+tests/fm-busy-adapter-wiring.test.sh 46180
+tests/fm-busy-state.test.sh 4602
+tests/fm-calm-pi-extension.test.sh 51670
+tests/fm-check-unregister.test.sh 446
+tests/fm-classify-corr-token.test.sh 21961
+tests/fm-classify-decision-key.test.sh 3355
+tests/fm-claude-stop-autoarm-live-e2e.test.sh 94
+tests/fm-claude-stop-autoarm.test.sh 60698
+tests/fm-claude-trust.test.sh 5800
+tests/fm-cmux-claude-composer-live-e2e.test.sh 142
+tests/fm-codex-continuity-live-e2e.test.sh 76
+tests/fm-composer-matrix-live-e2e.test.sh 45
+tests/fm-control-relaunch.test.sh 53470
+tests/fm-control.test.sh 52346
+tests/fm-cursor-harness.test.sh 30230
+tests/fm-cursor-primary-live-e2e.test.sh 41
+tests/fm-cursor-primary.test.sh 56554
+tests/fm-daemon.test.sh 56305
+tests/fm-documentation-audiences.test.sh 1738
+tests/fm-extension-binding.test.sh 9446
+tests/fm-fleet-snapshot-view.test.sh 8487
+tests/fm-fleet-sync.test.sh 37343
+tests/fm-gate-refuse.test.sh 5673
+tests/fm-gemini-harness.test.sh 580
+tests/fm-gitignore-config.test.sh 78
+tests/fm-gotmp.test.sh 1492
+tests/fm-grok-continuity-live-e2e.test.sh 113
+tests/fm-grok-stop-live-e2e.test.sh 123
+tests/fm-guard-stale-banner.test.sh 11501
+tests/fm-harness-adapter-instructions-live-e2e.test.sh 44
+tests/fm-harness-adapter-references.test.sh 84
+tests/fm-harness-liveness-drift-live-e2e.test.sh 866
+tests/fm-herdr-session-cleanup.test.sh 6576
+tests/fm-herdr-submit-confirm-live-e2e.test.sh 96
+tests/fm-herdr-version-floor-live-e2e.test.sh 83
+tests/fm-home-summary-refresh.test.sh 36440
+tests/fm-inactive-reconcile.test.sh 71075
+tests/fm-kimi-harness.test.sh 34610
+tests/fm-lint-workflows.test.sh 908
+tests/fm-live-gate.test.sh 4320
+tests/fm-muse-harness.test.sh 40688
+tests/fm-muse-signals-live-e2e.test.sh 43
+tests/fm-nm-test-contract.test.sh 1271
+tests/fm-no-mistakes-required.test.sh 484
+tests/fm-omp-harness.test.sh 59370
+tests/fm-omp-primary-live-e2e.test.sh 69
+tests/fm-on.test.sh 11528
+tests/fm-opencode-primary-live-e2e.test.sh 95
+tests/fm-operational-input.test.sh 229
+tests/fm-peek-remote.test.sh 1225
+tests/fm-pending-reply.test.sh 27300
+tests/fm-pi-branch-extension.test.sh 162503
+tests/fm-pi-branch-live-e2e.test.sh 43
+tests/fm-pi-branch-responsiveness-live-e2e.test.sh 13640
+tests/fm-pi-primary-live-e2e.test.sh 94
+tests/fm-pi-watch-extension.test.sh 51680
 tests/fm-pi-windows-shell-invocation.test.sh 5121
-tests/fm-pr-check-security.test.sh 160475
-tests/fm-procevent-quota.test.sh 1949
-tests/fm-procevent-when.test.sh 17392
-tests/fm-procevent.test.sh 69715
-tests/fm-project-origin.test.sh 137
-tests/fm-public-followup.test.sh 196745
-tests/fm-quota-array-dispatch-live-e2e.test.sh 21
-tests/fm-quota-choose.test.sh 1461
-tests/fm-remote-backlog-handoff.test.sh 41432
-tests/fm-remote-doctor.test.sh 5198
-tests/fm-remote-entrypoint.test.sh 132
-tests/fm-remote-job-orphan-reap.test.sh 2972
-tests/fm-remote-job.test.sh 59603
-tests/fm-remote-reply.test.sh 101690
-tests/fm-remote-secondmate-lifecycle-e2e.test.sh 209631
-tests/fm-remote-secondmate-parent-binding.test.sh 29562
-tests/fm-remote-secondmate-trace-context.test.sh 67096
-tests/fm-remote-transport-lanes.test.sh 63140
-tests/fm-secondmate-harness.test.sh 151589
-tests/fm-secondmate-lifecycle-e2e.test.sh 8793
-tests/fm-secondmate-liveness.test.sh 18146
-tests/fm-secondmate-reconcile.test.sh 62726
-tests/fm-secondmate-safety.test.sh 57689
-tests/fm-secondmate-sync.test.sh 17183
-tests/fm-send-inbox-doorbell-live-e2e.test.sh 22
-tests/fm-send-inbox.test.sh 38956
-tests/fm-send-remote-delivery.test.sh 27686
-tests/fm-send-resolve-key.test.sh 19619
-tests/fm-send-secondmate-marker-herdr-e2e.test.sh 51
-tests/fm-send-secondmate-marker.test.sh 6252
-tests/fm-session-lock-ancestry.test.sh 1414
-tests/fm-session-start.test.sh 156952
-tests/fm-sessionstart-hook-live-e2e.test.sh 20
-tests/fm-sessionstart-instruction-refresh-live-e2e.test.sh 22
-tests/fm-sessionstart-nudge.test.sh 66194
-tests/fm-shared-captain-inheritance.test.sh 6108
-tests/fm-spawn-dispatch-profile.test.sh 63996
-tests/fm-spawn-pool-base-freshen.test.sh 34920
-tests/fm-spawn-worktree-settle.test.sh 5687
-tests/fm-startup-memory-budget.test.sh 6964
-tests/fm-startup-network.test.sh 54700
-tests/fm-stow-cascade.test.sh 3101
-tests/fm-subagent-pretool-check.test.sh 1030
-tests/fm-supervision-events.test.sh 719
-tests/fm-tangle-guard.test.sh 9662
-tests/fm-task-delivery.test.sh 5952
-tests/fm-task-inbox.test.sh 25369
-tests/fm-teardown-endpoint-safety.test.sh 4620
-tests/fm-teardown.test.sh 97603
-tests/fm-test-fixture-cleanup.test.sh 915
-tests/fm-test-fixtures.test.sh 151
-tests/fm-test-isolation-proof.test.sh 2567
-tests/fm-tmux-agent-liveness.test.sh 1516
-tests/fm-tool-update-check.test.sh 14176
-tests/fm-trace-context-lib.test.sh 209
-tests/fm-trace-context-spawn.test.sh 44702
-tests/fm-turnend-guard.test.sh 42565
-tests/fm-update.test.sh 5212
-tests/fm-vendor-auth-probe.test.sh 43316
-tests/fm-voice-relay.test.sh 28699
-tests/fm-wake-daemon-lifecycle-e2e.test.sh 7381
-tests/fm-wake-drain-open-decisions-cursor.test.sh 20629
-tests/fm-wake-drain-open-decisions.test.sh 6240
-tests/fm-wake-drain-outcome-backstop.test.sh 15182
-tests/fm-wake-drain-unread-status.test.sh 35078
-tests/fm-wake-queue.test.sh 56674
-tests/fm-watch-arm.test.sh 58528
-tests/fm-watch-checkpoint.test.sh 5779
-tests/fm-watch-recovery-loop.test.sh 58731
-tests/fm-watch-triage.test.sh 262626
-tests/fm-watcher-lock.test.sh 88554
+tests/fm-pr-check-security.test.sh 159447
+tests/fm-procevent-quota.test.sh 1861
+tests/fm-procevent-when.test.sh 18098
+tests/fm-procevent.test.sh 83817
+tests/fm-project-origin.test.sh 161
+tests/fm-public-followup.test.sh 146885
+tests/fm-quota-array-dispatch-live-e2e.test.sh 41
+tests/fm-quota-choose.test.sh 1570
+tests/fm-remote-backlog-handoff.test.sh 42096
+tests/fm-remote-doctor.test.sh 5180
+tests/fm-remote-entrypoint.test.sh 114
+tests/fm-remote-job-orphan-reap.test.sh 4420
+tests/fm-remote-job.test.sh 58887
+tests/fm-remote-reply.test.sh 51789
+tests/fm-remote-secondmate-lifecycle-e2e.test.sh 227636
+tests/fm-remote-secondmate-parent-binding.test.sh 31279
+tests/fm-remote-secondmate-trace-context.test.sh 57841
+tests/fm-remote-transport-lanes.test.sh 63636
+tests/fm-rovo-harness.test.sh 13736
+tests/fm-rovo-signals-live-e2e.test.sh 46
+tests/fm-secondmate-harness.test.sh 151942
+tests/fm-secondmate-lifecycle-e2e.test.sh 19571
+tests/fm-secondmate-liveness.test.sh 18846
+tests/fm-secondmate-reconcile.test.sh 98219
+tests/fm-secondmate-restart.test.sh 45097
+tests/fm-secondmate-safety.test.sh 61166
+tests/fm-secondmate-sync.test.sh 53637
+tests/fm-send-inbox-doorbell-live-e2e.test.sh 128
+tests/fm-send-inbox.test.sh 40542
+tests/fm-send-remote-delivery.test.sh 28116
+tests/fm-send-resolve-key.test.sh 29965
+tests/fm-send-secondmate-marker-herdr-e2e.test.sh 50
+tests/fm-send-secondmate-marker.test.sh 14805
+tests/fm-session-lock-ancestry.test.sh 1417
+tests/fm-session-start.test.sh 157199
+tests/fm-sessionstart-hook-live-e2e.test.sh 107
+tests/fm-sessionstart-instruction-refresh-live-e2e.test.sh 43
+tests/fm-sessionstart-nudge.test.sh 64440
+tests/fm-shared-captain-inheritance.test.sh 5333
+tests/fm-spawn-dispatch-profile.test.sh 104739
+tests/fm-spawn-pool-base-freshen.test.sh 57066
+tests/fm-spawn-worktree-settle.test.sh 8452
+tests/fm-startup-memory-budget.test.sh 17689
+tests/fm-startup-network.test.sh 61148
+tests/fm-stat-shadowing.test.sh 136
+tests/fm-stow-cascade.test.sh 3163
+tests/fm-subagent-pretool-check.test.sh 1069
+tests/fm-supervision-events.test.sh 645
+tests/fm-tangle-guard.test.sh 7347
+tests/fm-task-delivery.test.sh 15330
+tests/fm-task-inbox.test.sh 29368
+tests/fm-teardown-endpoint-safety.test.sh 31783
+tests/fm-teardown.test.sh 145526
+tests/fm-test-fixture-cleanup.test.sh 924
+tests/fm-test-fixtures.test.sh 427
+tests/fm-test-isolation-proof.test.sh 2813
+tests/fm-tmux-agent-liveness.test.sh 3583
+tests/fm-tool-update-check.test.sh 25280
+tests/fm-trace-context-lib.test.sh 249
+tests/fm-trace-context-spawn.test.sh 47274
+tests/fm-turnend-guard.test.sh 22530
+tests/fm-update.test.sh 21551
+tests/fm-vendor-auth-probe.test.sh 43431
+tests/fm-voice-relay.test.sh 29429
+tests/fm-wake-daemon-lifecycle-e2e.test.sh 7350
+tests/fm-wake-drain-open-decisions-cursor.test.sh 24288
+tests/fm-wake-drain-open-decisions.test.sh 7954
+tests/fm-wake-drain-outcome-backstop.test.sh 45697
+tests/fm-wake-drain-unread-status.test.sh 18904
+tests/fm-wake-queue.test.sh 79267
+tests/fm-watch-arm.test.sh 65359
+tests/fm-watch-checkpoint.test.sh 9457
+tests/fm-watch-recovery-loop.test.sh 58810
+tests/fm-watch-triage.test.sh 515417
+tests/fm-watcher-lock.test.sh 110998
 EOF
 }
 
@@ -1008,6 +1044,167 @@ run_coverage_guard() {
     "$(wc -l <"$tmp/herdr" | tr -d ' ')"
   rm -rf "$tmp"
   return 0
+}
+
+# Balance guard over the durations the serial lanes already upload: turns "a
+# shard got cancelled" into a named, dated instruction to re-measure, before the
+# cap is reached rather than after. Each artifact carries the lane it ran as and
+# every script it ran, so a shard is checked against its own recorded work
+# rather than against a re-derived assignment. A cancelled shard uploads no
+# artifact at all, so missing input is reported and skipped rather than guessed.
+check_portable_serial_balance() {
+  local bound_minutes=$1 tmp rc
+  shift
+  [ "$#" -gt 0 ] || die "--check-shard-balance requires at least one timing JSON"
+  command -v python3 >/dev/null 2>&1 || die "--check-shard-balance requires python3"
+  tmp=$(mktemp -d "${TMPDIR:-/tmp}/fm-shard-balance.XXXXXX") || die "mktemp failed"
+  portable_serial_weight_hints >"$tmp/hints"
+  python3 - "$tmp/hints" "$bound_minutes" "$PORTABLE_SERIAL_DEFAULT_WEIGHT_MS" \
+    "$PORTABLE_SERIAL_MAX_HINT_DRIFT_PERCENT" \
+    "$PORTABLE_SERIAL_MAX_SHARD_BUDGET_PERCENT" \
+    "$PORTABLE_SERIAL_SHARDS" "$@" <<'PY'
+import json, sys
+from pathlib import Path
+
+hints_path, bound_s, default_s, drift_s, budget_s, shards_s = sys.argv[1:7]
+inputs = [Path(p) for p in sys.argv[7:]]
+bound_ms = int(bound_s) * 60000
+default_ms = int(default_s)
+max_drift = int(drift_s)
+max_budget = int(budget_s)
+expected_shards = int(shards_s)
+
+# Below this a percentage says more about rounding than about balance.
+MIN_HINTED_MS = 60000
+
+hints = {}
+for line in Path(hints_path).read_text().splitlines():
+    line = line.strip()
+    if not line:
+        continue
+    path, ms = line.rsplit(" ", 1)
+    hints[path] = int(ms)
+
+
+def lane_of(data):
+    for field in str(data.get("selection", "")).split(";"):
+        if field.startswith("lane="):
+            return field[len("lane="):]
+    return ""
+
+
+def minutes(ms):
+    return "%.2f min" % (ms / 60000.0)
+
+
+shards = []
+for path in inputs:
+    if not path.exists():
+        continue
+    data = json.loads(path.read_text())
+    lane = lane_of(data)
+    if not lane.startswith("portable-serial-"):
+        continue
+    scripts = [s for s in data.get("scripts", []) if s.get("path")]
+    if not scripts:
+        continue
+    rows = []
+    for s in scripts:
+        real = int(s["duration_ms"])
+        hint = hints.get(s["path"], default_ms)
+        rows.append((real - hint, s["path"], real, hint, s["path"] not in hints))
+    shards.append(
+        {
+            "lane": lane,
+            "measured": sum(r[2] for r in rows),
+            "hinted": sum(r[3] for r in rows),
+            "rows": rows,
+        }
+    )
+
+if not shards:
+    print(
+        "FM_TEST_SHARD_BALANCE skipped no portable serial timing artifacts "
+        "(a cancelled shard uploads none)"
+    )
+    sys.exit(0)
+
+shards.sort(key=lambda s: s["lane"])
+if len(shards) < expected_shards:
+    print(
+        "FM_TEST_SHARD_BALANCE partial %d of %d portable serial shards reported "
+        "a timing artifact; a cancelled shard uploads none, so the rest are "
+        "unchecked" % (len(shards), expected_shards)
+    )
+failures = []
+for s in shards:
+    share = s["measured"] * 100.0 / bound_ms
+    s["share"] = share
+    s["drift"] = (
+        (s["measured"] - s["hinted"]) * 100.0 / s["hinted"] if s["hinted"] else 0.0
+    )
+    if share > max_budget:
+        failures.append(
+            "shard balance guard: %s measured %s, %.0f%% of the %s min job cap "
+            "(max %s%%)\n"
+            "  accurate hints cannot fix this: the lane has outgrown its shard "
+            "count, so raise PORTABLE_SERIAL_SHARDS and the ci.yml matrix "
+            "(docs/fm-test-portable-shards.md)"
+            % (s["lane"], minutes(s["measured"]), share, bound_s, max_budget)
+        )
+    if s["hinted"] >= MIN_HINTED_MS and s["drift"] > max_drift:
+        worst = sorted(s["rows"], reverse=True)[:5]
+        lines = [
+            "shard balance guard: %s measured %s against %s of hint weight "
+            "(+%.0f%%, max +%s%%)\n"
+            "  the hint table is stale; re-measure these scripts "
+            "(docs/fm-test-portable-shards.md):"
+            % (
+                s["lane"],
+                minutes(s["measured"]),
+                minutes(s["hinted"]),
+                s["drift"],
+                max_drift,
+            )
+        ]
+        for delta, path, real, hint, unhinted in worst:
+            if delta <= 0:
+                continue
+            lines.append(
+                "    %s measured %.1fs hint %.1fs (%+.1fs)%s"
+                % (
+                    path,
+                    real / 1000.0,
+                    hint / 1000.0,
+                    delta / 1000.0,
+                    " [no hint, default weight]" if unhinted else "",
+                )
+            )
+        failures.append("\n".join(lines))
+
+if failures:
+    for f in failures:
+        print(f, file=sys.stderr)
+    sys.exit(1)
+
+worst_share = max(shards, key=lambda s: s["share"])
+worst_drift = max(shards, key=lambda s: s["drift"])
+print(
+    "FM_TEST_SHARD_BALANCE ok shards=%d worst_share=%s@%.0f%% "
+    "worst_drift=%s@%+.0f%% bound=%smin"
+    % (
+        len(shards),
+        worst_share["lane"],
+        worst_share["share"],
+        worst_drift["lane"],
+        worst_drift["drift"],
+        bound_s,
+    )
+)
+PY
+  rc=$?
+  rm -rf "$tmp"
+  return $rc
 }
 
 aggregate_timing_json() {
@@ -1773,6 +1970,19 @@ while [ "$#" -gt 0 ]; do
       CHECK_COVERAGE=1
       shift
       ;;
+    --check-shard-balance)
+      MODE='shard-balance'
+      shift
+      ;;
+    --job-timeout-minutes)
+      [ "$#" -gt 1 ] || die "--job-timeout-minutes requires a value"
+      JOB_TIMEOUT_MINUTES=$2
+      shift 2
+      ;;
+    --job-timeout-minutes=*)
+      JOB_TIMEOUT_MINUTES=${1#--job-timeout-minutes=}
+      shift
+      ;;
     --aggregate-json)
       [ "$#" -gt 1 ] || die "--aggregate-json requires an output path"
       AGGREGATE_OUT=$2
@@ -1814,7 +2024,7 @@ while [ "$#" -gt 0 ]; do
       die "unknown option: $1"
       ;;
     *)
-      if [ "${MODE:-}" = "aggregate" ]; then
+      if [ "${MODE:-}" = "aggregate" ] || [ "${MODE:-}" = "shard-balance" ]; then
         SCRIPTS+=("$1")
       elif [ -z "$MODE" ] || [ "$MODE" = scripts ]; then
         MODE=scripts
@@ -1844,6 +2054,26 @@ fi
 
 if [ "$CHECK_COVERAGE" -eq 1 ]; then
   run_coverage_guard
+  exit $?
+fi
+
+if [ "${MODE:-}" = "shard-balance" ]; then
+  if [ -n "$JOB_TIMEOUT_MINUTES" ]; then
+    case "$JOB_TIMEOUT_MINUTES" in
+      ''|*[!0-9]*) die "--job-timeout-minutes must be a positive integer" ;;
+    esac
+    # One owner, cross-checked: ci.yml passes back the cap it actually sets on
+    # the tests-portable-serial job, so changing it in either place without the
+    # other fails loudly instead of leaving this guard measuring headroom
+    # against a cap that no longer exists.
+    [ "$JOB_TIMEOUT_MINUTES" -eq "$PORTABLE_SERIAL_JOB_TIMEOUT_MINUTES" ] ||
+      die "--job-timeout-minutes $JOB_TIMEOUT_MINUTES disagrees with this runner's recorded portable serial job cap of $PORTABLE_SERIAL_JOB_TIMEOUT_MINUTES minutes (see PORTABLE_SERIAL_JOB_TIMEOUT_MINUTES)"
+  fi
+  [ "${#SCRIPTS[@]}" -gt 0 ] || die "--check-shard-balance requires at least one timing JSON"
+  for s in "${SCRIPTS[@]}"; do
+    [ -f "$s" ] || die "shard balance input not found: $s"
+  done
+  check_portable_serial_balance "$PORTABLE_SERIAL_JOB_TIMEOUT_MINUTES" "${SCRIPTS[@]}"
   exit $?
 fi
 

--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -1047,7 +1047,7 @@ run_coverage_guard() {
 # cap is reached rather than after. Each artifact carries the lane it ran as and
 # every script it ran, so a shard is checked against its own recorded work
 # rather than against a re-derived assignment. A cancelled shard uploads no
-# artifact at all, so missing input is reported and skipped rather than guessed.
+# artifact at all.
 check_portable_serial_balance() {
   local bound_minutes=$1 tmp rc
   shift

--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -204,11 +204,18 @@ PORTABLE_SERIAL_MAX_UNHINTED_PERCENT=15
 # refresh, and the guard names the scripts that drifted most.
 PORTABLE_SERIAL_MAX_HINT_DRIFT_PERCENT=15
 
-# Headroom: the worst shard's measured duration against this share of the job
-# cap. Accurate hints cannot fix a lane that has simply outgrown its shard
-# count, so this is the property actually being protected and the remedy is
-# another shard. It degrades gracefully as the suite grows.
-PORTABLE_SERIAL_MAX_SHARD_BUDGET_PERCENT=75
+# Headroom: the worst shard's measured duration against a share of the job cap.
+# This is the property actually being protected, and it degrades gracefully as
+# the suite grows. Two shares, because the guard has to speak long before the
+# badge goes red and still not redden a suite that is merely unlucky.
+#
+# Warn: loud, non-fatal, and low enough that a lane growing at a few minutes a
+# day is told about it with days of margin left to add a shard in.
+PORTABLE_SERIAL_WARN_SHARD_BUDGET_PERCENT=75
+# Fail: far enough above the warning that ordinary hosted-runner spread cannot
+# turn an otherwise green suite red. Per-script noise on this lane reaches 3x,
+# and a guard that cries wolf gets switched off.
+PORTABLE_SERIAL_MAX_SHARD_BUDGET_PERCENT=90
 
 # The tests-portable-serial job cap the headroom share is taken against, in
 # minutes. .github/workflows/ci.yml owns that job's timeout-minutes and passes
@@ -1057,20 +1064,23 @@ check_portable_serial_balance() {
   shift
   [ "$#" -gt 0 ] || die "--check-shard-balance requires at least one timing JSON"
   command -v python3 >/dev/null 2>&1 || die "--check-shard-balance requires python3"
+  rc=0
   tmp=$(mktemp -d "${TMPDIR:-/tmp}/fm-shard-balance.XXXXXX") || die "mktemp failed"
   portable_serial_weight_hints >"$tmp/hints"
   python3 - "$tmp/hints" "$bound_minutes" "$PORTABLE_SERIAL_DEFAULT_WEIGHT_MS" \
     "$PORTABLE_SERIAL_MAX_HINT_DRIFT_PERCENT" \
+    "$PORTABLE_SERIAL_WARN_SHARD_BUDGET_PERCENT" \
     "$PORTABLE_SERIAL_MAX_SHARD_BUDGET_PERCENT" \
-    "$PORTABLE_SERIAL_SHARDS" "$@" <<'PY'
+    "$PORTABLE_SERIAL_SHARDS" "$@" <<'PY' || rc=$?
 import json, sys
 from pathlib import Path
 
-hints_path, bound_s, default_s, drift_s, budget_s, shards_s = sys.argv[1:7]
-inputs = [Path(p) for p in sys.argv[7:]]
+hints_path, bound_s, default_s, drift_s, warn_budget_s, budget_s, shards_s = sys.argv[1:8]
+inputs = [Path(p) for p in sys.argv[8:]]
 bound_ms = int(bound_s) * 60000
 default_ms = int(default_s)
 max_drift = int(drift_s)
+warn_budget = int(warn_budget_s)
 max_budget = int(budget_s)
 expected_shards = int(shards_s)
 
@@ -1130,32 +1140,104 @@ if not shards:
     sys.exit(0)
 
 shards.sort(key=lambda s: s["lane"])
-if len(shards) < expected_shards:
+complete = len(shards) >= expected_shards
+if not complete:
     print(
         "FM_TEST_SHARD_BALANCE partial %d of %d portable serial shards reported "
         "a timing artifact; a cancelled shard uploads none, so the rest are "
         "unchecked" % (len(shards), expected_shards)
     )
-failures = []
+
 for s in shards:
-    share = s["measured"] * 100.0 / bound_ms
-    s["share"] = share
+    s["share"] = s["measured"] * 100.0 / bound_ms
     s["drift"] = (
         (s["measured"] - s["hinted"]) * 100.0 / s["hinted"] if s["hinted"] else 0.0
     )
-    if share > max_budget:
-        failures.append(
-            "shard balance guard: %s measured %s, %.0f%% of the %s min job cap "
-            "(max %s%%)\n"
-            "  accurate hints cannot fix this: the lane has outgrown its shard "
-            "count, so raise PORTABLE_SERIAL_SHARDS and the ci.yml matrix "
-            "(docs/fm-test-portable-shards.md)"
-            % (s["lane"], minutes(s["measured"]), share, bound_s, max_budget)
+    s["drifted"] = s["hinted"] >= MIN_HINTED_MS and s["drift"] > max_drift
+
+# What an even repack of the reported work would put on each shard. Only that
+# answers whether the lane has outgrown its shard count, so the headroom report
+# never asserts that remedy without it.
+even_ms = sum(s["measured"] for s in shards) / expected_shards if complete else None
+
+
+def drifted_rows(s):
+    lines = []
+    for delta, path, real, hint, unhinted in sorted(s["rows"], reverse=True)[:5]:
+        if delta <= 0:
+            continue
+        lines.append(
+            "    %s measured %.1fs hint %.1fs (%+.1fs)%s"
+            % (
+                path,
+                real / 1000.0,
+                hint / 1000.0,
+                delta / 1000.0,
+                " [no hint, default weight]" if unhinted else "",
+            )
         )
-    if s["hinted"] >= MIN_HINTED_MS and s["drift"] > max_drift:
-        worst = sorted(s["rows"], reverse=True)[:5]
+    return lines
+
+
+# A shard can be heavy with every hint accurate, so the header is only printed
+# when there is something under it to read.
+def labelled_rows(s, header):
+    rows = drifted_rows(s)
+    return [header] + rows if rows else []
+
+
+# States what was measured against the cap, then the cause the guard could
+# actually establish: a shard over its budget is not by itself evidence that the
+# lane needs another runner.
+def headroom_report(s, limit, label):
+    lines = [
+        "shard balance guard %s: %s measured %s, %.0f%% of the %s min job cap "
+        "(over %d%%)"
+        % (label, s["lane"], minutes(s["measured"]), s["share"], bound_s, limit)
+    ]
+    if s["drifted"]:
+        lines.append(
+            "  it also ran %.0f%% over its own hint weight, so refresh the hints "
+            "and repack before adding a shard; the drift report below names the "
+            "scripts to re-measure" % s["drift"]
+        )
+    elif even_ms is None:
+        lines.append(
+            "  only %d of %d shards reported, so whether an even repack would fit "
+            "could not be determined (docs/fm-test-portable-shards.md)"
+            % (len(shards), expected_shards)
+        )
+        lines += labelled_rows(s, "  the scripts furthest over their hints:")
+    elif even_ms * 100.0 / bound_ms > limit:
+        lines.append(
+            "  an even repack across %d shards still gives %s each, so the lane has "
+            "outgrown its shard count: raise PORTABLE_SERIAL_SHARDS and the ci.yml "
+            "matrix (docs/fm-test-portable-shards.md)"
+            % (expected_shards, minutes(even_ms))
+        )
+    else:
+        lines.append(
+            "  an even repack across %d shards gives %s each, which fits, so this "
+            "shard is packed heavy rather than the lane having outgrown its shard "
+            "count (docs/fm-test-portable-shards.md)"
+            % (expected_shards, minutes(even_ms))
+        )
+        lines += labelled_rows(s, "  re-measure these scripts:")
+    return "\n".join(lines)
+
+
+warnings = []
+failures = []
+for s in shards:
+    # Warn well below the cap so the guard speaks before the badge goes red, and
+    # fail only where hosted-runner spread can no longer explain the shard.
+    if s["share"] > max_budget:
+        failures.append(headroom_report(s, max_budget, "failed"))
+    elif s["share"] > warn_budget:
+        warnings.append(headroom_report(s, warn_budget, "warning"))
+    if s["drifted"]:
         lines = [
-            "shard balance guard: %s measured %s against %s of hint weight "
+            "shard balance guard failed: %s measured %s against %s of hint weight "
             "(+%.0f%%, max +%s%%)\n"
             "  the hint table is stale; re-measure these scripts "
             "(docs/fm-test-portable-shards.md):"
@@ -1167,21 +1249,11 @@ for s in shards:
                 max_drift,
             )
         ]
-        for delta, path, real, hint, unhinted in worst:
-            if delta <= 0:
-                continue
-            lines.append(
-                "    %s measured %.1fs hint %.1fs (%+.1fs)%s"
-                % (
-                    path,
-                    real / 1000.0,
-                    hint / 1000.0,
-                    delta / 1000.0,
-                    " [no hint, default weight]" if unhinted else "",
-                )
-            )
+        lines += drifted_rows(s)
         failures.append("\n".join(lines))
 
+for w in warnings:
+    print(w, file=sys.stderr)
 if failures:
     for f in failures:
         print(f, file=sys.stderr)
@@ -1190,9 +1262,10 @@ if failures:
 worst_share = max(shards, key=lambda s: s["share"])
 worst_drift = max(shards, key=lambda s: s["drift"])
 print(
-    "FM_TEST_SHARD_BALANCE ok shards=%d worst_share=%s@%.0f%% "
+    "FM_TEST_SHARD_BALANCE %s shards=%d worst_share=%s@%.0f%% "
     "worst_drift=%s@%+.0f%% bound=%smin"
     % (
+        "warn" if warnings else "ok",
         len(shards),
         worst_share["lane"],
         worst_share["share"],
@@ -1202,7 +1275,6 @@ print(
     )
 )
 PY
-  rc=$?
   rm -rf "$tmp"
   return $rc
 }

--- a/docs/fm-test-portable-shards.md
+++ b/docs/fm-test-portable-shards.md
@@ -64,29 +64,32 @@ Each shard is still strictly serial in itself, and separate runners mean no two 
 `.github/workflows/ci.yml` derives the same `n` from `strategy.job-total` rather than a literal, so changing the shard count in either file without the other fails the lane loudly instead of leaving part of the required suite unrun.
 
 Assignment is longest-processing-time bin packing over per-script duration hints embedded in `bin/fm-test-run.sh`.
-The 142 current hints include the slowest measurements retained from the `fm-test-timing-portable-serial-*` artifacts of three green CI runs on 2026-09-01, [33558082172](https://github.com/kunchenguid/firstmate/actions/runs/33558082172), [33523597838](https://github.com/kunchenguid/firstmate/actions/runs/33523597838), and [33463326167](https://github.com/kunchenguid/firstmate/actions/runs/33463326167), plus the 5121 ms native-Windows focused runner measurement for `tests/fm-pi-windows-shell-invocation.test.sh` from 2026-09-06T21:02Z.
-Those per-script maxima total 3836189 ms of conservative balance weight.
-Taking the slowest of several CI runs rather than a single run keeps the balance honest on a slow runner: individual scripts varied by up to 20% between those three runs.
-A script with no hint gets the conservative `PORTABLE_SERIAL_DEFAULT_WEIGHT_MS` default; the current 152-script lane has ten such scripts, bringing its assignment weight to 4106189 ms.
+The 152 current hints are the slowest measurements retained from the `fm-test-timing-portable-serial-*` artifacts of four green CI runs on 2026-09-07 and 2026-09-08, [34180535832](https://github.com/kunchenguid/firstmate/actions/runs/34180535832), [34167501605](https://github.com/kunchenguid/firstmate/actions/runs/34167501605), [34167485767](https://github.com/kunchenguid/firstmate/actions/runs/34167485767), and [34156531229](https://github.com/kunchenguid/firstmate/actions/runs/34156531229), plus the 5121 ms native-Windows focused runner measurement for `tests/fm-pi-windows-shell-invocation.test.sh` from 2026-09-06T21:02Z.
+Those per-script maxima total 4974498 ms of conservative balance weight and cover the whole 152-script lane, so no script currently runs on the `PORTABLE_SERIAL_DEFAULT_WEIGHT_MS` default.
+Taking the slowest of several CI runs rather than a single run keeps the balance honest on a slow runner: individual scripts varied by up to 3x between single runs in the 2026-09-08 measurement.
 Hints only affect balance: the coverage guard keeps the partition complete and disjoint whatever they say, so a stale hint costs a slower shard rather than lost coverage.
-Balance is still worth keeping current, because enough unmeasured scripts let one shard carry more than twice another shard's real work and reach the job cap while another runner sits idle.
-That is not hypothetical: by 2026-09-01 the lane had grown from 116 to 139 scripts and from ~42 to ~63 minutes, 17 scripts were still unmeasured, and several hints were low by 2-5x, so shard 3 of 4 ran 17-20 minutes against its 20-minute cap while shard 1 ran 11.5 minutes and run [33574154856](https://github.com/kunchenguid/firstmate/actions/runs/33574154856) timed out seconds after a passing test.
-`bin/fm-test-run.sh --check-coverage` now reports the unmeasured share as `serial_unhinted=` and refuses past `PORTABLE_SERIAL_MAX_UNHINTED_PERCENT`, so hint drift fails the coverage guard instead of silently pushing one shard into its job cap.
-Refresh the hints whenever the serial lane gains scripts, rather than waiting for that bound to trip.
+Balance is still worth keeping current, because enough drifted hints let one shard carry far more than another shard's real work and reach the job cap while another runner sits idle.
+That is not hypothetical, and it has now happened twice.
+By 2026-09-01 the lane had grown from 116 to 139 scripts and from ~42 to ~63 minutes, 17 scripts were still unmeasured, and several hints were low by 2-5x, so shard 3 of 4 ran 17-20 minutes against its 20-minute cap while shard 1 ran 11.5 minutes and run [33574154856](https://github.com/kunchenguid/firstmate/actions/runs/33574154856) timed out seconds after a passing test.
+The 2026-09-01 remedy refreshed the hints and moved to five shards, and the lane was cancelling again within a day: shard 4 of 5 ran 15.7 minutes against the same cap by 2026-09-02T06:38Z, and by 2026-09-08 the hints predicted 13.69 minutes for every shard while the shards actually ran 13.08 to 19.15 minutes.
+Both occurrences were the same failure, so the guards below check hint accuracy and shard headroom rather than only hint presence.
+Refresh the hints whenever the serial lane gains scripts, rather than waiting for a guard to trip.
 
 | Lane | Script count | Estimated duration |
 |---|---:|---:|
-| `portable-serial-1of5` | 29 | 821231 ms (~13.69 min) |
-| `portable-serial-2of5` | 30 | 821243 ms (~13.69 min) |
-| `portable-serial-3of5` | 31 | 821236 ms (~13.69 min) |
-| `portable-serial-4of5` | 31 | 821247 ms (~13.69 min) |
-| `portable-serial-5of5` | 31 | 821232 ms (~13.69 min) |
-| imbalance | | 16 ms |
+| `portable-serial-1of6` | 23 | 829090 ms (~13.82 min) |
+| `portable-serial-2of6` | 26 | 829094 ms (~13.82 min) |
+| `portable-serial-3of6` | 26 | 829097 ms (~13.82 min) |
+| `portable-serial-4of6` | 26 | 829079 ms (~13.82 min) |
+| `portable-serial-5of6` | 25 | 829059 ms (~13.82 min) |
+| `portable-serial-6of6` | 26 | 829079 ms (~13.82 min) |
+| imbalance | | 38 ms |
 
-The current table is generated from the runner's retained maxima plus its default for the ten unhinted scripts.
-The last complete replay against the three source runs put the then-current partition's worst shard at 12.54 min, 63% of the 20-minute job cap.
+The current table is generated from the runner's retained maxima, which now cover every script in the lane.
+Those weights are deliberately conservative, so a healthy run comes in under them: regrouping the four source runs' real per-script durations under this six-shard partition puts the worst shard at 13.14 to 13.37 min, 66 to 67% of the 20-minute job cap, against 13.82 min of assignment weight.
 
-The single longest script, `tests/fm-watch-triage.test.sh` at 262626 ms, is the floor for any shard count.
+The single longest script, `tests/fm-watch-triage.test.sh` at 515417 ms, is the floor for any shard count.
+At 8.59 min it is 10.4% of the whole lane, so no shard count can bring a shard below it.
 
 Refresh the CI-derived hints by downloading the per-shard timing artifacts from several green CI runs, replacing the `portable_serial_weight_hints` table in `bin/fm-test-run.sh` with the slowest measured `duration_ms` per `path`, and updating the table above:
 
@@ -98,6 +101,7 @@ jq -r '.scripts[] | [.path, .duration_ms] | @tsv' /tmp/fm-serial/*/*.json \
   | awk -F'\t' '$2 > m[$1] { m[$1] = $2 } END { for (p in m) print p, m[p] }' \
   | LC_ALL=C sort
 bin/fm-test-run.sh --check-coverage
+bin/fm-test-run.sh --check-shard-balance /tmp/fm-serial/<run-id>/*/*.json
 ```
 
 A timed-out shard uploads no artifact, so pick runs where every serial shard is green or the lane's slowest scripts go unmeasured in exactly the shard that needs them most.
@@ -109,6 +113,24 @@ Measure native-Windows-only scripts through the focused Git Bash runner and reta
 It also verifies that the parallel lanes, portable serial lane, and real-Herdr family are disjoint and cover every `tests/*.test.sh` script.
 It separately verifies that the portable serial CI shards are non-empty, disjoint, and together equal the portable serial lane.
 It reports the unmeasured serial share as `serial_unhinted=` and refuses when that share exceeds `PORTABLE_SERIAL_MAX_UNHINTED_PERCENT`, so the shards stay balanced on evidence rather than on the default weight.
+
+## Shard balance guard
+
+`--check-coverage` catches a hint that is missing; it cannot catch a hint that is wrong.
+A hint table can be fully populated and still predict a perfect split while one shard runs 40% over and reaches its cap, which is how the 2026-09-08 recurrence passed the coverage guard green.
+`bin/fm-test-run.sh --check-shard-balance <serial-lane.json>...` closes that gap against the timing artifacts the serial lanes already upload on every run.
+Each artifact names the lane it ran as and every script it ran, so a shard is checked against its own recorded work rather than against a re-derived assignment.
+
+It checks two properties, because they fail for different reasons and call for different remedies:
+
+- Accuracy: a shard whose measured duration exceeds its hinted weight by more than `PORTABLE_SERIAL_MAX_HINT_DRIFT_PERCENT` fails, naming the scripts whose hints drifted most.
+  The remedy is a hint refresh.
+- Headroom: a shard whose measured duration exceeds `PORTABLE_SERIAL_MAX_SHARD_BUDGET_PERCENT` of the job cap fails.
+  The remedy is another shard, because accurate hints cannot fix a lane that has outgrown its shard count.
+
+`PORTABLE_SERIAL_JOB_TIMEOUT_MINUTES` records the cap the headroom share is taken against, and `.github/workflows/ci.yml` passes its own `tests-portable-serial` `timeout-minutes` back through `--job-timeout-minutes`, which is refused when the two disagree.
+The `tests-timing-aggregate` job runs the check after building the aggregate summary.
+A cancelled shard uploads no artifact, so the check reports how many shards it could read and leaves the rest unchecked rather than guessing.
 
 ## Timing artifacts
 
@@ -126,7 +148,7 @@ Portable shards, each portable serial shard, and the Herdr lane upload runner-ge
 | Lane | Bound | Rationale |
 |---|---|---|
 | portable parallel 1/2 | job `timeout-minutes: 10` | The measured shard sums are about three minutes and the timeout is a hang tripwire. |
-| portable serial 1-5 | job `timeout-minutes: 20` | Each balanced shard carries about 13.69 minutes of conservative assignment weight, leaving roughly 1.5x hang-tripwire margin for job setup and runner-speed spread. |
+| portable serial 1-6 | job `timeout-minutes: 20` | Each balanced shard carries about 13.82 minutes of conservative assignment weight and measures 13.1 to 13.4 minutes on a real run, leaving roughly 1.5x hang-tripwire margin for job setup and runner-speed spread. The shard balance guard checks that margin on every run. |
 | Herdr | family-run step `timeout-minutes: 20`; job `timeout-minutes: 75` backstop | Healthy runs finished around 7 minutes before this lane gained `fm-backend-herdr-focus-flash-e2e`, which measures about 2 minutes against a real lab locally, so the step bound is still the hang tripwire (cleanup and timing artifacts still upload) while the job cap stays a last-resort backstop. Refresh this figure from the lane's uploaded timing artifact. |
 
 Timeouts are hang tripwires rather than expected healthy durations.

--- a/docs/fm-test-portable-shards.md
+++ b/docs/fm-test-portable-shards.md
@@ -124,7 +124,11 @@ Each artifact names the lane it ran as and every script it ran, so a shard is ch
 It checks one property, the one actually being protected: how close a shard runs to the cap that would cancel it.
 
 A shard whose duration exceeds `PORTABLE_SERIAL_MAX_SHARD_BUDGET_PERCENT` of the job cap fails; anything under it passes.
-The duration is the shard's own recorded wall time (`summary.duration_ms` in its artifact), because the job cap bounds the wall clock rather than the sum of the scripts; an artifact carrying no usable wall time falls back to that sum.
+The duration is the shard's own recorded wall time (`summary.duration_ms` in its artifact) rather than the sum of its scripts; an artifact carrying no usable wall time falls back to that sum.
+That numerator is the *suite's* wall clock while `timeout-minutes` bounds the whole *job's*, so the share systematically understates the job by whatever the surrounding steps cost: checkout, the pinned ShellCheck and actionlint installs, the two `npm install -g` steps, the artifact upload, and job teardown.
+That bias is measured, not assumed. Across 30 `tests-portable-serial` jobs from 6 recent green CI runs, pre-suite setup ran 13 to 20 seconds (median 15 s) and total non-suite time including upload and teardown ran 15 to 24 seconds (median 18 s).
+The worst observed non-suite cost is 0.40 min, 2.0% of the 20-minute bound, against the 10% this threshold reserves: a shard scoring exactly 90% reaches about 18.40 min of job wall clock in the worst case, leaving 1.60 min still in hand.
+Re-measure those numbers rather than re-arguing the threshold if the job gains or loses steps.
 The failure names the scripts furthest over their hints, so it still says what to re-measure rather than only that a shard is slow.
 The hint table feeds that list and nothing else here: it no longer decides pass or fail on its own, and the coverage guard's `PORTABLE_SERIAL_MAX_UNHINTED_PERCENT` above still owns hints that are missing.
 
@@ -137,10 +141,7 @@ Do not re-derive that split and add it back.
 The `tests-timing-aggregate` job runs the check after building the aggregate summary.
 A cancelled shard uploads no artifact, so the check reports how many of the shards its artifacts declare could actually be read and leaves the rest unchecked rather than guessing.
 
-Reading several downloaded runs at once is the documented refresh workflow, so the guard is explicit about what it accepts.
 An artifact that names no numbered serial shard is skipped.
-The same shard supplied more than once is deduplicated to its slowest copy, the same worst-case rule the hint table is refreshed on, so a repeat is never counted as extra coverage.
-Artifacts from two different partitions are refused outright, because shard 3 of five and shard 3 of six cover different work and their totals cannot be added.
 
 ## Timing artifacts
 

--- a/docs/fm-test-portable-shards.md
+++ b/docs/fm-test-portable-shards.md
@@ -141,8 +141,6 @@ Do not re-derive that split and add it back.
 The `tests-timing-aggregate` job runs the check after building the aggregate summary.
 A cancelled shard uploads no artifact, so the check reports how many of the shards its artifacts declare could actually be read and leaves the rest unchecked rather than guessing.
 
-An artifact that names no numbered serial shard is skipped.
-
 ## Timing artifacts
 
 Portable shards, each portable serial shard, and the Herdr lane upload runner-generated timing JSON.

--- a/docs/fm-test-portable-shards.md
+++ b/docs/fm-test-portable-shards.md
@@ -125,10 +125,16 @@ It checks two properties, because they fail for different reasons and call for d
 
 - Accuracy: a shard whose measured duration exceeds its hinted weight by more than `PORTABLE_SERIAL_MAX_HINT_DRIFT_PERCENT` fails, naming the scripts whose hints drifted most.
   The remedy is a hint refresh.
-- Headroom: a shard whose measured duration exceeds `PORTABLE_SERIAL_MAX_SHARD_BUDGET_PERCENT` of the job cap fails.
-  The remedy is another shard, because accurate hints cannot fix a lane that has outgrown its shard count.
+- Headroom: a shard whose measured duration exceeds `PORTABLE_SERIAL_WARN_SHARD_BUDGET_PERCENT` of the job cap warns without failing the run, and one that exceeds `PORTABLE_SERIAL_MAX_SHARD_BUDGET_PERCENT` fails.
+  The warning sits well below the failure on purpose: the guard has to speak before the badge goes red, and per-script noise on this lane reaches 3x, so a failure line just above the worst healthy shard would redden green suites until someone switched the guard off.
+
+A shard over its budget is not by itself evidence that the lane needs another runner, so the headroom report states what it measured against the cap and then only the cause it could establish.
+It divides the reported work evenly across the configured shard count: when even that does not fit, the lane has outgrown its shard count and the remedy is raising `PORTABLE_SERIAL_SHARDS` and the `ci.yml` matrix; when it does fit, the shard is packed heavy rather than the lane being too big, and the report names the scripts that ran over their hints.
+A shard that trips the headroom bound while its own hints have also drifted is reported under both bounds, so the drifted scripts are named either way.
+Both remain visible and distinguishable: the estimates being wrong and the lane being too big have different remedies.
 
 `PORTABLE_SERIAL_JOB_TIMEOUT_MINUTES` records the cap the headroom share is taken against, and `.github/workflows/ci.yml` passes its own `tests-portable-serial` `timeout-minutes` back through `--job-timeout-minutes`, which is refused when the two disagree.
+`tests/fm-test-run.test.sh` parses the workflow and refuses when that job's real `timeout-minutes` key, the value the aggregate step passes, and the cap the runner reports do not all agree, so the cap cannot move in one place only.
 The `tests-timing-aggregate` job runs the check after building the aggregate summary.
 A cancelled shard uploads no artifact, so the check reports how many shards it could read and leaves the rest unchecked rather than guessing.
 

--- a/docs/fm-test-portable-shards.md
+++ b/docs/fm-test-portable-shards.md
@@ -72,7 +72,7 @@ Balance is still worth keeping current, because enough drifted hints let one sha
 That is not hypothetical, and it has now happened twice.
 By 2026-09-01 the lane had grown from 116 to 139 scripts and from ~42 to ~63 minutes, 17 scripts were still unmeasured, and several hints were low by 2-5x, so shard 3 of 4 ran 17-20 minutes against its 20-minute cap while shard 1 ran 11.5 minutes and run [33574154856](https://github.com/kunchenguid/firstmate/actions/runs/33574154856) timed out seconds after a passing test.
 The 2026-09-01 remedy refreshed the hints and moved to five shards, and the lane was cancelling again within a day: shard 4 of 5 ran 15.7 minutes against the same cap by 2026-09-02T06:38Z, and by 2026-09-08 the hints predicted 13.69 minutes for every shard while the shards actually ran 13.08 to 19.15 minutes.
-Both occurrences were the same failure, so the guards below check hint accuracy and shard headroom rather than only hint presence.
+Both occurrences were the same failure, so the balance guard below checks how close each shard runs to its cap rather than only whether its hints exist.
 Refresh the hints whenever the serial lane gains scripts, rather than waiting for a guard to trip.
 
 | Lane | Script count | Estimated duration |
@@ -121,31 +121,25 @@ A hint table can be fully populated and still predict a perfect split while one 
 `bin/fm-test-run.sh --check-shard-balance <serial-lane.json>...` closes that gap against the timing artifacts the serial lanes already upload on every run.
 Each artifact names the lane it ran as and every script it ran, so a shard is checked against its own recorded work rather than against a re-derived assignment.
 
-It checks two properties, because they fail for different reasons and call for different remedies:
+It checks one property, the one actually being protected: how close a shard runs to the cap that would cancel it.
 
-- Accuracy: a shard whose measured duration exceeds its hinted weight by more than `PORTABLE_SERIAL_MAX_HINT_DRIFT_PERCENT` fails, naming the scripts whose hints drifted most.
-  The remedy is a hint refresh.
-  Only scripts that carry a hint are compared, on both sides of the ratio: a hint that was never written is not a stale hint, the coverage guard's `PORTABLE_SERIAL_MAX_UNHINTED_PERCENT` above already owns those, and charging them here would make one new slow test a red aggregate job.
-  When a shard's comparison excludes any script, the failure says how many, so the ratio is not read against a denominator other than the one it used.
-- Headroom: a shard whose duration exceeds `PORTABLE_SERIAL_WARN_SHARD_BUDGET_PERCENT` of the job cap warns without failing the run, and one that exceeds `PORTABLE_SERIAL_MAX_SHARD_BUDGET_PERCENT` fails.
-  The duration here is the shard's own recorded wall time (`summary.duration_ms` in its artifact), because the job cap bounds the wall clock rather than the sum of the scripts; an artifact carrying no usable wall time falls back to that sum.
-  Unhinted scripts count in full toward this bound, so a slow new test still shows the lane outgrowing its shard count even though it never counts as drift.
-  The warning sits well below the failure on purpose: the guard has to speak before the badge goes red, and per-script noise on this lane reaches 3x, so a failure line just above the worst healthy shard would redden green suites until someone switched the guard off.
-  Under GitHub Actions the warning is raised as a `::warning::` annotation, so it reaches the run summary rather than only the step log; it still leaves the step green.
+A shard whose duration exceeds `PORTABLE_SERIAL_MAX_SHARD_BUDGET_PERCENT` of the job cap fails; anything under it passes.
+The duration is the shard's own recorded wall time (`summary.duration_ms` in its artifact), because the job cap bounds the wall clock rather than the sum of the scripts; an artifact carrying no usable wall time falls back to that sum.
+The failure names the scripts furthest over their hints, so it still says what to re-measure rather than only that a shard is slow.
+The hint table feeds that list and nothing else here: it no longer decides pass or fail on its own, and the coverage guard's `PORTABLE_SERIAL_MAX_UNHINTED_PERCENT` above still owns hints that are missing.
 
-A shard over its budget is not by itself evidence that the lane needs another runner, so the headroom report states what it measured against the cap and then only the cause it could establish.
-It divides the reported work evenly across the configured shard count: when even that does not fit, the lane has outgrown its shard count and the remedy is raising `PORTABLE_SERIAL_SHARDS` and the `ci.yml` matrix; when it does fit, the shard is packed heavy rather than the lane being too big, and the report names the scripts that ran over their hints.
-A shard that trips the headroom bound while its own hints have also drifted is reported under both bounds, so the drifted scripts are named either way.
-Both remain visible and distinguishable: the estimates being wrong and the lane being too big have different remedies.
+A richer diagnosis was built here and deliberately reduced away: a second pass/fail bound on hint drift, a non-failing warning share below this one, and a branch that told "the estimates are wrong" apart from "the lane has outgrown its shard count".
+Both properties that are actually required survive in this single check, because it fires while the shard still finishes and it still names what to re-measure.
+Do not re-derive that split and add it back.
 
-`PORTABLE_SERIAL_JOB_TIMEOUT_MINUTES` records the cap the headroom share is taken against, and `.github/workflows/ci.yml` passes its own `tests-portable-serial` `timeout-minutes` back through `--job-timeout-minutes`, which is refused when the two disagree.
-`tests/fm-test-run.test.sh` parses the workflow and refuses when that job's real `timeout-minutes` key, the value the aggregate step passes, and the cap the runner reports do not all agree, so the cap cannot move in one place only.
+`PORTABLE_SERIAL_JOB_TIMEOUT_MINUTES` is the single owner of the cap the share is taken against.
+`tests/fm-test-run.test.sh` parses `.github/workflows/ci.yml` and refuses when the `tests-portable-serial` job's real `timeout-minutes` key and the cap the runner reports disagree, so the cap cannot move in one place only.
 The `tests-timing-aggregate` job runs the check after building the aggregate summary.
-A cancelled shard uploads no artifact, so the check reports how many shards it could read and leaves the rest unchecked rather than guessing.
+A cancelled shard uploads no artifact, so the check reports how many of the shards its artifacts declare could actually be read and leaves the rest unchecked rather than guessing.
 
 Reading several downloaded runs at once is the documented refresh workflow, so the guard is explicit about what it accepts.
-An artifact whose lane is not a numbered serial shard is ignored and counted rather than accumulated.
-The same shard supplied more than once is deduplicated to its slowest copy, the same worst-case rule the hint table is refreshed on, so a repeat can never double the lane total or flip the reported remedy.
+An artifact that names no numbered serial shard is skipped.
+The same shard supplied more than once is deduplicated to its slowest copy, the same worst-case rule the hint table is refreshed on, so a repeat is never counted as extra coverage.
 Artifacts from two different partitions are refused outright, because shard 3 of five and shard 3 of six cover different work and their totals cannot be added.
 
 ## Timing artifacts

--- a/docs/fm-test-portable-shards.md
+++ b/docs/fm-test-portable-shards.md
@@ -124,7 +124,7 @@ Each artifact names the lane it ran as and every script it ran, so a shard is ch
 It checks one property, the one actually being protected: how close a shard runs to the cap that would cancel it.
 
 A shard whose duration exceeds `PORTABLE_SERIAL_MAX_SHARD_BUDGET_PERCENT` of the job cap fails; anything under it passes.
-The duration is the shard's own recorded wall time (`summary.duration_ms` in its artifact) rather than the sum of its scripts; an artifact carrying no usable wall time falls back to that sum.
+The duration is the shard's own recorded wall time (`summary.duration_ms` in its artifact) rather than the sum of its scripts.
 That numerator is the *suite's* wall clock while `timeout-minutes` bounds the whole *job's*, so the share systematically understates the job by whatever the surrounding steps cost: checkout, the pinned ShellCheck and actionlint installs, the two `npm install -g` steps, the artifact upload, and job teardown.
 That bias is measured, not assumed. Across 30 `tests-portable-serial` jobs from 6 recent green CI runs, pre-suite setup ran 13 to 20 seconds (median 15 s) and total non-suite time including upload and teardown ran 15 to 24 seconds (median 18 s).
 The worst observed non-suite cost is 0.40 min, 2.0% of the 20-minute bound, against the 10% this threshold reserves: a shard scoring exactly 90% reaches about 18.40 min of job wall clock in the worst case, leaving 1.60 min still in hand.

--- a/docs/fm-test-portable-shards.md
+++ b/docs/fm-test-portable-shards.md
@@ -125,8 +125,13 @@ It checks two properties, because they fail for different reasons and call for d
 
 - Accuracy: a shard whose measured duration exceeds its hinted weight by more than `PORTABLE_SERIAL_MAX_HINT_DRIFT_PERCENT` fails, naming the scripts whose hints drifted most.
   The remedy is a hint refresh.
-- Headroom: a shard whose measured duration exceeds `PORTABLE_SERIAL_WARN_SHARD_BUDGET_PERCENT` of the job cap warns without failing the run, and one that exceeds `PORTABLE_SERIAL_MAX_SHARD_BUDGET_PERCENT` fails.
+  Only scripts that carry a hint are compared, on both sides of the ratio: a hint that was never written is not a stale hint, the coverage guard's `PORTABLE_SERIAL_MAX_UNHINTED_PERCENT` above already owns those, and charging them here would make one new slow test a red aggregate job.
+  When a shard's comparison excludes any script, the failure says how many, so the ratio is not read against a denominator other than the one it used.
+- Headroom: a shard whose duration exceeds `PORTABLE_SERIAL_WARN_SHARD_BUDGET_PERCENT` of the job cap warns without failing the run, and one that exceeds `PORTABLE_SERIAL_MAX_SHARD_BUDGET_PERCENT` fails.
+  The duration here is the shard's own recorded wall time (`summary.duration_ms` in its artifact), because the job cap bounds the wall clock rather than the sum of the scripts; an artifact carrying no usable wall time falls back to that sum.
+  Unhinted scripts count in full toward this bound, so a slow new test still shows the lane outgrowing its shard count even though it never counts as drift.
   The warning sits well below the failure on purpose: the guard has to speak before the badge goes red, and per-script noise on this lane reaches 3x, so a failure line just above the worst healthy shard would redden green suites until someone switched the guard off.
+  Under GitHub Actions the warning is raised as a `::warning::` annotation, so it reaches the run summary rather than only the step log; it still leaves the step green.
 
 A shard over its budget is not by itself evidence that the lane needs another runner, so the headroom report states what it measured against the cap and then only the cause it could establish.
 It divides the reported work evenly across the configured shard count: when even that does not fit, the lane has outgrown its shard count and the remedy is raising `PORTABLE_SERIAL_SHARDS` and the `ci.yml` matrix; when it does fit, the shard is packed heavy rather than the lane being too big, and the report names the scripts that ran over their hints.
@@ -137,6 +142,11 @@ Both remain visible and distinguishable: the estimates being wrong and the lane 
 `tests/fm-test-run.test.sh` parses the workflow and refuses when that job's real `timeout-minutes` key, the value the aggregate step passes, and the cap the runner reports do not all agree, so the cap cannot move in one place only.
 The `tests-timing-aggregate` job runs the check after building the aggregate summary.
 A cancelled shard uploads no artifact, so the check reports how many shards it could read and leaves the rest unchecked rather than guessing.
+
+Reading several downloaded runs at once is the documented refresh workflow, so the guard is explicit about what it accepts.
+An artifact whose lane is not a numbered serial shard is ignored and counted rather than accumulated.
+The same shard supplied more than once is deduplicated to its slowest copy, the same worst-case rule the hint table is refreshed on, so a repeat can never double the lane total or flip the reported remedy.
+Artifacts from two different partitions are refused outright, because shard 3 of five and shard 3 of six cover different work and their totals cannot be added.
 
 ## Timing artifacts
 

--- a/tests/fm-backend.test.sh
+++ b/tests/fm-backend.test.sh
@@ -37,9 +37,6 @@ fm_git_identity fmtest fmtest@example.invalid
 . "$ROOT/bin/fm-backend.sh"
 
 TMP_ROOT=$(fm_test_tmproot fm-backend-tests)
-# Shared project locks use FM_HOME/state even when cases override state paths.
-export FM_HOME="$TMP_ROOT/firstmate-home"
-mkdir -p "$FM_HOME/state"
 # A claude spawn writes workspace trust into the launching user's own store,
 # and the script resolves it as ${CLAUDE_CONFIG_DIR:-${HOME:-}}, so the value
 # is pinned EMPTY beside the throwaway HOME: an inherited one would beat that

--- a/tests/fm-backend.test.sh
+++ b/tests/fm-backend.test.sh
@@ -37,6 +37,9 @@ fm_git_identity fmtest fmtest@example.invalid
 . "$ROOT/bin/fm-backend.sh"
 
 TMP_ROOT=$(fm_test_tmproot fm-backend-tests)
+# Shared project locks use FM_HOME/state even when cases override state paths.
+export FM_HOME="$TMP_ROOT/firstmate-home"
+mkdir -p "$FM_HOME/state"
 # A claude spawn writes workspace trust into the launching user's own store,
 # and the script resolves it as ${CLAUDE_CONFIG_DIR:-${HOME:-}}, so the value
 # is pinned EMPTY beside the throwaway HOME: an inherited one would beat that

--- a/tests/fm-test-run.test.sh
+++ b/tests/fm-test-run.test.sh
@@ -1538,6 +1538,161 @@ puts JSON.generate(
   pass "Herdr CI family-run step times out at 20 min under a 75 min job backstop"
 }
 
+# Writes one synthetic portable-serial timing artifact: <file> <shard> <count>
+# <per-script-ms>. The guard reads a shard's membership and durations from the
+# artifact itself, so a fixture needs no real lane. The lane label deliberately
+# carries a shard count the runner is not configured for, because an artifact
+# from an earlier partition must still be readable rather than refused.
+write_shard_timing_json() {
+  local file=$1 shard=$2 count=$3 each=$4
+  python3 - "$file" "$shard" "$count" "$each" <<'PY'
+import json, sys
+file, shard, count, each = sys.argv[1], sys.argv[2], int(sys.argv[3]), int(sys.argv[4])
+scripts = [
+    {
+        "path": "tests/fm-balance-fixture-%s-%d.test.sh" % (shard, i),
+        "family": "pure-contract-unit",
+        "duration_ms": each,
+        "exit": 0,
+        "gate_skip": False,
+    }
+    for i in range(count)
+]
+json.dump(
+    {
+        "run_id": "fixture",
+        "selection": "lane=portable-serial-%sof9" % shard,
+        "started_at": "2026-09-08T00:00:00Z",
+        "finished_at": "2026-09-08T00:10:00Z",
+        "summary": {
+            "total": count,
+            "failed": 0,
+            "skipped_gate": 0,
+            "duration_ms": each * count,
+        },
+        "scripts": scripts,
+    },
+    open(file, "w"),
+)
+PY
+}
+
+test_shard_balance_passes_and_reports_bound() {
+  local tmp out bound
+  tmp=$(mktemp -d "${TMPDIR:-/tmp}/fm-test-run-balance-ok.XXXXXX")
+  write_shard_timing_json "$tmp/1.json" 1 6 1000
+  write_shard_timing_json "$tmp/2.json" 2 6 1000
+  out=$("$RUNNER" --check-shard-balance "$tmp/1.json" "$tmp/2.json") \
+    || { rm -rf "$tmp"; fail "healthy shards must pass the balance guard: $out"; }
+  assert_contains "$out" "FM_TEST_SHARD_BALANCE ok shards=2" "balance summary line"
+  assert_contains "$out" "bound=" "balance summary must name the job cap it measured against"
+  bound=$(printf '%s\n' "$out" | sed -n 's/.*bound=\([0-9][0-9]*\)min.*/\1/p')
+  [ -n "$bound" ] && [ "$bound" -gt 0 ] \
+    || { rm -rf "$tmp"; fail "balance summary must carry a numeric job cap: $out"; }
+  rm -rf "$tmp"
+  pass "shard balance guard passes healthy shards and reports the cap it used"
+}
+
+test_shard_balance_fails_on_drifted_hints() {
+  local tmp out rc
+  tmp=$(mktemp -d "${TMPDIR:-/tmp}/fm-test-run-balance-drift.XXXXXX")
+  # Eight unhinted scripts carry eight default weights of hint, and running each
+  # well past that default drifts the shard far beyond the guard's bound while
+  # the shard total stays a small fraction of the job cap. That separation is
+  # the point: this shard is nowhere near timing out, and the guard must still
+  # say the hints are wrong. It assumes only that the default weight sits in the
+  # tens of seconds, and fails loudly rather than vacuously if that changes.
+  write_shard_timing_json "$tmp/4.json" 4 8 40000
+  out=$("$RUNNER" --check-shard-balance "$tmp/4.json" 2>&1) && rc=0 || rc=$?
+  [ "$rc" -ne 0 ] || { rm -rf "$tmp"; fail "drifted hints must fail the balance guard: $out"; }
+  assert_contains "$out" "the hint table is stale" "drift failure must name the stale table"
+  assert_contains "$out" "tests/fm-balance-fixture-4-" \
+    "drift failure must name a script to re-measure"
+  # The two signals carry different remedies, so a drift failure must not be
+  # reported as a shard-count problem.
+  case "$out" in
+    *"outgrown its shard count"*)
+      rm -rf "$tmp"
+      fail "a drift-only shard must not be reported as outgrowing its shard count: $out"
+      ;;
+  esac
+  rm -rf "$tmp"
+  pass "shard balance guard fails on drifted hints and names what to re-measure"
+}
+
+test_shard_balance_fails_on_lost_headroom() {
+  local tmp out rc
+  tmp=$(mktemp -d "${TMPDIR:-/tmp}/fm-test-run-balance-headroom.XXXXXX")
+  # Fifty scripts running just under their default weight keep the hints
+  # accurate, so only the headroom signal is left to notice that the shard now
+  # fills the whole job cap. Refreshing hints cannot fix this one.
+  write_shard_timing_json "$tmp/3.json" 3 50 24000
+  out=$("$RUNNER" --check-shard-balance "$tmp/3.json" 2>&1) && rc=0 || rc=$?
+  [ "$rc" -ne 0 ] || { rm -rf "$tmp"; fail "a shard filling the job cap must fail: $out"; }
+  assert_contains "$out" "outgrown its shard count" \
+    "headroom failure must name the shard-count remedy"
+  assert_contains "$out" "job cap" "headroom failure must name the cap it measured against"
+  case "$out" in
+    *"the hint table is stale"*)
+      rm -rf "$tmp"
+      fail "an accurately hinted shard must not be reported as stale: $out"
+      ;;
+  esac
+  rm -rf "$tmp"
+  pass "shard balance guard fails when a shard loses its job-cap headroom"
+}
+
+test_shard_balance_reports_missing_and_foreign_artifacts() {
+  local tmp out
+  tmp=$(mktemp -d "${TMPDIR:-/tmp}/fm-test-run-balance-partial.XXXXXX")
+  # A cancelled shard uploads no artifact at all, so the guard must say how much
+  # of the lane it could actually read instead of passing as though the missing
+  # shards were healthy.
+  write_shard_timing_json "$tmp/1.json" 1 6 1000
+  out=$("$RUNNER" --check-shard-balance "$tmp/1.json") \
+    || { rm -rf "$tmp"; fail "a single healthy shard must still pass: $out"; }
+  assert_contains "$out" "FM_TEST_SHARD_BALANCE partial" \
+    "an incomplete lane must be reported as partial"
+  # A parallel lane's artifact carries no serial shard, and must be skipped
+  # rather than counted or refused.
+  cat >"$tmp/parallel.json" <<'JSON'
+{
+  "run_id": "fixture",
+  "selection": "lane=portable-parallel-1",
+  "started_at": "2026-09-08T00:00:00Z",
+  "finished_at": "2026-09-08T00:01:00Z",
+  "summary": {"total": 1, "failed": 0, "skipped_gate": 0, "duration_ms": 1000},
+  "scripts": [{"path": "tests/a.test.sh", "family": "pure-contract-unit", "duration_ms": 1000, "exit": 0, "gate_skip": false}]
+}
+JSON
+  out=$("$RUNNER" --check-shard-balance "$tmp/parallel.json") \
+    || { rm -rf "$tmp"; fail "a non-serial artifact must not fail the guard: $out"; }
+  assert_contains "$out" "FM_TEST_SHARD_BALANCE skipped" \
+    "a lane with no serial shard must be reported as skipped"
+  rm -rf "$tmp"
+  pass "shard balance guard reports missing and foreign timing artifacts"
+}
+
+test_shard_balance_refuses_a_disagreeing_job_cap() {
+  local tmp out rc bound
+  tmp=$(mktemp -d "${TMPDIR:-/tmp}/fm-test-run-balance-cap.XXXXXX")
+  write_shard_timing_json "$tmp/1.json" 1 6 1000
+  bound=$("$RUNNER" --check-shard-balance "$tmp/1.json" \
+    | sed -n 's/.*bound=\([0-9][0-9]*\)min.*/\1/p')
+  # ci.yml passes back the cap it sets on the serial job, so a cap that moved in
+  # only one of the two places must be refused rather than silently measured
+  # against the wrong number.
+  out=$("$RUNNER" --check-shard-balance --job-timeout-minutes "$((bound + 7))" "$tmp/1.json" 2>&1) \
+    && rc=0 || rc=$?
+  [ "$rc" -ne 0 ] || { rm -rf "$tmp"; fail "a disagreeing job cap must be refused: $out"; }
+  assert_contains "$out" "disagrees" "cap mismatch must say the two records disagree"
+  out=$("$RUNNER" --check-shard-balance --job-timeout-minutes "$bound" "$tmp/1.json") \
+    || { rm -rf "$tmp"; fail "the recorded job cap must be accepted: $out"; }
+  assert_contains "$out" "FM_TEST_SHARD_BALANCE ok" "matching cap must pass"
+  rm -rf "$tmp"
+  pass "shard balance guard refuses a job cap that disagrees with ci.yml"
+}
+
 test_aggregate_json() {
   local tmp a b
   tmp=$(mktemp -d "${TMPDIR:-/tmp}/fm-test-run-aggjson.XXXXXX")
@@ -1615,3 +1770,8 @@ test_max_wall_ms_is_a_result_not_advice
 test_jobs_parallel_scheduler_and_failure_propagation
 test_herdr_ci_family_run_has_a_step_timeout
 test_aggregate_json
+test_shard_balance_passes_and_reports_bound
+test_shard_balance_fails_on_drifted_hints
+test_shard_balance_fails_on_lost_headroom
+test_shard_balance_reports_missing_and_foreign_artifacts
+test_shard_balance_refuses_a_disagreeing_job_cap

--- a/tests/fm-test-run.test.sh
+++ b/tests/fm-test-run.test.sh
@@ -1659,7 +1659,7 @@ test_shard_balance_fails_on_lost_headroom() {
   pass "shard balance guard fails when a shard loses its job-cap headroom"
 }
 
-test_shard_balance_reports_missing_and_foreign_artifacts() {
+test_shard_balance_reports_missing_artifacts() {
   local tmp out
   tmp=$(mktemp -d "${TMPDIR:-/tmp}/fm-test-run-balance-partial.XXXXXX")
   # A cancelled shard uploads no artifact at all, so the guard must say how much
@@ -1670,24 +1670,8 @@ test_shard_balance_reports_missing_and_foreign_artifacts() {
     || { rm -rf "$tmp"; fail "a single healthy shard must still pass: $out"; }
   assert_contains "$out" "FM_TEST_SHARD_BALANCE partial" \
     "an incomplete lane must be reported as partial"
-  # A parallel lane's artifact carries no serial shard, and must be skipped
-  # rather than counted or refused.
-  cat >"$tmp/parallel.json" <<'JSON'
-{
-  "run_id": "fixture",
-  "selection": "lane=portable-parallel-1",
-  "started_at": "2026-09-08T00:00:00Z",
-  "finished_at": "2026-09-08T00:01:00Z",
-  "summary": {"total": 1, "failed": 0, "skipped_gate": 0, "duration_ms": 1000},
-  "scripts": [{"path": "tests/a.test.sh", "family": "pure-contract-unit", "duration_ms": 1000, "exit": 0, "gate_skip": false}]
-}
-JSON
-  out=$("$RUNNER" --check-shard-balance "$tmp/parallel.json") \
-    || { rm -rf "$tmp"; fail "a non-serial artifact must not fail the guard: $out"; }
-  assert_contains "$out" "FM_TEST_SHARD_BALANCE skipped" \
-    "a lane with no serial shard must be reported as skipped"
   rm -rf "$tmp"
-  pass "shard balance guard reports missing and foreign timing artifacts"
+  pass "shard balance guard reports missing timing artifacts"
 }
 
 test_portable_serial_job_cap_has_one_owner() {
@@ -1794,5 +1778,5 @@ test_aggregate_json
 test_shard_balance_passes_and_reports_bound
 test_shard_balance_measures_the_recorded_wall_time
 test_shard_balance_fails_on_lost_headroom
-test_shard_balance_reports_missing_and_foreign_artifacts
+test_shard_balance_reports_missing_artifacts
 test_portable_serial_job_cap_has_one_owner

--- a/tests/fm-test-run.test.sh
+++ b/tests/fm-test-run.test.sh
@@ -1544,10 +1544,12 @@ puts JSON.generate(
 # carries a shard count the runner is not configured for, because an artifact
 # from an earlier partition must still be readable rather than refused.
 write_shard_timing_json() {
-  local file=$1 shard=$2 count=$3 each=$4
-  python3 - "$file" "$shard" "$count" "$each" <<'PY'
+  local file=$1 shard=$2 count=$3 each=$4 wall=${5:-} partition=${6:-9}
+  python3 - "$file" "$shard" "$count" "$each" "$wall" "$partition" <<'PY'
 import json, sys
-file, shard, count, each = sys.argv[1], sys.argv[2], int(sys.argv[3]), int(sys.argv[4])
+file, shard, count, each, wall, partition = (
+    sys.argv[1], sys.argv[2], int(sys.argv[3]), int(sys.argv[4]), sys.argv[5], sys.argv[6]
+)
 scripts = [
     {
         "path": "tests/fm-balance-fixture-%s-%d.test.sh" % (shard, i),
@@ -1558,17 +1560,63 @@ scripts = [
     }
     for i in range(count)
 ]
+summary = {"total": count, "failed": 0, "skipped_gate": 0}
+# The runner records the shard's wall time here and the guard measures headroom
+# against it, so a fixture can set it apart from the script sum, or drop it to
+# exercise the fallback.
+if wall != "none":
+    summary["duration_ms"] = int(wall) if wall else each * count
 json.dump(
     {
         "run_id": "fixture",
-        "selection": "lane=portable-serial-%sof9" % shard,
+        "selection": "lane=portable-serial-%sof%s" % (shard, partition),
+        "started_at": "2026-09-08T00:00:00Z",
+        "finished_at": "2026-09-08T00:10:00Z",
+        "summary": summary,
+        "scripts": scripts,
+    },
+    open(file, "w"),
+)
+PY
+}
+
+# Writes an artifact carrying a real serial shard's own scripts, so the hints
+# under test are the ones the runner actually ships. Every script is recorded at
+# <each> ms, which is above every hint in the table, and the shard's wall time is
+# set independently so drift can be exercised without also tripping headroom.
+write_hinted_shard_timing_json() {
+  local file=$1 lane=$2 each=$3 wall=$4 list
+  list="$file.paths"
+  "$RUNNER" --list --lane "$lane" >"$list" \
+    || fail "could not list the scripts of $lane"
+  [ -s "$list" ] || fail "$lane listed no scripts"
+  python3 - "$file" "$lane" "$each" "$wall" "$list" <<'PY'
+import json, sys
+file, lane, each, wall, list_path = (
+    sys.argv[1], sys.argv[2], int(sys.argv[3]), int(sys.argv[4]), sys.argv[5]
+)
+paths = [line.strip() for line in open(list_path) if line.strip()]
+scripts = [
+    {
+        "path": path,
+        "family": "pure-contract-unit",
+        "duration_ms": each,
+        "exit": 0,
+        "gate_skip": False,
+    }
+    for path in paths
+]
+json.dump(
+    {
+        "run_id": "fixture",
+        "selection": "lane=%s" % lane,
         "started_at": "2026-09-08T00:00:00Z",
         "finished_at": "2026-09-08T00:10:00Z",
         "summary": {
-            "total": count,
+            "total": len(scripts),
             "failed": 0,
             "skipped_gate": 0,
-            "duration_ms": each * count,
+            "duration_ms": wall,
         },
         "scripts": scripts,
     },
@@ -1594,20 +1642,21 @@ test_shard_balance_passes_and_reports_bound() {
 }
 
 test_shard_balance_fails_on_drifted_hints() {
-  local tmp out rc
+  local tmp out rc lane
   tmp=$(mktemp -d "${TMPDIR:-/tmp}/fm-test-run-balance-drift.XXXXXX")
-  # Eight unhinted scripts carry eight default weights of hint, and running each
-  # well past that default drifts the shard far beyond the guard's bound while
-  # the shard total stays a small fraction of the job cap. That separation is
-  # the point: this shard is nowhere near timing out, and the guard must still
-  # say the hints are wrong. It assumes only that the default weight sits in the
-  # tens of seconds, and fails loudly rather than vacuously if that changes.
-  write_shard_timing_json "$tmp/4.json" 4 8 40000
-  out=$("$RUNNER" --check-shard-balance "$tmp/4.json" 2>&1) && rc=0 || rc=$?
+  lane="portable-serial-1of$(configured_serial_shards)"
+  # A real shard's own scripts, every one of them hinted, each recorded at ten
+  # minutes: far above any hint in the table, so the hints this runner ships are
+  # unambiguously stale against it. The shard's recorded wall time is set low so
+  # it keeps its headroom, because the point of this bound is that it says the
+  # hints are wrong while the shard is nowhere near timing out.
+  write_hinted_shard_timing_json "$tmp/1.json" "$lane" 600000 60000
+  out=$("$RUNNER" --check-shard-balance "$tmp/1.json" 2>&1) && rc=0 || rc=$?
   [ "$rc" -ne 0 ] || { rm -rf "$tmp"; fail "drifted hints must fail the balance guard: $out"; }
   assert_contains "$out" "the hint table is stale" "drift failure must name the stale table"
-  assert_contains "$out" "tests/fm-balance-fixture-4-" \
-    "drift failure must name a script to re-measure"
+  assert_contains "$out" "tests/" "drift failure must name a script to re-measure"
+  assert_contains "$out" "hinted scripts" \
+    "drift failure must say how many hinted scripts it compared"
   # The two signals carry different remedies, so a drift failure must not be
   # reported as a shard-count problem.
   case "$out" in
@@ -1615,9 +1664,153 @@ test_shard_balance_fails_on_drifted_hints() {
       rm -rf "$tmp"
       fail "a drift-only shard must not be reported as outgrowing its shard count: $out"
       ;;
+    *"job cap"*)
+      rm -rf "$tmp"
+      fail "a shard that kept its headroom must not be reported against the cap: $out"
+      ;;
   esac
   rm -rf "$tmp"
   pass "shard balance guard fails on drifted hints and names what to re-measure"
+}
+
+test_shard_balance_never_charges_a_missing_hint_to_drift() {
+  local tmp out rc
+  tmp=$(mktemp -d "${TMPDIR:-/tmp}/fm-test-run-balance-unhinted.XXXXXX")
+  # Every script here is new to the lane, so none of them carries a hint. Each
+  # runs at ten minutes, hundreds of percent over the default weight the packer
+  # guessed. A hint that was never written is not a stale hint: the coverage
+  # guard owns the unmeasured share, and charging these to drift would turn any
+  # new slow test into a red aggregate job.
+  write_shard_timing_json "$tmp/2.json" 2 8 600000 60000
+  out=$("$RUNNER" --check-shard-balance "$tmp/2.json" 2>&1) && rc=0 || rc=$?
+  [ "$rc" -eq 0 ] \
+    || { rm -rf "$tmp"; fail "unhinted scripts must not fail the drift bound: $out"; }
+  case "$out" in
+    *"the hint table is stale"*)
+      rm -rf "$tmp"
+      fail "a shard with no hints at all must not be reported as stale: $out"
+      ;;
+  esac
+  # They must still count in full toward headroom, so the same scripts on a
+  # shard that actually took that long are reported against the job cap.
+  write_shard_timing_json "$tmp/3.json" 3 8 600000 4800000
+  out=$("$RUNNER" --check-shard-balance "$tmp/3.json" 2>&1) && rc=0 || rc=$?
+  [ "$rc" -ne 0 ] \
+    || { rm -rf "$tmp"; fail "unhinted work must still count toward headroom: $out"; }
+  assert_contains "$out" "job cap" "an unhinted shard over the cap must be reported against it"
+  rm -rf "$tmp"
+  pass "shard balance guard charges a missing hint to headroom, never to drift"
+}
+
+test_shard_balance_measures_the_recorded_wall_time() {
+  local tmp out rc
+  tmp=$(mktemp -d "${TMPDIR:-/tmp}/fm-test-run-balance-wall.XXXXXX")
+  # The job cap bounds the shard's wall clock, not the sum of its scripts. An
+  # artifact whose scripts total two minutes but which the runner recorded as
+  # nineteen must be measured as nineteen.
+  write_shard_timing_json "$tmp/1.json" 1 8 15000 1140000
+  out=$("$RUNNER" --check-shard-balance "$tmp/1.json" 2>&1) && rc=0 || rc=$?
+  [ "$rc" -ne 0 ] \
+    || { rm -rf "$tmp"; fail "a shard whose wall time fills the cap must fail: $out"; }
+  assert_contains "$out" "19.00 min" "the share must be taken from the recorded wall time"
+  # An artifact that carries no usable wall time still has to be checked, so the
+  # per-script sum stands in for it.
+  write_shard_timing_json "$tmp/2.json" 2 40 30000 none
+  out=$("$RUNNER" --check-shard-balance "$tmp/2.json" 2>&1) && rc=0 || rc=$?
+  [ "$rc" -ne 0 ] \
+    || { rm -rf "$tmp"; fail "a wall-less artifact must fall back to the script sum: $out"; }
+  assert_contains "$out" "20.00 min" "the fallback must be the sum of the scripts"
+  rm -rf "$tmp"
+  pass "shard balance guard measures recorded wall time and falls back to the script sum"
+}
+
+test_shard_balance_dedupes_repeated_shard_artifacts() {
+  local tmp out dup rc shards shard
+  tmp=$(mktemp -d "${TMPDIR:-/tmp}/fm-test-run-balance-dupe.XXXXXX")
+  shards=$(configured_serial_shards)
+  [ -n "$shards" ] || { rm -rf "$tmp"; fail "could not read the configured serial shard count"; }
+  # Globbing several downloaded runs together hands the guard the same shard
+  # more than once. One heavy shard sits above the warning share while an even
+  # repack of the lane still fits; counting each artifact twice would double the
+  # lane total and flip that verdict to "add a shard", so a repeat must change
+  # nothing.
+  write_shard_timing_json "$tmp/1.json" 1 4 30000 960000
+  shard=2
+  while [ "$shard" -le "$shards" ]; do
+    write_shard_timing_json "$tmp/$shard.json" "$shard" 4 30000 600000
+    shard=$((shard + 1))
+  done
+  shard=1
+  while [ "$shard" -le "$shards" ]; do
+    cp "$tmp/$shard.json" "$tmp/dup-$shard.json"
+    shard=$((shard + 1))
+  done
+  out=$("$RUNNER" --check-shard-balance "$tmp"/[0-9].json 2>&1) && rc=0 || rc=$?
+  [ "$rc" -eq 0 ] || { rm -rf "$tmp"; fail "the six distinct shards must pass: $out"; }
+  assert_contains "$out" "which fits" "the distinct lane must repack within the cap"
+  dup=$("$RUNNER" --check-shard-balance "$tmp"/*.json 2>&1) && rc=0 || rc=$?
+  [ "$rc" -eq 0 ] || { rm -rf "$tmp"; fail "duplicated shards must not fail: $dup"; }
+  assert_contains "$dup" "deduped" "a repeated shard must be reported as deduped"
+  assert_contains "$dup" "shards=$shards" "a repeated shard must not raise the shard count"
+  assert_contains "$dup" "which fits" "a repeated shard must not change the verdict"
+  case "$dup" in
+    *"raise PORTABLE_SERIAL_SHARDS"*)
+      rm -rf "$tmp"
+      fail "a repeated shard must not flip the remedy to adding a shard: $dup"
+      ;;
+  esac
+  rm -rf "$tmp"
+  pass "shard balance guard keeps one copy of a repeated shard artifact"
+}
+
+test_shard_balance_refuses_mixed_partitions() {
+  local tmp out rc
+  tmp=$(mktemp -d "${TMPDIR:-/tmp}/fm-test-run-balance-mixed.XXXXXX")
+  # Shard 1 of five and shard 1 of six cover different work, so their totals
+  # cannot be added. Refuse rather than quietly counting both.
+  write_shard_timing_json "$tmp/a.json" 1 4 30000 120000 5
+  write_shard_timing_json "$tmp/b.json" 1 4 30000 120000 6
+  out=$("$RUNNER" --check-shard-balance "$tmp/a.json" "$tmp/b.json" 2>&1) && rc=0 || rc=$?
+  [ "$rc" -ne 0 ] || { rm -rf "$tmp"; fail "mixed partitions must be refused: $out"; }
+  assert_contains "$out" "partitions" "the refusal must say the inputs mix partitions"
+  rm -rf "$tmp"
+  pass "shard balance guard refuses artifacts from two different partitions"
+}
+
+test_shard_balance_warning_is_annotated_under_actions() {
+  local tmp out rc shards shard
+  tmp=$(mktemp -d "${TMPDIR:-/tmp}/fm-test-run-balance-annot.XXXXXX")
+  shards=$(configured_serial_shards)
+  [ -n "$shards" ] || { rm -rf "$tmp"; fail "could not read the configured serial shard count"; }
+  shard=1
+  while [ "$shard" -le "$shards" ]; do
+    write_shard_timing_json "$tmp/$shard.json" "$shard" 40 24000
+    shard=$((shard + 1))
+  done
+  # The warning is the signal that has to arrive before the badge goes red, and
+  # a green step's stderr is not a signal anyone sees. Under Actions it must be
+  # raised as an annotation, and it must still not fail the step.
+  out=$(GITHUB_ACTIONS=true "$RUNNER" --check-shard-balance "$tmp"/*.json 2>&1) && rc=0 || rc=$?
+  [ "$rc" -eq 0 ] || { rm -rf "$tmp"; fail "an annotated warning must still exit 0: $out"; }
+  assert_contains "$out" "::warning::" "a warning under Actions must be an annotation"
+  assert_contains "$out" "job cap" "the annotation must carry the diagnosis"
+  case "$out" in
+    *"
+  an even repack"*)
+      rm -rf "$tmp"
+      fail "an annotation must not be split across lines: $out"
+      ;;
+  esac
+  out=$("$RUNNER" --check-shard-balance "$tmp"/*.json 2>&1) && rc=0 || rc=$?
+  [ "$rc" -eq 0 ] || { rm -rf "$tmp"; fail "a local warning must still exit 0: $out"; }
+  case "$out" in
+    *"::warning::"*)
+      rm -rf "$tmp"
+      fail "local output must stay plain text: $out"
+      ;;
+  esac
+  rm -rf "$tmp"
+  pass "shard balance guard raises its warning as a GitHub annotation"
 }
 
 # How many serial shards the runner is configured for, read from the lanes it
@@ -1895,6 +2088,11 @@ test_herdr_ci_family_run_has_a_step_timeout
 test_aggregate_json
 test_shard_balance_passes_and_reports_bound
 test_shard_balance_fails_on_drifted_hints
+test_shard_balance_never_charges_a_missing_hint_to_drift
+test_shard_balance_measures_the_recorded_wall_time
+test_shard_balance_dedupes_repeated_shard_artifacts
+test_shard_balance_refuses_mixed_partitions
+test_shard_balance_warning_is_annotated_under_actions
 test_shard_balance_fails_on_lost_headroom
 test_shard_balance_warns_before_it_fails
 test_shard_balance_headroom_names_scripts_when_a_repack_would_fit

--- a/tests/fm-test-run.test.sh
+++ b/tests/fm-test-run.test.sh
@@ -1611,7 +1611,7 @@ test_shard_balance_fails_on_drifted_hints() {
   # The two signals carry different remedies, so a drift failure must not be
   # reported as a shard-count problem.
   case "$out" in
-    *"outgrown its shard count"*)
+    *"raise PORTABLE_SERIAL_SHARDS"*)
       rm -rf "$tmp"
       fail "a drift-only shard must not be reported as outgrowing its shard count: $out"
       ;;
@@ -1620,16 +1620,37 @@ test_shard_balance_fails_on_drifted_hints() {
   pass "shard balance guard fails on drifted hints and names what to re-measure"
 }
 
+# How many serial shards the runner is configured for, read from the lanes it
+# actually offers. A complete set of artifacts is what lets the guard answer
+# whether an even repack over that many shards would fit.
+configured_serial_shards() {
+  "$RUNNER" --list-lanes | sed -n 's/^portable-serial-[0-9][0-9]*of\([0-9][0-9]*\)$/\1/p' \
+    | head -n 1
+}
+
+# Writes one synthetic artifact per configured shard, all the same size.
+write_even_shard_timing_jsons() {
+  local dir=$1 count=$2 each=$3 shards shard
+  shards=$(configured_serial_shards)
+  [ -n "$shards" ] || fail "could not read the configured serial shard count from --list-lanes"
+  shard=1
+  while [ "$shard" -le "$shards" ]; do
+    write_shard_timing_json "$dir/$shard.json" "$shard" "$count" "$each"
+    shard=$((shard + 1))
+  done
+}
+
 test_shard_balance_fails_on_lost_headroom() {
   local tmp out rc
   tmp=$(mktemp -d "${TMPDIR:-/tmp}/fm-test-run-balance-headroom.XXXXXX")
-  # Fifty scripts running just under their default weight keep the hints
-  # accurate, so only the headroom signal is left to notice that the shard now
-  # fills the whole job cap. Refreshing hints cannot fix this one.
-  write_shard_timing_json "$tmp/3.json" 3 50 24000
-  out=$("$RUNNER" --check-shard-balance "$tmp/3.json" 2>&1) && rc=0 || rc=$?
+  # Every shard runs fifty scripts just under their default weight: the hints
+  # stay accurate and each shard fills the whole job cap, so an even repack over
+  # the same shard count would not fit either. Only another runner fixes this.
+  write_even_shard_timing_jsons "$tmp" 50 24000
+  out=$("$RUNNER" --check-shard-balance "$tmp"/*.json 2>&1) && rc=0 || rc=$?
   [ "$rc" -ne 0 ] || { rm -rf "$tmp"; fail "a shard filling the job cap must fail: $out"; }
-  assert_contains "$out" "outgrown its shard count" \
+  assert_contains "$out" "shard balance guard failed" "headroom failure must say it failed"
+  assert_contains "$out" "raise PORTABLE_SERIAL_SHARDS" \
     "headroom failure must name the shard-count remedy"
   assert_contains "$out" "job cap" "headroom failure must name the cap it measured against"
   case "$out" in
@@ -1640,6 +1661,64 @@ test_shard_balance_fails_on_lost_headroom() {
   esac
   rm -rf "$tmp"
   pass "shard balance guard fails when a shard loses its job-cap headroom"
+}
+
+test_shard_balance_warns_before_it_fails() {
+  local tmp out rc
+  tmp=$(mktemp -d "${TMPDIR:-/tmp}/fm-test-run-balance-warn.XXXXXX")
+  # Forty accurately hinted scripts per shard sit above the warning share and
+  # below the failure share. The guard must say so loudly and still leave the
+  # suite green: a lane this size needs another shard soon, not a red badge for
+  # one slow runner.
+  write_even_shard_timing_jsons "$tmp" 40 24000
+  out=$("$RUNNER" --check-shard-balance "$tmp"/*.json 2>&1) && rc=0 || rc=$?
+  [ "$rc" -eq 0 ] \
+    || { rm -rf "$tmp"; fail "a shard between the warn and fail shares must not fail: $out"; }
+  assert_contains "$out" "shard balance guard warning" "the warning must be reported as one"
+  assert_contains "$out" "raise PORTABLE_SERIAL_SHARDS" \
+    "the warning must still name the remedy it established"
+  assert_contains "$out" "FM_TEST_SHARD_BALANCE warn" \
+    "a warned run must be distinguishable from a clean one"
+  case "$out" in
+    *"shard balance guard failed"*)
+      rm -rf "$tmp"
+      fail "a warned shard must not also be reported as failed: $out"
+      ;;
+  esac
+  rm -rf "$tmp"
+  pass "shard balance guard warns above its warning share without failing the suite"
+}
+
+test_shard_balance_headroom_names_scripts_when_a_repack_would_fit() {
+  local tmp out rc shard shards
+  tmp=$(mktemp -d "${TMPDIR:-/tmp}/fm-test-run-balance-heavy.XXXXXX")
+  shards=$(configured_serial_shards)
+  [ -n "$shards" ] || { rm -rf "$tmp"; fail "could not read the configured serial shard count"; }
+  # One shard carries most of the lane while the rest sit nearly idle, and its
+  # scripts run over their hints by less than the drift bound. The lane is
+  # nowhere near needing another runner, so the guard must not prescribe one: it
+  # must say a repack fits and name the scripts whose hints let it pack heavy.
+  write_shard_timing_json "$tmp/1.json" 1 32 30000
+  shard=2
+  while [ "$shard" -le "$shards" ]; do
+    write_shard_timing_json "$tmp/$shard.json" "$shard" 4 30000
+    shard=$((shard + 1))
+  done
+  out=$("$RUNNER" --check-shard-balance "$tmp"/*.json 2>&1) && rc=0 || rc=$?
+  [ "$rc" -eq 0 ] \
+    || { rm -rf "$tmp"; fail "an imbalanced but repackable lane must not fail: $out"; }
+  assert_contains "$out" "shard balance guard warning" "the heavy shard must be reported"
+  assert_contains "$out" "which fits" "the guard must report what an even repack gives"
+  assert_contains "$out" "tests/fm-balance-fixture-1-" \
+    "a heavy shard must name the scripts to re-measure"
+  case "$out" in
+    *"raise PORTABLE_SERIAL_SHARDS"*)
+      rm -rf "$tmp"
+      fail "a lane an even repack would fit must not be told to add a shard: $out"
+      ;;
+  esac
+  rm -rf "$tmp"
+  pass "shard balance guard names drifted scripts rather than asserting shard exhaustion"
 }
 
 test_shard_balance_reports_missing_and_foreign_artifacts() {
@@ -1691,6 +1770,50 @@ test_shard_balance_refuses_a_disagreeing_job_cap() {
   assert_contains "$out" "FM_TEST_SHARD_BALANCE ok" "matching cap must pass"
   rm -rf "$tmp"
   pass "shard balance guard refuses a job cap that disagrees with ci.yml"
+}
+
+test_portable_serial_job_cap_has_one_owner() {
+  # The headroom share is only meaningful against the cap CI actually enforces,
+  # so bind all three records of it: the tests-portable-serial job's real
+  # timeout-minutes key, the value the aggregate job hands the guard, and the
+  # cap the runner reports measuring against. Parse the workflow as YAML and
+  # read the step's own command line, so a nested key or a comment cannot stand
+  # in for either.
+  command -v ruby >/dev/null 2>&1 \
+    || fail "ruby is required to parse .github/workflows/ci.yml as YAML"
+  local json job_cap step_cap runner_cap tmp
+  json=$(ruby -ryaml -rjson -e '
+doc = YAML.load_file(ARGV[0])
+job = doc.fetch("jobs").fetch("tests-portable-serial")
+aggregate = doc.fetch("jobs").fetch("tests-timing-aggregate")
+step = aggregate.fetch("steps").find { |s|
+  s.is_a?(Hash) && s["name"] == "Check portable serial shard balance"
+}
+raise "missing shard balance step" if step.nil?
+argv = step.fetch("run").split
+i = argv.index("--job-timeout-minutes")
+raise "shard balance step does not pass --job-timeout-minutes" if i.nil?
+puts JSON.generate(
+  "job_cap" => job.fetch("timeout-minutes"),
+  "step_cap" => Integer(argv.fetch(i + 1))
+)
+' "$ROOT/.github/workflows/ci.yml") \
+    || fail "could not parse the portable serial job cap from ci.yml"
+  job_cap=$(python3 -c 'import json,sys; print(json.load(sys.stdin)["job_cap"])' <<<"$json") \
+    || fail "could not read the serial job timeout from the parsed workflow"
+  step_cap=$(python3 -c 'import json,sys; print(json.load(sys.stdin)["step_cap"])' <<<"$json") \
+    || fail "could not read the balance step's job cap from the parsed workflow"
+  tmp=$(mktemp -d "${TMPDIR:-/tmp}/fm-test-run-balance-owner.XXXXXX")
+  write_shard_timing_json "$tmp/1.json" 1 6 1000
+  runner_cap=$("$RUNNER" --check-shard-balance "$tmp/1.json" \
+    | sed -n 's/.*bound=\([0-9][0-9]*\)min.*/\1/p')
+  rm -rf "$tmp"
+  [ -n "$runner_cap" ] || fail "the balance guard must report the cap it measured against"
+  [ "$step_cap" = "$job_cap" ] \
+    || fail "the balance step passes $step_cap but tests-portable-serial caps at $job_cap"
+  [ "$runner_cap" = "$job_cap" ] \
+    || fail "the runner measures against $runner_cap but tests-portable-serial caps at $job_cap"
+  pass "the portable serial job cap agrees across ci.yml, the balance step, and the runner"
 }
 
 test_aggregate_json() {
@@ -1773,5 +1896,8 @@ test_aggregate_json
 test_shard_balance_passes_and_reports_bound
 test_shard_balance_fails_on_drifted_hints
 test_shard_balance_fails_on_lost_headroom
+test_shard_balance_warns_before_it_fails
+test_shard_balance_headroom_names_scripts_when_a_repack_would_fit
 test_shard_balance_reports_missing_and_foreign_artifacts
 test_shard_balance_refuses_a_disagreeing_job_cap
+test_portable_serial_job_cap_has_one_owner

--- a/tests/fm-test-run.test.sh
+++ b/tests/fm-test-run.test.sh
@@ -1539,12 +1539,12 @@ puts JSON.generate(
 }
 
 # Writes one synthetic portable-serial timing artifact: <file> <shard> <count>
-# <per-script-ms>. The guard reads a shard's membership and durations from the
-# artifact itself, so a fixture needs no real lane. The lane label deliberately
-# carries a shard count the runner is not configured for, because an artifact
-# from an earlier partition must still be readable rather than refused.
+# <per-script-ms> [wall-ms|none] [partition]. The guard reads a shard's
+# membership and durations from the artifact itself, so a fixture needs no real
+# lane, and it counts coverage against the partition the label declares.
 write_shard_timing_json() {
-  local file=$1 shard=$2 count=$3 each=$4 wall=${5:-} partition=${6:-9}
+  local file=$1 shard=$2 count=$3 each=$4 wall=${5:-} partition=${6:-}
+  [ -n "$partition" ] || partition=$(configured_serial_shards)
   python3 - "$file" "$shard" "$count" "$each" "$wall" "$partition" <<'PY'
 import json, sys
 file, shard, count, each, wall, partition = (
@@ -1584,47 +1584,6 @@ PY
 # under test are the ones the runner actually ships. Every script is recorded at
 # <each> ms, which is above every hint in the table, and the shard's wall time is
 # set independently so drift can be exercised without also tripping headroom.
-write_hinted_shard_timing_json() {
-  local file=$1 lane=$2 each=$3 wall=$4 list
-  list="$file.paths"
-  "$RUNNER" --list --lane "$lane" >"$list" \
-    || fail "could not list the scripts of $lane"
-  [ -s "$list" ] || fail "$lane listed no scripts"
-  python3 - "$file" "$lane" "$each" "$wall" "$list" <<'PY'
-import json, sys
-file, lane, each, wall, list_path = (
-    sys.argv[1], sys.argv[2], int(sys.argv[3]), int(sys.argv[4]), sys.argv[5]
-)
-paths = [line.strip() for line in open(list_path) if line.strip()]
-scripts = [
-    {
-        "path": path,
-        "family": "pure-contract-unit",
-        "duration_ms": each,
-        "exit": 0,
-        "gate_skip": False,
-    }
-    for path in paths
-]
-json.dump(
-    {
-        "run_id": "fixture",
-        "selection": "lane=%s" % lane,
-        "started_at": "2026-09-08T00:00:00Z",
-        "finished_at": "2026-09-08T00:10:00Z",
-        "summary": {
-            "total": len(scripts),
-            "failed": 0,
-            "skipped_gate": 0,
-            "duration_ms": wall,
-        },
-        "scripts": scripts,
-    },
-    open(file, "w"),
-)
-PY
-}
-
 test_shard_balance_passes_and_reports_bound() {
   local tmp out bound
   tmp=$(mktemp -d "${TMPDIR:-/tmp}/fm-test-run-balance-ok.XXXXXX")
@@ -1639,67 +1598,6 @@ test_shard_balance_passes_and_reports_bound() {
     || { rm -rf "$tmp"; fail "balance summary must carry a numeric job cap: $out"; }
   rm -rf "$tmp"
   pass "shard balance guard passes healthy shards and reports the cap it used"
-}
-
-test_shard_balance_fails_on_drifted_hints() {
-  local tmp out rc lane
-  tmp=$(mktemp -d "${TMPDIR:-/tmp}/fm-test-run-balance-drift.XXXXXX")
-  lane="portable-serial-1of$(configured_serial_shards)"
-  # A real shard's own scripts, every one of them hinted, each recorded at ten
-  # minutes: far above any hint in the table, so the hints this runner ships are
-  # unambiguously stale against it. The shard's recorded wall time is set low so
-  # it keeps its headroom, because the point of this bound is that it says the
-  # hints are wrong while the shard is nowhere near timing out.
-  write_hinted_shard_timing_json "$tmp/1.json" "$lane" 600000 60000
-  out=$("$RUNNER" --check-shard-balance "$tmp/1.json" 2>&1) && rc=0 || rc=$?
-  [ "$rc" -ne 0 ] || { rm -rf "$tmp"; fail "drifted hints must fail the balance guard: $out"; }
-  assert_contains "$out" "the hint table is stale" "drift failure must name the stale table"
-  assert_contains "$out" "tests/" "drift failure must name a script to re-measure"
-  assert_contains "$out" "hinted scripts" \
-    "drift failure must say how many hinted scripts it compared"
-  # The two signals carry different remedies, so a drift failure must not be
-  # reported as a shard-count problem.
-  case "$out" in
-    *"raise PORTABLE_SERIAL_SHARDS"*)
-      rm -rf "$tmp"
-      fail "a drift-only shard must not be reported as outgrowing its shard count: $out"
-      ;;
-    *"job cap"*)
-      rm -rf "$tmp"
-      fail "a shard that kept its headroom must not be reported against the cap: $out"
-      ;;
-  esac
-  rm -rf "$tmp"
-  pass "shard balance guard fails on drifted hints and names what to re-measure"
-}
-
-test_shard_balance_never_charges_a_missing_hint_to_drift() {
-  local tmp out rc
-  tmp=$(mktemp -d "${TMPDIR:-/tmp}/fm-test-run-balance-unhinted.XXXXXX")
-  # Every script here is new to the lane, so none of them carries a hint. Each
-  # runs at ten minutes, hundreds of percent over the default weight the packer
-  # guessed. A hint that was never written is not a stale hint: the coverage
-  # guard owns the unmeasured share, and charging these to drift would turn any
-  # new slow test into a red aggregate job.
-  write_shard_timing_json "$tmp/2.json" 2 8 600000 60000
-  out=$("$RUNNER" --check-shard-balance "$tmp/2.json" 2>&1) && rc=0 || rc=$?
-  [ "$rc" -eq 0 ] \
-    || { rm -rf "$tmp"; fail "unhinted scripts must not fail the drift bound: $out"; }
-  case "$out" in
-    *"the hint table is stale"*)
-      rm -rf "$tmp"
-      fail "a shard with no hints at all must not be reported as stale: $out"
-      ;;
-  esac
-  # They must still count in full toward headroom, so the same scripts on a
-  # shard that actually took that long are reported against the job cap.
-  write_shard_timing_json "$tmp/3.json" 3 8 600000 4800000
-  out=$("$RUNNER" --check-shard-balance "$tmp/3.json" 2>&1) && rc=0 || rc=$?
-  [ "$rc" -ne 0 ] \
-    || { rm -rf "$tmp"; fail "unhinted work must still count toward headroom: $out"; }
-  assert_contains "$out" "job cap" "an unhinted shard over the cap must be reported against it"
-  rm -rf "$tmp"
-  pass "shard balance guard charges a missing hint to headroom, never to drift"
 }
 
 test_shard_balance_measures_the_recorded_wall_time() {
@@ -1730,33 +1628,26 @@ test_shard_balance_dedupes_repeated_shard_artifacts() {
   shards=$(configured_serial_shards)
   [ -n "$shards" ] || { rm -rf "$tmp"; fail "could not read the configured serial shard count"; }
   # Globbing several downloaded runs together hands the guard the same shard
-  # more than once. One heavy shard sits above the warning share while an even
-  # repack of the lane still fits; counting each artifact twice would double the
-  # lane total and flip that verdict to "add a shard", so a repeat must change
-  # nothing.
-  write_shard_timing_json "$tmp/1.json" 1 4 30000 960000
-  shard=2
-  while [ "$shard" -le "$shards" ]; do
-    write_shard_timing_json "$tmp/$shard.json" "$shard" 4 30000 600000
-    shard=$((shard + 1))
-  done
+  # more than once. Counting a repeat as extra coverage would make an incomplete
+  # lane look whole, so a repeat must change nothing the guard reports.
   shard=1
   while [ "$shard" -le "$shards" ]; do
+    write_shard_timing_json "$tmp/$shard.json" "$shard" 4 30000 600000
     cp "$tmp/$shard.json" "$tmp/dup-$shard.json"
     shard=$((shard + 1))
   done
   out=$("$RUNNER" --check-shard-balance "$tmp"/[0-9].json 2>&1) && rc=0 || rc=$?
-  [ "$rc" -eq 0 ] || { rm -rf "$tmp"; fail "the six distinct shards must pass: $out"; }
-  assert_contains "$out" "which fits" "the distinct lane must repack within the cap"
+  [ "$rc" -eq 0 ] || { rm -rf "$tmp"; fail "the distinct shards must pass: $out"; }
+  assert_contains "$out" "FM_TEST_SHARD_BALANCE ok shards=$shards" "the distinct lane summary"
   dup=$("$RUNNER" --check-shard-balance "$tmp"/*.json 2>&1) && rc=0 || rc=$?
   [ "$rc" -eq 0 ] || { rm -rf "$tmp"; fail "duplicated shards must not fail: $dup"; }
   assert_contains "$dup" "deduped" "a repeated shard must be reported as deduped"
-  assert_contains "$dup" "shards=$shards" "a repeated shard must not raise the shard count"
-  assert_contains "$dup" "which fits" "a repeated shard must not change the verdict"
+  assert_contains "$dup" "FM_TEST_SHARD_BALANCE ok shards=$shards" \
+    "a repeated shard must not raise the shard count"
   case "$dup" in
-    *"raise PORTABLE_SERIAL_SHARDS"*)
+    *partial*)
       rm -rf "$tmp"
-      fail "a repeated shard must not flip the remedy to adding a shard: $dup"
+      fail "a deduped lane must not be reported as partial: $dup"
       ;;
   esac
   rm -rf "$tmp"
@@ -1777,45 +1668,8 @@ test_shard_balance_refuses_mixed_partitions() {
   pass "shard balance guard refuses artifacts from two different partitions"
 }
 
-test_shard_balance_warning_is_annotated_under_actions() {
-  local tmp out rc shards shard
-  tmp=$(mktemp -d "${TMPDIR:-/tmp}/fm-test-run-balance-annot.XXXXXX")
-  shards=$(configured_serial_shards)
-  [ -n "$shards" ] || { rm -rf "$tmp"; fail "could not read the configured serial shard count"; }
-  shard=1
-  while [ "$shard" -le "$shards" ]; do
-    write_shard_timing_json "$tmp/$shard.json" "$shard" 40 24000
-    shard=$((shard + 1))
-  done
-  # The warning is the signal that has to arrive before the badge goes red, and
-  # a green step's stderr is not a signal anyone sees. Under Actions it must be
-  # raised as an annotation, and it must still not fail the step.
-  out=$(GITHUB_ACTIONS=true "$RUNNER" --check-shard-balance "$tmp"/*.json 2>&1) && rc=0 || rc=$?
-  [ "$rc" -eq 0 ] || { rm -rf "$tmp"; fail "an annotated warning must still exit 0: $out"; }
-  assert_contains "$out" "::warning::" "a warning under Actions must be an annotation"
-  assert_contains "$out" "job cap" "the annotation must carry the diagnosis"
-  case "$out" in
-    *"
-  an even repack"*)
-      rm -rf "$tmp"
-      fail "an annotation must not be split across lines: $out"
-      ;;
-  esac
-  out=$("$RUNNER" --check-shard-balance "$tmp"/*.json 2>&1) && rc=0 || rc=$?
-  [ "$rc" -eq 0 ] || { rm -rf "$tmp"; fail "a local warning must still exit 0: $out"; }
-  case "$out" in
-    *"::warning::"*)
-      rm -rf "$tmp"
-      fail "local output must stay plain text: $out"
-      ;;
-  esac
-  rm -rf "$tmp"
-  pass "shard balance guard raises its warning as a GitHub annotation"
-}
-
 # How many serial shards the runner is configured for, read from the lanes it
-# actually offers. A complete set of artifacts is what lets the guard answer
-# whether an even repack over that many shards would fit.
+# actually offers, so a fixture set covers the lane the runner would really run.
 configured_serial_shards() {
   "$RUNNER" --list-lanes | sed -n 's/^portable-serial-[0-9][0-9]*of\([0-9][0-9]*\)$/\1/p' \
     | head -n 1
@@ -1836,82 +1690,28 @@ write_even_shard_timing_jsons() {
 test_shard_balance_fails_on_lost_headroom() {
   local tmp out rc
   tmp=$(mktemp -d "${TMPDIR:-/tmp}/fm-test-run-balance-headroom.XXXXXX")
-  # Every shard runs fifty scripts just under their default weight: the hints
-  # stay accurate and each shard fills the whole job cap, so an even repack over
-  # the same shard count would not fit either. Only another runner fixes this.
-  write_even_shard_timing_jsons "$tmp" 50 24000
+  # Forty scripts per shard, each running 3s over the weight the packer guessed
+  # for it, fill the whole job cap and put the shard well past the share the
+  # guard allows. This is the one bound that decides pass or fail, and it has to
+  # fire while the shard still finishes rather than after CI cancels it, so the
+  # failure must also say which scripts to re-measure.
+  write_even_shard_timing_jsons "$tmp" 40 30000
   out=$("$RUNNER" --check-shard-balance "$tmp"/*.json 2>&1) && rc=0 || rc=$?
   [ "$rc" -ne 0 ] || { rm -rf "$tmp"; fail "a shard filling the job cap must fail: $out"; }
-  assert_contains "$out" "shard balance guard failed" "headroom failure must say it failed"
-  assert_contains "$out" "raise PORTABLE_SERIAL_SHARDS" \
-    "headroom failure must name the shard-count remedy"
-  assert_contains "$out" "job cap" "headroom failure must name the cap it measured against"
-  case "$out" in
-    *"the hint table is stale"*)
-      rm -rf "$tmp"
-      fail "an accurately hinted shard must not be reported as stale: $out"
-      ;;
-  esac
+  assert_contains "$out" "shard balance guard failed" "the guard must say it failed"
+  assert_contains "$out" "job cap" "the failure must name the cap it measured against"
+  assert_contains "$out" "re-measure" "the failure must say what to re-measure"
+  assert_contains "$out" "tests/fm-balance-fixture-" \
+    "the failure must name the scripts furthest over their hints"
+  # The same shards well under the bound are not the guard's business.
+  rm -rf "$tmp"
+  tmp=$(mktemp -d "${TMPDIR:-/tmp}/fm-test-run-balance-headroom-ok.XXXXXX")
+  write_even_shard_timing_jsons "$tmp" 20 24000
+  out=$("$RUNNER" --check-shard-balance "$tmp"/*.json 2>&1) \
+    || { rm -rf "$tmp"; fail "a shard under the bound must pass: $out"; }
+  assert_contains "$out" "FM_TEST_SHARD_BALANCE ok" "a shard under the bound must pass"
   rm -rf "$tmp"
   pass "shard balance guard fails when a shard loses its job-cap headroom"
-}
-
-test_shard_balance_warns_before_it_fails() {
-  local tmp out rc
-  tmp=$(mktemp -d "${TMPDIR:-/tmp}/fm-test-run-balance-warn.XXXXXX")
-  # Forty accurately hinted scripts per shard sit above the warning share and
-  # below the failure share. The guard must say so loudly and still leave the
-  # suite green: a lane this size needs another shard soon, not a red badge for
-  # one slow runner.
-  write_even_shard_timing_jsons "$tmp" 40 24000
-  out=$("$RUNNER" --check-shard-balance "$tmp"/*.json 2>&1) && rc=0 || rc=$?
-  [ "$rc" -eq 0 ] \
-    || { rm -rf "$tmp"; fail "a shard between the warn and fail shares must not fail: $out"; }
-  assert_contains "$out" "shard balance guard warning" "the warning must be reported as one"
-  assert_contains "$out" "raise PORTABLE_SERIAL_SHARDS" \
-    "the warning must still name the remedy it established"
-  assert_contains "$out" "FM_TEST_SHARD_BALANCE warn" \
-    "a warned run must be distinguishable from a clean one"
-  case "$out" in
-    *"shard balance guard failed"*)
-      rm -rf "$tmp"
-      fail "a warned shard must not also be reported as failed: $out"
-      ;;
-  esac
-  rm -rf "$tmp"
-  pass "shard balance guard warns above its warning share without failing the suite"
-}
-
-test_shard_balance_headroom_names_scripts_when_a_repack_would_fit() {
-  local tmp out rc shard shards
-  tmp=$(mktemp -d "${TMPDIR:-/tmp}/fm-test-run-balance-heavy.XXXXXX")
-  shards=$(configured_serial_shards)
-  [ -n "$shards" ] || { rm -rf "$tmp"; fail "could not read the configured serial shard count"; }
-  # One shard carries most of the lane while the rest sit nearly idle, and its
-  # scripts run over their hints by less than the drift bound. The lane is
-  # nowhere near needing another runner, so the guard must not prescribe one: it
-  # must say a repack fits and name the scripts whose hints let it pack heavy.
-  write_shard_timing_json "$tmp/1.json" 1 32 30000
-  shard=2
-  while [ "$shard" -le "$shards" ]; do
-    write_shard_timing_json "$tmp/$shard.json" "$shard" 4 30000
-    shard=$((shard + 1))
-  done
-  out=$("$RUNNER" --check-shard-balance "$tmp"/*.json 2>&1) && rc=0 || rc=$?
-  [ "$rc" -eq 0 ] \
-    || { rm -rf "$tmp"; fail "an imbalanced but repackable lane must not fail: $out"; }
-  assert_contains "$out" "shard balance guard warning" "the heavy shard must be reported"
-  assert_contains "$out" "which fits" "the guard must report what an even repack gives"
-  assert_contains "$out" "tests/fm-balance-fixture-1-" \
-    "a heavy shard must name the scripts to re-measure"
-  case "$out" in
-    *"raise PORTABLE_SERIAL_SHARDS"*)
-      rm -rf "$tmp"
-      fail "a lane an even repack would fit must not be told to add a shard: $out"
-      ;;
-  esac
-  rm -rf "$tmp"
-  pass "shard balance guard names drifted scripts rather than asserting shard exhaustion"
 }
 
 test_shard_balance_reports_missing_and_foreign_artifacts() {
@@ -1945,68 +1745,28 @@ JSON
   pass "shard balance guard reports missing and foreign timing artifacts"
 }
 
-test_shard_balance_refuses_a_disagreeing_job_cap() {
-  local tmp out rc bound
-  tmp=$(mktemp -d "${TMPDIR:-/tmp}/fm-test-run-balance-cap.XXXXXX")
-  write_shard_timing_json "$tmp/1.json" 1 6 1000
-  bound=$("$RUNNER" --check-shard-balance "$tmp/1.json" \
-    | sed -n 's/.*bound=\([0-9][0-9]*\)min.*/\1/p')
-  # ci.yml passes back the cap it sets on the serial job, so a cap that moved in
-  # only one of the two places must be refused rather than silently measured
-  # against the wrong number.
-  out=$("$RUNNER" --check-shard-balance --job-timeout-minutes "$((bound + 7))" "$tmp/1.json" 2>&1) \
-    && rc=0 || rc=$?
-  [ "$rc" -ne 0 ] || { rm -rf "$tmp"; fail "a disagreeing job cap must be refused: $out"; }
-  assert_contains "$out" "disagrees" "cap mismatch must say the two records disagree"
-  out=$("$RUNNER" --check-shard-balance --job-timeout-minutes "$bound" "$tmp/1.json") \
-    || { rm -rf "$tmp"; fail "the recorded job cap must be accepted: $out"; }
-  assert_contains "$out" "FM_TEST_SHARD_BALANCE ok" "matching cap must pass"
-  rm -rf "$tmp"
-  pass "shard balance guard refuses a job cap that disagrees with ci.yml"
-}
-
 test_portable_serial_job_cap_has_one_owner() {
-  # The headroom share is only meaningful against the cap CI actually enforces,
-  # so bind all three records of it: the tests-portable-serial job's real
-  # timeout-minutes key, the value the aggregate job hands the guard, and the
-  # cap the runner reports measuring against. Parse the workflow as YAML and
-  # read the step's own command line, so a nested key or a comment cannot stand
-  # in for either.
+  # The guard's share is only meaningful against the cap CI actually enforces.
+  # The runner owns that number; this binds it to the tests-portable-serial
+  # job's real timeout-minutes key, parsed as YAML so a nested key or a comment
+  # cannot stand in for it.
   command -v ruby >/dev/null 2>&1 \
     || fail "ruby is required to parse .github/workflows/ci.yml as YAML"
-  local json job_cap step_cap runner_cap tmp
-  json=$(ruby -ryaml -rjson -e '
+  local job_cap runner_cap tmp
+  job_cap=$(ruby -ryaml -e '
 doc = YAML.load_file(ARGV[0])
-job = doc.fetch("jobs").fetch("tests-portable-serial")
-aggregate = doc.fetch("jobs").fetch("tests-timing-aggregate")
-step = aggregate.fetch("steps").find { |s|
-  s.is_a?(Hash) && s["name"] == "Check portable serial shard balance"
-}
-raise "missing shard balance step" if step.nil?
-argv = step.fetch("run").split
-i = argv.index("--job-timeout-minutes")
-raise "shard balance step does not pass --job-timeout-minutes" if i.nil?
-puts JSON.generate(
-  "job_cap" => job.fetch("timeout-minutes"),
-  "step_cap" => Integer(argv.fetch(i + 1))
-)
+puts doc.fetch("jobs").fetch("tests-portable-serial").fetch("timeout-minutes")
 ' "$ROOT/.github/workflows/ci.yml") \
     || fail "could not parse the portable serial job cap from ci.yml"
-  job_cap=$(python3 -c 'import json,sys; print(json.load(sys.stdin)["job_cap"])' <<<"$json") \
-    || fail "could not read the serial job timeout from the parsed workflow"
-  step_cap=$(python3 -c 'import json,sys; print(json.load(sys.stdin)["step_cap"])' <<<"$json") \
-    || fail "could not read the balance step's job cap from the parsed workflow"
   tmp=$(mktemp -d "${TMPDIR:-/tmp}/fm-test-run-balance-owner.XXXXXX")
   write_shard_timing_json "$tmp/1.json" 1 6 1000
   runner_cap=$("$RUNNER" --check-shard-balance "$tmp/1.json" \
     | sed -n 's/.*bound=\([0-9][0-9]*\)min.*/\1/p')
   rm -rf "$tmp"
   [ -n "$runner_cap" ] || fail "the balance guard must report the cap it measured against"
-  [ "$step_cap" = "$job_cap" ] \
-    || fail "the balance step passes $step_cap but tests-portable-serial caps at $job_cap"
   [ "$runner_cap" = "$job_cap" ] \
     || fail "the runner measures against $runner_cap but tests-portable-serial caps at $job_cap"
-  pass "the portable serial job cap agrees across ci.yml, the balance step, and the runner"
+  pass "the portable serial job cap agrees between ci.yml and the runner"
 }
 
 test_aggregate_json() {
@@ -2087,15 +1847,9 @@ test_jobs_parallel_scheduler_and_failure_propagation
 test_herdr_ci_family_run_has_a_step_timeout
 test_aggregate_json
 test_shard_balance_passes_and_reports_bound
-test_shard_balance_fails_on_drifted_hints
-test_shard_balance_never_charges_a_missing_hint_to_drift
 test_shard_balance_measures_the_recorded_wall_time
 test_shard_balance_dedupes_repeated_shard_artifacts
 test_shard_balance_refuses_mixed_partitions
-test_shard_balance_warning_is_annotated_under_actions
 test_shard_balance_fails_on_lost_headroom
-test_shard_balance_warns_before_it_fails
-test_shard_balance_headroom_names_scripts_when_a_repack_would_fit
 test_shard_balance_reports_missing_and_foreign_artifacts
-test_shard_balance_refuses_a_disagreeing_job_cap
 test_portable_serial_job_cap_has_one_owner

--- a/tests/fm-test-run.test.sh
+++ b/tests/fm-test-run.test.sh
@@ -1539,12 +1539,12 @@ puts JSON.generate(
 }
 
 # Writes one synthetic portable-serial timing artifact: <file> <shard> <count>
-# <per-script-ms> [wall-ms|none] [partition]. The guard reads a shard's
-# membership and durations from the artifact itself, so a fixture needs no real
-# lane, and it counts coverage against the partition the label declares.
+# <per-script-ms> [wall-ms|none]. The guard reads a shard's membership and
+# durations from the artifact itself, so a fixture needs no real lane, and it
+# counts coverage against the shard count the lane label declares.
 write_shard_timing_json() {
-  local file=$1 shard=$2 count=$3 each=$4 wall=${5:-} partition=${6:-}
-  [ -n "$partition" ] || partition=$(configured_serial_shards)
+  local file=$1 shard=$2 count=$3 each=$4 wall=${5:-} partition
+  partition=$(configured_serial_shards)
   python3 - "$file" "$shard" "$count" "$each" "$wall" "$partition" <<'PY'
 import json, sys
 file, shard, count, each, wall, partition = (
@@ -1580,10 +1580,6 @@ json.dump(
 PY
 }
 
-# Writes an artifact carrying a real serial shard's own scripts, so the hints
-# under test are the ones the runner actually ships. Every script is recorded at
-# <each> ms, which is above every hint in the table, and the shard's wall time is
-# set independently so drift can be exercised without also tripping headroom.
 test_shard_balance_passes_and_reports_bound() {
   local tmp out bound
   tmp=$(mktemp -d "${TMPDIR:-/tmp}/fm-test-run-balance-ok.XXXXXX")
@@ -1620,52 +1616,6 @@ test_shard_balance_measures_the_recorded_wall_time() {
   assert_contains "$out" "20.00 min" "the fallback must be the sum of the scripts"
   rm -rf "$tmp"
   pass "shard balance guard measures recorded wall time and falls back to the script sum"
-}
-
-test_shard_balance_dedupes_repeated_shard_artifacts() {
-  local tmp out dup rc shards shard
-  tmp=$(mktemp -d "${TMPDIR:-/tmp}/fm-test-run-balance-dupe.XXXXXX")
-  shards=$(configured_serial_shards)
-  [ -n "$shards" ] || { rm -rf "$tmp"; fail "could not read the configured serial shard count"; }
-  # Globbing several downloaded runs together hands the guard the same shard
-  # more than once. Counting a repeat as extra coverage would make an incomplete
-  # lane look whole, so a repeat must change nothing the guard reports.
-  shard=1
-  while [ "$shard" -le "$shards" ]; do
-    write_shard_timing_json "$tmp/$shard.json" "$shard" 4 30000 600000
-    cp "$tmp/$shard.json" "$tmp/dup-$shard.json"
-    shard=$((shard + 1))
-  done
-  out=$("$RUNNER" --check-shard-balance "$tmp"/[0-9].json 2>&1) && rc=0 || rc=$?
-  [ "$rc" -eq 0 ] || { rm -rf "$tmp"; fail "the distinct shards must pass: $out"; }
-  assert_contains "$out" "FM_TEST_SHARD_BALANCE ok shards=$shards" "the distinct lane summary"
-  dup=$("$RUNNER" --check-shard-balance "$tmp"/*.json 2>&1) && rc=0 || rc=$?
-  [ "$rc" -eq 0 ] || { rm -rf "$tmp"; fail "duplicated shards must not fail: $dup"; }
-  assert_contains "$dup" "deduped" "a repeated shard must be reported as deduped"
-  assert_contains "$dup" "FM_TEST_SHARD_BALANCE ok shards=$shards" \
-    "a repeated shard must not raise the shard count"
-  case "$dup" in
-    *partial*)
-      rm -rf "$tmp"
-      fail "a deduped lane must not be reported as partial: $dup"
-      ;;
-  esac
-  rm -rf "$tmp"
-  pass "shard balance guard keeps one copy of a repeated shard artifact"
-}
-
-test_shard_balance_refuses_mixed_partitions() {
-  local tmp out rc
-  tmp=$(mktemp -d "${TMPDIR:-/tmp}/fm-test-run-balance-mixed.XXXXXX")
-  # Shard 1 of five and shard 1 of six cover different work, so their totals
-  # cannot be added. Refuse rather than quietly counting both.
-  write_shard_timing_json "$tmp/a.json" 1 4 30000 120000 5
-  write_shard_timing_json "$tmp/b.json" 1 4 30000 120000 6
-  out=$("$RUNNER" --check-shard-balance "$tmp/a.json" "$tmp/b.json" 2>&1) && rc=0 || rc=$?
-  [ "$rc" -ne 0 ] || { rm -rf "$tmp"; fail "mixed partitions must be refused: $out"; }
-  assert_contains "$out" "partitions" "the refusal must say the inputs mix partitions"
-  rm -rf "$tmp"
-  pass "shard balance guard refuses artifacts from two different partitions"
 }
 
 # How many serial shards the runner is configured for, read from the lanes it
@@ -1848,8 +1798,6 @@ test_herdr_ci_family_run_has_a_step_timeout
 test_aggregate_json
 test_shard_balance_passes_and_reports_bound
 test_shard_balance_measures_the_recorded_wall_time
-test_shard_balance_dedupes_repeated_shard_artifacts
-test_shard_balance_refuses_mixed_partitions
 test_shard_balance_fails_on_lost_headroom
 test_shard_balance_reports_missing_and_foreign_artifacts
 test_portable_serial_job_cap_has_one_owner

--- a/tests/fm-test-run.test.sh
+++ b/tests/fm-test-run.test.sh
@@ -1539,9 +1539,9 @@ puts JSON.generate(
 }
 
 # Writes one synthetic portable-serial timing artifact: <file> <shard> <count>
-# <per-script-ms> [wall-ms|none]. The guard reads a shard's membership and
-# durations from the artifact itself, so a fixture needs no real lane, and it
-# counts coverage against the shard count the lane label declares.
+# <per-script-ms> [wall-ms]. The guard reads a shard's membership and durations
+# from the artifact itself, so a fixture needs no real lane, and it counts
+# coverage against the shard count the lane label declares.
 write_shard_timing_json() {
   local file=$1 shard=$2 count=$3 each=$4 wall=${5:-} partition
   partition=$(configured_serial_shards)
@@ -1560,12 +1560,14 @@ scripts = [
     }
     for i in range(count)
 ]
-summary = {"total": count, "failed": 0, "skipped_gate": 0}
 # The runner records the shard's wall time here and the guard measures headroom
-# against it, so a fixture can set it apart from the script sum, or drop it to
-# exercise the fallback.
-if wall != "none":
-    summary["duration_ms"] = int(wall) if wall else each * count
+# against it, so a fixture can set it apart from the script sum.
+summary = {
+    "total": count,
+    "failed": 0,
+    "skipped_gate": 0,
+    "duration_ms": int(wall) if wall else each * count,
+}
 json.dump(
     {
         "run_id": "fixture",
@@ -1607,15 +1609,8 @@ test_shard_balance_measures_the_recorded_wall_time() {
   [ "$rc" -ne 0 ] \
     || { rm -rf "$tmp"; fail "a shard whose wall time fills the cap must fail: $out"; }
   assert_contains "$out" "19.00 min" "the share must be taken from the recorded wall time"
-  # An artifact that carries no usable wall time still has to be checked, so the
-  # per-script sum stands in for it.
-  write_shard_timing_json "$tmp/2.json" 2 40 30000 none
-  out=$("$RUNNER" --check-shard-balance "$tmp/2.json" 2>&1) && rc=0 || rc=$?
-  [ "$rc" -ne 0 ] \
-    || { rm -rf "$tmp"; fail "a wall-less artifact must fall back to the script sum: $out"; }
-  assert_contains "$out" "20.00 min" "the fallback must be the sum of the scripts"
   rm -rf "$tmp"
-  pass "shard balance guard measures recorded wall time and falls back to the script sum"
+  pass "shard balance guard measures the shard's recorded wall time"
 }
 
 # How many serial shards the runner is configured for, read from the lanes it


### PR DESCRIPTION
## What this changes

The portable serial lane was being cancelled at its 20-minute cap on roughly one pull-request run in five. The split algorithm was sound; it was fed stale numbers. Three changes, together:

1. **Refreshed the duration hints** from the slowest measured duration per script across four green CI runs on 2026-09-07 and 2026-09-08 ([34180535832](https://github.com/kunchenguid/firstmate/actions/runs/34180535832), [34167501605](https://github.com/kunchenguid/firstmate/actions/runs/34167501605), [34167485767](https://github.com/kunchenguid/firstmate/actions/runs/34167485767), [34156531229](https://github.com/kunchenguid/firstmate/actions/runs/34156531229)). They now cover all 152 lane scripts, so `serial_unhinted` goes 10 to 0.
2. **Five shards to six**, in the runner and the `ci.yml` matrix.
3. **A guard that checks estimate accuracy, not just presence** - `--check-shard-balance`, run by `tests-timing-aggregate` over the timing artifacts every serial lane already uploads. It fails when a shard's measured wall time exceeds 90% of the job cap, and names the scripts furthest over their hints so the failure says what to re-measure.

Without point 3 the table goes stale silently again. That is not hypothetical: the same remedy was applied on 2026-09-01 and the lane was cancelling again 19 hours later.

## Evidence

Before, the coverage guard was green while a shard ran 40% over its predicted weight:

```
$ bin/fm-test-run.sh --check-coverage
FM_TEST_COVERAGE ok total=189 parallel=24 serial=152 serial_shards=5 serial_unhinted=10 herdr=13   # before
FM_TEST_COVERAGE ok total=189 parallel=24 serial=152 serial_shards=6 serial_unhinted=0  herdr=13   # after
```

The new check fires on the stale table and passes on the refreshed one:

```
# stale 2026-09-01 hints, real lanes from green run 34180535832
shard balance guard failed: portable-serial-4of5 ran 19.19 min, 96.0% of the 20 min job cap (max 90%); repack the lane
  re-measure the scripts furthest over their hints:
    tests/fm-pi-branch-extension.test.sh measured 162.5s hint 22.2s (+140.3s)
    tests/fm-bearings-board.test.sh      measured  36.8s hint  4.2s  (+32.6s)
    ...

# refreshed hints, six shards
FM_TEST_SHARD_BALANCE ok shards=6 worst_share=portable-serial-5of6@66.8% bound=20min
```

Balance from the real packer at six shards: 13.82 min of assignment weight each, 38 ms imbalance. Regrouping the four source runs' real per-script durations under that partition puts the worst shard at 13.14-13.37 min, 66-67% of the bound.

**Threshold, chosen on measurement.** 90% of 20 min fires at 18.00 min. At the measured lane growth of +2.1 min/day over six shards (+0.35 min/shard/day) that gives about 5.7 days of warning before a shard would actually be cancelled. The share is the suite's wall clock against the job's, so it understates by the surrounding steps' cost: measured across 30 `tests-portable-serial` jobs from 6 green runs, that is 15-24 s, worst case 2.0% of the bound against the 10% the threshold reserves.

## The check on this PR is red, and it is not from this change

**14 checks: 13 passed, 1 failed, none cancelled.** The failure is `Behavior portable serial 1`, on `tests/fm-backend.test.sh`:

```
not ok - fm-spawn.sh should succeed for a project reached through a symlinked prefix when the backend reports physical cwd
error: could not resolve the shared Treehouse project lock ... expected exit 0, got 1
```

It is a genuine assertion failure, not a ceiling cut: the lane ended at **13.25 min** against the 20-minute cap, where a cut lands on the bound at ~20.27 min and reports cancelled.

Two measurements establish it is not caused by this change:

- The script **passes when run alone** on this branch (28 assertions, 0 failures).
- The identical assertion **fails in a real CI lane on `fm/fm-captain-hold-recursive-stale-lock`** (`0753b42b`), a branch that contains none of this work and runs the **old five-way packing** - and it failed there in shard 5, not shard 1.

A coupling created by this repacking could not fail on a branch without the repacking. This branch also touches neither the failing test nor `bin/fm-spawn.sh`, where that error originates. A test that passes alone and fails in a real lane says something about running conditions rather than about the assertion; it is routed for its own investigation.

## Two moves that would have produced a green badge, both declined

**Adjusting the shard packing** would have moved that test to different neighbours and very likely turned the check green. It was deliberately not done. If the failure is a latent condition, hiding it behind a packing choice is how it returns on a day nobody is looking, and a test that only passes next to the right neighbours is not a test we actually have.

**The pipeline auto-committed a repair** for it (`d65ceb7e`, a three-line `FM_HOME/state` fixture in `tests/fm-backend.test.sh`) and pushed it. It is **deliberately reverted** in `d0866aa5`.

Had that repair stood, it would have buried a defect **already routed for its own investigation**. The cost of accepting it was not untidiness in this pull request: it was the finding itself. The investigation depends on the failure still being reproducible, and a fixture that makes the symptom disappear without diagnosing it destroys exactly the evidence that investigation was opened to examine. The repair also touches a file this delivery otherwise does not, and it reversed an explicit decision not to fix that failure here. The fixture may well be diagnostically right - that belongs to the investigation, with evidence, not to a three-line drive-by inside a shard-balance change.

## Status of the checks: a red mark accepted by decision, not a clean pass

`Behavior portable serial 1` is **red, and was accepted by explicit decision** rather than fixed or hidden. The reason: the failure is pre-existing, established by the two measurements above, reproduced on an unrelated branch running the old five-way packing, and routed as its own separate investigation. Accepting it was a decision taken deliberately; this pull request should not be read as having passed its checks.

Every other check passes.

### A second observation, recorded because it is a negative result

After the revert, the pipeline was run once more to produce a valid attestation for the current head. That run reached **the same step, on the same branch, with the same red check** that had earlier produced the unrequested auto-commit - and this time it **asked instead of acting**: it parked at an approval gate rather than committing a repair. Head unchanged, no commits, and a written 25-check expectation recorded before the run all still passing afterwards.

So the behaviour is **situational, not deterministic**. That is harder to characterise than a defect that always acts, and that difficulty is itself the finding.

## What the six lanes prove

**All six serial lanes ran to completion. None was cancelled** - 12.31, 13.25, 13.46, 14.03, 14.33 and 15.40 min against the 20-minute cap. On a lane that had been cut at 20 minutes on about one run in five, that is the first direct evidence the split works, and it is the thing this change set out to fix.

## Publication steps can remove required content, unpredictably

This description had to be restored after publication. The pipeline's PR step rewrote the body and **deleted the whole description** - both measurements, both declined green-badge moves, and the revert rationale - replacing it with a generated summary. It was restored by appending the step's own attestation section to the description rather than overwriting either, so both artefacts survive; the attestation's `head_sha` matches the validated head.

This is the third instance today across two deliveries, which makes it a property of the tooling rather than an accident of one branch. It also corrects an earlier reading: on another delivery the step removed *some* content and left other content intact, which looked selective. Here it removed *everything*. So it is **not reliably selective, it varies** - nobody can predict what survives a publication step.

The only safe assumption is therefore that **required content must be verified present after publication**, not trusted to persist through it.

## Note for a later reader

The guard's final shape is deliberately minimal. A richer two-shape diagnosis was built during validation and then removed on purpose: a second pass/fail bound on hint drift, a non-failing warning share below the failure line, and a branch separating "the estimates are wrong" from "the lane has outgrown its shard count". Several defensive branches were likewise added and then removed. Both properties actually required survive in the single check - it fires before the badge goes red, and it names what to re-measure - and `docs/fm-test-portable-shards.md` records the decision so it is not re-derived and added back.

---

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"d0866aa569c25bf3a5a0d70e27b3ee68a0501544","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}],"live_validation":{"verdict":"go","live":5,"total":6}} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- Live validation: ✅ go - 5 of 6 scenarios driven live against the product

| Scenario | Result | Live | Evidence |
| --- | --- | --- | --- |
| List the refreshed partition: six nonempty, disjoint shards cover all 152 scripts and match the documented partition derived from four green runs. | ✅ pass | live | Six-shard selection and refusals; Measured-source comparison and historical replay |
| Request an obsolete five-shard lane or an invalid shard index: the runner refuses instead of silently omitting work. | ✅ pass | live | Six-shard selection and refusals |
| Check a freshly completed, filtered numbered shard: the guard passes, reports the 20-minute bound, and explicitly leaves five missing shards unchecked. | ✅ pass | live | Healthy live guard |
| Delay an isolated shard and let it finish before cancellation: at 18.06 minutes the guard exits 1, reports 90.3% of the cap, and names the slowed script for remeasurement. | ✅ pass | live | Delayed live guard; Fresh delayed-shard timing JSON; Live runner and controlled pause |
| Invoke the guard without artifacts or with a missing file: it refuses with exit code 2. | ✅ pass | live | Missing-input refusals |
| Run the complete six-shard GitHub workflow and observe fresh job headroom and aggregate-guard execution. | ⏸️ untested | no | This phase is forbidden from running the complete suite or executing CI. The outer executor must run the target through the GitHub workflow. |

- <code>`TMPDIR=&#34;$PWD/.test-phase-tmp&#34; bash tests/fm-test-run.test.sh` — passed, including fixture-based wall-time measurement checks.</code>
- <code>`bin/fm-test-run.sh --list-lanes`, `--check-coverage`, and `--list --lane` for all six numbered shards.</code>
- <code>`bin/fm-test-run.sh --list --lane` with `portable-serial-1of5`, `portable-serial-7of6`, and `portable-serial-0of6`.</code>
- <code>Parsed `.github/workflows/ci.yml` with Ruby YAML; confirmed the six-member matrix and unchanged 20-minute cap.</code>
- <code>`gh-axi run view` and `gh-axi run download` for runs 34180535832, 34167501605, 34167485767, and 34156531229.</code>
- `python3 ~/.no-mistakes/evidence/01M20TE28ZPPZJ712ASRP3J3S9/measurements-check.py`
- <code>`python3 ~/.no-mistakes/evidence/01M20TE28ZPPZJ712ASRP3J3S9/live-guard-driver.py` — healthy execution and a real 1082-second process pause, without mocked clocks or timing data.</code>
- `Exercised missing-input CLI refusals; removed temporary worktree files and confirmed no remaining test processes, a clean worktree, and unchanged target HEAD.`
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>


