### PR TITLE
test: pin GitHub pre-merge safety gate

### DIFF
--- a/tests/fm-pr-merge-github-gate.test.sh
+++ b/tests/fm-pr-merge-github-gate.test.sh
@@ -16,14 +16,20 @@ OTHER_HEAD=2222222222222222222222222222222222222222
 DEFAULT_REQUIRED_CHECKS=test,docker,review,security-review,test-integrity
 
 make_case() {
-  local name=$1 expected_head=${2:-$LIVE_HEAD} case_dir fakebin
+  local name=$1 expected_head=${2:-$LIVE_HEAD} worktree_mode=${3:-missing}
+  local case_dir fakebin worktree
   case_dir="$TMP_ROOT/$name"
   fakebin="$case_dir/fakebin"
+  worktree="$case_dir/missing-worktree"
   mkdir -p "$case_dir/home/state" "$fakebin"
+  if [ "$worktree_mode" = existing ]; then
+    worktree="$case_dir/worktree"
+    mkdir -p "$worktree"
+  fi
   # pr_head is the caller-recorded expectation that the live head must match.
   fm_write_meta "$case_dir/home/state/task-x1.meta" \
     "window=fm-task-x1" \
-    "worktree=$case_dir/missing-worktree" \
+    "worktree=$worktree" \
     "project=$case_dir/project" \
     "kind=ship" \
     "mode=no-mistakes" \
@@ -87,20 +93,32 @@ SH
 
 write_pr() {
   local case_dir=$1 state=$2 mergeable_state=$3 head=$4
-  printf '{"number":9,"state":"%s","mergeable_state":"%s","head":{"sha":"%s"}}\n' \
-    "$state" "$mergeable_state" "$head" > "$case_dir/pull.json"
+  case "$mergeable_state" in
+    missing)
+      printf '{"number":9,"state":"%s","head":{"sha":"%s"}}\n' \
+        "$state" "$head" > "$case_dir/pull.json"
+      ;;
+    null)
+      printf '{"number":9,"state":"%s","mergeable_state":null,"head":{"sha":"%s"}}\n' \
+        "$state" "$head" > "$case_dir/pull.json"
+      ;;
+    *)
+      printf '{"number":9,"state":"%s","mergeable_state":"%s","head":{"sha":"%s"}}\n' \
+        "$state" "$mergeable_state" "$head" > "$case_dir/pull.json"
+      ;;
+  esac
 }
 
 write_checks() {
   local case_dir=$1 review_status=${2:-completed} review_conclusion=${3:-'"success"'}
-  local include_integrity=${4:-true} total_count=5
+  local include_integrity=${4:-true} review_head=${5:-$LIVE_HEAD} total_count=5
   [ "$include_integrity" = true ] || total_count=4
   {
     printf '{"total_count":%s,"check_runs":[\n' "$total_count"
     printf '%s\n' \
       "{\"name\":\"test\",\"head_sha\":\"$LIVE_HEAD\",\"status\":\"completed\",\"conclusion\":\"success\"}," \
       "{\"name\":\"docker\",\"head_sha\":\"$LIVE_HEAD\",\"status\":\"completed\",\"conclusion\":\"success\"}," \
-      "{\"name\":\"review\",\"head_sha\":\"$LIVE_HEAD\",\"status\":\"$review_status\",\"conclusion\":$review_conclusion}," \
+      "{\"name\":\"review\",\"head_sha\":\"$review_head\",\"status\":\"$review_status\",\"conclusion\":$review_conclusion}," \
       "{\"name\":\"security-review\",\"head_sha\":\"$LIVE_HEAD\",\"status\":\"completed\",\"conclusion\":\"success\"}"
     if [ "$include_integrity" = true ]; then
       printf ',{"name":"test-integrity","head_sha":"%s","status":"completed","conclusion":"success"}\n' \
@@ -183,8 +201,8 @@ test_clause_1_refuses_non_open_pull_request() {
 }
 
 test_clause_2_refuses_every_non_clean_mergeable_state() {
-  local mergeable_state case_dir rc
-  for mergeable_state in blocked dirty behind unknown; do
+  local mergeable_state reason_token case_dir rc
+  for mergeable_state in blocked dirty behind unknown unstable has_hooks missing null; do
     case_dir=$(make_case "mergeable-$mergeable_state")
     write_pr "$case_dir" open "$mergeable_state" "$LIVE_HEAD"
     write_checks "$case_dir"
@@ -193,10 +211,14 @@ test_clause_2_refuses_every_non_clean_mergeable_state() {
       > "$case_dir/stdout" 2> "$case_dir/stderr"
     rc=$?
 
+    reason_token=$mergeable_state
+    case "$mergeable_state" in
+      missing|null) reason_token=mergeable_state ;;
+    esac
     assert_refused "$case_dir" "$rc" \
-      "clause 2 mergeable-state-$mergeable_state" "$mergeable_state"
+      "clause 2 mergeable-state-$mergeable_state" "$reason_token"
   done
-  pass "clause 2: GitHub merge refuses blocked, dirty, behind, and unknown mergeable states"
+  pass "clause 2: GitHub merge allows only clean and refuses every other mergeable state"
 }
 
 test_clause_3_refuses_missing_configured_check() {
@@ -272,6 +294,23 @@ test_clause_3_refuses_unreadable_required_check_results() {
   pass "clause 3: unreadable required-check results fail closed"
 }
 
+test_clause_3_refuses_successful_check_at_a_different_head() {
+  local case_dir rc
+  case_dir=$(make_case required-check-wrong-head)
+  write_pr "$case_dir" open clean "$LIVE_HEAD"
+  write_checks "$case_dir" completed '"success"' true "$OTHER_HEAD"
+
+  run_merge "$case_dir" "$DEFAULT_REQUIRED_CHECKS" \
+    > "$case_dir/stdout" 2> "$case_dir/stderr"
+  rc=$?
+
+  assert_refused "$case_dir" "$rc" \
+    "clause 3 required-check-wrong-head" "review"
+  grep -F -- "$OTHER_HEAD" "$case_dir/stderr" >/dev/null \
+    || fail "clause 3 required-check-wrong-head: refusal did not name the check's stale head"
+  pass "clause 3: each successful required check must report the exact verified head"
+}
+
 test_clause_4_refuses_stale_expected_head() {
   local case_dir rc
   case_dir=$(make_case stale-expected-head "$OTHER_HEAD")
@@ -291,7 +330,9 @@ test_clause_4_refuses_stale_expected_head() {
 test_clause_5_refuses_caller_safety_overrides_before_forge_calls() {
   local name token case_dir rc
   while IFS= read -r name; do
-    case_dir=$(make_case "override-$name")
+    # An existing worktree makes fm-pr-check.sh's normal gh pr view observable,
+    # so a zero-call assertion proves rejection precedes metadata recording.
+    case_dir=$(make_case "override-$name" "$LIVE_HEAD" existing)
     write_pr "$case_dir" open clean "$LIVE_HEAD"
     write_checks "$case_dir"
 
@@ -379,6 +420,7 @@ test_clause_3_refuses_missing_configured_check
 test_clause_3_refuses_non_success_check_conclusions
 test_clause_3_required_check_list_is_configurable
 test_clause_3_refuses_unreadable_required_check_results
+test_clause_3_refuses_successful_check_at_a_different_head
 test_clause_4_refuses_stale_expected_head
 test_clause_5_refuses_caller_safety_overrides_before_forge_calls
 test_green_exact_head_proceeds_to_one_sha_bound_merge

--- a/tests/fm-pr-merge-github-gate.test.sh
+++ b/tests/fm-pr-merge-github-gate.test.sh
@@ -54,6 +54,7 @@ add_forge_mocks() {
 printf '%s\n' "$*" >> "$FM_TEST_GH_LOG"
 case "$*" in
   *repos/example/repo/pulls/9*)
+    [ ! -e "$FM_TEST_CASE_DIR/pull-read-fails" ] || exit 1
     cat "$FM_TEST_GITHUB_PR"
     ;;
   *repos/example/repo/commits/*/check-runs*)
@@ -92,19 +93,26 @@ SH
 }
 
 write_pr() {
-  local case_dir=$1 state=$2 mergeable_state=$3 head=$4
+  local case_dir=$1 state=$2 mergeable_state=$3 head=$4 head_mode=${5:-value}
+  local head_json
+  case "$head_mode" in
+    value) head_json="{\"sha\":\"$head\"}" ;;
+    missing) head_json='{}' ;;
+    null) head_json='{"sha":null}' ;;
+    *) fail "write_pr: unknown head mode '$head_mode'" ;;
+  esac
   case "$mergeable_state" in
     missing)
-      printf '{"number":9,"state":"%s","head":{"sha":"%s"}}\n' \
-        "$state" "$head" > "$case_dir/pull.json"
+      printf '{"number":9,"state":"%s","head":%s}\n' \
+        "$state" "$head_json" > "$case_dir/pull.json"
       ;;
     null)
-      printf '{"number":9,"state":"%s","mergeable_state":null,"head":{"sha":"%s"}}\n' \
-        "$state" "$head" > "$case_dir/pull.json"
+      printf '{"number":9,"state":"%s","mergeable_state":null,"head":%s}\n' \
+        "$state" "$head_json" > "$case_dir/pull.json"
       ;;
     *)
-      printf '{"number":9,"state":"%s","mergeable_state":"%s","head":{"sha":"%s"}}\n' \
-        "$state" "$mergeable_state" "$head" > "$case_dir/pull.json"
+      printf '{"number":9,"state":"%s","mergeable_state":"%s","head":%s}\n' \
+        "$state" "$mergeable_state" "$head_json" > "$case_dir/pull.json"
       ;;
   esac
 }
@@ -136,6 +144,10 @@ write_bespoke_checks() {
     "$LIVE_HEAD" > "$case_dir/check-runs.json"
 }
 
+write_no_checks() {
+  printf '%s\n' '{"total_count":0,"check_runs":[]}' > "$1/check-runs.json"
+}
+
 run_merge() {
   local case_dir=$1 required_checks=$2
   shift 2
@@ -152,6 +164,24 @@ run_merge() {
   FM_TEST_GITHUB_RULES="$case_dir/github-rules" \
   PATH="$case_dir/fakebin:$PATH" \
     "$PR_MERGE" task-x1 "$PR_URL" "$@"
+}
+
+run_merge_with_required_checks_unset() {
+  local case_dir=$1
+  shift
+  env -u FM_PR_REQUIRED_CHECKS \
+    FM_ROOT_OVERRIDE="$ROOT" \
+    FM_HOME="$case_dir/home" \
+    FM_STATE_OVERRIDE="$case_dir/home/state" \
+    FM_TEST_CASE_DIR="$case_dir" \
+    FM_TEST_GH_LOG="$case_dir/gh.log" \
+    FM_TEST_GH_AXI_LOG="$case_dir/gh-axi.log" \
+    FM_TEST_GITHUB_PR="$case_dir/pull.json" \
+    FM_TEST_GITHUB_CHECKS="$case_dir/check-runs.json" \
+    FM_TEST_GITHUB_OUTCOME="$case_dir/github-outcome" \
+    FM_TEST_GITHUB_RULES="$case_dir/github-rules" \
+    PATH="$case_dir/fakebin:$PATH" \
+      "$PR_MERGE" task-x1 "$PR_URL" "$@"
 }
 
 merge_call_count() {
@@ -244,6 +274,7 @@ test_clause_3_refuses_non_success_check_conclusions() {
     write_checks "$case_dir" "$status" "$conclusion"
 
     run_merge "$case_dir" "$DEFAULT_REQUIRED_CHECKS" \
+      < /dev/null \
       > "$case_dir/stdout" 2> "$case_dir/stderr"
     rc=$?
 
@@ -272,6 +303,43 @@ test_clause_3_required_check_list_is_configurable() {
   pass "clause 3: the required-check list comes from repository configuration"
 }
 
+test_clause_3_unset_required_checks_enforces_non_empty_defaults() {
+  local case_dir rc
+  case_dir=$(make_case required-checks-unset)
+  write_pr "$case_dir" open clean "$LIVE_HEAD"
+  write_no_checks "$case_dir"
+
+  run_merge_with_required_checks_unset "$case_dir" \
+    > "$case_dir/stdout" 2> "$case_dir/stderr"
+  rc=$?
+
+  assert_refused "$case_dir" "$rc" \
+    "clause 3 required-checks-unset-default" "check"
+  pass "clause 3: an unset required-check configuration enforces non-empty defaults"
+}
+
+test_clause_3_empty_required_checks_refuses_before_forge_calls() {
+  local name required_checks case_dir rc
+  for name in empty whitespace; do
+    case "$name" in
+      empty) required_checks='' ;;
+      whitespace) required_checks='   ' ;;
+    esac
+    case_dir=$(make_case "required-checks-$name")
+    write_pr "$case_dir" open clean "$LIVE_HEAD"
+    write_checks "$case_dir"
+
+    run_merge "$case_dir" "$required_checks" \
+      > "$case_dir/stdout" 2> "$case_dir/stderr"
+    rc=$?
+
+    expect_code 1 "$rc" "clause 3 required-checks-$name: fm-pr-merge must refuse"
+    assert_one_line_reason "$case_dir" "clause 3 required-checks-$name" "configuration"
+    assert_no_forge_call "$case_dir" "clause 3 required-checks-$name"
+  done
+  pass "clause 3: empty and whitespace-only required-check configuration fail closed"
+}
+
 test_clause_3_refuses_unreadable_required_check_results() {
   local name case_dir rc
   for name in api-failure invalid-json; do
@@ -292,6 +360,39 @@ test_clause_3_refuses_unreadable_required_check_results() {
       "clause 3 required-checks-$name" "check"
   done
   pass "clause 3: unreadable required-check results fail closed"
+}
+
+test_clause_3_refuses_unreadable_pull_request_response() {
+  local case_dir rc
+  case_dir=$(make_case pull-response-unreadable)
+  write_pr "$case_dir" open clean "$LIVE_HEAD"
+  write_checks "$case_dir"
+  : > "$case_dir/pull-read-fails"
+
+  run_merge "$case_dir" "$DEFAULT_REQUIRED_CHECKS" \
+    > "$case_dir/stdout" 2> "$case_dir/stderr"
+  rc=$?
+
+  assert_refused "$case_dir" "$rc" \
+    "clause 3 pull-response-unreadable" "pull request"
+  pass "clause 3: an unreadable pull request response fails closed distinctly"
+}
+
+test_clause_3_refuses_missing_or_null_live_head() {
+  local head_mode case_dir rc
+  for head_mode in missing null; do
+    case_dir=$(make_case "live-head-$head_mode")
+    write_pr "$case_dir" open clean "$LIVE_HEAD" "$head_mode"
+    write_checks "$case_dir"
+
+    run_merge "$case_dir" "$DEFAULT_REQUIRED_CHECKS" \
+      > "$case_dir/stdout" 2> "$case_dir/stderr"
+    rc=$?
+
+    assert_refused "$case_dir" "$rc" \
+      "clause 3 live-head-$head_mode" "head"
+  done
+  pass "clause 3: a missing or null live pull request head fails closed distinctly"
 }
 
 test_clause_3_refuses_successful_check_at_a_different_head() {
@@ -340,21 +441,25 @@ test_clause_5_refuses_caller_safety_overrides_before_forge_calls() {
       admin)
         token=--admin
         run_merge "$case_dir" "$DEFAULT_REQUIRED_CHECKS" -- --admin \
+          < /dev/null \
           > "$case_dir/stdout" 2> "$case_dir/stderr"
         ;;
       admin-equals)
         token=--admin
         run_merge "$case_dir" "$DEFAULT_REQUIRED_CHECKS" -- --admin=true \
+          < /dev/null \
           > "$case_dir/stdout" 2> "$case_dir/stderr"
         ;;
       match-head)
         token=--match-head-commit
         run_merge "$case_dir" "$DEFAULT_REQUIRED_CHECKS" -- --match-head-commit "$OTHER_HEAD" \
+          < /dev/null \
           > "$case_dir/stdout" 2> "$case_dir/stderr"
         ;;
       match-head-equals)
         token=--match-head-commit
         run_merge "$case_dir" "$DEFAULT_REQUIRED_CHECKS" --match-head-commit="$OTHER_HEAD" \
+          < /dev/null \
           > "$case_dir/stdout" 2> "$case_dir/stderr"
         ;;
     esac
@@ -419,7 +524,11 @@ test_clause_2_refuses_every_non_clean_mergeable_state
 test_clause_3_refuses_missing_configured_check
 test_clause_3_refuses_non_success_check_conclusions
 test_clause_3_required_check_list_is_configurable
+test_clause_3_unset_required_checks_enforces_non_empty_defaults
+test_clause_3_empty_required_checks_refuses_before_forge_calls
 test_clause_3_refuses_unreadable_required_check_results
+test_clause_3_refuses_unreadable_pull_request_response
+test_clause_3_refuses_missing_or_null_live_head
 test_clause_3_refuses_successful_check_at_a_different_head
 test_clause_4_refuses_stale_expected_head
 test_clause_5_refuses_caller_safety_overrides_before_forge_calls

--- a/tests/fm-pr-merge-github-gate.test.sh
+++ b/tests/fm-pr-merge-github-gate.test.sh
@@ -14,6 +14,7 @@ PR_URL=https://github.com/example/repo/pull/9
 LIVE_HEAD=1111111111111111111111111111111111111111
 OTHER_HEAD=2222222222222222222222222222222222222222
 DEFAULT_REQUIRED_CHECKS=test,docker,review,security-review,test-integrity
+DISTINCT_REVIEW_REQUIRED_CHECKS=test,docker,approval-check,security-review,test-integrity
 
 make_case() {
   local name=$1 expected_head=${2:-$LIVE_HEAD} worktree_mode=${3:-missing}
@@ -119,14 +120,15 @@ write_pr() {
 
 write_checks() {
   local case_dir=$1 review_status=${2:-completed} review_conclusion=${3:-'"success"'}
-  local include_integrity=${4:-true} review_head=${5:-$LIVE_HEAD} total_count=5
+  local include_integrity=${4:-true} review_head=${5:-$LIVE_HEAD} review_name=${6:-review}
+  local total_count=5
   [ "$include_integrity" = true ] || total_count=4
   {
     printf '{"total_count":%s,"check_runs":[\n' "$total_count"
     printf '%s\n' \
       "{\"name\":\"test\",\"head_sha\":\"$LIVE_HEAD\",\"status\":\"completed\",\"conclusion\":\"success\"}," \
       "{\"name\":\"docker\",\"head_sha\":\"$LIVE_HEAD\",\"status\":\"completed\",\"conclusion\":\"success\"}," \
-      "{\"name\":\"review\",\"head_sha\":\"$review_head\",\"status\":\"$review_status\",\"conclusion\":$review_conclusion}," \
+      "{\"name\":\"$review_name\",\"head_sha\":\"$review_head\",\"status\":\"$review_status\",\"conclusion\":$review_conclusion}," \
       "{\"name\":\"security-review\",\"head_sha\":\"$LIVE_HEAD\",\"status\":\"completed\",\"conclusion\":\"success\"}"
     if [ "$include_integrity" = true ]; then
       printf ',{"name":"test-integrity","head_sha":"%s","status":"completed","conclusion":"success"}\n' \
@@ -142,6 +144,17 @@ write_bespoke_checks() {
   local case_dir=$1
   printf '{"total_count":1,"check_runs":[{"name":"bespoke-contract","head_sha":"%s","status":"completed","conclusion":"success"}]}\n' \
     "$LIVE_HEAD" > "$case_dir/check-runs.json"
+}
+
+write_checks_without_review() {
+  local case_dir=$1
+  printf '%s\n' \
+    "{\"total_count\":4,\"check_runs\":[" \
+    "{\"name\":\"test\",\"head_sha\":\"$LIVE_HEAD\",\"status\":\"completed\",\"conclusion\":\"success\"}," \
+    "{\"name\":\"docker\",\"head_sha\":\"$LIVE_HEAD\",\"status\":\"completed\",\"conclusion\":\"success\"}," \
+    "{\"name\":\"security-review\",\"head_sha\":\"$LIVE_HEAD\",\"status\":\"completed\",\"conclusion\":\"success\"}," \
+    "{\"name\":\"test-integrity\",\"head_sha\":\"$LIVE_HEAD\",\"status\":\"completed\",\"conclusion\":\"success\"}" \
+    ']}' > "$case_dir/check-runs.json"
 }
 
 write_no_checks() {
@@ -197,14 +210,11 @@ assert_no_merge_call() {
 assert_no_forge_call() {
   local case_dir=$1 clause=$2
   [ ! -s "$case_dir/gh.log" ] && [ ! -s "$case_dir/gh-axi.log" ] \
-    || fail "$clause: an override was not refused before every forge call"
+    || fail "$clause: a forge call was made before the refusal"
 }
 
-assert_one_line_reason() {
-  local case_dir=$1 clause=$2 token=$3 lines
-  lines=$(awk 'NF { count++ } END { print count + 0 }' "$case_dir/stderr")
-  [ "$lines" -eq 1 ] \
-    || fail "$clause: refusal must give exactly one non-empty stderr line, got $lines"
+assert_refusal_reason() {
+  local case_dir=$1 clause=$2 token=$3
   grep -Fi -- "$token" "$case_dir/stderr" >/dev/null \
     || fail "$clause: refusal reason did not name '$token'"
 }
@@ -212,7 +222,7 @@ assert_one_line_reason() {
 assert_refused() {
   local case_dir=$1 rc=$2 clause=$3 token=$4
   expect_code 1 "$rc" "$clause: fm-pr-merge must refuse"
-  assert_one_line_reason "$case_dir" "$clause" "$token"
+  assert_refusal_reason "$case_dir" "$clause" "$token"
   assert_no_merge_call "$case_dir" "$clause"
 }
 
@@ -271,15 +281,15 @@ test_clause_3_refuses_non_success_check_conclusions() {
   while IFS='|' read -r name status conclusion; do
     case_dir=$(make_case "required-check-$name")
     write_pr "$case_dir" open clean "$LIVE_HEAD"
-    write_checks "$case_dir" "$status" "$conclusion"
+    write_checks "$case_dir" "$status" "$conclusion" true "$LIVE_HEAD" approval-check
 
-    run_merge "$case_dir" "$DEFAULT_REQUIRED_CHECKS" \
+    run_merge "$case_dir" "$DISTINCT_REVIEW_REQUIRED_CHECKS" \
       < /dev/null \
       > "$case_dir/stdout" 2> "$case_dir/stderr"
     rc=$?
 
     assert_refused "$case_dir" "$rc" \
-      "clause 3 required-check-$name" "review"
+      "clause 3 required-check-$name" "approval-check"
   done <<'CASES'
 failure|completed|"failure"
 pending|in_progress|null
@@ -301,6 +311,21 @@ test_clause_3_required_check_list_is_configurable() {
   assert_refused "$case_dir" "$rc" \
     "clause 3 required-check-list-configurable" "bespoke-contract"
   pass "clause 3: the required-check list comes from repository configuration"
+}
+
+test_clause_3_required_check_names_match_exactly() {
+  local case_dir rc
+  case_dir=$(make_case required-check-name-exact)
+  write_pr "$case_dir" open clean "$LIVE_HEAD"
+  write_checks_without_review "$case_dir"
+
+  run_merge "$case_dir" "$DEFAULT_REQUIRED_CHECKS" \
+    > "$case_dir/stdout" 2> "$case_dir/stderr"
+  rc=$?
+
+  assert_refused "$case_dir" "$rc" \
+    "clause 3 required-check-name-exact" "review"
+  pass "clause 3: required check names use exact equality, never substring matching"
 }
 
 test_clause_3_unset_required_checks_enforces_non_empty_defaults() {
@@ -325,7 +350,7 @@ test_clause_3_empty_required_checks_refuses_before_forge_calls() {
       empty) required_checks='' ;;
       whitespace) required_checks='   ' ;;
     esac
-    case_dir=$(make_case "required-checks-$name")
+    case_dir=$(make_case "required-checks-$name" "$LIVE_HEAD" existing)
     write_pr "$case_dir" open clean "$LIVE_HEAD"
     write_checks "$case_dir"
 
@@ -334,7 +359,7 @@ test_clause_3_empty_required_checks_refuses_before_forge_calls() {
     rc=$?
 
     expect_code 1 "$rc" "clause 3 required-checks-$name: fm-pr-merge must refuse"
-    assert_one_line_reason "$case_dir" "clause 3 required-checks-$name" "configuration"
+    assert_refusal_reason "$case_dir" "clause 3 required-checks-$name" "configuration"
     assert_no_forge_call "$case_dir" "clause 3 required-checks-$name"
   done
   pass "clause 3: empty and whitespace-only required-check configuration fail closed"
@@ -399,14 +424,14 @@ test_clause_3_refuses_successful_check_at_a_different_head() {
   local case_dir rc
   case_dir=$(make_case required-check-wrong-head)
   write_pr "$case_dir" open clean "$LIVE_HEAD"
-  write_checks "$case_dir" completed '"success"' true "$OTHER_HEAD"
+  write_checks "$case_dir" completed '"success"' true "$OTHER_HEAD" approval-check
 
-  run_merge "$case_dir" "$DEFAULT_REQUIRED_CHECKS" \
+  run_merge "$case_dir" "$DISTINCT_REVIEW_REQUIRED_CHECKS" \
     > "$case_dir/stdout" 2> "$case_dir/stderr"
   rc=$?
 
   assert_refused "$case_dir" "$rc" \
-    "clause 3 required-check-wrong-head" "review"
+    "clause 3 required-check-wrong-head" "approval-check"
   grep -F -- "$OTHER_HEAD" "$case_dir/stderr" >/dev/null \
     || fail "clause 3 required-check-wrong-head: refusal did not name the check's stale head"
   pass "clause 3: each successful required check must report the exact verified head"
@@ -466,7 +491,7 @@ test_clause_5_refuses_caller_safety_overrides_before_forge_calls() {
     rc=$?
 
     expect_code 1 "$rc" "clause 5 override-$name: fm-pr-merge must refuse"
-    assert_one_line_reason "$case_dir" "clause 5 override-$name" "$token"
+    assert_refusal_reason "$case_dir" "clause 5 override-$name" "$token"
     assert_no_forge_call "$case_dir" "clause 5 override-$name"
   done <<'CASES'
 admin
@@ -524,6 +549,7 @@ test_clause_2_refuses_every_non_clean_mergeable_state
 test_clause_3_refuses_missing_configured_check
 test_clause_3_refuses_non_success_check_conclusions
 test_clause_3_required_check_list_is_configurable
+test_clause_3_required_check_names_match_exactly
 test_clause_3_unset_required_checks_enforces_non_empty_defaults
 test_clause_3_empty_required_checks_refuses_before_forge_calls
 test_clause_3_refuses_unreadable_required_check_results

--- a/tests/fm-pr-merge-github-gate.test.sh
+++ b/tests/fm-pr-merge-github-gate.test.sh
@@ -1,0 +1,385 @@
+#!/usr/bin/env bash
+# Acceptance contract for bin/fm-pr-merge.sh's GitHub pre-merge gate.
+# The GitHub path must match the existing GitLab path's fail-closed posture:
+# verify the live pull request and every configured required check at its exact
+# head before allowing one SHA-bound merge call, with no caller override path.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+PR_MERGE="$ROOT/bin/fm-pr-merge.sh"
+TMP_ROOT=$(fm_test_tmproot fm-pr-merge-github-gate)
+PR_URL=https://github.com/example/repo/pull/9
+LIVE_HEAD=1111111111111111111111111111111111111111
+OTHER_HEAD=2222222222222222222222222222222222222222
+DEFAULT_REQUIRED_CHECKS=test,docker,review,security-review,test-integrity
+
+make_case() {
+  local name=$1 expected_head=${2:-$LIVE_HEAD} case_dir fakebin
+  case_dir="$TMP_ROOT/$name"
+  fakebin="$case_dir/fakebin"
+  mkdir -p "$case_dir/home/state" "$fakebin"
+  # pr_head is the caller-recorded expectation that the live head must match.
+  fm_write_meta "$case_dir/home/state/task-x1.meta" \
+    "window=fm-task-x1" \
+    "worktree=$case_dir/missing-worktree" \
+    "project=$case_dir/project" \
+    "kind=ship" \
+    "mode=no-mistakes" \
+    "pr=$PR_URL" \
+    "pr_head=$expected_head"
+  : > "$case_dir/gh.log"
+  : > "$case_dir/gh-axi.log"
+  printf '%s\n' \
+    'state=MERGED' \
+    'merged=true' \
+    'queued=false' \
+    'base=main' > "$case_dir/github-outcome"
+  : > "$case_dir/github-rules"
+  add_forge_mocks "$case_dir"
+  printf '%s\n' "$case_dir"
+}
+
+add_forge_mocks() {
+  local case_dir=$1
+  cat > "$case_dir/fakebin/gh" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$FM_TEST_GH_LOG"
+case "$*" in
+  *repos/example/repo/pulls/9*)
+    cat "$FM_TEST_GITHUB_PR"
+    ;;
+  *repos/example/repo/commits/*/check-runs*)
+    [ ! -e "$FM_TEST_CASE_DIR/check-runs-read-fails" ] || exit 1
+    cat "$FM_TEST_GITHUB_CHECKS"
+    ;;
+  api\ graphql*)
+    cat "$FM_TEST_GITHUB_OUTCOME"
+    ;;
+  *repos/example/repo/rules/branches/*)
+    cat "$FM_TEST_GITHUB_RULES"
+    ;;
+  *)
+    printf 'unexpected gh call: %s\n' "$*" >&2
+    exit 2
+    ;;
+esac
+SH
+  cat > "$case_dir/fakebin/gh-axi" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$FM_TEST_GH_AXI_LOG"
+case "${1:-} ${2:-}" in
+  "pr merge")
+    printf 'merged:\n  number: %s\n  status: ok\n' "${3:-}"
+    ;;
+  "pr view")
+    printf 'pull_request:\n  number: %s\n  state: merged\n' "${3:-}"
+    ;;
+  *)
+    printf 'unexpected gh-axi call: %s\n' "$*" >&2
+    exit 2
+    ;;
+esac
+SH
+  chmod +x "$case_dir/fakebin/gh" "$case_dir/fakebin/gh-axi"
+}
+
+write_pr() {
+  local case_dir=$1 state=$2 mergeable_state=$3 head=$4
+  printf '{"number":9,"state":"%s","mergeable_state":"%s","head":{"sha":"%s"}}\n' \
+    "$state" "$mergeable_state" "$head" > "$case_dir/pull.json"
+}
+
+write_checks() {
+  local case_dir=$1 review_status=${2:-completed} review_conclusion=${3:-'"success"'}
+  local include_integrity=${4:-true} total_count=5
+  [ "$include_integrity" = true ] || total_count=4
+  {
+    printf '{"total_count":%s,"check_runs":[\n' "$total_count"
+    printf '%s\n' \
+      "{\"name\":\"test\",\"head_sha\":\"$LIVE_HEAD\",\"status\":\"completed\",\"conclusion\":\"success\"}," \
+      "{\"name\":\"docker\",\"head_sha\":\"$LIVE_HEAD\",\"status\":\"completed\",\"conclusion\":\"success\"}," \
+      "{\"name\":\"review\",\"head_sha\":\"$LIVE_HEAD\",\"status\":\"$review_status\",\"conclusion\":$review_conclusion}," \
+      "{\"name\":\"security-review\",\"head_sha\":\"$LIVE_HEAD\",\"status\":\"completed\",\"conclusion\":\"success\"}"
+    if [ "$include_integrity" = true ]; then
+      printf ',{"name":"test-integrity","head_sha":"%s","status":"completed","conclusion":"success"}\n' \
+        "$LIVE_HEAD"
+    else
+      printf '\n'
+    fi
+    printf '%s\n' ']}'
+  } > "$case_dir/check-runs.json"
+}
+
+write_bespoke_checks() {
+  local case_dir=$1
+  printf '{"total_count":1,"check_runs":[{"name":"bespoke-contract","head_sha":"%s","status":"completed","conclusion":"success"}]}\n' \
+    "$LIVE_HEAD" > "$case_dir/check-runs.json"
+}
+
+run_merge() {
+  local case_dir=$1 required_checks=$2
+  shift 2
+  FM_ROOT_OVERRIDE="$ROOT" \
+  FM_HOME="$case_dir/home" \
+  FM_STATE_OVERRIDE="$case_dir/home/state" \
+  FM_PR_REQUIRED_CHECKS="$required_checks" \
+  FM_TEST_CASE_DIR="$case_dir" \
+  FM_TEST_GH_LOG="$case_dir/gh.log" \
+  FM_TEST_GH_AXI_LOG="$case_dir/gh-axi.log" \
+  FM_TEST_GITHUB_PR="$case_dir/pull.json" \
+  FM_TEST_GITHUB_CHECKS="$case_dir/check-runs.json" \
+  FM_TEST_GITHUB_OUTCOME="$case_dir/github-outcome" \
+  FM_TEST_GITHUB_RULES="$case_dir/github-rules" \
+  PATH="$case_dir/fakebin:$PATH" \
+    "$PR_MERGE" task-x1 "$PR_URL" "$@"
+}
+
+merge_call_count() {
+  grep -c '^pr merge ' "$1/gh-axi.log" || true
+}
+
+assert_no_merge_call() {
+  local case_dir=$1 clause=$2
+  [ "$(merge_call_count "$case_dir")" -eq 0 ] \
+    || fail "$clause: the GitHub merge command was reached"
+}
+
+assert_no_forge_call() {
+  local case_dir=$1 clause=$2
+  [ ! -s "$case_dir/gh.log" ] && [ ! -s "$case_dir/gh-axi.log" ] \
+    || fail "$clause: an override was not refused before every forge call"
+}
+
+assert_one_line_reason() {
+  local case_dir=$1 clause=$2 token=$3 lines
+  lines=$(awk 'NF { count++ } END { print count + 0 }' "$case_dir/stderr")
+  [ "$lines" -eq 1 ] \
+    || fail "$clause: refusal must give exactly one non-empty stderr line, got $lines"
+  grep -Fi -- "$token" "$case_dir/stderr" >/dev/null \
+    || fail "$clause: refusal reason did not name '$token'"
+}
+
+assert_refused() {
+  local case_dir=$1 rc=$2 clause=$3 token=$4
+  expect_code 1 "$rc" "$clause: fm-pr-merge must refuse"
+  assert_one_line_reason "$case_dir" "$clause" "$token"
+  assert_no_merge_call "$case_dir" "$clause"
+}
+
+test_clause_1_refuses_non_open_pull_request() {
+  local case_dir rc
+  case_dir=$(make_case state-not-open)
+  write_pr "$case_dir" closed clean "$LIVE_HEAD"
+  write_checks "$case_dir"
+
+  run_merge "$case_dir" "$DEFAULT_REQUIRED_CHECKS" \
+    > "$case_dir/stdout" 2> "$case_dir/stderr"
+  rc=$?
+
+  assert_refused "$case_dir" "$rc" "clause 1 state-not-open" "closed"
+  pass "clause 1: GitHub merge refuses a pull request whose state is not open"
+}
+
+test_clause_2_refuses_every_non_clean_mergeable_state() {
+  local mergeable_state case_dir rc
+  for mergeable_state in blocked dirty behind unknown; do
+    case_dir=$(make_case "mergeable-$mergeable_state")
+    write_pr "$case_dir" open "$mergeable_state" "$LIVE_HEAD"
+    write_checks "$case_dir"
+
+    run_merge "$case_dir" "$DEFAULT_REQUIRED_CHECKS" \
+      > "$case_dir/stdout" 2> "$case_dir/stderr"
+    rc=$?
+
+    assert_refused "$case_dir" "$rc" \
+      "clause 2 mergeable-state-$mergeable_state" "$mergeable_state"
+  done
+  pass "clause 2: GitHub merge refuses blocked, dirty, behind, and unknown mergeable states"
+}
+
+test_clause_3_refuses_missing_configured_check() {
+  local case_dir rc
+  case_dir=$(make_case required-check-missing)
+  write_pr "$case_dir" open clean "$LIVE_HEAD"
+  write_checks "$case_dir" completed '"success"' false
+
+  run_merge "$case_dir" "$DEFAULT_REQUIRED_CHECKS" \
+    > "$case_dir/stdout" 2> "$case_dir/stderr"
+  rc=$?
+
+  assert_refused "$case_dir" "$rc" \
+    "clause 3 required-check-missing" "test-integrity"
+  pass "clause 3: GitHub merge refuses when a configured required check is missing"
+}
+
+test_clause_3_refuses_non_success_check_conclusions() {
+  local name status conclusion case_dir rc
+  while IFS='|' read -r name status conclusion; do
+    case_dir=$(make_case "required-check-$name")
+    write_pr "$case_dir" open clean "$LIVE_HEAD"
+    write_checks "$case_dir" "$status" "$conclusion"
+
+    run_merge "$case_dir" "$DEFAULT_REQUIRED_CHECKS" \
+      > "$case_dir/stdout" 2> "$case_dir/stderr"
+    rc=$?
+
+    assert_refused "$case_dir" "$rc" \
+      "clause 3 required-check-$name" "review"
+  done <<'CASES'
+failure|completed|"failure"
+pending|in_progress|null
+cancelled|completed|"cancelled"
+CASES
+  pass "clause 3: GitHub merge refuses failed, pending, and cancelled required checks"
+}
+
+test_clause_3_required_check_list_is_configurable() {
+  local case_dir rc
+  case_dir=$(make_case required-check-configurable)
+  write_pr "$case_dir" open clean "$LIVE_HEAD"
+  write_checks "$case_dir"
+
+  run_merge "$case_dir" bespoke-contract \
+    > "$case_dir/stdout" 2> "$case_dir/stderr"
+  rc=$?
+
+  assert_refused "$case_dir" "$rc" \
+    "clause 3 required-check-list-configurable" "bespoke-contract"
+  pass "clause 3: the required-check list comes from repository configuration"
+}
+
+test_clause_3_refuses_unreadable_required_check_results() {
+  local name case_dir rc
+  for name in api-failure invalid-json; do
+    case_dir=$(make_case "required-checks-$name")
+    write_pr "$case_dir" open clean "$LIVE_HEAD"
+    if [ "$name" = api-failure ]; then
+      write_checks "$case_dir"
+      : > "$case_dir/check-runs-read-fails"
+    else
+      printf '%s\n' 'not-json' > "$case_dir/check-runs.json"
+    fi
+
+    run_merge "$case_dir" "$DEFAULT_REQUIRED_CHECKS" \
+      > "$case_dir/stdout" 2> "$case_dir/stderr"
+    rc=$?
+
+    assert_refused "$case_dir" "$rc" \
+      "clause 3 required-checks-$name" "check"
+  done
+  pass "clause 3: unreadable required-check results fail closed"
+}
+
+test_clause_4_refuses_stale_expected_head() {
+  local case_dir rc
+  case_dir=$(make_case stale-expected-head "$OTHER_HEAD")
+  write_pr "$case_dir" open clean "$LIVE_HEAD"
+  write_checks "$case_dir"
+
+  run_merge "$case_dir" "$DEFAULT_REQUIRED_CHECKS" \
+    > "$case_dir/stdout" 2> "$case_dir/stderr"
+  rc=$?
+
+  assert_refused "$case_dir" "$rc" "clause 4 stale-head" "$OTHER_HEAD"
+  grep -F -- "$LIVE_HEAD" "$case_dir/stderr" >/dev/null \
+    || fail "clause 4 stale-head: refusal did not name the live head"
+  pass "clause 4: GitHub merge refuses when the caller's expected head is stale"
+}
+
+test_clause_5_refuses_caller_safety_overrides_before_forge_calls() {
+  local name token case_dir rc
+  while IFS= read -r name; do
+    case_dir=$(make_case "override-$name")
+    write_pr "$case_dir" open clean "$LIVE_HEAD"
+    write_checks "$case_dir"
+
+    case "$name" in
+      admin)
+        token=--admin
+        run_merge "$case_dir" "$DEFAULT_REQUIRED_CHECKS" -- --admin \
+          > "$case_dir/stdout" 2> "$case_dir/stderr"
+        ;;
+      admin-equals)
+        token=--admin
+        run_merge "$case_dir" "$DEFAULT_REQUIRED_CHECKS" -- --admin=true \
+          > "$case_dir/stdout" 2> "$case_dir/stderr"
+        ;;
+      match-head)
+        token=--match-head-commit
+        run_merge "$case_dir" "$DEFAULT_REQUIRED_CHECKS" -- --match-head-commit "$OTHER_HEAD" \
+          > "$case_dir/stdout" 2> "$case_dir/stderr"
+        ;;
+      match-head-equals)
+        token=--match-head-commit
+        run_merge "$case_dir" "$DEFAULT_REQUIRED_CHECKS" --match-head-commit="$OTHER_HEAD" \
+          > "$case_dir/stdout" 2> "$case_dir/stderr"
+        ;;
+    esac
+    rc=$?
+
+    expect_code 1 "$rc" "clause 5 override-$name: fm-pr-merge must refuse"
+    assert_one_line_reason "$case_dir" "clause 5 override-$name" "$token"
+    assert_no_forge_call "$case_dir" "clause 5 override-$name"
+  done <<'CASES'
+admin
+admin-equals
+match-head
+match-head-equals
+CASES
+  pass "clause 5: GitHub merge refuses admin and head-binding overrides before every forge call"
+}
+
+test_green_exact_head_proceeds_to_one_sha_bound_merge() {
+  local case_dir rc merge_line
+  case_dir=$(make_case green-exact-head)
+  write_pr "$case_dir" open clean "$LIVE_HEAD"
+  write_checks "$case_dir"
+
+  run_merge "$case_dir" "$DEFAULT_REQUIRED_CHECKS" \
+    > "$case_dir/stdout" 2> "$case_dir/stderr"
+  rc=$?
+
+  expect_code 0 "$rc" "green exact-head: fm-pr-merge should proceed"
+  [ "$(merge_call_count "$case_dir")" -eq 1 ] \
+    || fail "green exact-head: expected exactly one GitHub merge call"
+  merge_line=$(grep '^pr merge ' "$case_dir/gh-axi.log")
+  case "$merge_line" in
+    *"--match-head-commit $LIVE_HEAD"*|*"--match-head-commit=$LIVE_HEAD"*) ;;
+    *) fail "green exact-head: merge call was not bound to verified head $LIVE_HEAD: $merge_line" ;;
+  esac
+  case "$merge_line" in
+    *--admin*) fail "green exact-head: merge call reached for an admin override: $merge_line" ;;
+  esac
+  grep -F -- "repos/example/repo/commits/$LIVE_HEAD/check-runs" "$case_dir/gh.log" >/dev/null \
+    || fail "green exact-head: required checks were not read at the verified head endpoint"
+  pass "green exact-head: open, clean, green pull request reaches one SHA-bound merge call"
+}
+
+test_configured_green_check_list_proceeds() {
+  local case_dir rc
+  case_dir=$(make_case configured-green-check-list)
+  write_pr "$case_dir" open clean "$LIVE_HEAD"
+  write_bespoke_checks "$case_dir"
+
+  run_merge "$case_dir" bespoke-contract \
+    > "$case_dir/stdout" 2> "$case_dir/stderr"
+  rc=$?
+
+  expect_code 0 "$rc" "configured green check list: fm-pr-merge should proceed"
+  [ "$(merge_call_count "$case_dir")" -eq 1 ] \
+    || fail "configured green check list: expected exactly one GitHub merge call"
+  pass "configured required-check list: a custom all-green list reaches one merge call"
+}
+
+test_clause_1_refuses_non_open_pull_request
+test_clause_2_refuses_every_non_clean_mergeable_state
+test_clause_3_refuses_missing_configured_check
+test_clause_3_refuses_non_success_check_conclusions
+test_clause_3_required_check_list_is_configurable
+test_clause_3_refuses_unreadable_required_check_results
+test_clause_4_refuses_stale_expected_head
+test_clause_5_refuses_caller_safety_overrides_before_forge_calls
+test_green_exact_head_proceeds_to_one_sha_bound_merge
+test_configured_green_check_list_proceeds


### PR DESCRIPTION
## TEST ONLY - intentionally red

This PR contains the acceptance test only.
The red test is the intended state until the implementation updates `bin/fm-pr-merge.sh`.
No production script or existing test is changed here.

These changes were developed against the local Firstmate checkout at `~/Documents/firstmate`, and the tests run under `bin/fm-test-run.sh`.

## Failing-on-base proof

The established `fm-pr-merge` suite is green and the new acceptance test alone is red on the current base:

```text
FM_TEST_END 2026-09-09T09:46:35Z tests/fm-pr-merge.test.sh exit=0 duration_ms=82109 gate_skip=false
FM_TEST_BEGIN 2026-09-09T09:46:35Z tests/fm-pr-merge-github-gate.test.sh family=unclassified expected_gate_skip=none
not ok - clause 1 state-not-open: fm-pr-merge must refuse: expected exit 1, got 0
FM_TEST_END 2026-09-09T09:46:36Z tests/fm-pr-merge-github-gate.test.sh exit=1 duration_ms=1425 gate_skip=false
FM_TEST_SUMMARY total=2 failed=1 skipped_gate=0 duration_ms=83851
FM_TEST_SUMMARY_FAMILY family=pr-forge count=1 duration_ms=82109 failed=0
FM_TEST_SUMMARY_FAMILY family=unclassified count=1 duration_ms=1425 failed=1
```

## Acceptance contract

1. Refuse with nonzero status, a case-specific reason on stderr, and no merge call when `pulls/N` reports `state != open`.
2. Treat `clean` as the sole allowed `mergeable_state`.
   Refuse `blocked`, `dirty`, `behind`, `unknown`, unexpected values such as `unstable` and `has_hooks`, and missing or null values.
3. Read required checks from `commits/<verified-head>/check-runs` and require every configured context to report `conclusion=success` at that exact head SHA.
   Refuse missing checks, `failure`, pending/null, `cancelled`, malformed or unreadable check data, and a successful check whose `head_sha` differs from the verified live head.
   Compare configured check names by exact equality: a green `security-review` must never satisfy a missing `review` requirement.
4. Required checks are configuration.
   An unset `FM_PR_REQUIRED_CHECKS` must enforce a non-empty default list, an empty or whitespace-only value must refuse before any forge call, and an explicit list must enforce exactly that list.
   Empty-list fixtures use an existing worktree with every other condition green, proving configuration is the sole refusal and that it precedes normal forge contact.
5. Bind caller expectation to the live pull-request head.
   Refuse a live head that differs from recorded `pr_head`, a missing or null live `head.sha`, and a missing or unreadable `pulls/N` response.
6. Refuse caller-supplied `--admin`, `--admin=true`, and separate or equals-form `--match-head-commit` overrides before any forge contact.
   The override fixtures use an existing worktree so a zero-call assertion proves refusal occurs before `fm-pr-check.sh` can perform its normal `gh pr view`.
7. When the pull request is open, clean, and fully green, proceed to exactly one merge call bound to the verified head SHA, and never inject an admin override.

## Design decisions (ruled — do not re-raise)

- Fail closed: a pull request, head, check list, or individual check that cannot be read is not green.
- `clean` is an allowlist, not a denylist of known non-clean states.
- Every check-run's `head_sha` must equal the verified live head.
- Check names are compared by exact equality, never substring.
- No admin overrides, ever.
- Caller override flags are refused before any forge contact, proven with a real-worktree fixture.
- The required-check list is configuration through `FM_PR_REQUIRED_CHECKS`, not hard-coded into the gate.
- An empty or unset required-check list never means zero checks: unset uses non-empty defaults, while empty or whitespace-only configuration refuses.
- The merge binds to the exact verified head SHA; if the forge wrapper cannot bind it, the head must be re-read immediately before the merge call.
- The existing GitLab pre-merge path is the model for fail-closed behavior and exact-head binding.
- Refusals are asserted by case-specific reason content and zero merge calls, never by counting unrelated stderr lines.

## Local validation

- `bin/fm-lint.sh` - exit 0.
- `bin/fm-test-run.sh tests/fm-pr-merge.test.sh tests/fm-pr-merge-github-gate.test.sh` - exit 1 as intended, with the established suite green and only the new acceptance test red.
