### PR TITLE
test: make turn-end grace regression sensitive to beacon age

### DIFF
--- a/bin/fm-wake-lib.sh
+++ b/bin/fm-wake-lib.sh
@@ -114,7 +114,7 @@ fm_path_age() {
 # given, so a caller with no independent notion of the poll cadence still
 # derives the same default fm-watch.sh itself would use.
 # docs/turnend-guard.md "Guard grace and the poll cadence" is the single owner
-# of the rationale; every FM_GUARD_GRACE default should derive from this.
+# of the rationale and caller-specific grace defaults.
 fm_poll_derived_grace() {
   local poll=${1:-${FM_POLL:-15}} margin=60 derived
   case "$poll" in ''|*[!0-9]*) poll=15 ;; esac

--- a/tests/fm-turnend-guard.test.sh
+++ b/tests/fm-turnend-guard.test.sh
@@ -2046,26 +2046,36 @@ test_hook_away_daemon_blocks_beacon_older_than_poll_derived_grace() {
 }
 
 test_hook_no_afk_ignores_poll_derived_grace() {
-  local dir pid out status beat
-  dir=$(make_away_home_between_cycles "$TMP_ROOT/hook-no-afk-poll-grace")
-  rm -f "$dir/state/.afk"
+  local dir pid identity out status beat fresh_out fresh_status restored_out restored_status
+  dir=$(make_primary_dir "$TMP_ROOT/hook-no-afk-poll-grace")
+  : > "$dir/state/task1.meta"
   sleep 60 &
   pid=$!
-  record_daemon_lock "$dir" "$pid" || {
+  identity=$(watcher_identity "$dir" "$pid") || {
     kill "$pid" 2>/dev/null || true
     wait "$pid" 2>/dev/null || true
-    fail "could not identify live daemon holder"
+    fail "could not identify live watcher holder"
   }
-  # 400s would be within the poll-derived grace the away-mode branch would
-  # accept, but away mode is off here, so the strict watcher predicate and its
-  # flat default govern instead - old behavior, unaffected by FM_POLL.
+  record_watcher_lock "$dir" "$pid" "$identity"
+  # A fresh beacon must allow this same live watcher before age is varied;
+  # otherwise missing ownership could make the stale-beacon assertion vacuous.
+  touch "$dir/state/.last-watcher-beat"
+  fresh_out=$(FM_GUARD_GRACE='' FM_POLL=600 run_hook "$dir" false); fresh_status=$?
+  # 400s fits the away-mode poll-derived grace (660s at FM_POLL=600), but
+  # exceeds the normal 300s default. With away mode off, only age must block.
   beat=$(( $(date +%s) - 400 ))
   fm_touch_epoch "$beat" "$dir/state/.last-watcher-beat"
   out=$(FM_GUARD_GRACE='' FM_POLL=600 run_hook "$dir" false); status=$?
+  touch "$dir/state/.last-watcher-beat"
+  restored_out=$(FM_GUARD_GRACE='' FM_POLL=600 run_hook "$dir" false); restored_status=$?
   kill "$pid" 2>/dev/null || true
   wait "$pid" 2>/dev/null || true
+  expect_code 0 "$fresh_status" "without .afk, a live watcher with a fresh beacon must allow before aging"
+  [ -z "$fresh_out" ] || fail "fresh watcher control produced a block banner: $fresh_out"
   expect_code 2 "$status" "without .afk, FM_POLL must not widen the strict watcher predicate's grace"
   assert_contains "$out" "$REQUIRED_REASON" "block reason must contain the exact required instruction"
+  expect_code 0 "$restored_status" "refreshing only the beacon must restore the same watcher's healthy verdict"
+  [ -z "$restored_out" ] || fail "refreshed watcher control produced a block banner: $restored_out"
   pass "fm-turnend-guard: with away mode off, the poll-derived grace never applies"
 }
 


### PR DESCRIPTION
## Intent

A case in the turn-end guard suite PASSES without being able to fail for the reason it announces.

ESTABLISHED 2026-09-08 by the second mate during fm-turnend-guard-suite-red-on-macos, reported and
deliberately NOT fixed there because it is a different defect and that delivery was not to widen.

THE CASE: tests/fm-turnend-guard.test.sh, the case around line 2063 - 400-second beacon, away mode
off, must block. Its verdict is IDENTICAL with a 0-second beacon and a 400-second beacon: it blocks
either way. The timestamp repair gave it the input its name claims, but something other than beacon
age forces the block - the fixture records a daemon lock and no watcher lock, and with away mode off
the daemon lock proves nothing.

WHY IT MATTERS: the case cannot fall if the protection it guards disappears. It is green and
protecting nothing - exactly like the two cases the timestamp work proved vacuous, except this one
is NOT cured by that delivery. Same family as fm-bare-fixture-pins-and-weak-assertion.

TO ESTABLISH THEN DELIVER:
1. What the case is SUPPOSED to verify, read from its name and its context, not from its code.
2. What actually forces the block today, measured.
3. Either make the assertion sensitive to beacon age - PROOF REQUIRED: it must FAIL when that
protection is removed, and pass when it is present - or, if the case really verifies something
else, rename it and declare that explicitly.

FORBIDDEN: making the case green by adjusting the fixture without first showing it can fail. A case
that cannot fail is worth nothing, whatever colour it is.

## What Changed

- Replace the daemon-only fixture with a live watcher and matching ownership lock in the non-away grace case.
- Assert that fresh and refreshed beacons allow completion, while a 400-second-old beacon blocks with `FM_POLL=600`.
- Correct one comment in the runtime file `bin/fm-wake-lib.sh`: its blanket instruction that every grace default should derive from the poll cadence contradicted the strict watcher's normal 300-second default, which this regression protects. The replacement retains the pointer to `docs/turnend-guard.md`, whose "Guard grace and the poll cadence" section states the caller-specific rules. No executable runtime code changed.

## Contract Class: RESTORE

This restores one existing case's ability to fail when its promised protection disappears.
It adds no runtime behavior and enables nothing by default.

**Argument against this classification:** the branch strengthens an enforced test and also changes guidance in a runtime file, so its effects extend beyond a cosmetic test rewrite: future changes that the old case accepted can now fail, and maintainers receive corrected guidance.
The classification remains RESTORE because both changes enforce the already documented caller-specific grace contract; neither changes executable guard behavior or introduces a new default.

## Measured Cause and Mutation Proof

The original fixture had a live daemon lock, no watcher lock, and away mode off.
It blocked at both 0 and 400 seconds because missing watcher ownership masked beacon age; daemon ownership is not accepted outside away mode.
Adding valid watcher ownership changed the pair to fresh=0 and stale=2.
The revised case holds that owner constant and asserts fresh -> 400 seconds old -> fresh exits 0 -> 2 -> 0.

Both mutations were measured against the original and revised cases in isolated product copies:

| Removed protection | Original case | Revised case |
| --- | --- | --- |
| Delete watcher beacon-age rejection | GREEN | RED at the stale-beacon assertion: expected exit 2, got 0 |
| Incorrectly apply poll-derived grace to the normal watcher (`FM_POLL=600`, grace 660 seconds) | GREEN | RED at the stale-beacon assertion: expected exit 2, got 0 |

Restoring the production protections makes the revised case GREEN.
The original case's GREEN result under widened grace was measured in the implementation-worker probe in addition to the pipeline's published matrix, which records only the original age-deletion mutation.

**Why the neighboring timestamp repairs sufficed:** the adjacent away-mode cases already had valid live daemon ownership while `.afk` existed.
Their `fm_touch_epoch` repair made the intended 400- and 700-second beacon ages real on macOS and Linux, allowing those cases to test either side of the 660-second grace.
This case turned away mode off, so its daemon lock ceased to prove ownership; timestamp repair alone could not remove that independent reason to block.
No neighboring case was changed in this delivery.

## Risk Assessment

✅ Low: The change strengthens one behavioral test with fresh/stale/fresh controls, uses existing helpers, and leaves production behavior unchanged.

## Testing

On macOS, baseline and mutation replays proved the repaired assertion can fail for the intended reason; live watcher checks confirmed fresh/stale/recovery and missing-ownership behavior. Transcripts and reproduction code were saved. No source changes, full suite, or other pipeline phases were needed.

- Live validation: ✅ go - 3 of 3 scenarios driven live against the product

| Scenario | Result | Live | Evidence |
| --- | --- | --- | --- |
| End a turn outside away mode with a healthy watcher and fresh beacon; the guard allows it. | ✅ pass | live | Real watcher and guard transcript: product-created watcher ownership and fresh beacon produced exit 0 with no output. |
| Age the same watcher&#39;s beacon to 400 seconds with FM_POLL=600; ending the turn blocks, and refreshing only the beacon restores permission. | ✅ pass | live | Real watcher transcript: same PID returned 0 → 2 → 0. Supporting mutation proof: repaired test fails when age rejection is removed or grace incorrectly becomes 660 seconds; the original test survives… |
| Remove watcher ownership while its beacon remains fresh; the guard blocks until ownership is restored. | ✅ pass | live | Real watcher transcript: hiding ownership produced exit 2 despite a fresh beacon; restoring ownership produced exit 0. Supporting test replay: omitting ownership makes the repaired fresh control fail. |

<details>
<summary>Evidence: Validation report</summary>

Source: [Validation report](https://github.com/mremond/firstmate/blob/1d1e1ba2bbd50b1289a63e4fbf30fa1639ee9a48/.no-mistakes/evidence/fm/fm-turnend-case-2063-cannot-fail/validation-report.md)

```text
# Turn-end beacon-age test validation

Result: GO for the assigned test phase. No source changes were needed.

Target: c4c2314ae98784915d0cffa7b60fdfc487e5fc29
Base: 40c50ea8843c5b6a5351db8352675537252b653e
Platform: macOS, with native BSD timestamp tools.

## Intended protection and measured cause

Outside away mode, a 600-second poll interval must not extend the ordinary
300-second watcher-beacon grace. With the same valid watcher owner, a fresh
beacon allows a turn to end, a 400-second beacon blocks, and refreshing only
the beacon allows again.

The base fixture had a daemon lock and no watcher lock. Both a 0-second and a
400-second beacon returned exit 2. Removing watcher beacon-age rejection still
left the old test green. Missing watcher ownership masked the intended test.
These historical-fixture and mutation checks are focused behavioral tests,
not live watcher sessions.

## Executable counterfactual proof

| Test version / injected regression | Observed result |
| --- | --- |
| Base test, original product | Pass |
| Base test, watcher age rejection removed | Pass: demonstrates original defect |
| Repaired test, watcher age rejection removed | Fails: expected exit 2, got 0 |
| Repaired test, normal grace incorrectly widened to 660 seconds | Fails: expected exit 2, got 0 |
| Repaired test, watcher ownership omitted | Fresh control fails: expected exit 0, got 2 |
| Repaired test, original product restored | Pass: hook exits 0, 2, 0 |

The two deliberately broken product copies were exercised before the final
green repaired-test execution. No tracked production file was mutated.
Six nearby watcher-ownership and away-mode grace cases also passed.
The initial trace capture emitted a descriptor warning; the evidence driver
was corrected and the complete focused matrix rerun cleanly.

## Real running product

Registered a real custom watcher check through bin/fm-check-register.sh and
started bin/fm-watch.sh in an isolated home inside the submitted worktree.
The check executed and wrote its expected local side effect; the watcher
published its own PID, identity, home, watcher path, and beacon.
No agent, terminal backend, or watcher process was mocked in this run.

Called the actual bin/fm-turnend-guard.sh executable with a Stop payload,
FM_POLL=600, unset/default FM_GUARD_GRACE, and away mode off:

- Fresh product-generated beacon: exit 0, no output.
- Same watcher, beacon aged to 400 seconds: exit 2 and recovery instruction.
- Same watcher, only beacon refreshed: exit 0, no output.
- Fresh beacon, ownership lock temporarily hidden: exit 2.
- Same ownership restored: exit 0, no output.

Age was controlled by changing the beacon's persisted mtime; this did not wait
400 real seconds. The real process remained running with the same identity.
The transcript records each payload, measured age, exit, and emitted banner.
The watcher was explicitly stopped after verification; its final sleep SIGTERM
line in real-watcher.log is cleanup, not a product failure.
No vendor-agent session or rendered UI was involved in this CLI/test change.

## Reproduction and evidence

Run from the submitted worktree:

`` `sh
python3 ~/.no-mistakes/evidence/01M22GJM13BYHFAZ319P7Z0YVF/verify-turnend.py matrix
python3 ~/.no-mistakes/evidence/01M22GJM13BYHFAZ319P7Z0YVF/verify-turnend.py live
`` `

- mutation-matrix.log and mutation-matrix.json: baseline, injected failures, final green.
- target-pristine.trace.log: executed fresh_status=0, status=2, restored_status=0.
- live-guard-transcript.log and live-guard-results.json: actual product output and ownership proof.
- validation-context.json: target tree, source hashes, host, clean final worktree.

All transient product copies and homes were removed. Evidence remains only in
this evidence directory. No full repository suite, linter, formatter, static
analysis, publication, or other pipeline phase was run.
```
</details>
<details>
<summary>Evidence: Real watcher and guard transcript</summary>

Source: [Real watcher and guard transcript](https://github.com/mremond/firstmate/blob/1d1e1ba2bbd50b1289a63e4fbf30fa1639ee9a48/.no-mistakes/evidence/fm/fm-turnend-case-2063-cannot-fail/live-guard-transcript.log)

```text
COMMAND: bin/fm-check-register.sh beacon-verification
registered: state/beacon-verification.check.sh


COMMAND: bin/fm-watch.sh (FM_POLL=600, away mode off)


Product-owned lock:
{
  "pid": "89280",
  "fm-home": "~/.no-mistakes/worktrees/acf4a767348a/01M22GJM13BYHFAZ319P7Z0YVF/.turnend-phase-qu0_qbo_/live-home",
  "watcher-path": "~/.no-mistakes/worktrees/acf4a767348a/01M22GJM13BYHFAZ319P7Z0YVF/bin/fm-watch.sh",
  "pid-identity": "Wed Sep  9 09:26:24 2026     bash ~/.no-mistakes/worktrees/acf4a767348a/01M22GJM13BYHFAZ319P7Z0YVF/bin/fm-watch.sh"
}

Process proof:
89280 87518 Wed Sep  9 09:26:24 2026     bash ~/.no-mistakes/worktrees/acf4a767348a/01M22GJM13BYHFAZ319P7Z0YVF/bin/fm-watch.sh


COMMAND: printf '{"stop_hook_active":false}' | FM_GUARD_GRACE="" FM_POLL=600 bin/fm-turnend-guard.sh
{
  "name": "real watcher permits fresh beacon",
  "watcher_pid": 89280,
  "beacon_age": 2,
  "away_mode": false,
  "poll_seconds": 600,
  "exit": 0,
  "stdout": "",
  "stderr": ""
}

COMMAND: printf '{"stop_hook_active":false}' | FM_GUARD_GRACE="" FM_POLL=600 bin/fm-turnend-guard.sh
{
  "name": "same real watcher blocks 400-second beacon despite FM_POLL=600",
  "watcher_pid": 89280,
  "beacon_age": 400,
  "away_mode": false,
  "poll_seconds": 600,
  "exit": 2,
  "stdout": "",
  "stderr": "\u25cf\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\n\u25cf  TURN WOULD END BLIND - SUPERVISION IS OFF\n\u25cf  1 registered custom check(s), but no live watcher holds this home lock (last beat: 401s ago).\n\u25cf  watcher supervision needs Stop-owned automatic recovery; inspect the hook registration and startup status before ending the turn.\n\u25cf\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\n"
}

COMMAND: printf '{"stop_hook_active":false}' | FM_GUARD_GRACE="" FM_POLL=600 bin/fm-turnend-guard.sh
{
  "name": "refreshing only beacon restores permission",
  "watcher_pid": 89280,
  "beacon_age": 0,
  "away_mode": false,
  "poll_seconds": 600,
  "exit": 0,
  "stdout": "",
  "stderr": ""
}

{
  "name": "fresh beacon without published watcher ownership blocks",
  "exit": 2,
  "stdout": "",
  "stderr": "\u25cf\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\n\u25cf  TURN WOULD END BLIND - SUPERVISION IS OFF\n\u25cf  1 registered custom check(s), but no live watcher holds this home lock (last beat: 0s ago).\n\u25cf  watcher supervision needs Stop-owned automatic recovery; inspect the hook registration and startup status before ending the turn.\n\u25cf\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\n"
}

COMMAND: printf '{"stop_hook_active":false}' | FM_GUARD_GRACE="" FM_POLL=600 bin/fm-turnend-guard.sh
{
  "name": "restoring same ownership restores permission",
  "watcher_pid": 89280,
  "beacon_age": 0,
  "away_mode": false,
  "poll_seconds": 600,
  "exit": 0,
  "stdout": "",
  "stderr": ""
}
```
</details>
<details>
<summary>Evidence: Baseline and mutation proof</summary>

Source: [Baseline and mutation proof](https://github.com/mremond/firstmate/blob/1d1e1ba2bbd50b1289a63e4fbf30fa1639ee9a48/.no-mistakes/evidence/fm/fm-turnend-case-2063-cannot-fail/mutation-matrix.log)

```text
=== old-fixture-age-contrast: expected exit 0, actual 0 ===
old fixture: beacon_age=0 away=off daemon_lock=present watcher_lock=absent exit=2
●━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
●  TURN WOULD END BLIND - SUPERVISION IS OFF
●  1 task(s) in flight, but no live watcher holds this home lock (last beat: 0s ago).
●  watcher supervision needs Stop-owned automatic recovery; inspect the hook registration and startup status before ending the turn.
●━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
old fixture: beacon_age=400 away=off daemon_lock=present watcher_lock=absent exit=2
●━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
●  TURN WOULD END BLIND - SUPERVISION IS OFF
●  1 task(s) in flight, but no live watcher holds this home lock (last beat: 400s ago).
●  watcher supervision needs Stop-owned automatic recovery; inspect the hook registration and startup status before ending the turn.
●━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━

=== base-pristine: expected exit 0, actual 0 ===
ok - fm-turnend-guard: with away mode off, the poll-derived grace never applies

=== base-age-rejection-removed: expected exit 0, actual 0 ===
ok - fm-turnend-guard: with away mode off, the poll-derived grace never applies

=== target-age-rejection-removed: expected exit 1, actual 1 ===
not ok - without .afk, FM_POLL must not widen the strict watcher predicate's grace: expected exit 2, got 0

=== target-wrong-660-second-grace: expected exit 1, actual 1 ===
not ok - without .afk, FM_POLL must not widen the strict watcher predicate's grace: expected exit 2, got 0

=== target-missing-watcher-control: expected exit 1, actual 1 ===
not ok - without .afk, a live watcher with a fresh beacon must allow before aging: expected exit 0, got 2

=== target-pristine: expected exit 0, actual 0 ===
ok - fm-turnend-guard: with away mode off, the poll-derived grace never applies

=== target-adjacent-boundaries: expected exit 0, actual 0 ===
ok - fm-turnend-guard: silent no-op with a live watcher lock and fresh beacon
ok - fm-turnend-guard: blocks on a live watcher lock with an ancient beacon
ok - fm-turnend-guard: a daemon lock proves nothing while away mode is off
ok - fm-turnend-guard: away-mode beacon freshness uses the poll-derived grace, not the flat default
ok - fm-turnend-guard: a dead away-mode daemon still blocks under the poll-derived grace
ok - fm-turnend-guard: the poll-derived grace is bounded, not unlimited
```
</details>
<details>
<summary>Evidence: Reproducible verification driver</summary>

Source: [Reproducible verification driver](https://github.com/mremond/firstmate/blob/1d1e1ba2bbd50b1289a63e4fbf30fa1639ee9a48/.no-mistakes/evidence/fm/fm-turnend-case-2063-cannot-fail/verify-turnend.py)

```text
#!/usr/bin/env python3
"""Focused executable checks; temporary product copies stay inside the worktree.

Run from the submitted worktree: python3 <this-file> matrix|live.
Source text is used only to select executable tests and make deliberate mutants.
All verdicts come from running commands and observing their outputs and state.
"""
import json
import os
from pathlib import Path
import shutil
import signal
import subprocess
import sys
import tempfile
import time

ROOT = Path.cwd()
EVIDENCE = Path(__file__).parent
BASE = '40c50ea8843c5b6a5351db8352675537252b653e'
CASE = 'test_hook_no_afk_ignores_poll_derived_grace'
env = {k: v for k, v in os.environ.items()
       if not k.startswith(('FM_', 'GIT_', 'CLAUDE', 'CURSOR', 'GROK', 'CODEX_'))}
env.update(GIT_CONFIG_GLOBAL='/dev/null', GIT_CONFIG_NOSYSTEM='1',
           GIT_AUTHOR_NAME='test', GIT_AUTHOR_EMAIL='test@example.invalid',
           GIT_COMMITTER_NAME='test', GIT_COMMITTER_EMAIL='test@example.invalid')


def command(args, *, cwd=ROOT, extra=None, input=None, timeout=40):
    return subprocess.run([str(x) for x in args], cwd=cwd,
                          env=env | (extra or {}), input=input, text=True,
                          capture_output=True, timeout=timeout)


def definitions(text):
    # The suite has a list of bare function calls after its definitions.
    # Select the definitions, then execute named cases without walking the suite.
    return text.split('\ntest_predicate_healthy_no_inflight\n', 1)[0] + '\n'


def matrix(scratch):
    product = scratch / 'product'
    (product / 'tests').mkdir(parents=True)
    shutil.copytree(ROOT / 'bin', product / 'bin')
    shutil.copytree(ROOT / 'docs/supervision-protocols',
                    product / 'docs/supervision-protocols')
    shutil.copy2(ROOT / 'tests/lib.sh', product / 'tests/lib.sh')
    target = (ROOT / 'tests/fm-turnend-guard.test.sh').read_text()
    base = command(['git', 'show', f'{BASE}:tests/fm-turnend-guard.test.sh'])
    assert base.returncode == 0, base.stderr
    wake = (ROOT / 'bin/fm-wake-lib.sh').read_text()
    guard = (ROOT / 'bin/fm-turnend-guard.sh').read_text()
    remove_age = wake.replace('  [ "$age" -lt "$grace" ] || return 1\n',
                              '  : # mutation: remove watcher beacon-age rejection\n', 1)
    wider_grace = guard.replace('GRACE=${FM_GUARD_GRACE:-300}',
                                'GRACE=${FM_GUARD_GRACE:-660}', 1)
    results = []
    transcript = []

    def run(label, text, body, expected=0, wake_text=wake, guard_text=guard):
        (product / 'bin/fm-wake-lib.sh').write_text(wake_text)
        (product / 'bin/fm-turnend-guard.sh').write_text(guard_text)
        (product / 'tests/selected.sh').write_text(definitions(text) + body + '\n')
        run_env = {'TMPDIR': str(scratch)}
        trace = EVIDENCE / f'{label}.trace.log'
        with trace.open('w') as out:
            p = subprocess.run(['bash', '-c', 'exec 3>"$1"; export BASH_XTRACEFD=3; bash -x "$2"',
                                '_', str(trace), str(product / 'tests/selected.sh')],
                               cwd=product, env=env | run_env, text=True,
                               capture_output=True, timeout=45)
        entry = dict(name=label, expected_exit=expected, actual_exit=p.returncode,
                     stdout=p.stdout, stderr=p.stderr)
        results.append(entry)
        transcript.append(f'=== {label}: expected exit {expected}, actual {p.returncode} ===\n'
                          + p.stdout + p.stderr)
        print(transcript[-1], flush=True)
        assert p.returncode == expected, entry

    # Establish the reported masking condition before executing the repaired test.
    run('old-fixture-age-contrast', base.stdout, r'''
dir=$(make_away_home_between_cycles "$TMP_ROOT/old-contrast")
rm -f "$dir/state/.afk"
sleep 60 &
pid=$!
record_daemon_lock "$dir" "$pid" || fail 'daemon identity unavailable'
for age in 0 400; do
  fm_touch_epoch "$(( $(date +%s) - age ))" "$dir/state/.last-watcher-beat"
  out=$(FM_GUARD_GRACE='' FM_POLL=600 run_hook "$dir" false); status=$?
  printf 'old fixture: beacon_age=%s away=off daemon_lock=present watcher_lock=absent exit=%s\n%s\n' "$age" "$status" "$out"
  expect_code 2 "$status" 'old fixture blocks regardless of beacon age'
done
kill "$pid"; wait "$pid" 2>/dev/null || true
''')
    run('base-pristine', base.stdout, CASE)
    run('base-age-rejection-removed', base.stdout, CASE, wake_text=remove_age)
    run('target-age-rejection-removed', target, CASE, expected=1, wake_text=remove_age)
    run('target-wrong-660-second-grace', target, CASE, expected=1, guard_text=wider_grace)
    run('target-missing-watcher-control', target,
        'record_watcher_lock() { :; }\n' + CASE, expected=1)
    run('target-pristine', target, CASE)
    neighboring = [
        'test_hook_silent_with_live_lock_and_fresh_beacon',
        'test_hook_blocks_with_live_lock_and_stale_beacon',
        'test_hook_daemon_lock_is_ignored_without_away_mode',
        'test_hook_away_daemon_allows_beacon_within_poll_derived_grace',
        'test_hook_away_daemon_blocks_dead_daemon_despite_poll_derived_grace',
        'test_hook_away_daemon_blocks_beacon_older_than_poll_derived_grace']
    run('target-adjacent-boundaries', target, '\n'.join(neighboring))
    (EVIDENCE / 'mutation-matrix.json').write_text(json.dumps(results, indent=2) + '\n')
    (EVIDENCE / 'mutation-matrix.log').write_text('\n'.join(transcript))


def live(scratch):
    home = scratch / 'live-home'
    state = home / 'state'
    state.mkdir(parents=True)
    (home / 'config').mkdir()
    (home / 'data').mkdir()
    (home / 'AGENTS.md').write_text('')
    (home / 'bin').symlink_to(ROOT / 'bin', target_is_directory=True)
    p = command(['git', 'init', '-q', home])
    assert p.returncode == 0, p.stderr
    live_env = {'FM_HOME': str(home), 'FM_ROOT_OVERRIDE': str(home),
                'FM_STATE_OVERRIDE': str(state), 'FM_POLL': '600',
                'FM_GUARD_GRACE': '', 'TMPDIR': str(scratch), 'CLAUDECODE': '1'}
    # A real registered custom check gives the watcher useful work without an
    # agent session, a fabricated task record, or a fake watcher owner.
    check = state / 'beacon-verification.check.sh'
    check.write_text('#!/usr/bin/env bash\nprintf executed > "$FM_HOME/state/check-executed"\n')
    check.chmod(0o700)
    registered = command([ROOT / 'bin/fm-check-register.sh', 'beacon-verification'],
                         extra=live_env)
    assert registered.returncode == 0, registered.stderr
    transcript = ['COMMAND: bin/fm-check-register.sh beacon-verification\n' + registered.stdout]
    observations = []
    watcher_log = (EVIDENCE / 'real-watcher.log').open('w')
    watcher = subprocess.Popen([str(ROOT / 'bin/fm-watch.sh')], cwd=home,
                               env=env | live_env, stdout=watcher_log,
                               stderr=subprocess.STDOUT, start_new_session=True)
    try:
        deadline = time.monotonic() + 20
        while time.monotonic() < deadline:
            if (state / 'check-executed').exists() and (state / '.last-watcher-beat').exists():
                break
            assert watcher.poll() is None, 'real watcher exited before startup'
            time.sleep(0.1)
        assert (state / 'check-executed').read_text() == 'executed'
        # Confirm that the product itself published the ownership proof.
        lock = state / '.watch.lock'
        identity = (lock / 'pid-identity').read_text()
        pid = int((lock / 'pid').read_text())
        assert pid == watcher.pid
        process = command(['ps', '-p', str(pid), '-o', 'pid=,ppid=,lstart=,command='])
        transcript += ['COMMAND: bin/fm-watch.sh (FM_POLL=600, away mode off)\n',
                       'Product-owned lock:\n' + json.dumps({
                           x: (lock / x).read_text().strip()
                           for x in ['pid', 'fm-home', 'watcher-path', 'pid-identity']}, indent=2),
                       'Process proof:\n' + process.stdout]
        # Let the initial cycle reach its 600-second wait; the check's side
        # effect above proves the watcher is executing real registered work.
        time.sleep(1)

        def invoke(name, expected, age=None):
            beacon = state / '.last-watcher-beat'
            if age is not None:
                stamp = int(time.time()) - age
                os.utime(beacon, (stamp, stamp))
            measured_age = int(time.time()) - int(beacon.stat().st_mtime)
            p = command([ROOT / 'bin/fm-turnend-guard.sh'], cwd=home,
                        extra=live_env, input='{"stop_hook_active":false}')
            entry = dict(name=name, watcher_pid=pid, beacon_age=measured_age,
                         away_mode=False, poll_seconds=600, exit=p.returncode,
                         stdout=p.stdout, stderr=p.stderr)
            observations.append(entry)
            transcript.append('COMMAND: printf \'{"stop_hook_active":false}\' | '
                              'FM_GUARD_GRACE="" FM_POLL=600 bin/fm-turnend-guard.sh\n'
                              + json.dumps(entry, indent=2))
            print(json.dumps(entry), flush=True)
            assert p.returncode == expected, entry
            if expected == 0:
                assert not p.stdout and not p.stderr, entry
            else:
                assert 'watcher supervision needs Stop-owned automatic recovery' in p.stderr, entry
            assert watcher.poll() is None, 'watcher stopped during same-owner contrast'
            assert (lock / 'pid-identity').read_text() == identity
            return entry

        invoke('real watcher permits fresh beacon', 0)
        invoke('same real watcher blocks 400-second beacon despite FM_POLL=600', 2, 400)
        invoke('refreshing only beacon restores permission', 0, 0)
        # Reversibly hide the ownership lock to challenge the new fresh control.
        hidden = state / '.watch.saved'
        lock.rename(hidden)
        try:
            p = command([ROOT / 'bin/fm-turnend-guard.sh'], cwd=home,
                        extra=live_env, input='{"stop_hook_active":false}')
            entry = dict(name='fresh beacon without published watcher ownership blocks',
                         exit=p.returncode, stdout=p.stdout, stderr=p.stderr)
            observations.append(entry)
            transcript.append(json.dumps(entry, indent=2))
            print(json.dumps(entry), flush=True)
            assert p.returncode == 2, entry
        finally:
            hidden.rename(lock)
        invoke('restoring same ownership restores permission', 0, 0)
    finally:
        os.killpg(watcher.pid, signal.SIGTERM)
        try:
            watcher.wait(timeout=8)
        except subprocess.TimeoutExpired:
            os.killpg(watcher.pid, signal.SIGKILL)
            watcher.wait()
        watcher_log.close()
        (EVIDENCE / 'live-guard-transcript.log').write_text('\n\n'.join(transcript) + '\n')
        (EVIDENCE / 'live-guard-results.json').write_text(json.dumps(observations, indent=2) + '\n')


if __name__ == '__main__':
    with tempfile.TemporaryDirectory(prefix='.turnend-phase-', dir=ROOT) as tmp:
        scratch = Path(tmp)
        if sys.argv[1] == 'matrix':
            matrix(scratch)
        elif sys.argv[1] == 'live':
            live(scratch)
        else:
            raise SystemExit('expected matrix or live')
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"ce5be77dfa487676af4ca93b514b65ec26d5d9ed","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- Live validation: ✅ go - 3 of 3 scenarios driven live against the product

| Scenario | Result | Live | Evidence |
| --- | --- | --- | --- |
| End a turn outside away mode with a healthy watcher and fresh beacon; the guard allows it. | ✅ pass | live | Real watcher and guard transcript: product-created watcher ownership and fresh beacon produced exit 0 with no output. |
| Age the same watcher&#39;s beacon to 400 seconds with FM_POLL=600; ending the turn blocks, and refreshing only the beacon restores permission. | ✅ pass | live | Real watcher transcript: same PID returned 0 → 2 → 0. Supporting mutation proof: repaired test fails when age rejection is removed or grace incorrectly becomes 660 seconds; the original test survives… |
| Remove watcher ownership while its beacon remains fresh; the guard blocks until ownership is restored. | ✅ pass | live | Real watcher transcript: hiding ownership produced exit 2 despite a fresh beacon; restoring ownership produced exit 0. Supporting test replay: omitting ownership makes the repaired fresh control fail. |

- <code>`python3 ~/.no-mistakes/evidence/01M22GJM13BYHFAZ319P7Z0YVF/verify-turnend.py matrix` — reproduced the old fixture&#39;s identical fresh/stale verdicts, exercised removal and widening mutations, verified the missing-owner control, and ran the repaired case plus six adjacent cases. Rerun cleanly after correcting trace capture.</code>
- <code>`python3 ~/.no-mistakes/evidence/01M22GJM13BYHFAZ319P7Z0YVF/verify-turnend.py live` — registered a real custom check, launched the actual watcher, and invoked the guard through its CLI with controlled beacon timestamps and ownership.</code>
- <code>`git status --short` and transient-directory inspection — clean after removing isolated test homes and product copies.</code>
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
