### PR TITLE
feat(pr): accept Gitea pull request URLs and poll their merge state

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,7 @@ Firstmate's skills live in two separate places with different audiences:
 - [docs/cmux-backend.md](docs/cmux-backend.md) - current setup, socket security, and limits for the experimental cmux backend.
 - [docs/codex-app-backend.md](docs/codex-app-backend.md) - the current blocked Codex App backend boundary and rollout contract.
 - [docs/verification/runtime-backends.md](docs/verification/runtime-backends.md) - active maintainer verification for runtime backend guarantees.
+- [docs/gitea-merge-watch.md](docs/gitea-merge-watch.md) - maintainer verification for watching Gitea pull requests on a self-hosted instance, including one on a non-default port.
 - [docs/gitlab-merge-watch.md](docs/gitlab-merge-watch.md) - maintainer verification for watching and merging GitLab merge requests on arbitrary instances.
 - [docs/turnend-guard.md](docs/turnend-guard.md) - the primary session's current "no turn ends blind" backstop, scope, loop safety, and compatibility limits.
 - [docs/verification/supervision.md](docs/verification/supervision.md) - active maintainer verification for session-start, guard, continuity, and wedge integrations.

--- a/bin/fm-backlog-transition-lib.sh
+++ b/bin/fm-backlog-transition-lib.sh
@@ -409,6 +409,83 @@ fm_backlog_mutate() {  # <data-dir> <verb> <id> [flag...]
   return "$command_status"
 }
 
+# Is this an https URL a completion link may carry? Shape only: an authority
+# with valid labels and an optional numeric port, a non-empty path, no
+# whitespace, no character outside the URL set, and every percent escape
+# complete. Shared by the close-argument builder and the pending-close record
+# validator so a staged close and its replay judge the same string identically.
+fm_backlog_link_url_valid() {  # <url>
+  local url=${1-} tail authority path host port rest label valid=1 percent_tail
+  [ "${#url}" -le 2048 ] || return 1
+  case "$url" in https://*) ;; *) return 1 ;; esac
+  case "$url" in
+    *[[:space:]]*|*[!A-Za-z0-9:/?\&=._#%+~@-]*) return 1 ;;
+  esac
+  tail=${url#https://}
+  authority=${tail%%/*}
+  path=${tail#*/}
+  [ "$path" != "$tail" ] || return 1
+  host=$authority
+  port=
+  case "$authority" in
+    *:*) host=${authority%%:*}; port=${authority#*:} ;;
+  esac
+  case "$host" in
+    ''|[-.]*|*[-.]|*..*|*[!A-Za-z0-9.-]*) return 1 ;;
+    *[A-Za-z0-9]*) ;;
+    *) return 1 ;;
+  esac
+  rest=$host
+  while :; do
+    label=${rest%%.*}
+    case "$label" in ''|-*|*-) valid=0; break ;; esac
+    [ "$rest" = "$label" ] && break
+    rest=${rest#*.}
+  done
+  [ "$valid" = 1 ] || return 1
+  case "$authority" in
+    *:*) case "$port" in ''|*[!0-9]*|??????*) return 1 ;; esac ;;
+  esac
+  case "$path" in *[A-Za-z0-9]*) ;; *) return 1 ;; esac
+  percent_tail=$path
+  while case "$percent_tail" in *%*) true ;; *) false ;; esac; do
+    percent_tail=${percent_tail#*%}
+    case "$percent_tail" in
+      [0-9A-Fa-f][0-9A-Fa-f]*) percent_tail=${percent_tail#??} ;;
+      *) return 1 ;;
+    esac
+  done
+  return 0
+}
+
+# tasks-axi records a link through `--pr` only when the URL is one its own
+# validator accepts: http(s) whose path ends in `/pull/<number>`. GitHub is the
+# only forge that shape fits. Gitea's `/pulls/<number>` and GitLab's
+# `/-/merge_requests/<number>` are refused there, which would wedge the close
+# that carries them, so they go through `--note` instead: the closed row then
+# shows the URL on its own body line, still clickable.
+fm_backlog_pr_link_recordable() {  # <url>
+  local LC_ALL=C
+  [[ "${1-}" =~ ^https?://[^[:space:]]+/pull/[0-9]+$ ]]
+}
+
+# The completion flags for a shipped task's recorded pull request URL. The
+# routing is decided by the URL, never by the forge, so every forge whose URL
+# tasks-axi cannot hold as a link is recorded the same way. Empty for an empty
+# URL, so a caller with nothing recorded closes with no completion flags.
+# shellcheck disable=SC2034 # Output global, read by the sourcing caller.
+FM_BACKLOG_COMPLETION_LINK_ARGS=()
+fm_backlog_completion_link_args() {  # <pr-url>
+  local url=${1-}
+  FM_BACKLOG_COMPLETION_LINK_ARGS=()
+  [ -n "$url" ] || return 0
+  if fm_backlog_pr_link_recordable "$url"; then
+    FM_BACKLOG_COMPLETION_LINK_ARGS=(--pr "$url")
+  else
+    FM_BACKLOG_COMPLETION_LINK_ARGS=(--note "$url")
+  fi
+}
+
 fm_backlog_start() {  # <data-dir> <id>
   fm_backlog_mutate "$1" start "$2"
 }
@@ -707,8 +784,6 @@ fm_backlog_close_marker_path() {  # <state-dir> <id>
 fm_backlog_close_marker_validate() {  # <marker-path> <authorized-data-dir> <expected-id> <state-dir>
   local marker=$1 authorized_data data_resolved expected_id=$3 state=$4
   local id='' data='' marker_spawn_gen='' cleanup_incomplete=0 mode=close line raw_bytes arg_value
-  local url_tail url_authority url_path url_host url_port host_rest host_label host_valid
-  local percent_tail percent_valid
   local id_count=0 data_count=0 spawn_gen_count=0 cleanup_incomplete_count=0 mode_count=0
   local args=()
   FM_BACKLOG_CLOSE_VALIDATED_ID=
@@ -803,60 +878,13 @@ fm_backlog_close_marker_validate() {  # <marker-path> <authorized-data-dir> <exp
     0) ;;
     2)
       case "${args[0]}" in
-        --note) [ "${args[1]}" = "local%20main" ] ;;
-        --pr)
-          arg_value=${args[1]}
-          [ "${#arg_value}" -le 2048 ] \
-            && case "$arg_value" in https://*) true ;; *) false ;; esac \
-            && case "$arg_value" in
-              *[[:space:]]*|*[!A-Za-z0-9:/?\&=._#%+~@-]*) false ;;
-              *) true ;;
-            esac \
-            && {
-              url_tail=${arg_value#https://}
-              url_authority=${url_tail%%/*}
-              url_path=${url_tail#*/}
-              url_host=$url_authority
-              url_port=
-              case "$url_authority" in
-                *:*) url_host=${url_authority%%:*}; url_port=${url_authority#*:} ;;
-              esac
-              [ "$url_path" != "$url_tail" ] \
-                && case "$url_host" in
-                  ''|[-.]*|*[-.]|*..*|*[!A-Za-z0-9.-]*) false ;;
-                  *[A-Za-z0-9]*) true ;;
-                  *) false ;;
-                esac \
-                && {
-                  host_rest=$url_host
-                  host_valid=1
-                  while :; do
-                    host_label=${host_rest%%.*}
-                    case "$host_label" in ''|-*|*-) host_valid=0; break ;; esac
-                    [ "$host_rest" = "$host_label" ] && break
-                    host_rest=${host_rest#*.}
-                  done
-                  [ "$host_valid" = 1 ]
-                } \
-                && case "$url_authority" in
-                  *:*) case "$url_port" in ''|*[!0-9]*|??????*) false ;; *) true ;; esac ;;
-                  *) true ;;
-                esac \
-                && case "$url_path" in *[A-Za-z0-9]*) true ;; *) false ;; esac \
-                && {
-                  percent_tail=$url_path
-                  percent_valid=1
-                  while case "$percent_tail" in *%*) true ;; *) false ;; esac; do
-                    percent_tail=${percent_tail#*%}
-                    case "$percent_tail" in
-                      [0-9A-Fa-f][0-9A-Fa-f]*) percent_tail=${percent_tail#??} ;;
-                      *) percent_valid=0; break ;;
-                    esac
-                  done
-                  [ "$percent_valid" = 1 ]
-                }
-            }
+        --note)
+          # A close whose URL tasks-axi cannot hold as a link records it here
+          # instead, so the note carries either that fixed token or a URL held
+          # to exactly the shape the --pr branch demands.
+          [ "${args[1]}" = "local%20main" ] || fm_backlog_link_url_valid "${args[1]}"
           ;;
+        --pr) fm_backlog_link_url_valid "${args[1]}" ;;
         --report)
           arg_value=${args[1]}
           [ "${#arg_value}" -le 4096 ] \
@@ -977,7 +1005,7 @@ fm_backlog_close_marker_replay() {  # <state-dir> <marker-path> <authorized-data
   mode=$FM_BACKLOG_CLOSE_VALIDATED_MODE
   [ "$mode" = close ] || mode_flags=(--retain)
   args=("${FM_BACKLOG_CLOSE_VALIDATED_ARGS[@]+"${FM_BACKLOG_CLOSE_VALIDATED_ARGS[@]}"}")
-  if [ "${args[0]-}" = --note ]; then
+  if [ "${args[0]-}" = --note ] && [ "${args[1]-}" = "local%20main" ]; then
     args[1]="local main"
   fi
   meta="$state/$id.meta"

--- a/bin/fm-pr-check.sh
+++ b/bin/fm-pr-check.sh
@@ -3,8 +3,9 @@
 # exact pr_head=<sha> when available, then atomically arm a static merge poll.
 # The watcher check source is byte-for-byte bin/fm-pr-poll.sh; task and PR data
 # live only in a private sidecar and are never interpolated into shell source.
-# A GitHub pull request URL and a GitLab merge request URL are both accepted,
-# including a merge request on a self-hosted GitLab instance.
+# A GitHub pull request URL, a GitLab merge request URL, and a Gitea pull
+# request URL are all accepted, including one on a self-hosted GitLab or Gitea
+# instance and, for Gitea, on a non-default port.
 # Usage: fm-pr-check.sh <task-id> <pr-url>
 set -eu
 
@@ -60,12 +61,36 @@ if [ "$PROVIDER" = gitlab ] && ! command -v glab >/dev/null 2>&1; then
   exit 1
 fi
 
+# A Gitea watch is refused here for the same reason, and its requirements are
+# reported together rather than one per attempt. Gitea is read over its REST
+# API, so the watch needs curl and jq, and it needs a credential for that exact
+# instance from git's own helper chain: the operator's existing login for the
+# host they already clone and push to, never a firstmate-specific token.
+if [ "$PROVIDER" = gitea ]; then
+  GITEA_MISSING=
+  for GITEA_TOOL in curl jq git; do
+    command -v "$GITEA_TOOL" >/dev/null 2>&1 \
+      || GITEA_MISSING="${GITEA_MISSING:+$GITEA_MISSING and }$GITEA_TOOL"
+  done
+  if [ -n "$GITEA_MISSING" ]; then
+    echo "error: watching a Gitea pull request requires $GITEA_MISSING on PATH" >&2
+    exit 1
+  fi
+  if ! fm_pr_gitea_credential_available "$HOST"; then
+    printf 'error: watching a Gitea pull request on %s requires a git credential for that host; store one with: printf '"'"'protocol=https\\nhost=%s\\nusername=<user>\\npassword=<token>\\n\\n'"'"' | git credential approve\n' \
+      "$HOST" "$HOST" >&2
+    exit 1
+  fi
+fi
+
 "$FM_ROOT/bin/fm-guard.sh" || true
 
 # pr_head is recorded only when the forge's CLI can supply it. gh exposes the
 # head commit as a selectable field; plain glab exposes it only inside its JSON
 # output, which would need a JSON processor firstmate does not require, so a
-# GitLab task records no pr_head. Both consumers already treat it as optional:
+# GitLab task records no pr_head. Gitea records none either: its API returns the
+# head, but reading it would spend the instance credential at arm time for a
+# value no consumer requires. Both consumers already treat it as optional:
 # bin/fm-teardown.sh reads the head from the forge at teardown rather than from
 # metadata and falls back to its provider-agnostic content check, and
 # bin/fm-review-diff.sh resolves the head from the remote when none is recorded.

--- a/bin/fm-pr-lib.sh
+++ b/bin/fm-pr-lib.sh
@@ -4,13 +4,14 @@
 # constructing task paths or performing any side effect.
 #
 # The stored identity is provider-tagged: provider, url, host, path, number.
-# "path" is the full project path, which is owner/repository on GitHub and an
-# arbitrarily nested group/subgroup/project namespace on GitLab. A GitLab
-# project can sit at any depth, so no owner/repository pair can address one and
-# the sidecar carries the whole path instead. GitLab also runs on self-hosted
-# instances, so the host is part of that identity rather than a constant. Every
-# consumer re-derives the identity from the stored URL and refuses any record
-# whose parts do not reconstruct that exact URL.
+# "path" is the full project path, which is owner/repository on GitHub and
+# Gitea and an arbitrarily nested group/subgroup/project namespace on GitLab. A
+# GitLab project can sit at any depth, so no owner/repository pair can address
+# one and the sidecar carries the whole path instead. GitLab and Gitea both run
+# on self-hosted instances, so the host is part of that identity rather than a
+# constant, and for Gitea it carries the instance's port when it serves one.
+# Every consumer re-derives the identity from the stored URL and refuses any
+# record whose parts do not reconstruct that exact URL.
 #
 # A validated exact merged result is retired through a private receipt only
 # after its durable wake is appended.
@@ -109,14 +110,16 @@ fm_task_id_creation_valid() {
   [ "${#id}" -le 64 ]
 }
 
-# GitLab serves self-hosted instances, so the host is part of the identity
-# rather than a constant. It is accepted only as a lowercase DNS name with no
-# userinfo, port, or trailing dot, which keeps one canonical spelling per MR.
-# github.com is refused here even though its shape is otherwise valid: it is
-# GitHub's own host and never a GitLab instance, so a URL like
-# https://github.com/o/r/-/merge_requests/1 (a typo'd or spoofed GitHub URL)
-# would otherwise be armed as a GitLab watch that can never succeed.
-fm_pr_gitlab_host_valid() {
+# GitLab and Gitea both serve self-hosted instances, so the host is part of the
+# identity rather than a constant. It is accepted only as a lowercase DNS name
+# with no userinfo, port, or trailing dot, which keeps one canonical spelling
+# per merge request or pull request. github.com is refused here even though its
+# shape is otherwise valid: it is GitHub's own host and never a self-hosted
+# instance, so a URL like https://github.com/o/r/-/merge_requests/1 (a typo'd or
+# spoofed GitHub URL) would otherwise be armed as a watch that can never
+# succeed. A port is not part of this name; fm_pr_gitea_authority_valid owns the
+# host[:port] authority a Gitea instance can serve.
+fm_pr_self_hosted_host_valid() {
   local host=${1-} label
   local LC_ALL=C
   local -a labels
@@ -156,17 +159,85 @@ fm_pr_gitlab_path_valid() {
   done
 }
 
+# A Gitea instance is commonly published on a non-default port, so the
+# authority a Gitea identity carries is host[:port] rather than a bare host, and
+# the port is part of the canonical URL that every consumer reconstructs. The
+# host half is the shared self-hosted name; the port is accepted only as a
+# decimal 1-65535 with no leading zero, so one instance has one spelling.
+fm_pr_gitea_authority_valid() {
+  local authority=${1-} host port
+  local LC_ALL=C
+  case "$authority" in
+    *:*)
+      host=${authority%%:*}
+      port=${authority#*:}
+      case "$port" in
+        ''|*[!0-9]*|0*) return 1 ;;
+      esac
+      [ "${#port}" -le 5 ] || return 1
+      [ "$port" -ge 1 ] && [ "$port" -le 65535 ] || return 1
+      ;;
+    *) host=$authority ;;
+  esac
+  fm_pr_self_hosted_host_valid "$host"
+}
+
+# Gitea has no nested namespaces: a repository is always owner/repository, so a
+# Gitea path is exactly two segments and each is validated with the same rule.
+# "." and ".." are refused because they are path traversal rather than a name,
+# a leading hyphen is not a legal Gitea name, and a ".git" suffix is reserved by
+# Gitea for the clone path rather than available as a repository name.
+fm_pr_gitea_segment_valid() {
+  local segment=${1-}
+  local LC_ALL=C
+  [ "${#segment}" -ge 1 ] && [ "${#segment}" -le 100 ] || return 1
+  case "$segment" in
+    .|..|-*|*.git|*[!A-Za-z0-9._-]*) return 1 ;;
+  esac
+}
+
+# Gitea has no first-party CLI in firstmate's tool set, so its API is read over
+# HTTPS with the credential the operator already holds for that instance in
+# git's own credential helper chain, which is what their clones and pushes to it
+# already use. No firstmate-specific token, file, or environment variable is
+# introduced, and nothing is stored in this repo.
+#
+# This answers only "is a credential available for that authority", so the
+# secret is never returned to the caller. bin/fm-pr-poll.sh resolves the
+# credential itself, because the poll is byte-static and sources nothing.
+# GIT_TERMINAL_PROMPT and GIT_ASKPASS are pinned off so an absent credential
+# fails here instead of hanging an unattended run on a prompt.
+fm_pr_gitea_credential_available() {
+  local authority=${1-} filled
+  local LC_ALL=C
+  fm_pr_gitea_authority_valid "$authority" || return 1
+  command -v git >/dev/null 2>&1 || return 1
+  filled=$(printf 'protocol=https\nhost=%s\n\n' "$authority" \
+    | GIT_TERMINAL_PROMPT=0 GIT_ASKPASS=/usr/bin/false git credential fill 2>/dev/null) || return 1
+  printf '%s\n' "$filled" | grep -q '^username=.' || return 1
+  printf '%s\n' "$filled" | grep -q '^password=.'
+}
+
 # Parse a canonical PR or MR URL into the provider-tagged identity. Validation
 # is strict and per provider: the GitHub username and repository rules are
-# unchanged, and GitLab gets its own host and namespace rules rather than a
-# loosened GitHub rule.
+# unchanged, and GitLab and Gitea each get their own host and namespace rules
+# rather than a loosened GitHub rule.
 #
-# FM_PR_OWNER and FM_PR_REPO are additionally set for github because
-# bin/fm-pr-merge.sh addresses GitHub by owner/repository. A gitlab URL leaves
-# them empty, and that path addresses the project by FM_PR_HOST and FM_PR_PATH
-# instead, so a merge request on any instance resolves without a hardcoded host.
+# The provider is decided by the forge's own path shape, never by the host, so a
+# self-hosted instance on any host and any port resolves: "/pull/<n>" under
+# github.com is GitHub, "/-/merge_requests/<n>" is GitLab, and "/pulls/<n>" is
+# Gitea. The three shapes are disjoint, so the order below only fixes which
+# pattern is tried first and never changes which provider a URL resolves to.
+#
+# FM_PR_OWNER and FM_PR_REPO are additionally set for github and gitea because
+# bin/fm-pr-merge.sh addresses GitHub by owner/repository and the Gitea API
+# addresses a pull request the same way. A gitlab URL leaves them empty, and
+# that path addresses the project by FM_PR_HOST and FM_PR_PATH instead, so a
+# merge request on any instance resolves without a hardcoded host. FM_PR_HOST
+# carries the port for a gitea URL that has one, because that port is part of
+# the canonical URL each consumer must reconstruct exactly.
 fm_pr_url_parse() {
-  local raw=${1-} pattern host path
+  local raw=${1-} pattern host path owner repo
   local LC_ALL=C
   FM_PR_PROVIDER=
   FM_PR_URL=
@@ -195,16 +266,41 @@ fm_pr_url_parse() {
   # "/-/merge_requests/". Any earlier separator therefore lands inside the
   # captured path, where the reserved "-" segment is refused.
   pattern='^https://([a-z0-9.-]{1,253})/([A-Za-z0-9._/-]+)/-/merge_requests/([1-9][0-9]*)$'
+  if [[ "$raw" =~ $pattern ]]; then
+    host=${BASH_REMATCH[1]}
+    path=${BASH_REMATCH[2]}
+    fm_pr_self_hosted_host_valid "$host" || return 1
+    fm_pr_gitlab_path_valid "$path" || return 1
+    FM_PR_PROVIDER=gitlab
+    FM_PR_URL=$raw
+    FM_PR_HOST=$host
+    FM_PR_PATH=$path
+    FM_PR_NUMBER=${BASH_REMATCH[3]}
+    return 0
+  fi
+  # Gitea's pull request page is /<owner>/<repository>/pulls/<number>, with the
+  # segment plural. The authority is captured whole, port included, because the
+  # port belongs to the identity; the owner and repository are separate captures
+  # because Gitea's path is exactly two segments deep.
+  pattern='^https://([a-z0-9.-]{1,253}(:[0-9]{1,5})?)/([A-Za-z0-9._-]{1,100})/([A-Za-z0-9._-]{1,100})/pulls/([1-9][0-9]*)$'
   [[ "$raw" =~ $pattern ]] || return 1
   host=${BASH_REMATCH[1]}
-  path=${BASH_REMATCH[2]}
-  fm_pr_gitlab_host_valid "$host" || return 1
-  fm_pr_gitlab_path_valid "$path" || return 1
-  FM_PR_PROVIDER=gitlab
+  owner=${BASH_REMATCH[3]}
+  repo=${BASH_REMATCH[4]}
+  fm_pr_gitea_authority_valid "$host" || return 1
+  fm_pr_gitea_segment_valid "$owner" || return 1
+  fm_pr_gitea_segment_valid "$repo" || return 1
+  FM_PR_PROVIDER=gitea
   FM_PR_URL=$raw
   FM_PR_HOST=$host
-  FM_PR_PATH=$path
-  FM_PR_NUMBER=${BASH_REMATCH[3]}
+  FM_PR_PATH="$owner/$repo"
+  # Consumed by the Gitea API path, which addresses a pull request by
+  # owner/repository/index exactly as GitHub does.
+  # shellcheck disable=SC2034
+  FM_PR_OWNER=$owner
+  # shellcheck disable=SC2034
+  FM_PR_REPO=$repo
+  FM_PR_NUMBER=${BASH_REMATCH[5]}
 }
 
 fm_pr_head_valid() {

--- a/bin/fm-pr-lib.sh
+++ b/bin/fm-pr-lib.sh
@@ -229,13 +229,13 @@ fm_pr_gitea_credential_available() {
 # Gitea. The three shapes are disjoint, so the order below only fixes which
 # pattern is tried first and never changes which provider a URL resolves to.
 #
-# FM_PR_OWNER and FM_PR_REPO are additionally set for github and gitea because
-# bin/fm-pr-merge.sh addresses GitHub by owner/repository and the Gitea API
-# addresses a pull request the same way. A gitlab URL leaves them empty, and
-# that path addresses the project by FM_PR_HOST and FM_PR_PATH instead, so a
-# merge request on any instance resolves without a hardcoded host. FM_PR_HOST
-# carries the port for a gitea URL that has one, because that port is part of
-# the canonical URL each consumer must reconstruct exactly.
+# FM_PR_OWNER and FM_PR_REPO are additionally set for github alone, because
+# bin/fm-pr-merge.sh addresses GitHub by owner/repository. A gitlab or gitea URL
+# leaves them empty; those paths address the project by FM_PR_HOST and
+# FM_PR_PATH instead, so a merge request or pull request on any instance
+# resolves without a hardcoded host. FM_PR_HOST carries the port for a gitea URL
+# that has one, because that port is part of the canonical URL each consumer
+# must reconstruct exactly.
 fm_pr_url_parse() {
   local raw=${1-} pattern host path owner repo
   local LC_ALL=C
@@ -294,12 +294,6 @@ fm_pr_url_parse() {
   FM_PR_URL=$raw
   FM_PR_HOST=$host
   FM_PR_PATH="$owner/$repo"
-  # Consumed by the Gitea API path, which addresses a pull request by
-  # owner/repository/index exactly as GitHub does.
-  # shellcheck disable=SC2034
-  FM_PR_OWNER=$owner
-  # shellcheck disable=SC2034
-  FM_PR_REPO=$repo
   FM_PR_NUMBER=${BASH_REMATCH[5]}
 }
 

--- a/bin/fm-pr-merge.sh
+++ b/bin/fm-pr-merge.sh
@@ -4,7 +4,9 @@
 # The full canonical URL is parsed by bin/fm-pr-lib.sh. A GitHub pull request is
 # addressed through gh-axi by the derived owner and repository; a GitLab merge
 # request is addressed through glab by the project URL rebuilt from the parsed
-# host and path, so any instance works and no host is hardcoded.
+# host and path, so any instance works and no host is hardcoded. A Gitea pull
+# request parses and can be watched by bin/fm-pr-check.sh, but merging one is
+# refused here before any state is recorded: no Gitea merge path is implemented.
 #
 # Merge method on GitHub defaults to --squash when the caller passes none of
 # --squash, --merge, --rebase, or --method after the optional -- separator.
@@ -208,6 +210,16 @@ if [ "$PROVIDER" = gitlab ]; then
     echo "error: merging a GitLab merge request requires $GITLAB_MISSING on PATH" >&2
     exit 1
   fi
+fi
+
+# A Gitea pull request parses and can be watched, but merging one is not
+# implemented here. The refusal has to come before anything is recorded:
+# record_pr_metadata below arms the merge poll, so a later refusal would leave
+# a watch armed for a merge this script then declined to perform, reported as
+# an invalid request rather than as an unimplemented one.
+if [ "$PROVIDER" = gitea ]; then
+  printf 'error: merging a Gitea pull request is not supported; merge %s on the forge itself\n' "$URL" >&2
+  exit 1
 fi
 
 # The recorded head is read before bin/fm-pr-check.sh rewrites the metadata,

--- a/bin/fm-pr-poll.sh
+++ b/bin/fm-pr-poll.sh
@@ -4,8 +4,14 @@
 # otherwise, including on every error, so a failed lookup can never be read as
 # a merge. The provider-tagged identity is data in the sidecar and is never
 # interpolated into this source: these bytes are identical for every task.
-# Each provider is read through its own standard CLI, gh for GitHub and glab
-# for GitLab, so an upstream checkout needs no extra tooling to follow either.
+# GitHub and GitLab are each read through their own standard CLI, gh and glab,
+# so an upstream checkout needs no extra tooling to follow either. Gitea has no
+# CLI in that set, so it is read from its own REST API with curl and jq, using
+# the credential the operator already holds for that instance in git's own
+# credential helper chain; no firstmate-specific token or credential store is
+# introduced. bin/fm-pr-check.sh requires all three tools and a resolvable
+# credential before it arms a Gitea watch, because an unreadable merge state is
+# silent here and silence must never be read as "not merged".
 set -u
 LC_ALL=C
 export LC_ALL
@@ -103,6 +109,72 @@ case "$provider" in
     # unreadable merge request stays silent instead of reporting a merge.
     raw=$(glab mr view "$number" -R "https://$host/$path" 2>/dev/null) || exit 0
     state=$(printf '%s\n' "$raw" | sed -n 's/^state:[[:space:]]*//p' | head -1) || exit 0
+    [ "$state" = merged ] && printf '%s\n' merged
+    ;;
+  gitea)
+    # Gitea commonly serves a non-default port, so the stored authority is
+    # host[:port] and both halves are revalidated before either is used.
+    port=
+    hostname=$host
+    case "$host" in
+      *:*) hostname=${host%%:*}; port=${host#*:} ;;
+    esac
+    if [ -n "$port" ]; then
+      case "$port" in
+        *[!0-9]*|0*) exit 0 ;;
+      esac
+      [ "${#port}" -ge 1 ] && [ "${#port}" -le 5 ] || exit 0
+      [ "$port" -ge 1 ] && [ "$port" -le 65535 ] || exit 0
+    fi
+    [ "${#hostname}" -ge 1 ] && [ "${#hostname}" -le 253 ] || exit 0
+    [ "$hostname" != github.com ] || exit 0
+    case "$hostname" in
+      .*|*.|*..*|*[!a-z0-9.-]*) exit 0 ;;
+    esac
+    # Gitea has no nested namespaces: the path is exactly owner/repository.
+    case "$path" in
+      */*/*|/*|*/) exit 0 ;;
+      */*) ;;
+      *) exit 0 ;;
+    esac
+    owner=${path%%/*}
+    repo=${path#*/}
+    for segment in "$owner" "$repo"; do
+      [ "${#segment}" -ge 1 ] && [ "${#segment}" -le 100 ] || exit 0
+      case "$segment" in
+        .|..|-*|*.git|*[!A-Za-z0-9._-]*) exit 0 ;;
+      esac
+    done
+    [ "$url" = "https://$host/$owner/$repo/pulls/$number" ] || exit 0
+    command -v curl >/dev/null 2>&1 || exit 0
+    command -v jq >/dev/null 2>&1 || exit 0
+    command -v git >/dev/null 2>&1 || exit 0
+    # The credential comes from git's helper chain for this exact authority, so
+    # the instance's own stored login is reused rather than a second one being
+    # invented. The prompt and askpass paths are pinned off: an unattended poll
+    # cannot answer either, and a missing credential must fail rather than hang.
+    filled=$(printf 'protocol=https\nhost=%s\n\n' "$host" \
+      | GIT_TERMINAL_PROMPT=0 GIT_ASKPASS=/usr/bin/false git credential fill 2>/dev/null) || exit 0
+    user=$(printf '%s\n' "$filled" | sed -n 's/^username=//p' | head -1)
+    secret=$(printf '%s\n' "$filled" | sed -n 's/^password=//p' | head -1)
+    [ -n "$user" ] && [ -n "$secret" ] || exit 0
+    # The credential is handed to curl on stdin as a config file rather than on
+    # the command line, so it never appears in this process's arguments. curl's
+    # config parser reads backslash and double quote as escapes inside a quoted
+    # value, so both are escaped rather than assumed absent from a token.
+    user=${user//\\/\\\\}
+    user=${user//\"/\\\"}
+    secret=${secret//\\/\\\\}
+    secret=${secret//\"/\\\"}
+    # --fail turns any HTTP error into a non-zero exit, so an unauthorized,
+    # missing, or moved pull request stays silent instead of being parsed. Only
+    # an exact JSON "merged": true wakes firstmate; every other body, including
+    # one this build cannot parse, produces nothing rather than a false merge.
+    body=$(printf 'user = "%s:%s"\n' "$user" "$secret" \
+      | curl -sS --fail --max-time 20 -K - \
+        "https://$host/api/v1/repos/$owner/$repo/pulls/$number" 2>/dev/null) || exit 0
+    state=$(printf '%s' "$body" \
+      | jq -r 'if type == "object" and .merged == true then "merged" else "open" end' 2>/dev/null) || exit 0
     [ "$state" = merged ] && printf '%s\n' merged
     ;;
   *) exit 0 ;;

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -1378,7 +1378,9 @@ work_is_landed() {
 
 # The completion links this teardown already holds locally. A scout's
 # deliverable is its report, a local-only ship lands on local main, and every
-# other ship carries the PR recorded on its own record.
+# other ship carries the PR recorded on its own record. How that PR URL is
+# recorded belongs to fm_backlog_completion_link_args, which decides from the
+# URL rather than the forge.
 BACKLOG_DONE_ARGS=()
 backlog_done_args() {
   local data_relative
@@ -1391,8 +1393,9 @@ backlog_done_args() {
     *)
       if [ "$MODE" = local-only ]; then
         BACKLOG_DONE_ARGS=(--note "local main")
-      elif [ -n "$PR_URL" ]; then
-        BACKLOG_DONE_ARGS=(--pr "$PR_URL")
+      else
+        fm_backlog_completion_link_args "$PR_URL"
+        BACKLOG_DONE_ARGS=("${FM_BACKLOG_COMPLETION_LINK_ARGS[@]+"${FM_BACKLOG_COMPLETION_LINK_ARGS[@]}"}")
       fi
       ;;
   esac

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -307,6 +307,8 @@ PR-based task merges go through `bin/fm-pr-merge.sh`, which records `pr=` and an
 The helper requires a full canonical URL and rejects malformed URLs or repo override flags before recording merge state.
 A `https://github.com/<owner>/<repo>/pull/<n>` URL invokes `gh-axi pr merge <n> --repo <owner>/<repo>`, defaults to `--squash`, and preserves explicit merge-method flags.
 A `https://<host>/<path>/-/merge_requests/<n>` URL (see [docs/gitlab-merge-watch.md](gitlab-merge-watch.md)) invokes `glab mr merge <n> -R https://<host>/<path>`, so the instance comes from the URL, and adds no merge-method flag because the project's own merge method applies.
+A `https://<host>/<owner>/<repo>/pulls/<n>` URL (see [docs/gitea-merge-watch.md](gitea-merge-watch.md)) is recognised as Gitea by that path segment rather than by any hostname, so a self-hosted instance on any host and any port is recorded and watched.
+Its merge state is read from the instance's own REST API with the credential git's helper chain already holds for that host, and merging one is refused before anything is recorded because no Gitea merge path is implemented.
 That path merges only after one live read of the merge request confirms it is open, mergeable, conflict-free, with blocking discussions resolved and a successful pipeline at the current head, and it binds the merge to that verified head; recorded metadata is never the authority for those conditions because a rebase leaves it stale.
 After either forge command returns, the script confirms the PR or MR actually landed, and only a confirmed landing records a landed outcome; a queued or unconfirmed request records none and leaves its poll armed.
 On GitLab an auto-merge-queued or unconfirmed request is reported without failing the run.

--- a/docs/documentation-audiences.json
+++ b/docs/documentation-audiences.json
@@ -353,6 +353,10 @@
       "audience": "maintainer-verification"
     },
     {
+      "path": "docs/gitea-merge-watch.md",
+      "audience": "maintainer-verification"
+    },
+    {
       "path": "docs/gitlab-merge-watch.md",
       "audience": "maintainer-verification"
     },

--- a/docs/gitea-merge-watch.md
+++ b/docs/gitea-merge-watch.md
@@ -200,10 +200,10 @@ g3.meta
 Merge a Gitea pull request on the forge itself.
 The watch then reports the merge exactly as it does for a merge performed anywhere else.
 
-## The task backlog still cannot hold a Gitea URL
+## How the task backlog records a Gitea URL
 
-`tasks-axi` ships from a separate repository, `github.com/kunchenguid/tasks-axi`, so its validator is not firstmate's to widen and nothing here works around it.
-At version 0.2.5 its `--pr` validator is `/^https:\/\/[^?#\s]+\/pull\/\d+$/`, singular, so a Gitea URL is rejected:
+`tasks-axi` ships from a separate repository, `github.com/kunchenguid/tasks-axi`, so its validator is not firstmate's to widen from this checkout.
+At version 0.2.5 its `--pr` flag accepts only an http(s) URL whose path ends in `/pull/<number>`, singular, so a Gitea URL is rejected there:
 
 ```
 $ tasks-axi update gitea-probe --pr https://code.fedgroup.co.za:7990/Firefly/Zuri2/pulls/188
@@ -218,10 +218,21 @@ help[1]:
 
 The GitHub URL is accepted on the same command and the same throwaway backlog, so the rejection is the path segment and nothing else.
 
-Until that repository accepts `/pulls/<number>`, a Gitea pull request URL lives in the task's free-form note by deliberate choice, not by accident.
-The URL firstmate itself watches is unaffected: `bin/fm-pr-check.sh` records it as `pr=` in the task's own metadata, shown above.
+The backlog does hold the link, in the note rather than the pr field.
+`fm_backlog_completion_link_args` in `bin/fm-backlog-transition-lib.sh` is the single rule every close path uses, and it decides from the URL rather than from the forge.
+A URL whose path ends in `/pull/<number>` is recorded through `--pr` exactly as before.
+Any other URL is recorded through `--note`, which places it on its own body line under the closed row, still a link a reader can click.
+One rule therefore covers Gitea's `/pulls/<number>` and GitLab's `/-/merge_requests/<number>` alike, and nothing about a closed GitHub task changes.
+
+A URL that is not a well-formed https URL at all is still refused by the pending-close record validator, so an unrecordable close fails visibly rather than closing the row with a broken link.
+Widening the `--pr` validator to accept `/pulls/<number>` belongs to the `tasks-axi` repository and is filed there, not here.
+
+The URL firstmate itself watches is unaffected either way: `bin/fm-pr-check.sh` records it as `pr=` in the task's own metadata, shown above.
 
 ## Hermetic regression coverage
 
 `tests/fm-pr-check-security.test.sh` covers the parser, the poll, the arming refusals, and the merge refusal without reaching any instance.
 It pins the proven URL and a default-port Gitea URL as gitea, keeps a GitHub `/pull/<n>` URL and a GitLab `/-/merge_requests/<n>` URL parsing as before, rejects twenty-three near-miss Gitea URLs, and drives the poll against a fake curl and a fake `git credential fill` to assert the API address, the redacted argv, the escaped stdin config, and silence on every failure and every tampered sidecar.
+
+`tests/fm-teardown.test.sh` covers the close itself against the real `tasks-axi`.
+It tears a shipped task down three times, once per forge, and reads the closed row back through `tasks-axi show --full`: the GitHub URL lands in the row's `pr` link, the Gitea and GitLab URLs land in the row's body, and no pending-close record is left behind in any of the three.

--- a/docs/gitea-merge-watch.md
+++ b/docs/gitea-merge-watch.md
@@ -1,0 +1,227 @@
+# Gitea pull request watch
+
+Empirical record for the merge watch on Gitea, alongside the existing GitHub and GitLab ones.
+Every command below was run on 2026-09-08 and every output is reproduced exactly, with the credential's password redacted and nothing else changed.
+
+## Versions
+
+```
+$ git --version
+git version 2.55.0
+
+$ curl --version | head -1
+curl 8.7.1 (x86_64-apple-darwin25.0) libcurl/8.7.1 (SecureTransport) LibreSSL/3.3.6 zlib/1.2.12 nghttp2/1.68.1
+
+$ jq --version
+jq-1.8.2
+
+$ bash --version | head -1
+GNU bash, version 3.2.57(1)-release (arm64-apple-darwin25)
+
+$ sw_vers -productVersion
+26.5.2
+```
+
+## The evidence instance
+
+All live evidence here reads `Firefly/Zuri2` on a private Gitea instance at `code.fedgroup.co.za:7990`.
+That instance is not public, so a reader outside its network cannot rerun these commands; the hermetic equivalents in `tests/fm-pr-check-security.test.sh` are what CI enforces everywhere.
+The instance is used anyway because two of its properties are the whole point of this work and no public fixture has them: it serves a non-default port, and it is reachable only with a credential the operator already holds.
+Pull request 188 is merged and pull request 149 is open, so both outcomes are shown against real data.
+
+Every run below used a throwaway `FM_HOME` under the scratchpad, so no live task record was touched.
+
+## Why the path segment identifies Gitea, not the hostname
+
+A self-hosted forge can live on any hostname and any port, so a hostname test would recognise this instance and no other.
+The three forges' pull request paths are disjoint instead: GitHub uses `/pull/<n>` under `github.com`, GitLab uses `/-/merge_requests/<n>`, and Gitea uses `/pulls/<n>`, plural.
+`fm_pr_url_parse` in `bin/fm-pr-lib.sh` therefore matches Gitea on that segment alone, and the GitHub and GitLab branches keep matching exactly as they did.
+
+Gitea has no nested namespaces, so a project is addressed by exactly one owner and one repository, unlike GitLab where a project sits under at least one group at no fixed depth.
+The stored record carries `provider`, `url`, `host`, `path`, and `number` as before, with the host holding `host:port` when the instance uses one, and every consumer rebuilds the URL from those parts and refuses any record that does not reconstruct the stored URL exactly.
+
+## Why the credential comes from git's own helper chain
+
+Gitea has no CLI in the set firstmate already requires, so the merge state is read from the instance's REST API rather than through a tool like `gh` or `glab`.
+That read needs a credential, and the operator already holds one for the host they clone and push to.
+`git credential fill` returns it from whatever helper chain is configured, so no firstmate-specific token, token file, or environment variable is introduced:
+
+```
+$ printf 'protocol=https\nhost=code.fedgroup.co.za:7990\n\n' \
+    | GIT_TERMINAL_PROMPT=0 GIT_ASKPASS=/usr/bin/false git credential fill
+protocol=https
+host=code.fedgroup.co.za:7990
+username=MarcoCerutti
+password=<redacted>
+```
+
+The prompt and askpass paths are pinned off because an unattended poll cannot answer either, so a missing credential fails rather than hanging.
+The credential is handed to curl as a config file on stdin, never on the command line, so it never appears in the poll process's arguments; `tests/fm-pr-check-security.test.sh` asserts both halves of that against a fake curl that records its argv and its stdin.
+
+## What the API returns
+
+The base URL is derived from the parsed pull request URL, so the host, the port, and the project all come from the record rather than from any configured default:
+
+```
+$ curl -sS --fail --max-time 20 -K - \
+    "https://code.fedgroup.co.za:7990/api/v1/repos/Firefly/Zuri2/pulls/188" \
+    | jq '{number, state, merged, merge_commit_sha}'
+{
+  "number": 188,
+  "state": "closed",
+  "merged": true,
+  "merge_commit_sha": "fbda0283584299cebd1363e5fdeafe3c47560f4a"
+}
+```
+
+Only an exact JSON `"merged": true` wakes firstmate.
+`state` is `closed` on a merged pull request and on a declined one alike, so it is not the field the poll decides on.
+
+## End to end: arming and polling a real pull request
+
+Two tasks were armed against the instance, one on the merged pull request and one on the open one:
+
+```
+$ fm-pr-check.sh g1 https://code.fedgroup.co.za:7990/Firefly/Zuri2/pulls/188
+armed: state/g1.check.sh
+$ fm-pr-check.sh g2 https://code.fedgroup.co.za:7990/Firefly/Zuri2/pulls/149
+armed: state/g2.check.sh
+```
+
+The stored record, showing the port as part of the host and the owner and repository as the whole path:
+
+```
+$ cat state/g1.pr-poll
+gitea
+https://code.fedgroup.co.za:7990/Firefly/Zuri2/pulls/188
+code.fedgroup.co.za:7990
+Firefly/Zuri2
+188
+```
+
+The provenance record, on the same version tag the other providers use:
+
+```
+$ cat state/g1.pr-poll-registration
+fm-pr-poll-registration-v2
+g1
+gitea
+https://code.fedgroup.co.za:7990/Firefly/Zuri2/pulls/188
+code.fedgroup.co.za:7990
+Firefly/Zuri2
+188
+960bbbee3e03a14ca33854f603fdff171d6176ad1a0b80da8cec1d7d0e9bb729
+44c2a922497ce8a7f8e0ec5892090e52fb0d486881139da3bb8617b3e7743f2d
+16777233:458805547
+16777233:458805548
+```
+
+The task metadata now holds the URL the captain can quote:
+
+```
+$ grep '^pr' state/g1.meta
+pr=https://code.fedgroup.co.za:7990/Firefly/Zuri2/pulls/188
+```
+
+The published poll is the shared program byte for byte, with no task or PR data compiled into it:
+
+```
+$ cmp bin/fm-pr-poll.sh state/g1.check.sh && echo identical
+identical
+```
+
+Running each poll the way the watcher does, where an empty result means the poll stayed silent and produced no wake:
+
+```
+$ fm-pr-poll.sh --validated $(tr '\n' ' ' < state/g1.pr-poll)
+merged
+$ fm-pr-poll.sh --validated $(tr '\n' ' ' < state/g2.pr-poll)
+```
+
+The merged pull request produces exactly one `merged` line and the open one produces nothing.
+
+## A missing tool or credential produces no wake, never a false merge
+
+The poll is silent on every error by design, so a missing `curl` would otherwise be indistinguishable from a pull request that is never merged.
+With `curl` removed from `PATH`, the poll stays silent even for the pull request that is genuinely merged:
+
+```
+$ PATH="$nocurl" fm-pr-poll.sh --validated $(tr '\n' ' ' < state/g1.pr-poll)
+$ echo $?
+0
+```
+
+Arming is the one point where that can be reported, so it refuses there instead of arming a watch that can never fire:
+
+```
+$ PATH="$nocurl" fm-pr-check.sh g3 https://code.fedgroup.co.za:7990/Firefly/Zuri2/pulls/188
+error: watching a Gitea pull request requires curl on PATH
+$ echo $?
+1
+```
+
+An unresolvable credential is reported the same way, and names the command that stores one:
+
+```
+$ HOME="$nohome" fm-pr-check.sh g3 https://code.fedgroup.co.za:7990/Firefly/Zuri2/pulls/188
+error: watching a Gitea pull request on code.fedgroup.co.za:7990 requires a git credential for that host; store one with: printf 'protocol=https\nhost=code.fedgroup.co.za:7990\nusername=<user>\npassword=<token>\n\n' | git credential approve
+$ echo $?
+1
+```
+
+Neither refusal armed a poll or recorded a `pr=`, so a missing requirement leaves no half-prepared watch behind:
+
+```
+$ ls state/ | grep g3
+g3.meta
+```
+
+A GitHub task is unaffected by a missing `curl`:
+
+```
+$ PATH="$nocurl" fm-pr-check.sh g4 https://github.com/kunchenguid/firstmate/pull/3904
+armed: state/g4.check.sh
+```
+
+## Merging is refused, and refused before anything is recorded
+
+A Gitea pull request parses and can be watched, but `bin/fm-pr-merge.sh` implements no Gitea merge path.
+The refusal comes before the shared recording helper runs, because that helper arms the merge poll: a later refusal would leave a watch armed for a merge the script then declined to perform.
+
+```
+$ fm-pr-merge.sh g3 https://code.fedgroup.co.za:7990/Firefly/Zuri2/pulls/188
+error: merging a Gitea pull request is not supported; merge https://code.fedgroup.co.za:7990/Firefly/Zuri2/pulls/188 on the forge itself
+$ echo $?
+1
+$ ls state/ | grep g3
+g3.meta
+```
+
+Merge a Gitea pull request on the forge itself.
+The watch then reports the merge exactly as it does for a merge performed anywhere else.
+
+## The task backlog still cannot hold a Gitea URL
+
+`tasks-axi` ships from a separate repository, `github.com/kunchenguid/tasks-axi`, so its validator is not firstmate's to widen and nothing here works around it.
+At version 0.2.5 its `--pr` validator is `/^https:\/\/[^?#\s]+\/pull\/\d+$/`, singular, so a Gitea URL is rejected:
+
+```
+$ tasks-axi update gitea-probe --pr https://code.fedgroup.co.za:7990/Firefly/Zuri2/pulls/188
+error: "--pr must be an http(s) pull request URL ending in /pull/<number>"
+code: VALIDATION_ERROR
+
+$ tasks-axi update gitea-probe --pr https://github.com/kunchenguid/firstmate/pull/3904
+  body: ""
+help[1]:
+  - Run `tasks-axi show gitea-probe --full` to see the result
+```
+
+The GitHub URL is accepted on the same command and the same throwaway backlog, so the rejection is the path segment and nothing else.
+
+Until that repository accepts `/pulls/<number>`, a Gitea pull request URL lives in the task's free-form note by deliberate choice, not by accident.
+The URL firstmate itself watches is unaffected: `bin/fm-pr-check.sh` records it as `pr=` in the task's own metadata, shown above.
+
+## Hermetic regression coverage
+
+`tests/fm-pr-check-security.test.sh` covers the parser, the poll, the arming refusals, and the merge refusal without reaching any instance.
+It pins the proven URL and a default-port Gitea URL as gitea, keeps a GitHub `/pull/<n>` URL and a GitLab `/-/merge_requests/<n>` URL parsing as before, rejects twenty-three near-miss Gitea URLs, and drives the poll against a fake curl and a fake `git credential fill` to assert the API address, the redacted argv, the escaped stdin config, and silence on every failure and every tampered sidecar.

--- a/docs/gitlab-merge-watch.md
+++ b/docs/gitlab-merge-watch.md
@@ -273,3 +273,8 @@ It is optional by design, and the other consumers already treat it that way: `bi
 The merge path does not record one either, and deliberately does not depend on one.
 A rebase moves the head and leaves any recorded value stale, so a merge decided from metadata can verify a commit that no longer exists.
 Reading the head live at merge time, reporting a recorded value that disagrees, and binding the merge to what was actually verified is what closes that gap.
+
+## How the task backlog records a merge request URL
+
+`tasks-axi` holds a completion link through `--pr` only when the URL's path ends in `/pull/<number>`, so a `/-/merge_requests/<number>` URL is recorded through `--note` and appears on the closed row's body line instead.
+That routing is decided by the URL rather than by the forge and is described once, with its evidence, in [docs/gitea-merge-watch.md](gitea-merge-watch.md#how-the-task-backlog-records-a-gitea-url).

--- a/tests/fm-pr-check-security.test.sh
+++ b/tests/fm-pr-check-security.test.sh
@@ -426,20 +426,20 @@ EOF
   # Gitea is recognised by its plural "/pulls/" segment and never by hostname,
   # so a self-hosted instance on any host and any port resolves. The proven
   # instance in docs/gitea-merge-watch.md is the first row.
-  while IFS='|' read -r url host path owner repo number; do
+  while IFS='|' read -r url host path number; do
     [ -n "$url" ] || continue
     fm_pr_url_parse "$url" || fail "parser rejected a canonical Gitea pull request URL"
     [ "$FM_PR_PROVIDER" = gitea ] || fail "parser did not tag a Gitea pull request URL as gitea"
     [ "$FM_PR_URL" = "$url" ] || fail "parser changed a canonical Gitea pull request URL"
     [ "$FM_PR_HOST" = "$host" ] || fail "parser returned wrong Gitea authority"
     [ "$FM_PR_PATH" = "$path" ] || fail "parser returned wrong Gitea project path"
-    [ "$FM_PR_OWNER" = "$owner" ] || fail "parser returned wrong Gitea owner"
-    [ "$FM_PR_REPO" = "$repo" ] || fail "parser returned wrong Gitea repository"
     [ "$FM_PR_NUMBER" = "$number" ] || fail "parser returned wrong Gitea pull request number"
+    [ -z "$FM_PR_OWNER" ] && [ -z "$FM_PR_REPO" ] \
+      || fail "parser set GitHub owner/repository for a Gitea pull request URL"
   done <<'EOF'
-https://code.fedgroup.co.za:7990/Firefly/Zuri2/pulls/188|code.fedgroup.co.za:7990|Firefly/Zuri2|Firefly|Zuri2|188
-https://gitea.example.com/Firefly/Zuri2/pulls/7|gitea.example.com|Firefly/Zuri2|Firefly|Zuri2|7
-https://git.internal:3000/team/tools_v2.x/pulls/123456|git.internal:3000|team/tools_v2.x|team|tools_v2.x|123456
+https://code.fedgroup.co.za:7990/Firefly/Zuri2/pulls/188|code.fedgroup.co.za:7990|Firefly/Zuri2|188
+https://gitea.example.com/Firefly/Zuri2/pulls/7|gitea.example.com|Firefly/Zuri2|7
+https://git.internal:3000/team/tools_v2.x/pulls/123456|git.internal:3000|team/tools_v2.x|123456
 EOF
   fm_pr_url_parse https://github.com/a/b/pull/1 || fail "parser rejected canonical URL"
   [ "$FM_PR_PROVIDER" = github ] || fail "parser did not tag a pull request URL as github"

--- a/tests/fm-pr-check-security.test.sh
+++ b/tests/fm-pr-check-security.test.sh
@@ -221,6 +221,30 @@ run_merge_entry() {
     "$PR_MERGE" "$@"
 }
 
+# Mirror the whole search path with one command removed. An absent-tool case
+# proves nothing while a real copy of that tool is still reachable anywhere on
+# PATH, so the mirror replaces the search path rather than prepending to it.
+mirror_path_without() {  # <case dir> <command name>; prints the mirror directory
+  local dir=$1 missing=$2 out bindir entry name
+  out="$dir/without-$missing"
+  mkdir -p "$out"
+  while IFS= read -r bindir; do
+    [ -d "$bindir" ] || continue
+    for entry in "$bindir"/*; do
+      [ -e "$entry" ] || continue
+      name=$(basename "$entry")
+      [ "$name" = "$missing" ] && continue
+      [ -e "$out/$name" ] || ln -s "$entry" "$out/$name" 2>/dev/null
+    done
+  done <<EOF
+$dir/fakebin
+$(printf '%s\n' "$BASE_PATH" | tr ':' '\n')
+EOF
+  ! PATH="$out" command -v "$missing" >/dev/null 2>&1 \
+    || fail "the $missing-free search path still resolved $missing"
+  printf '%s\n' "$out"
+}
+
 # shellcheck disable=SC2016 # Literal rejected URL bytes are parser test data.
 INVALID_URLS=(
   'https://gitlab.com/single/-/merge_requests/1'
@@ -310,6 +334,29 @@ INVALID_URLS=(
   'https://github.com/o/'\''"r"'\''/pull/1'
   "https://github.com/o/r/pull/1'"
   'https://github.com/o/r/pull/1"'
+  'https://code.fedgroup.co.za:7990/Firefly/Zuri2/issues/188'
+  'https://code.fedgroup.co.za:7990/Firefly/Zuri2/pull/188'
+  'https://code.fedgroup.co.za:7990/Firefly/Zuri2/pulls/188/files'
+  'https://code.fedgroup.co.za:7990/Firefly/Zuri2/pulls/188/'
+  'https://code.fedgroup.co.za:7990/Firefly/Zuri2/pulls/0'
+  'https://code.fedgroup.co.za:7990/Firefly/Zuri2/pulls/01'
+  'https://code.fedgroup.co.za:70000/Firefly/Zuri2/pulls/188'
+  'https://code.fedgroup.co.za:07990/Firefly/Zuri2/pulls/188'
+  'https://code.fedgroup.co.za:/Firefly/Zuri2/pulls/188'
+  'https://github.com/o/r/pulls/1'
+  'https://gitea.example/Firefly/Zuri2/sub/pulls/188'
+  'https://gitea.example/Firefly/pulls/188'
+  'https://gitea.example/../Zuri2/pulls/188'
+  'https://gitea.example/Firefly/../pulls/188'
+  'https://gitea.example//Zuri2/pulls/188'
+  'https://gitea.example/Firefly//pulls/188'
+  'https://gitea.example/-Firefly/Zuri2/pulls/188'
+  'https://gitea.example/Firefly/Zuri2.git/pulls/188'
+  'https://user@gitea.example/Firefly/Zuri2/pulls/188'
+  'https://GITEA.example/Firefly/Zuri2/pulls/188'
+  'http://gitea.example/Firefly/Zuri2/pulls/188'
+  'https://gitea.example/Firefly/Zuri2/pulls/188?tab=files'
+  'https://gitea.example/Firefly/Zuri2/pulls/188#issuecomment-1'
 )
 
 # shellcheck disable=SC2016 # Literal shell syntax is task-ID test data.
@@ -375,6 +422,24 @@ https://gitlab.com/group/project/-/merge_requests/1|gitlab.com|group/project|1
 https://gitlab.com/group/sub/deep/project/-/merge_requests/42|gitlab.com|group/sub/deep/project|42
 https://gitlab.example.co.uk/g/p/-/merge_requests/7|gitlab.example.co.uk|g/p|7
 https://code.internal/team/tools/ci-runner/-/merge_requests/123456|code.internal|team/tools/ci-runner|123456
+EOF
+  # Gitea is recognised by its plural "/pulls/" segment and never by hostname,
+  # so a self-hosted instance on any host and any port resolves. The proven
+  # instance in docs/gitea-merge-watch.md is the first row.
+  while IFS='|' read -r url host path owner repo number; do
+    [ -n "$url" ] || continue
+    fm_pr_url_parse "$url" || fail "parser rejected a canonical Gitea pull request URL"
+    [ "$FM_PR_PROVIDER" = gitea ] || fail "parser did not tag a Gitea pull request URL as gitea"
+    [ "$FM_PR_URL" = "$url" ] || fail "parser changed a canonical Gitea pull request URL"
+    [ "$FM_PR_HOST" = "$host" ] || fail "parser returned wrong Gitea authority"
+    [ "$FM_PR_PATH" = "$path" ] || fail "parser returned wrong Gitea project path"
+    [ "$FM_PR_OWNER" = "$owner" ] || fail "parser returned wrong Gitea owner"
+    [ "$FM_PR_REPO" = "$repo" ] || fail "parser returned wrong Gitea repository"
+    [ "$FM_PR_NUMBER" = "$number" ] || fail "parser returned wrong Gitea pull request number"
+  done <<'EOF'
+https://code.fedgroup.co.za:7990/Firefly/Zuri2/pulls/188|code.fedgroup.co.za:7990|Firefly/Zuri2|Firefly|Zuri2|188
+https://gitea.example.com/Firefly/Zuri2/pulls/7|gitea.example.com|Firefly/Zuri2|Firefly|Zuri2|7
+https://git.internal:3000/team/tools_v2.x/pulls/123456|git.internal:3000|team/tools_v2.x|team|tools_v2.x|123456
 EOF
   fm_pr_url_parse https://github.com/a/b/pull/1 || fail "parser rejected canonical URL"
   [ "$FM_PR_PROVIDER" = github ] || fail "parser did not tag a pull request URL as github"
@@ -1285,7 +1350,7 @@ SH
 # https://gitlab.com/KarotKris/gitlab-merge-watch-fixture is in
 # docs/gitlab-merge-watch.md; this exercises the same paths hermetically.
 test_gitlab_merge_watch() {
-  local dir state out rc url value noglab entry bindir name
+  local dir state out rc url value noglab
   dir=$(make_case gitlab-merge-watch)
   state="$dir/home/state"
   url=https://gitlab.example/group/subgroup/project/-/merge_requests/7
@@ -1321,25 +1386,8 @@ group/subgroup/project
   ! grep -qF -- "$url" "$dir/glab.log" \
     || fail "GitLab poll passed a merge request URL to glab"
 
-  # An absent CLI must produce no wake rather than a false merge. The whole
-  # search path is mirrored without glab, because a real glab anywhere on
-  # PATH would make this prove nothing.
-  noglab="$dir/noglab"
-  mkdir -p "$noglab"
-  while IFS= read -r bindir; do
-    [ -d "$bindir" ] || continue
-    for entry in "$bindir"/*; do
-      [ -e "$entry" ] || continue
-      name=$(basename "$entry")
-      [ "$name" = glab ] && continue
-      [ -e "$noglab/$name" ] || ln -s "$entry" "$noglab/$name" 2>/dev/null
-    done
-  done <<EOF
-$dir/fakebin
-$(printf '%s\n' "$BASE_PATH" | tr ':' '\n')
-EOF
-  ! PATH="$noglab" command -v glab >/dev/null 2>&1 \
-    || fail "the glab-free search path still resolved glab"
+  # An absent CLI must produce no wake rather than a false merge.
+  noglab=$(mirror_path_without "$dir" glab)
   out=$(FM_TEST_GLAB_STATE=merged FM_TEST_GH_LOG="$dir/gh.log" FM_TEST_GLAB_LOG="$dir/glab.log" \
     PATH="$noglab" \
     bash "$state/task-a.check.sh")
@@ -1394,6 +1442,177 @@ EOF
     || fail "merge wrapper merged despite an unreadable merge request state"
 
   pass "GitLab merge requests are followed on any instance and never wake falsely"
+}
+
+# Gitea has no CLI in firstmate's tool set, so the watch reads that instance's
+# own REST API with curl and jq and resolves its credential through git's own
+# helper chain. These stand in for the network and for the operator's stored
+# login; jq is the real one, so the merge verdict is decided by the same parse
+# the shipped watch runs.
+write_gitea_fakes() {
+  local dir=$1
+  cat > "$dir/fakebin/git" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "${FM_TEST_GIT_LOG:-/dev/null}"
+if [ "${1:-}" = credential ] && [ "${2:-}" = fill ]; then
+  cat >> "${FM_TEST_GIT_STDIN:-/dev/null}"
+  [ "${FM_TEST_GIT_CRED_FAIL:-0}" = 0 ] || exit 1
+  [ "${FM_TEST_GIT_CRED_EMPTY:-0}" = 0 ] || exit 0
+  printf 'protocol=https\nusername=%s\npassword=%s\n' \
+    "${FM_TEST_GIT_USER:-fixture-user}" "${FM_TEST_GIT_PASSWORD:-fixture-secret}"
+  exit 0
+fi
+exit 0
+SH
+  cat > "$dir/fakebin/curl" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "${FM_TEST_CURL_LOG:-/dev/null}"
+cat >> "${FM_TEST_CURL_STDIN:-/dev/null}"
+[ "${FM_TEST_CURL_FAIL:-0}" = 0 ] || exit 22
+printf '%s' "${FM_TEST_GITEA_BODY-}"
+SH
+  chmod +x "$dir/fakebin/git" "$dir/fakebin/curl"
+  ln -sf "$REAL_JQ" "$dir/fakebin/jq"
+  : > "$dir/git.log"
+  : > "$dir/git.stdin"
+  : > "$dir/curl.log"
+  : > "$dir/curl.stdin"
+}
+
+run_gitea_poll() {
+  local dir=$1
+  FM_TEST_GIT_LOG="$dir/git.log" FM_TEST_GIT_STDIN="$dir/git.stdin" \
+    FM_TEST_CURL_LOG="$dir/curl.log" FM_TEST_CURL_STDIN="$dir/curl.stdin" \
+    PATH="$dir/fakebin:$BASE_PATH" \
+    bash "$dir/home/state/task-a.check.sh"
+}
+
+# The Gitea watch must follow a pull request on a self-hosted instance,
+# including one published on a non-default port, and must never turn an
+# unreadable pull request into a merge. Its evidence against the real instance
+# is in docs/gitea-merge-watch.md; this exercises the same paths hermetically.
+test_gitea_merge_watch() {
+  local dir state out rc url value before nocurl
+  dir=$(make_case gitea-merge-watch)
+  state="$dir/home/state"
+  url=https://gitea.example:7990/Firefly/Zuri2/pulls/188
+  write_gitea_fakes "$dir"
+
+  write_poll_meta "$state" task-a "$url"
+  fm_pr_poll_prepare "$state" task-a gitea "$url" gitea.example:7990 Firefly/Zuri2 188 "$POLL" \
+    || fail "could not prepare a Gitea poll"
+  fm_pr_poll_publish_prepared || fail "could not publish a Gitea poll"
+  fm_pr_poll_artifacts_valid "$state" task-a "$POLL" \
+    || fail "published Gitea poll provenance or metadata binding was invalid"
+  [ "$(cat "$state/task-a.pr-poll")" = "gitea
+$url
+gitea.example:7990
+Firefly/Zuri2
+188" ] || fail "published Gitea sidecar bytes were not exact"
+
+  # Only an exact "merged": true wakes firstmate. Every other body, including
+  # one this build cannot parse, stays silent rather than reporting a merge.
+  for value in '{"merged": false, "state": "open"}' '{"merged": "true"}' \
+    '{"state": "closed"}' '{"merged": true' '[{"merged": true}]' 'merged' ''; do
+    out=$(FM_TEST_GITEA_BODY="$value" run_gitea_poll "$dir")
+    [ -z "$out" ] || fail "Gitea poll emitted for a body that is not an exact merge"
+  done
+  out=$(FM_TEST_GITEA_BODY='{"merged": true, "state": "closed", "merge_commit_sha": "fbda0283"}' \
+    run_gitea_poll "$dir")
+  [ "$out" = merged ] || fail "Gitea poll did not emit exactly one merged line"
+
+  # A failed read and an unresolvable credential are both silent here, because
+  # bin/fm-pr-check.sh is where a missing prerequisite is reported instead.
+  out=$(FM_TEST_CURL_FAIL=1 FM_TEST_GITEA_BODY='{"merged": true}' run_gitea_poll "$dir")
+  [ -z "$out" ] || fail "Gitea poll emitted after the API read failed"
+  out=$(FM_TEST_GIT_CRED_EMPTY=1 FM_TEST_GITEA_BODY='{"merged": true}' run_gitea_poll "$dir")
+  [ -z "$out" ] || fail "Gitea poll emitted with no credential for the instance"
+  out=$(FM_TEST_GIT_CRED_FAIL=1 FM_TEST_GITEA_BODY='{"merged": true}' run_gitea_poll "$dir")
+  [ -z "$out" ] || fail "Gitea poll emitted after the credential lookup failed"
+
+  # The API is addressed by the stored authority, owner, repository and index,
+  # and the credential is handed to curl on stdin so it never reaches argv.
+  : > "$dir/curl.log"
+  : > "$dir/curl.stdin"
+  : > "$dir/git.stdin"
+  out=$(FM_TEST_GIT_PASSWORD='tok"en\back' FM_TEST_GITEA_BODY='{"merged": true}' \
+    run_gitea_poll "$dir")
+  [ "$out" = merged ] || fail "Gitea poll did not emit for a merged pull request"
+  grep -qF -- 'https://gitea.example:7990/api/v1/repos/Firefly/Zuri2/pulls/188' "$dir/curl.log" \
+    || fail "Gitea poll did not address the instance's own API by owner, repository and index"
+  ! grep -qF -- "$url" "$dir/curl.log" \
+    || fail "Gitea poll passed the browser URL to the API"
+  grep -qxF -- 'host=gitea.example:7990' "$dir/git.stdin" \
+    || fail "Gitea poll asked git for a credential for some other authority"
+  ! grep -qF -- 'tok' "$dir/curl.log" \
+    || fail "Gitea poll exposed the credential in curl's arguments"
+  grep -qxF -- 'user = "fixture-user:tok\"en\\back"' "$dir/curl.stdin" \
+    || fail "Gitea poll did not escape the credential for curl's config parser"
+
+  # A doctored sidecar cannot redirect the poll: the stored parts must rebuild
+  # the stored URL exactly, and the port is part of that identity.
+  printf '%s\n%s\n%s\n%s\n%s\n' gitea "$url" elsewhere.example:7990 Firefly/Zuri2 188 \
+    > "$state/task-a.pr-poll"
+  out=$(FM_TEST_GITEA_BODY='{"merged": true}' run_gitea_poll "$dir")
+  [ -z "$out" ] || fail "Gitea poll emitted for a sidecar whose host was swapped"
+  printf '%s\n%s\n%s\n%s\n%s\n' gitea "$url" gitea.example:7990 Firefly/Other 188 \
+    > "$state/task-a.pr-poll"
+  out=$(FM_TEST_GITEA_BODY='{"merged": true}' run_gitea_poll "$dir")
+  [ -z "$out" ] || fail "Gitea poll emitted for a sidecar whose repository was swapped"
+  printf '%s\n%s\n%s\n%s\n%s\n' gitea "$url" gitea.example Firefly/Zuri2 188 \
+    > "$state/task-a.pr-poll"
+  out=$(FM_TEST_GITEA_BODY='{"merged": true}' run_gitea_poll "$dir")
+  [ -z "$out" ] || fail "Gitea poll emitted for a sidecar whose port was dropped"
+
+  # Arming is the one point where a missing prerequisite can still be reported,
+  # so an absent tool and an unresolvable credential each stop the watch there.
+  write_task_meta "$dir" task-b
+  nocurl=$(mirror_path_without "$dir" curl)
+  set +e
+  out=$(FM_ROOT_OVERRIDE="$dir/root" FM_HOME="$dir/home" \
+    FM_TEST_GUARD_LOG="$dir/guard.log" PATH="$nocurl" \
+    "$PR_CHECK" task-b "$url" 2>&1)
+  rc=$?
+  set -e
+  [ "$rc" -ne 0 ] || fail "arming a Gitea watch succeeded with curl absent"
+  case "$out" in
+    *"requires curl on PATH"*) ;;
+    *) fail "arming a Gitea watch with curl absent did not report the missing tool" ;;
+  esac
+  [ ! -e "$state/task-b.check.sh" ] || fail "refused Gitea arming left a poll armed"
+
+  set +e
+  out=$(FM_TEST_GIT_CRED_EMPTY=1 run_check_entry "$dir" task-b "$url" 2>&1)
+  rc=$?
+  set -e
+  [ "$rc" -ne 0 ] || fail "arming a Gitea watch succeeded with no credential for the instance"
+  case "$out" in
+    *"requires a git credential for that host"*) ;;
+    *) fail "arming a Gitea watch with no credential did not name the missing credential" ;;
+  esac
+  [ ! -e "$state/task-b.check.sh" ] || fail "refused Gitea arming left a poll armed"
+
+  out=$(run_check_entry "$dir" task-b "$url" 2>&1) \
+    || fail "arming a Gitea watch failed with every prerequisite present: $out"
+  [ -e "$state/task-b.check.sh" ] || fail "arming a Gitea watch published no poll"
+  grep -qxF "pr=$url" "$state/task-b.meta" \
+    || fail "arming a Gitea watch recorded no canonical PR URL"
+
+  # Merging a Gitea pull request is not implemented. The refusal comes before
+  # anything is recorded, so it never arms a watch for a merge it then declines.
+  write_task_meta "$dir" task-c
+  before=$(state_snapshot "$state")
+  set +e
+  run_merge_entry "$dir" task-c "$url" > "$dir/merge-c.out" 2> "$dir/merge-c.err"
+  rc=$?
+  set -e
+  [ "$rc" -ne 0 ] || fail "merge wrapper accepted a Gitea pull request"
+  grep -qF 'merging a Gitea pull request is not supported' "$dir/merge-c.err" \
+    || fail "merge wrapper refused a Gitea pull request for some other reason"
+  [ "$(state_snapshot "$state")" = "$before" ] || fail "refused Gitea merge changed state"
+  [ ! -s "$dir/gh-axi.log" ] || fail "merge wrapper reached the GitHub CLI for a Gitea URL"
+
+  pass "Gitea pull requests are followed on any instance and port and never wake falsely"
 }
 
 seed_canonical_poll() {
@@ -2129,6 +2348,7 @@ test_gitlab_merged_poll_retires() {
 
 test_parser_matrix
 test_gitlab_merge_watch
+test_gitea_merge_watch
 test_merged_poll_retires_once
 test_merged_poll_reregistration_after_notification_is_absorbed
 test_merged_poll_retries_a_failed_upward_report

--- a/tests/fm-teardown.test.sh
+++ b/tests/fm-teardown.test.sh
@@ -753,7 +753,7 @@ test_teardown_records_a_pr_url_the_backlog_can_hold() {
 
     run_teardown "$case_dir" >/dev/null \
       || fail "close-link-$label: teardown failed on a $label pull request URL"
-    [ "$(backlog_row_state "$case_dir")" = done ] \
+    [ "$(backlog_row_state "$case_dir")" = "done" ] \
       || fail "close-link-$label: teardown returned success with its backlog item still open"
     [ "$(backlog_row_field "$case_dir" links)" = "$expected_links" ] \
       || fail "close-link-$label: closed row recorded links $(backlog_row_field "$case_dir" links)"

--- a/tests/fm-teardown.test.sh
+++ b/tests/fm-teardown.test.sh
@@ -651,6 +651,14 @@ backlog_row_state() {
     sed -n 's/^  state: *//p' | head -1
 }
 
+# One field of the row as tasks-axi itself reports it, read from the structured
+# `show --full` view rather than from the rendered markdown.
+backlog_row_field() {  # <case-dir> <field>
+  local case_dir=$1 field=$2
+  tasks-axi show task-x1 --full --file "$case_dir/data/backlog.md" 2>/dev/null |
+    sed -n "s/^  $field: *//p" | head -1
+}
+
 # Build the teardown test's executable search path without lsof, regardless of
 # whether the host installs it in /usr/bin, /usr/sbin, or a package-manager bin.
 make_path_without_lsof() {  # <case-dir>
@@ -725,6 +733,40 @@ test_teardown_closes_the_backlog_item_itself() {
   printf '%s\n' "$out" | grep -F 'Run tasks-axi done' >/dev/null \
     && fail "teardown still asked a later turn to close the item it already closed: $out"
   pass "teardown closes its own backlog item before reporting success"
+}
+
+# tasks-axi accepts a completion link through --pr only when the URL's path ends
+# in /pull/<number>. A Gitea /pulls/<n> or GitLab /-/merge_requests/<n> URL is
+# rejected there, and the close runs after the endpoint and the isolated copy are
+# already gone, so a rejected close is an unfinishable teardown that retries the
+# same rejected command forever. Teardown therefore routes by the URL: the shape
+# tasks-axi holds as a link goes to --pr, everything else to --note, where the
+# closed row still shows a URL a reader can click.
+test_teardown_records_a_pr_url_the_backlog_can_hold() {
+  local case_dir label url expected_links expected_body
+  while IFS='|' read -r label url expected_links expected_body; do
+    [ -n "$label" ] || continue
+    case_dir=$(make_case "close-link-$label")
+    write_meta "$case_dir" no-mistakes ship
+    printf '%s\n' "pr=$url" >> "$case_dir/state/task-x1.meta"
+    seed_backlog_in_flight "$case_dir"
+
+    run_teardown "$case_dir" >/dev/null \
+      || fail "close-link-$label: teardown failed on a $label pull request URL"
+    [ "$(backlog_row_state "$case_dir")" = done ] \
+      || fail "close-link-$label: teardown returned success with its backlog item still open"
+    [ "$(backlog_row_field "$case_dir" links)" = "$expected_links" ] \
+      || fail "close-link-$label: closed row recorded links $(backlog_row_field "$case_dir" links)"
+    [ "$(backlog_row_field "$case_dir" body)" = "$expected_body" ] \
+      || fail "close-link-$label: closed row recorded body $(backlog_row_field "$case_dir" body)"
+    assert_absent "$case_dir/state/task-x1.backlog-close" \
+      "close-link-$label: a landed close left its pending-close record behind"
+  done <<'EOF'
+github|https://github.com/example/repo/pull/7|"pr:https://github.com/example/repo/pull/7"|""
+gitea|https://code.fedgroup.co.za:7990/Firefly/Zuri2/pulls/188|none|"https://code.fedgroup.co.za:7990/Firefly/Zuri2/pulls/188"
+gitlab|https://gitlab.example.com/group/project/-/merge_requests/42|none|"https://gitlab.example.com/group/project/-/merge_requests/42"
+EOF
+  pass "teardown records a PR URL through --pr or --note by URL shape, so every forge closes cleanly"
 }
 
 test_teardown_manual_backend_leaves_the_backlog_to_the_operator() {
@@ -3657,6 +3699,7 @@ EOF
 
 test_local_only_fork_remote_allows
 test_teardown_closes_the_backlog_item_itself
+test_teardown_records_a_pr_url_the_backlog_can_hold
 test_teardown_manual_backend_leaves_the_backlog_to_the_operator
 test_local_only_truly_unpushed_refuses
 test_local_only_merged_to_local_main_allows


### PR DESCRIPTION
## What changes for an operator

Gitea pull requests can now be recorded and watched, so a merge wakes firstmate instead of having to be spotted by hand.

Before this change, `bin/fm-pr-check.sh` rejected every Gitea pull request URL with "error: invalid PR check request", so the watcher's merge poll was never armed for any task on a Gitea-hosted project and the clone refresh a merge wake triggers never fired.

## What changed

- `bin/fm-pr-lib.sh`: `fm_pr_url_parse` accepts a third provider, `gitea`, matching `/<owner>/<repo>/pulls/<number>`.
  The forge is identified by that path segment, not by hostname, so a self-hosted instance on any host and any port parses.
  GitHub's `/pull/<number>` and GitLab's `/-/merge_requests/<number>` shapes are unchanged; the three shapes are disjoint.
- `bin/fm-pr-poll.sh`: the byte-static poll reads Gitea merge state from `GET /api/v1/repos/{owner}/{repo}/pulls/{index}`.
  The base URL is derived from the parsed PR URL itself; no host, port, org, or token is hardcoded.
  Credentials come from the operator's existing git credential helper chain for that exact authority, the same pattern the other providers already rely on, and the secret is passed to curl through a config file on stdin so it never appears in argv.
- `bin/fm-pr-check.sh`: refuses to arm a Gitea watch when `curl`, `jq`, or `git` is missing, or when no credential resolves for that host, and prints the concrete `git credential approve` recipe.
  This follows the existing GitLab precedent of reporting a missing prerequisite at arm time, because the poll itself is silent on every error by design.
- `bin/fm-backlog-transition-lib.sh` and `bin/fm-teardown.sh`: the backlog close arguments are now chosen by the URL rather than by the forge name.
  A URL whose path ends in `/pull/<number>` goes through `--pr` exactly as before; anything else goes through `--note` so the link is still recorded and clickable on the closed row.
  That fixes the same latent defect for GitLab as well as Gitea, and leaves GitHub untouched.

## The tasks-axi validator

The captain's ask also covered `tasks-axi update <id> --pr`, which rejects a Gitea URL because it requires a path ending in `/pull/<number>`.
That validator lives in a separate repository and is not firstmate's to widen from this checkout, so this change does not touch it and does not wrap or shim around it.
Instead the backlog holds the Gitea link in the task note rather than the `pr` field, which is a deliberate routing choice recorded in `docs/gitea-merge-watch.md`.
Widening the `tasks-axi` validator is filed separately.

## Tests

`tests/fm-pr-check-security.test.sh` covers the parser matrix: the proven URL `https://code.fedgroup.co.za:7990/Firefly/Zuri2/pulls/188`, a Gitea URL on a default port with no port segment, a GitHub `/pull/<n>` URL still parsed as GitHub, a GitLab `/-/merge_requests/<n>` URL still parsed as GitLab, and a URL that is not a pull request at all, still rejected.
`tests/fm-teardown.test.sh` tears a shipped task down once per forge against the real `tasks-axi` and reads the closed row back: a GitHub URL lands in `links`, Gitea and GitLab land in `body`, and no pending-close record is left behind.

The Gitea watch was proven end to end against the live instance named in the intent: the armed poll reported the merge, and an open pull request on the same instance produced no output, so a watch cannot wake falsely.

## Delivery note

This branch was validated through the no-mistakes pipeline; the review, test, document, and lint gates all carry their fix commits here.
It is opened from a fork because the author has no push access to this repository.
