### PR TITLE
feat: add pre-validation method to ship briefs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -529,9 +529,9 @@ Preserve durable structured identifiers, dependencies, and completion artifact l
 
 ## 11. Crewmate briefs
 
-`bin/fm-brief.sh` and its help own scaffold syntax, generated variants, status protocol, delivery-mode definitions of done, and exact safety mechanics.
+`bin/fm-brief.sh` and its help own scaffold syntax, generated variants, status protocol, and exact safety mechanics.
 Use its scaffold as the contract, then fill `## Captain's intent` (`{TASK}`) with the captain's own ask plus the context needed to read it, including the substance of any report, decision, or PR the ask refers to, and fill `## Firstmate spec` (`{FIRSTMATE_SPEC}`) with Firstmate's build instructions.
-`bin/fm-dod-lib.sh` owns what a no-mistakes worker may pass as `--intent` and its rule that the string must be self-sufficient.
+`bin/fm-dod-lib.sh` owns the mode-specific ship delivery blocks and what a no-mistakes worker may pass as `--intent`, including the rule that the string must be self-sufficient.
 Keep additions task-specific rather than repeating lifecycle instructions, and alter generated sections only when the task genuinely differs from the standard shape.
 
 Every ship brief must retain the worktree-isolation assertion and stop if launched in the primary checkout.

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -353,6 +353,14 @@ IFS= read -r -d '' TASK_SECTION <<'EOF' || true
 EOF
 TASK_SECTION=${TASK_SECTION%$'\n'}
 
+IFS= read -r -d '' SHIP_METHOD_SECTION <<'EOF' || true
+# Method
+1. REPRODUCE BEFORE TOUCHING CODE. Establish a failing test or capture wrong behaviour in-tree that names the defect before editing code. For a feature rather than a bug, use a failing test for the new behaviour; without reproduction, do not fix.
+2. SWEEP THE CLASS BEFORE THE FIRST EDIT. If the change adds, moves, or renames a fact, grep every site that defines, rebuilds, filters, or persists it before editing any of them, and record the count found. Fix all sites in the same change, then report how many were found, how many were fixed, and why each remaining site is correct as it stands.
+3. SELF-VERIFY BEFORE VALIDATION. Run the same gate commands on clean origin/main and on the branch and compare results. Prove every new behavioural test can fail by breaking it once, confirm the deletion fence is empty against the pushed HEAD with `git diff --name-status origin/main...HEAD`, and drive the visible surface locally; only then start no-mistakes. If validation finds something one of these steps would have caught, call it a workflow defect in the report.
+EOF
+SHIP_METHOD_SECTION=${SHIP_METHOD_SECTION%$'\n'}
+
 if [ "$KIND" = scout ]; then
 cat > "$BRIEF" <<EOF
 You are a crewmate: an autonomous worker agent managed by firstmate. Work on your own; do not wait for a human.
@@ -455,6 +463,8 @@ The path check is authoritative: \`git rev-parse --git-dir\` and \`git rev-parse
 If the top-level path is the primary checkout or not the worktree you were launched in, STOP - do not branch or commit here - append \`blocked: launched in primary checkout, not an isolated worktree\` to the status file and stop.
 
 1. First action: create your branch: \`git checkout -b fm/$ID\`$SETUP2
+
+$SHIP_METHOD_SECTION
 
 # Rules
 $RULE1

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -353,14 +353,6 @@ IFS= read -r -d '' TASK_SECTION <<'EOF' || true
 EOF
 TASK_SECTION=${TASK_SECTION%$'\n'}
 
-IFS= read -r -d '' SHIP_METHOD_SECTION <<'EOF' || true
-# Method
-1. REPRODUCE BEFORE TOUCHING CODE. Establish a failing test or capture wrong behaviour in-tree that names the defect before editing code. For a feature rather than a bug, use a failing test for the new behaviour; without reproduction, do not fix.
-2. SWEEP THE CLASS BEFORE THE FIRST EDIT. If the change adds, moves, or renames a fact, grep every site that defines, rebuilds, filters, or persists it before editing any of them, and record the count found. Fix all sites in the same change, then report how many were found, how many were fixed, and why each remaining site is correct as it stands.
-3. SELF-VERIFY BEFORE VALIDATION. Run the same gate commands on clean origin/main and on the branch and compare results. Prove every new behavioural test can fail by breaking it once, confirm the deletion fence is empty against the pushed HEAD with `git diff --name-status origin/main...HEAD`, and drive the visible surface locally; only then start no-mistakes. If validation finds something one of these steps would have caught, call it a workflow defect in the report.
-EOF
-SHIP_METHOD_SECTION=${SHIP_METHOD_SECTION%$'\n'}
-
 if [ "$KIND" = scout ]; then
 cat > "$BRIEF" <<EOF
 You are a crewmate: an autonomous worker agent managed by firstmate. Work on your own; do not wait for a human.
@@ -447,6 +439,7 @@ case "$MODE" in
     ;;
 esac
 DOD=$(fm_dod_block "$MODE" "$ID") || exit 1
+SHIP_METHOD_SECTION=$(fm_ship_method_block "$MODE") || exit 1
 
 cat > "$BRIEF" <<EOF
 You are a crewmate: an autonomous worker agent managed by firstmate. Work on your own; do not wait for a human.

--- a/bin/fm-dod-lib.sh
+++ b/bin/fm-dod-lib.sh
@@ -202,7 +202,7 @@ fm_ship_method_block() {  # <mode>
       delivery="only then push and open the PR."
       ;;
     local-only)
-      verification="Run the same gate commands on clean local \`main\` and on the branch and compare results. Prove every new behavioural test can fail by breaking it once, confirm the deletion fence is empty against the local HEAD with \`git diff --name-status main...HEAD\`, and drive the visible surface locally."
+      verification="Run the same gate commands on clean local default branch and on the branch and compare results. Prove every new behavioural test can fail by breaking it once, resolve the local default branch from \`refs/remotes/origin/HEAD\` (stripping \`origin/\` and falling back to the first existing local branch among \`main\` and \`master\`), then confirm the deletion fence is empty against the local HEAD with \`git diff --name-status \"\$default_branch\"...HEAD\`, and drive the visible surface locally."
       delivery="only then stop with a clean ready branch."
       ;;
     *)

--- a/bin/fm-dod-lib.sh
+++ b/bin/fm-dod-lib.sh
@@ -192,11 +192,19 @@ EOF
 }
 
 fm_ship_method_block() {  # <mode>
-  local mode=$1 delivery
+  local mode=$1 delivery verification
+  verification="Run the same gate commands on clean origin/main and on the branch and compare results. Prove every new behavioural test can fail by breaking it once, confirm the deletion fence is empty against the pushed HEAD with \`git diff --name-status origin/main...HEAD\`, and drive the visible surface locally."
   case "$mode" in
-    no-mistakes) delivery="only then start no-mistakes." ;;
-    direct-PR) delivery="only then push and open the PR." ;;
-    local-only) delivery="only then stop with a clean ready branch." ;;
+    no-mistakes)
+      delivery="only then start no-mistakes."
+      ;;
+    direct-PR)
+      delivery="only then push and open the PR."
+      ;;
+    local-only)
+      verification="Run the same gate commands on clean local \`main\` and on the branch and compare results. Prove every new behavioural test can fail by breaking it once, confirm the deletion fence is empty against the local HEAD with \`git diff --name-status main...HEAD\`, and drive the visible surface locally."
+      delivery="only then stop with a clean ready branch."
+      ;;
     *)
       echo "error: fm_ship_method_block: unknown delivery mode '$mode'" >&2
       return 1 ;;
@@ -205,7 +213,7 @@ fm_ship_method_block() {  # <mode>
 # Method
 1. REPRODUCE BEFORE TOUCHING CODE. Establish a failing test or capture wrong behaviour in-tree that names the defect before editing code. For a feature rather than a bug, use a failing test for the new behaviour; without reproduction, do not fix.
 2. SWEEP THE CLASS BEFORE THE FIRST EDIT. If the change adds, moves, or renames a fact, grep every site that defines, rebuilds, filters, or persists it before editing any of them, and record the count found. Fix all sites in the same change, then report how many were found, how many were fixed, and why each remaining site is correct as it stands.
-3. SELF-VERIFY BEFORE VALIDATION. Run the same gate commands on clean origin/main and on the branch and compare results. Prove every new behavioural test can fail by breaking it once, confirm the deletion fence is empty against the pushed HEAD with \`git diff --name-status origin/main...HEAD\`, and drive the visible surface locally; $delivery If validation finds something one of these steps would have caught, call it a workflow defect in the report.
+3. SELF-VERIFY BEFORE VALIDATION. $verification $delivery If validation finds something one of these steps would have caught, call it a workflow defect in the report.
 EOF
 }
 

--- a/bin/fm-dod-lib.sh
+++ b/bin/fm-dod-lib.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
-# Single owner of a ship task's mode-specific "Definition of done" block.
-# Sourced by bin/fm-brief.sh, which renders it into a generated ship brief, and by
+# Single owner of a ship task's mode-specific delivery blocks, including the
+# "Definition of done" and Method sections.
+# Sourced by bin/fm-brief.sh, which renders them into a generated ship brief, and by
 # bin/fm-promote.sh, which renders it into the ship instructions a promoted scout
 # receives. Both paths must hand the worker the same contract: a promoted
 # no-mistakes worker that never received the ask-user escalation rule or the
@@ -187,6 +188,24 @@ fm_ask_user_escalation_block() {  # <data-dir> <task-id>
    For a no-mistakes ask-user gate specifically, escalate all ask-user findings as one event plus one snapshot file, using that same shape even when the gate holds only a single ask-user finding: write only the ask-user findings, verbatim and unparaphrased (id, severity, file, line, description, authority), to \`$data/$id/nm-<run>-findings.txt\`, then report the gate with
    \`needs-decision [key=nm-<run>-<step>]: ask-user findings=<id1>,<id2>,... file=$data/$id/nm-<run>-findings.txt\`
    naming every ask-user finding id from that gate. The status line only points at the file; it never restates or summarizes a finding's content.
+EOF
+}
+
+fm_ship_method_block() {  # <mode>
+  local mode=$1 delivery
+  case "$mode" in
+    no-mistakes) delivery="only then start no-mistakes." ;;
+    direct-PR) delivery="only then push and open the PR." ;;
+    local-only) delivery="only then stop with a clean ready branch." ;;
+    *)
+      echo "error: fm_ship_method_block: unknown delivery mode '$mode'" >&2
+      return 1 ;;
+  esac
+  cat <<EOF
+# Method
+1. REPRODUCE BEFORE TOUCHING CODE. Establish a failing test or capture wrong behaviour in-tree that names the defect before editing code. For a feature rather than a bug, use a failing test for the new behaviour; without reproduction, do not fix.
+2. SWEEP THE CLASS BEFORE THE FIRST EDIT. If the change adds, moves, or renames a fact, grep every site that defines, rebuilds, filters, or persists it before editing any of them, and record the count found. Fix all sites in the same change, then report how many were found, how many were fixed, and why each remaining site is correct as it stands.
+3. SELF-VERIFY BEFORE VALIDATION. Run the same gate commands on clean origin/main and on the branch and compare results. Prove every new behavioural test can fail by breaking it once, confirm the deletion fence is empty against the pushed HEAD with \`git diff --name-status origin/main...HEAD\`, and drive the visible surface locally; $delivery If validation finds something one of these steps would have caught, call it a workflow defect in the report.
 EOF
 }
 

--- a/bin/fm-promote.sh
+++ b/bin/fm-promote.sh
@@ -163,6 +163,7 @@ PROMOTION_ASK_USER_BLOCK=
 if [ "$MODE" = no-mistakes ]; then
   PROMOTION_ASK_USER_BLOCK=$(fm_ask_user_escalation_block "$DATA" "$ID")
 fi
+SHIP_METHOD_SECTION=$(fm_ship_method_block "$MODE") || exit 1
 mkdir -p "$DATA/$ID"
 [ ! -d "$INSTRUCTIONS" ] || { echo "error: ship instructions path is a directory: $INSTRUCTIONS" >&2; exit 1; }
 TMP="$DATA/$ID/.ship-instructions.md.${BASHPID:-$$}"
@@ -186,6 +187,8 @@ EOF
 $PROMOTION_ASK_USER_BLOCK
 7. Treat the scout-time Firstmate spec and any unmarked legacy \`# Task\` text as investigation context, not captain intent or ship-time instructions.
 EOF
+  printf '\n'
+  printf '%s\n' "$SHIP_METHOD_SECTION"
   printf '\n'
   fm_dod_block "$MODE" "$ID"
 } > "$TMP" || { echo "error: could not render ship instructions for mode=$MODE" >&2; exit 1; }

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -304,7 +304,7 @@ The `data/secondmates.md` line contract is owned by the [`secondmate-provisionin
 Each task's mode and `yolo` merge posture are firstmate's decision at intake.
 The mode is passed explicitly to `bin/fm-brief.sh`, and both values are passed explicitly to `bin/fm-spawn.sh` and `bin/fm-promote.sh`; each command refuses to guess the values it consumes.
 A ship brief records its mode as a fixed machine-readable line and the spawn refuses to launch on a different one, so the worker's instructions and the recorded task delivery cannot diverge.
-`bin/fm-dod-lib.sh` is the one owner of that mode's definition of done, rendered both into a generated ship brief and into the ship instructions a promoted scout receives, so a promoted worker cannot be handed a weaker contract than a briefed one.
+`bin/fm-dod-lib.sh` is the one owner of that mode's delivery blocks, including Method and Definition of done, rendered both into a generated ship brief and into the ship instructions a promoted scout receives, so a promoted worker cannot be handed a weaker contract than a briefed one.
 It is also the one owner of the no-mistakes `--intent` contract those workers follow.
 `data/projects.md` records each project's standing posture and optional `+yolo` merge flag as the captain's default and as context for that decision, including the conditional `no-mistakes-prod-only` policy; a ship spawn that drops below the registered rigor prints a deviation notice and continues.
 `bin/fm-project-mode.sh` remains the one registry parser for the mechanical consumers that have no task in hand: fleet sync's `local-only` skip and home seeding's refusal and no-mistakes initialization.

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -33,7 +33,7 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-captain-hold.sh`     | Hold tasks for the captain, record the captain's answers, gate investigation completion, and report record divergence between the status log and the backlog |
 | `fm-decision-hold.sh`    | One-release compatibility shim mapping the retired decision commands onto fm-captain-hold.sh |
 | `fm-brief.sh`            | Scaffold ship (explicit `--mode`), scout, secondmate-charter, and Herdr-lab briefs, with Captain's intent and Firstmate spec subsections on ship/scout |
-| [`fm-dod-lib.sh`](../bin/fm-dod-lib.sh) | Own ship/scout worker role scope, ship definitions of done, and the no-mistakes `--intent` contract |
+| [`fm-dod-lib.sh`](../bin/fm-dod-lib.sh) | Own ship/scout worker role scope, mode-specific delivery blocks including Method and Definition of done, and the no-mistakes `--intent` contract |
 | `fm-herdr-lab.sh`        | Provision and guardedly operate an isolated, never-default Herdr lab session         |
 | `fm-install-herdr.sh`    | Install CI's exact-version Herdr pin with official asset URL, SHA-256, and protocol checks |
 | `fm-install-treehouse.sh`| Install CI's exact-version Treehouse pin for real-Herdr E2E that needs spawn worktrees |
@@ -130,7 +130,7 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-pr-merge.sh`         | Record PR metadata, merge a task's canonical full GitHub or GitLab URL, then refuse an outcome it cannot prove landed or queued |
 | `fm-merge-outcome-lib.sh` | Publish a confirmed merge's durable, role-routed supervision outcome                 |
 | `fm-parent-channel-lib.sh` | Resolve a secondmate home's parent channel and append a captain-facing outcome line to it at most once |
-| `fm-promote.sh`          | Promote a scout task in place to a protected ship task with an explicit delivery mode, and write the ship instructions carrying that mode's definition of done |
+| `fm-promote.sh`          | Promote a scout task in place to a protected ship task with an explicit delivery mode, and write the ship instructions carrying that mode's Method and Definition of done blocks |
 | `fm-teardown.sh`         | Fail-closed teardown: return landed ship worktrees, require completed scout deliverables, retire secondmate homes |
 | `fm-harness.sh`          | Detect the running harness, resolve crew or secondmate harness, model, and effort, and validate the native-only `ultra` effort |
 | `fm-lock.sh`             | Per-home firstmate session lock                                                      |

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -250,10 +250,17 @@ test_ship_method_section_is_ship_only() {
   FM_HOME="$home" "$ROOT/bin/fm-brief.sh" method-local-only some-proj --mode local-only >/dev/null 2>&1 \
     || fail "local-only Method fixture did not scaffold"
   local_only="$home/data/method-local-only/brief.md"
-  assert_grep "clean local \`main\`" "$local_only" \
+  assert_grep "clean local default branch" "$local_only" \
     "local-only Method section did not use the local default branch"
-  assert_grep 'git diff --name-status main...HEAD' "$local_only" \
-    "local-only Method section did not use the local deletion fence"
+  assert_grep "refs/remotes/origin/HEAD" "$local_only" \
+    "local-only Method section did not resolve the remote default branch"
+  assert_grep "falling back to the first existing local branch among \`main\` and \`master\`" \
+    "$local_only" \
+    "local-only Method section did not cover local main/master fallback"
+  assert_grep "git diff --name-status \"\$default_branch\"...HEAD" "$local_only" \
+    "local-only Method section did not use the resolved deletion fence"
+  assert_no_grep 'git diff --name-status main...HEAD' "$local_only" \
+    "local-only Method section hard-coded main in the deletion fence"
   assert_no_grep "origin/main" "$local_only" \
     "local-only Method section referenced an unavailable remote"
   assert_no_grep "pushed HEAD" "$local_only" \

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -221,6 +221,34 @@ test_ship_modes_generate_clean_briefs() {
   pass "fm-brief.sh: no-mistakes/direct-PR/local-only briefs generate cleanly"
 }
 
+test_ship_method_section_is_ship_only() {
+  local home ship scout setup_line method_line rules_line
+  home="$TMP_ROOT/method-section-home"
+  mkdir -p "$home/data"
+
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" method-ship some-proj --mode no-mistakes >/dev/null 2>&1 \
+    || fail "ship method fixture did not scaffold"
+  ship="$home/data/method-ship/brief.md"
+  assert_grep "# Method" "$ship" "ship brief missing Method section"
+  assert_grep "1. REPRODUCE BEFORE TOUCHING CODE." "$ship" \
+    "ship Method section missing reproduction step"
+  assert_grep "2. SWEEP THE CLASS BEFORE THE FIRST EDIT." "$ship" \
+    "ship Method section missing class-sweep step"
+  assert_grep "3. SELF-VERIFY BEFORE VALIDATION." "$ship" \
+    "ship Method section missing self-verification step"
+  setup_line=$(grep -n '^# Setup$' "$ship" | cut -d: -f1)
+  method_line=$(grep -n '^# Method$' "$ship" | cut -d: -f1)
+  rules_line=$(grep -n '^# Rules$' "$ship" | cut -d: -f1)
+  [ "$setup_line" -lt "$method_line" ] && [ "$method_line" -lt "$rules_line" ] \
+    || fail "ship Method section must be between Setup and Rules"
+
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" method-scout some-proj --scout >/dev/null 2>&1 \
+    || fail "scout method fixture did not scaffold"
+  scout="$home/data/method-scout/brief.md"
+  assert_no_grep "# Method" "$scout" "scout brief received ship-only Method section"
+  pass "fm-brief.sh: ship Method section emits all three steps and scouts omit it"
+}
+
 # A ship task's delivery mode is firstmate's per-task decision, so a missing or
 # unusable value must stop the scaffold instead of silently defaulting. The
 # no-mistakes-prod-only row is the conditional registry policy: it is never a task
@@ -873,6 +901,7 @@ test_script_parses
 test_no_heredoc_in_command_substitution
 test_help_includes_entire_header
 test_ship_modes_generate_clean_briefs
+test_ship_method_section_is_ship_only
 test_ship_mode_is_required_and_closed_set
 test_ship_mode_is_explicit_not_registry
 test_delivery_flags_are_refused_where_they_do_not_apply

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -222,7 +222,7 @@ test_ship_modes_generate_clean_briefs() {
 }
 
 test_ship_method_section_is_ship_only() {
-  local home ship scout setup_line method_line rules_line
+  local home ship local_only scout setup_line method_line rules_line
   home="$TMP_ROOT/method-section-home"
   mkdir -p "$home/data"
 
@@ -246,6 +246,18 @@ test_ship_method_section_is_ship_only() {
     || fail "scout method fixture did not scaffold"
   scout="$home/data/method-scout/brief.md"
   assert_no_grep "# Method" "$scout" "scout brief received ship-only Method section"
+
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" method-local-only some-proj --mode local-only >/dev/null 2>&1 \
+    || fail "local-only Method fixture did not scaffold"
+  local_only="$home/data/method-local-only/brief.md"
+  assert_grep "clean local \`main\`" "$local_only" \
+    "local-only Method section did not use the local default branch"
+  assert_grep 'git diff --name-status main...HEAD' "$local_only" \
+    "local-only Method section did not use the local deletion fence"
+  assert_no_grep "origin/main" "$local_only" \
+    "local-only Method section referenced an unavailable remote"
+  assert_no_grep "pushed HEAD" "$local_only" \
+    "local-only Method section required a push"
   pass "fm-brief.sh: ship Method section emits all three steps and scouts omit it"
 }
 

--- a/tests/fm-task-delivery.test.sh
+++ b/tests/fm-task-delivery.test.sh
@@ -307,7 +307,7 @@ test_promote_refuses_a_symlinked_task_record() {
 # prints against a capturing fm-send.sh, and asserts on the message the worker would
 # actually receive - for every supported mode.
 test_promotion_delivers_the_real_definition_of_done() {
-  local home meta out sendroot payload mode id brief_dod delivered_dod
+  local home meta out sendroot payload mode id method_delivery brief_method delivered_method brief_dod delivered_dod
   home="$TMP_ROOT/promote-dod/home"
   sendroot="$TMP_ROOT/promote-dod/sendroot"
   mkdir -p "$home/state" "$sendroot/bin"
@@ -354,6 +354,21 @@ STUB
       "$mode: promoted worker did not receive the Captain's intent subsection"
     assert_grep "## Firstmate spec" "$payload" \
       "$mode: promoted worker did not receive the Firstmate spec subsection"
+    assert_grep "# Method" "$payload" \
+      "$mode: promoted worker did not receive the Method section"
+    assert_grep "1. REPRODUCE BEFORE TOUCHING CODE." "$payload" \
+      "$mode: promoted worker did not receive the reproduction step"
+    assert_grep "2. SWEEP THE CLASS BEFORE THE FIRST EDIT." "$payload" \
+      "$mode: promoted worker did not receive the class-sweep step"
+    assert_grep "3. SELF-VERIFY BEFORE VALIDATION." "$payload" \
+      "$mode: promoted worker did not receive the self-verification step"
+    case "$mode" in
+      no-mistakes) method_delivery="only then start no-mistakes." ;;
+      direct-PR) method_delivery="only then push and open the PR." ;;
+      local-only) method_delivery="only then stop with a clean ready branch." ;;
+    esac
+    assert_grep "$method_delivery" "$payload" \
+      "$mode: promoted worker did not receive its mode-specific Method delivery step"
 
     # Compare the public outputs of both real generation paths. The promoted
     # payload ends at its Definition of done, as does an ordinary generated
@@ -361,6 +376,14 @@ STUB
     rm "$home/data/$id/brief.md"
     FM_HOME="$home" "$BRIEF" "$id" fixture-project --mode "$mode" >/dev/null 2>&1 \
       || fail "$mode: ordinary ship brief generation should succeed"
+    brief_method="$TMP_ROOT/promote-dod/brief-method-$id"
+    delivered_method="$TMP_ROOT/promote-dod/delivered-method-$id"
+    awk '/^# Method$/ { emit=1 } emit { if (seen && /^# /) exit; print; seen=1 }' \
+      "$home/data/$id/brief.md" > "$brief_method"
+    awk '/^# Method$/ { emit=1 } emit { if (seen && /^# /) exit; print; seen=1 }' \
+      "$payload" > "$delivered_method"
+    cmp -s "$brief_method" "$delivered_method" \
+      || fail "$mode: promotion and ordinary brief generation delivered different Method sections"
     brief_dod="$TMP_ROOT/promote-dod/brief-dod-$id"
     delivered_dod="$TMP_ROOT/promote-dod/delivered-dod-$id"
     awk '/^# Definition of done$/ { emit=1 } emit' "$home/data/$id/brief.md" > "$brief_dod"


### PR DESCRIPTION
## Intent

The captain reviewed tonight's crew workflow - a Pi worker on GPT-5.6 Luna at xhigh, running a Ralph loop, then no-mistakes validation - and asked where it could be faster without losing quality. Firstmate's answer, which he approved with "okay lets proceed with that": the shape is right, but roughly 80 percent of tonight's elapsed time was serial review rounds, and three of the steps that would have prevented those rounds are not in the brief every worker receives.
THE EVIDENCE, so the change is proportionate rather than speculative. The attendee-link lane went back FIVE times for the same fault class in a new place each round - three text-match consumers, then a view-rebuild file that omitted the new column. The magic-event lane burned six rounds guessing at a defect it had never reproduced. Two lanes self-reported corrections that were not in the saved file. Every one of those rounds was recoverable by a step the worker could have taken before validation started.
THE CHANGE: add a Method section to the SHIP brief scaffold in bin/fm-brief.sh so every coding worker gets three steps by default, between Setup and Rules:
1, REPRODUCE BEFORE TOUCHING CODE. A failing test or a captured wrong behaviour, in-tree, that names the defect. No reproduction, no fix. For a feature rather than a bug, the equivalent is a failing test for the new behaviour.
2, SWEEP THE CLASS BEFORE THE FIRST EDIT. If the change adds, moves or renames a fact, grep every site that defines, rebuilds, filters or persists it BEFORE editing any of them, and record the count found. Fix all of them in the same change, and state in the report how many were found, how many were fixed, and why any remaining one is correct as it stands.
3, SELF-VERIFY BEFORE VALIDATION. Run the same gate commands on clean origin/main and on the branch and compare; prove every new behavioural test can fail by breaking it once; confirm the deletion fence is empty against the PUSHED head with git diff --name-status origin/main...HEAD; drive the surface locally for anything visible. Only then start no-mistakes. If validation then finds something one of these steps would have caught, that is a workflow defect and the worker says so in the report.

## What Changed

- Added a ship-only `# Method` section covering reproduction, class-wide dependency sweeps, and pre-validation self-verification with mode-specific completion guidance.
- Centralized Method and Definition-of-done delivery blocks so generated ship briefs and promoted worker instructions receive the same contract.
- Updated architecture/script documentation and tests to verify Method placement, scout exclusion, and delivery parity across modes.

## Risk Assessment

✅ Low: Captain, the change is a bounded shared prompt-rendering update with mode-aware delivery and preserved scout/secondmate behavior.

## Testing

Inspected the target diff, ran the focused brief-scaffold and promotion-delivery suites, and captured generated mode-specific Method sections as reviewer-visible evidence. No full-suite, lint, formatter, or static-analysis commands were run.

<details>
<summary>Evidence: Generated no-mistakes SHIP brief</summary>

Source: [Generated no-mistakes SHIP brief](https://github.com/jericho1050/firstmate/blob/d24e920b26a650a84a21b7ab51fd987889bf8ac2/.no-mistakes/evidence/fm/fm-brief-hard-task-method/method-brief-e2e/data/evidence-no-mistakes/brief.md)

```text
You are a crewmate: an autonomous worker agent managed by firstmate. Work on your own; do not wait for a human.

# Task
## Captain's intent
{TASK}

## Firstmate spec
{FIRSTMATE_SPEC}

# Herdr lifecycle declaration - NOT ENABLED
**HARD SAFETY GATE:** this scaffold cannot inspect the task text filled in above.
If the task will start, stop, delete, restart, profile, or otherwise drive Herdr lifecycle behavior, stop and regenerate the brief with `--herdr-lab` before dispatch.
Do not add Herdr lifecycle commands to this unguarded brief by hand.

# Setup
You are in a disposable git worktree of fixture-project, at a detached HEAD on a clean default branch.

**Verify isolation before anything else.** Run `pwd -P` and `git rev-parse --show-toplevel`; both must resolve to the disposable task worktree you were launched in, such as a treehouse pool path or an Orca-managed worktree, not the primary checkout firstmate operates from.
The path check is authoritative: `git rev-parse --git-dir` and `git rev-parse --git-common-dir` can help inspect the repo, but they do not prove you are outside the primary checkout.
If the top-level path is the primary checkout or not the worktree you were launched in, STOP - do not branch or commit here - append `blocked: launched in primary checkout, not an isolated worktree` to the status file and stop.

1. First action: create your branch: `git checkout -b fm/evidence-no-mistakes`
2. Run `no-mistakes doctor`; if it reports the repo is not initialized here, run `no-mistakes init`.

# Method
1. REPRODUCE BEFORE TOUCHING CODE. Establish a failing test or capture wrong behaviour in-tree that names the defect before editing code. For a feature rather than a bug, use a failing test for the new behaviour; without reproduction, do not fix.
2. SWEEP THE CLASS BEFORE THE FIRST EDIT. If the change adds, moves, or renames a fact, grep every site that defines, rebuilds, filters, or persists it before editing any of them, and record the count found. Fix all sites in the same change, then report how many were found, how many were fixed, and why each remaining site is correct as it stands.
3. SELF-VERIFY BEFORE VALIDATION. Run the same gate commands on clean origin/main and on the branch and compare results. Prove every new behavioural test can fail by breaking it once, confirm the deletion fence is empty against the pushed HEAD with `git diff --name-status origin/main...HEAD`, and drive the visible surface locally; only then start no-mistakes. If validation finds something one of these steps would have caught, call it a workflow defect in the report.

# Rules
1. Never push to the default branch. Never merge a PR.
2. Stay inside this worktree; modify nothing outside it.
3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.
4. Report status by appending one line:
   `echo "{state}: {one short line}" >> '~/.no-mistakes/evidence/01M234M889VM363ZY2Z64RJGWN/method-brief-e2e/state/evidence-no-mistakes.status'`
   States: working, needs-decision, blocked, paused, done, failed.
   Each append wakes firstmate, so report sparingly: only phase changes a supervisor
   would act on (setup done, bug reproduced, fix implemented, validation passed) and the
   needs-decision/blocked/paused/done/failed states. No step-by-step FYI progress lines;
   firstmate reads your pane for that.
   Whenever you mention a PR anywhere - a status line, your terminal, a summary - write its full
   https:// URL exactly as the forge printed it, never a bare number such as "PR 108"; firstmate
   copies that URL from your line rather than assembling one.
   A mid-task `working:` line (including setup complete) is nonterminal: do not end the
   turn after it; continue the same stage until a defined `done:` gate under Definition of done.
   Use `paused: {why}` - distinct from `blocked:` - ONLY when you are deliberately idling on a
   known external wait you expect to clear on its own (an upstream release, a rate-limit reset,
   a scheduled window): firstmate then leaves your idle pane alone and rechecks it on a long
   cadence instead of treating it as a possible wedge. Use `blocked:` when you are stuck and need help.
5. If you hit the same obstacle twice, append `blocked: {why}` and stop; firstmate will help.
6. If a decision belongs above the implementation worker (product choices, destructive actions),
   append `needs-decision: {summary of options}` and stop. Firstmate will reply with the decision.
   For a no-mistakes ask-user gate specifically, escalate all ask-user findings as one event plus one snapshot file, using that same shape even when the gate holds only a single ask-user finding: write only the ask-user findings, verbatim and unparaphrased (id, severity, file, line, description, authority), to `~/.no-mistakes/evidence/01M234M889VM363ZY2Z64RJGWN/method-brief-e2e/data/evidence-no-mistakes/nm-<run>-findings.txt`, then report the gate with
   `needs-decision [key=nm-<run>-<step>]: ask-user findings=<id1>,<id2>,... file=~/.no-mistakes/evidence/01M234M889VM363ZY2Z64RJGWN/method-brief-e2e/data/evidence-no-mistakes/nm-<run>-findings.txt`
   naming every ask-user finding id from that gate. The status line only points at the file; it never restates or summarizes a finding's content.
   A decision or blocker you opened stays open until a `resolved` line carrying its exact key lands; a later `done:` or `working:` line never closes it, even when the answer is what started that work.
   Firstmate's reply normally writes that closing line at answer time; when a blocker or wait clears WITHOUT a firstmate reply, append `resolved: {how it cleared}` yourself (same `[key=<slug>]` if you opened it with one) as you resume.
7. Never stop, restart, or update the shared `no-mistakes` daemon - it is one instance serving
   every lane/home, so restarting it kills other lanes' in-flight pipeline runs; only firstmate
   manages the daemon.
   Before you append `blocked:` about the pipeline, run `no-mistakes daemon status` and
   `no-mistakes axi status`. If the daemon socket refuses connections or is missing, append
   `blocked: {the daemon error}` and stop even when the local run record still says running or
   fixing, because that record can be stale after the daemon exits. A run record failed with a
   daemon error is also a real block.
   Only after ruling out socket refusal, if the run is still running or fixing, reattach and keep
   going. A drive-call error, timeout, slow read, or generic unreachability is NOT a daemon error:
   the daemon accepts `respond` immediately and runs the round in the background, so a killed or
   timed-out call was only waiting for a read while the run kept working.

# Firstmate instruction inbox
Firstmate steers you through durable message files in '~/.no-mistakes/evidence/01M234M889VM363ZY2Z64RJGWN/method-brief-e2e/state/evidence-no-mistakes.inbox'.
When a terminal message says an instruction is waiting there - and at any natural checkpoint when you are unsure - list '~/.no-mistakes/evidence/01M234M889VM363ZY2Z64RJGWN/method-brief-e2e/state/evidence-no-mistakes.inbox'/*.msg, read and act on each message in numeric order, then acknowledge each handled message by moving it: `mv '~/.no-mistakes/evidence/01M234M889VM363ZY2Z64RJGWN/method-brief-e2e/state/evidence-no-mistakes.inbox'/NNN.msg '~/.no-mistakes/evidence/01M234M889VM363ZY2Z64RJGWN/method-brief-e2e/state/evidence-no-mistakes.inbox'/handled/`.
The move IS the acknowledgement: without it firstmate rings again and eventually treats you as stuck. An empty or absent inbox needs no action.

# Project memory
If `AGENTS.md` or `CLAUDE.md` already exists, or if this task produced durable project-intrinsic knowledge, run `~/.no-mistakes/worktrees/d335fa506761/01M234M889VM363ZY2Z64RJGWN/bin/fm-ensure-agents-md.sh .` in the worktree.
Record only project knowledge useful to almost every future session.
For anything the codebase already shows, prefer a pointer to the authoritative file, command, or doc over copying the detail.
If you touch a project `AGENTS.md`, follow `~/.no-mistakes/worktrees/d335fa506761/01M234M889VM363ZY2Z64RJGWN/bin/fm-ensure-agents-md.sh`'s self-governance contract in the same pass.
Keep it proportionate: skip `AGENTS.md` edits for trivial tasks that produced no durable project knowledge.

# Definition of done
Delivery contract: mode=no-mistakes
The task is complete only when committed on your branch.
When you believe it is complete, append `done: {summary}` to the status file and stop.
Firstmate will then instruct you to run /no-mistakes to validate and ship a PR.

You drive no-mistakes by responding to its gates, not by implementing fixes.
Follow the guidance no-mistakes itself provides for the mechanics: it loads when you invoke /no-mistakes, and `no-mistakes axi run --help` plus the `help` lines in each `axi` response are authoritative and version-matched to the installed binary.
When starting no-mistakes, pass `--intent` as only this brief's `## Captain's intent` subsection plus any later words the captain actually said.
For a legacy brief with no such subsection, include only words explicitly labeled `Captain:`, `Captain's words:`, `Captain's ask:`, or `Captain's intent:`; never copy its mixed `# Task` wholesale. If it has no provenance-marked captain words, stop and ask firstmate instead of starting no-mistakes.
Do not include `## Firstmate spec`, later Firstmate build constraints, or your own decisions and tradeoffs.
The `--intent` string you pass must be self-sufficient: that string plus the codebase must let a reader reconstruct roughly the same specification, without depending on a separate report, a PR, or context that lives only in this conversation.
When the captain's intent refers to a report, decision, or PR ("do items 1, 2, 3, and 7 of the report"), write the substance of the referenced items into `--intent` in the captain's terms, not only the pointer; that substance is the captain's ask by reference, while Firstmate's build instructions and your own decisions still stay out.
This replaces the no-mistakes skill's advice to enrich `--intent` with decisions and tradeoffs; that advice does not apply to Firstmate-dispatched work.
Do not hand-edit, commit, or fix findings yourself while a run is active - the pipeline applies every fix.

One drive call blocks until the next gate or outcome, which routinely outlives what your harness lets a single command run: Claude Code kills a command at ten minutes maximum, while one fix round is capped around thirty minutes and up to three rounds chain.
So background the drive call and poll `no-mistakes axi status` from a separate call instead of sitting in one blocking hold your harness will kill.
Where a harness's own command limit is not established, assume it bounds commands and use that same background-and-poll shape.
A killed or timed-out call is never evidence the daemon died: the daemon accepts your response immediately and runs the round in the background, so the call was only ever waiting for a read while the run kept working.
Reattach and keep going rather than reporting the pipeline blocked; rule 7 owns the checks that decide when a pipeline block is real.

Two firstmate-specific rules layer on top of that guidance:
- ask-user findings are never yours to answer: escalate to firstmate using rule 6's ask-user format and stop.
  Firstmate applies `ask-user-authority` and obtains any required captain decision.
  When the decision comes back, feed it to the gate with `no-mistakes axi respond` and let the pipeline apply it - do not route the question to "the user" or implement the fix yourself.
- NEVER pass `--yes` (or `-y`) to `no-mistakes axi run` or `no-mistakes axi respond`. It is banned fleet-wide.
  It auto-resolves every gate including ask-user findings with no escalation, and answering your own ask-user finding is a hard rule violation.

After /no-mistakes reports CI green (the CI-ready return point - do not wait for it to keep monitoring in the background until merge), append `done: PR {url} checks green` and stop. You are finished.
```
</details>
<details>
<summary>Evidence: Generated direct-PR SHIP brief</summary>

Source: [Generated direct-PR SHIP brief](https://github.com/jericho1050/firstmate/blob/d24e920b26a650a84a21b7ab51fd987889bf8ac2/.no-mistakes/evidence/fm/fm-brief-hard-task-method/method-brief-e2e/data/evidence-direct-PR/brief.md)

```text
You are a crewmate: an autonomous worker agent managed by firstmate. Work on your own; do not wait for a human.

# Task
## Captain's intent
{TASK}

## Firstmate spec
{FIRSTMATE_SPEC}

# Herdr lifecycle declaration - NOT ENABLED
**HARD SAFETY GATE:** this scaffold cannot inspect the task text filled in above.
If the task will start, stop, delete, restart, profile, or otherwise drive Herdr lifecycle behavior, stop and regenerate the brief with `--herdr-lab` before dispatch.
Do not add Herdr lifecycle commands to this unguarded brief by hand.

# Setup
You are in a disposable git worktree of fixture-project, at a detached HEAD on a clean default branch.

**Verify isolation before anything else.** Run `pwd -P` and `git rev-parse --show-toplevel`; both must resolve to the disposable task worktree you were launched in, such as a treehouse pool path or an Orca-managed worktree, not the primary checkout firstmate operates from.
The path check is authoritative: `git rev-parse --git-dir` and `git rev-parse --git-common-dir` can help inspect the repo, but they do not prove you are outside the primary checkout.
If the top-level path is the primary checkout or not the worktree you were launched in, STOP - do not branch or commit here - append `blocked: launched in primary checkout, not an isolated worktree` to the status file and stop.

1. First action: create your branch: `git checkout -b fm/evidence-direct-PR`

# Method
1. REPRODUCE BEFORE TOUCHING CODE. Establish a failing test or capture wrong behaviour in-tree that names the defect before editing code. For a feature rather than a bug, use a failing test for the new behaviour; without reproduction, do not fix.
2. SWEEP THE CLASS BEFORE THE FIRST EDIT. If the change adds, moves, or renames a fact, grep every site that defines, rebuilds, filters, or persists it before editing any of them, and record the count found. Fix all sites in the same change, then report how many were found, how many were fixed, and why each remaining site is correct as it stands.
3. SELF-VERIFY BEFORE VALIDATION. Run the same gate commands on clean origin/main and on the branch and compare results. Prove every new behavioural test can fail by breaking it once, confirm the deletion fence is empty against the pushed HEAD with `git diff --name-status origin/main...HEAD`, and drive the visible surface locally; only then push and open the PR. If validation finds something one of these steps would have caught, call it a workflow defect in the report.

# Rules
1. Never push to the default branch (push only your `fm/evidence-direct-PR` branch). Never merge a PR.
2. Stay inside this worktree; modify nothing outside it.
3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.
4. Report status by appending one line:
   `echo "{state}: {one short line}" >> '~/.no-mistakes/evidence/01M234M889VM363ZY2Z64RJGWN/method-brief-e2e/state/evidence-direct-PR.status'`
   States: working, needs-decision, blocked, paused, done, failed.
   Each append wakes firstmate, so report sparingly: only phase changes a supervisor
   would act on (setup done, bug reproduced, fix implemented, validation passed) and the
   needs-decision/blocked/paused/done/failed states. No step-by-step FYI progress lines;
   firstmate reads your pane for that.
   Whenever you mention a PR anywhere - a status line, your terminal, a summary - write its full
   https:// URL exactly as the forge printed it, never a bare number such as "PR 108"; firstmate
   copies that URL from your line rather than assembling one.
   A mid-task `working:` line (including setup complete) is nonterminal: do not end the
   turn after it; continue the same stage until a defined `done:` gate under Definition of done.
   Use `paused: {why}` - distinct from `blocked:` - ONLY when you are deliberately idling on a
   known external wait you expect to clear on its own (an upstream release, a rate-limit reset,
   a scheduled window): firstmate then leaves your idle pane alone and rechecks it on a long
   cadence instead of treating it as a possible wedge. Use `blocked:` when you are stuck and need help.
5. If you hit the same obstacle twice, append `blocked: {why}` and stop; firstmate will help.
6. If a decision belongs above the implementation worker (product choices, destructive actions),
   append `needs-decision: {summary of options}` and stop. Firstmate will reply with the decision.

   A decision or blocker you opened stays open until a `resolved` line carrying its exact key lands; a later `done:` or `working:` line never closes it, even when the answer is what started that work.
   Firstmate's reply normally writes that closing line at answer time; when a blocker or wait clears WITHOUT a firstmate reply, append `resolved: {how it cleared}` yourself (same `[key=<slug>]` if you opened it with one) as you resume.
7. Never stop, restart, or update the shared `no-mistakes` daemon - it is one instance serving
   every lane/home, so restarting it kills other lanes' in-flight pipeline runs; only firstmate
   manages the daemon.
   Before you append `blocked:` about the pipeline, run `no-mistakes daemon status` and
   `no-mistakes axi status`. If the daemon socket refuses connections or is missing, append
   `blocked: {the daemon error}` and stop even when the local run record still says running or
   fixing, because that record can be stale after the daemon exits. A run record failed with a
   daemon error is also a real block.
   Only after ruling out socket refusal, if the run is still running or fixing, reattach and keep
   going. A drive-call error, timeout, slow read, or generic unreachability is NOT a daemon error:
   the daemon accepts `respond` immediately and runs the round in the background, so a killed or
   timed-out call was only waiting for a read while the run kept working.

# Firstmate instruction inbox
Firstmate steers you through durable message files in '~/.no-mistakes/evidence/01M234M889VM363ZY2Z64RJGWN/method-brief-e2e/state/evidence-direct-PR.inbox'.
When a terminal message says an instruction is waiting there - and at any natural checkpoint when you are unsure - list '~/.no-mistakes/evidence/01M234M889VM363ZY2Z64RJGWN/method-brief-e2e/state/evidence-direct-PR.inbox'/*.msg, read and act on each message in numeric order, then acknowledge each handled message by moving it: `mv '~/.no-mistakes/evidence/01M234M889VM363ZY2Z64RJGWN/method-brief-e2e/state/evidence-direct-PR.inbox'/NNN.msg '~/.no-mistakes/evidence/01M234M889VM363ZY2Z64RJGWN/method-brief-e2e/state/evidence-direct-PR.inbox'/handled/`.
The move IS the acknowledgement: without it firstmate rings again and eventually treats you as stuck. An empty or absent inbox needs no action.

# Project memory
If `AGENTS.md` or `CLAUDE.md` already exists, or if this task produced durable project-intrinsic knowledge, run `~/.no-mistakes/worktrees/d335fa506761/01M234M889VM363ZY2Z64RJGWN/bin/fm-ensure-agents-md.sh .` in the worktree.
Record only project knowledge useful to almost every future session.
For anything the codebase already shows, prefer a pointer to the authoritative file, command, or doc over copying the detail.
If you touch a project `AGENTS.md`, follow `~/.no-mistakes/worktrees/d335fa506761/01M234M889VM363ZY2Z64RJGWN/bin/fm-ensure-agents-md.sh`'s self-governance contract in the same pass.
Keep it proportionate: skip `AGENTS.md` edits for trivial tasks that produced no durable project knowledge.

# Definition of done
Delivery contract: mode=direct-PR
This task ships **direct-PR**: you raise the PR yourself, without the no-mistakes pipeline.
The task is complete only when committed on your branch.
When it is implemented and committed, push your branch and open a PR with `gh-axi`, then append `done: PR {url}` to the status file and stop.
Do NOT run /no-mistakes. The configured merge authority decides whether to merge the PR; firstmate relays the outcome.
```
</details>
<details>
<summary>Evidence: Generated local-only SHIP brief</summary>

Source: [Generated local-only SHIP brief](https://github.com/jericho1050/firstmate/blob/d24e920b26a650a84a21b7ab51fd987889bf8ac2/.no-mistakes/evidence/fm/fm-brief-hard-task-method/method-brief-e2e/data/evidence-local-only/brief.md)

```text
You are a crewmate: an autonomous worker agent managed by firstmate. Work on your own; do not wait for a human.

# Task
## Captain's intent
{TASK}

## Firstmate spec
{FIRSTMATE_SPEC}

# Herdr lifecycle declaration - NOT ENABLED
**HARD SAFETY GATE:** this scaffold cannot inspect the task text filled in above.
If the task will start, stop, delete, restart, profile, or otherwise drive Herdr lifecycle behavior, stop and regenerate the brief with `--herdr-lab` before dispatch.
Do not add Herdr lifecycle commands to this unguarded brief by hand.

# Setup
You are in a disposable git worktree of fixture-project, at a detached HEAD on a clean default branch.

**Verify isolation before anything else.** Run `pwd -P` and `git rev-parse --show-toplevel`; both must resolve to the disposable task worktree you were launched in, such as a treehouse pool path or an Orca-managed worktree, not the primary checkout firstmate operates from.
The path check is authoritative: `git rev-parse --git-dir` and `git rev-parse --git-common-dir` can help inspect the repo, but they do not prove you are outside the primary checkout.
If the top-level path is the primary checkout or not the worktree you were launched in, STOP - do not branch or commit here - append `blocked: launched in primary checkout, not an isolated worktree` to the status file and stop.

1. First action: create your branch: `git checkout -b fm/evidence-local-only`

# Method
1. REPRODUCE BEFORE TOUCHING CODE. Establish a failing test or capture wrong behaviour in-tree that names the defect before editing code. For a feature rather than a bug, use a failing test for the new behaviour; without reproduction, do not fix.
2. SWEEP THE CLASS BEFORE THE FIRST EDIT. If the change adds, moves, or renames a fact, grep every site that defines, rebuilds, filters, or persists it before editing any of them, and record the count found. Fix all sites in the same change, then report how many were found, how many were fixed, and why each remaining site is correct as it stands.
3. SELF-VERIFY BEFORE VALIDATION. Run the same gate commands on clean origin/main and on the branch and compare results. Prove every new behavioural test can fail by breaking it once, confirm the deletion fence is empty against the pushed HEAD with `git diff --name-status origin/main...HEAD`, and drive the visible surface locally; only then stop with a clean ready branch. If validation finds something one of these steps would have caught, call it a workflow defect in the report.

# Rules
1. Never push to any remote and never open a PR. Work only on your `fm/evidence-local-only` branch; firstmate handles the merge into local `main`.
2. Stay inside this worktree; modify nothing outside it.
3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.
4. Report status by appending one line:
   `echo "{state}: {one short line}" >> '~/.no-mistakes/evidence/01M234M889VM363ZY2Z64RJGWN/method-brief-e2e/state/evidence-local-only.status'`
   States: working, needs-decision, blocked, paused, done, failed.
   Each append wakes firstmate, so report sparingly: only phase changes a supervisor
   would act on (setup done, bug reproduced, fix implemented, validation passed) and the
   needs-decision/blocked/paused/done/failed states. No step-by-step FYI progress lines;
   firstmate reads your pane for that.
   Whenever you mention a PR anywhere - a status line, your terminal, a summary - write its full
   https:// URL exactly as the forge printed it, never a bare number such as "PR 108"; firstmate
   copies that URL from your line rather than assembling one.
   A mid-task `working:` line (including setup complete) is nonterminal: do not end the
   turn after it; continue the same stage until a defined `done:` gate under Definition of done.
   Use `paused: {why}` - distinct from `blocked:` - ONLY when you are deliberately idling on a
   known external wait you expect to clear on its own (an upstream release, a rate-limit reset,
   a scheduled window): firstmate then leaves your idle pane alone and rechecks it on a long
   cadence instead of treating it as a possible wedge. Use `blocked:` when you are stuck and need help.
5. If you hit the same obstacle twice, append `blocked: {why}` and stop; firstmate will help.
6. If a decision belongs above the implementation worker (product choices, destructive actions),
   append `needs-decision: {summary of options}` and stop. Firstmate will reply with the decision.

   A decision or blocker you opened stays open until a `resolved` line carrying its exact key lands; a later `done:` or `working:` line never closes it, even when the answer is what started that work.
   Firstmate's reply normally writes that closing line at answer time; when a blocker or wait clears WITHOUT a firstmate reply, append `resolved: {how it cleared}` yourself (same `[key=<slug>]` if you opened it with one) as you resume.
7. Never stop, restart, or update the shared `no-mistakes` daemon - it is one instance serving
   every lane/home, so restarting it kills other lanes' in-flight pipeline runs; only firstmate
   manages the daemon.
   Before you append `blocked:` about the pipeline, run `no-mistakes daemon status` and
   `no-mistakes axi status`. If the daemon socket refuses connections or is missing, append
   `blocked: {the daemon error}` and stop even when the local run record still says running or
   fixing, because that record can be stale after the daemon exits. A run record failed with a
   daemon error is also a real block.
   Only after ruling out socket refusal, if the run is still running or fixing, reattach and keep
   going. A drive-call error, timeout, slow read, or generic unreachability is NOT a daemon error:
   the daemon accepts `respond` immediately and runs the round in the background, so a killed or
   timed-out call was only waiting for a read while the run kept working.

# Firstmate instruction inbox
Firstmate steers you through durable message files in '~/.no-mistakes/evidence/01M234M889VM363ZY2Z64RJGWN/method-brief-e2e/state/evidence-local-only.inbox'.
When a terminal message says an instruction is waiting there - and at any natural checkpoint when you are unsure - list '~/.no-mistakes/evidence/01M234M889VM363ZY2Z64RJGWN/method-brief-e2e/state/evidence-local-only.inbox'/*.msg, read and act on each message in numeric order, then acknowledge each handled message by moving it: `mv '~/.no-mistakes/evidence/01M234M889VM363ZY2Z64RJGWN/method-brief-e2e/state/evidence-local-only.inbox'/NNN.msg '~/.no-mistakes/evidence/01M234M889VM363ZY2Z64RJGWN/method-brief-e2e/state/evidence-local-only.inbox'/handled/`.
The move IS the acknowledgement: without it firstmate rings again and eventually treats you as stuck. An empty or absent inbox needs no action.

# Project memory
If `AGENTS.md` or `CLAUDE.md` already exists, or if this task produced durable project-intrinsic knowledge, run `~/.no-mistakes/worktrees/d335fa506761/01M234M889VM363ZY2Z64RJGWN/bin/fm-ensure-agents-md.sh .` in the worktree.
Record only project knowledge useful to almost every future session.
For anything the codebase already shows, prefer a pointer to the authoritative file, command, or doc over copying the detail.
If you touch a project `AGENTS.md`, follow `~/.no-mistakes/worktrees/d335fa506761/01M234M889VM363ZY2Z64RJGWN/bin/fm-ensure-agents-md.sh`'s self-governance contract in the same pass.
Keep it proportionate: skip `AGENTS.md` edits for trivial tasks that produced no durable project knowledge.

# Definition of done
Delivery contract: mode=local-only
This task ships **local-only**: no remote, no PR, no pipeline.
The task is complete only when committed on your branch `fm/evidence-local-only`. Do NOT push, do NOT open a PR, do NOT merge.
Keep your branch a clean fast-forward onto the current default branch - if `main` has advanced, rebase onto it so the eventual merge stays a fast-forward.
When it is implemented and committed, append `done: ready in branch fm/evidence-local-only` to the status file and stop.
The configured merge authority approves the ready branch, then firstmate merges it into local `main` through the guarded fast-forward path.
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"87d62d7435a30bef79708c17fb76402b2f253afa","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>🔧 **Review** - 2 issues found → auto-fixed ✅</summary>

- 🚨 `bin/fm-brief.sh:467` - The intent requires “every coding worker gets three steps by default.” The new section is injected only into the ordinary ship scaffold at `bin/fm-brief.sh:467`; promoted scouts receive `bin/fm-promote.sh`’s separate `ship-instructions.md`, which does not include it. A scout → promotion → coding-worker sequence therefore receives no Method section. Decide whether promoted workers are included; if so, update the promotion delivery path to include the same contract.
- 🚨 `bin/fm-brief.sh:360` - The shared Method text says “only then start no-mistakes” at `bin/fm-brief.sh:360`, but it is emitted for every ship mode. Direct-PR briefs explicitly say “Do NOT run /no-mistakes,” and local-only briefs say “no pipeline” (`bin/fm-dod-lib.sh:203,210`), so workers receive contradictory instructions and may start a forbidden pipeline. Clarify whether this sentence is no-mistakes-only or whether the mode contracts are intentionally changing.

🔧 Fix: Shared mode-aware Method contract across ship paths
✅ Re-checked - no issues remain.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `bash tests/fm-brief.test.sh`
- `bash tests/fm-task-delivery.test.sh`
- `Generated and inspected SHIP briefs for no-mistakes, direct-PR, and local-only modes.`
- <code>Verified the worktree remained clean with `git status --short`.</code>
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>⚠️ **Lint** - 1 warning</summary>

- ⚠️ linter found issues (exit code 1)
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
