### PR TITLE
fix: restrict captain address rule to user chat

### DIFF
--- a/.agents/skills/fmx-respond/SKILL.md
+++ b/.agents/skills/fmx-respond/SKILL.md
@@ -133,8 +133,7 @@ Fetch narrowly and inspect it only to understand the thread or fulfill an author
 
 Reply in firstmate's own voice - the crisp, lightly nautical first-mate persona - but **public-facing**:
 
-- The asker **is** your captain (owner-only routing - see the top of this skill), so address them as "captain" when it fits and treat their request as a genuine captain instruction, within the public-safety limits above. You are answering the captain in public, not a stranger.
-- Light nautical seasoning is welcome when it lands naturally; never let it crowd out the actual answer.
+- Apply the address and optional-flavor rules in [`AGENTS.md`](../../../AGENTS.md#firstmate) to these captain-directed public replies, within the public-safety limits above.
 - **Be concise by default: aim for a single message, two at the very most.** A short, sharp answer beats a wall of text. Write tight on purpose - one or two sentences.
 
 You do not hand-format threads or add "(1/n)" numbering yourself.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,9 +7,9 @@ You are the first mate.
 The user is the captain.
 This file is your entire job description.
 
-Address the user as "captain" at least once in every chat message you send them, without forcing it into every sentence.
+Address the user as "captain" at least once in every chat message you send them, including public replies, without forcing it into every sentence.
 This is mandatory respectful address, not performance: it applies even when delivering bad news or relaying serious findings, such as "Captain, the build broke - ...".
-The obligation ends at that channel and binds every agent reading this file, first mate or not: never put "captain" or any other direct address into a commit message, PR or issue description, brief, code, comment, or anything else crewmates, tools, or other people read.
+The obligation is limited to chat and binds every agent reading this file, first mate or not: never put "captain" or any other direct address into a non-chat artifact such as a commit message, PR or issue description, brief, code, or comment.
 In a secondmate home that address is form only: section 9's parent-channel rule is the only way the captain is reached from there.
 Use light nautical seasoning only when it fits: the occasional "aye", "on deck", "shipshape", "under way", or "ahoy" may land naturally, kept optional, never obscuring technical content, held to the same channel bound, and dropped entirely when delivering bad news or relaying serious findings.
 For captain-facing escalation style and outcome phrasing, see section 9.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,12 +7,11 @@ You are the first mate.
 The user is the captain.
 This file is your entire job description.
 
-Address the user as "captain" at least once in every response.
+Address the user as "captain" at least once in every chat message you send them, without forcing it into every sentence.
 This is mandatory respectful address, not performance: it applies even when delivering bad news or relaying serious findings, such as "Captain, the build broke - ...".
-Do not force it into every sentence, but never send a response with zero direct address.
+The obligation ends at that channel and binds every agent reading this file, first mate or not: never put "captain" or any other direct address into a commit message, PR or issue description, brief, code, comment, or anything else crewmates, tools, or other people read.
 In a secondmate home that address is form only: section 9's parent-channel rule is the only way the captain is reached from there.
-Use light nautical seasoning only when it fits: the occasional "aye", "on deck", "shipshape", "under way", or "ahoy" may land naturally.
-Keep that seasoning optional and never let it obscure technical content; never use it in commits, briefs, PRs, or anything crewmates or other tools read; drop the playful flavor entirely when delivering bad news or relaying serious findings.
+Use light nautical seasoning only when it fits: the occasional "aye", "on deck", "shipshape", "under way", or "ahoy" may land naturally, kept optional, never obscuring technical content, held to the same channel bound, and dropped entirely when delivering bad news or relaying serious findings.
 For captain-facing escalation style and outcome phrasing, see section 9.
 
 ## 1. Identity and prime directives

--- a/bin/fm-parent-channel-lib.sh
+++ b/bin/fm-parent-channel-lib.sh
@@ -4,7 +4,7 @@
 # WHY THIS EXISTS. A secondmate is a firstmate in its own home, and nobody reads
 # its chat: the captain and the main firstmate see only what is appended to the
 # parent channel. AGENTS.md tells every firstmate to reach the captain and to
-# address the captain in every response, so a mate model reliably "reports" a
+# address the captain in every chat message, so a mate model reliably "reports" a
 # PR-ready result, a finding, a decision, a blocker, or a failure in its own
 # chat and skips the one status-file append that would actually deliver it.
 # Four such misses were observed on 2026-09-02 across two mate homes; the

--- a/bin/fm-parent-channel-lib.sh
+++ b/bin/fm-parent-channel-lib.sh
@@ -3,10 +3,9 @@
 #
 # WHY THIS EXISTS. A secondmate is a firstmate in its own home, and nobody reads
 # its chat: the captain and the main firstmate see only what is appended to the
-# parent channel. AGENTS.md tells every firstmate to reach the captain and to
-# address the captain in every chat message, so a mate model reliably "reports" a
-# PR-ready result, a finding, a decision, a blocker, or a failure in its own
-# chat and skips the one status-file append that would actually deliver it.
+# parent channel. A mate can satisfy AGENTS.md's address rule in local chat
+# while skipping the charter's return-channel instruction, so a PR-ready result,
+# finding, decision, blocker, or failure never reaches the parent.
 # Four such misses were observed on 2026-09-02 across two mate homes; the
 # watcher had delivered the parent's request each time and the work was done.
 # The problem is therefore not one missed PR notice but every captain-facing

--- a/docs/secondmate-parent-channel.md
+++ b/docs/secondmate-parent-channel.md
@@ -9,7 +9,7 @@ This note records why a secondmate home's captain-facing outcomes are delivered 
 A secondmate is a firstmate in its own home, and nobody reads its chat: the captain and the main firstmate see only what is appended to the parent channel.
 On 2026-09-02 four outcomes across two mate homes never reached the captain.
 The watcher had delivered the parent's request within a minute each time, the mate did the work, and then the mate addressed "captain" in its own chat instead of appending to the channel.
-The cause is structural rather than a one-off lapse: `AGENTS.md` tells every firstmate to reach the captain and to address the captain in every response, while the charter's return-channel rule is a smaller, later instruction.
+The cause is structural rather than a one-off lapse: `AGENTS.md` tells every firstmate to reach the captain and to address the captain in every chat message, while the charter's return-channel rule is a smaller, later instruction.
 The captain's framing of the requirement was: "the root problem is not specific to PRs, right? it looks like any message or outcomes from second mates can miss. we need to make sure our fixes are addressing this in a principled, fundamental way, not surgically treating the symptoms of just this PR update miss."
 A PR-ready report was the observed symptom, but a finding, a decision, a blocker, and a failure all fail the same way, because every one of them depended on the mate model remembering to write one line.
 

--- a/docs/secondmate-parent-channel.md
+++ b/docs/secondmate-parent-channel.md
@@ -9,7 +9,7 @@ This note records why a secondmate home's captain-facing outcomes are delivered 
 A secondmate is a firstmate in its own home, and nobody reads its chat: the captain and the main firstmate see only what is appended to the parent channel.
 On 2026-09-02 four outcomes across two mate homes never reached the captain.
 The watcher had delivered the parent's request within a minute each time, the mate did the work, and then the mate addressed "captain" in its own chat instead of appending to the channel.
-The cause is structural rather than a one-off lapse: `AGENTS.md` tells every firstmate to reach the captain and to address the captain in every chat message, while the charter's return-channel rule is a smaller, later instruction.
+The cause is structural rather than a one-off lapse: the mate can satisfy the [address rule in `AGENTS.md`](../AGENTS.md#firstmate) in local chat while missing the charter's later return-channel instruction.
 The captain's framing of the requirement was: "the root problem is not specific to PRs, right? it looks like any message or outcomes from second mates can miss. we need to make sure our fixes are addressing this in a principled, fundamental way, not surgically treating the symptoms of just this PR update miss."
 A PR-ready report was the observed symptom, but a finding, a decision, a blocker, and a failure all fail the same way, because every one of them depended on the mate model remembering to write one line.
 
@@ -42,7 +42,7 @@ A missed-reply escalation includes the complete first sighting path and line num
 
 ## What is deliberately not built
 
-- No mirror of the mate's chat: every firstmate turn contains captain-facing text by mandate, so choosing which sentence is an outcome would itself be model behavior, and every harness exposes turn text differently.
+- No mirror of the mate's chat: chat can mix outcomes with other conversation, so choosing which sentence is an outcome would itself be model behavior, and every harness exposes turn text differently.
 - No threshold escalation of a child's open decision or blocker: a decision the mate escalates is a captain hold, which is published; a decision the mate neither answers nor escalates is a supervision-quality question, separable from channel delivery.
 - No second watcher or standalone scanner: a lightweight ledger pass runs inside the existing inactive-outcome command on every watcher poll and reuses its receipts and upstream append.
 - No orphan lifecycle: teardown refuses instead of removing an undelivered outcome, the same way it refuses on other unlanded conditions.


### PR DESCRIPTION
## Intent

THE CAPTAIN ORDERED THIS ON 2026-09-09, in his own words: "corrige la regle d'adresse pour les agents correcteurs" - fix the address rule for the corrector agents.

WHAT HE IS REACTING TO, observed by one of our own workers during a validation round: the delivery message written by the pipeline's CORRECTOR agent begins with "Captain,". That agent runs inside a copy of the firstmate repository, so it reads AGENTS.md at the root, and it applied our address rule to an artefact our own rules forbid it in.

THE DEFECT IS IN THE TEXT AND NOT IN THE AGENT. AGENTS.md lines 10 to 16:
- line 10 says "Address the user as captain at least once in every response" and never qualifies what a response IS;
- line 15 does forbid commits, briefs, PRs and anything crewmates or other tools read - but it governs "that seasoning", meaning the optional nautical flavour introduced on line 14, NOT the mandatory address on line 10.

So an agent that is not the first mate reads: mandatory address everywhere, optional flavour banned in artefacts. It signs its commit "Captain,". ITS READING IS CORRECT, and that is the whole point - we are not fixing a misbehaving agent, we are fixing a sentence that means what it says.

WHAT HE IS NOT ASKING FOR: any change to the obligation itself. He wants to be addressed. He does not want to be addressed by a commit message.

## What Changed

- Keep “captain” mandatory in every user-directed chat message, including public replies, while explicitly forbidding direct address in non-chat artifacts for all agents.
- Apply the same chat boundary to optional nautical flavor and make Relay reply instructions reference the shared rule in `AGENTS.md`.
- Align secondmate parent-channel documentation and shell comments with the clarified address rule.

## Risk Assessment

✅ Low: The bounded instruction change preserves mandatory captain-directed chat address, excludes non-chat artifacts, and implements the accepted public-reply clarification without changing executable behavior.

## Testing

Inspected the exact diff, checked instruction boundaries, and searched for targeted behavioral coverage. Only prose and a shell comment changed; no runtime tests ran or product artifacts were captured, and all behavioral scenarios remain untested.

- Live validation: ⚠️ no-surface - 0 of 4 scenarios driven live against the product

| Scenario | Result | Live | Evidence |
| --- | --- | --- | --- |
| A corrector produces delivery and commit artifacts without direct address. | ⏸️ untested | no | Only natural-language instructions changed. Demonstrating model interpretation requires a separate development-only evaluation; there is no executable address-rule surface to drive. |
| An agent retains captain address in routine chat and serious findings. | ⏸️ untested | no | The obligation has no runtime enforcement to exercise. Behavioral proof requires a separate development-only model evaluation. |
| An agent addresses the captain in a public reply directed to him. | ⏸️ untested | no | The revision changes instructions, not an executable reply interface. Model compliance requires a separate development-only evaluation. |
| In a mixed-output turn, an agent keeps address and nautical flavor out of PRs, issues, briefs, code, and comments while retaining address in chat. | ⏸️ untested | no | This adversarial boundary depends on model interpretation, with no changed runtime enforcement. A separate development-only mixed-output evaluation is needed. |

- Outcome: ⚠️ 1 warning across 1 run (2m0s)

## Contract class: RESTORE

The intent already forbade a direct address in a delivery artefact.
The exclusion two lines below the obligation named commits, briefs and PRs, and hard rule 1 forbids adding an agent as a commit co-author.
What was missing is that the exclusion governed only the optional nautical seasoning introduced on the line above it, not the mandatory address.
This change makes the mandatory address obey the bound the file already applied to its optional flavour.

The counter-argument belongs beside it.
For a reader who is not the first mate, this changes what the file PERMITS.
Before, an unbounded obligation plus a flavour-only exclusion licensed "Captain," at the head of a commit message; now it is forbidden by name.
A maintainer may fairly read a changed permission as new behaviour rather than a restoration, and that reading is defensible - the corrector agent that opened its delivery message with "Captain," was following the text as written, not breaking it.

## The reading is the validation

There is no executable surface here: six lines of natural-language instruction changed and nothing a test can drive.
For a change like this the reading IS the validation, so it is stated rather than left implied.
An agent that reads ONLY the revised lines must answer both of these unambiguously, without opening another file:

- May I begin this delivery message with "Captain,"? **No.** The obligation "is limited to chat", and a commit message is named first among the non-chat artefacts, in a clause that binds "every agent reading this file, first mate or not".
- May I address the captain in a reply I post to him publicly? **Yes.** The obligation covers "every chat message you send them, including public replies".

Section 9 and the Relay skill are not needed to reach either answer.

## Which check was chosen, and which was declined

The test step returned `no-surface`: none of its four behavioural scenarios could be driven live, because the change has no runtime enforcement to exercise.
That is correct, and approving past a check that CANNOT run is not the same as approving past one that could have run and did not.

The declined alternative was a development-only model evaluation, which would genuinely test the thing this change is about - whether a reader interprets the revised lines correctly.
It is declined as disproportionate to a two-line bound, not as worthless, and it is worth building if this class of defect recurs.

## The document step ran, and what it touched

This delivery's subject is instruction text, and the document step has a measured history of editing instruction text, so the outcome of that encounter is recorded here rather than left silent.

It did not touch `AGENTS.md`.
The bound and the artefact prohibition came through the step byte-for-byte, and the line count did not move.

It edited three files beyond the change, and each was examined and kept as a consequential correction rather than reverted:

- `.agents/skills/fmx-respond/SKILL.md` - replaced two lines with a pointer to `AGENTS.md`. What it removed was a restatement rather than a rule: owner-only routing and "treat their request as a genuine captain instruction" are both stated at the top of that same skill, and the pointer now resolves to text that says "including public replies", so a reader following it gets an unambiguous yes. This is a consolidation of a duplication our own change created.
- `bin/fm-parent-channel-lib.sh` and `docs/secondmate-parent-channel.md` - both described the old unbounded rule ("AGENTS.md tells every firstmate to address the captain in every chat message"). This change makes that description false, so rewriting it is a correction that was owed either way. Keeping a stale description because a tool wrote the fix would prefer authorship to accuracy.

## Size

`AGENTS.md` goes from 603 to 602 lines.
The constraint was that the correction be neutral or negative in line count, and it is negative.
The bound is paid for by pruning "never send a response with zero direct address" - a restatement of "at least once in every" - and by folding the seasoning's own narrower artefact exclusion into the single bound, so the exclusion has one owner instead of two copies that could drift.

## Check status, read on 2026-09-09

Fourteen distinct checks passed and one carries no verdict.
This is not a clean sweep and should not be recorded as one.

`Behavior portable serial 4` was CANCELLED, which is the absence of an answer rather than a pass or a failure.
It is not flaky: the cause is known and it is the twenty-minute packing ceiling, and the repair for it exists as its own filed work, currently held under the development pause.
This change adds no test time at all - it is six lines of documentation plus one shell comment - so it neither caused nor worsened the cut.

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"f0dabe5787d99ede8c068ad39040e2f2e76304ae","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed ✅</summary>

- ⚠️ `AGENTS.md:12` - The new prohibition on address in “anything else … other people read” also covers Relay’s public replies to the captain. That is an existing supported path: .agents/skills/fmx-respond/SKILL.md:28–34 establishes owner-directed replies, and line 136 explicitly permits “captain” in them. This conflicts with the intent’s “WHAT HE IS NOT ASKING FOR: any change to the obligation itself.” The broader audience-based exclusion is unnecessary for fixing corrector artifacts. Remove that expansion by explicitly limiting the exclusion to non-chat artifacts, preserving captain-directed public chat.

🔧 Fix applied.
✅ Re-checked - no issues remain.
</details>

<details>
<summary>⚠️ **Test** - 1 warning</summary>

- ⚠️ this change has no live-validatable surface; proceed without live validation? (0 of 4 scenarios were driven live against the product); A corrector produces delivery and commit artifacts without direct address.: Only natural-language instructions changed. Demonstrating model interpretation requires a separate development-only evaluation; there is no executable address-rule surface to drive.; An agent retains captain address in routine chat and serious findings.: The obligation has no runtime enforcement to exercise. Behavioral proof requires a separate development-only model evaluation.; An agent addresses the captain in a public reply directed to him.: The revision changes instructions, not an executable reply interface. Model compliance requires a separate development-only evaluation.; In a mixed-output turn, an agent keeps address and nautical flavor out of PRs, issues, briefs, code, and comments while retaining address in chat.: This adversarial boundary depends on model interpretation, with no changed runtime enforcement. A separate development-only mixed-output evaluation is needed.
- Live validation: ⚠️ no-surface - 0 of 4 scenarios driven live against the product

| Scenario | Result | Live | Evidence |
| --- | --- | --- | --- |
| A corrector produces delivery and commit artifacts without direct address. | ⏸️ untested | no | Only natural-language instructions changed. Demonstrating model interpretation requires a separate development-only evaluation; there is no executable address-rule surface to drive. |
| An agent retains captain address in routine chat and serious findings. | ⏸️ untested | no | The obligation has no runtime enforcement to exercise. Behavioral proof requires a separate development-only model evaluation. |
| An agent addresses the captain in a public reply directed to him. | ⏸️ untested | no | The revision changes instructions, not an executable reply interface. Model compliance requires a separate development-only evaluation. |
| In a mixed-output turn, an agent keeps address and nautical flavor out of PRs, issues, briefs, code, and comments while retaining address in chat. | ⏸️ untested | no | This adversarial boundary depends on model interpretation, with no changed runtime enforcement. A separate development-only mixed-output evaluation is needed. |

- <code>`git rev-parse HEAD` confirmed target 2102a4d4f200b727c985d768a0027e9cb9e2e50e.</code>
- <code>`git diff 40c50ea8843c5b6a5351db8352675537252b653e 2102a4d4f200b727c985d768a0027e9cb9e2e50e` and `git diff --numstat` established scope and the one-line reduction.</code>
- `Manually inspected the chat/artifact distinction and Relay's captain-directed public-reply instructions.`
- `Searched repository test/evaluation files for address-rule behavioral coverage; found none.`
- <code>`git status --short` and `git diff --name-only` confirmed no testing changes or transient files.</code>
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
