### PR TITLE
fix(bin): route remaining large snapshot JSON through files instead of argv

### DIFF
--- a/bin/fm-bearings-snapshot.sh
+++ b/bin/fm-bearings-snapshot.sh
@@ -205,11 +205,16 @@ HOME_LABEL=$(printf '%s' "$SNAP" | jq -er '.fm_home | strings | split("/") | (.[
 
 # --- optional live GitHub PR enrichment -------------------------------------
 PR_STATUS='not_requested (run: /bearings include PRs)'
-CANDIDATE_PRS='[]'
 PR_REPOS_TOTAL=0
 PR_REPOS_SHOWN=0
 PR_ROWS_CAPPED=0
 PR_ROWS_MIN_TOTAL=0
+CANDIDATE_PRS_FILE=$(umask 077; mktemp "${TMPDIR:-/tmp}/fm-bearings-prs.XXXXXX") \
+  || { echo "fm-bearings-snapshot: candidate PR transport creation failed" >&2; exit 1; }
+cleanup_candidate_prs() {
+  rm -f -- "$CANDIDATE_PRS_FILE"
+}
+trap cleanup_candidate_prs EXIT
 
 # Parse owner/repo from an https or ssh GitHub remote/PR URL; empty if not GitHub.
 repo_slug() {  # <url>
@@ -247,7 +252,7 @@ $(printf '%s' "$SNAP" | jq -r '.tasks[] | select(.kind != "secondmate") | .paths
 EOF
 
     for repo in $repos; do PR_REPOS_TOTAL=$((PR_REPOS_TOTAL + 1)); done
-    nrepos=0; npr=0; nwarn=0; ncapped=0; rows='[]'
+    nrepos=0; npr=0; nwarn=0; ncapped=0
     pr_fetch_limit=$((FM_BEARINGS_PR_LIMIT + 1))
     for repo in $repos; do
       if [ "$ALL_PR_REPOS" != 1 ] && [ "$nrepos" -ge "$FM_BEARINGS_PR_REPOS" ]; then break; fi
@@ -276,12 +281,12 @@ EOF
       cnt=$(printf '%s' "$repo_rows" | jq 'length')
       [ "$returned" -gt "$FM_BEARINGS_PR_LIMIT" ] && ncapped=$((ncapped + 1))
       npr=$((npr + cnt))
-      rows=$(jq -n --argjson a "$rows" --argjson b "$repo_rows" '$a + $b')
+      printf '%s' "$repo_rows" | jq -c '.[]' >> "$CANDIDATE_PRS_FILE" \
+        || { echo "fm-bearings-snapshot: candidate PR transport write failed" >&2; exit 1; }
     done
     PR_REPOS_SHOWN=$nrepos
     PR_ROWS_CAPPED=$ncapped
     PR_ROWS_MIN_TOTAL=$((npr + ncapped))
-    CANDIDATE_PRS=$rows
     warnnote=""
     [ "$nwarn" -gt 0 ] && warnnote="; ${nwarn} repo(s) unavailable"
     cappednote=""
@@ -328,7 +333,7 @@ MODEL=$(printf '%s' "$SNAP" | jq \
   --argjson pr_repos_shown "$PR_REPOS_SHOWN" \
   --argjson pr_rows_capped "$PR_ROWS_CAPPED" \
   --argjson pr_rows_min_total "$PR_ROWS_MIN_TOTAL" \
-  --argjson candidate_prs "$CANDIDATE_PRS" '
+  --slurpfile candidate_prs "$CANDIDATE_PRS_FILE" '
   def trunc($n): if . == null then null else
     (tostring | gsub("\\s+"; " ") | if (length > $n) then (.[:$n] + "…") else . end) end;
   def fit($n):

--- a/bin/fm-fleet-snapshot.sh
+++ b/bin/fm-fleet-snapshot.sh
@@ -275,6 +275,44 @@ bool_json() {
   if [ "$1" = 1 ]; then printf 'true'; else printf 'false'; fi
 }
 
+# Large JSON components travel to jq through files, never argv. The transport is
+# a single named-key object so the mapping producer->consumer is explicit, and
+# every member is written verbatim: an empty or malformed component yields
+# invalid JSON and the consuming jq exits non-zero rather than silently reading
+# a shifted or absent value.
+json_envelope_file() {  # <output-file> <key> <json> [<key> <json> ...]
+  local out=$1 sep='' key value
+  shift
+  [ $(($# % 2)) -eq 0 ] || return 1
+  {
+    printf '{'
+    while [ "$#" -ge 2 ]; do
+      key=$1
+      value=$2
+      shift 2
+      printf '%s"%s":' "$sep" "$key"
+      printf '%s' "$value"
+      sep=','
+    done
+    printf '}\n'
+  } > "$out"
+}
+
+# jq prelude shared by every named-envelope consumer: `envelope` rejects a
+# transport file that is not exactly one JSON object, and `member` rejects an
+# absent key instead of folding it to null.
+# shellcheck disable=SC2016 # jq program text: $slurped, $label, and $k are jq variables.
+JQ_ENVELOPE_PRELUDE='
+def envelope($slurped; $label):
+  (if ($slurped | length) == 1 then $slurped[0]
+   else error("fm-fleet-snapshot: \($label) envelope is not a single JSON value") end)
+  | if type == "object" then .
+    else error("fm-fleet-snapshot: \($label) envelope is not a JSON object") end;
+def member($k):
+  if has($k) then .[$k]
+  else error("fm-fleet-snapshot: envelope member \($k) is missing") end;
+'
+
 path_present_json() {  # <contract-path> [<observed-path>]
   local path=$1 observed=${2:-$1} present=0
   [ -e "$observed" ] && present=1
@@ -798,10 +836,17 @@ task_json_lines() {
       home_json=$(jq -n '{path:null,present:false}')
     fi
     components_file="$SNAPSHOT_TASK_DIR/$id.components.json"
-    printf '%s\n%s\n%s\n%s\n%s\n%s\n%s\n' \
-      "$current_json" "$meta_json" "$status_json" "$report_json" \
-      "$worktree_json" "$home_json" "$open_decisions_json" > "$components_file" \
-      || return 1
+    json_envelope_file "$components_file" \
+      current_state "$current_json" \
+      meta_path "$meta_json" \
+      status_log "$status_json" \
+      report "$report_json" \
+      worktree_path "$worktree_json" \
+      home_path "$home_json" \
+      open_decisions "$open_decisions_json" || {
+      snapshot_task_cleanup
+      return 1
+    }
 
     jq -n \
       --arg id "$id" \
@@ -827,13 +872,15 @@ task_json_lines() {
       --argjson pending_decision "$(bool_json "$pending_decision")" \
       --argjson blocked_event "$(bool_json "$blocked_event")" \
       --argjson report_present "$(bool_json "$report_present")" \
-      '($components[0]) as $current_state
-      | ($components[1]) as $meta_path
-      | ($components[2]) as $status_log
-      | ($components[3]) as $report
-      | ($components[4]) as $worktree_path
-      | ($components[5]) as $home_path
-      | ($components[6]) as $open_decisions
+      "$JQ_ENVELOPE_PRELUDE"'
+      envelope($components; "task components") as $components
+      | ($components | member("current_state")) as $current_state
+      | ($components | member("meta_path")) as $meta_path
+      | ($components | member("status_log")) as $status_log
+      | ($components | member("report")) as $report
+      | ($components | member("worktree_path")) as $worktree_path
+      | ($components | member("home_path")) as $home_path
+      | ($components | member("open_decisions")) as $open_decisions
       | {
         id:$id,
         kind:$kind,
@@ -1581,11 +1628,13 @@ terminal_evidence_json() {  # <parent-task-json> <event-note> <evidence-contradi
     '{provenance:"parent-direct-report-terminal",trust:"untrusted-supplement",captured:true,observed_at:$observed,freshness:"fresh",reason:null,lines:$lines,bytes:$bytes,event_note_seen:$seen,contradiction:$contradiction}'
 }
 
-parent_evidence_reconciliation_json() {  # <summary-json-file> <evidence-json-file>
-  jq -n --slurpfile summary "$1" --slurpfile evidence "$2" '
+parent_evidence_reconciliation_json() {  # <summary-json-file> <parent-evidence-envelope-file>
+  jq -n --slurpfile summary "$1" --slurpfile evidence "$2" \
+    "$JQ_ENVELOPE_PRELUDE"'
     ($summary[0]) as $summary
-    | ($evidence[2]) as $activities
-    | ($evidence[3]) as $decisions
+    | envelope($evidence; "parent evidence") as $evidence
+    | ($evidence | member("activity_scan") | .records) as $activities
+    | ($evidence | member("task") | .hints.open_decisions // []) as $decisions
     |
     def keyed: . != null and . != "" and . != "default";
     def result($e; $matches; $complete; $surface):
@@ -1648,7 +1697,7 @@ parent_evidence_reconciliation_json() {  # <summary-json-file> <evidence-json-fi
 secondmate_current_json() {  # <parent-tasks-json-file> <output-file>
   local tasks_file=$1 output_file=$2 registry_file union_file records_file rows total_registered total shown truncated
   local row id home host remote registered registry_error task sampled_spawn_gen status_file status_observation_file event_raw event_note event_epoch event_age
-  local activity_scan activities decisions reconciliation provenance freshness reason summary_file evidence_file summary_sampled summary_valid summary_invalidity state terminal terminal_contradiction contradiction
+  local activity_scan reconciliation provenance freshness reason summary_file evidence_file note_file summary_sampled summary_valid summary_invalidity state terminal terminal_contradiction contradiction
   local summary_source summary_age summary_observed summary_freshness cache_path collection_status collection_slot summary_index=0
   local seen_homes=''
   registry_file="$JSON_TRANSPORT_DIR/secondmate-registry.json"
@@ -1700,8 +1749,6 @@ secondmate_current_json() {  # <parent-tasks-json-file> <output-file>
     event_raw=$(printf '%s' "$task" | jq -r '.paths.status_log.last_event.raw // ""')
     event_note=$(printf '%s' "$task" | jq -r '.paths.status_log.last_event.note // ""')
     activity_scan=$(bounded_parent_activities_json "$status_observation_file")
-    activities=$(printf '%s' "$activity_scan" | jq -c '.records')
-    decisions=$(printf '%s' "$task" | jq -c '.hints.open_decisions // []')
     event_epoch=$(file_mtime_epoch "$status_observation_file")
     event_age=null
     if [ -n "$event_epoch" ]; then
@@ -1713,9 +1760,12 @@ secondmate_current_json() {  # <parent-tasks-json-file> <output-file>
     summary_index=$((summary_index + 1))
     summary_file="$SNAPSHOT_COLLECT_DIR/selected-summary-$summary_index.json"
     evidence_file="$SNAPSHOT_COLLECT_DIR/parent-evidence-$summary_index.json"
+    note_file="$SNAPSHOT_COLLECT_DIR/parent-event-note-$summary_index.txt"
     printf '{}\n' > "$summary_file" || return 1
-    printf '%s\n%s\n%s\n%s\n' "$task" "$activity_scan" "$activities" "$decisions" \
-      > "$evidence_file" || return 1
+    json_envelope_file "$evidence_file" \
+      task "$task" \
+      activity_scan "$activity_scan" || return 1
+    printf '%s' "$event_note" > "$note_file" || return 1
     summary_sampled=false
     summary_valid=false
     if [ -z "$reason" ] && [ -z "$home" ]; then reason="no recorded secondmate home"; fi
@@ -1793,9 +1843,8 @@ secondmate_current_json() {  # <parent-tasks-json-file> <output-file>
       reconciliation=$(parent_evidence_reconciliation_json "$summary_file" "$evidence_file")
       contradiction=$(printf '%s' "$reconciliation" | jq -r '.contradiction')
       terminal_contradiction=$(printf '%s' "$reconciliation" | jq -r \
-        --slurpfile evidence "$evidence_file" '
-        ($evidence[0].paths.status_log.last_event.note // "") as $note
-        | any(.activities[]; .verdict == "contradicts" and .summary == $note)')
+        --rawfile note "$note_file" '
+        any(.activities[]; .verdict == "contradicts" and .summary == $note)')
       if [ "$terminal_contradiction" = true ]; then
         terminal=$(terminal_evidence_json "$task" "$event_note" true)
       else
@@ -1803,20 +1852,26 @@ secondmate_current_json() {  # <parent-tasks-json-file> <output-file>
           '{provenance:"parent-direct-report-terminal",trust:"untrusted-supplement",captured:false,observed_at:$observed,freshness:"not-collected",reason:"no useful contradiction check",lines:0,bytes:0,event_note_seen:false,contradiction:false}')
       fi
       if printf '%s' "$terminal" | jq -e '.contradiction == true' >/dev/null; then contradiction=true; fi
-      printf '%s\n%s\n' "$reconciliation" "$terminal" >> "$evidence_file" || return 1
+      json_envelope_file "$evidence_file" \
+        task "$task" \
+        activity_scan "$activity_scan" \
+        reconciliation "$reconciliation" \
+        terminal "$terminal" || return 1
       jq -n \
         --arg id "$id" --arg home "$home" --arg host "$host" --argjson remote "$remote" --arg state "$state" --arg observed "$summary_observed" \
         --arg summary_source "$summary_source" --arg summary_freshness "$summary_freshness" --argjson summary_age "$summary_age" \
         --arg spawn_gen "$sampled_spawn_gen" \
         --argjson registered "$registered" --slurpfile summary "$summary_file" --argjson summary_valid "$summary_valid" \
-        --slurpfile evidence "$evidence_file" --argjson contradiction "$contradiction" --argjson event_age "$event_age" '
+        --slurpfile evidence "$evidence_file" --argjson contradiction "$contradiction" --argjson event_age "$event_age" \
+        "$JQ_ENVELOPE_PRELUDE"'
         ($summary[0]) as $summary
-        | ($evidence[0]) as $task
-        | ($evidence[1]) as $activity_scan
-        | ($evidence[2]) as $activities
-        | ($evidence[3]) as $decisions
-        | ($evidence[4]) as $reconciliation
-        | ($evidence[5]) as $terminal
+        | envelope($evidence; "parent evidence") as $evidence
+        | ($evidence | member("task")) as $task
+        | ($evidence | member("activity_scan")) as $activity_scan
+        | ($evidence | member("reconciliation")) as $reconciliation
+        | ($evidence | member("terminal")) as $terminal
+        | ($activity_scan.records) as $activities
+        | ($task.hints.open_decisions // []) as $decisions
         | ($task.paths.status_log.last_event.raw // "") as $event_raw
         | ($task.paths.status_log.last_event.note // "") as $event_note
         |
@@ -1846,19 +1901,24 @@ secondmate_current_json() {  # <parent-tasks-json-file> <output-file>
         terminal=$(jq -n --arg observed "$SNAPSHOT_NOW" \
           '{provenance:"parent-direct-report-terminal",trust:"untrusted-supplement",captured:false,observed_at:$observed,freshness:"not-collected",reason:"no parent event to compare",lines:0,bytes:0,event_note_seen:false,contradiction:false}')
       fi
-      printf '{}\n%s\n' "$terminal" >> "$evidence_file" || return 1
+      json_envelope_file "$evidence_file" \
+        task "$task" \
+        activity_scan "$activity_scan" \
+        terminal "$terminal" || return 1
       jq -n \
         --arg id "$id" --arg home "$home" --arg host "$host" --argjson remote "$remote" --arg reason "$reason" --arg observed "$SNAPSHOT_NOW" \
         --arg spawn_gen "$sampled_spawn_gen" \
         --arg provenance "$provenance" --arg freshness "$freshness" \
         --argjson registered "$registered" --argjson event_age "$event_age" --slurpfile evidence "$evidence_file" \
-        --slurpfile summary "$summary_file" --argjson summary_sampled "$summary_sampled" '
+        --slurpfile summary "$summary_file" --argjson summary_sampled "$summary_sampled" \
+        "$JQ_ENVELOPE_PRELUDE"'
         ($summary[0]) as $summary
-        | ($evidence[0]) as $task
-        | ($evidence[1]) as $activity_scan
-        | ($evidence[2]) as $activities
-        | ($evidence[3]) as $decisions
-        | ($evidence[5]) as $terminal
+        | envelope($evidence; "parent evidence") as $evidence
+        | ($evidence | member("task")) as $task
+        | ($evidence | member("activity_scan")) as $activity_scan
+        | ($evidence | member("terminal")) as $terminal
+        | ($activity_scan.records) as $activities
+        | ($task.hints.open_decisions // []) as $decisions
         | ($task.paths.status_log.last_event.raw // "") as $event_raw
         | ($task.paths.status_log.last_event.note // "") as $event_note
         |

--- a/bin/fm-fleet-snapshot.sh
+++ b/bin/fm-fleet-snapshot.sh
@@ -727,11 +727,19 @@ prefetch_task_current_states() {
 
 task_json_lines() {
   local meta original_meta id kind harness mode yolo project worktree home projects spawn_gen backend target status_log report_path
-  local remote_host remote_root current_file endpoint_file components_file observation_line index=0
+  local remote_host remote_root current_file endpoint_file components_file lines_file observation_line index=0
   local pr pr_source event_json current_json endpoint_exists agent_alive meta_json status_json report_json worktree_json home_json
   local current_state current_source pending_decision blocked_event report_present=0 pr_from_status
   local open_decisions_tsv open_decisions_json
 
+  # Rows accumulate in a file, never through a piped loop: composition failures
+  # must fail this function rather than abort a subshell and leave a sorted
+  # truncated prefix as the published inventory.
+  lines_file="$SNAPSHOT_TASK_DIR/task-lines.jsonl"
+  : > "$lines_file" || {
+    snapshot_task_cleanup
+    return 1
+  }
   while [ "$index" -lt "$SNAPSHOT_TASK_META_COUNT" ]; do
     meta=${SNAPSHOT_TASK_METAS[index]}
     index=$((index + 1))
@@ -923,8 +931,12 @@ task_json_lines() {
              steer:"bin/fm-send.sh fm-\($id) \u0027<instruction>\u0027",
              return_channel_note:null}
           end)
-      }'
-  done | jq -s 'sort_by(.id)'
+      }' >> "$lines_file" || {
+      snapshot_task_cleanup
+      return 1
+    }
+  done
+  jq -s 'sort_by(.id)' < "$lines_file"
 }
 
 # Main-home current-inventory validity: same orphan / unstructured-current checks
@@ -1697,7 +1709,7 @@ parent_evidence_reconciliation_json() {  # <summary-json-file> <parent-evidence-
 secondmate_current_json() {  # <parent-tasks-json-file> <output-file>
   local tasks_file=$1 output_file=$2 registry_file union_file records_file rows total_registered total shown truncated
   local row id home host remote registered registry_error task sampled_spawn_gen status_file status_observation_file event_raw event_note event_epoch event_age
-  local activity_scan reconciliation provenance freshness reason summary_file evidence_file note_file summary_sampled summary_valid summary_invalidity state terminal terminal_contradiction contradiction
+  local activity_scan reconciliation provenance freshness reason summary_file evidence_file summary_sampled summary_valid summary_invalidity state terminal terminal_contradiction contradiction
   local summary_source summary_age summary_observed summary_freshness cache_path collection_status collection_slot summary_index=0
   local seen_homes=''
   registry_file="$JSON_TRANSPORT_DIR/secondmate-registry.json"
@@ -1760,12 +1772,7 @@ secondmate_current_json() {  # <parent-tasks-json-file> <output-file>
     summary_index=$((summary_index + 1))
     summary_file="$SNAPSHOT_COLLECT_DIR/selected-summary-$summary_index.json"
     evidence_file="$SNAPSHOT_COLLECT_DIR/parent-evidence-$summary_index.json"
-    note_file="$SNAPSHOT_COLLECT_DIR/parent-event-note-$summary_index.txt"
     printf '{}\n' > "$summary_file" || return 1
-    json_envelope_file "$evidence_file" \
-      task "$task" \
-      activity_scan "$activity_scan" || return 1
-    printf '%s' "$event_note" > "$note_file" || return 1
     summary_sampled=false
     summary_valid=false
     if [ -z "$reason" ] && [ -z "$home" ]; then reason="no recorded secondmate home"; fi
@@ -1840,11 +1847,17 @@ secondmate_current_json() {  # <parent-tasks-json-file> <output-file>
 
     if [ -z "$reason" ]; then
       state=$(jq -r '.state' "$summary_file")
+      json_envelope_file "$evidence_file" \
+        task "$task" \
+        activity_scan "$activity_scan" || return 1
       reconciliation=$(parent_evidence_reconciliation_json "$summary_file" "$evidence_file")
       contradiction=$(printf '%s' "$reconciliation" | jq -r '.contradiction')
       terminal_contradiction=$(printf '%s' "$reconciliation" | jq -r \
-        --rawfile note "$note_file" '
-        any(.activities[]; .verdict == "contradicts" and .summary == $note)')
+        --slurpfile evidence "$evidence_file" \
+        "$JQ_ENVELOPE_PRELUDE"'
+        (envelope($evidence; "parent evidence") | member("task")
+         | .paths.status_log.last_event.note // "") as $note
+        | any(.activities[]; .verdict == "contradicts" and .summary == $note)')
       if [ "$terminal_contradiction" = true ]; then
         terminal=$(terminal_evidence_json "$task" "$event_note" true)
       else

--- a/bin/fm-fleet-snapshot.sh
+++ b/bin/fm-fleet-snapshot.sh
@@ -736,10 +736,7 @@ task_json_lines() {
   # must fail this function rather than abort a subshell and leave a sorted
   # truncated prefix as the published inventory.
   lines_file="$SNAPSHOT_TASK_DIR/task-lines.jsonl"
-  : > "$lines_file" || {
-    snapshot_task_cleanup
-    return 1
-  }
+  : > "$lines_file" || return 1
   while [ "$index" -lt "$SNAPSHOT_TASK_META_COUNT" ]; do
     meta=${SNAPSHOT_TASK_METAS[index]}
     index=$((index + 1))
@@ -779,10 +776,7 @@ task_json_lines() {
     fi
 
     current_file="$SNAPSHOT_TASK_DIR/$id.json"
-    current_json=$(<"$current_file") || {
-      snapshot_task_cleanup
-      return 1
-    }
+    current_json=$(<"$current_file") || return 1
     event_json=$(status_event_json "$status_log" "$STATE/$id.status")
     read -r current_state current_source < <(
       printf '%s' "$current_json" | jq -r '[.state // "", .source // ""] | @tsv'
@@ -827,10 +821,7 @@ task_json_lines() {
         endpoint_exists=*) endpoint_exists=${observation_line#*=} ;;
         agent_alive=*) agent_alive=${observation_line#*=} ;;
       esac
-    done < "$endpoint_file" || {
-      snapshot_task_cleanup
-      return 1
-    }
+    done < "$endpoint_file" || return 1
     [ -f "$report_path" ] && report_present=1 || report_present=0
     meta_json=$(path_present_json "$original_meta" "$meta")
     status_json=$event_json
@@ -851,10 +842,7 @@ task_json_lines() {
       report "$report_json" \
       worktree_path "$worktree_json" \
       home_path "$home_json" \
-      open_decisions "$open_decisions_json" || {
-      snapshot_task_cleanup
-      return 1
-    }
+      open_decisions "$open_decisions_json" || return 1
 
     jq -n \
       --arg id "$id" \
@@ -931,10 +919,7 @@ task_json_lines() {
              steer:"bin/fm-send.sh fm-\($id) \u0027<instruction>\u0027",
              return_channel_note:null}
           end)
-      }' >> "$lines_file" || {
-      snapshot_task_cleanup
-      return 1
-    }
+      }' >> "$lines_file" || return 1
   done
   jq -s 'sort_by(.id)' < "$lines_file"
 }
@@ -1710,7 +1695,7 @@ secondmate_current_json() {  # <parent-tasks-json-file> <output-file>
   local tasks_file=$1 output_file=$2 registry_file union_file records_file rows total_registered total shown truncated
   local row id home host remote registered registry_error task sampled_spawn_gen status_file status_observation_file event_raw event_note event_epoch event_age
   local activity_scan reconciliation provenance freshness reason summary_file evidence_file summary_sampled summary_valid summary_invalidity state terminal terminal_contradiction contradiction
-  local summary_source summary_age summary_observed summary_freshness cache_path collection_status collection_slot summary_index=0
+  local summary_source summary_age summary_observed summary_freshness cache_path collection_status collection_slot note_file summary_index=0
   local seen_homes=''
   registry_file="$JSON_TRANSPORT_DIR/secondmate-registry.json"
   union_file="$JSON_TRANSPORT_DIR/secondmate-union.json"
@@ -1850,14 +1835,25 @@ secondmate_current_json() {  # <parent-tasks-json-file> <output-file>
       json_envelope_file "$evidence_file" \
         task "$task" \
         activity_scan "$activity_scan" || return 1
-      reconciliation=$(parent_evidence_reconciliation_json "$summary_file" "$evidence_file")
-      contradiction=$(printf '%s' "$reconciliation" | jq -r '.contradiction')
-      terminal_contradiction=$(printf '%s' "$reconciliation" | jq -r \
-        --slurpfile evidence "$evidence_file" \
-        "$JQ_ENVELOPE_PRELUDE"'
-        (envelope($evidence; "parent evidence") | member("task")
-         | .paths.status_log.last_event.note // "") as $note
-        | any(.activities[]; .verdict == "contradicts" and .summary == $note)')
+      reconciliation=$(parent_evidence_reconciliation_json "$summary_file" "$evidence_file") || {
+        echo "fm-fleet-snapshot: parent evidence reconciliation failed for $id" >&2
+        return 1
+      }
+      contradiction=$(printf '%s' "$reconciliation" | jq -r '.contradiction') || {
+        echo "fm-fleet-snapshot: parent evidence contradiction read failed for $id" >&2
+        return 1
+      }
+      # The status-log note has no enforced byte limit, so it reaches jq through a
+      # file rather than argv; $event_note is already the value the record and the
+      # terminal capture use, so it is not re-derived from the evidence envelope.
+      note_file="$SNAPSHOT_COLLECT_DIR/parent-event-note-$summary_index"
+      printf '%s' "$event_note" > "$note_file" || return 1
+      terminal_contradiction=$(printf '%s' "$reconciliation" \
+        | jq -r --rawfile note "$note_file" \
+          'any(.activities[]; .verdict == "contradicts" and .summary == $note)') || {
+        echo "fm-fleet-snapshot: parent activity contradiction check failed for $id" >&2
+        return 1
+      }
       if [ "$terminal_contradiction" = true ]; then
         terminal=$(terminal_evidence_json "$task" "$event_note" true)
       else
@@ -1979,19 +1975,28 @@ secondmate_landed_from_current_json() {  # <secondmate-current-json-file> <outpu
     | .records |= sort_by([(.completion.date // ""), .id]) | .records |= reverse' > "$2"
 }
 
+# Same fail-closed shape as task_json_lines: an unreadable task directory or a
+# single failed record composition must fail this function rather than publish a
+# silently truncated report inventory that the captain reads as complete.
 scout_report_lines() {
-  local report id
+  local report id paths_file sorted_file lines_file
   if [ ! -d "$DATA" ]; then
     jq -n '[]'
     return 0
   fi
+  paths_file="$JSON_TRANSPORT_DIR/scout-report-paths"
+  sorted_file="$JSON_TRANSPORT_DIR/scout-report-paths.sorted"
+  lines_file="$JSON_TRANSPORT_DIR/scout-report-lines.jsonl"
   LC_ALL=C find "$DATA" -mindepth 2 -maxdepth 2 -type f -name report.md -print \
-    | sort \
-    | while IFS= read -r report; do
-      id=$(basename "$(dirname "$report")")
-      jq -n --arg id "$id" --arg path "$report" '{id:$id,path:$path}'
-    done \
-    | jq -s 'sort_by(.id)'
+    > "$paths_file" || return 1
+  LC_ALL=C sort "$paths_file" > "$sorted_file" || return 1
+  : > "$lines_file" || return 1
+  while IFS= read -r report; do
+    [ -n "$report" ] || continue
+    id=$(basename "$(dirname "$report")")
+    jq -n --arg id "$id" --arg path "$report" '{id:$id,path:$path}' >> "$lines_file" || return 1
+  done < "$sorted_file" || return 1
+  jq -s 'sort_by(.id)' < "$lines_file"
 }
 
 BACKLOG_JSON=$(backlog_json) || { echo "fm-fleet-snapshot: backlog read failed" >&2; exit 1; }

--- a/bin/fm-fleet-snapshot.sh
+++ b/bin/fm-fleet-snapshot.sh
@@ -689,9 +689,9 @@ prefetch_task_current_states() {
 
 task_json_lines() {
   local meta original_meta id kind harness mode yolo project worktree home projects spawn_gen backend target status_log report_path
-  local remote_host remote_root current_file endpoint_file observation_line index=0
+  local remote_host remote_root current_file endpoint_file components_file observation_line index=0
   local pr pr_source event_json current_json endpoint_exists agent_alive meta_json status_json report_json worktree_json home_json
-  local last_event_raw current_state current_source pending_decision blocked_event report_present=0 pr_from_status
+  local current_state current_source pending_decision blocked_event report_present=0 pr_from_status
   local open_decisions_tsv open_decisions_json
 
   while [ "$index" -lt "$SNAPSHOT_TASK_META_COUNT" ]; do
@@ -738,7 +738,6 @@ task_json_lines() {
       return 1
     }
     event_json=$(status_event_json "$status_log" "$STATE/$id.status")
-    last_event_raw=$(printf '%s' "$event_json" | jq -r '.last_event.raw // ""')
     read -r current_state current_source < <(
       printf '%s' "$current_json" | jq -r '[.state // "", .source // ""] | @tsv'
     )
@@ -798,6 +797,11 @@ task_json_lines() {
     else
       home_json=$(jq -n '{path:null,present:false}')
     fi
+    components_file="$SNAPSHOT_TASK_DIR/$id.components.json"
+    printf '%s\n%s\n%s\n%s\n%s\n%s\n%s\n' \
+      "$current_json" "$meta_json" "$status_json" "$report_json" \
+      "$worktree_json" "$home_json" "$open_decisions_json" > "$components_file" \
+      || return 1
 
     jq -n \
       --arg id "$id" \
@@ -818,19 +822,19 @@ task_json_lines() {
       --arg pr_source "$pr_source" \
       --arg agent_alive "$agent_alive" \
       --arg observed_at "$SNAPSHOT_NOW" \
-      --arg last_event_raw "$last_event_raw" \
-      --argjson current_state "$current_json" \
-      --argjson meta_path "$meta_json" \
-      --argjson status_log "$status_json" \
-      --argjson report "$report_json" \
-      --argjson worktree_path "$worktree_json" \
-      --argjson home_path "$home_json" \
+      --slurpfile components "$components_file" \
       --argjson endpoint_exists "$endpoint_exists" \
-      --argjson open_decisions "$open_decisions_json" \
       --argjson pending_decision "$(bool_json "$pending_decision")" \
       --argjson blocked_event "$(bool_json "$blocked_event")" \
       --argjson report_present "$(bool_json "$report_present")" \
-      '{
+      '($components[0]) as $current_state
+      | ($components[1]) as $meta_path
+      | ($components[2]) as $status_log
+      | ($components[3]) as $report
+      | ($components[4]) as $worktree_path
+      | ($components[5]) as $home_path
+      | ($components[6]) as $open_decisions
+      | {
         id:$id,
         kind:$kind,
         harness:($harness // ""),
@@ -860,7 +864,7 @@ task_json_lines() {
           blocked_event:$blocked_event,
           open_decisions:$open_decisions,
           scout_report_present:$report_present,
-          last_event_text:$last_event_raw
+          last_event_text:($status_log.last_event.raw // "")
         },
         actions:(
           if $kind == "secondmate" then
@@ -1577,9 +1581,11 @@ terminal_evidence_json() {  # <parent-task-json> <event-note> <evidence-contradi
     '{provenance:"parent-direct-report-terminal",trust:"untrusted-supplement",captured:true,observed_at:$observed,freshness:"fresh",reason:null,lines:$lines,bytes:$bytes,event_note_seen:$seen,contradiction:$contradiction}'
 }
 
-parent_evidence_reconciliation_json() {  # <summary-json-file> <activities-json> <decisions-json>
-  jq -n --slurpfile summary "$1" --argjson activities "$2" --argjson decisions "$3" '
+parent_evidence_reconciliation_json() {  # <summary-json-file> <evidence-json-file>
+  jq -n --slurpfile summary "$1" --slurpfile evidence "$2" '
     ($summary[0]) as $summary
+    | ($evidence[2]) as $activities
+    | ($evidence[3]) as $decisions
     |
     def keyed: . != null and . != "" and . != "default";
     def result($e; $matches; $complete; $surface):
@@ -1642,7 +1648,7 @@ parent_evidence_reconciliation_json() {  # <summary-json-file> <activities-json>
 secondmate_current_json() {  # <parent-tasks-json-file> <output-file>
   local tasks_file=$1 output_file=$2 registry_file union_file records_file rows total_registered total shown truncated
   local row id home host remote registered registry_error task sampled_spawn_gen status_file status_observation_file event_raw event_note event_epoch event_age
-  local activity_scan activities decisions reconciliation provenance freshness reason summary_file summary_sampled summary_valid summary_invalidity state terminal terminal_contradiction contradiction
+  local activity_scan activities decisions reconciliation provenance freshness reason summary_file evidence_file summary_sampled summary_valid summary_invalidity state terminal terminal_contradiction contradiction
   local summary_source summary_age summary_observed summary_freshness cache_path collection_status collection_slot summary_index=0
   local seen_homes=''
   registry_file="$JSON_TRANSPORT_DIR/secondmate-registry.json"
@@ -1706,7 +1712,10 @@ secondmate_current_json() {  # <parent-tasks-json-file> <output-file>
     reason=$registry_error
     summary_index=$((summary_index + 1))
     summary_file="$SNAPSHOT_COLLECT_DIR/selected-summary-$summary_index.json"
+    evidence_file="$SNAPSHOT_COLLECT_DIR/parent-evidence-$summary_index.json"
     printf '{}\n' > "$summary_file" || return 1
+    printf '%s\n%s\n%s\n%s\n' "$task" "$activity_scan" "$activities" "$decisions" \
+      > "$evidence_file" || return 1
     summary_sampled=false
     summary_valid=false
     if [ -z "$reason" ] && [ -z "$home" ]; then reason="no recorded secondmate home"; fi
@@ -1781,10 +1790,12 @@ secondmate_current_json() {  # <parent-tasks-json-file> <output-file>
 
     if [ -z "$reason" ]; then
       state=$(jq -r '.state' "$summary_file")
-      reconciliation=$(parent_evidence_reconciliation_json "$summary_file" "$activities" "$decisions")
+      reconciliation=$(parent_evidence_reconciliation_json "$summary_file" "$evidence_file")
       contradiction=$(printf '%s' "$reconciliation" | jq -r '.contradiction')
-      terminal_contradiction=$(printf '%s' "$reconciliation" | jq -r --arg note "$event_note" '
-        any(.activities[]; .verdict == "contradicts" and .summary == $note)')
+      terminal_contradiction=$(printf '%s' "$reconciliation" | jq -r \
+        --slurpfile evidence "$evidence_file" '
+        ($evidence[0].paths.status_log.last_event.note // "") as $note
+        | any(.activities[]; .verdict == "contradicts" and .summary == $note)')
       if [ "$terminal_contradiction" = true ]; then
         terminal=$(terminal_evidence_json "$task" "$event_note" true)
       else
@@ -1792,15 +1803,22 @@ secondmate_current_json() {  # <parent-tasks-json-file> <output-file>
           '{provenance:"parent-direct-report-terminal",trust:"untrusted-supplement",captured:false,observed_at:$observed,freshness:"not-collected",reason:"no useful contradiction check",lines:0,bytes:0,event_note_seen:false,contradiction:false}')
       fi
       if printf '%s' "$terminal" | jq -e '.contradiction == true' >/dev/null; then contradiction=true; fi
+      printf '%s\n%s\n' "$reconciliation" "$terminal" >> "$evidence_file" || return 1
       jq -n \
         --arg id "$id" --arg home "$home" --arg host "$host" --argjson remote "$remote" --arg state "$state" --arg observed "$summary_observed" \
         --arg summary_source "$summary_source" --arg summary_freshness "$summary_freshness" --argjson summary_age "$summary_age" \
         --arg spawn_gen "$sampled_spawn_gen" \
-        --argjson registered "$registered" --slurpfile summary "$summary_file" --argjson summary_valid "$summary_valid" --argjson decisions "$decisions" \
-        --argjson activities "$activities" --argjson activity_scan "$activity_scan" \
-        --argjson reconciliation "$reconciliation" --argjson terminal "$terminal" --argjson contradiction "$contradiction" \
-        --arg event_raw "$event_raw" --arg event_note "$event_note" --argjson event_age "$event_age" '
+        --argjson registered "$registered" --slurpfile summary "$summary_file" --argjson summary_valid "$summary_valid" \
+        --slurpfile evidence "$evidence_file" --argjson contradiction "$contradiction" --argjson event_age "$event_age" '
         ($summary[0]) as $summary
+        | ($evidence[0]) as $task
+        | ($evidence[1]) as $activity_scan
+        | ($evidence[2]) as $activities
+        | ($evidence[3]) as $decisions
+        | ($evidence[4]) as $reconciliation
+        | ($evidence[5]) as $terminal
+        | ($task.paths.status_log.last_event.raw // "") as $event_raw
+        | ($task.paths.status_log.last_event.note // "") as $event_note
         |
         {id:$id,home:$home,host:($host | if . == "" then null else . end),remote:$remote,registered:$registered,
          spawn_gen:($spawn_gen | if . == "" then null else . end),
@@ -1828,13 +1846,21 @@ secondmate_current_json() {  # <parent-tasks-json-file> <output-file>
         terminal=$(jq -n --arg observed "$SNAPSHOT_NOW" \
           '{provenance:"parent-direct-report-terminal",trust:"untrusted-supplement",captured:false,observed_at:$observed,freshness:"not-collected",reason:"no parent event to compare",lines:0,bytes:0,event_note_seen:false,contradiction:false}')
       fi
+      printf '{}\n%s\n' "$terminal" >> "$evidence_file" || return 1
       jq -n \
         --arg id "$id" --arg home "$home" --arg host "$host" --argjson remote "$remote" --arg reason "$reason" --arg observed "$SNAPSHOT_NOW" \
         --arg spawn_gen "$sampled_spawn_gen" \
-        --arg provenance "$provenance" --arg freshness "$freshness" --arg event_raw "$event_raw" --arg event_note "$event_note" \
-        --argjson registered "$registered" --argjson event_age "$event_age" --argjson activities "$activities" --argjson activity_scan "$activity_scan" \
-        --argjson decisions "$decisions" --argjson terminal "$terminal" --slurpfile summary "$summary_file" --argjson summary_sampled "$summary_sampled" '
+        --arg provenance "$provenance" --arg freshness "$freshness" \
+        --argjson registered "$registered" --argjson event_age "$event_age" --slurpfile evidence "$evidence_file" \
+        --slurpfile summary "$summary_file" --argjson summary_sampled "$summary_sampled" '
         ($summary[0]) as $summary
+        | ($evidence[0]) as $task
+        | ($evidence[1]) as $activity_scan
+        | ($evidence[2]) as $activities
+        | ($evidence[3]) as $decisions
+        | ($evidence[5]) as $terminal
+        | ($task.paths.status_log.last_event.raw // "") as $event_raw
+        | ($task.paths.status_log.last_event.note // "") as $event_note
         |
         {id:$id,home:($home | if . == "" then null else . end),host:($host | if . == "" then null else . end),remote:$remote,registered:$registered,
          spawn_gen:($spawn_gen | if . == "" then null else . end),

--- a/bin/fm-fleet-snapshot.sh
+++ b/bin/fm-fleet-snapshot.sh
@@ -3,6 +3,11 @@
 #
 # Output contract: `--json` prints one object with schema
 # `fm-fleet-snapshot.v1`.
+# Records are omitted only through the documented bounds below, which the
+# output itself discloses. A record that fails to compose is never silently
+# dropped instead: the command prints no object, writes a diagnostic to stderr,
+# and exits non-zero rather than publishing a truncated tasks[] or
+# scout_reports[] that a consumer would read as a complete fleet.
 # The command does not acquire the session lock, drain wakes, arm watchers,
 # mutate backlog state, or write reports. Its default ledger collector may
 # atomically refresh parent-side cached copies of remote home summaries under

--- a/tests/fm-bearings-snapshot.test.sh
+++ b/tests/fm-bearings-snapshot.test.sh
@@ -58,6 +58,24 @@ if [ "${FAKE_GH_MANY:-0}" = 1 ]; then
 JSON
   exit 0
 fi
+if [ "${FAKE_GH_LARGE:-0}" = 1 ]; then
+  suffix=''
+  i=1
+  while [ "$i" -le 160 ]; do
+    suffix="${suffix}x"
+    i=$((i + 1))
+  done
+  printf '['
+  i=1
+  while [ "$i" -le 1200 ]; do
+    [ "$i" -eq 1 ] || printf ','
+    printf '{"number":%s,"title":"Large PR %s %s","url":"https://github.com/acme/repo/pull/%s","headRefName":"feature/large-%s","reviewDecision":"","mergeable":"MERGEABLE","statusCheckRollup":[]}' \
+      "$i" "$i" "$suffix" "$i" "$i"
+    i=$((i + 1))
+  done
+  printf ']\n'
+  exit 0
+fi
 cat <<'JSON'
 [{"number":9,"title":"Ship the thing","url":"https://github.com/kunchenguid/firstmate/pull/9","headRefName":"fm/ship-task","reviewDecision":"APPROVED","mergeable":"MERGEABLE","statusCheckRollup":[{"conclusion":"SUCCESS","status":"COMPLETED"}]}]
 JSON
@@ -1527,6 +1545,49 @@ test_per_repository_pr_cap_is_disclosed() {
   pass "per-repository open-PR caps are disclosed with an expansion knob"
 }
 
+test_large_candidate_pr_inventory_avoids_argument_transport() {
+  local home fakebin json
+  home=$(make_home large-pr-inventory); write_fixture "$home"
+  fakebin=$(make_fakebin "$home")
+  json=$(FM_BEARINGS_PR_LIMIT=1200 FAKE_GH_LARGE=1 \
+    run "$home" "$fakebin" --include-prs --json)
+  [ "$(printf '%s' "$json" | wc -c | tr -d ' ')" -gt 131072 ] \
+    || fail "large candidate PR fixture did not exceed the per-argument limit"
+  printf '%s' "$json" | jq -e '
+    .schema == "fm-bearings.v1"
+      and (.candidate_prs | length) == 1200
+      and .candidate_prs[1199].num == "1200"
+  ' >/dev/null || fail "large candidate PR inventory did not render completely"
+  pass "large candidate PR inventories avoid argument transport"
+}
+
+test_large_task_decision_inventory_avoids_argument_transport() {
+  local home fakebin canonical suffix='' i
+  home=$(make_home large-task-decisions); write_fixture "$home"
+  fakebin=$(make_fakebin "$home")
+  i=1
+  while [ "$i" -le 1400 ]; do
+    suffix="${suffix}x"
+    i=$((i + 1))
+  done
+  i=1
+  while [ "$i" -le 100 ]; do
+    printf 'needs-decision [key=large-%s]: choose %s %s\n' "$i" "$i" "$suffix" \
+      >> "$home/state/mate.status"
+    i=$((i + 1))
+  done
+  canonical=$(PATH="$fakebin:$PATH" FM_HOME="$home" \
+    FM_SNAPSHOT_NOW=2026-07-11T18:00:00Z FM_SNAPSHOT_NOW_EPOCH=1783792800 \
+    "$ROOT/bin/fm-fleet-snapshot.sh" --json)
+  [ "$(printf '%s' "$canonical" | wc -c | tr -d ' ')" -gt 131072 ] \
+    || fail "large task-decision fixture did not exceed the per-argument limit"
+  printf '%s' "$canonical" | jq -e '
+    .schema == "fm-fleet-snapshot.v1"
+      and ([.tasks[] | select(.id == "mate")][0].hints.open_decisions | length) == 101
+  ' >/dev/null || fail "large task-decision inventory did not render completely"
+  pass "large task-decision inventories avoid argument transport"
+}
+
 install_failing_jq() {  # <fakebin> <model|toon>
   local fakebin=$1 phase=$2 real
   real=$(command -v jq)
@@ -2973,4 +3034,6 @@ test_blocked_deferred_hold_has_concrete_disclosure
 test_revealed_deferred_holds_show_their_deferral_reason
 test_pr_repository_cap_and_expansion
 test_per_repository_pr_cap_is_disclosed
+test_large_candidate_pr_inventory_avoids_argument_transport
+test_large_task_decision_inventory_avoids_argument_transport
 test_projection_and_toon_fail_closed

--- a/tests/fm-bearings-snapshot.test.sh
+++ b/tests/fm-bearings-snapshot.test.sh
@@ -1588,6 +1588,51 @@ test_large_task_decision_inventory_avoids_argument_transport() {
   pass "large task-decision inventories avoid argument transport"
 }
 
+# Fail the Nth per-task open-decision fold, so one task in the middle of the
+# inventory loses a composition component while its neighbours stay intact.
+install_failing_task_component() {  # <fakebin> <counter-file> <occurrence>
+  local fakebin=$1 counter=$2 occurrence=$3 real
+  real=$(command -v jq)
+  rm -f "$counter"
+  cat > "$fakebin/jq" <<SH
+#!/usr/bin/env bash
+case "\$*" in
+  *'(?<verb>'*)
+    count=0
+    [ ! -f "$counter" ] || count=\$(cat "$counter")
+    count=\$((count + 1))
+    printf '%s' "\$count" > "$counter"
+    [ "\$count" -ne $occurrence ] || exit 9
+    ;;
+esac
+exec "$real" "\$@"
+SH
+  chmod +x "$fakebin/jq"
+}
+
+# A per-task component that fails partway through the inventory must fail the
+# whole snapshot. Composition feeds a sorted collector, so a failure that only
+# aborts a subshell leaves the collector succeeding on the truncated prefix and
+# publishes an exit-0 snapshot with tasks silently missing - and the observation
+# directory that later parent reads depend on already torn down.
+test_task_component_failure_fails_closed() {
+  local home fakebin out err rc
+  home=$(make_home task-component-fail-closed); write_fixture "$home"
+  fakebin=$(make_fakebin "$home")
+  install_failing_task_component "$fakebin" "$home/fold.count" 2
+  err="$home/task-component.err"
+  out=$(PATH="$fakebin:$PATH" FM_HOME="$home" \
+    FM_SNAPSHOT_NOW=2026-07-11T18:00:00Z FM_SNAPSHOT_NOW_EPOCH=1783792800 \
+    "$ROOT/bin/fm-fleet-snapshot.sh" --json 2> "$err"); rc=$?
+  [ "$rc" -ne 0 ] || fail "a failed task component published an exit-0 snapshot: $out"
+  if printf '%s' "$out" | jq -e '.tasks' >/dev/null 2>&1; then
+    fail "a failed task component still emitted a task inventory: $out"
+  fi
+  grep -F 'task snapshot failed' "$err" >/dev/null \
+    || fail "a failed task component lacked a diagnostic: $(cat "$err")"
+  pass "a failed per-task component fails the snapshot instead of dropping tasks"
+}
+
 install_failing_jq() {  # <fakebin> <model|toon>
   local fakebin=$1 phase=$2 real
   real=$(command -v jq)
@@ -3036,4 +3081,5 @@ test_pr_repository_cap_and_expansion
 test_per_repository_pr_cap_is_disclosed
 test_large_candidate_pr_inventory_avoids_argument_transport
 test_large_task_decision_inventory_avoids_argument_transport
+test_task_component_failure_fails_closed
 test_projection_and_toon_fail_closed

--- a/tests/fm-bearings-snapshot.test.sh
+++ b/tests/fm-bearings-snapshot.test.sh
@@ -1579,8 +1579,9 @@ test_large_task_decision_inventory_avoids_argument_transport() {
   canonical=$(PATH="$fakebin:$PATH" FM_HOME="$home" \
     FM_SNAPSHOT_NOW=2026-07-11T18:00:00Z FM_SNAPSHOT_NOW_EPOCH=1783792800 \
     "$ROOT/bin/fm-fleet-snapshot.sh" --json)
-  [ "$(printf '%s' "$canonical" | wc -c | tr -d ' ')" -gt 131072 ] \
-    || fail "large task-decision fixture did not exceed the per-argument limit"
+  printf '%s' "$canonical" | jq -e '
+    ([.tasks[] | select(.id == "mate")][0].hints.open_decisions | tojson | length) > 131072
+  ' >/dev/null || fail "large task-decision component did not exceed the per-argument limit"
   printf '%s' "$canonical" | jq -e '
     .schema == "fm-fleet-snapshot.v1"
       and ([.tasks[] | select(.id == "mate")][0].hints.open_decisions | length) == 101
@@ -1631,6 +1632,53 @@ test_task_component_failure_fails_closed() {
   grep -F 'task snapshot failed' "$err" >/dev/null \
     || fail "a failed task component lacked a diagnostic: $(cat "$err")"
   pass "a failed per-task component fails the snapshot instead of dropping tasks"
+}
+
+# Fail the Nth scout-report record composition, so one report in the middle of
+# the inventory drops out while its neighbours stay intact.
+install_failing_scout_report() {  # <fakebin> <counter-file> <occurrence>
+  local fakebin=$1 counter=$2 occurrence=$3 real
+  real=$(command -v jq)
+  rm -f "$counter"
+  cat > "$fakebin/jq" <<SH
+#!/usr/bin/env bash
+case "\$*" in
+  *'{id:\$id,path:\$path}'*)
+    count=0
+    [ ! -f "$counter" ] || count=\$(cat "$counter")
+    count=\$((count + 1))
+    printf '%s' "\$count" > "$counter"
+    [ "\$count" -ne $occurrence ] || exit 9
+    ;;
+esac
+exec "$real" "\$@"
+SH
+  chmod +x "$fakebin/jq"
+}
+
+# The scout-report collector sorts its input, so a record failure that only
+# aborts a subshell leaves the collector succeeding on the truncated prefix and
+# publishes an exit-0 snapshot whose scout_reports silently omit a finished
+# report the captain is waiting on.
+test_scout_report_failure_fails_closed() {
+  local home fakebin out err rc
+  home=$(make_home scout-report-fail-closed); write_fixture "$home"
+  mkdir -p "$home/data/scout-y" "$home/data/scout-z"
+  printf '# Scout Y\n' > "$home/data/scout-y/report.md"
+  printf '# Scout Z\n' > "$home/data/scout-z/report.md"
+  fakebin=$(make_fakebin "$home")
+  install_failing_scout_report "$fakebin" "$home/scout.count" 2
+  err="$home/scout-report.err"
+  out=$(PATH="$fakebin:$PATH" FM_HOME="$home" \
+    FM_SNAPSHOT_NOW=2026-07-11T18:00:00Z FM_SNAPSHOT_NOW_EPOCH=1783792800 \
+    "$ROOT/bin/fm-fleet-snapshot.sh" --json 2> "$err"); rc=$?
+  [ "$rc" -ne 0 ] || fail "a failed scout-report record published an exit-0 snapshot: $out"
+  if printf '%s' "$out" | jq -e '.scout_reports' >/dev/null 2>&1; then
+    fail "a failed scout-report record still emitted a report inventory: $out"
+  fi
+  grep -F 'scout report snapshot failed' "$err" >/dev/null \
+    || fail "a failed scout-report record lacked a diagnostic: $(cat "$err")"
+  pass "a failed scout-report record fails the snapshot instead of dropping reports"
 }
 
 install_failing_jq() {  # <fakebin> <model|toon>
@@ -3082,4 +3130,5 @@ test_per_repository_pr_cap_is_disclosed
 test_large_candidate_pr_inventory_avoids_argument_transport
 test_large_task_decision_inventory_avoids_argument_transport
 test_task_component_failure_fails_closed
+test_scout_report_failure_fails_closed
 test_projection_and_toon_fail_closed


### PR DESCRIPTION
## Intent

Filed 2026-09-01 and reproduced then. Priority 1, and it has sat queued a week because the fleet
kept having louder problems - which is itself the argument for fixing it now.

**Bearings is completely blocked.** `/bearings` in every mode - plain, file, and lavish - fails
before any field projection:

```
/usr/bin/jq: Argument list too long (bin/fm-fleet-snapshot.sh:611)
fm-fleet-snapshot: main inventory summary failed
```

Passing a reduced `--fields` list does not help, because the failure is upstream of projection.

**Cause, already diagnosed:** `main_inventory_json()` passes the entire backlog JSON and the entire
tasks JSON to jq as COMMAND-LINE arguments, via `--argjson "$1"` / `--argjson "$2"`. Those blobs
land in argv, so once they exceed the kernel argument limit the exec simply fails.
`data/backlog.md` is now 129,785 bytes and this home carries 73 open captain holds, several with
long multi-sentence reasons. That is what crossed the threshold.

**Why it matters more than one broken command.** This is the single deterministic fleet-state
source the bearings skill mandates, and that skill explicitly forbids substituting a second reader.
So the failure removes the fleet's entire catch-up surface at exactly the moment the backlog is
large enough to need one. It is a threshold failure rather than a gradual one: it worked earlier
that day and now fails on every invocation until the backlog shrinks, and it will recur in any home
whose backlog grows.

There is an interim workaround - read `state/*.meta`, `bin/fm-crew-state.sh` per task, and the
backlog directly - but the skill deliberately prohibits that substitute and it must not become the
norm.

## What Changed

- `fm-bearings-snapshot.sh` now accumulates candidate open-PR rows in a `mktemp` JSONL file (cleaned up via an `EXIT` trap) and hands them to the model `jq` with `--slurpfile`, replacing the `--argjson` accumulator that put the whole PR inventory in argv.
- `fm-fleet-snapshot.sh` gains a `json_envelope_file` helper plus a shared `JQ_ENVELOPE_PRELUDE` (`envelope`/`member`) so per-task components, parent-evidence bundles, and the unbounded status-log note travel to `jq` as named-key files (`--slurpfile`/`--rawfile`) rather than `--argjson` arguments; the prelude errors out on a transport that is not a single JSON object or that is missing a key instead of folding it to `null`.
- `task_json_lines` and `scout_report_lines` now build rows into a file instead of a piped `jq -s` loop, so a failed record composition returns non-zero and aborts the snapshot instead of publishing a silently truncated `tasks[]`/`scout_reports[]`; parent evidence reconciliation and contradiction reads fail closed with per-task diagnostics, and the header documents that records are omitted only through disclosed bounds. Four tests cover large PR/decision inventories exceeding the per-argument limit and mid-inventory task and scout-report composition failures.

## Risk Assessment

✅ Low: The change is a well-bounded argv-to-file transport migration whose durable fix I reproduced end to end (base commit both overflows `jq` argv and fail-opens with a task silently missing; HEAD renders the same 146 KB component correctly), every remaining `--arg`/`--argjson` in both scripts carries a bounded per-item scalar, the new envelope guard provably fails closed on empty or multi-value components, and the only findings are three informational polish/attribution items.

## Testing

Built real FM_HOME fixtures matching the report (131,485-byte backlog, 73 long-reason captain holds, live crewmate metas/status logs, one registered secondmate home) and drove /bearings the way each mode does, on both the base and target commits. Base reproduces the reported failure on the argv transports this change removes: the PR-enrichment path exits 1 with `jq: Argument list too long` and no fleet state, and an oversized per-task component makes the snapshot exit 0 while silently omitting a live task from Underway and from the fleet-state inventory the bearings skill mandates. Target projects all of it completely with clean stderr (620 PR rows, 401-decision secondmate present, parked crewmate visible in Underway). I also ran the full owning suite tests/fm-bearings-snapshot.test.sh and the downstream tests/fm-fleet-snapshot-view.test.sh at target (all ok), and ran each of the 4 new tests against base scripts where all 4 fail, confirming they are real regressions. No visual artifact applies: the change is shell/JSON transport with no rendered surface, and the lavish board is composed downstream from the same --json step I exercised and is untouched by the diff. Worktree left clean; transient fixture scaffolding removed and only transcripts plus reproduction scripts kept in the evidence directory.

<details>
<summary>Evidence: Before/after CLI transcript: three argv-overflow scenarios plus base-vs-target verdicts for the 4 new tests</summary>

Source: [Before/after CLI transcript: three argv-overflow scenarios plus base-vs-target verdicts for the 4 new tests](https://github.com/mihneamanolache/firstmate/blob/8b675db9421842ddd9bac1884ed05021422158e4/.no-mistakes/evidence/bugfix/fm-bearings-snapshot-argv-overflow/bearings-before-after.txt)

```text
=======================================================================
/bearings argv-overflow reproduction - BEFORE (base b84e0e3) vs AFTER (target 6f64ebe)
Reproduced on Linux (MAX_ARG_STRLEN = 131072 bytes per single argument).
Every home below is a real FM_HOME on disk: data/backlog.md is 131,485 bytes
carrying 73 open captain holds with long multi-sentence reasons, plus live
crewmate metas/status logs and one registered local secondmate home.
=======================================================================

=======================================================================
SCENARIO A - "/bearings include PRs" over a 31-repo fleet home
  Documented expansion only: --include-prs --all-pr-repos, default
  FM_BEARINGS_PR_LIMIT=20, 20 open PRs per repo.
=======================================================================
--- BEFORE (base b84e0e3) ---
$ bin/fm-bearings-snapshot.sh --include-prs --all-pr-repos --json
  /tmp/fm-argv-repro/base/bin/fm-bearings-snapshot.sh: line 279: /usr/bin/jq: Argument list too long
  jq: invalid JSON text passed to --argjson
  Use jq --help for help with command-line options,
  or see the jq manpage, or online docs  at https://jqlang.github.io/jq
  jq: invalid JSON text passed to --argjson
  exit: 1   stdout bytes: 0   -> the captain gets no fleet state at all

--- AFTER (target 6f64ebe) ---
$ bin/fm-bearings-snapshot.sh --include-prs --all-pr-repos --json
  stderr: (empty)
  exit: 0
  {"prs":"checked (31 repos, 620 open)","candidate_prs":620,"first_row":{"num":"1","repo":"kunchenguid/service-1","task":"fleet-transport-1","url":"https://github.com/kunchenguid/firstmate/pull/1","review":"","mergeable":"MERGEABLE","checks":"passing"},"last_row":{"num":"20","repo":"kunchenguid/firstmate","task":"fleet-transport-20","url":"https://github.com/kunchenguid/firstmate/pull/20","review":"","mergeable":"MERGEABLE","checks":"passing"}}

=======================================================================
SCENARIO C - plain "/bearings" in a home with a parked crewmate that has
  accumulated 520 keyed open captain decisions (state/ship-parked.status
  is 124 KB; its open-decision component serializes to ~137 KB).
  This is the silent-loss case: exit 0, but the crewmate waiting on the
  captain disappears from the captain-facing Underway section.
=======================================================================
--- BEFORE (base b84e0e3) ---
$ bin/fm-bearings-snapshot.sh --fields home,in_flight,decisions_open
  stderr: /tmp/fm-argv-repro/base/bin/fm-fleet-snapshot.sh: line 802: /usr/bin/jq: Argument list too long
  exit: 0
  in_flight[3]{id,kind,state,repo,doing}:
    scout-x,scout,done,firstmate,"report ready for the captain, the failure reproduces on every invocation"
    ship-task,ship,working,firstmate,harness busy (claude-hook)
    mate/mate,ship,working,firstmate,harness busy (claude-hook)
  secondmates[1]{id,state,doing,provenance,freshness,age_seconds,contradiction,reason}:

--- AFTER (target 6f64ebe) ---
$ bin/fm-bearings-snapshot.sh --fields home,in_flight,decisions_open
  stderr: (empty)
  exit: 0
  in_flight[4]{id,kind,state,repo,doing}:
    scout-x,scout,done,firstmate,"report ready for the captain, the failure reproduces on every invocation"
    ship-parked,ship,paused,firstmate,parked waiting on the captain to pick a route
    ship-task,ship,working,firstmate,harness busy (claude-hook)
    mate/mate,ship,working,firstmate,harness busy (claude-hook)

=======================================================================
SCENARIO B - the same class on the deterministic fleet-state source the
  bearings skill mandates: a persistent secondmate stream carrying 401
  keyed open captain decisions (state/mate.status is 122 KB).
=======================================================================
--- BEFORE (base b84e0e3) ---
$ bin/fm-fleet-snapshot.sh --json
  stderr: /tmp/fm-argv-repro/base/bin/fm-fleet-snapshot.sh: line 802: /usr/bin/jq: Argument list too long
  exit: 0
  tasks[] inventory: scout-x, ship-task
  task "mate" open captain decisions: TASK MISSING FROM INVENTORY

--- AFTER (target 6f64ebe) ---
$ bin/fm-fleet-snapshot.sh --json
  stderr: (empty)
  exit: 0
  tasks[] inventory: mate, scout-x, ship-task
  task "mate" open captain decisions: 401

=======================================================================
REGRESSION TESTS - tests/fm-bearings-snapshot.test.sh (the 4 cases this
  change adds), run against the BASE scripts and the TARGET scripts.
=======================================================================
  base b84e0e3   not ok - large candidate PR fixture did not exceed the per-argument limit
  base b84e0e3   not ok - large task-decision component did not exceed the per-argument limit
  base b84e0e3   not ok - a failed task component published an exit-0 snapshot
  base b84e0e3   not ok - a failed scout-report record published an exit-0 snapshot

  target 6f64ebe ok - large candidate PR inventories avoid argument transport
  target 6f64ebe ok - large task-decision inventories avoid argument transport
  target 6f64ebe ok - a failed per-task component fails the snapshot instead of dropping tasks
  target 6f64ebe ok - a failed scout-report record fails the snapshot instead of dropping reports
```
</details>
<details>
<summary>Evidence: /bearings on the reproduced reported home at the target commit - plain, reduced --fields, --json, --include-prs</summary>

Source: [/bearings on the reproduced reported home at the target commit - plain, reduced --fields, --json, --include-prs](https://github.com/mihneamanolache/firstmate/blob/8b675db9421842ddd9bac1884ed05021422158e4/.no-mistakes/evidence/bugfix/fm-bearings-snapshot-argv-overflow/bearings-modes-fixed.txt)

```text
# /bearings on a faithful rebuild of the reported home, TARGET commit 6f64ebe.
# data/backlog.md = 131,485 bytes, 73 open captain holds with long multi-sentence
# reasons, 3 live tasks, 1 registered local secondmate home.
# Covers every mode's entry point: plain (TOON digest), a reduced --fields list,
# --json (the single step file mode and lavish mode both start from), and
# --include-prs.

===== home under test =====
FM_HOME=/tmp/fm-argv-repro/home-report
data/backlog.md: 131485 bytes, 73 open captain holds
tasks: 3

===== /bearings (plain mode) -> bin/fm-bearings-snapshot.sh =====
schema: fm-bearings.v1
home: fm-argv-repro/home-report
generated: "2026-09-08T12:00:00Z"
prs: "not_requested (run: /bearings include PRs)"
in_flight[3]{id,kind,state,repo,doing}:
  scout-x,scout,done,firstmate,"report ready for the captain, the failure reproduces on every invocation"
  ship-task,ship,working,firstmate,harness busy (claude-hook)
  mate/mate,ship,working,firstmate,harness busy (claude-hook)
secondmates[1]{id,state,doing,provenance,freshness,age_seconds,contradiction,reason}:
  mate,captain_decision,Choose subscription order,structured-home,fresh,0,true,"-"
secondmate_reconcile[1]{id,spawn_gen,host,kind,ids}:
  mate,null,null,null,"[]"
decisions_open[20]{id,key,verb,summary,owner}:
  hold-01,hold-01,captain-hold,"Captain decision 01 on fleet route 01: the captain has to choose between keeping the curre…",(main)
  hold-02,hold-02,captain-hold,"Captain decision 02 on fleet route 02: the captain has to choose between keeping the curre…",(main)
  hold-03,hold-03,captain-hold,"Captain decision 03 on fleet route 03: the captain has to choose between keeping the curre…",(main)
  hold-04,hold-04,captain-hold,"Captain decision 04 on fleet route 04: the captain has to choose between keeping the curre…",(main)
  hold-05,hold-05,captain-hold,"Captain decision 05 on fleet route 05: the captain has to choose between keeping the curre…",(main)
  hold-06,hold-06,captain-hold,"Captain decision 06 on fleet route 06: the captain has to choose between keeping the curre…",(main)
  hold-07,hold-07,captain-hold,"Captain decision 07 on fleet route 07: the captain has to choose between keeping the curre…",(main)
  hold-08,hold-08,captain-hold,"Captain decision 08 on fleet route 08: the captain has to choose between keeping the curre…",(main)
  hold-09,hold-09,captain-hold,"Captain decision 09 on fleet route 09: the captain has to choose between keeping the curre…",(main)
  hold-10,hold-10,captain-hold,"Captain decision 10 on fleet route 10: the captain has to choose between keeping the curre…",(main)
  hold-11,hold-11,captain-hold,"Captain decision 11 on fleet route 11: the captain has to choose between keeping the curre…",(main)
  hold-12,hold-12,captain-hold,"Captain decision 12 on fleet route 12: the captain has to choose between keeping the curre…",(main)
  hold-13,hold-13,captain-hold,"Captain decision 13 on fleet route 13: the captain has to choose between keeping the curre…",(main)
  hold-14,hold-14,captain-hold,"Captain decision 14 on fleet route 14: the captain has to choose between keeping the curre…",(main)
  hold-15,hold-15,captain-hold,"Captain decision 15 on fleet route 15: the captain has to choose between keeping the curre…",(main)
  hold-16,hold-16,captain-hold,"Captain decision 16 on fleet route 16: the captain has to choose between keeping the curre…",(main)
  hold-17,hold-17,captain-hold,"Captain decision 17 on fleet route 17: the captain has to choose between keeping the curre…",(main)
  hold-18,hold-18,captain-hold,"Captain decision 18 on fleet route 18: the captain has to choose between keeping the curre…",(main)
  hold-19,hold-19,captain-hold,"Captain decision 19 on fleet route 19: the captain has to choose between keeping the curre…",(main)
  hold-20,hold-20,captain-hold,"Captain decision 20 on fleet route 20: the captain has to choose between keeping the curre…",(main)
landed[6]{id,what,artifact,owner}:
  done-083,Landed fleet work 083,"https://github.com/kunchenguid/firstmate/pull/3083",(main)
  mate-landed,Secondmate-managed fix,"https://github.com/kunchenguid/firstmate/pull/50",mate
  done-055,Landed fleet work 055,"https://github.com/kunchenguid/firstmate/pull/3055",(main)
  done-027,Landed fleet work 027,"https://github.com/kunchenguid/firstmate/pull/3027",(main)
  done-082,Landed fleet work 082,"https://github.com/kunchenguid/firstmate/pull/3082",(main)
  done-054,Landed fleet work 054,"https://github.com/kunchenguid/firstmate/pull/3054",(main)
gates[20]{id,title,blocked_by,reason,owner}:
  queued-001,Queued fleet work 001,ship-task,"-",(main)
  queued-002,Queued fleet work 002,ship-task,"-",(main)
  queued-003,Queued fleet work 003,ship-task,"-",(main)
  queued-004,Queued fleet work 004,ship-task,"-",(main)
  queued-005,Queued fleet work 005,ship-task,"-",(main)
  queued-006,Queued fleet work 006,ship-task,"-",(main)
  queued-007,Queued fleet work 007,ship-task,"-",(main)
  queued-008,Queued fleet work 008,ship-task,"-",(main)
  queued-009,Queued fleet work 009,ship-task,"-",(main)
  queued-010,Queued fleet work 010,ship-task,"-",(main)
  queued-011,Queued fleet work 011,ship-task,"-",(main)
  queued-012,Queued fleet work 012,ship-task,"-",(main)
  queued-013,Queued fleet work 013,ship-task,"-",(main)
  queued-014,Queued fleet work 014,ship-task,"-",(main)
  queued-015,Queued fleet work 015,ship-task,"-",(main)
  queued-016,Queued fleet work 016,ship-task,"-",(main)
  queued-017,Queued fleet work 017,ship-task,"-",(main)
  queued-018,Queued fleet work 018,ship-task,"-",(main)
  queued-019,Queued fleet work 019,ship-task,"-",(main)
  queued-020,Queued fleet work 020,ship-task,"-",(main)
reports[1]{id,path}:
  scout-x,/tmp/fm-argv-repro/home-report/data/scout-x/report.md
recorded_prs[1]{id,url}:
  ship-task,"https://github.com/kunchenguid/firstmate/pull/9"
unhealthy_endpoints[1]{id,backend,target,exists,agent}:
  mate,tmux,"firstmate:fm-mate",true,dead
omitted[10]{surface,reveal}:
  backlog item bodies,"--fields bodies"
  task paths,"--fields paths"
  watch/steer actions,"--fields actions"
  healthy endpoint detail,"--fields endpoints"
  full scout-report inventory,"--all-reports"
  landed showing 6 of 7 (incl. 1 secondmate home(s)),"--all-landed"
  landed per-home capped at 6 for 1 home(s),"--all-landed"
  decisions_open showing 20 of 74,"--all-decisions"
  gates showing 20 of 90,"--all-queued"
  live PR discovery + checks,"--include-prs"
exit=0

===== /bearings with a reduced --fields list =====
schema: fm-bearings.v1
home: fm-argv-repro/home-report
generated: "2026-09-08T12:00:00Z"
prs: "not_requested (run: /bearings include PRs)"
in_flight[3]{id,kind,state,repo,doing}:
  scout-x,scout,done,firstmate,"report ready for the captain, the failure reproduces on every invocation"
  ship-task,ship,working,firstmate,harness busy (claude-hook)
  mate/mate,ship,working,firstmate,harness busy (claude-hook)
secondmates[1]{id,state,doing,provenance,freshness,age_seconds,contradiction,reason}:
  mate,captain_decision,Choose subscription order,structured-home,fresh,0,true,"-"
secondmate_reconcile[1]{id,spawn_gen,host,kind,ids}:
  mate,null,null,null,"[]"
decisions_open[20]{id,key,verb,summary,owner}:
  hold-01,hold-01,captain-hold,"Captain decision 01 on fleet route 01: the captain has to choose between keeping the curre…",(main)
  hold-02,hold-02,captain-hold,"Captain decision 02 on fleet route 02: the captain has to choose between keeping the curre…",(main)
  hold-03,hold-03,captain-hold,"Captain decision 03 on fleet route 03: the captain has to choose between keeping the curre…",(main)
  hold-04,hold-04,captain-hold,"Captain decision 04 on fleet route 04: the captain has to choose between keeping the curre…",(main)
  hold-05,hold-05,captain-hold,"Captain decision 05 on fleet route 05: the captain has to choose between keeping the curre…",(main)
  hold-06,hold-06,captain-hold,"Captain decision 06 on fleet route 06: the captain has to choose between keeping the curre…",(main)
  hold-07,hold-07,captain-hold,"Captain decision 07 on fleet route 07: the captain has to choose between keeping the curre…",(main)
  hold-08,hold-08,captain-hold,"Captain decision 08 on fleet route 08: the captain has to choose between keeping the curre…",(main)
  hold-09,hold-09,captain-hold,"Captain decision 09 on fleet route 09: the captain has to choose between keeping the curre…",(main)
  hold-10,hold-10,captain-hold,"Captain decision 10 on fleet route 10: the captain has to choose between keeping the curre…",(main)
  hold-11,hold-11,captain-hold,"Captain decision 11 on fleet route 11: the captain has to choose between keeping the curre…",(main)
  hold-12,hold-12,captain-hold,"Captain decision 12 on fleet route 12: the captain has to choose between keeping the curre…",(main)
  hold-13,hold-13,captain-hold,"Captain decision 13 on fleet route 13: the captain has to choose between keeping the curre…",(main)
  hold-14,hold-14,captain-hold,"Captain decision 14 on fleet route 14: the captain has to choose between keeping the curre…",(main)
  hold-15,hold-15,captain-hold,"Captain decision 15 on fleet route 15: the captain has to choose between keeping the curre…",(main)
  hold-16,hold-16,captain-hold,"Captain decision 16 on fleet route 16: the captain has to choose between keeping the curre…",(main)
  hold-17,hold-17,captain-hold,"Captain decision 17 on fleet route 17: the captain has to choose between keeping the curre…",(main)
  hold-18,hold-18,captain-hold,"Captain decision 18 on fleet route 18: the captain has to choose between keeping the curre…",(main)
  hold-19,hold-19,captain-hold,"Captain decision 19 on fleet route 19: the captain has to choose between keeping the curre…",(main)
  hold-20,hold-20,captain-hold,"Captain decision 20 on fleet route 20: the captain has to choose between keeping the curre…",(main)
landed[6]{id,what,artifact,owner}:
  done-083,Landed fleet work 083,"https://github.com/kunchenguid/firstmate/pull/3083",(main)
  mate-landed,Secondmate-managed fix,"https://github.com/kunchenguid/firstmate/pull/50",mate
  done-055,Landed fleet work 055,"https://github.com/kunchenguid/firstmate/pull/3055",(main)
  done-027,Landed fleet work 027,"https://github.com/kunchenguid/firstmate/pull/3027",(main)
  done-082,Landed fleet work 082,"https://github.com/kunchenguid/firstmate/pull/3082",(main)
  done-054,Landed fleet work 054,"https://github.com/kunchenguid/firstmate/pull/3054",(main)
gates[20]{id,title,blocked_by,reason,owner}:
  queued-001,Queued fleet work 001,ship-task,"-",(main)
  queued-002,Queued fleet work 002,ship-task,"-",(main)
  queued-003,Queued fleet work 003,ship-task,"-",(main)
  queued-004,Queued fleet work 004,ship-task,"-",(main)
  queued-005,Queued fleet work 005,ship-task,"-",(main)
  queued-006,Queued fleet work 006,ship-task,"-",(main)
  queued-007,Queued fleet work 007,ship-task,"-",(main)
  queued-008,Queued fleet work 008,ship-task,"-",(main)
  queued-009,Queued fleet work 009,ship-task,"-",(main)
  queued-010,Queued fleet work 010,ship-task,"-",(main)
  queued-011,Queued fleet work 011,ship-task,"-",(main)
  queued-012,Queued fleet work 012,ship-task,"-",(main)
  queued-013,Queued fleet work 013,ship-task,"-",(main)
  queued-014,Queued fleet work 014,ship-task,"-",(main)
  queued-015,Queued fleet work 015,ship-task,"-",(main)
  queued-016,Queued fleet work 016,ship-task,"-",(main)
  queued-017,Queued fleet work 017,ship-task,"-",(main)
  queued-018,Queued fleet work 018,ship-task,"-",(main)
  queued-019,Queued fleet work 019,ship-task,"-",(main)
  queued-020,Queued fleet work 020,ship-task,"-",(main)
reports[1]{id,path}:
  scout-x,/tmp/fm-argv-repro/home-report/data/scout-x/report.md
recorded_prs[1]{id,url}:
  ship-task,"https://github.com/kunchenguid/firstmate/pull/9"
unhealthy_endpoints[1]{id,backend,target,exists,agent}:
  mate,tmux,"firstmate:fm-mate",true,dead
omitted[10]{surface,reveal}:
  backlog item bodies,"--fields bodies"
  task paths,"--fields paths"
  watch/steer actions,"--fields actions"
  healthy endpoint detail,"--fields endpoints"
  full scout-report inventory,"--all-reports"
  landed showing 6 of 7 (incl. 1 secondmate home(s)),"--all-landed"
  landed per-home capped at 6 for 1 home(s),"--all-landed"
  decisions_open showing 20 of 74,"--all-decisions"
  gates showing 20 of 90,"--all-queued"
  live PR discovery + checks,"--include-prs"
exit=0

===== /bearings file + lavish mode step 1 -> bin/fm-bearings-snapshot.sh --json =====
exit=0 bytes=11290
{
  "schema": "fm-bearings.v1",
  "home": "fm-argv-repro/home-report",
  "in_flight": 3,
  "decisions_open": 20,
  "gates": 20,
  "landed": 6,
  "reports": 1,
  "secondmates": 1,
  "omitted": 10
}
first three Captain's Call rows:
{"id":"hold-01","key":"hold-01","verb":"captain-hold","summary":"Captain decision 01 on fleet route 01: the captain has to choose between keeping the curre…","owner":"(main)"}
{"id":"hold-02","key":"hold-02","verb":"captain-hold","summary":"Captain decision 02 on fleet route 02: the captain has to choose between keeping the curre…","owner":"(main)"}
{"id":"hold-03","key":"hold-03","verb":"captain-hold","summary":"Captain decision 03 on fleet route 03: the captain has to choose between keeping the curre…","owner":"(main)"}
secondmate row:
{"id":"mate","state":"captain_decision","doing":"Choose subscription order","provenance":"structured-home","freshness":"fresh","age_seconds":0,"contradiction":true,"reason":"-"}

===== /bearings include PRs -> bin/fm-bearings-snapshot.sh --include-prs --json =====
exit=0
{
  "prs": "checked (1 repos, 60 open)",
  "candidate_prs": 60
}
```
</details>
<details>
<summary>Evidence: Same mode sweep at the base commit (honest context: that home&#39;s plain path already survives on base after #3677)</summary>

Source: [Same mode sweep at the base commit (honest context: that home&#39;s plain path already survives on base after #3677)](https://github.com/mihneamanolache/firstmate/blob/8b675db9421842ddd9bac1884ed05021422158e4/.no-mistakes/evidence/bugfix/fm-bearings-snapshot-argv-overflow/bearings-modes-base.txt)

```text
# The same runs against the BASE commit b84e0e3, for honest context: base already
# carries the backlog/tasks file transport (#3677), so this particular home no
# longer reproduces the reported crash on the plain path. The remaining argv
# transports this change removes still fail on base - see bearings-before-after.txt.

===== home under test =====
FM_HOME=/tmp/fm-argv-repro/home-report-base
data/backlog.md: 131485 bytes, 73 open captain holds
tasks: 3

===== /bearings (plain mode) -> bin/fm-bearings-snapshot.sh =====
schema: fm-bearings.v1
home: fm-argv-repro/home-report-base
generated: "2026-09-08T12:00:00Z"
prs: "not_requested (run: /bearings include PRs)"
in_flight[3]{id,kind,state,repo,doing}:
  scout-x,scout,done,firstmate,"report ready for the captain, the failure reproduces on every invocation"
  ship-task,ship,working,firstmate,harness busy (claude-hook)
  mate/mate,ship,working,firstmate,harness busy (claude-hook)
secondmates[1]{id,state,doing,provenance,freshness,age_seconds,contradiction,reason}:
  mate,captain_decision,Choose subscription order,structured-home,fresh,0,true,"-"
secondmate_reconcile[1]{id,spawn_gen,host,kind,ids}:
  mate,null,null,null,"[]"
decisions_open[20]{id,key,verb,summary,owner}:
  hold-01,hold-01,captain-hold,"Captain decision 01 on fleet route 01: the captain has to choose between keeping the curre…",(main)
  hold-02,hold-02,captain-hold,"Captain decision 02 on fleet route 02: the captain has to choose between keeping the curre…",(main)
  hold-03,hold-03,captain-hold,"Captain decision 03 on fleet route 03: the captain has to choose between keeping the curre…",(main)
  hold-04,hold-04,captain-hold,"Captain decision 04 on fleet route 04: the captain has to choose between keeping the curre…",(main)
  hold-05,hold-05,captain-hold,"Captain decision 05 on fleet route 05: the captain has to choose between keeping the curre…",(main)
  hold-06,hold-06,captain-hold,"Captain decision 06 on fleet route 06: the captain has to choose between keeping the curre…",(main)
  hold-07,hold-07,captain-hold,"Captain decision 07 on fleet route 07: the captain has to choose between keeping the curre…",(main)
  hold-08,hold-08,captain-hold,"Captain decision 08 on fleet route 08: the captain has to choose between keeping the curre…",(main)
  hold-09,hold-09,captain-hold,"Captain decision 09 on fleet route 09: the captain has to choose between keeping the curre…",(main)
  hold-10,hold-10,captain-hold,"Captain decision 10 on fleet route 10: the captain has to choose between keeping the curre…",(main)
  hold-11,hold-11,captain-hold,"Captain decision 11 on fleet route 11: the captain has to choose between keeping the curre…",(main)
  hold-12,hold-12,captain-hold,"Captain decision 12 on fleet route 12: the captain has to choose between keeping the curre…",(main)
  hold-13,hold-13,captain-hold,"Captain decision 13 on fleet route 13: the captain has to choose between keeping the curre…",(main)
  hold-14,hold-14,captain-hold,"Captain decision 14 on fleet route 14: the captain has to choose between keeping the curre…",(main)
  hold-15,hold-15,captain-hold,"Captain decision 15 on fleet route 15: the captain has to choose between keeping the curre…",(main)
  hold-16,hold-16,captain-hold,"Captain decision 16 on fleet route 16: the captain has to choose between keeping the curre…",(main)
  hold-17,hold-17,captain-hold,"Captain decision 17 on fleet route 17: the captain has to choose between keeping the curre…",(main)
  hold-18,hold-18,captain-hold,"Captain decision 18 on fleet route 18: the captain has to choose between keeping the curre…",(main)
  hold-19,hold-19,captain-hold,"Captain decision 19 on fleet route 19: the captain has to choose between keeping the curre…",(main)
  hold-20,hold-20,captain-hold,"Captain decision 20 on fleet route 20: the captain has to choose between keeping the curre…",(main)
landed[6]{id,what,artifact,owner}:
  done-083,Landed fleet work 083,"https://github.com/kunchenguid/firstmate/pull/3083",(main)
  mate-landed,Secondmate-managed fix,"https://github.com/kunchenguid/firstmate/pull/50",mate
  done-055,Landed fleet work 055,"https://github.com/kunchenguid/firstmate/pull/3055",(main)
  done-027,Landed fleet work 027,"https://github.com/kunchenguid/firstmate/pull/3027",(main)
  done-082,Landed fleet work 082,"https://github.com/kunchenguid/firstmate/pull/3082",(main)
  done-054,Landed fleet work 054,"https://github.com/kunchenguid/firstmate/pull/3054",(main)
gates[20]{id,title,blocked_by,reason,owner}:
  queued-001,Queued fleet work 001,ship-task,"-",(main)
  queued-002,Queued fleet work 002,ship-task,"-",(main)
  queued-003,Queued fleet work 003,ship-task,"-",(main)
  queued-004,Queued fleet work 004,ship-task,"-",(main)
  queued-005,Queued fleet work 005,ship-task,"-",(main)
  queued-006,Queued fleet work 006,ship-task,"-",(main)
  queued-007,Queued fleet work 007,ship-task,"-",(main)
  queued-008,Queued fleet work 008,ship-task,"-",(main)
  queued-009,Queued fleet work 009,ship-task,"-",(main)
  queued-010,Queued fleet work 010,ship-task,"-",(main)
  queued-011,Queued fleet work 011,ship-task,"-",(main)
  queued-012,Queued fleet work 012,ship-task,"-",(main)
  queued-013,Queued fleet work 013,ship-task,"-",(main)
  queued-014,Queued fleet work 014,ship-task,"-",(main)
  queued-015,Queued fleet work 015,ship-task,"-",(main)
  queued-016,Queued fleet work 016,ship-task,"-",(main)
  queued-017,Queued fleet work 017,ship-task,"-",(main)
  queued-018,Queued fleet work 018,ship-task,"-",(main)
  queued-019,Queued fleet work 019,ship-task,"-",(main)
  queued-020,Queued fleet work 020,ship-task,"-",(main)
reports[1]{id,path}:
  scout-x,/tmp/fm-argv-repro/home-report-base/data/scout-x/report.md
recorded_prs[1]{id,url}:
  ship-task,"https://github.com/kunchenguid/firstmate/pull/9"
unhealthy_endpoints[1]{id,backend,target,exists,agent}:
  mate,tmux,"firstmate:fm-mate",true,dead
omitted[10]{surface,reveal}:
  backlog item bodies,"--fields bodies"
  task paths,"--fields paths"
  watch/steer actions,"--fields actions"
  healthy endpoint detail,"--fields endpoints"
  full scout-report inventory,"--all-reports"
  landed showing 6 of 7 (incl. 1 secondmate home(s)),"--all-landed"
  landed per-home capped at 6 for 1 home(s),"--all-landed"
  decisions_open showing 20 of 74,"--all-decisions"
  gates showing 20 of 90,"--all-queued"
  live PR discovery + checks,"--include-prs"
exit=0

===== /bearings with a reduced --fields list =====
schema: fm-bearings.v1
home: fm-argv-repro/home-report-base
generated: "2026-09-08T12:00:00Z"
prs: "not_requested (run: /bearings include PRs)"
in_flight[3]{id,kind,state,repo,doing}:
  scout-x,scout,done,firstmate,"report ready for the captain, the failure reproduces on every invocation"
  ship-task,ship,working,firstmate,harness busy (claude-hook)
  mate/mate,ship,working,firstmate,harness busy (claude-hook)
secondmates[1]{id,state,doing,provenance,freshness,age_seconds,contradiction,reason}:
  mate,captain_decision,Choose subscription order,structured-home,fresh,0,true,"-"
secondmate_reconcile[1]{id,spawn_gen,host,kind,ids}:
  mate,null,null,null,"[]"
decisions_open[20]{id,key,verb,summary,owner}:
  hold-01,hold-01,captain-hold,"Captain decision 01 on fleet route 01: the captain has to choose between keeping the curre…",(main)
  hold-02,hold-02,captain-hold,"Captain decision 02 on fleet route 02: the captain has to choose between keeping the curre…",(main)
  hold-03,hold-03,captain-hold,"Captain decision 03 on fleet route 03: the captain has to choose between keeping the curre…",(main)
  hold-04,hold-04,captain-hold,"Captain decision 04 on fleet route 04: the captain has to choose between keeping the curre…",(main)
  hold-05,hold-05,captain-hold,"Captain decision 05 on fleet route 05: the captain has to choose between keeping the curre…",(main)
  hold-06,hold-06,captain-hold,"Captain decision 06 on fleet route 06: the captain has to choose between keeping the curre…",(main)
  hold-07,hold-07,captain-hold,"Captain decision 07 on fleet route 07: the captain has to choose between keeping the curre…",(main)
  hold-08,hold-08,captain-hold,"Captain decision 08 on fleet route 08: the captain has to choose between keeping the curre…",(main)
  hold-09,hold-09,captain-hold,"Captain decision 09 on fleet route 09: the captain has to choose between keeping the curre…",(main)
  hold-10,hold-10,captain-hold,"Captain decision 10 on fleet route 10: the captain has to choose between keeping the curre…",(main)
  hold-11,hold-11,captain-hold,"Captain decision 11 on fleet route 11: the captain has to choose between keeping the curre…",(main)
  hold-12,hold-12,captain-hold,"Captain decision 12 on fleet route 12: the captain has to choose between keeping the curre…",(main)
  hold-13,hold-13,captain-hold,"Captain decision 13 on fleet route 13: the captain has to choose between keeping the curre…",(main)
  hold-14,hold-14,captain-hold,"Captain decision 14 on fleet route 14: the captain has to choose between keeping the curre…",(main)
  hold-15,hold-15,captain-hold,"Captain decision 15 on fleet route 15: the captain has to choose between keeping the curre…",(main)
  hold-16,hold-16,captain-hold,"Captain decision 16 on fleet route 16: the captain has to choose between keeping the curre…",(main)
  hold-17,hold-17,captain-hold,"Captain decision 17 on fleet route 17: the captain has to choose between keeping the curre…",(main)
  hold-18,hold-18,captain-hold,"Captain decision 18 on fleet route 18: the captain has to choose between keeping the curre…",(main)
  hold-19,hold-19,captain-hold,"Captain decision 19 on fleet route 19: the captain has to choose between keeping the curre…",(main)
  hold-20,hold-20,captain-hold,"Captain decision 20 on fleet route 20: the captain has to choose between keeping the curre…",(main)
landed[6]{id,what,artifact,owner}:
  done-083,Landed fleet work 083,"https://github.com/kunchenguid/firstmate/pull/3083",(main)
  mate-landed,Secondmate-managed fix,"https://github.com/kunchenguid/firstmate/pull/50",mate
  done-055,Landed fleet work 055,"https://github.com/kunchenguid/firstmate/pull/3055",(main)
  done-027,Landed fleet work 027,"https://github.com/kunchenguid/firstmate/pull/3027",(main)
  done-082,Landed fleet work 082,"https://github.com/kunchenguid/firstmate/pull/3082",(main)
  done-054,Landed fleet work 054,"https://github.com/kunchenguid/firstmate/pull/3054",(main)
gates[20]{id,title,blocked_by,reason,owner}:
  queued-001,Queued fleet work 001,ship-task,"-",(main)
  queued-002,Queued fleet work 002,ship-task,"-",(main)
  queued-003,Queued fleet work 003,ship-task,"-",(main)
  queued-004,Queued fleet work 004,ship-task,"-",(main)
  queued-005,Queued fleet work 005,ship-task,"-",(main)
  queued-006,Queued fleet work 006,ship-task,"-",(main)
  queued-007,Queued fleet work 007,ship-task,"-",(main)
  queued-008,Queued fleet work 008,ship-task,"-",(main)
  queued-009,Queued fleet work 009,ship-task,"-",(main)
  queued-010,Queued fleet work 010,ship-task,"-",(main)
  queued-011,Queued fleet work 011,ship-task,"-",(main)
  queued-012,Queued fleet work 012,ship-task,"-",(main)
  queued-013,Queued fleet work 013,ship-task,"-",(main)
  queued-014,Queued fleet work 014,ship-task,"-",(main)
  queued-015,Queued fleet work 015,ship-task,"-",(main)
  queued-016,Queued fleet work 016,ship-task,"-",(main)
  queued-017,Queued fleet work 017,ship-task,"-",(main)
  queued-018,Queued fleet work 018,ship-task,"-",(main)
  queued-019,Queued fleet work 019,ship-task,"-",(main)
  queued-020,Queued fleet work 020,ship-task,"-",(main)
reports[1]{id,path}:
  scout-x,/tmp/fm-argv-repro/home-report-base/data/scout-x/report.md
recorded_prs[1]{id,url}:
  ship-task,"https://github.com/kunchenguid/firstmate/pull/9"
unhealthy_endpoints[1]{id,backend,target,exists,agent}:
  mate,tmux,"firstmate:fm-mate",true,dead
omitted[10]{surface,reveal}:
  backlog item bodies,"--fields bodies"
  task paths,"--fields paths"
  watch/steer actions,"--fields actions"
  healthy endpoint detail,"--fields endpoints"
  full scout-report inventory,"--all-reports"
  landed showing 6 of 7 (incl. 1 secondmate home(s)),"--all-landed"
  landed per-home capped at 6 for 1 home(s),"--all-landed"
  decisions_open showing 20 of 74,"--all-decisions"
  gates showing 20 of 90,"--all-queued"
  live PR discovery + checks,"--include-prs"
exit=0

===== /bearings file + lavish mode step 1 -> bin/fm-bearings-snapshot.sh --json =====
exit=0 bytes=11300
{
  "schema": "fm-bearings.v1",
  "home": "fm-argv-repro/home-report-base",
  "in_flight": 3,
  "decisions_open": 20,
  "gates": 20,
  "landed": 6,
  "reports": 1,
  "secondmates": 1,
  "omitted": 10
}
first three Captain's Call rows:
{"id":"hold-01","key":"hold-01","verb":"captain-hold","summary":"Captain decision 01 on fleet route 01: the captain has to choose between keeping the curre…","owner":"(main)"}
{"id":"hold-02","key":"hold-02","verb":"captain-hold","summary":"Captain decision 02 on fleet route 02: the captain has to choose between keeping the curre…","owner":"(main)"}
{"id":"hold-03","key":"hold-03","verb":"captain-hold","summary":"Captain decision 03 on fleet route 03: the captain has to choose between keeping the curre…","owner":"(main)"}
secondmate row:
{"id":"mate","state":"captain_decision","doing":"Choose subscription order","provenance":"structured-home","freshness":"fresh","age_seconds":0,"contradiction":true,"reason":"-"}

===== /bearings include PRs -> bin/fm-bearings-snapshot.sh --include-prs --json =====
exit=0
{
  "prs": "checked (1 repos, 60 open)",
  "candidate_prs": 60
}
```
</details>
- Evidence: [Reproduction fixture generator for the reported home (backlog size, captain holds, tasks, secondmate, gh fake)](https://github.com/mihneamanolache/firstmate/blob/8b675db9421842ddd9bac1884ed05021422158e4/.no-mistakes/evidence/bugfix/fm-bearings-snapshot-argv-overflow/make-home.sh)
- Evidence: [Reproduction helper adding the parked crewmate whose 520 keyed open decisions overflow one argument](https://github.com/mihneamanolache/firstmate/blob/8b675db9421842ddd9bac1884ed05021422158e4/.no-mistakes/evidence/bugfix/fm-bearings-snapshot-argv-overflow/mk-parked.sh)
- Evidence: [Mode-sweep runner used for the reported-home transcripts](https://github.com/mihneamanolache/firstmate/blob/8b675db9421842ddd9bac1884ed05021422158e4/.no-mistakes/evidence/bugfix/fm-bearings-snapshot-argv-overflow/run-modes.sh)
<details>
<summary>Evidence: Captain-facing digest difference (excerpt)</summary>

```text
BASE b84e0e3 (stderr: fm-fleet-snapshot.sh: line 802: /usr/bin/jq: Argument list too long; exit 0)
in_flight[3]{id,kind,state,repo,doing}:
scout-x,scout,done,firstmate,"report ready for the captain..."
ship-task,ship,working,firstmate,harness busy (claude-hook)
mate/mate,ship,working,firstmate,harness busy (claude-hook)

TARGET 6f64ebe (stderr: empty; exit 0)
in_flight[4]{id,kind,state,repo,doing}:
scout-x,scout,done,firstmate,"report ready for the captain..."
ship-parked,ship,paused,firstmate,parked waiting on the captain to pick a route
ship-task,ship,working,firstmate,harness busy (claude-hook)
mate/mate,ship,working,firstmate,harness busy (claude-hook)
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"8cf268dbffa5bdd0adaddd9b7d4859d9dbaece07","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 3 infos</summary>

- ⚠️ `bin/fm-fleet-snapshot.sh:1994` - `scout_report_lines` still uses the exact fail-open piped-loop shape that commit ab116ce removed from `task_json_lines`: `find … | sort | while … jq -n … done | jq -s &#39;sort_by(.id)&#39;`. The script does not set `pipefail`, so the function&#39;s exit status is the final `jq -s`, which succeeds on whatever prefix reached it. Concrete path: make one task directory under `$DATA` unreadable (mode 000). `find` prints its readable entries, writes &#39;Permission denied&#39; to stderr and exits 1; `jq -s` exits 0 on the partial stream; `scout_report_lines &gt; &#34;$SCOUT_REPORTS_JSON_FILE&#34; || { … exit 1; }` never fires, and the snapshot publishes `scout_reports` with records silently missing - so a completed scout report never reaches the captain and `/bearings` shows an inventory it believes is complete. The same holds if the inner `jq -n` fails for any single report. This is the identical violated invariant (&#39;composition failures must fail this function rather than … leave a sorted truncated prefix as the published inventory&#39;) at the immediately adjacent sibling collector, and the fix is the same one already applied at line 939: accumulate into a file with `|| return 1` per record, then `jq -s &#39;sort_by(.id)&#39; &lt; &#34;$file&#34;`.
- ℹ️ `bin/fm-fleet-snapshot.sh:1853` - `reconciliation=$(parent_evidence_reconciliation_json &#34;$summary_file&#34; &#34;$evidence_file&#34;)` discards the return status, and the new envelope guard gives that call a real new failure mode (a malformed `task`/`activity_scan` component now makes it `error()` out). When it fails, `$reconciliation` is empty, `contradiction=$(printf &#39;&#39; | jq -r &#39;.contradiction&#39;)` yields the empty string, and the run only fails later because `--argjson contradiction &#34;&#34;` is rejected as invalid JSON by the record-composing jq. It does fail closed, but via a downstream accident and with an opaque &#39;Invalid JSON text passed to --argjson&#39; message rather than the named diagnostic the rest of this branch establishes. Add `|| return 1` to the call so the failure is attributed where it happens.
- ℹ️ `bin/fm-fleet-snapshot.sh:1855` - The `terminal_contradiction` jq now loads the whole parent-evidence envelope via `--slurpfile` plus the prelude solely to re-derive `$note` from `$task.paths.status_log.last_event.note`, when the identical value is already in the shell as `$event_note` (line 1762) and is passed as a plain argument to `terminal_evidence_json` on the next line. `$event_note` is a single bounded status-log note, not an unbounded blob, so it does not need file transport. Replacing the `--slurpfile`/prelude with `--arg note &#34;$event_note&#34;` removes a redundant file read and one of the two places this field is derived.
- ℹ️ `bin/fm-fleet-snapshot.sh:739` - Each failure path in `task_json_lines` (lines 739, 783, 831, 850, 931) calls `snapshot_task_cleanup` before `return 1`, but `trap snapshot_cleanup EXIT` already runs `snapshot_task_cleanup`, and the sole caller (`TASKS_JSON=$(task_json_lines) || … exit 1`) exits immediately. Because the caller is a command substitution, these in-function calls also tear down the observation directory that the parent shell&#39;s `SNAPSHOT_TASK_DIR` still names, which would break any future non-fatal handling of a `task_json_lines` failure. Dropping the five `snapshot_task_cleanup` calls and keeping bare `return 1` leaves behavior identical and removes the duplicated teardown.
- ℹ️ `tests/fm-bearings-snapshot.test.sh:1582` - `test_large_task_decision_inventory_avoids_argument_transport` asserts that the whole canonical snapshot exceeds 131072 bytes, but the bug it guards is a single argument (`--argjson open_decisions`) exceeding MAX_ARG_STRLEN. Those are different quantities: the snapshot already carries the backlog, task rows and secondmate records, so a later fixture trim (fewer decisions, or a shorter suffix) could keep the total above 131072 while `open_decisions` itself drops under 128 KiB, and the test would then pass against the pre-fix code. Assert on the component instead, e.g. `[.tasks[] | select(.id == &#34;mate&#34;)][0].hints.open_decisions | tojson | length &gt; 131072`, so the guard pins the argument that actually overflowed. (The sibling candidate-PR test at line 1554 is tight enough, since candidate_prs dominates that model.)

🔧 Fix: fail closed on scout report and reconciliation failures
3 infos still open:
- ℹ️ `bin/fm-fleet-snapshot.sh:1992` - `scout_report_lines` writes find output to `paths_file`, sorts it into `sorted_file`, then loops over `sorted_file` - but the function&#39;s final `jq -s &#39;sort_by(.id)&#39;` (line 1999) re-orders every record by `.id`, and `.id` is `basename(dirname(report))`, which is unique per record. The pre-sort therefore cannot affect the published order: it is one extra file plus one extra process per snapshot for no observable difference. Read the loop directly from `paths_file` and drop `sorted_file` (and the `LC_ALL=C sort` line). Verified: the emitted `scout_reports` array is identical either way because `sort_by(.id)` is total over unique ids.
- ℹ️ `bin/fm-fleet-snapshot.sh:1858` - `terminal=$(terminal_evidence_json &#34;$task&#34; &#34;$event_note&#34; true)` (and the sibling at line 1908) discards the return status, two lines below the `parent_evidence_reconciliation_json` call this fix round deliberately hardened with `|| { echo ...; return 1; }`. `terminal_evidence_json` can exit non-zero: its final `jq -n --argjson bytes &#34;$bytes&#34; --argjson lines &#34;$lines&#34;` rejects an empty `bytes`/`lines`, which happens if the `wc -c`/`wc -l` pipeline fails. On that path `$terminal` is empty, `json_envelope_file` (line 1863) emits `&#34;terminal&#34;:}`, and the run dies at the record-composing jq with a bare `Invalid JSON text` parse error against a temp file path rather than the named per-task diagnostic the surrounding code now establishes. It does fail closed, so this is attribution only - add the same `|| { echo &#34;fm-fleet-snapshot: terminal evidence capture failed for $id&#34; &gt;&amp;2; return 1; }` guard to both call sites.
- ℹ️ `bin/fm-fleet-snapshot.sh:1990` - Noting a verified behavior change for visibility, not as a defect: `find ... &gt; &#34;$paths_file&#34; || return 1` now propagates any non-zero `find` exit, so a single unreadable directory under `$DATA` aborts the entire snapshot. Verified directly - with `chmod 000 $DATA/locked`, base b84e0e3 exits 0 and publishes the readable reports, HEAD exits 1 with `fm-fleet-snapshot: scout report snapshot failed` and emits nothing, taking down the whole `/bearings` catch-up surface the intent calls the fleet&#39;s only deterministic fleet-state source. This is precisely the fail-closed behavior round 1 requested (its repro was a mode-000 task directory) and is the right trade against silently omitting a finished scout report, so no change is recommended. Nothing in the repo creates a `$DATA/&lt;id&gt;` directory with restricted permissions or removes one (`fm-brief.sh:186` only `mkdir -p`s them), so there is no reachable transient-race path that would make this fire in normal operation. If a degraded-but-published surface is ever wanted here, the script already has the idiom for it (`available:false` / `reasons` in `bounded_parent_activities_json`).

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`bash tests/fm-bearings-snapshot.test.sh` at target commit - full owning suite, every case ok including the 4 new argv/fail-closed cases</code>
- <code>`bash tests/fm-fleet-snapshot-view.test.sh` at target commit - downstream consumer of the changed snapshot producer, all ok</code>
- <code>`ONLY_TEST=&lt;test&gt; bash tests/fm-bearings-snapshot.test.sh` for each of the 4 new tests against a base-commit tree: all report `not ok` (fail-before / pass-after proven)</code>
- <code>Manual scenario A: `bin/fm-bearings-snapshot.sh --include-prs --all-pr-repos --json` on a 31-repo home with 20 open PRs per repo and default caps - base vs target</code>
- <code>Manual scenario C: `bin/fm-bearings-snapshot.sh --fields home,in_flight,decisions_open` on a home whose parked crewmate carries 520 keyed open decisions (124,334-byte status log, 136,761-byte component) - base vs target</code>
- <code>Manual scenario B: `bin/fm-fleet-snapshot.sh --json` on a home whose persistent secondmate stream carries 401 keyed open decisions (122 KB status log) - base vs target, comparing tasks[] inventory and hints.open_decisions</code>
- <code>Manual mode sweep on the reproduced reported home: `bin/fm-bearings-snapshot.sh`, `--fields home,decisions_open,in_flight`, `--json`, `--include-prs --json`</code>
- <code>Edge checks at target: fresh empty FM_HOME still snapshots (exit 0, empty inventories) and no `/tmp/fm-bearings-prs.*` transport files leak after a run</code>

</details>

<details>
<summary>⚠️ **Document** - 1 info</summary>

- ℹ️ `.agents/skills/bearings/SKILL.md:37` - .agents/skills/bearings/SKILL.md step 1 mandates bin/fm-bearings-snapshot.sh --json as the single fleet-state source and forbids a second reader, but gives no guidance for a non-zero exit - which this change makes a reachable outcome for a composition failure, not just a missing home. Left unchanged deliberately: the failure mode is pre-existing (the command could always exit non-zero on a backlog or observation failure), and restating the exit contract in the skill would duplicate the script header that the skill already names as authoritative. Worth a follow-up only if the captain wants an explicit &#34;report the failure, do not fall back to reading state/*.meta&#34; instruction in the skill.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
