### PR TITLE
fix(bearings): show PR link on underway rows with an open PR

### DIFF
--- a/.agents/skills/bearings/assets/board-template.html
+++ b/.agents/skills/bearings/assets/board-template.html
@@ -622,6 +622,11 @@ __FM_BEARINGS_BOARD_DATA__
        no repo is known */
     main.appendChild(el("div", "bb-row__sub", t.kind + " · " + (t.repo || t.id)));
     row.appendChild(main);
+    if (t.pr_url) {
+      var uwa = el("a", "bb-row__pr", "#" + t.pr_url.split("/").pop());
+      uwa.href = t.pr_url; uwa.title = t.pr_url; uwa.target = "_blank"; uwa.rel = "noopener";
+      row.appendChild(uwa);
+    }
     uw.appendChild(row);
   });
 

--- a/bin/fm-bearings-board.sh
+++ b/bin/fm-bearings-board.sh
@@ -153,7 +153,8 @@ validate_payload() {  # <data.json>
       and (if .type == "merge" then (.risk | nonempty_string) else true end);
     def underway_item:
       type == "object" and repo_marker and (.id | nonempty_string)
-      and (.state | nonempty_string) and (.doing | nonempty_string) and (.kind | nonempty_string);
+      and (.state | nonempty_string) and (.doing | nonempty_string) and (.kind | nonempty_string)
+      and optional_https_url("pr_url");
     def landed_item:
       type == "object" and repo_marker and (.id | nonempty_string)
       and (.what | nonempty_string) and (.owner | nonempty_string)

--- a/tests/assets/board-render-harness.mjs
+++ b/tests/assets/board-render-harness.mjs
@@ -3,7 +3,7 @@
 // asserted through the real template rather than by reading its source.
 //
 // Usage: node board-render-harness.mjs <built-board.html>
-// Prints one JSON document: { stats:[{n,label}], charted:[{title,sub,badges,pickable}] }
+// Prints one JSON document: { stats:[{n,label}], charted:[{title,sub,badges,pickable}], underway:[{pr_href}] }
 import { readFileSync } from "node:fs";
 
 const html = readFileSync(process.argv[2], "utf8");
@@ -114,4 +114,12 @@ const errorText = [...byId.entries()]
 const empty = ch.children.filter((c) => c.className.includes("bb-empty")).map((c) => c.textContent);
 const more = ch.children.filter((c) => c.className.includes("bb-morechip")).map((c) => c.textContent);
 
-process.stdout.write(JSON.stringify({ stats, charted, empty, more, error: errorText }) + "\n");
+const uw = byId.get("bb-underway") || new Node("div");
+const underway = uw.children
+  .filter((r) => r.className.split(/\s+/).includes("bb-row"))
+  .map((row) => {
+    const pr = row.children.find((c) => c.className.includes("bb-row__pr"));
+    return { pr_href: pr?.href ?? null };
+  });
+
+process.stdout.write(JSON.stringify({ stats, charted, underway, empty, more, error: errorText }) + "\n");

--- a/tests/fm-bearings-board-render.test.sh
+++ b/tests/fm-bearings-board-render.test.sh
@@ -57,11 +57,12 @@ SH
 }
 
 # Build the board from <charted-json> and return what the renderer produced.
-render() {  # <home> <charted-json> [charted_more] [charted_warning_more]
-  local home=$1 charted=$2 more=${3:-0} warning_more=${4:-0} data="$1/payload.json"
-  jq -n --argjson charted "$charted" --argjson more "$more" --argjson warning_more "$warning_more" '{
+render() {  # <home> <charted-json> [charted_more] [charted_warning_more] [underway-json]
+  local home=$1 charted=$2 more=${3:-0} warning_more=${4:-0} underway=${5:-[]} data="$1/payload.json"
+  jq -n --argjson charted "$charted" --argjson more "$more" --argjson warning_more "$warning_more" \
+    --argjson underway "$underway" '{
     schema:"fm-bearings-board.v1", home:"render-home", generated:"2026-08-26T00:00Z",
-    prs_live:false, captains_call:[], underway:[], landed:[],
+    prs_live:false, captains_call:[], underway:$underway, landed:[],
     charted:$charted, charted_more:$more, charted_warning_more:$warning_more}' > "$data"
   PATH="$home/fakebin:$PATH" FM_HOME="$home" \
     FM_STATE_OVERRIDE="$home/state" FM_DATA_OVERRIDE="$home/data" \
@@ -158,8 +159,24 @@ test_an_omitted_kind_keeps_the_existing_queued_rendering() {
   pass "an omitted kind renders exactly as queued work always did"
 }
 
+test_an_underway_row_with_a_pr_renders_a_pr_link() {
+  local home out
+  home=$(make_home underway-pr)
+  out=$(render "$home" '[]' 0 0 '[
+    {"id":"task-a","repo":"sample","state":"done","doing":"Waiting on review","kind":"ship","pr_url":"https://github.com/example/sample/pull/42"},
+    {"id":"task-b","repo":"sample","state":"working","doing":"Implementing","kind":"ship"}
+  ]')
+  printf '%s' "$out" | jq -e '
+    (.underway | length) == 2
+      and (.underway[0].pr_href == "https://github.com/example/sample/pull/42")
+      and (.underway[1].pr_href == null)
+  ' >/dev/null || fail "a done underway row with a pr_url did not render a PR link: $out"
+  pass "an underway row with a pr_url renders a PR link, and one without stays unchanged"
+}
+
 test_a_warning_row_reads_as_a_repair_not_as_queued_work
 test_warnings_are_excluded_from_the_charted_next_count
 test_a_board_of_only_warnings_still_reports_nothing_queued
 test_omitted_warnings_never_count_as_more_queued
 test_an_omitted_kind_keeps_the_existing_queued_rendering
+test_an_underway_row_with_a_pr_renders_a_pr_link


### PR DESCRIPTION
## Intent

On the /bearings lavish fleet board, the Underway section shows tasks that already have an open PR (state "done", waiting on review), but unlike the Landed section it never shows a link to that PR. The captain noticed a done Underway row with a pr_url in the composed payload still rendered with no PR link, and asked for it to be fixed so Underway rows with a PR link visibly show it, the same way Landed rows already do.

## What Changed
- Render a PR link on Underway rows in the fleet board template when the row's `pr_url` is present, matching the existing Landed row behavior.
- Extend the board data validator (`fm-bearings-board.sh`) to accept an optional `pr_url` field on underway items.
- Update the render harness and test suite to capture underway row PR links and add a test asserting a done Underway row with `pr_url` renders a link while one without stays unchanged.

## Risk Assessment

✅ Low: The change is a small, well-scoped fix that mirrors the existing Landed row PR-link rendering pattern exactly for Underway rows, includes matching schema validation (optional_https_url for pr_url) consistent with other item types, and is covered by a behavior-level test that exercises the real rendered DOM rather than source text.

## Testing

Ran the focused fm-bearings-board render test suite (uses a real DOM-harness against the built board.html, not source-string matching) at the target commit and all cases pass, including the new case asserting a done Underway row with pr_url renders an anchor with the PR href while a row without pr_url stays unchanged; reproduced the regression by isolating the fix from board-template.html/fm-bearings-board.sh and confirmed the same test fails without the fix, then restored the target commit's working tree state cleanly.

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"39ff3d7c778a5932124dd79b2af86be679539226","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `bash tests/fm-bearings-board-render.test.sh (full targeted suite including the new test_an_underway_row_with_a_pr_renders_a_pr_link)`
- `Manually reverted only .agents/skills/bearings/assets/board-template.html and bin/fm-bearings-board.sh to the base commit while keeping the new test, confirming the new test fails pre-fix (pr_href rendered as null) and passes post-fix`
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>⚠️ **Lint** - 1 warning</summary>

- ⚠️ linter found issues (exit code 1)
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
