### PR TITLE
fix(bin): make settled pending-reply tick pass subprocess- and lock-free

### DIFF
--- a/bin/fm-pending-reply-lib.sh
+++ b/bin/fm-pending-reply-lib.sh
@@ -1407,28 +1407,63 @@ fm_pending_reply_tick_one() {  # <state-dir> <corr_id> <busy_state> [secondmate-
   return 0
 }
 
+# Read the dispatch fields one tick pass needs from a record in a single
+# builtin pass (no subprocess), assigning each named variable: corr_id,
+# task_id, phase, escalated_epoch, escalation_closed_epoch. A record without a
+# key, or a missing record file, leaves that variable empty - the same result
+# fm_pending_reply_get returns for a missing key. A later occurrence of a key
+# wins, matching fm_pending_reply_get's tail -1. This is the read that keeps a
+# fully settled record (phase resolved, escalation closed or never opened)
+# subprocess-free on every later poll.
+fm_pending_reply_tick_capture() {  # <record-path> <corr-var> <task-var> <phase-var> <escalated-var> <closed-var>
+  local rec=$1 corr_var=$2 task_var=$3 phase_var=$4 escalated_var=$5 closed_var=$6
+  local line value
+  printf -v "$corr_var" ''
+  printf -v "$task_var" ''
+  printf -v "$phase_var" ''
+  printf -v "$escalated_var" ''
+  printf -v "$closed_var" ''
+  [ -f "$rec" ] || return 0
+  while IFS= read -r line || [ -n "$line" ]; do
+    case "$line" in
+      corr_id=*) value=${line#corr_id=}; printf -v "$corr_var" '%s' "$value" ;;
+      task_id=*) value=${line#task_id=}; printf -v "$task_var" '%s' "$value" ;;
+      phase=*) value=${line#phase=}; printf -v "$phase_var" '%s' "$value" ;;
+      escalated_epoch=*) value=${line#escalated_epoch=}; printf -v "$escalated_var" '%s' "$value" ;;
+      escalation_closed_epoch=*) value=${line#escalation_closed_epoch=}; printf -v "$closed_var" '%s' "$value" ;;
+    esac
+  done < "$rec"
+}
+
 # Scan every pending record for this parent state. Safe to call every poll.
 # Never scrapes secondmate conversation; uses only parent status, backend busy
 # state, and optional secondmate-home wrong-home path checks.
+# The resolved-record fast path uses fm_pending_reply_tick_capture above, so a
+# fully settled record costs no subprocess and no lock on any poll.
 fm_pending_reply_tick() {  # <state-dir>
   local state=$1 dir rec corr task_id phase delivered meta backend target label busy sm_home harness remote_host
-  local observation observation_task found i
+  local observation observation_task found i escalated closed
   local -a observation_tasks=() observation_values=()
   dir=$(fm_pending_reply_dir "$state")
   [ -d "$dir" ] || return 0
   for rec in "$dir"/*; do
     [ -f "$rec" ] || continue
-    case "$(basename "$rec")" in
+    case "${rec##*/}" in
       .*) continue ;;
     esac
-    corr=$(fm_pending_reply_get "$rec" corr_id)
-    [ -n "$corr" ] || corr=$(basename "$rec")
-    task_id=$(fm_pending_reply_get "$rec" task_id)
-    phase=$(fm_pending_reply_get "$rec" phase)
+    # One builtin pass captures every field this loop dispatches on, replacing
+    # the three per-record fm_pending_reply_get subprocess reads.
+    fm_pending_reply_tick_capture "$rec" corr task_id phase escalated closed
+    [ -n "$corr" ] || corr=${rec##*/}
     if [ "$phase" = resolved ]; then
       # Cheap no-op unless an escalation for this record is still open; this is
       # the retry that makes the close converge after a transient write failure.
-      fm_pending_reply_close_escalation "$state" "$corr" || true
+      # A resolved record whose escalation is already closed (escalation_closed_epoch
+      # set) or was never opened (escalated_epoch empty) needs no lock and no
+      # status rescan on this or any later poll.
+      if [ -n "$escalated" ] && [ -z "$closed" ]; then
+        fm_pending_reply_close_escalation "$state" "$corr" || true
+      fi
       continue
     fi
     fm_pending_reply_reconcile_delivery "$state" "$corr" || true

--- a/tests/fm-pending-reply.test.sh
+++ b/tests/fm-pending-reply.test.sh
@@ -1504,6 +1504,101 @@ test_failed_send_discards_undelivered_expectation() {
   pass "failed transport discards undelivered expectation only"
 }
 
+test_tick_settled_records_skip_lock_and_subprocess_work() {
+  # A resolved record whose escalation is already closed, or that never
+  # escalated, is fully settled: later tick passes must not re-lock it, re-read
+  # it through fm_pending_reply_get, or rescan its parent status. This is the
+  # fast path that keeps a healthy watcher cycle inside the stale-beacon grace
+  # as the retained settled store grows (measured: ~5.8 field reads plus one
+  # per-correlation lock per settled record per poll before this path).
+  (
+    local home state c_closed c_never rec log
+    home=$(setup_parent settled-fast-path)
+    state="$home/state"
+    # This fixture clock is intentionally scoped to the isolated subshell.
+    # shellcheck disable=SC2030,SC2031
+    export FM_PENDING_REPLY_NOW=12000
+    log="$home/close-calls.log"
+    : > "$log"
+    # Record 1: resolved AND escalation_closed_epoch set (fully settled).
+    c_closed=$(fm_pending_reply_create "$home" "$state" hibit "settled request")
+    fm_pending_reply_mark_delivered "$state" "$c_closed"
+    rec=$(fm_pending_reply_path "$state" "$c_closed")
+    fm_pending_reply_set "$rec" phase escalated || fail "fixture escalation failed"
+    fm_pending_reply_set "$rec" escalated_epoch 12000 || fail "fixture escalated_epoch failed"
+    printf 'blocked [key=pending-reply-%s]: pending-reply-missed: task=hibit pending-reply-id=%s request=settled request\n' \
+      "$c_closed" "$c_closed" > "$state/hibit.status"
+    printf 'done [corr=%s]: late reply\n' "$c_closed" >> "$state/hibit.status"
+    fm_pending_reply_try_resolve "$state" "$c_closed" || fail "settled fixture should resolve"
+    [ -n "$(fm_pending_reply_get "$rec" escalation_closed_epoch)" ] \
+      || fail "settled fixture should have closed its escalation"
+    # Record 2: resolved with no escalation at all.
+    c_never=$(fm_pending_reply_create "$home" "$state" hibit "plain answer")
+    fm_pending_reply_mark_delivered "$state" "$c_never"
+    printf 'done [corr=%s]: answer\n' "$c_never" > "$state/plain.status"
+    fm_pending_reply_try_resolve "$state" "$c_never" "$state/plain.status" \
+      || fail "plain fixture should resolve"
+    rec=$(fm_pending_reply_path "$state" "$c_never")
+    [ -z "$(fm_pending_reply_get "$rec" escalated_epoch)" ] \
+      || fail "plain fixture must never have escalated"
+    # Count how many times a tick pass reaches the escalation-close path (the
+    # only remaining place the per-correlation lock is taken for a resolved
+    # record). Runtime override called by the tick.
+    # shellcheck disable=SC2329
+    fm_pending_reply_close_escalation() { printf 'close\n' >> "$log"; }
+    fm_pending_reply_tick "$state" || fail "settled tick failed"
+    [ ! -s "$log" ] \
+      || fail "a settled store must not take the per-correlation lock, close log: $(cat "$log")"
+    # The settled fast path is builtin-only: the same store must still tick with
+    # no external subprocess available at all. PATH is deliberately stripped here.
+    # shellcheck disable=SC2123
+    PATH=/nonexistent
+    fm_pending_reply_tick "$state" || fail "settled tick must need no external subprocess"
+  ) || fail "settled fast-path regression failed"
+  pass "tick fast path: settled records cost no lock, no re-read, no subprocess"
+}
+
+test_tick_still_closes_an_open_escalation_on_a_resolved_record() {
+  # The fast path must not weaken the retry that converges an open escalation:
+  # a resolved record whose close was deferred (escalation_closed_epoch still
+  # empty, e.g. its status destination was unreachable at resolve time) is
+  # retried by the next tick under the per-correlation lock, exactly as before.
+  local home state corr rec open_status open
+  home=$(setup_parent open-close-retry)
+  state="$home/state"
+  # This fixture clock is intentionally reset after the isolated subshell tests.
+  # shellcheck disable=SC2031
+  export FM_PENDING_REPLY_NOW=13000
+  corr=$(fm_pending_reply_create "$home" "$state" hibit "converge close")
+  fm_pending_reply_mark_delivered "$state" "$corr"
+  rec=$(fm_pending_reply_path "$state" "$corr")
+  fm_pending_reply_set "$rec" phase escalated || fail "fixture escalation failed"
+  fm_pending_reply_set "$rec" escalated_epoch 12900 || fail "fixture escalated_epoch failed"
+  open_status="$state/hibit.status"
+  printf 'blocked [key=pending-reply-%s]: pending-reply-missed: task=hibit pending-reply-id=%s request=converge close\n' \
+    "$corr" "$corr" > "$open_status"
+  printf 'done [corr=%s]: late reply\n' "$corr" >> "$open_status"
+  # Defer the close the way a transient failure does: the record's status
+  # destination is unreachable at resolve time, so try_resolve leaves
+  # escalation_closed_epoch empty while still resolving the record.
+  fm_pending_reply_set "$rec" parent_status "" || fail "fixture parent_status failed"
+  fm_pending_reply_try_resolve "$state" "$corr" "$open_status" || fail "record should resolve"
+  [ "$(phase_of "$state" "$corr")" = resolved ] || fail "record should be resolved"
+  [ -z "$(fm_pending_reply_get "$rec" escalation_closed_epoch)" ] \
+    || fail "fixture close should still be open"
+  # The escalation's status destination is reachable again; the next tick must
+  # retry the close and converge.
+  fm_pending_reply_set "$rec" parent_status "$open_status" || fail "restore parent_status failed"
+  fm_pending_reply_tick "$state" || fail "tick should retry the deferred close"
+  [ -n "$(fm_pending_reply_get "$rec" escalation_closed_epoch)" ] \
+    || fail "tick did not close the still-open escalation"
+  [ "$(grep -Fc "resolved [key=pending-reply-$corr]: pending-reply-resolved:" "$open_status")" -eq 1 ] \
+    || fail "tick should append exactly one guarded decision close"
+  open=$(status_open_decisions "$open_status")
+  [ -z "$open" ] || fail "open escalation remained open after the tick: $open"
+  pass "tick still closes an open escalation on a resolved record"
+}
+
 # --- run --------------------------------------------------------------------
 
 test_normal_correlated_reply_resolves_once
@@ -1533,6 +1628,8 @@ test_busy_idle_observation_via_backend_abstraction
 test_unknown_backend_state_uses_capture_fallback
 test_kimi_capture_fallback_uses_recorded_harness
 test_tick_skips_terminal_and_reuses_target_observation
+test_tick_settled_records_skip_lock_and_subprocess_work
+test_tick_still_closes_an_open_escalation_on_a_resolved_record
 test_correlations_reuse_only_for_matching_open_task
 test_tick_end_to_end_missed_then_escalate
 test_failed_send_discards_undelivered_expectation


### PR DESCRIPTION
## Intent

Fix a measured supervision-reliability defect in bin/fm-pending-reply-lib.sh's fm_pending_reply_tick: on the primary home the retained pending-replies store holds ~2539 per-correlation records (2166 phase=resolved), and every poll iterates EVERY record; for a resolved record the tick calls fm_pending_reply_close_escalation, which takes a per-correlation lock (plus fm-wake-lib.sh sourcing) and re-reads the same record through fm_pending_reply_get (one subprocess per field) for phase, escalated_epoch, and escalation_closed_epoch before its early return - roughly 13,000 subprocess launches per poll for already-fully-closed records, so a healthy watcher cycle's .last-watcher-beat goes stale past the 300 s grace and false "supervision is off" alarms fire. Implement change option 1: make the resolved-record fast path cheap and allocation-free - read the record once (a single builtin pass capturing corr_id, task_id, phase, escalated_epoch, escalation_closed_epoch) and skip lock acquisition entirely when the escalation is already closed (escalation_closed_epoch set) or was never opened (escalated_epoch empty), so a closed record costs no subprocess and no lock. Keep existing semantics EXACTLY: a resolved record whose escalation is still open MUST still be retried and closed by the tick as today, and the per-correlation lock must still serialize any real close against a concurrent escalation. Do NOT implement option 2 (bounded retention/archive of fully-settled records) - option 1 alone brings a full poll comfortably inside the grace (measured after: ~1 s on the 2283 settled records vs ~202 s before); never add any silent delete or retention change. Hard constraints: do NOT weaken the fail-closed behavior of any gate, lock, or guard; do NOT change escalation policy, reply-window length, grace values, or how ghosts are closed; the reply-window-vs-turn-duration question is out of scope. Colocate regression coverage in tests/fm-pending-reply.test.sh following the existing sibling style: a fixture with resolved+closed vs resolved+open-escalation vs never-escalated records, asserting the settled ones perform no lock/subprocess work on a tick pass (no close_escalation call; ticks fine with PATH stripped, proving builtin-only) and the open-escalation one still converges (escalation_closed_epoch set, decision closed once) through the tick. Acceptance: paste before/after measurements on the same fixture store (wall-clock and count of subprocesses or record reads per fm_pending_reply_tick pass) showing the resolved-closed fast path is now cheap; tests green; shellcheck clean on touched bin scripts; no behavior change for open escalations (proved by a test that a still-open escalation IS closed by the tick after the change); no change to any safety gate, lock ordering, or supervision protocol. Report pre-existing environment failures (e.g. actionlint not installed) separately rather than fixing them.

## What Changed

- Added `fm_pending_reply_tick_capture` in `bin/fm-pending-reply-lib.sh`, a single builtin pass that reads `corr_id`, `task_id`, `phase`, `escalated_epoch`, and `escalation_closed_epoch` from a record into named variables with no subprocess launches (last-occurrence-wins, matching `fm_pending_reply_get`'s semantics, and empty for a missing record or key).
- `fm_pending_reply_tick` now uses that capture instead of three per-record `fm_pending_reply_get` subprocess reads, and skips `fm_pending_reply_close_escalation` (and its per-correlation lock) entirely for resolved records whose escalation is already closed or was never opened; a resolved record with a still-open escalation is still retried and closed under the lock exactly as before.
- Added two sibling-style regression tests in `tests/fm-pending-reply.test.sh`: one asserting settled (resolved+closed and never-escalated) records trigger no `close_escalation` call on a tick pass and tick fine with `PATH` stripped (builtin-only), and one proving a resolved record with a still-open escalation still converges to a single guarded decision close through the tick.

## Risk Assessment

✅ Low: The change is a narrow, well-bounded performance fix: the new single-pass builtin capture is semantically equivalent to the replaced per-field fm_pending_reply_get reads, the skip guard exactly matches the set of records whose locked close was already a guaranteed no-op (escalated_epoch cannot be committed on a resolved record, so no reachable snapshot needs a skipped close), the open-escalation convergence retry is preserved under the per-correlation lock, and dedicated behavior tests pin both sides of the fast path; no gate, lock ordering, grace value, escalation policy, or retention behavior changed.

## Testing

Exercised the fm_pending_reply_tick change end-to-end: full pending-reply test suite green (36/36) including the new resolved-fast-path and open-escalation-convergence tests; reproduced the regression by running the new tests against the pre-fix base library where the fast-path test correctly fails; and produced before/after acceptance measurements on the same 2283-record settled fixture store — base tick 171,271 ms with 13,698 record reads and 2,283 per-correlation lock acquisitions vs target tick ~0.9-1.5 s with 0 reads and 0 locks, plus a PATH-stripped builtin-only tick that passes. Open-escalation stores converge identically before and after (escalation_closed_epoch set, one guarded decision close). Evidence artifacts (reproducible harness script fmpr-measure.sh, raw transcript fmpr-measure.raw.log, report fmpr-evidence.md) were written to the evidence directory; worktree left clean. No findings; shellcheck is not run in this phase by policy (CI owns it) and no other environment failures surfaced.

<details>
<summary>Evidence: Raw before/after measurement transcript (2283 settled records + open-escalation convergence)</summary>

Source: [Raw before/after measurement transcript (2283 settled records + open-escalation convergence)](https://github.com/mejerome/firstmate/blob/fb353e232a6ec02865df22a108d831ad46afeed5/.no-mistakes/evidence/fm/pending-reply-tick-cost-20260909/fmpr-measure.raw.log)

<code>BEFORE(base) get_calls=13698 close_calls=2283 capture_passes=0 elapsed_ms=171271&#10;AFTER(target) get_calls=0 close_calls=0 capture_passes=2283 elapsed_ms=1454&#10;AFTER(target)-pass2 get_calls=0 close_calls=0 capture_passes=2283 elapsed_ms=905&#10;settled tick OK with PATH stripped&#10;BEFORE(base) corr=aeba1ede6a7bfa5e CONVERGED (escalation_closed_epoch set, 1 decision close)&#10;AFTER(target) corr=aeba1ede6a7bfa5e CONVERGED (escalation_closed_epoch set, 1 decision close)</code>

```text
fixture root: /tmp/fmpr-measure.t9CIej
golden settled record b860d1e7c7ed3fd9 phase=resolved escalated=12000 closed=12000
settled stores built: 2283 records each
=== instrumented tick passes over the SAME settled store (2283 records) ===
BEFORE(base) get_calls=13698 close_calls=2283 capture_passes=0 elapsed_ms=171271
AFTER(target) get_calls=0 close_calls=0 capture_passes=2283 elapsed_ms=1454
AFTER(target)-pass2 get_calls=0 close_calls=0 capture_passes=2283 elapsed_ms=905
=== builtin-only proof: settled tick with PATH stripped (target) ===
settled tick OK with PATH stripped
=== open-escalation convergence: same behavior before and after ===
open-escalation fixture seed=1 corr=aeba1ede6a7bfa5e (resolved, escalation still open)
open-escalation fixture seed=2 corr=ce70cb1674cbe895 (resolved, escalation still open)
open-escalation fixture seed=3 corr=cd263526fdade163 (resolved, escalation still open)
-- BEFORE(base) tick over the open-escalation store --
BEFORE(base) open-escalation tick OK elapsed_ms=1086
-- AFTER(target) tick over the identical open-escalation store --
AFTER(target) open-escalation tick OK elapsed_ms=736
-- verify convergence equality (escalation_closed_epoch set, decision closed exactly once) --
BEFORE(base) corr=aeba1ede6a7bfa5e CONVERGED (escalation_closed_epoch set, 1 decision close)
BEFORE(base) corr=cd263526fdade163 CONVERGED (escalation_closed_epoch set, 1 decision close)
BEFORE(base) corr=ce70cb1674cbe895 CONVERGED (escalation_closed_epoch set, 1 decision close)
AFTER(target) corr=aeba1ede6a7bfa5e CONVERGED (escalation_closed_epoch set, 1 decision close)
AFTER(target) corr=cd263526fdade163 CONVERGED (escalation_closed_epoch set, 1 decision close)
AFTER(target) corr=ce70cb1674cbe895 CONVERGED (escalation_closed_epoch set, 1 decision close)
ALL MEASUREMENTS DONE
```
</details>
<details>
<summary>Evidence: Measurement + evidence report (before/after table, regression reproduction, scope notes)</summary>

Source: [Measurement + evidence report (before/after table, regression reproduction, scope notes)](https://github.com/mejerome/firstmate/blob/fb353e232a6ec02865df22a108d831ad46afeed5/.no-mistakes/evidence/fm/pending-reply-tick-cost-20260909/fmpr-evidence.md)

```text
# fm_pending_reply_tick settled-record fast path — test evidence

Change under test: `fm/pending-reply-tick-cost-20260909`
Base: `60915d9` · Target: `cb95908` (`bin/fm-pending-reply-lib.sh` + `tests/fm-pending-reply.test.sh`)

## 1. Automated regression coverage (tests/fm-pending-reply.test.sh)

Full file run on the target tree: **all 36 tests pass**, including the two new ones:

`` `
ok - tick fast path: settled records cost no lock, no re-read, no subprocess
ok - tick still closes an open escalation on a resolved record
`` `

Regression reproduction — same test file sourced against the BASE (pre-fix) library:
all 35 pre-existing tests still pass, and the new fast-path test **fails**, proving it
guards the fix:

`` `
not ok - a settled store must not take the per-correlation lock, close log: close
close
not ok - settled fast-path regression failed
`` `

The new tests exercise real library behavior (fixtures built through the public
`fm_pending_reply_create`/`mark_delivered`/`try_resolve` API):
- resolved+closed and never-escalated records perform zero `close_escalation` work on a
  tick pass, and the same store still ticks with `PATH=/nonexistent` (builtin-only, no
  subprocess);
- a resolved record with a still-open escalation IS still closed by the tick exactly
  once (escalation_closed_epoch set, decision closed once) — semantics unchanged.

## 2. Before/after measurement on the same fixture store (2283 settled records)

Fixtures: 2283 fully settled records (phase=resolved, escalated_epoch and
escalation_closed_epoch set) cloned from a real record produced through the API,
mirroring the production retained store. Two byte-identical stores; each tick pass
instrumented for wall-clock time, `fm_pending_reply_get` record reads (each read =
`$( )` subshell over a `grep|tail|cut` subprocess chain), and
`fm_pending_reply_close_escalation` calls (each = per-correlation lock + sourcing
`bin/fm-wake-lib.sh`).

| pass over the same 2283-record store | record reads (get_calls) | close_escalation calls (locks) | wall clock |
| --- | ---: | ---: | ---: |
| BEFORE (base `60915d9` tick) | 13,698 (6 per record) | 2,283 (1 per record) | 171,271 ms (~171 s) |
| AFTER (target tick, pass 1) | 0 | 0 | 1,454 ms |
| AFTER (target tick, pass 2, steady state) | 0 | 0 | 905 ms (~0.9 s) |
| AFTER with `PATH=/nonexistent` | builtin-only pass | — | OK, no failure |

Result: ~171 s → ~0.9-1.5 s per pass on 2283 settled records (~120-190× faster), with
zero subprocesses and zero per-correlation lock acquisitions on the settled path,
comfortably inside the 300 s `.last-watcher-beat` grace. (Field report cited ~202 s
before / ~1 s after; sandbox reproduces both orders of magnitude.)

The 6-reads-per-record figure matches the field estimate (~13,000 subprocess launches
per poll for ~2539 records when each read spawns grep|tail|cut).

## 3. No behavior change for open escalations

Three resolved records with a still-open escalation (escalation_closed_epoch empty,
close deferred as in the unit test) were closed by one tick pass under BOTH
implementations on identical stores: escalation_closed_epoch set and the guarded
`resolved [key=pending-reply-<corr>]: pending-reply-resolved:` decision line appended
exactly once per record. Real close work (lock + guarded status append) still runs and
costs real time in both (BEFORE ~1.09 s / AFTER ~0.74 s for 3 real closes) — only the
settled no-op path was made lock/subprocess-free.

## 4. Safety-gate scope

Diff touches only the tick dispatch read path and adds regression tests. No gate,
lock-ordering, escalation-policy, grace, reply-window, retention, or ghost-close
logic was modified. `git status` clean after evidence collection.
```
</details>
<details>
<summary>Evidence: Reproducible measurement harness (builds fixture store, runs base/target ticks with instrumentation)</summary>

Source: [Reproducible measurement harness (builds fixture store, runs base/target ticks with instrumentation)](https://github.com/mejerome/firstmate/blob/fb353e232a6ec02865df22a108d831ad46afeed5/.no-mistakes/evidence/fm/pending-reply-tick-cost-20260909/fmpr-measure.sh)

```text
#!/usr/bin/env bash
# Before/after measurement harness for the fm_pending_reply_tick settled-record
# fast path (bin/fm-pending-reply-lib.sh).
#
# The same fixture store (2283 fully settled records, mirroring the production
# retained store) is ticked once with the BASE implementation and once with the
# TARGET implementation. For each pass we record wall-clock time, the number of
# fm_pending_reply_get record reads (each one is a $( ) subshell over a
# grep|tail|cut subprocess chain), and the number of close_escalation calls
# (each takes the per-correlation lock and sources bin/fm-wake-lib.sh).
# Counters are appended to a file because fm_pending_reply_get runs inside
# command substitutions (forked subshells) whose variable writes are lost.
set -u
W=/root/.no-mistakes/worktrees/5810ae86d8a1/01M224RAN2FN3579BPCB2VMT5G
BASE_LIB_DIR="$1"            # directory holding the BASE fm-pending-reply-lib.sh + sibling bin files
N="${2:-2283}"               # number of settled records in the store
OUT="$3"                     # raw transcript output file
EVD="$(cd "$(dirname "$0")" && pwd)"

. "$W/tests/lib.sh"
. "$W/bin/fm-marker-lib.sh"
. "$W/bin/fm-pending-reply-lib.sh"

export FM_PENDING_REPLY_GRACE_SECS=0
export FM_SEND_SETTLE=0

TMP="$(mktemp -d /tmp/fmpr-measure.XXXXXX)" || exit 1
if [ "${FM_KEEP:-}" != 1 ]; then trap 'rm -rf "$TMP" "$EVD/.fmpr-base-bin"' EXIT; fi
echo "fixture root: $TMP"

# --- fixture: one real, fully settled record (resolved, escalation closed) ---
golden_home="$TMP/golden"
mkdir -p "$golden_home/state"
export FM_PENDING_REPLY_NOW=12000
g_state="$golden_home/state"
g_corr=$(fm_pending_reply_create "$golden_home" "$g_state" hibit "settled request") || exit 1
fm_pending_reply_mark_delivered "$g_state" "$g_corr"
g_rec=$(fm_pending_reply_path "$g_state" "$g_corr")
fm_pending_reply_set "$g_rec" phase escalated
fm_pending_reply_set "$g_rec" escalated_epoch 12000
printf 'blocked [key=pending-reply-%s]: pending-reply-missed: task=hibit pending-reply-id=%s request=settled request\n' "$g_corr" "$g_corr" > "$g_state/hibit.status"
printf 'done [corr=%s]: late reply\n' "$g_corr" >> "$g_state/hibit.status"
fm_pending_reply_try_resolve "$g_state" "$g_corr" || exit 1
[ "$(fm_pending_reply_get "$g_rec" phase)" = resolved ] || exit 1
[ -n "$(fm_pending_reply_get "$g_rec" escalation_closed_epoch)" ] || exit 1
echo "golden settled record $g_corr phase=$(fm_pending_reply_get "$g_rec" phase) escalated=$(fm_pending_reply_get "$g_rec" escalated_epoch) closed=$(fm_pending_reply_get "$g_rec" escalation_closed_epoch)"

# --- build N identical settled stores ----------------------------------------
mk_settled_store() {  # <dir> -> fills dir/state/pending-replies
  local store=$1 corr i line
  mkdir -p "$store/state/pending-replies"
  i=0
  while [ "$i" -lt "$N" ]; do
    corr=$(printf '%016x' "$(( 9000000000 + i ))")
    while IFS= read -r line || [ -n "$line" ]; do
      case "$line" in
        corr_id=*) printf 'corr_id=%s\n' "$corr" ;;
        *) printf '%s\n' "$line" ;;
      esac
    done < "$g_rec" > "$store/state/pending-replies/$corr"
    i=$((i + 1))
  done
}
store_a="$TMP/store-settled-a"
store_b="$TMP/store-settled-b"
mk_settled_store "$store_a"
cp -a "$store_a" "$store_b"
echo "settled stores built: $(find "$store_a/state/pending-replies" -maxdepth 1 -type f | wc -l) records each"

# --- instrumented tick runner ------------------------------------------------
# Run fm_pending_reply_tick over <state> in a fresh bash sourcing <libfile>.
# fm_pending_reply_get reads, fm_pending_reply_close_escalation calls
# (per-correlation lock acquisitions) and fm_pending_reply_tick_capture passes
# are counted by appending one line per call to a counter file (subshell-safe).
run_tick() {  # <libdir> <state> <label>
  local libdir=$1 state=$2 label=$3 out cnt
  out="$TMP/$label.out"
  cnt="$TMP/$label.cnt"
  : > "$cnt"
  FM_ROOT_OVERRIDE="$TMP/fakehome" FM_HOME="$TMP/fakehome" FM_PR_COUNT_FILE="$cnt" \
  bash -s "$libdir" "$state" "$label" > "$out" 2>&1 <<'SH'
set -u
libdir=$1 state=$2 label=$3
cnt=${FM_PR_COUNT_FILE:?}
# shellcheck disable=SC1091
. "$libdir/fm-pending-reply-lib.sh"
# Rename each instrumented function and install a counting wrapper; counts are
# appended to $cnt so increments inside $( ) subshells are not lost.
eval "$(declare -f fm_pending_reply_get | sed '1s/^fm_pending_reply_get /fm_pending_reply_get_orig /')"
fm_pending_reply_get() { printf 'get\n' >> "$cnt"; fm_pending_reply_get_orig "$@"; }
eval "$(declare -f fm_pending_reply_close_escalation | sed '1s/^fm_pending_reply_close_escalation /fm_pending_reply_close_escalation_orig /')"
fm_pending_reply_close_escalation() { printf 'close\n' >> "$cnt"; fm_pending_reply_close_escalation_orig "$@"; }
if declare -F fm_pending_reply_tick_capture >/dev/null 2>&1; then
  eval "$(declare -f fm_pending_reply_tick_capture | sed '1s/^fm_pending_reply_tick_capture /fm_pending_reply_tick_capture_orig /')"
  fm_pending_reply_tick_capture() { printf 'cap\n' >> "$cnt"; fm_pending_reply_tick_capture_orig "$@"; }
fi
t0=${EPOCHREALTIME/./}
fm_pending_reply_tick "$state" || { echo "tick FAILED"; exit 1; }
t1=${EPOCHREALTIME/./}
# EPOCHREALTIME is seconds with 6 fractional digits (microseconds).
elapsed_ms=$(( (10#$t1 - 10#$t0) / 1000 ))
get_count=$(grep -Fc 'get' "$cnt" 2>/dev/null || true)
close_count=$(grep -Fc 'close' "$cnt" 2>/dev/null || true)
cap_count=$(grep -Fc 'cap' "$cnt" 2>/dev/null || true)
printf '%s get_calls=%d close_calls=%d capture_passes=%d elapsed_ms=%d\n' "$label" "$get_count" "$close_count" "$cap_count" "$elapsed_ms"
SH
  cat "$out"
}

echo "=== instrumented tick passes over the SAME settled store ($N records) ==="
run_tick "$BASE_LIB_DIR" "$store_a/state" "BEFORE(base)"
run_tick "$W/bin" "$store_b/state" "AFTER(target)"
# A second AFTER pass (steady state: each pass must stay cheap).
run_tick "$W/bin" "$store_b/state" "AFTER(target)-pass2"

# Builtin-only proof: the settled store must tick with no external subprocess at all.
echo "=== builtin-only proof: settled tick with PATH stripped (target) ==="
FM_ROOT_OVERRIDE="$TMP/fakehome" FM_HOME="$TMP/fakehome" \
bash -c '
  set -u
  # shellcheck disable=SC1091
  . "$1/fm-pending-reply-lib.sh"
  PATH=/nonexistent
  fm_pending_reply_tick "$2" && echo "settled tick OK with PATH stripped" || echo "settled tick FAILED with PATH stripped"
' _ "$W/bin" "$store_b/state"

echo "=== open-escalation convergence: same behavior before and after ==="
# A store holding three resolved records whose escalation close was deferred
# (escalation_closed_epoch empty), mirroring tests/fm-pending-reply.test.sh:
# the tick must still close each one exactly once under the per-correlation lock.
store_c="$TMP/store-open-before"
store_d="$TMP/store-open-after"
mkdir -p "$store_c/state/pending-replies"
make_open_record() {  # <state> <seed> <now> -> corr
  local state=$1 seed=$2 now=$3 corr rec open_status
  corr=$(FM_PENDING_REPLY_NOW=$now fm_pending_reply_create "$(dirname "$state")" "$state" hibit "converge close") || return 1
  fm_pending_reply_mark_delivered "$state" "$corr"
  rec=$(fm_pending_reply_path "$state" "$corr")
  fm_pending_reply_set "$rec" phase escalated
  fm_pending_reply_set "$rec" escalated_epoch $((now - 100))
  open_status="$state/hibit.status"
  # Real parent statuses accumulate lines over time: append each record's lines.
  printf 'blocked [key=pending-reply-%s]: pending-reply-missed: task=hibit pending-reply-id=%s request=converge close\n' "$corr" "$corr" >> "$open_status"
  printf 'done [corr=%s]: late reply\n' "$corr" >> "$open_status"
  fm_pending_reply_set "$rec" parent_status ""
  FM_PENDING_REPLY_NOW=$now fm_pending_reply_try_resolve "$state" "$corr" "$open_status" || return 1
  [ "$(fm_pending_reply_get "$rec" phase)" = resolved ] || return 1
  if [ -n "$(fm_pending_reply_get "$rec" escalation_closed_epoch)" ]; then return 1; fi
  fm_pending_reply_set "$rec" parent_status "$open_status" || return 1
  printf '%s' "$corr"
}
for seed in 1 2 3; do
  corr=$(make_open_record "$store_c/state" "$seed" $((13000 + seed))) || exit 1
  echo "open-escalation fixture seed=$seed corr=$corr (resolved, escalation still open)"
done
cp -a "$store_c" "$store_d"
# Records carry an absolute parent_status written at create time; repoint each
# copied record at its own store so each tick closes into its own status file.
for rec in "$store_d/state/pending-replies"/*; do
  [ -f "$rec" ] || continue
  sed -i "s|^parent_status=.*|parent_status=$store_d/state/hibit.status|; s|^parent_home=.*|parent_home=$store_d|" "$rec"
done
echo "-- BEFORE(base) tick over the open-escalation store --"
FM_ROOT_OVERRIDE="$TMP/fakehome" FM_HOME="$TMP/fakehome" \
bash -s "$BASE_LIB_DIR" "$store_c/state" "BEFORE(base)" <<'SH' 2>&1
set -u
# shellcheck disable=SC1091
. "$1/fm-pending-reply-lib.sh"
t0=${EPOCHREALTIME/./}
fm_pending_reply_tick "$2" || { echo "base converge tick FAILED"; exit 1; }
t1=${EPOCHREALTIME/./}
printf 'BEFORE(base) open-escalation tick OK elapsed_ms=%d\n' "$(( (10#$t1 - 10#$t0) / 1000 ))"
SH
echo "-- AFTER(target) tick over the identical open-escalation store --"
FM_ROOT_OVERRIDE="$TMP/fakehome" FM_HOME="$TMP/fakehome" \
bash -s "$W/bin" "$store_d/state" "AFTER(target)" <<'SH' 2>&1
set -u
# shellcheck disable=SC1091
. "$1/fm-pending-reply-lib.sh"
t0=${EPOCHREALTIME/./}
fm_pending_reply_tick "$2" || { echo "target converge tick FAILED"; exit 1; }
t1=${EPOCHREALTIME/./}
printf 'AFTER(target) open-escalation tick OK elapsed_ms=%d\n' "$(( (10#$t1 - 10#$t0) / 1000 ))"
SH

# Verify both stores converged identically: escalation_closed_epoch set and the
# guarded decision close appended exactly once per record.
echo "-- verify convergence equality (escalation_closed_epoch set, decision closed exactly once) --"
verify_store() {  # <store> <label>
  local store=$1 label=$2 state="$1/state" rec corr status n ok=1
  for rec in "$state/pending-replies"/*; do
    [ -f "$rec" ] || continue
    corr=$(sed -n 's/^corr_id=//p' "$rec" | tail -1)
    status="$state/hibit.status"
    if [ -z "$(sed -n 's/^escalation_closed_epoch=//p' "$rec" | tail -1)" ]; then
      echo "$label corr=$corr MISSING escalation_closed_epoch"; ok=0; continue
    fi
    n=$(grep -Fc "resolved [key=pending-reply-$corr]: pending-reply-resolved:" "$status" 2>/dev/null || true)
    if [ "$n" != 1 ]; then echo "$label corr=$corr expected exactly 1 decision close, found $n"; ok=0; continue; fi
    echo "$label corr=$corr CONVERGED (escalation_closed_epoch set, 1 decision close)"
  done
  [ "$ok" = 1 ]
}
verify_store "$store_c" "BEFORE(base)" || exit 1
verify_store "$store_d" "AFTER(target)" || exit 1
echo "ALL MEASUREMENTS DONE"
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"cb9590831bc1f122a618078ff87034f2c240cdf1","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>⚠️ **Review** - 2 infos</summary>

- ℹ️ `tests/fm-pending-reply.test.sh:1328` - The PATH=/nonexistent assertion proves a settled tick *succeeds* with no external tools, but it would not fail if a regression reintroduced an external subprocess whose failure is swallowed by the surrounding `|| true` (e.g. a per-record fm_pending_reply_get/grep re-read on settled records: grep missing prints to stderr and returns 127, tick still returns 0). The log-based assertion covers only the no-close/no-lock half. Today the settled path is genuinely builtin-only (verified by trace of fm_pending_reply_tick_capture and the resolved branch), so this is a note on assertion scope, not a current defect; if the &#39;zero external subprocesses on a settled pass&#39; property must be hard-pinned later, count executed external commands at runtime (e.g. PS4/xtrace of the tick) rather than reading source text.
- ℹ️ `tests/fm-pending-reply.test.sh:1357` - The deferred-close fixture simulates the state by clearing parent_status=&#34;&#34;, which makes _fm_pending_reply_close_escalation_locked bail at its `[ -n &#34;$parent_status&#34; ] || return 1` guard. Production deferral happens differently (guarded append rc=2 leaves parent_status set, or a crash between phase=resolved and the closed-epoch write), but the record state the tick dispatches on (resolved + escalated_epoch set + escalation_closed_epoch empty) and the subsequent converging close path (escalation_line match -&gt; guarded append -&gt; set closed_epoch) are identical, so the regression value (open escalation still closed by the tick) is preserved. Fidelity note only.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`bash tests/fm-pending-reply.test.sh` — full file, 36/36 ok, including the two new tests `test_tick_settled_records_skip_lock_and_subprocess_work` and `test_tick_still_closes_an_open_escalation_on_a_resolved_record`</code>
- `Regression reproduction: ran the test file against the BASE library (60915d9 tick) — all 35 pre-existing tests still pass, new settled fast-path test fails with 'a settled store must not take the per-correlation lock, close log: close close' (fails pre-fix, passes post-fix)`
- <code>`fmpr-measure.sh` before/after harness on an identical 2283-record settled fixture store: BEFORE(base) 171,271 ms with 13,698 fm_pending_reply_get record reads and 2,283 close_escalation/lock calls; AFTER(target) 1,454 ms (pass 1) and 905 ms (pass 2) with 0 reads, 0 lock calls, 2,283 builtin tick_capture passes</code>
- `Settled tick with PATH=/nonexistent on the full 2283-record store (target): passes, proving no external subprocess is required on the fast path`
- <code>Open-escalation convergence: identical 3-record stores of resolved+open-escalation records ticked with base and target — both set escalation_closed_epoch and append exactly one `resolved [key=pending-reply-&lt;corr&gt;]` decision close per record (no behavior change for open escalations)</code>
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>⚠️ **Lint** - 1 warning</summary>

- ⚠️ linter found issues (exit code 1)
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
