### PR TITLE
fix(bin): accept control_relaunch_tx in PR poll registration metadata

### DIFF
--- a/bin/fm-pr-lib.sh
+++ b/bin/fm-pr-lib.sh
@@ -315,7 +315,7 @@ fm_pr_metadata_identity_parse() {
           fm_pr_head_valid "$value" || post_pr_invalid=1
         fi
         ;;
-      x_request=*|x_request_ts=*|x_followups=*|x_platform=*|x_reply_max_chars=*)
+      x_request=*|x_request_ts=*|x_followups=*|x_platform=*|x_reply_max_chars=*|control_relaunch_tx=*)
         ;;
       *)
         [ "$seen_pr" -eq 0 ] || post_pr_invalid=1

--- a/bin/fm-pr-lib.sh
+++ b/bin/fm-pr-lib.sh
@@ -315,6 +315,11 @@ fm_pr_metadata_identity_parse() {
           fm_pr_head_valid "$value" || post_pr_invalid=1
         fi
         ;;
+      # Keys other firstmate producers append to a task's meta (relay links
+      # write x_*, fm-control's relaunch writes control_relaunch_tx) do not
+      # change the canonical PR identity, so they are tolerated; any other
+      # line after pr= invalidates the record. A new producer key must be
+      # added here and covered in tests/fm-pr-check-security.test.sh.
       x_request=*|x_request_ts=*|x_followups=*|x_platform=*|x_reply_max_chars=*|control_relaunch_tx=*)
         ;;
       *)

--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -810,7 +810,7 @@ portable_serial_unhinted() {
   tmp=$(mktemp -d "${TMPDIR:-/tmp}/fm-test-unhinted.XXXXXX") || return 1
   portable_serial_weight_hints | awk 'NF { print $1 }' | LC_ALL=C sort -u >"$tmp/hinted"
   list_portable_serial | LC_ALL=C sort -u >"$tmp/serial"
-  comm -23 "$tmp/serial" "$tmp/hinted"
+  LC_ALL=C comm -23 "$tmp/serial" "$tmp/hinted"
   rm -rf "$tmp"
 }
 
@@ -969,8 +969,8 @@ run_coverage_guard() {
     return 1
   fi
   cat "$tmp/s1" "$tmp/s2" | LC_ALL=C sort -u >"$tmp/shards_union"
-  missing=$(comm -23 "$tmp/proven" "$tmp/shards_union" || true)
-  extra=$(comm -13 "$tmp/proven" "$tmp/shards_union" || true)
+  missing=$(LC_ALL=C comm -23 "$tmp/proven" "$tmp/shards_union" || true)
+  extra=$(LC_ALL=C comm -13 "$tmp/proven" "$tmp/shards_union" || true)
   if [ -n "$missing" ] || [ -n "$extra" ]; then
     log "coverage guard: portable shards must equal the proven-isolated set"
     [ -z "$missing" ] || { log "missing from shards:"; printf '%s\n' "$missing" >&2; }
@@ -1014,8 +1014,8 @@ run_coverage_guard() {
     return 1
   fi
   LC_ALL=C sort -u "$tmp/serial_shards_raw" >"$tmp/serial_shards"
-  missing=$(comm -23 "$tmp/serial" "$tmp/serial_shards" || true)
-  extra=$(comm -13 "$tmp/serial" "$tmp/serial_shards" || true)
+  missing=$(LC_ALL=C comm -23 "$tmp/serial" "$tmp/serial_shards" || true)
+  extra=$(LC_ALL=C comm -13 "$tmp/serial" "$tmp/serial_shards" || true)
   if [ -n "$missing" ] || [ -n "$extra" ]; then
     log "coverage guard: portable serial shards must equal the portable serial lane"
     [ -z "$missing" ] || { log "missing from serial shards:"; printf '%s\n' "$missing" >&2; }
@@ -1027,7 +1027,7 @@ run_coverage_guard() {
   for pair in "shards_union:serial" "shards_union:herdr" "serial:herdr"; do
     a=${pair%%:*}
     b=${pair#*:}
-    comm -12 "$tmp/$a" "$tmp/$b" >"$tmp/overlap"
+    LC_ALL=C comm -12 "$tmp/$a" "$tmp/$b" >"$tmp/overlap"
     if [ -s "$tmp/overlap" ]; then
       log "coverage guard: overlap between $a and $b:"
       cat "$tmp/overlap" >&2
@@ -1045,8 +1045,8 @@ run_coverage_guard() {
     return 1
   fi
   LC_ALL=C sort -u "$tmp/union_raw" >"$tmp/union"
-  missing=$(comm -23 "$tmp/all" "$tmp/union" || true)
-  extra=$(comm -13 "$tmp/all" "$tmp/union" || true)
+  missing=$(LC_ALL=C comm -23 "$tmp/all" "$tmp/union" || true)
+  extra=$(LC_ALL=C comm -13 "$tmp/all" "$tmp/union" || true)
   if [ -n "$missing" ] || [ -n "$extra" ]; then
     log "coverage guard: union of portable shards + portable serial + Herdr must equal tests/*.test.sh"
     [ -z "$missing" ] || { log "missing from union:"; printf '%s\n' "$missing" >&2; }
@@ -1076,7 +1076,7 @@ run_coverage_guard() {
     "$ROOT/bin/fm-test-isolation-proof.sh" --list | LC_ALL=C sort -u >"$tmp/proof_list"
     if ! cmp -s "$tmp/proven" "$tmp/proof_list"; then
       log "coverage guard: embedded proven-isolated set diverges from bin/fm-test-isolation-proof.sh --list"
-      comm -3 "$tmp/proven" "$tmp/proof_list" >&2 || true
+      LC_ALL=C comm -3 "$tmp/proven" "$tmp/proof_list" >&2 || true
       rm -rf "$tmp"
       return 1
     fi

--- a/tests/fm-pr-check-security.test.sh
+++ b/tests/fm-pr-check-security.test.sh
@@ -631,6 +631,34 @@ SH
   pass "valid direct and merge flows record exact metadata and reject multiline head metadata"
 }
 
+test_relaunch_metadata_keeps_registered_poll_authenticated() {
+  local dir state url registration_tmp
+  dir=$(make_case relaunch-metadata-poll)
+  state="$dir/home/state"
+  url=https://github.com/o/r/pull/1
+  fm_write_meta "$state/task-a.meta" \
+    "window=fm-task-a" \
+    "pr=$url" \
+    'pr_head=0123456789abcdef0123456789abcdef01234567' \
+    'control_relaunch_tx=tx-1'
+  fm_pr_poll_prepare "$state" task-a github "$url" github.com o/r 1 "$POLL" \
+    || fail "could not prepare a poll beside relaunch metadata"
+  fm_pr_poll_publish_prepared || fail "could not publish a poll beside relaunch metadata"
+  fm_pr_poll_artifacts_valid "$state" task-a "$POLL" \
+    || fail "valid registration was rejected when control metadata followed pr"
+
+  registration_tmp="$dir/tampered-registration"
+  awk 'NR == 8 { $0 = "0000000000000000000000000000000000000000000000000000000000000000" } { print }' \
+    "$state/task-a.pr-poll-registration" > "$registration_tmp" \
+    || fail "could not stage a tampered registration"
+  mv "$registration_tmp" "$state/task-a.pr-poll-registration" \
+    || fail "could not replace the registration in the tamper fixture"
+  chmod 0600 "$state/task-a.pr-poll-registration"
+  ! fm_pr_poll_artifacts_valid "$state" task-a "$POLL" \
+    || fail "tampered registration data hash remained authenticated"
+  pass "relaunch metadata preserves valid poll registration and tampering is rejected"
+}
+
 run_watcher_bounded() {
   local home=$1 fakebin=$2 check_interval=${FM_TEST_CHECK_INTERVAL:-0} watch_root=${FM_TEST_WATCH_ROOT:-$ROOT}
   local check_timeout=${FM_TEST_CHECK_TIMEOUT:-1}
@@ -2439,6 +2467,7 @@ test_retirement_queue_failure_and_receipt_tampering
 test_gitlab_merged_poll_retires
 test_invalid_entrypoints_have_zero_side_effects
 test_valid_recording_and_merge_derivation
+test_relaunch_metadata_keeps_registered_poll_authenticated
 test_rejected_metacharacter_bytes_are_inert
 test_static_poll_contract
 test_atomic_interruption_leaves_no_partial_artifact


### PR DESCRIPTION
## Intent

Repair the internal Firstmate watcher failure that rejects a valid PR-poll registration and leaves automatic merge detection unproven. Use the exact deployed parser and the fm-pr3417-attest registration as the end-to-end reproduction, compare it with a proven valid registration path and relevant history, and test the smallest single-variable counterfactual before accepting or rejecting the reported duplicate-data_hash cause. If the cause is confirmed, make the minimal parser correction and add regression coverage for valid acceptance plus malformed or tampered registration rejection. Ship the correction through no-mistakes with the task's yolo delivery posture, and restore coverage only when the real registered poll passes.

## What Changed

- Tolerate the `control_relaunch_tx` meta key after `pr=` in the PR poll metadata identity parser, so registrations written by fm-control relaunches authenticate instead of being rejected as invalid post-`pr` lines; other unrecognized keys still invalidate the record.
- Add a security regression test covering valid acceptance of a registration carrying relaunch metadata and rejection of a tampered registration data hash.
- Pin `LC_ALL=C` on `comm` invocations in the test coverage guard so shard comparisons are locale-independent.

## Risk Assessment

✅ Low: The change is a minimal, fail-closed producer-key allowlist extension at the shared parse boundary with a real-interface regression test, plus mechanical LC_ALL=C comm portability pinning; no reachable failure path or wrong-value computation was found in the changed logic.

## Testing

Re-validated the rebased parser fix through the focused regression suite, a single-variable counterfactual that reproduces the original rejection, and a real end-to-end watcher flow proving automatic merge detection for the fm-pr3417-attest registration shape; also confirmed the corrected shard docs against the real --check-coverage consumer. All checks pass and the worktree is clean.

<details>
<summary>Evidence: End-to-end fix-vs-counterfactual transcript on rebased commit 9817c564 (real fm-pr-check.sh / fm-watch.sh / fm-wake-drain.sh)</summary>

Source: [End-to-end fix-vs-counterfactual transcript on rebased commit 9817c564 (real fm-pr-check.sh / fm-watch.sh / fm-wake-drain.sh)](https://github.com/RooseveltAdvisors/firstmate/blob/072671e966c182af1bcf281deb2cd3a8d312da66/.no-mistakes/evidence/fm/fm-pr-poll-registration-parser-20260908/e2e-pr3417-rebase-9817c564.log)

```text
== SHIPPED PARSER (accept-list includes control_relaunch_tx) ==
ARM: ok; armed poll check is byte-identical to bin/fm-pr-poll.sh: yes
registration (fm-pr-poll-registration-v2) id/url/data_hash lines:
  task-a
  github
  14301287d7b07dd8f9947a8fcb9efea7179c469816a34847195497c62d8ce390
meta after arming (canonical pr identity recorded):
  window=fm-pr3417-attest
  endpoint_task_id=task-a
  worktree=/tmp/e2e-pr3417.qR8thv/shipped/wt
  project=/tmp/e2e-pr3417.qR8thv/shipped/project
  kind=ship
  mode=no-mistakes
  pr=https://github.com/o/r/pull/3417
  pr_head=0123456789abcdef0123456789abcdef01234567
meta after relaunch append gains: control_relaunch_tx=tx-3417
watcher cycle with PR still open: exit=0
  out: check: /tmp/e2e-pr3417.qR8thv/shipped/home/state/z-stop.check.sh: stop-cycle
  poll artifacts survived the relaunch metadata: still armed and authenticated
watcher cycle with PR merged (attempt 1): exit=0
  out: check: rearm-resurface
watcher cycle with PR merged (attempt 2): exit=0
  out: check: /tmp/e2e-pr3417.qR8thv/shipped/home/state/task-a.check.sh: merged
  automatic merge detection: DELIVERED
  merged notification acknowledged via bin/fm-wake-drain.sh
  poll retired after merged notification (check.sh, pr-poll, registration all removed)
  canonical meta preserved after retirement: 1 pr= lines, 1 control_relaunch_tx= lines

== COUNTERFACTUAL (accept-list reverted to base 40c50ea) ==
ARM: ok; armed poll check is byte-identical to bin/fm-pr-poll.sh: yes
registration (fm-pr-poll-registration-v2) id/url/data_hash lines:
  task-a
  github
  14301287d7b07dd8f9947a8fcb9efea7179c469816a34847195497c62d8ce390
meta after arming (canonical pr identity recorded):
  window=fm-pr3417-attest
  endpoint_task_id=task-a
  worktree=/tmp/e2e-pr3417.qR8thv/counterfactual/wt
  project=/tmp/e2e-pr3417.qR8thv/counterfactual/project
  kind=ship
  mode=no-mistakes
  pr=https://github.com/o/r/pull/3417
  pr_head=0123456789abcdef0123456789abcdef01234567
meta after relaunch append gains: control_relaunch_tx=tx-3417
watcher cycle with PR still open: exit=0
  out: check: /tmp/e2e-pr3417.qR8thv/counterfactual/home/state/z-stop.check.sh: stop-cycle
  poll artifacts survived the relaunch metadata: still armed and authenticated
watcher cycle with PR merged (attempt 1): exit=0
  out: check: rearm-resurface
watcher cycle with PR merged (attempt 2): exit=0
  out: check: /tmp/e2e-pr3417.qR8thv/counterfactual/home/state/z-stop.check.sh: stop-cycle
watcher cycle with PR merged (attempt 3): exit=0
  out: check: /tmp/e2e-pr3417.qR8thv/counterfactual/home/state/z-stop.check.sh: stop-cycle
  automatic merge detection: NOT DELIVERED
  merged notification acknowledgement: FAILED
  poll artifacts still present after merged retirement
  canonical meta preserved after retirement: 1 pr= lines, 1 control_relaunch_tx= lines

worktree restored to shipped parser
```
</details>
<details>
<summary>Evidence: Coverage guard output and docs numeric-claims cross-check</summary>

Source: [Coverage guard output and docs numeric-claims cross-check](https://github.com/RooseveltAdvisors/firstmate/blob/072671e966c182af1bcf281deb2cd3a8d312da66/.no-mistakes/evidence/fm/fm-pr-poll-registration-parser-20260908/coverage-docs-verification-rebased.txt)

`FM_TEST_COVERAGE ok total=204 parallel=24 parallel_max_ms=417163 parallel_imbalance_ms=2894 parallel_unhinted=0 serial=164 serial_shards=5 serial_unhinted=16 herdr=16`

```text
== bin/fm-test-run.sh --check-coverage (real consumer) ==
FM_TEST_COVERAGE ok total=204 parallel=24 parallel_max_ms=417163 parallel_imbalance_ms=2894 parallel_unhinted=0 serial=164 serial_shards=5 serial_unhinted=16 herdr=16

== docs/fm-test-portable-shards.md numeric claims vs ground truth ==
doc: 'all 24 candidates'        <-> parallel=24: match
doc: watch-triage 262626 ms     <-> hint table line 800 'tests/fm-watch-triage.test.sh 262626': match
doc: 'portable serial 1-5'      <-> serial_shards=5 and ci.yml strategy.matrix shard [1,2,3,4,5]: match
doc: no copied hint counts/totals/per-shard table remain (defers to --check-coverage output): verified by grep for stale figures (4312606/4314106/4638106/4555606/145/146/153/154-script/158-script/'nine unhinted'/911128/927620): none found
```
</details>
<details>
<summary>Evidence: Prior-round end-to-end transcript retained for continuity (pre-rebase commit 32eb5cda)</summary>

Source: [Prior-round end-to-end transcript retained for continuity (pre-rebase commit 32eb5cda)](https://github.com/RooseveltAdvisors/firstmate/blob/072671e966c182af1bcf281deb2cd3a8d312da66/.no-mistakes/evidence/fm/fm-pr-poll-registration-parser-20260908/e2e-pr3417-relaunch-fix-vs-counterfactual.log)

```text
== SHIPPED PARSER (accept-list includes control_relaunch_tx) ==
ARM: ok; armed poll check is byte-identical to bin/fm-pr-poll.sh: yes
registration (fm-pr-poll-registration-v2) id/url/data_hash lines:
  task-a
  github
  14301287d7b07dd8f9947a8fcb9efea7179c469816a34847195497c62d8ce390
meta after arming (canonical pr identity recorded):
  window=fm-pr3417-attest
  endpoint_task_id=task-a
  worktree=/tmp/e2e-pr3417.Iyrd4a/shipped/wt
  project=/tmp/e2e-pr3417.Iyrd4a/shipped/project
  kind=ship
  mode=no-mistakes
  pr=https://github.com/o/r/pull/3417
  pr_head=0123456789abcdef0123456789abcdef01234567
meta after relaunch append gains: control_relaunch_tx=tx-3417
watcher cycle with PR still open: exit=0
  out: check: /tmp/e2e-pr3417.Iyrd4a/shipped/home/state/z-stop.check.sh: stop-cycle
  poll artifacts survived the relaunch metadata: still armed and authenticated
watcher cycle with PR merged (attempt 1): exit=0
  out: check: rearm-resurface
watcher cycle with PR merged (attempt 2): exit=0
  out: check: /tmp/e2e-pr3417.Iyrd4a/shipped/home/state/task-a.check.sh: merged
  automatic merge detection: DELIVERED
  merged notification acknowledged via bin/fm-wake-drain.sh
  poll retired after merged notification (check.sh, pr-poll, registration all removed)
  canonical meta preserved after retirement: 1 pr= lines, 1 control_relaunch_tx= lines

== COUNTERFACTUAL (accept-list reverted to base 40c50ea) ==
ARM: ok; armed poll check is byte-identical to bin/fm-pr-poll.sh: yes
registration (fm-pr-poll-registration-v2) id/url/data_hash lines:
  task-a
  github
  14301287d7b07dd8f9947a8fcb9efea7179c469816a34847195497c62d8ce390
meta after arming (canonical pr identity recorded):
  window=fm-pr3417-attest
  endpoint_task_id=task-a
  worktree=/tmp/e2e-pr3417.Iyrd4a/counterfactual/wt
  project=/tmp/e2e-pr3417.Iyrd4a/counterfactual/project
  kind=ship
  mode=no-mistakes
  pr=https://github.com/o/r/pull/3417
  pr_head=0123456789abcdef0123456789abcdef01234567
meta after relaunch append gains: control_relaunch_tx=tx-3417
watcher cycle with PR still open: exit=0
  out: check: /tmp/e2e-pr3417.Iyrd4a/counterfactual/home/state/z-stop.check.sh: stop-cycle
  poll artifacts survived the relaunch metadata: still armed and authenticated
watcher cycle with PR merged (attempt 1): exit=0
  out: check: rearm-resurface
watcher cycle with PR merged (attempt 2): exit=0
  out: check: /tmp/e2e-pr3417.Iyrd4a/counterfactual/home/state/z-stop.check.sh: stop-cycle
watcher cycle with PR merged (attempt 3): exit=0
  out: check: /tmp/e2e-pr3417.Iyrd4a/counterfactual/home/state/z-stop.check.sh: stop-cycle
  automatic merge detection: NOT DELIVERED
  merged notification acknowledgement: FAILED
  poll artifacts still present after merged retirement
  canonical meta preserved after retirement: 1 pr= lines, 1 control_relaunch_tx= lines

worktree restored to shipped parser
```
</details>
- Outcome: 🔧 1 issue found → auto-fixed ✅ across 5 runs (1h46m10s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"9817c5643c1bded8ccd5eb0923910ca323d9ac06","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>⚠️ **Review** - 0 issues</summary>

✅ No issues found.

- ⚠️ `docs/fm-test-portable-shards.md:68` - The refreshed docs assert the hints table now measures every serial script: &#39;The 152 current hints include every script in the lane&#39; (line 67), &#39;assignment weight is 4941240 ms with no unhinted scripts&#39; (line 68), and &#39;every serial script is measured, so no default weight is in play&#39; (line 86). The committed state contradicts this: the hint table in bin/fm-test-run.sh has 153 entries summing 4944240 ms, the serial lane has 154 scripts, and running the real consumer (bin/fm-test-run.sh --check-coverage) reports serial_unhinted=1 with tests/fm-pi-codex-native.test.sh unhinted and balanced at the 27000 ms PORTABLE_SERIAL_DEFAULT_WEIGHT_MS. The docs&#39; totals also omit the fm-afk-contract.test.sh 3000 ms entry (4941240 vs actual 4944240), so the per-shard table (~823.5 s / 13.73 min) understates the real assignment weight (~828.5 s / 13.81 min). Balance impact is negligible and the 15% unhinted guard still passes, but these false factual claims (echoed in the commit&#39;s &#39;serial_unhinted=0&#39; verification claim) will mislead the next documented hint refresh; the mechanical remedy is correcting the doc counts/totals to state 153 hints, one unhinted live-optin script at the default weight, and the true per-shard weight.

🔧 Fix: Correct stale portable-serial shard doc counts, totals, and per-shard weights to match the committed hint table and coverage guard
✅ Re-checked - no issues remain.

✅ No issues found.

✅ No issues found.
</details>

<details>
<summary>🔧 **Test** - 1 issue found → auto-fixed ✅</summary>

- ℹ️ The actual fm-pr3417-attest registration state lives on the deployed Firstmate host and is not present on this machine, so the end-to-end reproduction used a byte-equivalent registration (window/pr/pr_head meta plus an appended control_relaunch_tx, armed via the deployed bin/fm-pr-check.sh and validated through a real fm-watch.sh cycle). The single-variable counterfactual (reverting only the fm_pr_metadata_identity_parse accept-list line) reproduces the reported rejection, confirming the parser cause and rejecting the reported duplicate-data_hash cause. If the author wants proof against the literal deployed state, re-running the watcher on the host holding that registration is the remaining step.
- <code>`bash tests/.tmp-relaunch-driver.sh` (new `test_relaunch_metadata_keeps_registered_poll_authenticated`): passes with the fix — valid poll registration accepted beside control_relaunch_tx, tampered registration data hash rejected</code>
- <code>Counterfactual: reverted only the `control_relaunch_tx=*` term in `bin/fm-pr-lib.sh` and re-ran the new test — fails at poll publish, confirming the single-variable cause and that the test fails before the fix and passes after</code>
- <code>End-to-end reproduction: armed a poll via the deployed `bin/fm-pr-check.sh`, appended `control_relaunch_tx=tx-3417` to the meta (as `fm-spawn` relaunch does), then ran deployed `fm_pr_metadata_identity_parse`/`fm_pr_poll_artifacts_valid` and a real `fm-watch.sh` watcher cycle — parser and artifact auth ACCEPT and the watcher cycle still recognizes and runs the poll</code>
- <code>End-to-end counterfactual: same reproduction with the parser fix reverted — `fm_pr_metadata_identity_parse: REJECT`, `fm_pr_poll_artifacts_valid: REJECT`, watcher rejects the valid registration</code>
- `Verified worktree restored to commit a4cac48 with no transient files left after testing`

✅ No issues found.
- <code>`head -2158 tests/fm-pr-check-security.test.sh + test_relaunch_metadata_keeps_registered_poll_authenticated` focused driver: new regression test passes on target commit (exit 0)</code>
- <code>Counterfactual: reverted only the `control_relaunch_tx=*` accept-list alternative in bin/fm-pr-lib.sh and re-ran the focused driver — test fails with &#39;could not publish a poll beside relaunch metadata&#39; (exit 1), proving fails-before-fix; parser file restored via git checkout afterwards</code>
- <code>`bash tests/fm-pr-check-security.test.sh` — full owning suite (28 cases incl. adversarial parser matrix and tampered-registration rejection) passes, exit 0, ~88s</code>
- <code>End-to-end reproduction of the fm-pr3417-attest scenario with the real consumers: wrote the task meta (window=fm-pr3417-attest, pr=https://github.com/o/r/pull/3417), armed via real `bin/fm-pr-check.sh task-a ...` (records pr_head and a byte-identical fm-pr-poll.sh check plus fm-pr-poll-registration-v2 with data_hash), appended `control_relaunch_tx=tx-3417` to meta exactly as fm-control relaunch does, then ran real `bin/fm-watch.sh` cycles: OPEN cycle stays silent with artifacts intact; MERGED cycles deliver `check: ...task-a.check.sh: merged`, acknowledgement via real `bin/fm-wake-drain.sh` succeeds, and check.sh/pr-poll/pr-poll-registration are all retired with canonical meta preserved</code>
- <code>Counterfactual end-to-end: with only the accept-list line reverted, the identical armed registration + relaunch metadata is silently rejected by the watcher (poll never runs, merged never delivered, no wake ack) — reproducing the reported deployed failure; worktree restored clean and verified with `git status --porcelain`</code>
- `Verified no transient artifacts remain in the worktree (test temp dirs were self-cleaning; parser file restored; worktree clean at target commit 2e78802)`

- ⚠️ `docs/fm-test-portable-shards.md:63` - The rebase-only resolution kept main&#39;s newer portable-serial rebalance but the shard docs still describe the old packing: line 58 says &#39;The 145 current hints&#39; (committed table has 146), line 61 says maxima &#39;total 4312606 ms&#39; (actual 4314106 ms), line 63 says &#39;the current 154-script lane has nine such scripts, bringing its assignment weight to 4555606 ms&#39; (actual: 158-script lane, 12 unhinted at the 27000 ms default, assignment weight 4638106 ms), the per-shard table (30/31/32/31/30 scripts at ~911128 ms) is actually 32/32/31/31/32 at ~927620 ms, and line 79 repeats &#39;the nine unhinted scripts&#39;. The real consumer confirms the mismatch: bin/fm-test-run.sh --check-coverage reports serial=158 serial_unhinted=12 and passes the 15% guard, so this is docs-only, but it is the same false-factual-claim class the user already chose to auto-fix in review round 2 and it was reintroduced by the rebase. Mechanical remedy: update the doc counts, totals, per-shard table, and &#39;nine unhinted&#39; references to 146 hints, 158 scripts, 12 unhinted, 4314106 ms hinted total, 4638106 ms assignment weight.
- <code>`tests/fm-pr-check-security.test.sh` (full focused suite, including new `test_relaunch_metadata_keeps_registered_poll_authenticated` valid-acceptance and tampered-registration-rejection cases)</code>
- <code>End-to-end registration through the deployed consumers: `fm_write_meta` with `window`/`pr`/`pr_head` plus `control_relaunch_tx` (byte-equivalent to the reported fm-pr3417-attest shape), then `fm_pr_poll_prepare` + `fm_pr_poll_publish_prepared`, then `fm_pr_poll_artifacts_valid` — validator authenticated the registration</code>
- <code>Real `bin/fm-watch.sh` bounded cycle over the authenticated poll with fake `gh` reporting MERGED — watcher exited 0 and emitted exactly one `check: ...: merged` wake</code>
- <code>Tamper check: flipped one hash byte in `task-a.pr-poll-registration` and confirmed `fm_pr_poll_artifacts_valid` rejects it</code>
- <code>Single-variable counterfactual: copy of `bin/fm-pr-lib.sh` with only the `control_relaunch_tx=*` accept-list entry reverted rejects the same valid registration, reproducing the reported failure</code>
- <code>`bin/fm-test-run.sh --check-coverage` — coverage guard passes (`FM_TEST_COVERAGE ok ... serial=158 serial_shards=5 serial_unhinted=12`)</code>
- <code>`tests/fm-test-run.test.sh` (runner suite over the `LC_ALL=C comm` pinning and rebalance changes)</code>
- <code>Doc-vs-consumer cross-check: counted 146 hint entries summing 4314106 ms in `portable_serial_weight_hints`, recomputed per-shard assignment weights (~927620 ms) via `fm-test-run.sh --list-scheduled --lane portable-serial-&lt;k&gt;of5`, and compared against `docs/fm-test-portable-shards.md` claims</code>

🔧 Fix: Correct stale portable-serial shard docs to match the committed hint table and coverage consumer (146 hints, 4314106 ms, 158 scripts, 12 unhinted, 4638106 ms, refreshed per-shard weights)
✅ Re-checked - no issues remain.
- <code>`bin/fm-test-run.sh --check-coverage` on the target commit — coverage guard ok with serial=158, serial_unhinted=12</code>
- <code>Sourced the real `portable_serial_weight_hints`/`portable_serial_assignments` functions from `bin/fm-test-run.sh` and recomputed the packing: 146 hints, 4314106 ms hinted total, 12 unhinted at the 27000 ms default, 4638106 ms assignment weight, per-shard 32/927624, 32/927618, 31/927619, 31/927618, 32/927627, imbalance 9 ms — all matching `docs/fm-test-portable-shards.md` exactly</code>
- <code>Focused run of `tests/fm-pr-check-security.test.sh` through the new regression plus its 13 predecessors (`bash tests/fm-pr-check-security-single.test.sh`) — all pass including &#39;relaunch metadata preserves valid poll registration and tampering is rejected&#39;</code>
- <code>Single-variable counterfactual: reverted only the `control_relaunch_tx=` accept line in `bin/fm-pr-lib.sh` and reran the focused test — 13 prior tests still passed but the new regression failed (&#39;could not publish a poll beside relaunch metadata&#39;), reproducing the reported rejection; restored the fix and reran green</code>
- <code>Tamper half of the regression: zeroed data_hash in a registration with `control_relaunch_tx=` metadata and confirmed `fm_pr_poll_artifacts_valid` rejects it (asserted inside the passing regression test)</code>
- <code>End-to-end watch-cycle reproduction with a byte-equivalent fm-pr3417-attest registration (window/pr/pr_head meta plus appended control_relaunch_tx) armed via the deployed `bin/fm-pr-check.sh` and validated through a real `fm-watch.sh` cycle — carried over from round 1 and re-confirmed by the passing regression suite</code>

✅ No issues found.
- <code>`bin/fm-test-run.sh tests/fm-pr-check-security.test.sh` - full focused suite passes, including `test_relaunch_metadata_keeps_registered_poll_authenticated` (valid acceptance beside relaunch metadata plus tampered data_hash rejection)</code>
- <code>Single-variable counterfactual: reverted only the `control_relaunch_tx=*` accept-list term in `bin/fm-pr-metadata_identity_parse` and re-ran `bin/fm-test-run.sh tests/fm-pr-check-security.test.sh` - `not ok - could not publish a poll beside relaunch metadata`, proving the regression test fails before the fix; worktree restored to HEAD afterwards</code>
- <code>End-to-end reproduction with the real consumers (`bin/fm-pr-check.sh` arm, real `bin/fm-watch.sh` cycles, real `bin/fm-wake-drain.sh` acknowledgement) on the rebased commit, using the byte-equivalent fm-pr3417-attest meta shape (window/pr/pr_head plus appended `control_relaunch_tx=tx-3417`): armed poll survives, watcher emits `task-a.check.sh: merged`, notification acknowledged, poll retired; counterfactual branch shows merge detection NOT DELIVERED</code>
- <code>`bin/fm-test-run.sh --check-coverage` - real coverage guard passes (total=204 parallel=24 parallel_unhinted=0 serial=164 serial_shards=5 serial_unhinted=16 herdr=16), exercising the rebased `LC_ALL=C comm` pinning</code>
- <code>Docs cross-check of `docs/fm-test-portable-shards.md` against ground truth: 24 parallel candidates matches coverage output, watch-triage 262626 ms matches the embedded hint table, &#39;portable serial 1-5&#39; matches serial_shards=5 and ci.yml shard matrix [1,2,3,4,5], and no stale copied counts/totals/per-shard tables remain</code>
- <code>`bin/fm-test-run.sh tests/fm-test-run.test.sh` - runner-focused suite (scheduling, shard packing, coverage guard, budget regressions) passes</code>
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

✅ No issues found.

✅ No issues found.

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

✅ No issues found.

✅ No issues found.

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

✅ No issues found.

✅ No issues found.

✅ No issues found.
</details>
