### PR TITLE
fix: detect OMP through deeper startup ancestry

### DIFF
--- a/bin/fm-harness.sh
+++ b/bin/fm-harness.sh
@@ -111,9 +111,10 @@ detect_own() {
   # by ancestry alone below. Do NOT promote MUSE_CURRENT_SESSION_LOG to a marker
   # without verifying it reaches children AND that it cannot survive in a
   # multiplexer's stored environment, which is the precedence hazard above.
-  # Layer 2: walk the parent chain and match the command name.
+  # Layer 2: walk the parent chain. Native omp startup wrappers can place its
+  # process at entry nine, so retain enough headroom for that verified shape.
   local pid=$$ comm args argv0
-  for _ in 1 2 3 4 5 6 7 8; do
+  for _ in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16; do
     comm=$(ps -o comm= -p "$pid" 2>/dev/null) || break
     argv0=$(fm_cursor_argv0_for_pid "$pid" "$comm" 2>/dev/null || true)
     if fm_cursor_process_matches "$comm" '' "$argv0"; then
@@ -184,12 +185,13 @@ detect_own() {
   echo unknown
 }
 
-# True when an exact `omp` process sits within eight parents of this one. The
-# same anchored match as the ancestry walk in detect_own, kept separate so the
-# marker precedence above can demand real process evidence.
+# True when an exact `omp` process sits within sixteen ancestry entries. Native
+# omp startup wrappers can place it at entry nine. The same anchored match as
+# the ancestry walk in detect_own is kept separate so the marker precedence
+# above can demand real process evidence.
 ancestry_names_omp() {
   local pid=$$ comm
-  for _ in 1 2 3 4 5 6 7 8; do
+  for _ in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16; do
     comm=$(ps -o comm= -p "$pid" 2>/dev/null) || return 1
     [ "$(basename -- "$comm")" = omp ] && return 0
     pid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d ' ')

--- a/docs/verification/runtime-backends.md
+++ b/docs/verification/runtime-backends.md
@@ -1464,7 +1464,8 @@ The evidence below was produced on 2026-09-05 against omp 18.1.11 (`~/.local/bin
 
 `ps -o comm=` reports the bare name `omp` for the agent process, from both its `!` bash path and the model's bash tool, so identity is the anchored name; `ompd` and `comp` never match.
 omp publishes no harness marker: `PI_CODING_AGENT` is absent from the binary, and the default profile sets neither `PI_CODING_AGENT_DIR` nor `OMP_PROFILE` in the process environment.
-`FM_OMP_HARNESS=omp` is Firstmate's own launch marker and wins over an inherited `CLAUDECODE` only under a real omp ancestor; `tests/fm-omp-harness.test.sh` pins both directions with real processes.
+`FM_OMP_HARNESS=omp` is Firstmate's own launch marker and wins over an inherited `CLAUDECODE` only under a real omp ancestor.
+`tests/fm-omp-harness.test.sh` pins the positive marker path with a real omp-named process and uses deterministic process-chain fixtures for the leaked-marker negative and the ancestry-entry-nine boundary.
 
 ### Composer
 

--- a/tests/fm-omp-harness.test.sh
+++ b/tests/fm-omp-harness.test.sh
@@ -62,40 +62,34 @@ make_named_shells() {  # <dir> -> echoes <bindir>
 }
 
 # A deterministic parent chain for the depth boundary. The detector process is
-# entry one; pid 100 is entry nine. FAKE_PS_FIRST_COMM lets anchored-name
-# negatives keep their immediate process identity without seeing the outer
-# harness that launched this suite.
+# entry one; its eighth successor is entry nine. Deriving every synthetic pid
+# from the captured detector pid keeps all nine entries distinct.
 make_omp_ancestry_fakebin() {  # <dir>
   local fakebin
   fakebin=$(fm_fakebin "$1")
   cat > "$fakebin/ps" <<'SH'
 #!/usr/bin/env bash
+root=${FAKE_PS_ROOT_PID:?}
 pid=${!#}
+entry_nine=$((root + 8))
 case "$*" in
   *"comm="*)
-    if [ "$pid" = 100 ] && [ "${FAKE_OMP_AT_NINE:-0}" = 1 ]; then
+    if [ "$pid" = "$entry_nine" ] && [ "${FAKE_OMP_AT_NINE:-0}" = 1 ]; then
       printf '%s\n' omp
-    elif [ "$pid" != 800 ] && [ "$pid" != 700 ] && [ "$pid" != 600 ] \
-      && [ "$pid" != 500 ] && [ "$pid" != 400 ] && [ "$pid" != 300 ] \
-      && [ "$pid" != 200 ] && [ "$pid" != 100 ] \
-      && [ -n "${FAKE_PS_FIRST_COMM:-}" ]; then
+    elif [ "$pid" = "$root" ] && [ -n "${FAKE_PS_FIRST_COMM:-}" ]; then
       printf '%s\n' "$FAKE_PS_FIRST_COMM"
     else
       printf '%s\n' bash
     fi
     ;;
   *"ppid="*)
-    case "$pid" in
-      800) printf '%s\n' 700 ;;
-      700) printf '%s\n' 600 ;;
-      600) printf '%s\n' 500 ;;
-      500) printf '%s\n' 400 ;;
-      400) printf '%s\n' 300 ;;
-      300) printf '%s\n' 200 ;;
-      200) printf '%s\n' 100 ;;
-      100) printf '%s\n' 1 ;;
-      *) printf '%s\n' 800 ;;
-    esac
+    if [ "$pid" -ge "$root" ] && [ "$pid" -lt "$entry_nine" ]; then
+      printf '%s\n' "$((pid + 1))"
+    elif [ "$pid" = "$entry_nine" ]; then
+      printf '%s\n' 1
+    else
+      exit 1
+    fi
     ;;
   *) exit 1 ;;
 esac
@@ -115,8 +109,10 @@ test_detection_anchored_name_and_marker_precedence() {
     "$bin/omp" -c '"$1"; :' _ "$HARNESS")
   [ "$out" = omp ] || fail "a process named omp must detect as omp, got '$out'"
   for decoy in ompd comp; do
+    # shellcheck disable=SC2016 # the quoted body captures the child shell's pid
     out=$(env -u CLAUDECODE -u FM_OMP_HARNESS -u PI_CODING_AGENT -u CURSOR_AGENT -u CURSOR_INVOKED_AS \
-      FAKE_PS_FIRST_COMM="$decoy" PATH="$fakebin:$PATH" "$HARNESS")
+      FAKE_PS_FIRST_COMM="$decoy" PATH="$fakebin:$PATH" \
+      bash -c 'export FAKE_PS_ROOT_PID=$$; exec "$1"' _ "$HARNESS")
     [ "$out" != omp ] || fail "'$decoy' merely contains omp and must not detect as omp"
   done
   # The marker beats an inherited CLAUDECODE only under a real omp ancestor.
@@ -125,8 +121,9 @@ test_detection_anchored_name_and_marker_precedence() {
     "$bin/omp" -c '"$1"; :' _ "$HARNESS")
   [ "$out" = omp ] || fail "FM_OMP_HARNESS under an omp ancestor must outrank an inherited CLAUDECODE, got '$out'"
   # ...and is inert when it leaks into a worker with no omp ancestor.
+  # shellcheck disable=SC2016 # the quoted body captures the child shell's pid
   out=$(env -u PI_CODING_AGENT -u CURSOR_AGENT -u CURSOR_INVOKED_AS CLAUDECODE=1 FM_OMP_HARNESS=omp \
-    PATH="$fakebin:$PATH" "$HARNESS")
+    PATH="$fakebin:$PATH" bash -c 'export FAKE_PS_ROOT_PID=$$; exec "$1"' _ "$HARNESS")
   [ "$out" = claude ] || fail "a leaked FM_OMP_HARNESS without an omp ancestor must not relabel a claude worker, got '$out'"
   pass "fm-harness: omp detects by its anchored name; the marker is a precedence override that needs real omp ancestry"
 }
@@ -135,12 +132,14 @@ test_detection_reaches_omp_at_ancestry_entry_nine() {
   local fakebin out
   fakebin=$(make_omp_ancestry_fakebin "$TMP_ROOT/entry-nine")
 
+  # shellcheck disable=SC2016 # the quoted body captures the child shell's pid
   out=$(env -u CLAUDECODE -u FM_OMP_HARNESS -u PI_CODING_AGENT -u CURSOR_AGENT -u CURSOR_INVOKED_AS \
-    FAKE_OMP_AT_NINE=1 PATH="$fakebin:$PATH" "$HARNESS")
+    FAKE_OMP_AT_NINE=1 PATH="$fakebin:$PATH" bash -c 'export FAKE_PS_ROOT_PID=$$; exec "$1"' _ "$HARNESS")
   [ "$out" = omp ] || fail "an omp process at ancestry entry nine must detect as omp, got '$out'"
 
+  # shellcheck disable=SC2016 # the quoted body captures the child shell's pid
   out=$(env -u PI_CODING_AGENT -u CURSOR_AGENT -u CURSOR_INVOKED_AS CLAUDECODE=1 FM_OMP_HARNESS=omp \
-    FAKE_OMP_AT_NINE=1 PATH="$fakebin:$PATH" "$HARNESS")
+    FAKE_OMP_AT_NINE=1 PATH="$fakebin:$PATH" bash -c 'export FAKE_PS_ROOT_PID=$$; exec "$1"' _ "$HARNESS")
   [ "$out" = omp ] || fail "FM_OMP_HARNESS must outrank CLAUDECODE when omp is at ancestry entry nine, got '$out'"
 
   pass "fm-harness: native startup wrappers may place omp at ancestry entry nine"

--- a/tests/fm-omp-harness.test.sh
+++ b/tests/fm-omp-harness.test.sh
@@ -61,19 +61,62 @@ make_named_shells() {  # <dir> -> echoes <bindir>
   printf '%s' "$dir"
 }
 
+# A deterministic parent chain for the depth boundary. The detector process is
+# entry one; pid 100 is entry nine. FAKE_PS_FIRST_COMM lets anchored-name
+# negatives keep their immediate process identity without seeing the outer
+# harness that launched this suite.
+make_omp_ancestry_fakebin() {  # <dir>
+  local fakebin
+  fakebin=$(fm_fakebin "$1")
+  cat > "$fakebin/ps" <<'SH'
+#!/usr/bin/env bash
+pid=${!#}
+case "$*" in
+  *"comm="*)
+    if [ "$pid" = 100 ] && [ "${FAKE_OMP_AT_NINE:-0}" = 1 ]; then
+      printf '%s\n' omp
+    elif [ "$pid" != 800 ] && [ "$pid" != 700 ] && [ "$pid" != 600 ] \
+      && [ "$pid" != 500 ] && [ "$pid" != 400 ] && [ "$pid" != 300 ] \
+      && [ "$pid" != 200 ] && [ "$pid" != 100 ] \
+      && [ -n "${FAKE_PS_FIRST_COMM:-}" ]; then
+      printf '%s\n' "$FAKE_PS_FIRST_COMM"
+    else
+      printf '%s\n' bash
+    fi
+    ;;
+  *"ppid="*)
+    case "$pid" in
+      800) printf '%s\n' 700 ;;
+      700) printf '%s\n' 600 ;;
+      600) printf '%s\n' 500 ;;
+      500) printf '%s\n' 400 ;;
+      400) printf '%s\n' 300 ;;
+      300) printf '%s\n' 200 ;;
+      200) printf '%s\n' 100 ;;
+      100) printf '%s\n' 1 ;;
+      *) printf '%s\n' 800 ;;
+    esac
+    ;;
+  *) exit 1 ;;
+esac
+SH
+  chmod +x "$fakebin/ps"
+  printf '%s' "$fakebin"
+}
+
 # --- 1. Detection --------------------------------------------------------------
 
 test_detection_anchored_name_and_marker_precedence() {
-  local bin out
+  local bin fakebin out
   bin=$(make_named_shells "$TMP_ROOT/named")
+  fakebin=$(make_omp_ancestry_fakebin "$TMP_ROOT/anchored-ancestry")
   # shellcheck disable=SC2016 # the quoted body expands inside the named shell
   out=$(env -u CLAUDECODE -u FM_OMP_HARNESS -u PI_CODING_AGENT -u CURSOR_AGENT -u CURSOR_INVOKED_AS \
     "$bin/omp" -c '"$1"; :' _ "$HARNESS")
   [ "$out" = omp ] || fail "a process named omp must detect as omp, got '$out'"
   for decoy in ompd comp; do
-    # shellcheck disable=SC2016 # the quoted body expands inside the named shell
     out=$(env -u CLAUDECODE -u FM_OMP_HARNESS -u PI_CODING_AGENT -u CURSOR_AGENT -u CURSOR_INVOKED_AS \
-      "$bin/$decoy" -c '"$1"; :' _ "$HARNESS")
+      FAKE_PS_FIRST_COMM="$decoy" PATH="$fakebin:$PATH" "$HARNESS")
     [ "$out" != omp ] || fail "'$decoy' merely contains omp and must not detect as omp"
   done
   # The marker beats an inherited CLAUDECODE only under a real omp ancestor.
@@ -82,11 +125,25 @@ test_detection_anchored_name_and_marker_precedence() {
     "$bin/omp" -c '"$1"; :' _ "$HARNESS")
   [ "$out" = omp ] || fail "FM_OMP_HARNESS under an omp ancestor must outrank an inherited CLAUDECODE, got '$out'"
   # ...and is inert when it leaks into a worker with no omp ancestor.
-  # shellcheck disable=SC2016 # the quoted body expands inside the named shell
   out=$(env -u PI_CODING_AGENT -u CURSOR_AGENT -u CURSOR_INVOKED_AS CLAUDECODE=1 FM_OMP_HARNESS=omp \
-    bash -c '"$1"; :' _ "$HARNESS")
+    PATH="$fakebin:$PATH" "$HARNESS")
   [ "$out" = claude ] || fail "a leaked FM_OMP_HARNESS without an omp ancestor must not relabel a claude worker, got '$out'"
   pass "fm-harness: omp detects by its anchored name; the marker is a precedence override that needs real omp ancestry"
+}
+
+test_detection_reaches_omp_at_ancestry_entry_nine() {
+  local fakebin out
+  fakebin=$(make_omp_ancestry_fakebin "$TMP_ROOT/entry-nine")
+
+  out=$(env -u CLAUDECODE -u FM_OMP_HARNESS -u PI_CODING_AGENT -u CURSOR_AGENT -u CURSOR_INVOKED_AS \
+    FAKE_OMP_AT_NINE=1 PATH="$fakebin:$PATH" "$HARNESS")
+  [ "$out" = omp ] || fail "an omp process at ancestry entry nine must detect as omp, got '$out'"
+
+  out=$(env -u PI_CODING_AGENT -u CURSOR_AGENT -u CURSOR_INVOKED_AS CLAUDECODE=1 FM_OMP_HARNESS=omp \
+    FAKE_OMP_AT_NINE=1 PATH="$fakebin:$PATH" "$HARNESS")
+  [ "$out" = omp ] || fail "FM_OMP_HARNESS must outrank CLAUDECODE when omp is at ancestry entry nine, got '$out'"
+
+  pass "fm-harness: native startup wrappers may place omp at ancestry entry nine"
 }
 
 test_lock_identity_and_liveness_classification() {
@@ -575,6 +632,7 @@ EOF
 }
 
 test_detection_anchored_name_and_marker_precedence
+test_detection_reaches_omp_at_ancestry_entry_nine
 test_lock_identity_and_liveness_classification
 test_spawn_launch_line_and_worker_wiring
 test_spawn_model_validation_scoped_to_listed_providers


### PR DESCRIPTION
## Intent

Fix Firstmate reporting native OMP as unknown during startup using the minimal agreed change: raise both bounded ancestry searches in bin/fm-harness.sh from eight to sixteen entries with matching rationale and focused regression coverage. Preserve exact process-name matching and require real OMP ancestry for FM_OMP_HARNESS precedence; inherited CLAUDECODE contamination is out of scope. The user explicitly requests recovering all previous no-mistakes changes, fixing Greptile's PID-collision finding, and restarting validation. The prior run was cancelled through AXI, all pipeline changes were synchronized, and the correction was committed on top without dropping documentation updates. Synthetic test ancestors now derive from the detector PID, preserving nine distinct entries rather than colliding with fixed 100..800 values. The full OMP regression and explicit-file canonical lint passed. Throwaway executable counterfactuals with formerly colliding roots 100 and 800 rejected the old eight-entry detector and accepted the sixteen-entry detector on markerless and guarded-marker paths. A full canonical lint attempt in the interactive environment timed out after 300 seconds; do not claim it passed, and run the configured lint step normally. The user approved Codex for validation. Keep the fix minimal, no production scope expansion, no dependency/config/workflow-security changes, no CI bypass, and no merge. Continue updating the existing PR for review; GitHub fork workflow approval remains an external maintainer requirement if still present.

## What Changed

- Extend both OMP ancestry searches from 8 to 16 entries so native startup wrappers can place `omp` at entry nine without detection falling back to `unknown`.
- Preserve exact `omp` process-name matching and require real OMP ancestry before `FM_OMP_HARNESS` can override `CLAUDECODE`.
- Add PID-derived process-chain regressions for entry-nine detection and marker precedence, and document the updated verification coverage.

## Risk Assessment

✅ Low: The change is minimal and well-bounded: both ancestry searches now cover sixteen entries, exact OMP matching and marker precedence remain intact, and executable regression coverage deterministically reproduces the entry-nine boundary without PID collisions.

## Testing

Ran the focused OMP regression and drove the real `bin/fm-harness.sh` executable through real OS process chains. Markerless and guarded entry-nine detection passed, `comp` stayed excluded, entry sixteen was accepted, and entry seventeen returned `unknown`. The CLI transcript was captured as reviewer-visible evidence. No lint, broad suite, CI, push, PR, or pipeline-control command was run during this assigned test phase.

- Live validation: ✅ go - 3 of 3 scenarios driven live against the product

| Scenario | Result | Live | Evidence |
| --- | --- | --- | --- |
| A markerless OMP session with the exact `omp` process at ancestry entry nine reports `omp` instead of `unknown`. | ✅ pass | live | Live OMP ancestry transcript |
| With `FM_OMP_HARNESS=omp`, inherited `CLAUDECODE=1`, and exact OMP ancestry at entry nine, Firstmate gives OMP precedence. | ✅ pass | live | Live OMP ancestry transcript |
| A `comp` lookalike cannot satisfy OMP ancestry, while entry sixteen is accepted and entry seventeen remains outside the bounded search. | ✅ pass | live | Live OMP ancestry transcript |

<details>
<summary>Evidence: Live OMP ancestry transcript</summary>

Source: [Live OMP ancestry transcript](https://github.com/nikolauska/firstmate/blob/712ce9c747aed169eae9fb957144cc259ed05473/.no-mistakes/evidence/omp-ancestry-depth/omp-ancestry-live-transcript.txt)

```text
Live fm-harness OMP ancestry scenarios
Real kernel process chains; depth 7 places launcher at ancestry entry 9, depth 14 at entry 16, depth 15 at entry 17.
markerless exact omp at entry 9 | expected=omp | observed=omp
guarded exact omp at entry 9 | expected=omp | observed=omp
guarded comp lookalike at entry 9 | expected=claude | observed=claude
markerless exact omp at entry 16 | expected=omp | observed=omp
markerless exact omp at entry 17 | expected=unknown | observed=unknown
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"c58023aad7cc24f8afe30045dd17e297fec773f3","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}],"live_validation":{"verdict":"go","live":3,"total":3}} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- Live validation: ✅ go - 3 of 3 scenarios driven live against the product

| Scenario | Result | Live | Evidence |
| --- | --- | --- | --- |
| A markerless OMP session with the exact `omp` process at ancestry entry nine reports `omp` instead of `unknown`. | ✅ pass | live | Live OMP ancestry transcript |
| With `FM_OMP_HARNESS=omp`, inherited `CLAUDECODE=1`, and exact OMP ancestry at entry nine, Firstmate gives OMP precedence. | ✅ pass | live | Live OMP ancestry transcript |
| A `comp` lookalike cannot satisfy OMP ancestry, while entry sixteen is accepted and entry seventeen remains outside the bounded search. | ✅ pass | live | Live OMP ancestry transcript |

- `tests/fm-omp-harness.test.sh`
- <code>Live `bin/fm-harness.sh` execution through real kernel process chains with exact `omp` at ancestry entries 9, 16, and 17, plus guarded `comp` at entry 9; captured with `tee ~/.no-mistakes/evidence/01M21DG5KNGG8YFMWA74FTC0V1/omp-ancestry-live-transcript.txt`</code>
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
