### PR TITLE
fix: prevent autonomous Lavish reviews from stealing focus

### DIFF
--- a/.agents/skills/bearings/SKILL.md
+++ b/.agents/skills/bearings/SKILL.md
@@ -104,7 +104,7 @@ Compose the payload from the same snapshot with the same ranking judgment as the
 - Every Captain's Call item and every Underway, Recently Landed, and Charted Next row carries an explicit `repo` field. Fill it from the snapshot and task records wherever known; use null or an empty string only as the deliberate genuinely-no-repo marker, in which case the template may show the internal id. Ids otherwise stay in the payload only as the routing channel, and composed reasons name blockers in plain words.
 
 Run `build` once after composing the payload.
-Its serve-first sequence publishes the board, establishes and verifies its Lavish session with `lavish-axi`, reopens an ended session when necessary, and only then binds the answer source and proves a live polling listener; use the session URL it prints in the chat digest.
+Its serve-first sequence publishes the board, establishes and verifies its Lavish session with `lavish-axi` without opening a browser, reopens an ended session when necessary without opening a browser, and only then binds the answer source and proves a live polling listener; use the session URL it prints in the chat digest and open it explicitly when you want to review it.
 Never bind or arm the board before its session is listed open.
 Never run `lavish-axi poll` for the board yourself: the armed source's supervised runner owns the blocking poll, and both the build and the watcher's ordinary reconcile repair a missing listener, so no conversational turn ever blocks on the board.
 

--- a/bin/fm-bearings-board.sh
+++ b/bin/fm-bearings-board.sh
@@ -15,9 +15,10 @@
 #            already landed, give every surviving decision card the standard
 #            reconcile choice, and inject the result into a fresh copy of the
 #            shipped template at the stable board path. Establish the Lavish
-#            session on that board and PROVE it is live BEFORE binding and
-#            arming its answer source, so a registered poll can never race a
-#            session that does not exist or attach to one that has ended.
+#            session on that board without opening a browser, then PROVE it is
+#            live BEFORE binding and arming its answer source, so a registered
+#            poll can never race a session that does not exist or attach to one
+#            that has ended.
 #            Bind to the keyed-answer intake (bin/fm-captain-hold.sh) ALWAYS
 #            precedes arm, so the board can never produce an answer that has
 #            nowhere to go (captain-hold-lifecycle's ordering rule, enforced
@@ -221,22 +222,22 @@ lavish_board_live() {  # <establish output> <canonical-board-path>
   lavish_session_listed_open "$2"
 }
 
-# Establish the board session and PROVE it is live before anything arms a poll
-# on it. A session the captain ended is reopened once - the captain asked for
-# this board, which is exactly the attention `--reopen` exists for - and a
-# session that is still not live after that refuses the build rather than
-# arming a poll that can never attach.
+# Establish the board session without opening a browser and PROVE it is live
+# before anything arms a poll on it. A session the captain ended is reopened
+# once without opening a browser; the returned URL remains available for the
+# captain to open explicitly. A session that is still not live after that
+# refuses the build rather than arming a poll that can never attach.
 establish_board_session() {  # <board>
   local board=$1 real out status version
   BOARD_SESSION_REOPENED=0
   real=$(board_realpath "$board") || fail "cannot resolve the board path: $board"
-  out=$(lavish-axi "$board") || fail "cannot establish the board Lavish session"
+  out=$(lavish-axi "$board" --no-open) || fail "cannot establish the board Lavish session"
   printf '%s\n' "$out"
   if lavish_board_live "$out" "$real"; then
     printf 'session: live\n'
     return 0
   fi
-  out=$(lavish-axi "$board" --reopen) || fail "cannot reopen the ended board Lavish session"
+  out=$(lavish-axi "$board" --no-open --reopen) || fail "cannot reopen the ended board Lavish session"
   printf '%s\n' "$out"
   if lavish_board_live "$out" "$real"; then
     BOARD_SESSION_REOPENED=1

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -371,6 +371,7 @@ The report is the only thing that survives, so anything worth keeping must be in
 1. Never push to any remote and never open a PR.
 2. Stay inside this worktree; the only files you may write outside it are the report and the status file below.
 3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.
+When preparing or serving a Lavish artifact without a current explicit captain request to open it, pass \`--no-open\` and return the review URL without opening a browser. Use plain \`lavish-axi <html-file>\` or \`--reopen\` only when the captain explicitly asks to open or reopen that review.
 4. Report status by appending one line:
    \`echo "{state}: {one short line}" >> $STATUS_FILE\`
    States: working, needs-decision, blocked, $PAUSED_VERB, done, failed.
@@ -458,6 +459,7 @@ If the top-level path is the primary checkout or not the worktree you were launc
 $RULE1
 2. Stay inside this worktree; modify nothing outside it.
 3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.
+When preparing or serving a Lavish artifact without a current explicit captain request to open it, pass \`--no-open\` and return the review URL without opening a browser. Use plain \`lavish-axi <html-file>\` or \`--reopen\` only when the captain explicitly asks to open or reopen that review.
 4. Report status by appending one line:
    \`echo "{state}: {one short line}" >> $STATUS_FILE\`
    States: working, needs-decision, blocked, $PAUSED_VERB, done, failed.

--- a/tests/fm-bearings-board-lavish-live-e2e.test.sh
+++ b/tests/fm-bearings-board-lavish-live-e2e.test.sh
@@ -14,8 +14,10 @@
 #
 # The captain-ended state is reached through the same server route the browser's
 # End session button calls, so no browser is needed and nothing here depends on
-# a human. The artifact is a scratch page in a temporary directory, and the
-# session it opens is ended again before the guard returns.
+# a human. Every artifact-serving call uses --no-open because this guard needs
+# session state and URLs, not browser focus. The artifact is a scratch page in
+# a temporary directory, and the session it opens is ended again before the
+# guard returns.
 #
 # Standard CI has no lavish-axi, so this reports a capability skip there. The
 # portable counterpart in tests/fm-bearings-board.test.sh pins the build's logic
@@ -74,7 +76,7 @@ JSON
 
 run_board() {
   FM_HOME="$LAB" FM_STATE_OVERRIDE="$LAB/state" FM_DATA_OVERRIDE="$LAB/data" \
-    FM_PROCEVENT_CLAIM_ROOT="$LAB/procevent-claims" \
+    FM_PROCEVENT_CLAIM_ROOT="$LAB/procevent-claims" LAVISH_AXI_NO_OPEN=1 \
     "$ROOT/bin/fm-bearings-board.sh" "$@"
 }
 
@@ -82,7 +84,7 @@ BOARD="$LAB/.lavish/bearings-board.html"
 run_board build "$LAB/payload.json" >/dev/null 2>&1 || fail "the guard board did not build"
 [ -f "$BOARD" ] || fail "the guard board was not published"
 
-url=$(lavish-axi "$BOARD" | sed -n 's/^[[:space:]]*url:[[:space:]]*//p' | head -1 | tr -d '"')
+url=$(lavish-axi "$BOARD" --no-open | sed -n 's/^[[:space:]]*url:[[:space:]]*//p' | head -1 | tr -d '"')
 case "$url" in
   http://*/session/*) ;;
   *) fail "could not read the guard board session url: $url" ;;
@@ -96,7 +98,7 @@ curl -fsS -X POST "$base/api/$key/end" >/dev/null 2>&1 \
 
 # ASSUMPTION UNDER GUARD: this exits 0 while reporting the session is not live.
 set +e
-ended_out=$(lavish-axi "$BOARD" 2>&1)
+ended_out=$(lavish-axi "$BOARD" --no-open 2>&1)
 ended_rc=$?
 set -e
 [ "$ended_rc" -eq 0 ] \

--- a/tests/fm-bearings-board.test.sh
+++ b/tests/fm-bearings-board.test.sh
@@ -79,7 +79,12 @@ esac
 file=$1
 shift
 reopen=0
-for arg in "$@"; do [ "$arg" != --reopen ] || reopen=1; done
+no_open=0
+for arg in "$@"; do
+  [ "$arg" != --reopen ] || reopen=1
+  [ "$arg" != --no-open ] || no_open=1
+done
+[ "$no_open" = 1 ] || { printf 'automated artifact establishment must pass --no-open\n' >&2; exit 97; }
 real=$(cd "$(dirname "$file")" && pwd -P)/$(basename "$file")
 if [ -e "$state/user-ended" ] && [ "$reopen" = 0 ]; then
   emit "$real" user-ended

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -214,6 +214,8 @@ test_ship_modes_generate_clean_briefs() {
     assert_grep "## Captain's intent" "$brief" "$id: brief missing Captain's intent subsection"
     assert_grep "## Firstmate spec" "$brief" "$id: brief missing Firstmate spec subsection"
     assert_grep 'never a bare number such as "PR 108"' "$brief" "$id: brief missing the full-PR-URL rule"
+    assert_grep 'pass `--no-open`' "$brief" "$id: brief missing the automated Lavish no-open rule"
+    assert_grep 'captain explicitly asks to open or reopen' "$brief" "$id: brief missing the explicit Lavish open exception"
     assert_grep "mid-task \`working:\` line (including setup complete) is nonterminal" "$brief" \
       "$id: brief missing nonterminal working:/setup-complete gate protection"
     assert_no_grep "EOF" "$brief" "$id: brief leaked a heredoc EOF marker (unterminated heredoc)"
@@ -828,6 +830,10 @@ test_scout_and_secondmate_scaffold() {
   assert_grep "report.md" "$brief" "scout brief must point at the report deliverable"
   assert_grep "you may host the Lavish review loop yourself" "$brief" \
     "scout brief must mention the option to host a Lavish review loop"
+  assert_grep 'pass `--no-open`' "$brief" \
+    "scout brief must require automated Lavish serving without browser open"
+  assert_grep 'captain explicitly asks to open or reopen' "$brief" \
+    "scout brief must preserve explicit Lavish open behavior"
   assert_grep "## Captain's intent" "$brief" "scout brief missing Captain's intent subsection"
   assert_grep "## Firstmate spec" "$brief" "scout brief missing Firstmate spec subsection"
   assert_grep "{FIRSTMATE_SPEC}" "$brief" "scout brief missing the spec placeholder"

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -214,7 +214,7 @@ test_ship_modes_generate_clean_briefs() {
     assert_grep "## Captain's intent" "$brief" "$id: brief missing Captain's intent subsection"
     assert_grep "## Firstmate spec" "$brief" "$id: brief missing Firstmate spec subsection"
     assert_grep 'never a bare number such as "PR 108"' "$brief" "$id: brief missing the full-PR-URL rule"
-    assert_grep 'pass `--no-open`' "$brief" "$id: brief missing the automated Lavish no-open rule"
+    assert_grep "pass \`--no-open\`" "$brief" "$id: brief missing the automated Lavish no-open rule"
     assert_grep 'captain explicitly asks to open or reopen' "$brief" "$id: brief missing the explicit Lavish open exception"
     assert_grep "mid-task \`working:\` line (including setup complete) is nonterminal" "$brief" \
       "$id: brief missing nonterminal working:/setup-complete gate protection"
@@ -830,7 +830,7 @@ test_scout_and_secondmate_scaffold() {
   assert_grep "report.md" "$brief" "scout brief must point at the report deliverable"
   assert_grep "you may host the Lavish review loop yourself" "$brief" \
     "scout brief must mention the option to host a Lavish review loop"
-  assert_grep 'pass `--no-open`' "$brief" \
+  assert_grep "pass \`--no-open\`" "$brief" \
     "scout brief must require automated Lavish serving without browser open"
   assert_grep 'captain explicitly asks to open or reopen' "$brief" \
     "scout brief must preserve explicit Lavish open behavior"


### PR DESCRIPTION
## Intent

Autonomous Firstmate work must not interrupt an operator by opening a Lavish browser tab when it prepares a review.
The worker should prepare the server and session, return the review URL, and leave the decision to open it with the operator.
An explicit request to open or reopen a particular review must retain the existing browser-opening behavior.

## Problem and impact

Firstmate can perform unrelated work while a worker creates a visual review in the background.
The previous automation opened a new browser tab as a side effect of preparing that review.
That steals focus from the work in progress and creates an unwanted context switch.

## Reproduction

The original path is `/bearings lavish`, which runs `bin/fm-bearings-board.sh build <data.json>`.
The same behavior was reproduced with an isolated temporary artifact, isolated Lavish state, a non-default port, and a fake `open` executable that recorded invocations without launching a browser.
The automated path invoked `lavish-axi <artifact>` without `--no-open`, returned `status: opened`, and invoked the opener once with the session URL.
No real browser tab or active review was touched during reproduction.

## Root cause

Lavish's default artifact command both creates or resumes the session and opens the browser.
Lavish 0.1.63 provides the supported `--no-open` flag and the equivalent `LAVISH_AXI_NO_OPEN=1` environment setting.
Firstmate's Bearings helper omitted that flag on its initial establishment and automatic ended-session recovery calls.
Generated ship and scout instructions also did not tell autonomous workers to use the flag when serving their own artifacts.

## Implementation

- `bin/fm-bearings-board.sh` now passes `--no-open` for initial session establishment and `--no-open --reopen` for automatic ended-session recovery.
- The helper still verifies that the session is live before binding and arming the listener, and it still returns the session URL.
- `bin/fm-brief.sh` now gives generated ship and scout workers the same automation rule and reserves plain open and `--reopen` for an explicit operator request.
- The portable board fake rejects automated establishment or recovery without `--no-open`.
- The real Lavish live guard uses `--no-open` for artifact-serving inspection and an isolated no-open environment safeguard.
- Brief-generation tests assert both the automated no-open rule and the explicit open exception.

## Behavioral contract and compatibility

Automated Firstmate preparation, serving, recovery, and review setup return a URL without launching a browser.
Polling uses `lavish-axi poll` and remains unchanged.
A plain `lavish-axi <html-file>` invocation still opens or resumes a review when an operator explicitly requests it.
`lavish-axi <html-file> --reopen` still reopens a review that an operator explicitly asks to revisit.
The change does not set a global environment variable, change browser settings, modify Lavish, or alter listener binding and URL output.

## Risk assessment

✅ Low: The change is limited to automated invocation flags, generated worker guidance, and executable regression coverage.
The session lifecycle, liveness proof, recovery behavior, URL reporting, and polling contract remain unchanged.
The only changed side effect is the unwanted browser launch during autonomous preparation.

## Verification

The installed CLI was inspected directly at version 0.1.63.
Its help and implementation confirm that `--no-open` creates or resumes the session without invoking the browser opener.

The following targeted suites passed after the final implementation changes:

- `bin/fm-test-run.sh tests/fm-brief.test.sh`.
- `bin/fm-test-run.sh tests/fm-bearings-board.test.sh`.
- `bin/fm-test-run.sh tests/fm-bearings-board-render.test.sh`.
- `bin/fm-test-run.sh tests/fm-procevent.test.sh`.
- `FM_BEARINGS_LAVISH_LIVE=1 LAVISH_AXI_PORT=44990 LAVISH_AXI_STATE_DIR=<isolated> bin/fm-test-run.sh tests/fm-bearings-board-lavish-live-e2e.test.sh`.

The real Lavish live guard passed with isolated state and a non-default port.
The worker-style probe returned `http://127.0.0.1:44991/session/855d839b3c34e02f` with zero intercepted browser invocations when using `--no-open`.
The explicit reopen probe produced one intercepted opener invocation when using `--reopen` without `--no-open`.

`bin/fm-doc-audience-check.sh` passed with `fm-doc-audience-check: ok surfaces=97 local_links=352`.
The no-mistakes review, tests, documentation, lint, push, PR, and CI stages completed successfully.
The final CI gate noted unrelated baseline/environment failures in the broader run and an external attestation check, then accepted the result after the authorized review.

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes).

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"b75712a335d75a93466d4957f6596c37d56af635","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

- Intent passed with the requested outcome and compatibility contract.
- Rebase passed against the current upstream main branch.
- Review passed with no findings.
- Test passed with the targeted board, brief, process-event, render, and isolated real Lavish checks listed above.
- Document passed with no findings.
- Lint passed with ShellCheck and workflow checks.
- Push passed to the replacement fork.
- The PR was opened against `kunchenguid/firstmate` main.
