### PR TITLE
test: make timestamp fixtures portable across macOS and Linux

### DIFF
--- a/tests/fm-remote-backlog-handoff.test.sh
+++ b/tests/fm-remote-backlog-handoff.test.sh
@@ -311,11 +311,7 @@ pass "concurrent handoffs serialize staging through confirmed cleanup"
 # conservative procedure tasks-axi prints.
 write_backlog '- [ ] stale-lock-item - remote stale lock recovery (repo: alpha)'
 printf '999999:abandoned:0:1\n' > "$REMOTE/data/backlog.md.lock"
-if [ "$(uname 2>/dev/null)" = Darwin ]; then
-  touch -t 202001010000 "$REMOTE/data/backlog.md.lock"
-else
-  touch -d '2020-01-01 00:00:00' "$REMOTE/data/backlog.md.lock"
-fi
+touch -t 202001010000 "$REMOTE/data/backlog.md.lock"
 handoff_env "$ROOT/bin/fm-backlog-handoff.sh" ios stale-lock-item >/dev/null \
   || fail "host-local stale lock recovery did not retry receipt"
 assert_grep 'stale-lock-item' "$REMOTE/data/backlog.md" "stale-lock receipt lost the item"

--- a/tests/fm-test-fixtures.test.sh
+++ b/tests/fm-test-fixtures.test.sh
@@ -1,11 +1,11 @@
 #!/usr/bin/env bash
-# Behavior tests for tests/fixtures.sh fake-toolchain and spawn-world builders.
+# Behavior tests for tests/lib.sh primitives and tests/fixtures.sh builders.
 #
-# These cases drive the builders as a test would: they write stubs into a
-# fakebin and exec those stubs. Assertions are on the binaries' observable
-# output, exit status, and files they create - never on fixtures.sh source
-# text. Migrated spawn suites cover fm_test_run_spawn through the real
-# fm-spawn.sh; this file pins the stubs those suites now share.
+# Cases call shared primitives directly or write stubs into a fakebin and exec
+# them as a test would. Assertions are on observable output, exit status, and
+# filesystem effects - never on helper source text. Migrated spawn suites cover
+# fm_test_run_spawn through the real fm-spawn.sh; this file pins the shared
+# primitives and stubs those suites use.
 set -u
 
 # shellcheck source=tests/fixtures.sh

--- a/tests/fm-test-fixtures.test.sh
+++ b/tests/fm-test-fixtures.test.sh
@@ -13,6 +13,21 @@ set -u
 
 TMP_ROOT=$(fm_test_tmproot fm-test-fixtures)
 
+test_touch_epoch_preserves_repeated_dst_hour() {
+  local TZ=Europe/Paris epoch path actual
+  export TZ
+  for epoch in 1761438600 1761442200; do
+    fm_touch_epoch "$epoch" "$TMP_ROOT/epoch-one" "$TMP_ROOT/epoch two"
+    for path in "$TMP_ROOT/epoch-one" "$TMP_ROOT/epoch two"; do
+      actual=$(stat -c %Y "$path" 2>/dev/null || stat -f %m "$path" 2>/dev/null) \
+        || fail "could not read fixture mtime for $path"
+      [ "$actual" = "$epoch" ] \
+        || fail "fm_touch_epoch should preserve epoch $epoch, got $actual"
+    done
+  done
+  pass "fm_touch_epoch preserves both epochs in the repeated DST hour"
+}
+
 test_no_mistakes_version_constant() {
   local fakebin out
   fakebin=$(fm_fakebin "$TMP_ROOT/nm")
@@ -124,6 +139,7 @@ test_spawn_home_layout() {
   pass "spawn-home layout writes harness pin, beat, and brief"
 }
 
+test_touch_epoch_preserves_repeated_dst_hour
 test_no_mistakes_version_constant
 test_no_mistakes_init_doctor_markers
 test_fake_gh_and_gh_axi

--- a/tests/fm-turnend-guard.test.sh
+++ b/tests/fm-turnend-guard.test.sh
@@ -2003,7 +2003,7 @@ test_hook_away_daemon_allows_beacon_within_poll_derived_grace() {
   # grace (max(300, FM_POLL + 60) = 660 at FM_POLL=600) - a live daemon that
   # simply has not finished restarting its watcher yet.
   beat=$(( $(date +%s) - 400 ))
-  touch -d "@$beat" "$dir/state/.last-watcher-beat"
+  fm_touch_epoch "$beat" "$dir/state/.last-watcher-beat"
   out=$(FM_GUARD_GRACE='' FM_POLL=600 run_hook "$dir" false); status=$?
   kill "$pid" 2>/dev/null || true
   wait "$pid" 2>/dev/null || true
@@ -2036,7 +2036,7 @@ test_hook_away_daemon_blocks_beacon_older_than_poll_derived_grace() {
   # 700s exceeds even the wider poll-derived grace (660 at FM_POLL=600), so a
   # live daemon that has genuinely stopped restarting its watcher still blocks.
   beat=$(( $(date +%s) - 700 ))
-  touch -d "@$beat" "$dir/state/.last-watcher-beat"
+  fm_touch_epoch "$beat" "$dir/state/.last-watcher-beat"
   out=$(FM_GUARD_GRACE='' FM_POLL=600 run_hook "$dir" false); status=$?
   kill "$pid" 2>/dev/null || true
   wait "$pid" 2>/dev/null || true
@@ -2060,7 +2060,7 @@ test_hook_no_afk_ignores_poll_derived_grace() {
   # accept, but away mode is off here, so the strict watcher predicate and its
   # flat default govern instead - old behavior, unaffected by FM_POLL.
   beat=$(( $(date +%s) - 400 ))
-  touch -d "@$beat" "$dir/state/.last-watcher-beat"
+  fm_touch_epoch "$beat" "$dir/state/.last-watcher-beat"
   out=$(FM_GUARD_GRACE='' FM_POLL=600 run_hook "$dir" false); status=$?
   kill "$pid" 2>/dev/null || true
   wait "$pid" 2>/dev/null || true

--- a/tests/lib.sh
+++ b/tests/lib.sh
@@ -412,13 +412,14 @@ SH
 # spells that two incompatible ways. Probe them in this order: GNU date rejects
 # `-r <seconds>` (its -r takes a file), while BSD date rejects `-d` as an
 # illegal option, so whichever runs is the one that understood the request.
+# TZ is pinned to UTC for date and touch so repeated DST hours stay unambiguous.
 fm_touch_epoch() {
   local epoch=$1 stamp
   shift
-  stamp=$(date -d "@$epoch" +%Y%m%d%H%M.%S 2>/dev/null) \
-    || stamp=$(date -r "$epoch" +%Y%m%d%H%M.%S 2>/dev/null) \
+  stamp=$(TZ=UTC0 date -d "@$epoch" +%Y%m%d%H%M.%S 2>/dev/null) \
+    || stamp=$(TZ=UTC0 date -r "$epoch" +%Y%m%d%H%M.%S 2>/dev/null) \
     || fail "fm_touch_epoch: date(1) accepted neither -d @<epoch> nor -r <epoch>"
-  touch -t "$stamp" "$@" \
+  TZ=UTC0 touch -t "$stamp" "$@" \
     || fail "fm_touch_epoch: touch -t $stamp failed for $*"
 }
 

--- a/tests/lib.sh
+++ b/tests/lib.sh
@@ -398,6 +398,30 @@ SH
   chmod +x "$fakebin/$tool"
 }
 
+# --- portable file timestamps -----------------------------------------------
+
+# fm_touch_epoch <epoch> <path> [path...]: set each path's modification time to
+# an absolute epoch second on every supported host.
+#
+# There is no portable touch(1) flag that takes an epoch: `touch -d @<epoch>` is
+# a GNU extension and BSD touch rejects it outright ("out of range or illegal
+# time specification"), leaving the file at its current mtime. A test that wants
+# a beacon aged 700 seconds then silently measures a brand-new one.
+# `touch -t [[CC]YY]MMDDhhmm[.SS]` is POSIX and both accept it, so the only
+# host-specific step left is turning the epoch into that stamp, and date(1)
+# spells that two incompatible ways. Probe them in this order: GNU date rejects
+# `-r <seconds>` (its -r takes a file), while BSD date rejects `-d` as an
+# illegal option, so whichever runs is the one that understood the request.
+fm_touch_epoch() {
+  local epoch=$1 stamp
+  shift
+  stamp=$(date -d "@$epoch" +%Y%m%d%H%M.%S 2>/dev/null) \
+    || stamp=$(date -r "$epoch" +%Y%m%d%H%M.%S 2>/dev/null) \
+    || fail "fm_touch_epoch: date(1) accepted neither -d @<epoch> nor -r <epoch>"
+  touch -t "$stamp" "$@" \
+    || fail "fm_touch_epoch: touch -t $stamp failed for $*"
+}
+
 # --- deterministic git identity and fixtures --------------------------------
 
 # fm_git_identity [name] [email]: export a fixed author/committer identity so


### PR DESCRIPTION
## Intent

A case in the turn-end guard suite fails on macOS, for a reason that has nothing to do with what it tests: it uses a timestamp form only the Linux version of the tool accepts, so on a Mac the value is never set and the case falls over.

ESTABLISHED 2026-09-08 by the second mate, alongside the process-leak work. Present on the trunk today, arrived with an already-delivered change, unrelated to the branch it was noticed on.

WHY THIS IS NOT COSMETIC: the captain's machine is a Mac. A suite that is permanently red on its maintainer's own platform teaches everyone to ignore red. It is the same pattern as the rest of the day - something that looks like protection and in practice no longer protects - but in its social form.

TO DELIVER: the case must set its value on both platforms, or explicitly declare that it does not apply to one of them. No workaround that hides the case on a Mac.

ACCEPTANCE: the full suite passes on macOS with no exception and no silent skip.

USEFUL NEIGHBOUR: fm-tests-unpinned-bare-repos, same family - tests that depend on the machine rather than on their subject. Look for others while you are in there, without widening the delivery.

## Findings

These are the findings established while doing the work. An earlier publication of this description regenerated it and dropped them; they are restored here from the pre-pipeline baseline. They are also present, by substance, in the commit message of 6182c507.

### The headline: two cases were vacuous, not merely red

On macOS the visible symptom was ONE red case. The actual damage was TWO cases that had quietly stopped testing their subject. The red one was the harmless half - people read one red case as one broken thing, and here that intuition is wrong.

The 400s case exists to pin that a 400-second beacon is stale under the flat 300s default but fresh under the poll-derived grace (660s at `FM_POLL=600`). Deleting the grace it guards (`FM_POLL=60`, so `max(300,120)=300`) and re-running is the mutation that measures what the case was worth:

```
pre-fix input (beacon left at now):  ok     - passes with the feature DELETED
post-fix input (beacon 400s old):    not ok - expected exit 0, got 2
```

It was green while measuring nothing, and could not have caught a regression in the grace it names. That is vacuous, not broken. Only the 700s case broke loudly.

### Three real sites, and one consistency change - not four fixes

`tests/fm-remote-backlog-handoff.test.sh` was never a defect: its `uname = Darwin` branch made the `touch -d` line unreachable on macOS, and BSD touch accepts that space-separated form anyway. `touch -t` takes the date directly on both platforms, so the five-line branch is replaced by one line rather than left standing as a second copy of the same platform assumption.

### Known limit: case 2063 is only HALF recovered

The third case (away mode off, `tests/fm-turnend-guard.test.sh` around line 2063) now receives the input its name claims, but it is **still insensitive after this fix**: its verdict is identical with a 0s and a 400s beacon, because the fixture records a daemon lock and no watcher lock, and with away mode off the daemon lock proves nothing. Not fixed here; tracked separately, with the requirement that any fix be shown to FAIL when the protection is removed.

### A DST defect in the fix itself, caught by review

The first version of the helper formatted the epoch in local time, so during the autumn repeated hour two epochs an hour apart produce the identical `touch -t` stamp. Verified: under `TZ=Europe/Paris`, 1761438600 and 1761442200 both render `202510260230.00`, so one resolves an hour wrong - enough to reverse a guard verdict. Pinning `TZ=UTC0` across both `date` branches and the `touch` call makes them distinct and the round-trip exact. Same class as the defect being fixed: a fixture whose value depended on the machine rather than its subject, invisible on a UTC CI runner.

### Full suite on macOS: 189 scripts, four red, none from this change

Attribution came from a three-cell matrix, because base-idle against head-under-load moves two variables at once:

| script | head/loaded | base/idle | head/idle | verdict |
|---|---|---|---|---|
| `fm-calm-pi-extension` | red | red | red | pre-existing |
| `fm-backlog-atomicity` | red | red | red | pre-existing |
| `fm-procevent` | red | red | red | pre-existing |
| `fm-startup-network` | red | green | green | cause unestablished, load-sensitive under a full run |

Reported, not fixed. `fm-calm-pi-extension` deserves its own note: it FAILS because Chrome is absent instead of declaring the capability it needs and standing aside, so its verdict is about the machine rather than its subject - the same family as the defect above, with the red at least announcing itself.

Data point, not a claim: the Behavior portable serial 4 shard completed in this run, having been cut at the time cap on other deliveries today. This change did not touch shard packing and one clean run does not settle a flaky bound.

### What "untested" meant at the test gate

The pipeline recorded 0 of 5 scenarios driven live and a `no-surface` verdict. That means **no live product surface existed to drive - not that nothing was checked.** Only test code changed. What was actually done: the original macOS failure reproduced from a copy of the base commit; the DST error reproduced against the pre-UTC helper; three targeted suites run under stock macOS Bash with `TZ=Europe/Paris`, deliberately the hostile timezone, with no skips; and native BSD tools compared against GNU tools in a `debian:stable-slim` container, checking exact mtimes, multiple paths including filenames containing spaces, and explicit failure exits.

### Neighbouring class: reported, not changed

Other tests whose verdict depends on the machine rather than the subject. `file_mode()` - a verbatim `uname = Darwin ? stat -f %Lp : stat -c %a` - is copy-pasted across at least five test scripts plus a `reread_mode` variant, and epoch-mtime reads are open-coded as `date -r ... || stat -c %Y` in three more; same one-owner shape as the defect fixed here. `git init` without `-b main` depends on the host's `init.defaultBranch` in several scripts (branch-name case, tracked elsewhere). `timeout`, `sha256sum` and `sed -i` uses are all correctly guarded where checked.

### Observed while building the check rather than the fix

The first watcher written to wait for the suite **matched its own command line**, so it was waiting on its own existence and could never fire. Same shape as the cases above - machinery answering confidently about something other than its subject, by including itself in the evidence it was meant to judge. The file sentinel that replaced it cannot be produced by the observer that reads it.

## What Changed

- Add a UTC-based `fm_touch_epoch` helper supporting GNU and BSD date commands, and use it in three turn-end guard beacon-age cases.
- Add regression coverage for exact timestamps during a repeated DST hour across multiple paths, including a filename containing spaces.
- Simplify the remote handoff stale-lock fixture to use portable `touch -t` on both platforms.

## Risk Assessment

â Low: The changes are limited to test fixtures, preserve the affected cases, and correctly pin timestamp conversion and application to UTC.

## Testing

Reproduced the original macOS failure and pre-UTC DST error; all three targeted suites passed without skips, and native macOS/Linux probes confirmed exact timestamps and explicit failures. Evidence was saved and temporary files removed; checks are non-live because only tests changed, and broad repository regression remains with CI.

- Live validation: â ï¸ no-surface - 0 of 5 scenarios driven live against the product

| Scenario | Result | Live | Evidence |
| --- | --- | --- | --- |
| Run the macOS guard suite: accept the 400-second away-mode beacon, reject the 700-second beacon, and preserve dead-daemon and non-away-mode guards. | â¸ï¸ untested | no | Only test code changed. The suite uses simulated daemon processes, so its passing checks are non-live evidence; there is no changed runtime product surface. |
| Set fixture timestamps on macOS and Linux and observe exact epochs across multiple files, including filenames containing spaces. | â¸ï¸ untested | no | The helper was executed with real BSD and GNU tools, but it is test infrastructure with no runtime product surface. |
| Set both epochs within Paris&#39;s repeated autumn hour while preserving their one-hour separation and the caller&#39;s timezone. | â¸ï¸ untested | no | This exercises the test helper&#39;s filesystem behavior, not a changed running-product surface. |
| Supply an invalid epoch or nonexistent parent directory and receive an explicit failure instead of silent success. | â¸ï¸ untested | no | These are test-helper failure checks; no runtime product interface changed. |
| Age a remote backlog lock with the portable timestamp form and successfully recover the stale lock. | â¸ï¸ untested | no | The automated handoff suite substitutes SSH transport. This test-only change has no changed remote product surface to validate live. |

<details>
<summary>Evidence: Original macOS failure reproduction</summary>

Source: [Original macOS failure reproduction](https://github.com/mremond/firstmate/blob/0b795a869e789c8d168fc0b405b1ab72bc4a2992/.no-mistakes/evidence/fm/fm-turnend-guard-suite-red-on-macos/baseline-macos-turnend.log)

```text
Base b84e0e362face25f3dd8945297a3df1320d7668c test with unchanged production scripts; macOS native Bash/date/touch; TZ=Europe/Paris
Command: /bin/bash tests/.nm-baseline-turnend.test.sh
ok - fm_supervision_unhealthy: false with no state/*.meta at all
ok - fm_supervision_unhealthy: true with in-flight task and no beacon ever
ok - fm_supervision_unhealthy: true with in-flight task and a beacon far outside the grace window
ok - fm_supervision_unhealthy: false with in-flight task and a fresh beacon
ok - fm_supervision_status: FM_SUP_QUEUE_PENDING tracks state/.wake-queue
ok - fm_supervision_needed: X-mode relay poll needs supervision
ok - fm_supervision_unhealthy: source-only home needs supervision
ok - fm_supervision_needed: a registered custom check needs supervision with no task in flight
ok - fm_supervision_needed: a registered check whose bytes drifted still needs supervision
ok - fm_supervision_needed: false for a check.sh with no registration binding
ok - fm_supervision_needed: a task PR poll without a trust binding is not a registered custom check
ok - fm_supervision_status: the relay shim is not counted as a registered custom check
ok - fm-turnend-guard: silent no-op with nothing in flight
ok - fm-turnend-guard: blocks when a fresh beacon has no live watcher lock
ok - fm-turnend-guard: non-Claude path blocks a source-only home
ok - fm-turnend-guard: blocks on a dead watcher lock even when the beacon is fresh
ok - fm-turnend-guard: silent no-op with a live watcher lock and fresh beacon
ok - fm-turnend-guard: healthy non-Claude harness paths ignore Claude episode contention
ok - fm-turnend-guard: blocks on a live watcher lock with an ancient beacon
ok - fm-turnend-guard: blocks with the exact required reason in the primary when unhealthy
ok - fm-turnend-guard: blocks from active FM_HOME state, not only repo-root state
ok - fm-turnend-guard: X-mode repair reason sources the cadence config
ok - fm-turnend-guard: X-mode-only supervision remains guarded in default mode
ok - fm-turnend-guard: registered-check-only supervision is named in the block banner
ok - fm-turnend-guard: ignores stale repo-root state when FM_HOME is set
ok - fm-turnend-guard: uses FM_STATE_OVERRIDE ahead of FM_HOME/state
ok - fm-turnend-guard: stop_hook_active=true always allows the stop (never blocks twice in one turn)
ok - fm-turnend-guard: blocks a blind turn end in a secondmate's own home (.fm-secondmate-home no longer excludes it)
ok - fm-turnend-guard: idle-by-default - silent in a secondmate home with nothing in flight
ok - fm-turnend-guard: stop_hook_active=true allows the stop in a secondmate home (never blocks twice in one turn)
ok - fm-turnend-guard: secondmate deferred-death recovery - silent while watched, forces re-arm once the watcher exits
ok - fm-turnend-guard: inert in a secondmate's own child worktree (linked git worktree) even when unhealthy
ok - fm-turnend-guard: blocks a blind turn end in a treehouse-leased LINKED secondmate home (marker force-include)
ok - fm-turnend-guard: an invalid (empty) marker cannot spoof inclusion; linked worktree stays exempt
ok - fm-turnend-guard: a non-ASCII marker cannot spoof inclusion; linked worktree stays exempt
ok - fm-turnend-guard: inert in a crewmate/scout task worktree (linked git worktree) even when unhealthy
ok - fm-turnend-guard: fails open (never blocks) when jq is missing
ok - fm-turnend-guard: silent no-op on empty stdin
ok - fm-turnend-guard: runs well under the generous timing margin (1s)
ok - fm-turnend-guard-grok: forces one explicitly marked same-session resume when the shared predicate blocks
ok - fm-turnend-guard-grok: legacy environment loop guard prevents a nested resume loop
ok - fm-turnend-guard-grok: native false delegates blocking feedback with zero resume processes
ok - fm-turnend-guard-grok: native true remains bounded and starts no resume process
ok - fm-turnend-guard-grok: both spellings are typed and camelCase has deterministic precedence
ok - fm-turnend-guard-grok: malformed, invalidly typed, and missing-prerequisite payloads start neither path
ok - fm-turnend-guard-grok: missing jq and no-supervision-needed stops stay silent and bounded
ok - tracked .claude/settings.json entries: 5 inert under grok, the documented subagent exception still armed, all live under Claude
ok - .codex/hooks.json: Stop hook uses hook process root when payload cwd is outside
ok - .codex/hooks.json: Stop hook ignores nested git root guard scripts
ok - .opencode primary plugin: guard path is anchored to worktree, not directory
ok - .pi primary extension: no-tool and multi-tool runs each inject exactly one guard follow-up
ok - .pi primary extension: delivery failure resets the logical-run latch
ok - fm-turnend-guard --claude: re-blocks a loop-guarded stop while unhealthy and unclaimed (incident regression)
ok - fm-turnend-guard --claude: X-mode-only homes re-block when auto-arm recovery is absent
ok - fm-turnend-guard --claude: a live arming epoch advances once and repeated observation is idempotent
ok - fm-turnend-guard --claude: repeated failed-to-arming races make bounded monotonic progress
ok - fm-turnend-guard --claude: terminal owner boundary excludes a concurrent start without deadlock
ok - fm-turnend-guard --claude: fresh rewake epoch prevents a duplicate continuation for the same event
ok - fm-turnend-guard --claude: an abandoned auto-arm claim no longer allows a blind stop (incident regression)
ok - fm-turnend-guard --claude: a claim whose pid was reused stops counting as recovery even while its entry reads arming
ok - fm-turnend-guard --claude: a hung owner frozen at arming with no watcher beat no longer allows a blind stop
ok - fm-turnend-guard --claude: a live open generation claim owns recovery with no lock held
ok - fm-turnend-guard --claude: a stuck generation claim no longer allows a blind stop
ok - fm-turnend-guard --claude: the terminal path clears an abandoned claim instead of stepping aside silently
ok - fm-turnend-guard --claude: fresh failed epochs preserve and advance monotonic fail-open progression
ok - fm-turnend-guard --claude: integrated fresh failures reach one bounded fail-open, stop continuation, and reset on recovery
ok - fm-turnend-guard --claude: reset contention preserves all episode state until retry
ok - fm-turnend-guard --claude: concurrent auto-arm and guard resets are idempotent and deadlock-free
ok - fm-turnend-guard --claude: stale rewake epoch does not allow a blind stop
ok - fm-turnend-guard --claude: budget exhaustion alone cannot permit a blind stop
ok - fm-turnend-guard --claude: verified fail-open is loud, bounded, attended, and non-repeating
ok - fm-turnend-guard --claude: fail-open requires both exhausted retries and consumed notice
ok - fm-turnend-guard --claude: away ownership excludes the Stop-autoarm fail-open
ok - fm-turnend-guard --claude: positive watcher recovery resets failure episode state
ok - fm-turnend-guard --claude: bounded claim wait avoids a token-consuming forced continuation
ok - fm-turnend-guard --claude: secondmate home re-blocks unclaimed and allows auto-arm-claimed stops
ok - fm-turnend-guard: a live away-mode daemon satisfies supervision with no watcher holding the lock
ok - fm-turnend-guard: away-mode daemon ownership survives a leftover dead watcher lock
ok - fm-turnend-guard: away mode with no daemon and no watcher still blocks
ok - fm-turnend-guard: away mode blocks on a dead away-mode daemon
ok - fm-turnend-guard: away mode blocks on a pid-reused away-mode daemon lock
ok - fm-turnend-guard: away-mode daemon ownership never substitutes for a fresh beacon
ok - fm-turnend-guard: a daemon lock proves nothing while away mode is off
touch: out of range or illegal time specification: YYYY-MM-DDThh:mm:SS[.frac][tz]
ok - fm-turnend-guard: away-mode beacon freshness uses the poll-derived grace, not the flat default
ok - fm-turnend-guard: a dead away-mode daemon still blocks under the poll-derived grace
touch: out of range or illegal time specification: YYYY-MM-DDThh:mm:SS[.frac][tz]
not ok - a beacon older than the poll-derived grace must still block: expected exit 2, got 0

exit=1
```
</details>
<details>
<summary>Evidence: DST failure before UTC fix</summary>

Source: [DST failure before UTC fix](https://github.com/mremond/firstmate/blob/0b795a869e789c8d168fc0b405b1ab72bc4a2992/.no-mistakes/evidence/fm/fm-turnend-guard-suite-red-on-macos/before-utc-macos-timestamps.log)

```text
Pre-UTC helper from commit 6182c507; native macOS tools; TZ=Europe/Paris
Command: /bin/bash .nm-test-phase/timestamp-probe.sh tests/.nm-preutc-lib.sh
os=Darwin bash=3.2.57(1)-release date=/bin/date touch=/usr/bin/touch caller_TZ=Europe/Paris
requested_epoch=1761438600 observed_mtime=1761438600 file=beacon caller_TZ=Europe/Paris
requested_epoch=1761438600 observed_mtime=1761438600 file=beacon with spaces caller_TZ=Europe/Paris
requested_epoch=1761442200 observed_mtime=1761438600 file=beacon caller_TZ=Europe/Paris
not ok - epoch changed during round-trip

exit=1
```
</details>
<details>
<summary>Evidence: Native macOS timestamp observations</summary>

Source: [Native macOS timestamp observations](https://github.com/mremond/firstmate/blob/0b795a869e789c8d168fc0b405b1ab72bc4a2992/.no-mistakes/evidence/fm/fm-turnend-guard-suite-red-on-macos/native-macos-timestamps.log)

```text
os=Darwin bash=3.2.57(1)-release date=/bin/date touch=/usr/bin/touch caller_TZ=Europe/Paris
requested_epoch=1761438600 observed_mtime=1761438600 file=beacon caller_TZ=Europe/Paris
requested_epoch=1761438600 observed_mtime=1761438600 file=beacon with spaces caller_TZ=Europe/Paris
requested_epoch=1761442200 observed_mtime=1761442200 file=beacon caller_TZ=Europe/Paris
requested_epoch=1761442200 observed_mtime=1761442200 file=beacon with spaces caller_TZ=Europe/Paris
requested_epoch=1788913586 observed_mtime=1788913586 file=beacon caller_TZ=Europe/Paris
requested_epoch=1788913586 observed_mtime=1788913586 file=beacon with spaces caller_TZ=Europe/Paris
requested_epoch=1788913286 observed_mtime=1788913286 file=beacon caller_TZ=Europe/Paris
requested_epoch=1788913286 observed_mtime=1788913286 file=beacon with spaces caller_TZ=Europe/Paris
invalid_epoch exit=1 output=not ok - fm_touch_epoch: date(1) accepted neither -d @<epoch> nor -r <epoch>
missing_parent exit=1 output=touch: ~/.no-mistakes/worktrees/acf4a767348a/01M21RJT04BJFXQS2RBZ90GAC4/.nm-test-phase/tmp/fm-epoch-probe.WKz97H/missing-parent/beacon: No such file or directory
not ok - fm_touch_epoch: touch -t 202510260030.00 failed for ~/.no-mistakes/worktrees/acf4a767348a/01M21RJT04BJFXQS2RBZ90GAC4/.nm-test-phase/tmp/fm-epoch-probe.WKz97H/missing-parent/beacon
stale_backlog_lock stamp=202001010000 observed_mtime=1577833200 older_than_now=211080786
```
</details>
<details>
<summary>Evidence: Native Linux timestamp observations</summary>

Source: [Native Linux timestamp observations](https://github.com/mremond/firstmate/blob/0b795a869e789c8d168fc0b405b1ab72bc4a2992/.no-mistakes/evidence/fm/fm-turnend-guard-suite-red-on-macos/native-linux-timestamps.log)

```text
os=Linux bash=5.2.37(1)-release date=/usr/bin/date touch=/usr/bin/touch caller_TZ=Europe/Paris
requested_epoch=1761438600 observed_mtime=1761438600 file=beacon caller_TZ=Europe/Paris
requested_epoch=1761438600 observed_mtime=1761438600 file=beacon with spaces caller_TZ=Europe/Paris
requested_epoch=1761442200 observed_mtime=1761442200 file=beacon caller_TZ=Europe/Paris
requested_epoch=1761442200 observed_mtime=1761442200 file=beacon with spaces caller_TZ=Europe/Paris
requested_epoch=1788913596 observed_mtime=1788913596 file=beacon caller_TZ=Europe/Paris
requested_epoch=1788913596 observed_mtime=1788913596 file=beacon with spaces caller_TZ=Europe/Paris
requested_epoch=1788913296 observed_mtime=1788913296 file=beacon caller_TZ=Europe/Paris
requested_epoch=1788913296 observed_mtime=1788913296 file=beacon with spaces caller_TZ=Europe/Paris
invalid_epoch exit=1 output=not ok - fm_touch_epoch: date(1) accepted neither -d @<epoch> nor -r <epoch>
missing_parent exit=1 output=touch: cannot touch '~/.no-mistakes/worktrees/acf4a767348a/01M21RJT04BJFXQS2RBZ90GAC4/.nm-test-phase/tmp/fm-epoch-probe.u3m4bj/missing-parent/beacon': No such file or directory
not ok - fm_touch_epoch: touch -t 202510260030.00 failed for ~/.no-mistakes/worktrees/acf4a767348a/01M21RJT04BJFXQS2RBZ90GAC4/.nm-test-phase/tmp/fm-epoch-probe.u3m4bj/missing-parent/beacon
stale_backlog_lock stamp=202001010000 observed_mtime=1577833200 older_than_now=211080796
```
</details>
<details>
<summary>Evidence: Targeted macOS suite transcript</summary>

Source: [Targeted macOS suite transcript](https://github.com/mremond/firstmate/blob/0b795a869e789c8d168fc0b405b1ab72bc4a2992/.no-mistakes/evidence/fm/fm-turnend-guard-suite-red-on-macos/targeted-macos-suites.log)

```text
Target 358e827d0b5430fed614d7334fc7961a678f1b51; macOS native Bash/date/touch; TZ=Europe/Paris
Command: /bin/bash bin/fm-test-run.sh --jobs 1 --per-script-timeout-secs 600 --fail-on-gate-skip skip: --json ~/.no-mistakes/evidence/01M21RJT04BJFXQS2RBZ90GAC4/targeted-macos-timings.json tests/fm-turnend-guard.test.sh tests/fm-test-fixtures.test.sh tests/fm-remote-backlog-handoff.test.sh
FM_TEST_BEGIN 2026-09-09T00:33:32Z tests/fm-turnend-guard.test.sh family=watcher-wake-lock expected_gate_skip=none
ok - fm_supervision_unhealthy: false with no state/*.meta at all
ok - fm_supervision_unhealthy: true with in-flight task and no beacon ever
ok - fm_supervision_unhealthy: true with in-flight task and a beacon far outside the grace window
ok - fm_supervision_unhealthy: false with in-flight task and a fresh beacon
ok - fm_supervision_status: FM_SUP_QUEUE_PENDING tracks state/.wake-queue
ok - fm_supervision_needed: X-mode relay poll needs supervision
ok - fm_supervision_unhealthy: source-only home needs supervision
ok - fm_supervision_needed: a registered custom check needs supervision with no task in flight
ok - fm_supervision_needed: a registered check whose bytes drifted still needs supervision
ok - fm_supervision_needed: false for a check.sh with no registration binding
ok - fm_supervision_needed: a task PR poll without a trust binding is not a registered custom check
ok - fm_supervision_status: the relay shim is not counted as a registered custom check
ok - fm-turnend-guard: silent no-op with nothing in flight
ok - fm-turnend-guard: blocks when a fresh beacon has no live watcher lock
ok - fm-turnend-guard: non-Claude path blocks a source-only home
ok - fm-turnend-guard: blocks on a dead watcher lock even when the beacon is fresh
ok - fm-turnend-guard: silent no-op with a live watcher lock and fresh beacon
ok - fm-turnend-guard: healthy non-Claude harness paths ignore Claude episode contention
ok - fm-turnend-guard: blocks on a live watcher lock with an ancient beacon
ok - fm-turnend-guard: blocks with the exact required reason in the primary when unhealthy
ok - fm-turnend-guard: blocks from active FM_HOME state, not only repo-root state
ok - fm-turnend-guard: X-mode repair reason sources the cadence config
ok - fm-turnend-guard: X-mode-only supervision remains guarded in default mode
ok - fm-turnend-guard: registered-check-only supervision is named in the block banner
ok - fm-turnend-guard: ignores stale repo-root state when FM_HOME is set
ok - fm-turnend-guard: uses FM_STATE_OVERRIDE ahead of FM_HOME/state
ok - fm-turnend-guard: stop_hook_active=true always allows the stop (never blocks twice in one turn)
ok - fm-turnend-guard: blocks a blind turn end in a secondmate's own home (.fm-secondmate-home no longer excludes it)
ok - fm-turnend-guard: idle-by-default - silent in a secondmate home with nothing in flight
ok - fm-turnend-guard: stop_hook_active=true allows the stop in a secondmate home (never blocks twice in one turn)
ok - fm-turnend-guard: secondmate deferred-death recovery - silent while watched, forces re-arm once the watcher exits
ok - fm-turnend-guard: inert in a secondmate's own child worktree (linked git worktree) even when unhealthy
ok - fm-turnend-guard: blocks a blind turn end in a treehouse-leased LINKED secondmate home (marker force-include)
ok - fm-turnend-guard: an invalid (empty) marker cannot spoof inclusion; linked worktree stays exempt
ok - fm-turnend-guard: a non-ASCII marker cannot spoof inclusion; linked worktree stays exempt
ok - fm-turnend-guard: inert in a crewmate/scout task worktree (linked git worktree) even when unhealthy
ok - fm-turnend-guard: fails open (never blocks) when jq is missing
ok - fm-turnend-guard: silent no-op on empty stdin
ok - fm-turnend-guard: runs well under the generous timing margin (1s)
ok - fm-turnend-guard-grok: forces one explicitly marked same-session resume when the shared predicate blocks
ok - fm-turnend-guard-grok: legacy environment loop guard prevents a nested resume loop
ok - fm-turnend-guard-grok: native false delegates blocking feedback with zero resume processes
ok - fm-turnend-guard-grok: native true remains bounded and starts no resume process
ok - fm-turnend-guard-grok: both spellings are typed and camelCase has deterministic precedence
ok - fm-turnend-guard-grok: malformed, invalidly typed, and missing-prerequisite payloads start neither path
ok - fm-turnend-guard-grok: missing jq and no-supervision-needed stops stay silent and bounded
ok - tracked .claude/settings.json entries: 5 inert under grok, the documented subagent exception still armed, all live under Claude
ok - .codex/hooks.json: Stop hook uses hook process root when payload cwd is outside
ok - .codex/hooks.json: Stop hook ignores nested git root guard scripts
ok - .opencode primary plugin: guard path is anchored to worktree, not directory
ok - .pi primary extension: no-tool and multi-tool runs each inject exactly one guard follow-up
ok - .pi primary extension: delivery failure resets the logical-run latch
ok - fm-turnend-guard --claude: re-blocks a loop-guarded stop while unhealthy and unclaimed (incident regression)
ok - fm-turnend-guard --claude: X-mode-only homes re-block when auto-arm recovery is absent
ok - fm-turnend-guard --claude: a live arming epoch advances once and repeated observation is idempotent
ok - fm-turnend-guard --claude: repeated failed-to-arming races make bounded monotonic progress
ok - fm-turnend-guard --claude: terminal owner boundary excludes a concurrent start without deadlock
ok - fm-turnend-guard --claude: fresh rewake epoch prevents a duplicate continuation for the same event
ok - fm-turnend-guard --claude: an abandoned auto-arm claim no longer allows a blind stop (incident regression)
ok - fm-turnend-guard --claude: a claim whose pid was reused stops counting as recovery even while its entry reads arming
ok - fm-turnend-guard --claude: a hung owner frozen at arming with no watcher beat no longer allows a blind stop
ok - fm-turnend-guard --claude: a live open generation claim owns recovery with no lock held
ok - fm-turnend-guard --claude: a stuck generation claim no longer allows a blind stop
ok - fm-turnend-guard --claude: the terminal path clears an abandoned claim instead of stepping aside silently
ok - fm-turnend-guard --claude: fresh failed epochs preserve and advance monotonic fail-open progression
ok - fm-turnend-guard --claude: integrated fresh failures reach one bounded fail-open, stop continuation, and reset on recovery
ok - fm-turnend-guard --claude: reset contention preserves all episode state until retry
ok - fm-turnend-guard --claude: concurrent auto-arm and guard resets are idempotent and deadlock-free
ok - fm-turnend-guard --claude: stale rewake epoch does not allow a blind stop
ok - fm-turnend-guard --claude: budget exhaustion alone cannot permit a blind stop
ok - fm-turnend-guard --claude: verified fail-open is loud, bounded, attended, and non-repeating
ok - fm-turnend-guard --claude: fail-open requires both exhausted retries and consumed notice
ok - fm-turnend-guard --claude: away ownership excludes the Stop-autoarm fail-open
ok - fm-turnend-guard --claude: positive watcher recovery resets failure episode state
ok - fm-turnend-guard --claude: bounded claim wait avoids a token-consuming forced continuation
ok - fm-turnend-guard --claude: secondmate home re-blocks unclaimed and allows auto-arm-claimed stops
ok - fm-turnend-guard: a live away-mode daemon satisfies supervision with no watcher holding the lock
ok - fm-turnend-guard: away-mode daemon ownership survives a leftover dead watcher lock
ok - fm-turnend-guard: away mode with no daemon and no watcher still blocks
ok - fm-turnend-guard: away mode blocks on a dead away-mode daemon
ok - fm-turnend-guard: away mode blocks on a pid-reused away-mode daemon lock
ok - fm-turnend-guard: away-mode daemon ownership never substitutes for a fresh beacon
ok - fm-turnend-guard: a daemon lock proves nothing while away mode is off
ok - fm-turnend-guard: away-mode beacon freshness uses the poll-derived grace, not the flat default
ok - fm-turnend-guard: a dead away-mode daemon still blocks under the poll-derived grace
ok - fm-turnend-guard: the poll-derived grace is bounded, not unlimited
ok - fm-turnend-guard: with away mode off, the poll-derived grace never applies
FM_TEST_END 2026-09-09T00:34:52Z tests/fm-turnend-guard.test.sh exit=0 duration_ms=80076 gate_skip=false
FM_TEST_BEGIN 2026-09-09T00:34:52Z tests/fm-test-fixtures.test.sh family=standalone expected_gate_skip=none
ok - fm_touch_epoch preserves both epochs in the repeated DST hour
ok - fake no-mistakes --version is the shared constant and overridable
ok - init/doctor no-mistakes stub touches markers and refuses other verbs
ok - fake gh authenticates and fake gh-axi reports the shared version
ok - spawn fakebin answers pane path, logs -l payloads, and installs extra tools
ok - send stubs log typed text and fake ssh records argv with a controllable exit
ok - spawn-home layout writes harness pin, beat, and brief
FM_TEST_END 2026-09-09T00:34:55Z tests/fm-test-fixtures.test.sh exit=0 duration_ms=2130 gate_skip=false
FM_TEST_BEGIN 2026-09-09T00:34:55Z tests/fm-remote-backlog-handoff.test.sh family=secondmate expected_gate_skip=none
ok - confined put rejects incomplete and superseded payload generations
ok - confined put rejects directory replacement without external writes
ok - ambiguous receipt leaves one durable outbox and no duplicate dispatchable source
ok - re-delivery after unknown completion converges without duplication
ok - dropped transfer recovery overwrites scratch and delivers exactly once
ok - concurrent handoffs serialize staging through confirmed cleanup
ok - receiver removes one proven dead stale lock and retries once
ok - bootstrap detects pending outbox handoffs without a journal
ok - remote handoff wakes its supported endpoint or remains loudly recoverable
ok - fresh remote work gets a new wake after confirmed cleanup recovery
ok - route classification serializes with retirement before staging
ok - unconfigured bootstrap has no remote handoff behavior
ALL TESTS PASSED
FM_TEST_END 2026-09-09T00:36:11Z tests/fm-remote-backlog-handoff.test.sh exit=0 duration_ms=76738 gate_skip=false
FM_TEST_SUMMARY total=3 failed=0 skipped_gate=0 duration_ms=159135
FM_TEST_SUMMARY_FAMILY family=secondmate count=1 duration_ms=76738 failed=0
FM_TEST_SUMMARY_FAMILY family=standalone count=1 duration_ms=2130 failed=0
FM_TEST_SUMMARY_FAMILY family=watcher-wake-lock count=1 duration_ms=80076 failed=0
FM_TEST_SLOWEST rank=1 script=tests/fm-turnend-guard.test.sh duration_ms=80076
FM_TEST_SLOWEST rank=2 script=tests/fm-remote-backlog-handoff.test.sh duration_ms=76738
FM_TEST_SLOWEST rank=3 script=tests/fm-test-fixtures.test.sh duration_ms=2130
fm-test-run: wrote timing artifact: ~/.no-mistakes/evidence/01M21RJT04BJFXQS2RBZ90GAC4/targeted-macos-timings.json

exit=0
```
</details>
- Outcome: â ï¸ 1 warning across 1 run (8m26s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"91e88e7860ef067b3b34d2af211062a2296a8a54","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>â **intent** - passed</summary>

â No issues found.
</details>

<details>
<summary>â **Rebase** - passed</summary>

â No issues found.
</details>

<details>
<summary>ð§ **Review** - 1 issue found â auto-fixed â</summary>

- â ï¸ `tests/lib.sh:418` - The epoch conversion loses DST information: both date branches produce local time without an offset, which touch reparses. During the repeated autumn hour, two distinct epochs produce the same stamp. Apple&#39;s touch implementation resolves it through mktime with tm_isdst=-1, so a fixture can silently shift by an hour: a 400-second beacon can appear 4,000 seconds old, or a 700-second beacon can become future-dated, reversing the guard verdict. Pin TZ=UTC0 for both date branches and touch inside this helper. Source: [Apple touch implementation](https://github.com/apple-oss-distributions/file_cmds/blob/main/touch/touch.c).

ð§ Fix applied.
â Re-checked - no issues remain.
</details>

<details>
<summary>â ï¸ **Test** - 1 warning</summary>

- â ï¸ this change has no live-validatable surface; proceed without live validation? (0 of 5 scenarios were driven live against the product); Run the macOS guard suite: accept the 400-second away-mode beacon, reject the 700-second beacon, and preserve dead-daemon and non-away-mode guards.: Only test code changed. The suite uses simulated daemon processes, so its passing checks are non-live evidence; there is no changed runtime product surface.; Set fixture timestamps on macOS and Linux and observe exact epochs across multiple files, including filenames containing spaces.: The helper was executed with real BSD and GNU tools, but it is test infrastructure with no runtime product surface.; Set both epochs within Paris&#39;s repeated autumn hour while preserving their one-hour separation and the caller&#39;s timezone.: This exercises the test helper&#39;s filesystem behavior, not a changed running-product surface.; Supply an invalid epoch or nonexistent parent directory and receive an explicit failure instead of silent success.: These are test-helper failure checks; no runtime product interface changed.; Age a remote backlog lock with the portable timestamp form and successfully recover the stale lock.: The automated handoff suite substitutes SSH transport. This test-only change has no changed remote product surface to validate live.
- Live validation: â ï¸ no-surface - 0 of 5 scenarios driven live against the product

| Scenario | Result | Live | Evidence |
| --- | --- | --- | --- |
| Run the macOS guard suite: accept the 400-second away-mode beacon, reject the 700-second beacon, and preserve dead-daemon and non-away-mode guards. | â¸ï¸ untested | no | Only test code changed. The suite uses simulated daemon processes, so its passing checks are non-live evidence; there is no changed runtime product surface. |
| Set fixture timestamps on macOS and Linux and observe exact epochs across multiple files, including filenames containing spaces. | â¸ï¸ untested | no | The helper was executed with real BSD and GNU tools, but it is test infrastructure with no runtime product surface. |
| Set both epochs within Paris&#39;s repeated autumn hour while preserving their one-hour separation and the caller&#39;s timezone. | â¸ï¸ untested | no | This exercises the test helper&#39;s filesystem behavior, not a changed running-product surface. |
| Supply an invalid epoch or nonexistent parent directory and receive an explicit failure instead of silent success. | â¸ï¸ untested | no | These are test-helper failure checks; no runtime product interface changed. |
| Age a remote backlog lock with the portable timestamp form and successfully recover the stale lock. | â¸ï¸ untested | no | The automated handoff suite substitutes SSH transport. This test-only change has no changed remote product surface to validate live. |

- <code>Inspected `git diff b84e0e362face25f3dd8945297a3df1320d7668c 358e827d0b5430fed614d7334fc7961a678f1b51` and nearby timestamp conversions.</code>
- <code>Ran `/bin/bash tests/.nm-baseline-turnend.test.sh`, copied from the base commit: reproduced macOS timestamp rejection and the incorrect guard allowance.</code>
- <code>Ran `/bin/bash .nm-test-phase/timestamp-probe.sh tests/.nm-preutc-lib.sh` against commit 6182c507&#39;s helper: reproduced a 3,600-second DST error.</code>
- <code>Ran `/bin/bash bin/fm-test-run.sh --jobs 1 --per-script-timeout-secs 600 --fail-on-gate-skip skip: --json ~/.no-mistakes/evidence/01M21RJT04BJFXQS2RBZ90GAC4/targeted-macos-timings.json tests/fm-turnend-guard.test.sh tests/fm-test-fixtures.test.sh tests/fm-remote-backlog-handoff.test.sh` using stock macOS Bash and `TZ=Europe/Paris`.</code>
- <code>Executed `.nm-test-phase/timestamp-probe.sh` using native macOS tools and GNU tools in an isolated `debian:stable-slim` Docker container; checked exact mtimes, DST, multiple paths, error exits, and stale-lock timestamps.</code>
- <code>Preserved the probe as evidence `timestamp-probe.sh`; removed temporary scripts and fixtures, checked for remaining test processes, and verified the unchanged target and clean worktree.</code>
</details>

<details>
<summary>â **Document** - passed</summary>

â No issues found.
</details>

<details>
<summary>â **Lint** - passed</summary>

â No issues found.
</details>

<details>
<summary>â **Push** - passed</summary>

â No issues found.
</details>
