### PR TITLE
fix: name missing directories in Treehouse lock refusals

### DIFF
--- a/bin/fm-wake-lib.sh
+++ b/bin/fm-wake-lib.sh
@@ -1147,6 +1147,10 @@ fm_task_set_lock_path() {  # <state-dir>
 #
 # Everything else still fails closed: an unreadable or malformed binding, an
 # unreachable local parent, a cycle, and a chain deeper than the bound.
+# Failures normally leave stdout empty. With --print-unresolved-parent as the
+# second argument, an unenterable recorded local parent is printed on stdout
+# for the caller's diagnostic, but the status remains nonzero. Callers must
+# check that status before treating any output as a resolved root home.
 fm_firstmate_root_home() {
   local home=${1:-$FM_HOME} marker parent seen="|" depth=0
   home=$(CDPATH='' cd -- "$home" 2>/dev/null && pwd -P) || return 1
@@ -1175,9 +1179,6 @@ fm_firstmate_root_home() {
   printf '%s\n' "$home"
 }
 
-# One refusal line for fm_treehouse_project_lock_path, naming what it could not
-# resolve. Its callers capture that function's stdout through command
-# substitution, so the diagnosis has to leave by stderr to reach the operator.
 _fm_treehouse_lock_named() {  # <what-could-not-be-resolved> <path>
   printf 'fm_treehouse_project_lock_path: %s: %s\n' "$1" "$2" >&2
 }
@@ -1191,24 +1192,16 @@ _fm_treehouse_lock_named() {  # <what-could-not-be-resolved> <path>
 # separate clones of one origin share a single lock; an origin-less local-only
 # project falls back to its own worktree top instead of failing to resolve.
 #
-# Why every refusal below names the one thing it could not resolve.
-#
-# This function has eight failure exits, and every caller collapses all eight
-# into one sentence: "could not resolve the shared Treehouse project lock for
-# <project>". That sentence is true of all eight and diagnostic of none, and it
-# points the reader at the PROJECT even when the missing thing is in the HOME -
-# the root home itself, or its state directory. An investigation lost time to
-# exactly that and had to hand-patch this function to learn which exit fired
-# (data/fm-test-passes-alone-fails-in-lane, recommendation 2). So each exit
-# prints, to stderr, the concrete thing it could not resolve.
-#
-# The naming is the whole point of these lines; deleting it restores a silent
-# refusal that reads as a project fault. tests/fm-treehouse-lock-naming.test.sh
-# drives every exit and fails when a message stops naming its own cause.
-#
-# What is deliberately NOT changed here is the DECISION. In particular the root
-# state directory is named, not created: a root home that genuinely does not
-# exist must still be refused rather than conjured. Only the message changed.
+# Refusals leave stdout empty and name the failed resource on stderr, which
+# reaches the operator alongside the caller's context line even when stdout
+# is captured as the lock path. An unenterable recorded local parent is named
+# instead of the existing child home; other root-resolution failures name
+# FM_HOME. Success prints only the lock path, without a diagnostic.
+# The shared lock anchor remains <local-root-home>/state regardless of
+# FM_STATE_OVERRIDE. A missing home or root state directory remains a refusal;
+# resolving this lock must not create either directory to satisfy the guard.
+# tests/fm-treehouse-lock-naming.test.sh covers these diagnostic and refusal
+# invariants through the library interface and a spawn refusal.
 fm_treehouse_project_lock_path() {  # <project-dir>
   local project=$1 root origin identity hash top resolved
   [ -d "$project" ] || {

--- a/bin/fm-wake-lib.sh
+++ b/bin/fm-wake-lib.sh
@@ -1172,6 +1172,13 @@ fm_firstmate_root_home() {
   printf '%s\n' "$home"
 }
 
+# One refusal line for fm_treehouse_project_lock_path, naming what it could not
+# resolve. Its callers capture that function's stdout through command
+# substitution, so the diagnosis has to leave by stderr to reach the operator.
+_fm_treehouse_lock_named() {  # <what-could-not-be-resolved> <path>
+  printf 'fm_treehouse_project_lock_path: %s: %s\n' "$1" "$2" >&2
+}
+
 # The one lock serializing Treehouse slot allocation and return for a project.
 #
 # It is anchored in the local root home's state directory so that every home on
@@ -1180,25 +1187,78 @@ fm_firstmate_root_home() {
 # derives the identical path. Its identity is the project's resolved origin, so
 # separate clones of one origin share a single lock; an origin-less local-only
 # project falls back to its own worktree top instead of failing to resolve.
+#
+# Why every refusal below names the one thing it could not resolve.
+#
+# This function has eight failure exits, and every caller collapses all eight
+# into one sentence: "could not resolve the shared Treehouse project lock for
+# <project>". That sentence is true of all eight and diagnostic of none, and it
+# points the reader at the PROJECT even when the missing thing is in the HOME -
+# the root home itself, or its state directory. An investigation lost time to
+# exactly that and had to hand-patch this function to learn which exit fired
+# (data/fm-test-passes-alone-fails-in-lane, recommendation 2). So each exit
+# prints, to stderr, the concrete thing it could not resolve.
+#
+# The naming is the whole point of these lines; deleting it restores a silent
+# refusal that reads as a project fault. tests/fm-treehouse-lock-naming.test.sh
+# drives every exit and fails when a message stops naming its own cause.
+#
+# What is deliberately NOT changed here is the DECISION. In particular the root
+# state directory is named, not created: a root home that genuinely does not
+# exist must still be refused rather than conjured. Only the message changed.
 fm_treehouse_project_lock_path() {  # <project-dir>
-  local project=$1 root origin identity hash top
-  [ -d "$project" ] || return 1
-  root=$(fm_firstmate_root_home "$FM_HOME") || return 1
+  local project=$1 root origin identity hash top resolved
+  [ -d "$project" ] || {
+    _fm_treehouse_lock_named "project directory does not exist" "$project"
+    return 1
+  }
+  root=$(fm_firstmate_root_home "$FM_HOME") || {
+    _fm_treehouse_lock_named "cannot resolve the root firstmate home from FM_HOME" "$FM_HOME"
+    return 1
+  }
   origin=$(git -C "$project" remote get-url origin 2>/dev/null || true)
   if [ -n "$origin" ]; then
     case "$origin" in
-      /*) [ ! -d "$origin" ] || origin=$(CDPATH='' cd -- "$origin" 2>/dev/null && pwd -P) || return 1 ;;
+      /*)
+        if [ -d "$origin" ]; then
+          resolved=$(CDPATH='' cd -- "$origin" 2>/dev/null && pwd -P) || {
+            _fm_treehouse_lock_named "project origin directory cannot be entered" "$origin"
+            return 1
+          }
+          origin=$resolved
+        fi
+        ;;
       *://*|*:* ) ;;
-      *) [ ! -d "$project/$origin" ] || origin=$(CDPATH='' cd -- "$project/$origin" 2>/dev/null && pwd -P) || return 1 ;;
+      *)
+        if [ -d "$project/$origin" ]; then
+          resolved=$(CDPATH='' cd -- "$project/$origin" 2>/dev/null && pwd -P) || {
+            _fm_treehouse_lock_named "project origin directory cannot be entered" "$project/$origin"
+            return 1
+          }
+          origin=$resolved
+        fi
+        ;;
     esac
     identity=$origin
   else
-    top=$(git -C "$project" rev-parse --show-toplevel 2>/dev/null) || return 1
-    top=$(CDPATH='' cd -- "$top" 2>/dev/null && pwd -P) || return 1
-    identity=$top
+    top=$(git -C "$project" rev-parse --show-toplevel 2>/dev/null) || {
+      _fm_treehouse_lock_named "project has no origin and is not inside a git worktree" "$project"
+      return 1
+    }
+    resolved=$(CDPATH='' cd -- "$top" 2>/dev/null && pwd -P) || {
+      _fm_treehouse_lock_named "project worktree top cannot be entered" "$top"
+      return 1
+    }
+    identity=$resolved
   fi
-  hash=$(printf '%s' "$identity" | git hash-object --stdin 2>/dev/null) || return 1
-  [ -d "$root/state" ] || return 1
+  hash=$(printf '%s' "$identity" | git hash-object --stdin 2>/dev/null) || {
+    _fm_treehouse_lock_named "cannot hash the project lock identity, so git is unusable here" "$identity"
+    return 1
+  }
+  [ -d "$root/state" ] || {
+    _fm_treehouse_lock_named "the root firstmate home has no state directory" "$root/state"
+    return 1
+  }
   printf '%s/.treehouse-project-%s.lock\n' "$root/state" "$hash"
 }
 

--- a/bin/fm-wake-lib.sh
+++ b/bin/fm-wake-lib.sh
@@ -1162,7 +1162,10 @@ fm_firstmate_root_home() {
       remote) break ;;
       *) return 1 ;;
     esac
-    parent=$(CDPATH='' cd -- "$FM_SECONDMATE_PARENT_HOME" 2>/dev/null && pwd -P) || return 1
+    parent=$(CDPATH='' cd -- "$FM_SECONDMATE_PARENT_HOME" 2>/dev/null && pwd -P) || {
+      [ "${2:-}" != --print-unresolved-parent ] || printf '%s\n' "$FM_SECONDMATE_PARENT_HOME"
+      return 1
+    }
     case "$seen" in *"|$parent|"*) return 1 ;; esac
     seen="$seen$home|"
     home=$parent
@@ -1212,8 +1215,12 @@ fm_treehouse_project_lock_path() {  # <project-dir>
     _fm_treehouse_lock_named "project directory does not exist" "$project"
     return 1
   }
-  root=$(fm_firstmate_root_home "$FM_HOME") || {
-    _fm_treehouse_lock_named "cannot resolve the root firstmate home from FM_HOME" "$FM_HOME"
+  root=$(fm_firstmate_root_home "$FM_HOME" --print-unresolved-parent) || {
+    if [ -n "$root" ]; then
+      _fm_treehouse_lock_named "cannot resolve the recorded parent firstmate home" "$root"
+    else
+      _fm_treehouse_lock_named "cannot resolve the root firstmate home from FM_HOME" "$FM_HOME"
+    fi
     return 1
   }
   origin=$(git -C "$project" remote get-url origin 2>/dev/null || true)

--- a/bin/fm-wake-lib.sh
+++ b/bin/fm-wake-lib.sh
@@ -1252,7 +1252,7 @@ fm_treehouse_project_lock_path() {  # <project-dir>
     identity=$resolved
   fi
   hash=$(printf '%s' "$identity" | git hash-object --stdin 2>/dev/null) || {
-    _fm_treehouse_lock_named "cannot hash the project lock identity, so git is unusable here" "$identity"
+    _fm_treehouse_lock_named "cannot hash the project lock identity, so git is unusable here" "$project"
     return 1
   }
   [ -d "$root/state" ] || {

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -289,6 +289,7 @@ When it is unset, most scripts use the repo root as the home; when it is set, sc
 When `FM_HOME` is unset, it also behaves as the old whole-root override.
 `bin/fm-send.sh` is intentionally stricter than that general fallback: it requires `FM_HOME` to be set before resolving a target, so operator steers cannot silently resolve against the wrong home.
 `FM_STATE_OVERRIDE`, `FM_DATA_OVERRIDE`, `FM_PROJECTS_OVERRIDE`, and `FM_CONFIG_OVERRIDE` override individual operational directories for tests and specialized harness setup.
+For Treehouse project locks, [`fm_treehouse_project_lock_path`](../bin/fm-wake-lib.sh) owns the shared root-state requirement and refusal diagnostics.
 Before `fm-brief.sh`, `fm-spawn.sh`, or `fm-afk-launch.sh` persists a path or passes it to another process, it resolves each applicable relative `FM_HOME`, `FM_STATE_OVERRIDE`, or `FM_DATA_OVERRIDE` directory against the caller's working directory, preserves accepted absolute spellings unchanged, and rejects an unresolvable relative directory with the offending variable named.
 `fm-spawn.sh` additionally rejects control bytes in those raw directory inputs before shell or filesystem normalization can change which path the backlog gate checks.
 Lifecycle access to a backlog, task record, or pending-close record must resolve within its configured data or state root, and a final-component symlink is refused even when its target remains within that root.

--- a/tests/fm-treehouse-lock-naming.test.sh
+++ b/tests/fm-treehouse-lock-naming.test.sh
@@ -123,6 +123,55 @@ test_broken_secondmate_parent_chain_names_the_home() {
   pass "a broken secondmate parent chain names the home, not the project"
 }
 
+test_missing_recorded_parent_home_is_named() {
+  local dir out depth parent record_home
+  for depth in 1 2; do
+    dir=$(make_case "missing-parent-$depth")
+    fm_git_init_commit "$dir/project"
+    parent="$dir/absent parent"
+    record_home="$dir/home"
+    if [ "$depth" -eq 2 ]; then
+      record_home="$dir/intermediate"
+      mkdir -p "$record_home"
+      printf 'schema=fm-secondmate-parent.v1\nroute=local\nparent_home=%s\n' \
+        "$record_home" > "$dir/home/.fm-secondmate-parent"
+    fi
+    printf 'schema=fm-secondmate-parent.v1\nroute=local\nparent_home=%s\n' \
+      "$parent" > "$record_home/.fm-secondmate-parent"
+
+    out=$(resolve_lock "$dir/home" "$dir/elsewhere" "$dir/project")
+    expect_code 1 "$?" "a missing recorded parent home should still refuse"
+    assert_contains "$out" "cannot resolve the recorded parent firstmate home: $parent" \
+      "the refusal did not name the missing recorded parent home at depth $depth"
+    assert_not_contains "$out" "$dir/home" \
+      "the refusal named the existing child home instead of the missing parent"
+    assert_absent "$parent" "the refusal created the missing parent home"
+
+    out=$(FM_HOME="$dir/home" FM_STATE_OVERRIDE="$dir/elsewhere" \
+      bash -c '. "$1"; fm_firstmate_root_home "$FM_HOME"' _ "$LIB" 2>&1)
+    expect_code 1 "$?" "root resolution without diagnostics should still refuse"
+    [ -z "$out" ] || fail "root resolution without diagnostics should stay silent: $out"
+
+    mkdir -p "$parent"
+    out=$(resolve_lock "$dir/home" "$dir/elsewhere" "$dir/project")
+    expect_code 1 "$?" "the resolved parent with no state directory should still refuse"
+    assert_contains "$out" "the root firstmate home has no state directory: $parent/state" \
+      "the refusal did not advance to the parent's missing state directory"
+    assert_absent "$parent/state" "the refusal created the parent's missing state directory"
+
+    mkdir -p "$parent/state"
+    out=$(resolve_lock "$dir/home" "$dir/elsewhere" "$dir/project")
+    expect_code 0 "$?" "the parent chain with a root state directory should resolve"
+    case "$out" in
+      "$parent/state/.treehouse-project-"*.lock) ;;
+      *) fail "the resolved lock path did not name the parent root: $out" ;;
+    esac
+    assert_not_contains "$out" "fm_treehouse_project_lock_path:" \
+      "the resolved parent chain emitted a refusal diagnostic"
+    pass "a missing recorded parent at depth $depth is named until its root state exists"
+  done
+}
+
 test_unenterable_absolute_origin_is_named() {
   local dir out
   dir=$(make_case origin-absolute)
@@ -245,18 +294,18 @@ test_spawn_refusal_carries_the_named_cause() {
   fm_test_spawn_home "$home"
   fm_test_spawn_brief "$home" lock-naming-e2e
   fm_git_init_commit "$dir/project"
-  fakebin=$(make_spawn_fakebin "$dir")
+  fakebin=$(make_spawn_fakebin "$dir" orca)
   # The divergence that produced the original defect: the state root points away
   # from the home, so the library creates that directory and not the home's.
   mkdir -p "$dir/state-elsewhere"
   rmdir "$home/state" 2>/dev/null || rm -rf "$home/state"
   out=$(FM_ROOT_OVERRIDE='' FM_HOME="$home" HOME="$dir/user-home" \
-    CLAUDE_CONFIG_DIR='' \
+    CLAUDE_CONFIG_DIR='' FM_BACKEND=orca \
     FM_STATE_OVERRIDE="$dir/state-elsewhere" FM_DATA_OVERRIDE="$home/data" \
     FM_PROJECTS_OVERRIDE="$home/projects" FM_CONFIG_OVERRIDE="$home/config" \
     FM_SPAWN_NO_GUARD=1 FM_FAKE_PANE_PATH="$dir/pane" TMUX="${TMUX:-fake,1,0}" \
     PATH="$fakebin:$PATH" \
-    "$ROOT/bin/fm-spawn.sh" lock-naming-e2e "$dir/project" --scout 2>&1)
+    "$ROOT/bin/fm-spawn.sh" lock-naming-e2e "$dir/project" --scout --backend tmux 2>&1)
   status=$?
   expect_code 1 "$status" "the spawn should refuse when the home has no state directory"$'\n'"$out"
   assert_contains "$out" "the root firstmate home has no state directory: $home/state" \
@@ -269,6 +318,7 @@ test_spawn_refusal_carries_the_named_cause() {
 test_missing_project_directory_is_named
 test_unresolvable_root_home_is_named
 test_broken_secondmate_parent_chain_names_the_home
+test_missing_recorded_parent_home_is_named
 test_unenterable_absolute_origin_is_named
 test_unenterable_relative_origin_is_named
 test_originless_non_git_project_is_named

--- a/tests/fm-treehouse-lock-naming.test.sh
+++ b/tests/fm-treehouse-lock-naming.test.sh
@@ -1,24 +1,6 @@
 #!/usr/bin/env bash
-# tests/fm-treehouse-lock-naming.test.sh - every failure exit of
-# fm_treehouse_project_lock_path (bin/fm-wake-lib.sh) must name the one thing it
-# could not resolve.
-#
-# The function has eight failure exits and every caller collapses all eight into
-# the same sentence, "could not resolve the shared Treehouse project lock for
-# <project>", which is true of all eight and diagnostic of none - and which
-# points the reader at the PROJECT even when the missing thing is in the HOME.
-# An investigation lost time to that and had to hand-patch the function to learn
-# which exit fired. These cases drive each exit through the library's public
-# shell interface and assert the message names its own cause and path.
-#
-# Each case is written to go red if the naming is removed: with the diagnostics
-# deleted the refusals fall back to silence, and every assertion below reads an
-# empty stderr. The success case is the other half of that pin - it asserts the
-# naming never leaks onto the path that resolves, so a message emitted
-# unconditionally cannot satisfy the file either.
-#
-# Only the messages are under test. What each exit REFUSES is unchanged and
-# deliberately so: the root state directory is named, not created.
+# tests/fm-treehouse-lock-naming.test.sh - regression coverage for the diagnostic
+# and refusal contract owned by fm_treehouse_project_lock_path in bin/fm-wake-lib.sh.
 set -u
 
 # shellcheck source=tests/lib.sh
@@ -247,10 +229,6 @@ done')
   pass "an identity that cannot be hashed is named in the refusal"
 }
 
-# The exit the investigation actually hit: a directory the same library creates
-# unconditionally at bin/fm-wake-lib.sh:16, absent here because the state root
-# was pointed elsewhere. The refusal must name the HOME's missing directory and
-# must not read as a fault in the project.
 test_missing_root_state_directory_is_named() {
   local dir out
   dir=$(make_case root-state-missing)
@@ -267,8 +245,7 @@ test_missing_root_state_directory_is_named() {
   pass "a missing root state directory is named, not created, and the project is not blamed"
 }
 
-# The other half of the mutation pin: a diagnostic printed unconditionally would
-# satisfy every case above, so the resolving path must stay silent.
+# Success coverage prevents diagnostics from polluting captured lock paths.
 test_resolved_lock_path_stays_silent() {
   local dir out
   dir=$(make_case resolves)
@@ -295,8 +272,7 @@ test_spawn_refusal_carries_the_named_cause() {
   fm_test_spawn_brief "$home" lock-naming-e2e
   fm_git_init_commit "$dir/project"
   fakebin=$(make_spawn_fakebin "$dir" orca)
-  # The divergence that produced the original defect: the state root points away
-  # from the home, so the library creates that directory and not the home's.
+  # Preserve the missing root-state fixture as resolve_lock does above.
   mkdir -p "$dir/state-elsewhere"
   rmdir "$home/state" 2>/dev/null || rm -rf "$home/state"
   out=$(FM_ROOT_OVERRIDE='' FM_HOME="$home" HOME="$dir/user-home" \

--- a/tests/fm-treehouse-lock-naming.test.sh
+++ b/tests/fm-treehouse-lock-naming.test.sh
@@ -199,6 +199,7 @@ test_unenterable_worktree_top_is_named() {
   mkdir -p "$dir/project"
   # git reports a toplevel that is not there by the time it is entered: the
   # shape a checkout removed underneath a running spawn produces.
+  # shellcheck disable=SC2016 # Expand shim variables at runtime; interpolate only dir here.
   shim=$(git_shim "$dir/shim" '
 for a in "$@"; do
   [ "$a" = "--show-toplevel" ] && { echo "'"$dir"'/vanished"; exit 0; }
@@ -215,6 +216,7 @@ test_unhashable_identity_is_named() {
   local dir out shim
   dir=$(make_case identity-hash)
   mkdir -p "$dir/project"
+  # shellcheck disable=SC2016 # Expand variables when the generated shim runs.
   shim=$(git_shim "$dir/shim" '
 for a in "$@"; do
   [ "$a" = "get-url" ] && { echo "https://example.invalid/x.git"; exit 0; }

--- a/tests/fm-treehouse-lock-naming.test.sh
+++ b/tests/fm-treehouse-lock-naming.test.sh
@@ -212,23 +212,32 @@ done')
   pass "an unenterable worktree top is named in the refusal"
 }
 
-test_unhashable_identity_is_named() {
-  local dir out shim
+test_hash_failure_names_project_without_exposing_origin() {
+  local dir out shim origin
   dir=$(make_case identity-hash)
-  mkdir -p "$dir/project"
-  # shellcheck disable=SC2016 # Expand variables when the generated shim runs.
+  fm_git_init_commit "$dir/project"
+  origin='https://fixture-user:fixture-token@example.invalid/x.git'
+  git -C "$dir/project" remote add origin "$origin"
+  # Capture the hash command's stdin to prove the refusal reaches the original
+  # identity, while the operator's diagnostic must not disclose its credentials.
+  # shellcheck disable=SC2016 # Expand shim variables at runtime; interpolate only dir here.
   shim=$(git_shim "$dir/shim" '
-for a in "$@"; do
-  [ "$a" = "get-url" ] && { echo "https://example.invalid/x.git"; exit 0; }
-  [ "$a" = "hash-object" ] && exit 1
-done')
+if [ "$1" = hash-object ]; then
+  cat > "'"$dir"'/hash-input"
+  exit 1
+fi')
   out=$(resolve_lock "$dir/home" "$dir/elsewhere" "$dir/project" "$shim")
   expect_code 1 "$?" "an unusable git should still refuse"
+  [ "$(cat "$dir/hash-input")" = "$origin" ] || \
+    fail "the failing hash command did not receive the original project identity"
   assert_contains "$out" "cannot hash the project lock identity" \
     "the refusal did not say the project identity could not be hashed"
-  assert_contains "$out" "https://example.invalid/x.git" \
-    "the refusal did not name the identity it failed to hash"
-  pass "an identity that cannot be hashed is named in the refusal"
+  assert_not_contains "$out" "fixture-user" "the hash refusal exposed the origin username"
+  assert_not_contains "$out" "fixture-token" "the hash refusal exposed the origin token"
+  assert_not_contains "$out" "$origin" "the hash refusal exposed the raw origin"
+  assert_contains "$out" "$dir/project" \
+    "the hash refusal did not name the affected project directory"
+  pass "a hash failure names the project without exposing origin credentials"
 }
 
 test_missing_root_state_directory_is_named() {
@@ -270,7 +279,8 @@ test_spawn_refusal_carries_the_named_cause() {
   local dir home fakebin out status
   dir=$(make_case spawn-e2e)
   home="$dir/spawn-home"
-  fm_test_spawn_home "$home"
+  # CI has no agent to detect; pin the fixture harness before the lock guard.
+  fm_test_spawn_home "$home" claude
   fm_test_spawn_brief "$home" lock-naming-e2e
   fm_git_init_commit "$dir/project"
   fakebin=$(make_spawn_fakebin "$dir" orca)
@@ -301,7 +311,7 @@ test_unenterable_absolute_origin_is_named
 test_unenterable_relative_origin_is_named
 test_originless_non_git_project_is_named
 test_unenterable_worktree_top_is_named
-test_unhashable_identity_is_named
+test_hash_failure_names_project_without_exposing_origin
 test_missing_root_state_directory_is_named
 test_resolved_lock_path_stays_silent
 test_spawn_refusal_carries_the_named_cause

--- a/tests/fm-treehouse-lock-naming.test.sh
+++ b/tests/fm-treehouse-lock-naming.test.sh
@@ -1,0 +1,281 @@
+#!/usr/bin/env bash
+# tests/fm-treehouse-lock-naming.test.sh - every failure exit of
+# fm_treehouse_project_lock_path (bin/fm-wake-lib.sh) must name the one thing it
+# could not resolve.
+#
+# The function has eight failure exits and every caller collapses all eight into
+# the same sentence, "could not resolve the shared Treehouse project lock for
+# <project>", which is true of all eight and diagnostic of none - and which
+# points the reader at the PROJECT even when the missing thing is in the HOME.
+# An investigation lost time to that and had to hand-patch the function to learn
+# which exit fired. These cases drive each exit through the library's public
+# shell interface and assert the message names its own cause and path.
+#
+# Each case is written to go red if the naming is removed: with the diagnostics
+# deleted the refusals fall back to silence, and every assertion below reads an
+# empty stderr. The success case is the other half of that pin - it asserts the
+# naming never leaks onto the path that resolves, so a message emitted
+# unconditionally cannot satisfy the file either.
+#
+# Only the messages are under test. What each exit REFUSES is unchanged and
+# deliberately so: the root state directory is named, not created.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+# shellcheck source=tests/fixtures.sh
+. "$(dirname "${BASH_SOURCE[0]}")/fixtures.sh"
+
+LIB="$ROOT/bin/fm-wake-lib.sh"
+TMP_ROOT=$(fm_test_tmproot fm-treehouse-lock-naming)
+fm_git_identity
+
+# chmod-000 fixtures are restored on the way out: a mode-000 directory inside
+# TMP_ROOT would otherwise defeat the library's own recursive cleanup.
+UNREADABLE=
+cleanup_unreadable() {
+  local dir
+  for dir in $UNREADABLE; do chmod 755 "$dir" 2>/dev/null || true; done
+}
+trap 'cleanup_unreadable; fm_test_cleanup' EXIT INT TERM
+
+make_case() {  # <name> -> echoes a fresh case dir with a usable home
+  local dir="$TMP_ROOT/$1"
+  mkdir -p "$dir/home/state" "$dir/elsewhere"
+  printf '%s\n' "$dir"
+}
+
+# resolve_lock <home> <state-override> <project> [path-prefix]
+# Sources the library in a child shell exactly as the production callers do -
+# stdout captured through command substitution, stderr passed through - and
+# echoes the combined output. FM_STATE_OVERRIDE is always pointed away from
+# <home>/state so the library's own unconditional `mkdir -p "$STATE"` cannot
+# create the very directory a case is about to prove missing.
+resolve_lock() {
+  local home=$1 state=$2 project=$3 prefix=${4-}
+  PATH="${prefix:+$prefix:}$PATH" FM_HOME="$home" FM_STATE_OVERRIDE="$state" \
+    bash -c '. "$1"; fm_treehouse_project_lock_path "$2"' _ "$LIB" "$project" 2>&1
+}
+
+# make_unenterable <dir>: chmod 000 and PROVE the construction actually blocks
+# entry. Running as root (or on a filesystem that ignores the mode) would leave
+# the case asserting a refusal that never fires, which is coverage that reports
+# safety it does not have, so it fails loudly instead of passing vacuously.
+make_unenterable() {
+  local dir=$1
+  chmod 000 "$dir"
+  UNREADABLE="$UNREADABLE $dir"
+  if (CDPATH='' cd -- "$dir" 2>/dev/null); then
+    fail "fixture is not blocking: $dir is still enterable at mode 000 (running as root?)"
+  fi
+}
+
+# git_shim <dir> <body>: a PATH-front `git` that answers the queries this case
+# needs and delegates everything else to the real binary. Two exits can only be
+# reached when git answers one call and fails a later one, which no on-disk
+# fixture can arrange.
+git_shim() {
+  local dir=$1 body=$2 real
+  real=$(command -v git)
+  mkdir -p "$dir"
+  cat > "$dir/git" <<EOF
+#!/usr/bin/env bash
+$body
+exec "$real" "\$@"
+EOF
+  chmod +x "$dir/git"
+  printf '%s\n' "$dir"
+}
+
+
+test_missing_project_directory_is_named() {
+  local dir out
+  dir=$(make_case project-absent)
+  out=$(resolve_lock "$dir/home" "$dir/elsewhere" "$dir/no-such-project")
+  expect_code 1 "$?" "an absent project directory should still refuse"
+  assert_contains "$out" "project directory does not exist: $dir/no-such-project" \
+    "the refusal did not name the absent project directory"
+  pass "an absent project directory is named in the refusal"
+}
+
+test_unresolvable_root_home_is_named() {
+  local dir out
+  dir=$(make_case root-home-absent)
+  fm_git_init_commit "$dir/project"
+  out=$(resolve_lock "$dir/no-such-home" "$dir/elsewhere" "$dir/project")
+  expect_code 1 "$?" "an absent firstmate home should still refuse"
+  assert_contains "$out" "cannot resolve the root firstmate home from FM_HOME: $dir/no-such-home" \
+    "the refusal did not name the home it could not resolve"
+  assert_not_contains "$out" "$dir/project" \
+    "the refusal blamed the project for a home that could not be resolved"
+  pass "an unresolvable root firstmate home is named, and the project is not blamed"
+}
+
+test_broken_secondmate_parent_chain_names_the_home() {
+  local dir out
+  dir=$(make_case secondmate-chain)
+  fm_git_init_commit "$dir/project"
+  printf 'route=not-a-real-route\n' > "$dir/home/.fm-secondmate-parent"
+  out=$(resolve_lock "$dir/home" "$dir/elsewhere" "$dir/project")
+  expect_code 1 "$?" "an unparseable secondmate parent record should still refuse"
+  assert_contains "$out" "cannot resolve the root firstmate home from FM_HOME: $dir/home" \
+    "a broken secondmate parent chain did not name the home whose chain broke"
+  pass "a broken secondmate parent chain names the home, not the project"
+}
+
+test_unenterable_absolute_origin_is_named() {
+  local dir out
+  dir=$(make_case origin-absolute)
+  fm_git_init_commit "$dir/project"
+  fm_git_init_commit "$dir/origin"
+  git -C "$dir/project" remote add origin "$dir/origin"
+  make_unenterable "$dir/origin"
+  out=$(resolve_lock "$dir/home" "$dir/elsewhere" "$dir/project")
+  expect_code 1 "$?" "an unenterable absolute origin directory should still refuse"
+  assert_contains "$out" "project origin directory cannot be entered: $dir/origin" \
+    "the refusal did not name the origin directory it could not enter"
+  pass "an unenterable absolute origin directory is named in the refusal"
+}
+
+test_unenterable_relative_origin_is_named() {
+  local dir out
+  dir=$(make_case origin-relative)
+  fm_git_init_commit "$dir/project"
+  fm_git_init_commit "$dir/project/sibling"
+  git -C "$dir/project" remote add origin sibling
+  make_unenterable "$dir/project/sibling"
+  out=$(resolve_lock "$dir/home" "$dir/elsewhere" "$dir/project")
+  expect_code 1 "$?" "an unenterable relative origin directory should still refuse"
+  assert_contains "$out" "project origin directory cannot be entered: $dir/project/sibling" \
+    "the refusal did not name the relative origin directory it could not enter"
+  pass "an unenterable relative origin directory is named in the refusal"
+}
+
+test_originless_non_git_project_is_named() {
+  local dir out
+  dir=$(make_case originless-non-git)
+  mkdir -p "$dir/project"
+  out=$(resolve_lock "$dir/home" "$dir/elsewhere" "$dir/project")
+  expect_code 1 "$?" "a project outside any git worktree should still refuse"
+  assert_contains "$out" "project has no origin and is not inside a git worktree: $dir/project" \
+    "the refusal did not say the project has no origin and no worktree"
+  pass "an origin-less non-git project is named in the refusal"
+}
+
+test_unenterable_worktree_top_is_named() {
+  local dir out shim
+  dir=$(make_case worktree-top)
+  mkdir -p "$dir/project"
+  # git reports a toplevel that is not there by the time it is entered: the
+  # shape a checkout removed underneath a running spawn produces.
+  shim=$(git_shim "$dir/shim" '
+for a in "$@"; do
+  [ "$a" = "--show-toplevel" ] && { echo "'"$dir"'/vanished"; exit 0; }
+  [ "$a" = "get-url" ] && exit 1
+done')
+  out=$(resolve_lock "$dir/home" "$dir/elsewhere" "$dir/project" "$shim")
+  expect_code 1 "$?" "a vanished worktree top should still refuse"
+  assert_contains "$out" "project worktree top cannot be entered: $dir/vanished" \
+    "the refusal did not name the worktree top it could not enter"
+  pass "an unenterable worktree top is named in the refusal"
+}
+
+test_unhashable_identity_is_named() {
+  local dir out shim
+  dir=$(make_case identity-hash)
+  mkdir -p "$dir/project"
+  shim=$(git_shim "$dir/shim" '
+for a in "$@"; do
+  [ "$a" = "get-url" ] && { echo "https://example.invalid/x.git"; exit 0; }
+  [ "$a" = "hash-object" ] && exit 1
+done')
+  out=$(resolve_lock "$dir/home" "$dir/elsewhere" "$dir/project" "$shim")
+  expect_code 1 "$?" "an unusable git should still refuse"
+  assert_contains "$out" "cannot hash the project lock identity" \
+    "the refusal did not say the project identity could not be hashed"
+  assert_contains "$out" "https://example.invalid/x.git" \
+    "the refusal did not name the identity it failed to hash"
+  pass "an identity that cannot be hashed is named in the refusal"
+}
+
+# The exit the investigation actually hit: a directory the same library creates
+# unconditionally at bin/fm-wake-lib.sh:16, absent here because the state root
+# was pointed elsewhere. The refusal must name the HOME's missing directory and
+# must not read as a fault in the project.
+test_missing_root_state_directory_is_named() {
+  local dir out
+  dir=$(make_case root-state-missing)
+  fm_git_init_commit "$dir/project"
+  rmdir "$dir/home/state"
+  out=$(resolve_lock "$dir/home" "$dir/elsewhere" "$dir/project")
+  expect_code 1 "$?" "a root home with no state directory should still refuse"
+  assert_contains "$out" "the root firstmate home has no state directory: $dir/home/state" \
+    "the refusal did not name the home's missing state directory"
+  assert_not_contains "$out" "project directory does not exist" \
+    "the refusal blamed the project for a directory missing in the home"
+  assert_absent "$dir/home/state" \
+    "the refusal created the state directory instead of naming it"
+  pass "a missing root state directory is named, not created, and the project is not blamed"
+}
+
+# The other half of the mutation pin: a diagnostic printed unconditionally would
+# satisfy every case above, so the resolving path must stay silent.
+test_resolved_lock_path_stays_silent() {
+  local dir out
+  dir=$(make_case resolves)
+  fm_git_init_commit "$dir/project"
+  out=$(resolve_lock "$dir/home" "$dir/elsewhere" "$dir/project")
+  expect_code 0 "$?" "a resolvable project lock should not refuse"
+  assert_not_contains "$out" "fm_treehouse_project_lock_path:" \
+    "a resolved lock path emitted a refusal diagnostic"
+  case "$out" in
+    "$dir/home/state/.treehouse-project-"*.lock) ;;
+    *) fail "the resolved lock path was not the root home's project lock: $out" ;;
+  esac
+  pass "a resolved lock path is printed alone, with no diagnostic"
+}
+
+# End to end: the named cause has to survive the production call shape, where
+# stdout is captured by command substitution and only stderr reaches the
+# operator. It arrives alongside the caller's own line, not instead of it.
+test_spawn_refusal_carries_the_named_cause() {
+  local dir home fakebin out status
+  dir=$(make_case spawn-e2e)
+  home="$dir/spawn-home"
+  fm_test_spawn_home "$home"
+  fm_test_spawn_brief "$home" lock-naming-e2e
+  fm_git_init_commit "$dir/project"
+  fakebin=$(make_spawn_fakebin "$dir")
+  # The divergence that produced the original defect: the state root points away
+  # from the home, so the library creates that directory and not the home's.
+  mkdir -p "$dir/state-elsewhere"
+  rmdir "$home/state" 2>/dev/null || rm -rf "$home/state"
+  out=$(FM_ROOT_OVERRIDE='' FM_HOME="$home" HOME="$dir/user-home" \
+    CLAUDE_CONFIG_DIR='' \
+    FM_STATE_OVERRIDE="$dir/state-elsewhere" FM_DATA_OVERRIDE="$home/data" \
+    FM_PROJECTS_OVERRIDE="$home/projects" FM_CONFIG_OVERRIDE="$home/config" \
+    FM_SPAWN_NO_GUARD=1 FM_FAKE_PANE_PATH="$dir/pane" TMUX="${TMUX:-fake,1,0}" \
+    PATH="$fakebin:$PATH" \
+    "$ROOT/bin/fm-spawn.sh" lock-naming-e2e "$dir/project" --scout 2>&1)
+  status=$?
+  expect_code 1 "$status" "the spawn should refuse when the home has no state directory"$'\n'"$out"
+  assert_contains "$out" "the root firstmate home has no state directory: $home/state" \
+    "the spawn refusal did not carry the named cause to the operator"
+  assert_contains "$out" "could not resolve the shared Treehouse project lock" \
+    "the spawn refusal lost its own context line"
+  pass "a spawn refusal carries the named cause alongside its context line"
+}
+
+test_missing_project_directory_is_named
+test_unresolvable_root_home_is_named
+test_broken_secondmate_parent_chain_names_the_home
+test_unenterable_absolute_origin_is_named
+test_unenterable_relative_origin_is_named
+test_originless_non_git_project_is_named
+test_unenterable_worktree_top_is_named
+test_unhashable_identity_is_named
+test_missing_root_state_directory_is_named
+test_resolved_lock_path_stays_silent
+test_spawn_refusal_carries_the_named_cause
+
+echo "# all fm-treehouse-lock-naming tests passed"


### PR DESCRIPTION
## Contract class: RESTORE

Stated before the work was written, not chosen at publication, and decided by the behaviour rather than by the framing.

This restores what the refusal was always for. `fm_treehouse_project_lock_path` exists to tell the reader what is wrong when it will not resolve a lock, and today it tells them something false: it points at the PROJECT when the missing thing is in the HOME. Naming the missing directory is that message doing its own job.

**The case against this classification, which you should weigh rather than take on trust.** The new diagnostics do print unconditionally. Precisely: a path that emitted nothing now emits one line on the error stream - on a path that had already failed, and whose failure the caller already surfaced to the operator. That is the honest form of the objection, and it is weaker than "an already-printing path" because the function itself printed nothing before; what was already printing is the caller.

Why it does not move the class, measured and checkable by anyone:

| | baseline | this branch |
|---|---|---|
| exit code, all refusals | `1` | `1` |
| stdout, all refusals | empty | empty |
| exit code, resolving path | `0` | `0` |
| stdout, resolving path | the lock path | byte-identical lock path |
| stderr, per refusal | 0 lines | 1 line |
| stderr, resolving path | 0 lines | 0 lines |

Nothing new fires, nothing new is decided, nothing escalates anywhere it did not before. No new guarantee, subsystem, threat model, monitoring requirement, or compatibility surface. A regression case pins the resolving path as silent, so a diagnostic emitted unconditionally would fail this branch's own tests.

If you triage it as new-default anyway, that is your call and we accept the human gate; we will not repackage it to get a different answer.

## The count is eight, not four

The originating report states that one message covers FOUR causes. That number is not carried over here: every exit was enumerated from the code and driven at this branch's baseline, and there are **eight**, all reachable. Six are reachable from ordinary on-disk fixtures; two - a worktree top that vanishes between git reporting it and the code entering it, and git answering one call then failing a later one - need a git shim. None is dead weight, so none was dropped.

At baseline all eight returned `1` with completely empty output: one undifferentiated silent refusal.

Each naming is proven by mutation, one exit at a time: removing a single message turns exactly its own case red, and no case is vacuous. The resolving path is pinned silent as the other half of that proof, so a message printed unconditionally cannot satisfy the suite either. A fixture that fails to actually block directory entry fails loudly rather than passing empty.

The guard's decision is unchanged throughout. In particular the root state directory is named, not created: a root home that genuinely does not exist is still refused rather than conjured, which is what the captain chose between the two shapes the report offered.

## A credential the review bot caught, and we accepted

The automated review flagged one of these eight diagnostics as a security defect, and it was right. At the hash-failure exit the message printed the project's **origin identity**, so an origin carrying userinfo - `https://user:token@host/repo.git`, which `bin/fm-project-origin-lib.sh` explicitly accepts as a valid clone URL - would have put that credential on the error stream and into any capture of it.

It is worth recording that we did not accept it reflexively: a finding from the same tool was contested on another branch the same day. This one was measured and it held.

**Naming the project, not a redacted URL.** Redaction was the obvious fix; it is the weaker one. A redacted URL still carries a host and a repository path that the reader does not need, and it leaves a parser between the secret and the terminal. For a hash failure the thing that is wrong is the project, not its transport address - which is the whole premise of this change - so the message now names the project directory and the origin never reaches the output at all.

**Proven by execution, not by reading the code.** The exit was driven with a credential-bearing origin, and these assertions are made against what was actually printed:

```
$ fm_treehouse_project_lock_path <project>       # origin: https://octocat:ghp_SUPERSECRET…@github.example.invalid/acme/widgets.git
fm_treehouse_project_lock_path: cannot hash the project lock identity, so git is unusable here: /tmp/…/proj
rc=1
```

token absent, username absent, host absent, repository path absent, project directory named. A regression case pins it with a credential-bearing URL so the guarantee cannot quietly lapse.

Reachability bounds the exposure but does not excuse it: this exit needs git to answer `remote get-url` and then fail `hash-object`. It was fixed on that basis, not on how hard it is to reach.

**One thing deliberately not fixed here.** The same pattern - an origin URL printed into a diagnostic - exists elsewhere in the tree and predates this change: `bin/fm-home-seed.sh:478` prints two origin URLs on a source/seeded mismatch, `bin/fm-home-seed.sh:386` prints an expected origin, and `bin/fm-remote-home-seed.sh:181` prints a rejected one. Those paths are more ordinary than this one. They are reported rather than folded in, so a pre-existing credential path is filed as its own work instead of being buried inside a change about message wording.

## Intent

THE CAPTAIN ANSWERED A QUESTION AN INVESTIGATION DELIBERATELY REFUSED TO DECIDE ALONE.

Report: data/fm-test-passes-alone-fails-in-lane/report.md, recommendation 2. That investigation found a
test whose verdict depended on whether a gitignored state/ directory happened to exist inside the working
copy. While proving it, the investigator lost time to a refusal message that told them the wrong thing,
and recorded the product judgement rather than making it.

THE DEFECT, measured: bin/fm-wake-lib.sh:1201 refuses when a state/ directory is missing - the same
directory the same library creates unconditionally at bin/fm-wake-lib.sh:16. The refusal reads
"could not resolve the shared Treehouse project lock for <project>". That one message covers FOUR distinct
causes, and it points the reader at the PROJECT while the problem is in the HOME.

The report offered two shapes: create the directory and refuse only when creation fails, or - if refusing
is deliberate, which is defensible for a root home that genuinely does not exist - keep refusing but NAME
the missing directory.

THE CAPTAIN'S ANSWER, verbatim as relayed 2026-09-09 (corr=18f323df2b3ad649):
"SA REPONSE: les deux. Le garde de verrou doit NOMMER le repertoire manquant, et nous voulons la garantie
qui INTERDIT a un test d'ecrire dans la copie de travail.
Deux rappels que je vous demande de tenir. Le rapport dit lui-meme que le point 2 change du code produit
en amont et passe par la voie ordinaire des demandes de fusion. [...]
Ce sont des chantiers distincts. Ne les repliez pas l'un dans l'autre ni dans la reparation deja livree."

In English: he chose NAMING the missing directory. He also reminded us that this changes upstream product
code and goes through the ordinary pull-request path, and that the three pieces of work from that report
are DISTINCT and must not be folded into one another.

## What Changed

- Add stderr diagnostics identifying failed Treehouse lock resources, including missing root `state/` directories and recorded parent homes, while retaining refusal without creating those directories.
- Add regression coverage for resolution failures, nested parent chains, clean success output, and diagnostics reaching spawn callers.
- Link configuration documentation to the resolver’s shared root-state requirement and diagnostic contract.

## Risk Assessment

✅ Low: The diagnostic changes preserve refusal conditions and lock identity; no material defects or new scope violations were found.

## Testing

The focused suite and real before/after CLI scenarios passed; mutation checks caught the expected regressions. Product transcripts were saved and temporary fixtures removed. No broad suite or other gate phases were run.

- Live validation: ✅ go - 10 of 10 scenarios driven live against the product

| Scenario | Result | Live | Evidence |
| --- | --- | --- | --- |
| Spawn with missing root state: refusal names the exact directory and leaves it absent; creating it clears that guard. | ✅ pass | live | Before/after live CLI transcripts: root-state-absent |
| Spawn with an absent home: refusal names that home without creating it. | ✅ pass | live | Before/after live CLI transcripts: root-home-absent |
| Follow local parent records at two depths: refusal names the missing parent, then its missing state directory after repair. | ✅ pass | live | Before/after live CLI transcripts: parent-depth-1 and parent-depth-2 |
| Malformed and cyclic parent records remain refused; a remote parent still anchors the lock locally. | ✅ pass | live | Before/after live CLI transcripts: malformed-parent, parent-cycle, remote-parent-terminates-locally |
| Use inaccessible absolute or relative origins: refusal names the origin, and restoring access clears the guard. | ✅ pass | live | Before/after live CLI transcripts: absolute-origin-permission and relative-origin-permission |
| Missing and non-Git projects remain refused at their existing boundaries without creating directories. | ✅ pass | live | Before/after live CLI transcripts: not-a-git-project; Real Git failure and repair transcripts: real-missing-project |
| Git reports an absent worktree top: refusal names that path; creating it clears the guard. | ✅ pass | live | Real Git failure and repair transcripts: real-vanished-worktree-top |
| A malformed invocation-directory Git context prevents hashing: refusal names the identity; repairing the context clears the guard. | ✅ pass | live | Real Git failure and repair transcripts: real-hash-failure |
| Resolve valid locks: old and new paths match, diagnostics stay silent, and spawn advances to the subsequent brief check. | ✅ pass | live | Before/after live CLI transcripts: repaired directories and origin variants |
| Explicitly select tmux with Orca inherited: the command still reaches the named lock refusal. | ✅ pass | live | Before/after live CLI transcripts; Expected regression failures against altered copies: mutant-unpinned-backend |

<details>
<summary>Evidence: Before/after live CLI transcripts</summary>

Source: [Before/after live CLI transcripts](https://github.com/mremond/firstmate/blob/804ca46949d31591e52659a7a213be078747b18f/.no-mistakes/evidence/fm/fm-lock-guard-names-missing-directory/live-cli-transcript.log)

```text

[root-state-absent / base / spawn]
Environment: FM_HOME=~/.no-mistakes/worktrees/acf4a767348a/01M22J6W2BJAVGZZ9NSGWD23SR/.local-test-lock-naming/live/root-state-absent/home FM_STATE_OVERRIDE=~/.no-mistakes/worktrees/acf4a767348a/01M22J6W2BJAVGZZ9NSGWD23SR/.local-test-lock-naming/live/root-state-absent/external-state FM_DATA_OVERRIDE=~/.no-mistakes/worktrees/acf4a767348a/01M22J6W2BJAVGZZ9NSGWD23SR/.local-test-lock-naming/live/root-state-absent/data FM_BACKEND=orca
$ ~/.no-mistakes/worktrees/acf4a767348a/01M22J6W2BJAVGZZ9NSGWD23SR/.local-test-lock-naming/base/bin/fm-spawn.sh lock-check ~/.no-mistakes/worktrees/acf4a767348a/01M22J6W2BJAVGZZ9NSGWD23SR/.local-test-lock-naming/live/root-state-absent/project --scout --backend tmux --harness codex
exit=1
stdout: <empty>
stderr: error: could not resolve the shared Treehouse project lock for ~/.no-mistakes/worktrees/acf4a767348a/01M22J6W2BJAVGZZ9NSGWD23SR/.local-test-lock-naming/live/root-state-absent/project


[root-state-absent / target / spawn]
Environment: FM_HOME=~/.no-mistakes/worktrees/acf4a767348a/01M22J6W2BJAVGZZ9NSGWD23SR/.local-test-lock-naming/live/root-state-absent/home FM_STATE_OVERRIDE=~/.no-mistakes/worktrees/acf4a767348a/01M22J6W2BJAVGZZ9NSGWD23SR/.local-test-lock-naming/live/root-state-absent/external-state FM_DATA_OVERRIDE=~/.no-mistakes/worktrees/acf4a767348a/01M22J6W2BJAVGZZ9NSGWD23SR/.local-test-lock-naming/live/root-state-absent/data FM_BACKEND=orca
$ ~/.no-mistakes/worktrees/acf4a767348a/01M22J6W2BJAVGZZ9NSGWD23SR/bin/fm-spawn.sh lock-check ~/.no-mistakes/worktrees/acf4a767348a/01M22J6W2BJAVGZZ9NSGWD23SR/.local-test-lock-naming/live/root-state-absent/project --scout --backend tmux --harness codex
exit=1
stdout: <empty>
stderr: fm_treehouse_project_lock_path: the root firstmate home has no state directory: ~/.no-mistakes/worktrees/acf4a767348a/01M22J6W2BJAVGZZ9NSGWD23SR/.local-test-lock-naming/live/root-state-absent/home/state
error: could not resolve the shared Treehouse project lock for ~/.no-mistakes/worktrees/acf4a767348a/01M22J6W2BJAVGZZ9NSGWD23SR/.local-test-lock-naming/live/root-state-absent/project

filesystem: ~/.no-mistakes/worktrees/acf4a767348a/01M22J6W2BJAVGZZ9NSGWD23SR/.local-test-lock-naming/live/root-state-absent/home/state remains absent

[root-state-absent / base / spawn]
Environment: FM_HOME=~/.no-mistakes/worktrees/acf4a767348a/01M22J6W2BJAVGZZ9NSGWD23SR/.local-test-lock-naming/live/root-state-absent/home FM_STATE_OVERRIDE=~/.no-mistakes/worktrees/acf4a767348a/01M22J6W2BJAVGZZ9NSGWD23SR/.local-test-lock-naming/live/root-state-absent/external-state FM_DATA_OVERRIDE=~/.no-mistakes/worktrees/acf4a767348a/01M22J6W2BJAVGZZ9NSGWD23SR/.local-test-lock-naming/live/root-state-absent/data FM_BACKEND=orca
$ ~/.no-mistakes/worktrees/acf4a767348a/01M22J6W2BJAVGZZ9NSGWD23SR/.local-test-lock-naming/base/bin/fm-spawn.sh lock-check ~/.no-mistakes/worktrees/acf4a767348a/01M22J6W2BJAVGZZ9NSGWD23SR/.local-test-lock-naming/live/root-state-absent/project --scout --backend tmux --harness codex
exit=1
stdout: <empty>
stderr: error: task lock-check has no brief at inaccessible data path ~/.no-mistakes/worktrees/acf4a767348a/01M22J6W2BJAVGZZ9NSGWD23SR/.local-test-lock-naming/live/root-state-absent/data/lock-check/brief.md


[root-state-absent / target / spawn]
Environment: FM_HOME=~/.no-mistakes/worktrees/acf4a767348a/01M22J6W2BJAVGZZ9NSGWD23SR/.local-test-lock-naming/live/root-state-absent/home FM_STATE_OVERRIDE=~/.no-mistakes/worktrees/acf4a767348a/01M22J6W2BJAVGZZ9NSGWD23SR/.local-test-lock-naming/live/root-state-absent/external-state FM_DATA_OVERRIDE=~/.no-mistakes/worktrees/acf4a767348a/01M22J6W2BJAVGZZ9NSGWD23SR/.local-test-lock-naming/live/root-state-absent/data FM_BACKEND=orca
$ ~/.no-mistakes/worktrees/acf4a767348a/01M22J6W2BJAVGZZ9NSGWD23SR/bin/fm-spawn.sh lock-check ~/.no-mistakes/worktrees/acf4a767348a/01M22J6W2BJAVGZZ9NSGWD23SR/.local-test-lock-naming/live/root-state-absent/project --scout --backend tmux --harness codex
exit=1
stdout: <empty>
stderr: error: task lock-check has no brief at inaccessible data path ~/.no-mistakes/worktrees/acf4a767348a/01M22J6W2BJAVGZZ9NSGWD23SR/.local-test-lock-naming/live/root-state-absent/data/lock-check/brief.md


[root-state-absent / base / library]
Environment: FM_HOME=~/.no-mistakes/worktrees/acf4a767348a/01M22J6W2BJAVGZZ9NSGWD23SR/.local-test-lock-naming/live/root-state-absent/home FM_STATE_OVERRIDE=~/.no-mistakes/worktrees/acf4a767348a/01M22J6W2BJAVGZZ9NSGWD23SR/.local-test-lock-naming/live/root-state-absent/external-state FM_DATA_OVERRIDE=~/.no-mistakes/worktrees/acf4a767348a/01M22J6W2BJAVGZZ9NSGWD23SR/.local-test-lock-naming/live/root-state-absent/data FM_BACKEND=orca
$ /bin/bash -c '. "$1"; fm_treehouse_project_lock_path "$2"' _ ~/.no-mistakes/worktrees/acf4a767348a/01M22J6W2BJAVGZZ9NSGWD23SR/.local-test-lock-naming/base/bin/fm-wake-lib.sh ~/.no-mistakes/worktrees/acf4a767348a/01M22J6W2BJAVGZZ9NSGWD23SR/.local-test-lock-naming/live/root-state-absent/project
exit=0
stdout: ~/.no-mistakes/worktrees/acf4a767348a/01M22J6W2BJAVGZZ9NSGWD23SR/.local-test-lock-naming/live/root-state-absent/home/state/.treehouse-project-3336bc32d79ee1c3dffaa1a6c3baea7f4d30aa79.lock

stderr: <empty>

[root-state-absent / target / library]
Environment: FM_HOME=~/.no-mistakes/worktrees/acf4a767348a/01M22J6W2BJAVGZZ9NSGWD23SR/.local-test-lock-naming/live/root-state-absent/home FM_STATE_OVERRIDE=~/.no-mistakes/worktrees/acf4a767348a/01M22J6W2BJAVGZZ9NSGWD23SR/.local-test-lock-naming/live/root-state-absent/external-state FM_DATA_OVERRIDE=~/.no-mistakes/worktrees/acf4a767348a/01M22J6W2BJAVGZZ9NSGWD23SR/.local-test-lock-naming/live/root-state-absent/data FM_BACKEND=orca
$ /bin/bash -c '. "$1"; fm_treehouse_project_lock_path "$2"' _ ~/.no-mistakes/worktrees/acf4a767348a/01M22J6W2BJAVGZZ9NSGWD23SR/bin/fm-wake-lib.sh ~/.no-mistakes/worktrees/acf4a767348a/01M22J6W2BJAVGZZ9NSGWD23SR/.local-test-lock-naming/live/root-state-absent/project
exit=0
stdout: ~/.no-mistakes/worktrees/acf4a767348a/01M22J6W2BJAVGZZ9NSGWD23SR/.local-test-lock-naming/live/root-state-absent/home/state/.treehouse-project-3336bc32d79ee1c3dffaa1a6c3baea7f4d30aa79.lock

stderr: <empty>
CLI advanced past the project guard to the independently missing brief; task creation never began. Old and new lock paths match byte-for-byte.

[root-home-absent / base / spawn]
Environment: 'FM_HOME=~/.no-mistakes/worktrees/acf4a767348a/01M22J6W2BJAVGZZ9NSGWD23SR/.local-test-lock-naming/live/root-home-absent/missing home' FM_STATE_OVERRIDE=~/.no-mistakes/worktrees/acf4a767348a/01M22J6W2BJAVGZZ9NSGWD23SR/.local-test-lock-naming/live/root-home-absent/external-state FM_DATA_OVERRIDE=~/.no-mistakes/worktrees/acf4a767348a/01M22J6W2BJAVGZZ9NSGWD23SR/.local-test-lock-naming/live/root-home-absent/data FM_BACKEND=orca
$ ~/.no-mistakes/worktrees/acf4a767348a/01M22J6W2BJAVGZZ9NSGWD23SR/.local-test-lock-naming/base/bin/fm-spawn.sh lock-check ~/.no-mistakes/worktrees/acf4a767348a/01M22J6W2BJAVGZZ9NSGWD23SR/.local-test-lock-naming/live/root-home-absent/project --scout --backend tmux --harness codex
exit=1
stdout: <empty>
stderr: error: could not resolve the shared Treehouse project lock for ~/.no-mistakes/worktrees/acf4a767348a/01M22J6W2BJAVGZZ9NSGWD23SR/.local-test-lock-naming/live/root-home-absent/project


[root-home-absent / target / spawn]
Environment: 'FM_HOME=~/.no-mistakes/worktrees/acf4a767348a/01M22J6W2BJAVGZZ9NSGWD23SR/.local-test-lock-naming/live/root-home-absent/missing home' FM_STATE_OVERRIDE=~/.no-mistakes/worktrees/acf4a767348a/01M22J6W2BJAVGZZ9NSGWD23SR/.local-test-lock-naming/live/root-home-absent/external-state FM_DATA_OVE

... [48852 bytes truncated] ...

M22J6W2BJAVGZZ9NSGWD23SR/.local-test-lock-naming/live/origin-18/home FM_STATE_OVERRIDE=~/.no-mistakes/worktrees/acf4a767348a/01M22J6W2BJAVGZZ9NSGWD23SR/.local-test-lock-naming/live/origin-18/external-state FM_DATA_OVERRIDE=~/.no-mistakes/worktrees/acf4a767348a/01M22J6W2BJAVGZZ9NSGWD23SR/.local-test-lock-naming/live/origin-18/data FM_BACKEND=orca
$ ~/.no-mistakes/worktrees/acf4a767348a/01M22J6W2BJAVGZZ9NSGWD23SR/.local-test-lock-naming/base/bin/fm-spawn.sh lock-check ~/.no-mistakes/worktrees/acf4a767348a/01M22J6W2BJAVGZZ9NSGWD23SR/.local-test-lock-naming/live/origin-18/project --scout --backend tmux --harness codex
exit=1
stdout: <empty>
stderr: error: task lock-check has no brief at inaccessible data path ~/.no-mistakes/worktrees/acf4a767348a/01M22J6W2BJAVGZZ9NSGWD23SR/.local-test-lock-naming/live/origin-18/data/lock-check/brief.md


[origin-18 / target / spawn]
Environment: FM_HOME=~/.no-mistakes/worktrees/acf4a767348a/01M22J6W2BJAVGZZ9NSGWD23SR/.local-test-lock-naming/live/origin-18/home FM_STATE_OVERRIDE=~/.no-mistakes/worktrees/acf4a767348a/01M22J6W2BJAVGZZ9NSGWD23SR/.local-test-lock-naming/live/origin-18/external-state FM_DATA_OVERRIDE=~/.no-mistakes/worktrees/acf4a767348a/01M22J6W2BJAVGZZ9NSGWD23SR/.local-test-lock-naming/live/origin-18/data FM_BACKEND=orca
$ ~/.no-mistakes/worktrees/acf4a767348a/01M22J6W2BJAVGZZ9NSGWD23SR/bin/fm-spawn.sh lock-check ~/.no-mistakes/worktrees/acf4a767348a/01M22J6W2BJAVGZZ9NSGWD23SR/.local-test-lock-naming/live/origin-18/project --scout --backend tmux --harness codex
exit=1
stdout: <empty>
stderr: error: task lock-check has no brief at inaccessible data path ~/.no-mistakes/worktrees/acf4a767348a/01M22J6W2BJAVGZZ9NSGWD23SR/.local-test-lock-naming/live/origin-18/data/lock-check/brief.md


[origin-18 / base / library]
Environment: FM_HOME=~/.no-mistakes/worktrees/acf4a767348a/01M22J6W2BJAVGZZ9NSGWD23SR/.local-test-lock-naming/live/origin-18/home FM_STATE_OVERRIDE=~/.no-mistakes/worktrees/acf4a767348a/01M22J6W2BJAVGZZ9NSGWD23SR/.local-test-lock-naming/live/origin-18/external-state FM_DATA_OVERRIDE=~/.no-mistakes/worktrees/acf4a767348a/01M22J6W2BJAVGZZ9NSGWD23SR/.local-test-lock-naming/live/origin-18/data FM_BACKEND=orca
$ /bin/bash -c '. "$1"; fm_treehouse_project_lock_path "$2"' _ ~/.no-mistakes/worktrees/acf4a767348a/01M22J6W2BJAVGZZ9NSGWD23SR/.local-test-lock-naming/base/bin/fm-wake-lib.sh ~/.no-mistakes/worktrees/acf4a767348a/01M22J6W2BJAVGZZ9NSGWD23SR/.local-test-lock-naming/live/origin-18/project
exit=0
stdout: ~/.no-mistakes/worktrees/acf4a767348a/01M22J6W2BJAVGZZ9NSGWD23SR/.local-test-lock-naming/live/origin-18/home/state/.treehouse-project-a7715ce9a14d16bbba7f12acad66b0eb882a1995.lock

stderr: <empty>

[origin-18 / target / library]
Environment: FM_HOME=~/.no-mistakes/worktrees/acf4a767348a/01M22J6W2BJAVGZZ9NSGWD23SR/.local-test-lock-naming/live/origin-18/home FM_STATE_OVERRIDE=~/.no-mistakes/worktrees/acf4a767348a/01M22J6W2BJAVGZZ9NSGWD23SR/.local-test-lock-naming/live/origin-18/external-state FM_DATA_OVERRIDE=~/.no-mistakes/worktrees/acf4a767348a/01M22J6W2BJAVGZZ9NSGWD23SR/.local-test-lock-naming/live/origin-18/data FM_BACKEND=orca
$ /bin/bash -c '. "$1"; fm_treehouse_project_lock_path "$2"' _ ~/.no-mistakes/worktrees/acf4a767348a/01M22J6W2BJAVGZZ9NSGWD23SR/bin/fm-wake-lib.sh ~/.no-mistakes/worktrees/acf4a767348a/01M22J6W2BJAVGZZ9NSGWD23SR/.local-test-lock-naming/live/origin-18/project
exit=0
stdout: ~/.no-mistakes/worktrees/acf4a767348a/01M22J6W2BJAVGZZ9NSGWD23SR/.local-test-lock-naming/live/origin-18/home/state/.treehouse-project-a7715ce9a14d16bbba7f12acad66b0eb882a1995.lock

stderr: <empty>
CLI advanced past the project guard to the independently missing brief; task creation never began. Old and new lock paths match byte-for-byte.

[origin-19 / base / spawn]
Environment: FM_HOME=~/.no-mistakes/worktrees/acf4a767348a/01M22J6W2BJAVGZZ9NSGWD23SR/.local-test-lock-naming/live/origin-19/home FM_STATE_OVERRIDE=~/.no-mistakes/worktrees/acf4a767348a/01M22J6W2BJAVGZZ9NSGWD23SR/.local-test-lock-naming/live/origin-19/external-state FM_DATA_OVERRIDE=~/.no-mistakes/worktrees/acf4a767348a/01M22J6W2BJAVGZZ9NSGWD23SR/.local-test-lock-naming/live/origin-19/data FM_BACKEND=orca
$ ~/.no-mistakes/worktrees/acf4a767348a/01M22J6W2BJAVGZZ9NSGWD23SR/.local-test-lock-naming/base/bin/fm-spawn.sh lock-check ~/.no-mistakes/worktrees/acf4a767348a/01M22J6W2BJAVGZZ9NSGWD23SR/.local-test-lock-naming/live/origin-19/project --scout --backend tmux --harness codex
exit=1
stdout: <empty>
stderr: error: task lock-check has no brief at inaccessible data path ~/.no-mistakes/worktrees/acf4a767348a/01M22J6W2BJAVGZZ9NSGWD23SR/.local-test-lock-naming/live/origin-19/data/lock-check/brief.md


[origin-19 / target / spawn]
Environment: FM_HOME=~/.no-mistakes/worktrees/acf4a767348a/01M22J6W2BJAVGZZ9NSGWD23SR/.local-test-lock-naming/live/origin-19/home FM_STATE_OVERRIDE=~/.no-mistakes/worktrees/acf4a767348a/01M22J6W2BJAVGZZ9NSGWD23SR/.local-test-lock-naming/live/origin-19/external-state FM_DATA_OVERRIDE=~/.no-mistakes/worktrees/acf4a767348a/01M22J6W2BJAVGZZ9NSGWD23SR/.local-test-lock-naming/live/origin-19/data FM_BACKEND=orca
$ ~/.no-mistakes/worktrees/acf4a767348a/01M22J6W2BJAVGZZ9NSGWD23SR/bin/fm-spawn.sh lock-check ~/.no-mistakes/worktrees/acf4a767348a/01M22J6W2BJAVGZZ9NSGWD23SR/.local-test-lock-naming/live/origin-19/project --scout --backend tmux --harness codex
exit=1
stdout: <empty>
stderr: error: task lock-check has no brief at inaccessible data path ~/.no-mistakes/worktrees/acf4a767348a/01M22J6W2BJAVGZZ9NSGWD23SR/.local-test-lock-naming/live/origin-19/data/lock-check/brief.md


[origin-19 / base / library]
Environment: FM_HOME=~/.no-mistakes/worktrees/acf4a767348a/01M22J6W2BJAVGZZ9NSGWD23SR/.local-test-lock-naming/live/origin-19/home FM_STATE_OVERRIDE=~/.no-mistakes/worktrees/acf4a767348a/01M22J6W2BJAVGZZ9NSGWD23SR/.local-test-lock-naming/live/origin-19/external-state FM_DATA_OVERRIDE=~/.no-mistakes/worktrees/acf4a767348a/01M22J6W2BJAVGZZ9NSGWD23SR/.local-test-lock-naming/live/origin-19/data FM_BACKEND=orca
$ /bin/bash -c '. "$1"; fm_treehouse_project_lock_path "$2"' _ ~/.no-mistakes/worktrees/acf4a767348a/01M22J6W2BJAVGZZ9NSGWD23SR/.local-test-lock-naming/base/bin/fm-wake-lib.sh ~/.no-mistakes/worktrees/acf4a767348a/01M22J6W2BJAVGZZ9NSGWD23SR/.local-test-lock-naming/live/origin-19/project
exit=0
stdout: ~/.no-mistakes/worktrees/acf4a767348a/01M22J6W2BJAVGZZ9NSGWD23SR/.local-test-lock-naming/live/origin-19/home/state/.treehouse-project-e7a54bbf7debe187cb80576abefd756280922d45.lock

stderr: <empty>

[origin-19 / target / library]
Environment: FM_HOME=~/.no-mistakes/worktrees/acf4a767348a/01M22J6W2BJAVGZZ9NSGWD23SR/.local-test-lock-naming/live/origin-19/home FM_STATE_OVERRIDE=~/.no-mistakes/worktrees/acf4a767348a/01M22J6W2BJAVGZZ9NSGWD23SR/.local-test-lock-naming/live/origin-19/external-state FM_DATA_OVERRIDE=~/.no-mistakes/worktrees/acf4a767348a/01M22J6W2BJAVGZZ9NSGWD23SR/.local-test-lock-naming/live/origin-19/data FM_BACKEND=orca
$ /bin/bash -c '. "$1"; fm_treehouse_project_lock_path "$2"' _ ~/.no-mistakes/worktrees/acf4a767348a/01M22J6W2BJAVGZZ9NSGWD23SR/bin/fm-wake-lib.sh ~/.no-mistakes/worktrees/acf4a767348a/01M22J6W2BJAVGZZ9NSGWD23SR/.local-test-lock-naming/live/origin-19/project
exit=0
stdout: ~/.no-mistakes/worktrees/acf4a767348a/01M22J6W2BJAVGZZ9NSGWD23SR/.local-test-lock-naming/live/origin-19/home/state/.treehouse-project-e7a54bbf7debe187cb80576abefd756280922d45.lock

stderr: <empty>
CLI advanced past the project guard to the independently missing brief; task creation never began. Old and new lock paths match byte-for-byte.
```
</details>
<details>
<summary>Evidence: Real Git failure and repair transcripts</summary>

Source: [Real Git failure and repair transcripts](https://github.com/mremond/firstmate/blob/804ca46949d31591e52659a7a213be078747b18f/.no-mistakes/evidence/fm/fm-lock-guard-names-missing-directory/real-git-failures.log)

```text
cwd=~/.no-mistakes/worktrees/acf4a767348a/01M22J6W2BJAVGZZ9NSGWD23SR/.local-test-lock-naming/real-hash-failure
$ git init -q -b main ~/.no-mistakes/worktrees/acf4a767348a/01M22J6W2BJAVGZZ9NSGWD23SR/.local-test-lock-naming/real-hash-failure/project
exit=0
stdout: <empty>
stderr: <empty>

[real-hash-failure / base] FM_HOME=~/.no-mistakes/worktrees/acf4a767348a/01M22J6W2BJAVGZZ9NSGWD23SR/.local-test-lock-naming/real-hash-failure/home FM_STATE_OVERRIDE=~/.no-mistakes/worktrees/acf4a767348a/01M22J6W2BJAVGZZ9NSGWD23SR/.local-test-lock-naming/real-hash-failure/external-state FM_BACKEND=orca
cwd=~/.no-mistakes/worktrees/acf4a767348a/01M22J6W2BJAVGZZ9NSGWD23SR/.local-test-lock-naming/real-hash-failure/cwd
$ ~/.no-mistakes/worktrees/acf4a767348a/01M22J6W2BJAVGZZ9NSGWD23SR/.local-test-lock-naming/base/bin/fm-spawn.sh lock-check ~/.no-mistakes/worktrees/acf4a767348a/01M22J6W2BJAVGZZ9NSGWD23SR/.local-test-lock-naming/real-hash-failure/project --scout --backend tmux --harness codex
exit=1
stdout: <empty>
stderr: error: could not resolve the shared Treehouse project lock for ~/.no-mistakes/worktrees/acf4a767348a/01M22J6W2BJAVGZZ9NSGWD23SR/.local-test-lock-naming/real-hash-failure/project


[real-hash-failure / target] FM_HOME=~/.no-mistakes/worktrees/acf4a767348a/01M22J6W2BJAVGZZ9NSGWD23SR/.local-test-lock-naming/real-hash-failure/home FM_STATE_OVERRIDE=~/.no-mistakes/worktrees/acf4a767348a/01M22J6W2BJAVGZZ9NSGWD23SR/.local-test-lock-naming/real-hash-failure/external-state FM_BACKEND=orca
cwd=~/.no-mistakes/worktrees/acf4a767348a/01M22J6W2BJAVGZZ9NSGWD23SR/.local-test-lock-naming/real-hash-failure/cwd
$ ~/.no-mistakes/worktrees/acf4a767348a/01M22J6W2BJAVGZZ9NSGWD23SR/bin/fm-spawn.sh lock-check ~/.no-mistakes/worktrees/acf4a767348a/01M22J6W2BJAVGZZ9NSGWD23SR/.local-test-lock-naming/real-hash-failure/project --scout --backend tmux --harness codex
exit=1
stdout: <empty>
stderr: fm_treehouse_project_lock_path: cannot hash the project lock identity, so git is unusable here: ~/.no-mistakes/worktrees/acf4a767348a/01M22J6W2BJAVGZZ9NSGWD23SR/.local-test-lock-naming/real-hash-failure/project
error: could not resolve the shared Treehouse project lock for ~/.no-mistakes/worktrees/acf4a767348a/01M22J6W2BJAVGZZ9NSGWD23SR/.local-test-lock-naming/real-hash-failure/project


[real-hash-failure / base] FM_HOME=~/.no-mistakes/worktrees/acf4a767348a/01M22J6W2BJAVGZZ9NSGWD23SR/.local-test-lock-naming/real-hash-failure/home FM_STATE_OVERRIDE=~/.no-mistakes/worktrees/acf4a767348a/01M22J6W2BJAVGZZ9NSGWD23SR/.local-test-lock-naming/real-hash-failure/external-state FM_BACKEND=orca
cwd=~/.no-mistakes/worktrees/acf4a767348a/01M22J6W2BJAVGZZ9NSGWD23SR/.local-test-lock-naming/real-hash-failure/cwd
$ ~/.no-mistakes/worktrees/acf4a767348a/01M22J6W2BJAVGZZ9NSGWD23SR/.local-test-lock-naming/base/bin/fm-spawn.sh lock-check ~/.no-mistakes/worktrees/acf4a767348a/01M22J6W2BJAVGZZ9NSGWD23SR/.local-test-lock-naming/real-hash-failure/project --scout --backend tmux --harness codex
exit=1
stdout: <empty>
stderr: error: task lock-check has no brief at inaccessible data path ~/.no-mistakes/worktrees/acf4a767348a/01M22J6W2BJAVGZZ9NSGWD23SR/.local-test-lock-naming/real-hash-failure/data/lock-check/brief.md


[real-hash-failure / target] FM_HOME=~/.no-mistakes/worktrees/acf4a767348a/01M22J6W2BJAVGZZ9NSGWD23SR/.local-test-lock-naming/real-hash-failure/home FM_STATE_OVERRIDE=~/.no-mistakes/worktrees/acf4a767348a/01M22J6W2BJAVGZZ9NSGWD23SR/.local-test-lock-naming/real-hash-failure/external-state FM_BACKEND=orca
cwd=~/.no-mistakes/worktrees/acf4a767348a/01M22J6W2BJAVGZZ9NSGWD23SR/.local-test-lock-naming/real-hash-failure/cwd
$ ~/.no-mistakes/worktrees/acf4a767348a/01M22J6W2BJAVGZZ9NSGWD23SR/bin/fm-spawn.sh lock-check ~/.no-mistakes/worktrees/acf4a767348a/01M22J6W2BJAVGZZ9NSGWD23SR/.local-test-lock-naming/real-hash-failure/project --scout --backend tmux --harness codex
exit=1
stdout: <empty>
stderr: error: task lock-check has no brief at inaccessible data path ~/.no-mistakes/worktrees/acf4a767348a/01M22J6W2BJAVGZZ9NSGWD23SR/.local-test-lock-naming/real-hash-failure/data/lock-check/brief.md

After repairing only the named cause, both commands advanced to the missing-brief guard.
cwd=~/.no-mistakes/worktrees/acf4a767348a/01M22J6W2BJAVGZZ9NSGWD23SR/.local-test-lock-naming/real-vanished-worktree-top
$ git init -q -b main ~/.no-mistakes/worktrees/acf4a767348a/01M22J6W2BJAVGZZ9NSGWD23SR/.local-test-lock-naming/real-vanished-worktree-top/project
exit=0
stdout: <empty>
stderr: <empty>
cwd=~/.no-mistakes/worktrees/acf4a767348a/01M22J6W2BJAVGZZ9NSGWD23SR/.local-test-lock-naming/real-vanished-worktree-top/cwd
$ git -C ~/.no-mistakes/worktrees/acf4a767348a/01M22J6W2BJAVGZZ9NSGWD23SR/.local-test-lock-naming/real-vanished-worktree-top/project config core.worktree ~/.no-mistakes/worktrees/acf4a767348a/01M22J6W2BJAVGZZ9NSGWD23SR/.local-test-lock-naming/real-vanished-worktree-top/vanished
exit=0
stdout: <empty>
stderr: <empty>
cwd=~/.no-mistakes/worktrees/acf4a767348a/01M22J6W2BJAVGZZ9NSGWD23SR/.local-test-lock-naming/real-vanished-worktree-top/cwd
$ git -C ~/.no-mistakes/worktrees/acf4a767348a/01M22J6W2BJAVGZZ9NSGWD23SR/.local-test-lock-naming/real-vanished-worktree-top/project rev-parse --show-toplevel
exit=0
stdout: ~/.no-mistakes/worktrees/acf4a767348a/01M22J6W2BJAVGZZ9NSGWD23SR/.local-test-lock-naming/real-vanished-worktree-top/vanished

stderr: <empty>

[real-vanished-worktree-top / base] FM_HOME=~/.no-mistakes/worktrees/acf4a767348a/01M22J6W2BJAVGZZ9NSGWD23SR/.local-test-lock-naming/real-vanished-worktree-top/home FM_STATE_OVERRIDE=~/.no-mistakes/worktrees/acf4a767348a/01M22J6W2BJAVGZZ9NSGWD23SR/.local-test-lock-naming/real-vanished-worktree-top/external-state FM_BACKEND=orca
cwd=~/.no-mistakes/worktrees/acf4a767348a/01M22J6W2BJAVGZZ9NSGWD23SR/.local-test-lock-naming/real-vanished-worktree-top/cwd
$ ~/.no-mistakes/worktrees/acf4a767348a/01M22J6W2BJAVGZZ9NSGWD23SR/.local-test-lock-naming/base/bin/fm-spawn.sh lock-check ~/.no-mistakes/worktrees/acf4a767348a/01M22J6W2BJAVGZZ9NSGWD23SR/.local-test-lock-naming/real-vanished-worktree-top/project --scout --backend tmux --harness codex
exit=1
stdout: <empty>
stderr: error: could not resolve the shared Treehouse project lock for ~/.no-mistakes/worktrees/acf4a767348a/01M22J6W2BJAVGZZ9NSGWD23SR/.local-test-lock-naming/real-vanished-worktree-top/project


[real-vanished-worktree-top / target] FM_HOME=~/.no-mistakes/worktrees/acf4a767348a/01M22J6W2BJAVGZZ9NSGWD23SR/.local-test-lock-naming/real-vanished-worktree-top/home FM_STATE_OVERRIDE=~/.no-mistakes/worktrees/acf4a767348a/01M22J6W2BJAVGZZ9NSGWD23SR/.local-test-lock-naming/real-vanished-worktree-top/external-state FM_BACKEND=orca
cwd=~/.no-mistakes/worktrees/acf4a767348a/01M22J6W2BJAVGZZ9NSGWD23SR/.local-test-lock-naming/real-vanished-worktree-top/cwd
$ ~/.no-mistakes/worktrees/acf4a767348a/01M22J6W2BJAVGZZ9NSGWD23SR/bin/fm-spawn.sh lock-check ~/.no-mistakes/worktrees/acf4a767348a/01M22J6W2BJAVGZZ9NSGWD23SR/.local-test-lock-naming/real-vanished-worktree-top/project --scout --backend tmux --harness codex
exit=1
stdout: <empty>
stderr: fm_treehouse_project_lock_path: project worktree top cannot be entered: ~/.no-mistakes/worktrees/acf4a767348a/01M22J6W2BJAVGZZ9NSGWD23SR/.local-test-lock-naming/real-vanished-worktree-top/vanished
error: could not resolve the shared Treehouse project lock for ~/.no-mistakes/worktrees/acf4a767348a/01M22J6W2BJAVGZZ9NSGWD23SR/.local-test-lock-naming/real-vanished-worktree-top/project


[real-vanished-worktree-top / base] FM_HOME=~/.no-mistakes/worktrees/acf4a767348a/01M22J6W2BJAVGZZ9NSGWD23SR/.local-test-lock-naming/real-vanished-worktree-top/home FM_STATE_OVERRIDE=~/.no-mistakes/worktrees/acf4a767348a/01M22J6W2BJAVGZZ9NSGWD23SR/.local-test-lock-naming/real-vanished-worktree-top/external-state FM_BACKEND=orca
cwd=~/.no-mistakes/worktrees/acf4a767348a/01M22J6W2BJAVGZZ9NSGWD23SR/.local-test-lock-naming/real-vanished-worktree-top/cwd
$ ~/.no-mistakes/worktrees/acf4a767348a/01M22J6W2BJAVGZZ9NSGWD23SR/.local-test-lock-naming/base/bin/fm-spawn.sh lock-check ~/.no-mistakes/worktrees/acf4a767348a/01M22J6W2BJAVGZZ9NSGWD23SR/.local-test-lock-naming/real-vanished-worktree-top/project --scout --backend tmux --harness codex
exit=1
stdout: <empty>
stderr: error: task lock-check has no brief at inaccessible data path ~/.no-mistakes/worktrees/acf4a767348a/01M22J6W2BJAVGZZ9NSGWD23SR/.local-test-lock-naming/real-vanished-worktree-top/data/lock-check/brief.md


[real-vanished-worktree-top / target] FM_HOME=~/.no-mistakes/worktrees/acf4a767348a/01M22J6W2BJAVGZZ9NSGWD23SR/.local-test-lock-naming/real-vanished-worktree-top/home FM_STATE_OVERRIDE=~/.no-mistakes/worktrees/acf4a767348a/01M22J6W2BJAVGZZ9NSGWD23SR/.local-test-lock-naming/real-vanished-worktree-top/external-state FM_BACKEND=orca
cwd=~/.no-mistakes/worktrees/acf4a767348a/01M22J6W2BJAVGZZ9NSGWD23SR/.local-test-lock-naming/real-vanished-worktree-top/cwd
$ ~/.no-mistakes/worktrees/acf4a767348a/01M22J6W2BJAVGZZ9NSGWD23SR/bin/fm-spawn.sh lock-check ~/.no-mistakes/worktrees/acf4a767348a/01M22J6W2BJAVGZZ9NSGWD23SR/.local-test-lock-naming/real-vanished-worktree-top/project --scout --backend tmux --harness codex
exit=1
stdout: <empty>
stderr: error: task lock-check has no brief at inaccessible data path ~/.no-mistakes/worktrees/acf4a767348a/01M22J6W2BJAVGZZ9NSGWD23SR/.local-test-lock-naming/real-vanished-worktree-top/data/lock-check/brief.md

After repairing only the named cause, both commands advanced to the missing-brief guard.
cwd=~/.no-mistakes/worktrees/acf4a767348a/01M22J6W2BJAVGZZ9NSGWD23SR/.local-test-lock-naming/real-missing-project
$ git init -q -b main ~/.no-mistakes/worktrees/acf4a767348a/01M22J6W2BJAVGZZ9NSGWD23SR/.local-test-lock-naming/real-missing-project/project
exit=0
stdout: <empty>
stderr: <empty>

[real-missing-project / base] FM_HOME=~/.no-mistakes/worktrees/acf4a767348a/01M22J6W2BJAVGZZ9NSGWD23SR/.local-test-lock-naming/real-missing-project/home FM_STATE_OVERRIDE=~/.no-mistakes/worktrees/acf4a767348a/01M22J6W2BJAVGZZ9NSGWD23SR/.local-test-lock-naming/real-missing-project/external-state FM_BACKEND=orca
cwd=~/.no-mistakes/worktrees/acf4a767348a/01M22J6W2BJAVGZZ9NSGWD23SR/.local-test-lock-naming/real-missing-project/cwd
$ ~/.no-mistakes/worktrees/acf4a767348a/01M22J6W2BJAVGZZ9NSGWD23SR/.local-test-lock-naming/base/bin/fm-spawn.sh lock-check ~/.no-mistakes/worktrees/acf4a767348a/01M22J6W2BJAVGZZ9NSGWD23SR/.local-test-lock-naming/real-missing-project/project --scout --backend tmux --harness codex
exit=1
stdout: <empty>
stderr: ~/.no-mistakes/worktrees/acf4a767348a/01M22J6W2BJAVGZZ9NSGWD23SR/.local-test-lock-naming/base/bin/fm-spawn.sh: line 2178: cd: ~/.no-mistakes/worktrees/acf4a767348a/01M22J6W2BJAVGZZ9NSGWD23SR/.local-test-lock-naming/real-missing-project/project: No such file or directory


[real-missing-project / target] FM_HOME=~/.no-mistakes/worktrees/acf4a767348a/01M22J6W2BJAVGZZ9NSGWD23SR/.local-test-lock-naming/real-missing-project/home FM_STATE_OVERRIDE=~/.no-mistakes/worktrees/acf4a767348a/01M22J6W2BJAVGZZ9NSGWD23SR/.local-test-lock-naming/real-missing-project/external-state FM_BACKEND=orca
cwd=~/.no-mistakes/worktrees/acf4a767348a/01M22J6W2BJAVGZZ9NSGWD23SR/.local-test-lock-naming/real-missing-project/cwd
$ ~/.no-mistakes/worktrees/acf4a767348a/01M22J6W2BJAVGZZ9NSGWD23SR/bin/fm-spawn.sh lock-check ~/.no-mistakes/worktrees/acf4a767348a/01M22J6W2BJAVGZZ9NSGWD23SR/.local-test-lock-naming/real-missing-project/project --scout --backend tmux --harness codex
exit=1
stdout: <empty>
stderr: ~/.no-mistakes/worktrees/acf4a767348a/01M22J6W2BJAVGZZ9NSGWD23SR/bin/fm-spawn.sh: line 2178: cd: ~/.no-mistakes/worktrees/acf4a767348a/01M22J6W2BJAVGZZ9NSGWD23SR/.local-test-lock-naming/real-missing-project/project: No such file or directory

Missing project remains refused by the earlier CLI path guard; no directory was created.
```
</details>

- Evidence: [Expected regression failures against altered copies](https://github.com/mremond/firstmate/blob/804ca46949d31591e52659a7a213be078747b18f/.no-mistakes/evidence/fm/fm-lock-guard-names-missing-directory/regression-sensitivity.log)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"84a893d63934398ffe94d992da35c61e385eb3f2","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>🔧 **Review** - 2 issues found → auto-fixed ✅</summary>

- ⚠️ `bin/fm-wake-lib.sh:1212` - Simplification: the captain chose “NAMING the missing directory” for the missing root state directory. The change additionally diagnoses seven other exits: missing project, root-chain resolution, absolute/relative origin resolution, non-Git project, worktree-top resolution, and identity hashing. These additions, their shared formatter, and their dedicated fixtures are unnecessary for that requirement. Recommend retaining the missing-state diagnostic and its failure, success, and spawn coverage, while removing the broader diagnostic expansion. Removing these deliberate user-visible additions requires an intent decision.
- ⚠️ `tests/fm-treehouse-lock-naming.test.sh:259` - Pin this fake-tmux spawn to `--backend tmux`. The serial test runner preserves FM_BACKEND, which takes precedence over the fixture&#39;s TMUX value. With FM_BACKEND=orca, spawn either fails backend validation or skips the Treehouse lock guard entirely (fm-spawn.sh:2182), so the expected missing-directory diagnostic never appears despite correct production behavior. The new test therefore depends on the invoking environment.

🔧 Fix applied.
✅ Re-checked - no issues remain.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- Live validation: ✅ go - 10 of 10 scenarios driven live against the product

| Scenario | Result | Live | Evidence |
| --- | --- | --- | --- |
| Spawn with missing root state: refusal names the exact directory and leaves it absent; creating it clears that guard. | ✅ pass | live | Before/after live CLI transcripts: root-state-absent |
| Spawn with an absent home: refusal names that home without creating it. | ✅ pass | live | Before/after live CLI transcripts: root-home-absent |
| Follow local parent records at two depths: refusal names the missing parent, then its missing state directory after repair. | ✅ pass | live | Before/after live CLI transcripts: parent-depth-1 and parent-depth-2 |
| Malformed and cyclic parent records remain refused; a remote parent still anchors the lock locally. | ✅ pass | live | Before/after live CLI transcripts: malformed-parent, parent-cycle, remote-parent-terminates-locally |
| Use inaccessible absolute or relative origins: refusal names the origin, and restoring access clears the guard. | ✅ pass | live | Before/after live CLI transcripts: absolute-origin-permission and relative-origin-permission |
| Missing and non-Git projects remain refused at their existing boundaries without creating directories. | ✅ pass | live | Before/after live CLI transcripts: not-a-git-project; Real Git failure and repair transcripts: real-missing-project |
| Git reports an absent worktree top: refusal names that path; creating it clears the guard. | ✅ pass | live | Real Git failure and repair transcripts: real-vanished-worktree-top |
| A malformed invocation-directory Git context prevents hashing: refusal names the identity; repairing the context clears the guard. | ✅ pass | live | Real Git failure and repair transcripts: real-hash-failure |
| Resolve valid locks: old and new paths match, diagnostics stay silent, and spawn advances to the subsequent brief check. | ✅ pass | live | Before/after live CLI transcripts: repaired directories and origin variants |
| Explicitly select tmux with Orca inherited: the command still reaches the named lock refusal. | ✅ pass | live | Before/after live CLI transcripts; Expected regression failures against altered copies: mutant-unpinned-backend |

- <code>`FM_BACKEND=orca bin/fm-test-run.sh tests/fm-treehouse-lock-naming.test.sh --jobs 1` with isolated home, state, temporary directories, and Git configuration.</code>
- <code>`python3 ~/.no-mistakes/evidence/01M22J6W2BJAVGZZ9NSGWD23SR/drive-lock-guard.py` — real before/after CLI checks and lock-path comparisons.</code>
- <code>`python3 ~/.no-mistakes/evidence/01M22J6W2BJAVGZZ9NSGWD23SR/drive-git-failures.py` — real Git failures and repair counterfactuals.</code>
- <code>`python3 ~/.no-mistakes/evidence/01M22J6W2BJAVGZZ9NSGWD23SR/check-regression-sensitivity.py` — diagnostic, parent-resolution, and backend-pin mutations.</code>
- <code>Independently executed the depth-two parent regression against `2da46792`; it failed for naming the child instead of the missing parent.</code>
- `Removed disposable fixtures and confirmed the unchanged target commit and clean working tree.`
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>🔧 **Lint** - 1 issue found → auto-fixed ✅</summary>

- ⚠️ linter found issues (exit code 1)

🔧 Fix applied.
✅ Re-checked - no issues remain.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
