### PR TITLE
test(tests): detect empty alpha checkout in remote lifecycle

### DIFF
--- a/tests/fm-remote-secondmate-lifecycle-e2e.test.sh
+++ b/tests/fm-remote-secondmate-lifecycle-e2e.test.sh
@@ -108,7 +108,7 @@ git --git-dir="$REMOTE_ORIGIN" symbolic-ref HEAD refs/heads/main
 
 # One remote-backed direct-PR project. The remote home clones its origin, never
 # the primary working tree.
-git init -q --bare "$TMP_ROOT/alpha.git"
+git init -q --bare -b main "$TMP_ROOT/alpha.git"
 git -C "$PARENT/projects" init -q -b main alpha
 git -C "$PARENT/projects/alpha" config user.email test@example.com
 git -C "$PARENT/projects/alpha" config user.name Test
@@ -651,7 +651,7 @@ out=$(FM_SECONDMATE_CHARTER='Own iOS delivery on the build Mac.' \
 assert_contains "$out" "home=remote-mac:$REMOTE_HOME" "remote seed did not report the host-qualified home"
 assert_grep 'host: remote-mac; root:' "$PARENT/data/secondmates.md" "registry did not record the remote host dimension"
 assert_present "$REMOTE_HOME/.fm-secondmate-home" "remote provisioning did not publish the identity marker"
-assert_present "$REMOTE_HOME/projects/alpha/.git" "remote provisioning did not clone the project on that host"
+assert_present "$REMOTE_HOME/projects/alpha/README.md" "remote provisioning did not clone the project on that host"
 assert_grep "$REMOTE_HOME/state/parent-replies.status" "$REMOTE_HOME/data/charter.md" "remote charter did not use its append-only reply log"
 assert_no_grep "$PARENT/state/ios.status" "$REMOTE_HOME/data/charter.md" "remote charter retained the inaccessible local status path"
 if FM_SECONDMATE_CHARTER='Own iOS delivery on the build Mac.' \


### PR DESCRIPTION
## Contract class

**Restoring behaviour that was already intended.** There is no production code in this change and no new product behaviour. The assertion's own failure message already reads `remote provisioning did not clone the project on that host`; the change makes it actually test that, instead of accepting a clone whose working tree is empty.

One fact that cuts against that class, so you can weigh it rather than take my word: the strengthened assertion is active on every run of this suite with no opt-in, and it can newly fail where the weaker assertion passed. That is the purpose of the change, but it is not something a contributor opts into. It cannot sensibly be shipped behind a default-off switch either — an assertion that is off by default would leave the empty-checkout case undetected, which is the defect being fixed. The open caveat below is the one place where the new strictness could bite.

## What this changes

Two lines, both in `tests/fm-remote-secondmate-lifecycle-e2e.test.sh`. No production code is touched.

**The assertion (the substance of the change).** The remote lifecycle test asserted that `$REMOTE_HOME/projects/alpha/.git` exists. A clone with an *empty* working tree satisfies that assertion, so the test reported success while alpha's remote checkout contained no files at all. It now asserts alpha's committed `README.md` is present, which an empty checkout cannot satisfy.

**The pin.** `alpha.git` is now created with `git init -q --bare -b main`, matching the `-b main` its source repository already uses. Previously the bare origin followed whatever `init.defaultBranch` the machine was configured with, so on a host defaulting to `master` the clone had no matching branch to check out — which is how the empty checkout arose. The pin removes that dependence on the machine's configuration.

## How it was checked

With the strengthened assertion in place but the pin removed, and `init.defaultBranch=master` set for the test process only, the test fails at alpha exactly as intended: origin and checkout HEAD both name `master`, `.git` is present, `README.md` is absent. With the pin, alpha's checkout assertion passes under both a `master` and a `main` default, and the checked-out `README.md` matches its committed content. The paired beta fixture, deliberately untouched, keeps its working checkout in all three runs. No user or global Git configuration was modified.

The complete lifecycle file was then run unmodified under a process-local `master` default and passed end to end in 421 seconds.

### Deliberately left out

Beta's bare origin is still created without `-b`. Its counterpart pin has to move together with the `git init` inside `fm_git_init_commit` in `tests/lib.sh`; both sides currently follow the ambient default, and pinning either alone breaks their pairing. That belongs in a separate change.

The other bare-repository fixture sites in the test suite were reviewed and left unchanged: most already set `HEAD` explicitly via `symbolic-ref`, and the remaining two showed no effect from the ambient default.

### One open caveat

During local work on this change, one full run of the lifecycle file timed out collecting the mixed-state fleet snapshot. That timeout has **not** been shown to occur independently of this change, so it may be caused by it. A later full run of the same file on the same code passed, which does not settle the question in either direction. If the timeout is traced back to these two lines, this change should be reverted or reworked.

## CI status

Read from the check-run API for head `fae1f6a` on 2026-09-09. There are **15 distinct checks**. The raw run count is higher and the summary view quotes that instead: the `PR must be raised via no-mistakes` check reports again on every edit to this pull request, so one check accounts for several runs.

- **13 passed.**
- **1 failed — `Behavior portable serial 5`.** No test ran in this job. It died 12 seconds in, at the `npm install -g @earendil-works/pi-coding-agent` step, with `npm error code ECONNRESET` / `npm error network aborted` at 16:05:17 UTC on 2026-09-08. That is the npm registry connection dropping during dependency installation, not a result about this code. ([job log](https://github.com/kunchenguid/firstmate/actions/runs/34248862245/job/102137807657))
- **1 carries no verdict — `Behavior portable serial 1`.** Its conclusion is `cancelled`: neither a pass nor a fail. It reported 67 passing checks and zero failures, emitted its last output at 16:08:36 UTC, then produced nothing further and was cancelled at 16:25:20 UTC — 20 minutes and 15 seconds after it started, matching the 20-minute cap this job sets on itself. Its final line was `bin/fm-wake-lib.sh: trap: line 2: unexpected EOF while looking for matching ')'`. What stalled the shard is not established here, and we are not claiming it is unrelated to this change. One fact worth weighing: shard 1 does not run the file this change touches. That file runs in `Behavior portable serial 2`, which executed it on this exact head (`exit=0`, 230.6 s) and passed. ([job log](https://github.com/kunchenguid/firstmate/actions/runs/34248862245/job/102137807691))

Neither red lane can be re-run from this side: the account that opened this pull request has read-only access to the repository (`admin`, `maintain`, `push` and `triage` all report false), so re-running a job is a single click for a maintainer and simply not available to us. Nothing was pushed to re-trigger the checks, so the account above describes the record as it actually stands rather than a replacement for it.

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"fae1f6a76f29be62ca537d5e404aba12f1e06ec5","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}],"live_validation":{"verdict":"no-surface","live":0,"total":3}} -->
