### PR TITLE
fix(brief): forbid agent commit co-authors in generated crewmate briefs

### DIFF
--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -401,6 +401,7 @@ The report is the only thing that survives, so anything worth keeping must be in
    going. A drive-call error, timeout, slow read, or generic unreachability is NOT a daemon error:
    the daemon accepts \`respond\` immediately and runs the round in the background, so a killed or
    timed-out call was only waiting for a read while the run kept working.
+8. Never add an agent name as a commit co-author on any scratch commit you make here.
 
 $INBOX_SECTION
 
@@ -492,6 +493,7 @@ $ASK_USER_BLOCK
    going. A drive-call error, timeout, slow read, or generic unreachability is NOT a daemon error:
    the daemon accepts \`respond\` immediately and runs the round in the background, so a killed or
    timed-out call was only waiting for a read while the run kept working.
+8. Never add an agent name as a commit co-author on any commit you make here.
 
 $INBOX_SECTION
 

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -59,6 +59,9 @@
 # Every scaffold also carries the steering-inbox receive-and-ack section:
 # process state/<id>.inbox/*.msg in order and acknowledge each by moving it to
 # handled/ (record, doorbell, and ladder owned by bin/fm-task-inbox-lib.sh).
+# Ship and scout Rules each carry the no-agent-co-author rule as its own hard
+# rule, because a crewmate worktree never reads AGENTS.md's copy of it; the
+# attribution-off launch settings in bin/fm-spawn.sh are the mechanical half.
 # Ship tasks include a project-memory section so durable project-intrinsic
 # learnings can be committed to AGENTS.md through the project's delivery path;
 # it carries the AGENTS.md authoring bar (widely useful knowledge only, pointers

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -427,12 +427,14 @@ test_ask_user_escalation_format() {
 # Every crewmate brief must carry the no-agent-co-author rule as its own top-level
 # hard rule, not as a clause buried in another rule or in captain-only instructions
 # a crewmate worktree never reads. Parsed from the generated brief's Rules section
-# as numbered rules so the assertion is about the delivered contract's structure.
+# as numbered rules so the assertion is about the delivered contract's structure,
+# and matched on the prohibition itself so permissive wording or a rule that
+# drops the agent-name qualification stops counting instead of passing silently.
 count_coauthor_rules() {  # <brief>
   awk '
     $0 == "# Rules" { in_rules = 1; next }
     in_rules && /^# / { in_rules = 0 }
-    in_rules && /^[0-9]+\. / && /commit co-author/ { n++ }
+    in_rules && /^[0-9]+\. Never add an agent name as a commit co-author/ { n++ }
     END { print n + 0 }
   ' "$1"
 }

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -424,6 +424,41 @@ test_ask_user_escalation_format() {
   pass "fm-brief.sh: no-mistakes ask-user findings use one event plus a verbatim snapshot"
 }
 
+# Every crewmate brief must carry the no-agent-co-author rule as its own top-level
+# hard rule, not as a clause buried in another rule or in captain-only instructions
+# a crewmate worktree never reads. Parsed from the generated brief's Rules section
+# as numbered rules so the assertion is about the delivered contract's structure.
+count_coauthor_rules() {  # <brief>
+  awk '
+    $0 == "# Rules" { in_rules = 1; next }
+    in_rules && /^# / { in_rules = 0 }
+    in_rules && /^[0-9]+\. / && /commit co-author/ { n++ }
+    END { print n + 0 }
+  ' "$1"
+}
+
+test_every_worker_brief_forbids_an_agent_co_author() {
+  local home id brief mode n
+  home="$TMP_ROOT/coauthor-home"
+  mkdir -p "$home/data"
+  for mode in no-mistakes direct-PR local-only; do
+    id="brief-coauthor-$mode"
+    FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" some-proj --mode "$mode" >/dev/null 2>&1
+    brief="$home/data/$id/brief.md"
+    assert_present "$brief" "ship brief ($mode) was not scaffolded"
+    n=$(count_coauthor_rules "$brief")
+    [ "$n" = 1 ] || fail "ship brief ($mode) must carry exactly one co-author hard rule (found $n)"
+  done
+  id=brief-coauthor-scout
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" some-proj --scout >/dev/null 2>&1
+  brief="$home/data/$id/brief.md"
+  assert_present "$brief" "scout brief was not scaffolded"
+  n=$(count_coauthor_rules "$brief")
+  [ "$n" = 1 ] || fail "scout brief must carry exactly one co-author hard rule (found $n)"
+  pass "fm-brief.sh: ship and scout briefs forbid an agent commit co-author as a hard rule"
+}
+test_every_worker_brief_forbids_an_agent_co_author
+
 test_ship_project_memory_wording() {
   local home id brief
   home="$TMP_ROOT/project-memory-home"

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -449,7 +449,7 @@ test_every_worker_brief_forbids_an_agent_co_author() {
     n=$(count_coauthor_rules "$brief")
     [ "$n" = 1 ] || fail "ship brief ($mode) must carry exactly one co-author hard rule (found $n)"
   done
-  id=brief-coauthor-scout
+  id="brief-coauthor-scout"
   FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" some-proj --scout >/dev/null 2>&1
   brief="$home/data/$id/brief.md"
   assert_present "$brief" "scout brief was not scaffolded"


### PR DESCRIPTION
## Intent

Make the no-agent-co-author rule structural in the generated crewmate brief (bin/fm-brief.sh) so every crewmate is told directly not to add an agent name as a commit co-author, instead of firstmate catching violations by hand. Add exactly one hard rule line to both the ship and scout Rules sections of the generated brief scaffold. No hook, commit-message validator, lint rule, or other enforcement machinery. No project history rewrite - only stop it going forward. The Claude-Session trailer is out of scope; only the agent co-author line is in scope.

## Why This Exists

On 2026-09-08 firstmate found `Co-Authored-By: Claude ...` on 9 of 10 commits across 6 of 7 live landvera branches, then found ALL 40 of the last 40 commits on landvera's origin/main already carried it. The no-mistakes pipeline itself was not the source - three of its own gate-fix commits were verified clean - so every one of those 40 commits came from a crewmate that was never told the rule. The rule already lived in the captain's global agent instructions and in this repo's `AGENTS.md`, but a crewmate launched into a project worktree does not necessarily read either, and firstmate was catching violations by inspecting branches by hand, which is how this went unnoticed for 40 commits.

**Captain's ruling, verbatim ("Go with a", 2026-09-08):** leave main's history alone, stop it going forward only. A history rewrite was offered and declined. So this change is the entire remedy, not half of one - there is no follow-up cleanup of past commits to expect.

**Why no enforcement machinery:** this is a deliberate choice, not an oversight. The direct path is one line in the instructions every crewmate already reads, nothing has shown that path failing, and a hook or commit-message validator built on an unproven need is exactly the over-build firstmate's own `AGENTS.md` section 7 warns against. If a future measurement shows crewmates ignoring this line, that is when the machinery would earn its place - not before.

## What Changed

- `bin/fm-brief.sh` now emits one additional hard rule in the Rules section of both generated brief scaffolds: the scout brief gets "Never add an agent name as a commit co-author on any scratch commit you make here", and the ship brief gets the equivalent line for any commit made in its worktree.
- Documented in the script header why the rule is duplicated per scaffold (a crewmate worktree never reads `AGENTS.md`'s copy) and that `bin/fm-spawn.sh`'s attribution-off launch settings are the mechanical half.
- Added `tests/fm-brief.test.sh` coverage that scaffolds ship briefs in `no-mistakes`, `direct-PR`, and `local-only` modes plus a scout brief, and asserts each brief's Rules section contains exactly one numbered co-author rule.

## Risk Assessment

✅ Low: A two-line, additive, prose-only change to a generated brief scaffold that satisfies the intent exactly, uses correct list numbering in both sections, breaks no existing rule-number cross-references, and adds no enforcement machinery.

## Testing

I generated real briefs for all three ship modes, scout, and secondmate, then drove fm-spawn with a sandboxed fleet and a refusing fake backend so the product rendered the launch-brief.md that is actually encoded and handed to a crewmate. Ship and scout briefs each carry the new rule exactly once as its own top-level numbered hard rule, it survives into the delivered prompt payload, and a base-vs-target diff of the generated briefs shows that line is the only content change (the secondmate charter is untouched, and the Claude-Session trailer is unaffected). Adversarially, no hook, validator, or lint machinery was added: only bin/fm-brief.sh changed and a commit carrying an agent Co-Authored-By trailer still succeeds, and no history was rewritten. I added a focused regression case to tests/fm-brief.test.sh that parses the generated brief's Rules section semantically; it fails against the pre-fix script and passes after, and the whole fm-brief suite is green. There is no UI surface here, so the reviewer-visible evidence is the rendered launch-brief Rules section and the normalized generated-brief diff rather than screenshots.

- Live validation: ✅ go - 7 of 7 scenarios driven live against the product

| Scenario | Result | Live | Evidence |
| --- | --- | --- | --- |
| Firstmate scaffolds a ship brief in each delivery mode and the generated brief carries the no-agent-co-author rule as its own numbered hard rule | ✅ pass | live | `bin/fm-brief.sh &lt;id&gt; myrepo --mode no-mistakes\|direct-PR\|local-only` in an isolated FM_HOME; Rules section parsed into numbered rules -&gt; 8 rules, exactly 1 co-author rule in each mode |
| Firstmate scaffolds a scout brief and the generated brief carries the same rule, worded for scratch commits | ✅ pass | live | `bin/fm-brief.sh scout-1 myrepo --scout` -&gt; rule 8 `Never add an agent name as a commit co-author on any scratch commit you make here.` |
| A crewmate launched through fm-spawn actually receives the rule in its launch prompt | ✅ pass | live | fm-spawn rendered data/&lt;id&gt;/launch-brief.md for a ship and a scout task; rule present exactly once in Rules and present in the `fm-operational-input.sh encode launch-brief` payload (evidence: launch-b… |
| Adversarial: the change adds exactly one line per brief and alters nothing else a crewmate reads, including the secondmate charter | ✅ pass | live | base-vs-target `diff -ru` of all five generated briefs shows only the added rule line; secondmate charter identical (evidence: generated-brief-diff.md) |
| Adversarial: no hook, commit-message validator, or lint rule was introduced - an agent co-author commit is still accepted | ✅ pass | live | `git diff --name-status b84e0e3 HEAD` -&gt; only bin/fm-brief.sh (+2); sandbox `git commit` with a Co-Authored-By trailer exits 0 with the trailer retained; no hooks added |
| Adversarial: no project history rewrite - the change is forward-only | ✅ pass | live | `git diff --stat b84e0e3 HEAD` -&gt; single 2-line addition; no commits rewritten or removed relative to the base |
| Regression guard: the generated-brief contract fails without the fix | ✅ pass | live | new `test_every_worker_brief_forbids_an_agent_co_author` in tests/fm-brief.test.sh -&gt; `not ok ... (found 0)` with base bin/fm-brief.sh, `ok` with target |

<details>
<summary>Evidence: Rules section of the launch-brief.md actually delivered to ship and scout crewmates</summary>

Source: [Rules section of the launch-brief.md actually delivered to ship and scout crewmates](https://github.com/NicholasACTran/firstmate/blob/d8d37694fc20f806d7b1e50dbd0eaefb0a646258/.no-mistakes/evidence/fm/fm-brief-forbids-agent-coauthor/launch-brief-rules.md)

```text
# Rules section of the launch-brief.md actually handed to a crewmate (rendered by bin/fm-spawn.sh)

## SHIP (mode=no-mistakes) - /tmp/fmdrive.jBqRMW/home/data/ship-nm/launch-brief.md
`` `
# Rules
1. Never push to the default branch. Never merge a PR.
2. Stay inside this worktree; modify nothing outside it.
3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.
4. Report status by appending one line:
   `echo "{state}: {one short line}" >> '/tmp/fmdrive.jBqRMW/home/state/ship-nm.status'`
   States: working, needs-decision, blocked, paused, done, failed.
   Each append wakes firstmate, so report sparingly: only phase changes a supervisor
   would act on (setup done, bug reproduced, fix implemented, validation passed) and the
   needs-decision/blocked/paused/done/failed states. No step-by-step FYI progress lines;
   firstmate reads your pane for that.
   Whenever you mention a PR anywhere - a status line, your terminal, a summary - write its full
   https:// URL exactly as the forge printed it, never a bare number such as "PR 108"; firstmate
   copies that URL from your line rather than assembling one.
   A mid-task `working:` line (including setup complete) is nonterminal: do not end the
   turn after it; continue the same stage until a defined `done:` gate under Definition of done.
   Use `paused: {why}` - distinct from `blocked:` - ONLY when you are deliberately idling on a
   known external wait you expect to clear on its own (an upstream release, a rate-limit reset,
   a scheduled window): firstmate then leaves your idle pane alone and rechecks it on a long
   cadence instead of treating it as a possible wedge. Use `blocked:` when you are stuck and need help.
5. If you hit the same obstacle twice, append `blocked: {why}` and stop; firstmate will help.
6. If a decision belongs above the implementation worker (product choices, destructive actions),
   append `needs-decision: {summary of options}` and stop. Firstmate will reply with the decision.
   For a no-mistakes ask-user gate specifically, escalate all ask-user findings as one event plus one snapshot file, using that same shape even when the gate holds only a single ask-user finding: write only the ask-user findings, verbatim and unparaphrased (id, severity, file, line, description, authority), to `/tmp/fmdrive.jBqRMW/home/data/ship-nm/nm-<run>-findings.txt`, then report the gate with
   `needs-decision [key=nm-<run>-<step>]: ask-user findings=<id1>,<id2>,... file=/tmp/fmdrive.jBqRMW/home/data/ship-nm/nm-<run>-findings.txt`
   naming every ask-user finding id from that gate. The status line only points at the file; it never restates or summarizes a finding's content.
   A decision or blocker you opened stays open until a `resolved` line carrying its exact key lands; a later `done:` or `working:` line never closes it, even when the answer is what started that work.
   Firstmate's reply normally writes that closing line at answer time; when a blocker or wait clears WITHOUT a firstmate reply, append `resolved: {how it cleared}` yourself (same `[key=<slug>]` if you opened it with one) as you resume.
7. Never stop, restart, or update the shared `no-mistakes` daemon - it is one instance serving
   every lane/home, so restarting it kills other lanes' in-flight pipeline runs; only firstmate
   manages the daemon.
   Before you append `blocked:` about the pipeline, run `no-mistakes daemon status` and
   `no-mistakes axi status`. If the daemon socket refuses connections or is missing, append
   `blocked: {the daemon error}` and stop even when the local run record still says running or
   fixing, because that record can be stale after the daemon exits. A run record failed with a
   daemon error is also a real block.
   Only after ruling out socket refusal, if the run is still running or fixing, reattach and keep
   going. A drive-call error, timeout, slow read, or generic unreachability is NOT a daemon error:
   the daemon accepts `respond` immediately and runs the round in the background, so a killed or
   timed-out call was only waiting for a read while the run kept working.
8. Never add an agent name as a commit co-author on any commit you make here.

`` `

## SCOUT - /tmp/fmdrive.jBqRMW/home/data/scout-a/launch-brief.md
`` `
# Rules
1. Never push to any remote and never open a PR.
2. Stay inside this worktree; the only files you may write outside it are the report and the status file below.
3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.
4. Report status by appending one line:
   `echo "{state}: {one short line}" >> '/tmp/fmdrive.jBqRMW/home/state/scout-a.status'`
   States: working, needs-decision, blocked, paused, done, failed.
   Each append wakes firstmate, so report sparingly: only phase changes a supervisor
   would act on and the needs-decision/blocked/paused/done/failed states. No step-by-step
   FYI progress lines; firstmate reads your pane for that.
   Whenever you mention a PR anywhere - a status line, your terminal, a summary - write its full
   https:// URL exactly as the forge printed it, never a bare number such as "PR 108"; firstmate
   copies that URL from your line rather than assembling one.
   Use `paused: {why}` - distinct from `blocked:` - ONLY when you are deliberately idling on a
   known external wait you expect to clear on its own (an upstream release, a rate-limit reset):
   firstmate then leaves your idle pane alone and rechecks it on a long cadence instead of
   treating it as a possible wedge. Use `blocked:` when you are stuck and need help.
5. If you hit the same obstacle twice, append `blocked: {why}` and stop; firstmate will help.
6. If a decision belongs to a human (product choices, destructive actions),
   append `needs-decision: {summary of options}` and stop. Firstmate will reply with the decision.
   A decision or blocker you opened stays open until a `resolved` line carrying its exact key lands; a later `done:` or `working:` line never closes it, even when the answer is what started that work.
   Firstmate's reply normally writes that closing line at answer time; when a blocker or wait clears WITHOUT a firstmate reply, append `resolved: {how it cleared}` yourself (same `[key=<slug>]` if you opened it with one) as you resume.
7. Never stop, restart, or update the shared `no-mistakes` daemon - it is one instance serving
   every lane/home, so restarting it kills other lanes' in-flight pipeline runs; only firstmate
   manages the daemon.
   Before you append `blocked:` about the pipeline, run `no-mistakes daemon status` and
   `no-mistakes axi status`. If the daemon socket refuses connections or is missing, append
   `blocked: {the daemon error}` and stop even when the local run record still says running or
   fixing, because that record can be stale after the daemon exits. A run record failed with a
   daemon error is also a real block.
   Only after ruling out socket refusal, if the run is still running or fixing, reattach and keep
   going. A drive-call error, timeout, slow read, or generic unreachability is NOT a daemon error:
   the daemon accepts `respond` immediately and runs the round in the background, so a killed or
   timed-out call was only waiting for a read while the run kept working.
8. Never add an agent name as a commit co-author on any scratch commit you make here.

`` `
```
</details>
<details>
<summary>Evidence: Generated-brief diff, base b84e0e3 vs target 9816cab (paths normalized)</summary>

Source: [Generated-brief diff, base b84e0e3 vs target 9816cab (paths normalized)](https://github.com/NicholasACTran/firstmate/blob/d8d37694fc20f806d7b1e50dbd0eaefb0a646258/.no-mistakes/evidence/fm/fm-brief-forbids-agent-coauthor/generated-brief-diff.md)

```text
# Generated brief diff: base b84e0e3 -> target 9816cab (paths normalized)

`` `diff
diff -ru <HOME>/data/scout-1/brief.md <HOME>/data/scout-1/brief.md
@@ -23,7 +23,7 @@
 2. Stay inside this worktree; the only files you may write outside it are the report and the status file below.
 3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.
 4. Report status by appending one line:
    States: working, needs-decision, blocked, paused, done, failed.
    Each append wakes firstmate, so report sparingly: only phase changes a supervisor
    would act on and the needs-decision/blocked/paused/done/failed states. No step-by-step
@@ -52,16 +52,17 @@
    going. A drive-call error, timeout, slow read, or generic unreachability is NOT a daemon error:
    the daemon accepts `respond` immediately and runs the round in the background, so a killed or
    timed-out call was only waiting for a read while the run kept working.
+8. Never add an agent name as a commit co-author on any scratch commit you make here.
 
 # Firstmate instruction inbox
 The move IS the acknowledgement: without it firstmate rings again and eventually treats you as stuck. An empty or absent inbox needs no action.
 
 # Definition of done
 The report must stand alone: what you did, what you found, the evidence (commands run, output, file:line references), and what you recommend.
 If your deliverable is a visual artifact the captain will review and iterate on, you may host the Lavish review loop yourself (poll, revise, re-serve, staying alive) instead of handing it back to firstmate.
 When the report is complete, append `done: {one-line conclusion}` to the status file and stop.
 If your findings reveal work that should ship (e.g. you reproduced a bug and the fix is clear), say so in the report; firstmate may promote this task in place, and you would then receive mode-specific ship instructions as a follow-up message.
diff -ru <HOME>/data/sec-1/brief.md <HOME>/data/sec-1/brief.md
@@ -19,7 +19,7 @@
 Never start a survey, audit, or "find improvements" sweep on your own initiative; that is not your job and it is unwanted.
 
 # The captain and the parent channel
 That file is your parent channel, and in this home it IS the captain: every sentence you would say to the captain, and every outcome the local AGENTS.md tells a firstmate to bring to the captain, is one appended line there, never chat.
 Your own machinery publishes the durable facts about your crew's work for you (`bin/fm-parent-channel-lib.sh`): a child's terminal done or failed line with its note and PR on every supervision poll, a PR-ready line when you register a PR, a task you hold for the captain and its answer, a merge, and a child's final line at cleanup all reach the parent channel from the scripts that record them, whether or not you append anything.
 What only you can append is judgement: the answer to a marked request below, a recommendation or caveat on a delivered outcome, a blocker or failure of your own, and anything else you would otherwise say to the captain.
@@ -39,14 +39,14 @@
 A request arriving through the instruction inbox below follows the same marker and reply rules.
 
 # Firstmate instruction inbox
 The move IS the acknowledgement: without it firstmate rings again and eventually treats you as stuck. An empty or absent inbox needs no action.
 
 # Escalation to main firstmate
 Handle routine work yourself.
 Report only true captain-relevant outcomes or a declared external wait by appending one line:
 States: working, needs-decision, blocked, paused, done, failed.
 Use `paused: {why}` (distinct from `blocked:`) only when your domain is deliberately idling on a known external wait you expect to clear on its own; use `blocked:` when you are stuck and need firstmate to act.
 Use this only for material phase changes, a captain decision, a real blocker, a failure, work ready for review, or work you landed.
diff -ru <HOME>/data/ship-direct-PR/brief.md <HOME>/data/ship-direct-PR/brief.md
@@ -26,7 +26,7 @@
 2. Stay inside this worktree; modify nothing outside it.
 3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.
 4. Report status by appending one line:
    States: working, needs-decision, blocked, paused, done, failed.
    Each append wakes firstmate, so report sparingly: only phase changes a supervisor
    would act on (setup done, bug reproduced, fix implemented, validation passed) and the
@@ -59,17 +59,18 @@
    going. A drive-call error, timeout, slow read, or generic unreachability is NOT a daemon error:
    the daemon accepts `respond` immediately and runs the round in the background, so a killed or
    timed-out call was only waiting for a read while the run kept working.
+8. Never add an agent name as a commit co-author on any commit you make here.
 
 # Firstmate instruction inbox
 The move IS the acknowledgement: without it firstmate rings again and eventually treats you as stuck. An empty or absent inbox needs no action.
 
 # Project memory
 Record only project knowledge useful to almost every future session.
 For anything the codebase already shows, prefer a pointer to the authoritative file, command, or doc over copying the detail.
 Keep it proportionate: skip `AGENTS.md` edits for trivial tasks that produced no durable project knowledge.
 
 # Definition of done
diff -ru <HOME>/data/ship-local-only/brief.md <HOME>/data/ship-local-only/brief.md
@@ -26,7 +26,7 @@
 2. Stay inside this worktree; modify nothing outside it.
 3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.
 4. Report status by appending one line:
    States: working, needs-decision, blocked, paused, done, failed.
    Each append wakes firstmate, so report sparingly: only phase changes a supervisor
    would act on (setup done, bug reproduced, fix implemented, validation passed) and the
@@ -59,17 +59,18 @@
    going. A drive-call error, timeout, slow read, or generic unreachability is NOT a daemon error:
    the daemon accepts `respond` immediately and runs the round in the background, so a killed or
    timed-out call was only waiting for a read while the run kept working.
+8. Never add an agent name as a commit co-author on any commit you make here.
 
 # Firstmate instruction inbox
 The move IS the acknowledgement: without it firstmate rings again and eventually treats you as stuck. An empty or absent inbox needs no action.
 
 # Project memory
 Record only project knowledge useful to almost every future session.
 For anything the codebase already shows, prefer a pointer to the authoritative file, command, or doc over copying the detail.
 Keep it proportionate: skip `AGENTS.md` edits for trivial tasks that produced no durable project knowledge.
 
 # Definition of done
diff -ru <HOME>/data/ship-no-mistakes/brief.md <HOME>/data/ship-no-mistakes/brief.md
@@ -27,7 +27,7 @@
 2. Stay inside this worktree; modify nothing outside it.
 3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.
 4. Report status by appending one line:
    States: working, needs-decision, blocked, paused, done, failed.
    Each append wakes firstmate, so report sparingly: only phase changes a supervisor
    would act on (setup done, bug reproduced, fix implemented, validation passed) and the
@@ -45,8 +45,8 @@
 5. If you hit the same obstacle twice, append `blocked: {why}` and stop; firstmate will help.
 6. If a decision belongs above the implementation worker (product choices, destructive actions),
    append `needs-decision: {summary of options}` and stop. Firstmate will reply with the decision.
    naming every ask-user finding id from that gate. The status line only points at the file; it never restates or summarizes a finding's content.
    A decision or blocker you opened stays open until a `resolved` line carrying its exact key lands; a later `done:` or `working:` line never closes it, even when the answer is what started that work.
    Firstmate's reply normally writes that closing line at answer time; when a blocker or wait clears WITHOUT a firstmate reply, append `resolved: {how it cleared}` yourself (same `[key=<slug>]` if you opened it with one) as you resume.
@@ -62,17 +62,18 @@
    going. A drive-call error, timeout, slow read, or generic unreachability is NOT a daemon error:
    the daemon accepts `respond` immediately and runs the round in the background, so a killed or
    timed-out call was only waiting for a read while the run kept working.
+8. Never add an agent name as a commit co-author on any commit you make here.
 
 # Firstmate instruction inbox
 The move IS the acknowledgement: without it firstmate rings again and eventually treats you as stuck. An empty or absent inbox needs no action.
 
 # Project memory
 Record only project knowledge useful to almost every future session.
 For anything the codebase already shows, prefer a pointer to the authoritative file, command, or doc over copying the detail.
 Keep it proportionate: skip `AGENTS.md` edits for trivial tasks that produced no durable project knowledge.
 
 # Definition of done
`` `
```
</details>
<details>
<summary>Evidence: Regression proof: new test fails on pre-fix script, passes on target</summary>

```text
$ git show b84e0e3:bin/fm-brief.sh > bin/fm-brief.sh && bash tests/fm-brief.test.sh
not ok - ship brief (no-mistakes) must carry exactly one co-author hard rule (found 0)
$ # restore target bin/fm-brief.sh
ok - fm-brief.sh: ship and scout briefs forbid an agent commit co-author as a hard rule
```
</details>
<details>
<summary>Evidence: Adversarial: no enforcement machinery - agent co-author commit still succeeds</summary>

```text
$ git commit -F - <<'MSG'
test: commit carrying an agent co-author trailer

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
MSG
exit=0
test: commit carrying an agent co-author trailer
Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"5d461bfb1e9b9b79b63bc5d9752fc4f5e8072149","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>⚠️ **Review** - 1 info</summary>

- ℹ️ `bin/fm-brief.sh:496` - tests/fm-brief.test.sh maintains a contract suite over the generated brief output (e.g. the existing &#34;ship rule 6&#34; assertions), but no assertion covers the newly added rule 8 line in either the scout (bin/fm-brief.sh:404) or ship (bin/fm-brief.sh:496) Rules section. Since the whole point of the change is that the rule is structurally present in every generated brief, a future edit to either heredoc could drop it without any test failing. The repo&#39;s established convention here is a one-line assert_grep against the generated brief, which is the legitimate generated-output contract, not a source-content grep.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- Live validation: ✅ go - 7 of 7 scenarios driven live against the product

| Scenario | Result | Live | Evidence |
| --- | --- | --- | --- |
| Firstmate scaffolds a ship brief in each delivery mode and the generated brief carries the no-agent-co-author rule as its own numbered hard rule | ✅ pass | live | `bin/fm-brief.sh &lt;id&gt; myrepo --mode no-mistakes\|direct-PR\|local-only` in an isolated FM_HOME; Rules section parsed into numbered rules -&gt; 8 rules, exactly 1 co-author rule in each mode |
| Firstmate scaffolds a scout brief and the generated brief carries the same rule, worded for scratch commits | ✅ pass | live | `bin/fm-brief.sh scout-1 myrepo --scout` -&gt; rule 8 `Never add an agent name as a commit co-author on any scratch commit you make here.` |
| A crewmate launched through fm-spawn actually receives the rule in its launch prompt | ✅ pass | live | fm-spawn rendered data/&lt;id&gt;/launch-brief.md for a ship and a scout task; rule present exactly once in Rules and present in the `fm-operational-input.sh encode launch-brief` payload (evidence: launch-b… |
| Adversarial: the change adds exactly one line per brief and alters nothing else a crewmate reads, including the secondmate charter | ✅ pass | live | base-vs-target `diff -ru` of all five generated briefs shows only the added rule line; secondmate charter identical (evidence: generated-brief-diff.md) |
| Adversarial: no hook, commit-message validator, or lint rule was introduced - an agent co-author commit is still accepted | ✅ pass | live | `git diff --name-status b84e0e3 HEAD` -&gt; only bin/fm-brief.sh (+2); sandbox `git commit` with a Co-Authored-By trailer exits 0 with the trailer retained; no hooks added |
| Adversarial: no project history rewrite - the change is forward-only | ✅ pass | live | `git diff --stat b84e0e3 HEAD` -&gt; single 2-line addition; no commits rewritten or removed relative to the base |
| Regression guard: the generated-brief contract fails without the fix | ✅ pass | live | new `test_every_worker_brief_forbids_an_agent_co_author` in tests/fm-brief.test.sh -&gt; `not ok ... (found 0)` with base bin/fm-brief.sh, `ok` with target |

- <code>`FM_HOME=&lt;tmp&gt; bin/fm-brief.sh &lt;id&gt; myrepo --mode no-mistakes|direct-PR|local-only`, `--scout`, and `--secondmate --no-projects`, then parsed each generated brief&#39;s `# Rules` section into numbered rules</code>
- <code>`bin/fm-spawn.sh &lt;id&gt; &lt;proj&gt; claude --mode no-mistakes --yolo off` and `--scout` against a sandbox home with a refusing fake `tmux` (FM_SPAWN_NO_GUARD=1, FM_GATE_REFUSE_BYPASS=1), inspecting the rendered `data/&lt;id&gt;/launch-brief.md`</code>
- <code>`bin/fm-operational-input.sh encode launch-brief &lt; launch-brief.md` to confirm the rule is in the payload delivered to the agent</code>
- <code>`diff -ru` of briefs generated by base b84e0e3 vs target 9816cab</code>
- <code>adversarial: `git commit` with a `Co-Authored-By: Claude Opus 5` trailer in a sandbox repo containing bin/ (succeeded, exit 0); `git diff --name-status b84e0e3 HEAD` (only bin/fm-brief.sh, +2 lines)</code>
- <code>`bash tests/fm-brief.test.sh` (full suite green) including the new `test_every_worker_brief_forbids_an_agent_co_author`</code>
- <code>regression proof: swapped in the base `bin/fm-brief.sh` and re-ran `bash tests/fm-brief.test.sh` -&gt; `not ok - ship brief (no-mistakes) must carry exactly one co-author hard rule (found 0)`, then restored</code>
</details>

<details>
<summary>⚠️ **Document** - 1 info</summary>

- ℹ️ `AGENTS.md:49` - Out-of-scope consolidation candidate: the no-agent-co-author rule is stated in full in two places aimed at the same repo-contributor audience - AGENTS.md:49 (firstmate&#39;s own hard rules) and .agents/skills/firstmate-coding-guidelines/SKILL.md:126 (repo style rules). This duplication predates the change and neither copy was made stale by it, so I left both alone rather than restructuring unrelated documentation. A follow-up could reduce one to a pointer at the other. Note the new brief-scaffold copy is NOT part of this duplication: it is agent-runtime text delivered to a crewmate worktree that reads neither document, which is the entire point of the change.
</details>

<details>
<summary>🔧 **Lint** - 1 issue found → auto-fixed ✅</summary>

- ⚠️ linter found issues (exit code 1)

🔧 Fix applied.
✅ Re-checked - no issues remain.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>

