### PR TITLE
fix(backend): validate Orca's composite worktree id structurally

### DIFF
--- a/bin/fm-backend.sh
+++ b/bin/fm-backend.sh
@@ -382,6 +382,13 @@ fm_backend_meta_exact_value() {  # <meta-file> <key>
   printf '%s' "$value"
 }
 
+# Refusals name the value they rejected, but an endpoint value only ever reaches
+# a refusal because it is malformed, so it can carry control bytes an operator's
+# terminal would interpret. Render it printable before quoting it into stderr.
+fm_backend_printable() {  # <value>
+  printf '%s' "$1" | tr '[:cntrl:]' '?'
+}
+
 fm_backend_endpoint_atom_valid() {  # <value>
   case "$1" in
     ''|*[!A-Za-z0-9._@%+-]*) return 1 ;;
@@ -560,7 +567,7 @@ fm_backend_validate_task_endpoint() {  # <meta-file> <task-id>
         return 1
       fi
       if ! fm_backend_orca_worktree_id_valid "$worktree_id" "$worktree"; then
-        echo "REFUSED: Orca worktree id for task $id $FM_BACKEND_ORCA_ID_REASON; preserving task state." >&2
+        echo "REFUSED: Orca worktree id for task $id $FM_BACKEND_ORCA_ID_REASON; id '$(fm_backend_printable "$worktree_id")', recorded worktree '$(fm_backend_printable "$worktree")'; preserving task state." >&2
         return 1
       fi
       window=$terminal

--- a/bin/fm-backend.sh
+++ b/bin/fm-backend.sh
@@ -388,6 +388,54 @@ fm_backend_endpoint_atom_valid() {  # <value>
   esac
 }
 
+# Orca worktree ids are natively composite, unlike every other backend's opaque
+# endpoint atoms: docs/orca-backend.md "Task shape and metadata" owns that format.
+# Validating its structure here keeps fm_backend_endpoint_atom_valid's character
+# class intact for the tmux, Herdr, Zellij, and cmux atoms that share it, and adds
+# a cross-record check the character class could never express: the id's own path
+# half must be the task's recorded worktree, so a record whose id names another
+# directory refuses instead of releasing the wrong worktree. Every failure mode is
+# a refusal; sets FM_BACKEND_ORCA_ID_REASON to the concrete reason on return 1.
+fm_backend_orca_worktree_id_valid() {  # <orca-worktree-id> <recorded-worktree>
+  local value=$1 recorded=$2 repo path
+  FM_BACKEND_ORCA_ID_REASON=
+  case "$value" in
+    *'::'*) ;;
+    *)
+      FM_BACKEND_ORCA_ID_REASON='is not <repo id>::<absolute worktree path>'
+      return 1
+      ;;
+  esac
+  repo=${value%%::*}
+  path=${value#*::}
+  if [ -z "$repo" ] || [ -z "$path" ]; then
+    FM_BACKEND_ORCA_ID_REASON='has an empty repository id or worktree path half'
+    return 1
+  fi
+  if ! fm_backend_endpoint_atom_valid "$repo"; then
+    FM_BACKEND_ORCA_ID_REASON='has a repository id half with unsupported characters'
+    return 1
+  fi
+  case "$path" in
+    /*) ;;
+    *)
+      FM_BACKEND_ORCA_ID_REASON='has a worktree path half that is not absolute'
+      return 1
+      ;;
+  esac
+  case "$path" in
+    *[[:cntrl:]]*)
+      FM_BACKEND_ORCA_ID_REASON='has a worktree path half containing a control character'
+      return 1
+      ;;
+  esac
+  if [ "$path" != "$recorded" ]; then
+    FM_BACKEND_ORCA_ID_REASON='names a worktree path that is not the recorded worktree'
+    return 1
+  fi
+  return 0
+}
+
 fm_backend_validate_task_endpoint() {  # <meta-file> <task-id>
   local meta=$1 id=$2 backend_count backend window worktree project binding_count binding
   local session pane recorded_session workspace tab terminal worktree_id surface
@@ -507,9 +555,12 @@ fm_backend_validate_task_endpoint() {  # <meta-file> <task-id>
         return 1
       }
       if [ "$window" != "fm-$id" ] \
-        || ! fm_backend_endpoint_atom_valid "$terminal" \
-        || ! fm_backend_endpoint_atom_valid "$worktree_id"; then
+        || ! fm_backend_endpoint_atom_valid "$terminal"; then
         echo "REFUSED: Orca endpoint metadata for task $id is malformed or inconsistent; preserving task state." >&2
+        return 1
+      fi
+      if ! fm_backend_orca_worktree_id_valid "$worktree_id" "$worktree"; then
+        echo "REFUSED: Orca worktree id for task $id $FM_BACKEND_ORCA_ID_REASON; preserving task state." >&2
         return 1
       fi
       window=$terminal

--- a/docs/orca-backend.md
+++ b/docs/orca-backend.md
@@ -36,12 +36,18 @@ The normal isolation and unlanded-work refusal rules still apply.
 backend=orca
 window=fm-<id>
 terminal=<orca terminal handle>
-orca_worktree_id=<orca worktree id>
+orca_worktree_id=<repo id>::<absolute Orca worktree path>
 worktree=<absolute Orca worktree path>
 ```
 
 `window=` remains the caller-facing Firstmate alias.
 `terminal=` and `orca_worktree_id=` are the backend authority used by operation and cleanup paths.
+
+Unlike every other backend's opaque endpoint atom, an Orca worktree id is composite: the repository id, then a literal `::`, then the worktree's absolute path.
+Both halves come from the same `orca worktree create --json` response that supplies `worktree=`, so the id's path half is the recorded worktree path.
+Cleanup validation splits the value on its first `::` and refuses the record unless both halves are non-empty, the repository id half is a plain endpoint atom, and the path half is absolute, free of control characters, and exactly the task's own recorded `worktree=`.
+That last check is a cross-record consistency check rather than a character rule: a record whose id names a different directory than the task's own worktree refuses instead of releasing the wrong worktree.
+A value that cannot be parsed or does not agree with the record preserves task state and names the concrete reason.
 
 ## Current lifecycle and safety
 
@@ -59,7 +65,7 @@ Grok alone retains its isolated rendered-tail fallback.
 Cleanup keeps all shared Firstmate safety checks.
 A scout still requires its report and completed decision inventory.
 A ship still refuses dirty or unlanded work.
-Before release, cleanup resolves the recorded Orca worktree id and verifies its path matches the recorded worktree path.
+Beyond the record-level identity check above, cleanup also asks Orca to resolve the recorded worktree id and verifies the path Orca reports matches the recorded worktree path.
 A missing, unreadable, or mismatched identity preserves metadata and stops rather than deleting anything.
 After those checks, Firstmate closes the exact terminal and releases the exact worktree with Orca's worktree command.
 It never raw-deletes an Orca worktree.

--- a/docs/orca-backend.md
+++ b/docs/orca-backend.md
@@ -84,8 +84,11 @@ It never raw-deletes an Orca worktree.
 
 ```sh
 tests/fm-backend-orca.test.sh
+tests/fm-teardown-endpoint-safety.test.sh
 tests/fm-backend.test.sh
 tests/fm-bootstrap.test.sh
 ```
+
+`tests/fm-teardown-endpoint-safety.test.sh` pins the composite worktree id rule above: the real `<repo id>::<absolute path>` shape validates, every structural defect refuses with its concrete reason, and the shared endpoint-atom rule the other backends use stays unwidened.
 
 [`verification/runtime-backends.md`](verification/runtime-backends.md#orca) records the real readiness and response-shape smoke.

--- a/docs/orca-backend.md
+++ b/docs/orca-backend.md
@@ -91,4 +91,4 @@ tests/fm-bootstrap.test.sh
 
 `tests/fm-teardown-endpoint-safety.test.sh` pins the composite worktree id rule above: the real `<repo id>::<absolute path>` shape validates, every structural defect refuses with its concrete reason, and the shared endpoint-atom rule the other backends use stays unwidened.
 
-[`verification/runtime-backends.md`](verification/runtime-backends.md#orca) records the real readiness and response-shape smoke.
+[`verification/runtime-backends.md`](verification/runtime-backends.md#orca) records the real readiness smoke and the dated response-shape observations.

--- a/docs/verification/runtime-backends.md
+++ b/docs/verification/runtime-backends.md
@@ -1030,6 +1030,37 @@ tests/fm-bootstrap.test.sh
 
 The fake-Orca suite covers readiness, registration, create response parsing, metadata routing, popup-safe submit, and path-matched release refusal.
 
+### Composite worktree id shape
+
+Response shapes were observed on 2026-09-08 against `/opt/homebrew/bin/orca` with a running Orca app reporting `result.runtime.appVersion` 1.4.194.
+This entry is a response-shape observation firstmate made against the live app, not a full lifecycle smoke, and it does not supersede the 1.4.116 readiness evidence above.
+
+```sh
+orca status --json
+orca worktree list --json
+```
+
+Observed fields:
+
+```text
+result.runtime.appVersion=1.4.194
+result.runtime.reachable=true
+result.runtime.state=ready
+```
+
+Every worktree id Orca listed was composite, `<repo id>::<absolute worktree path>`, including the worktree a real `bin/fm-spawn.sh` run had created through `orca worktree create`.
+The observed ids carried a real repository UUID and a real absolute path; both are redacted here because the observation was made against a private project checkout:
+
+```text
+<repo uuid>::/Users/<user>/orca/workspaces/<project>/fm-<task id>
+```
+
+That task's recorded `orca_worktree_id=` was byte-identical to the listed id, and its path half equalled its recorded `worktree=`.
+[`orca-backend.md`](../orca-backend.md) owns the format and the cleanup rule that requires exactly that agreement.
+The portable regression pinning the rule is `tests/fm-teardown-endpoint-safety.test.sh`.
+
+Releasing a live Orca worktree was not exercised here, so the real teardown leg stays unverified until structural validation of the composite id ships.
+
 ## cmux
 
 The current compatibility floor is cmux 0.64, and the active live evidence uses 0.64.17 build 97 on macOS aarch64.

--- a/tests/fm-backend-orca.test.sh
+++ b/tests/fm-backend-orca.test.sh
@@ -27,6 +27,15 @@ Verify the Orca lifecycle behavior under test.
 EOF
 }
 
+# Orca worktree ids are natively COMPOSITE - <repo id>::<absolute worktree path>
+# (docs/orca-backend.md "Task shape and metadata"). Every fixture below builds an
+# id with this helper so the suite exercises the shape Orca actually returns
+# rather than a simple atom no real Orca record ever carries.
+ORCA_FIXTURE_REPO_ID=4ed83d32-9f01-49a2-808a-966c2035339e
+orca_composite_id() {  # <absolute-worktree-path>
+  printf '%s::%s' "$ORCA_FIXTURE_REPO_ID" "$1"
+}
+
 make_orca_fakebin() {  # <dir> -> echoes fakebin dir
   local fb="$1/fakebin"
   mkdir -p "$fb"
@@ -390,11 +399,11 @@ test_remove_worktree_rejects_orca_error_json() {
 test_worktree_path_resolves_id() {
   local out
   orca_case path-resolve
-  printf '{"ok":true,"result":{"worktree":{"id":"wt-123","path":"/tmp/orca-wt"}}}\n' > "$RESP/1.out"
+  printf '{"ok":true,"result":{"worktree":{"id":"%s","path":"/tmp/orca-wt"}}}\n' "$(orca_composite_id /tmp/orca-wt)" > "$RESP/1.out"
   out=$( PATH="$FB:$PATH" FM_ORCA_LOG="$LOG" FM_ORCA_RESPONSES="$RESP" \
-    bash -c '. "$0/bin/backends/orca.sh"; fm_backend_orca_worktree_path wt-123' "$ROOT" )
+    bash -c '. "$1/bin/backends/orca.sh"; fm_backend_orca_worktree_path "$2"' _ "$ROOT" "$(orca_composite_id /tmp/orca-wt)" )
   [ "$out" = /tmp/orca-wt ] || fail "worktree path helper should print the resolved path, got '$out'"
-  assert_contains "$(cat "$LOG")" $'orca\x1f''worktree'$'\x1f''show'$'\x1f''--worktree'$'\x1f''id:wt-123'$'\x1f''--json' \
+  assert_contains "$(cat "$LOG")" $'orca\x1f''worktree'$'\x1f''show'$'\x1f''--worktree'$'\x1f'"id:$(orca_composite_id /tmp/orca-wt)"$'\x1f''--json' \
     "worktree path helper did not call orca worktree show"
   pass "fm_backend_orca_worktree_path: resolves an Orca worktree id to its path"
 }
@@ -412,14 +421,14 @@ test_json_get_ignores_undocumented_terminal_id_shapes() {
 
   printf '1\n' > "$RESP/1.exit"
   printf '{"ok":true,"result":{"repo":{"id":"repo-123"}}}\n' > "$RESP/2.out"
-  printf '{"ok":true,"result":{"worktree":{"id":"wt-123","path":"/tmp/orca-wt","terminal":{"handle":"term-nested"}}}}\n' > "$RESP/3.out"
+  printf '{"ok":true,"result":{"worktree":{"id":"%s","path":"/tmp/orca-wt","terminal":{"handle":"term-nested"}}}}\n' "$(orca_composite_id /tmp/orca-wt)" > "$RESP/3.out"
   out=$( PATH="$FB:$PATH" FM_ORCA_LOG="$LOG" FM_ORCA_RESPONSES="$RESP" \
     bash -c '. "$0/bin/backends/orca.sh"; fm_backend_orca_worktree_create /repo/path fm-task' "$ROOT" )
   wt_id=${out%%$'\t'*}
   wt_path=${out#*$'\t'}
   term=${wt_path#*$'\t'}
   wt_path=${wt_path%%$'\t'*}
-  [ "$wt_id" = wt-123 ] || fail "worktree helper should still print worktree id, got '$wt_id'"
+  [ "$wt_id" = "$(orca_composite_id /tmp/orca-wt)" ] || fail "worktree helper should still print worktree id, got '$wt_id'"
   [ "$wt_path" = /tmp/orca-wt ] || fail "worktree helper should still print worktree path, got '$wt_path'"
   [ "$term" = "$wt_path" ] || fail "worktree helper should ignore undocumented result.worktree.terminal and omit an implicit terminal, got '$out'"
   pass "fm_backend_orca_json_get: ignores undocumented terminal id shapes"
@@ -430,16 +439,16 @@ test_worktree_and_terminal_helpers_parse_json() {
   orca_case lifecycle-helpers
   printf '1\n' > "$RESP/1.exit"
   printf '{"ok":true,"result":{"repo":{"id":"repo-123"}}}\n' > "$RESP/2.out"
-  printf '{"ok":true,"result":{"worktree":{"id":"wt-123","path":"/tmp/orca-wt"}}}\n' > "$RESP/3.out"
+  printf '{"ok":true,"result":{"worktree":{"id":"%s","path":"/tmp/orca-wt"}}}\n' "$(orca_composite_id /tmp/orca-wt)" > "$RESP/3.out"
   printf '{"ok":true,"result":{"terminal":{"handle":"term-123"}}}\n' > "$RESP/4.out"
   out=$( PATH="$FB:$PATH" FM_ORCA_LOG="$LOG" FM_ORCA_RESPONSES="$RESP" \
     bash -c '. "$0/bin/backends/orca.sh"; fm_backend_orca_worktree_create /repo/path fm-task' "$ROOT" )
   wt_id=${out%%$'\t'*}
   wt_path=${out#*$'\t'}
-  [ "$wt_id" = wt-123 ] || fail "worktree helper should print worktree id, got '$wt_id'"
+  [ "$wt_id" = "$(orca_composite_id /tmp/orca-wt)" ] || fail "worktree helper should print worktree id, got '$wt_id'"
   [ "$wt_path" = /tmp/orca-wt ] || fail "worktree helper should print worktree path, got '$wt_path'"
   term=$( PATH="$FB:$PATH" FM_ORCA_LOG="$LOG" FM_ORCA_RESPONSES="$RESP" \
-    bash -c '. "$0/bin/backends/orca.sh"; fm_backend_orca_terminal_create wt-123 fm-task' "$ROOT" )
+    bash -c '. "$1/bin/backends/orca.sh"; fm_backend_orca_terminal_create "$2" fm-task' _ "$ROOT" "$(orca_composite_id /tmp/orca-wt)" )
   [ "$term" = term-123 ] || fail "terminal helper should print terminal handle, got '$term'"
   assert_contains "$(cat "$LOG")" $'orca\x1f''repo'$'\x1f''show'$'\x1f''--repo'$'\x1f''path:/repo/path'$'\x1f''--json' \
     "worktree helper should first check repo registration"
@@ -447,7 +456,7 @@ test_worktree_and_terminal_helpers_parse_json() {
     "worktree helper should register an absent repo"
   assert_contains "$(cat "$LOG")" $'orca\x1f''worktree'$'\x1f''create'$'\x1f''--repo'$'\x1f''id:repo-123'$'\x1f''--name'$'\x1f''fm-task'$'\x1f''--no-parent'$'\x1f''--setup'$'\x1f''skip'$'\x1f''--json' \
     "worktree helper did not create an independent no-hook worktree"
-  assert_contains "$(cat "$LOG")" $'orca\x1f''terminal'$'\x1f''create'$'\x1f''--worktree'$'\x1f''id:wt-123'$'\x1f''--title'$'\x1f''fm-task'$'\x1f''--json' \
+  assert_contains "$(cat "$LOG")" $'orca\x1f''terminal'$'\x1f''create'$'\x1f''--worktree'$'\x1f'"id:$(orca_composite_id /tmp/orca-wt)"$'\x1f''--title'$'\x1f''fm-task'$'\x1f''--json' \
     "terminal helper did not create a titled terminal for the worktree"
   pass "Orca lifecycle helpers: register repo, create worktree, create terminal, parse stable ids"
 }
@@ -457,7 +466,7 @@ test_worktree_create_removes_worktree_when_path_missing() {
   orca_case lifecycle-missing-path
   printf '1\n' > "$RESP/1.exit"
   printf '{"ok":true,"result":{"repo":{"id":"repo-no-path"}}}\n' > "$RESP/2.out"
-  printf '{"ok":true,"result":{"worktree":{"id":"wt-no-path"},"terminal":{"handle":"term-no-path"}}}\n' > "$RESP/3.out"
+  printf '{"ok":true,"result":{"worktree":{"id":"%s"},"terminal":{"handle":"term-no-path"}}}\n' "$(orca_composite_id /tmp/orca-no-path)" > "$RESP/3.out"
   out=$( PATH="$FB:$PATH" FM_ORCA_LOG="$LOG" FM_ORCA_RESPONSES="$RESP" \
     bash -c '. "$0/bin/backends/orca.sh"; fm_backend_orca_worktree_create /repo/path fm-task' "$ROOT" 2>&1 )
   status=$?
@@ -466,7 +475,7 @@ test_worktree_create_removes_worktree_when_path_missing() {
     "worktree helper did not explain the missing path"
   assert_contains "$(cat "$LOG")" $'orca\x1f''terminal'$'\x1f''close'$'\x1f''--terminal'$'\x1f''term-no-path'$'\x1f''--json' \
     "worktree helper did not close the implicit terminal when path parsing failed"
-  assert_contains "$(cat "$LOG")" $'orca\x1f''worktree'$'\x1f''rm'$'\x1f''--worktree'$'\x1f''id:wt-no-path'$'\x1f''--force'$'\x1f''--json' \
+  assert_contains "$(cat "$LOG")" $'orca\x1f''worktree'$'\x1f''rm'$'\x1f''--worktree'$'\x1f'"id:$(orca_composite_id /tmp/orca-no-path)"$'\x1f''--force'$'\x1f''--json' \
     "worktree helper did not remove the pathless Orca worktree"
   pass "fm_backend_orca_worktree_create: removes created worktree when path is missing"
 }
@@ -485,7 +494,7 @@ test_spawn_preserves_orca_metadata_when_pathless_worktree_cleanup_fails() {
   orca_case pathless-cleanup-fail
   printf '1\n' > "$RESP/1.exit"
   printf '{"ok":true,"result":{"repo":{"id":"repo-pathless-cleanup"}}}\n' > "$RESP/2.out"
-  printf '{"ok":true,"result":{"worktree":{"id":"wt-pathless-cleanup"}}}\n' > "$RESP/3.out"
+  printf '{"ok":true,"result":{"worktree":{"id":"%s"}}}\n' "$(orca_composite_id /tmp/orca-pathless-cleanup)" > "$RESP/3.out"
   printf '{"ok":false,"error":{"code":"worktree_not_removed","message":"worktree not removed"}}\n' > "$RESP/4.out"
   printf '{"ok":false,"error":{"code":"worktree_not_removed","message":"worktree not removed"}}\n' > "$RESP/5.out"
   out=$( HOME="$SPAWN_HOME" CLAUDE_CONFIG_DIR='' PATH="$FB:$PATH" FM_ORCA_LOG="$LOG" FM_ORCA_RESPONSES="$RESP" \
@@ -496,12 +505,12 @@ test_spawn_preserves_orca_metadata_when_pathless_worktree_cleanup_fails() {
   [ "$status" -ne 0 ] || fail "Orca spawn should fail when path parsing and cleanup fail"
   assert_contains "$out" "orca worktree create did not return a path" \
     "pathless worktree failure should explain the missing path"
-  assert_contains "$(cat "$LOG")" $'orca\x1f''worktree'$'\x1f''rm'$'\x1f''--worktree'$'\x1f''id:wt-pathless-cleanup'$'\x1f''--force'$'\x1f''--json' \
+  assert_contains "$(cat "$LOG")" $'orca\x1f''worktree'$'\x1f''rm'$'\x1f''--worktree'$'\x1f'"id:$(orca_composite_id /tmp/orca-pathless-cleanup)"$'\x1f''--force'$'\x1f''--json' \
     "pathless cleanup should attempt helper-backed worktree removal"
   assert_present "$state/$id.meta" "failed pathless cleanup should preserve metadata"
   assert_grep "window=fm-$id" "$state/$id.meta" "preserved pathless metadata missing stable window alias"
   assert_grep "backend=orca" "$state/$id.meta" "preserved pathless metadata missing backend=orca"
-  assert_grep "orca_worktree_id=wt-pathless-cleanup" "$state/$id.meta" "preserved pathless metadata missing Orca worktree id"
+  assert_grep "orca_worktree_id=$(orca_composite_id /tmp/orca-pathless-cleanup)" "$state/$id.meta" "preserved pathless metadata missing Orca worktree id"
   assert_no_grep "terminal=" "$state/$id.meta" "preserved pathless metadata should not invent a terminal handle"
   pass "fm-spawn.sh --backend orca: preserves metadata when pathless cleanup fails"
 }
@@ -522,7 +531,7 @@ test_spawn_writes_orca_metadata_and_launches_harness() {
   log="$LOG"
   printf '1\n' > "$RESP/1.exit"
   printf '{"ok":true,"result":{"repo":{"id":"repo-spawn"}}}\n' > "$RESP/2.out"
-  printf '{"ok":true,"result":{"worktree":{"id":"wt-spawn","path":"%s"},"terminal":{"handle":"term-spawn"}}}\n' "$wt" > "$RESP/3.out"
+  printf '{"ok":true,"result":{"worktree":{"id":"%s","path":"%s"},"terminal":{"handle":"term-spawn"}}}\n' "$(orca_composite_id "$wt")" "$wt" > "$RESP/3.out"
   out=$( HOME="$SPAWN_HOME" CLAUDE_CONFIG_DIR='' PATH="$FB:$PATH" FM_ORCA_LOG="$LOG" FM_ORCA_RESPONSES="$RESP" \
     FM_ROOT_OVERRIDE="$ROOT" FM_STATE_OVERRIDE="$state" FM_DATA_OVERRIDE="$data" FM_CONFIG_OVERRIDE="$config" \
     FM_PROJECTS_OVERRIDE="$TMP_ROOT/unused-projects" FM_SPAWN_NO_GUARD=1 \
@@ -533,7 +542,7 @@ test_spawn_writes_orca_metadata_and_launches_harness() {
   assert_grep "backend=orca" "$state/$id.meta" "meta missing backend=orca"
   assert_grep "window=fm-$id" "$state/$id.meta" "meta missing stable Orca window alias"
   assert_grep "terminal=term-spawn" "$state/$id.meta" "meta missing terminal handle"
-  assert_grep "orca_worktree_id=wt-spawn" "$state/$id.meta" "meta missing Orca worktree id"
+  assert_grep "orca_worktree_id=$(orca_composite_id "$wt")" "$state/$id.meta" "meta missing Orca worktree id"
   assert_grep "worktree=$wt" "$state/$id.meta" "meta missing Orca worktree path"
   assert_not_contains "$(cat "$log")" $'orca\x1f''terminal'$'\x1f''create' \
     "spawn should reuse the implicit terminal returned by Orca worktree creation"
@@ -615,7 +624,7 @@ test_spawn_refuses_orca_nonisolated_worktree() {
   orca_case bad-spawn
   printf '1\n' > "$RESP/1.exit"
   printf '{"ok":true,"result":{"repo":{"id":"repo-bad"}}}\n' > "$RESP/2.out"
-  printf '{"ok":true,"result":{"worktree":{"id":"wt-bad","path":"%s"},"terminal":{"handle":"term-bad"}}}\n' "$proj" > "$RESP/3.out"
+  printf '{"ok":true,"result":{"worktree":{"id":"%s","path":"%s"},"terminal":{"handle":"term-bad"}}}\n' "$(orca_composite_id "$proj")" "$proj" > "$RESP/3.out"
   out=$( HOME="$SPAWN_HOME" CLAUDE_CONFIG_DIR='' PATH="$FB:$PATH" FM_ORCA_LOG="$LOG" FM_ORCA_RESPONSES="$RESP" \
     FM_ROOT_OVERRIDE="$ROOT" FM_STATE_OVERRIDE="$state" FM_DATA_OVERRIDE="$data" FM_CONFIG_OVERRIDE="$config" \
     FM_PROJECTS_OVERRIDE="$TMP_ROOT/unused-projects" FM_SPAWN_NO_GUARD=1 \
@@ -629,7 +638,7 @@ test_spawn_refuses_orca_nonisolated_worktree() {
     "Orca spawn should validate the worktree before creating a terminal"
   assert_contains "$(cat "$LOG")" $'orca\x1f''terminal'$'\x1f''close'$'\x1f''--terminal'$'\x1f''term-bad'$'\x1f''--json' \
     "Orca spawn should close the implicit terminal after validation aborts"
-  assert_contains "$(cat "$LOG")" $'orca\x1f''worktree'$'\x1f''rm'$'\x1f''--worktree'$'\x1f''id:wt-bad'$'\x1f''--force'$'\x1f''--json' \
+  assert_contains "$(cat "$LOG")" $'orca\x1f''worktree'$'\x1f''rm'$'\x1f''--worktree'$'\x1f'"id:$(orca_composite_id "$proj")"$'\x1f''--force'$'\x1f''--json' \
     "Orca spawn should remove the worktree after validation aborts"
   pass "fm-spawn.sh --backend orca: refuses non-isolated worktrees and closes implicit terminals"
 }
@@ -649,7 +658,7 @@ test_spawn_removes_orca_worktree_when_terminal_create_fails() {
   orca_case terminal-fail
   printf '1\n' > "$RESP/1.exit"
   printf '{"ok":true,"result":{"repo":{"id":"repo-terminal-fail"}}}\n' > "$RESP/2.out"
-  printf '{"ok":true,"result":{"worktree":{"id":"wt-terminal-fail","path":"%s"}}}\n' "$wt" > "$RESP/3.out"
+  printf '{"ok":true,"result":{"worktree":{"id":"%s","path":"%s"}}}\n' "$(orca_composite_id "$wt")" "$wt" > "$RESP/3.out"
   printf '1\n' > "$RESP/4.exit"
   out=$( HOME="$SPAWN_HOME" CLAUDE_CONFIG_DIR='' PATH="$FB:$PATH" FM_ORCA_LOG="$LOG" FM_ORCA_RESPONSES="$RESP" \
     FM_ROOT_OVERRIDE="$ROOT" FM_STATE_OVERRIDE="$state" FM_DATA_OVERRIDE="$data" FM_CONFIG_OVERRIDE="$config" \
@@ -658,9 +667,9 @@ test_spawn_removes_orca_worktree_when_terminal_create_fails() {
   status=$?
   [ "$status" -ne 0 ] || fail "Orca spawn should fail when terminal creation fails"
   assert_absent "$state/$id.meta" "terminal-create abort should not record metadata after successful cleanup"
-  assert_contains "$(cat "$LOG")" $'orca\x1f''terminal'$'\x1f''create'$'\x1f''--worktree'$'\x1f''id:wt-terminal-fail'$'\x1f''--title'$'\x1f'"fm-$id"$'\x1f''--json' \
+  assert_contains "$(cat "$LOG")" $'orca\x1f''terminal'$'\x1f''create'$'\x1f''--worktree'$'\x1f'"id:$(orca_composite_id "$wt")"$'\x1f''--title'$'\x1f'"fm-$id"$'\x1f''--json' \
     "Orca spawn should attempt terminal creation before abort cleanup"
-  assert_contains "$(cat "$LOG")" $'orca\x1f''worktree'$'\x1f''rm'$'\x1f''--worktree'$'\x1f''id:wt-terminal-fail'$'\x1f''--force'$'\x1f''--json' \
+  assert_contains "$(cat "$LOG")" $'orca\x1f''worktree'$'\x1f''rm'$'\x1f''--worktree'$'\x1f'"id:$(orca_composite_id "$wt")"$'\x1f''--force'$'\x1f''--json' \
     "Orca spawn should remove the worktree when terminal creation fails"
   assert_not_contains "$(cat "$LOG")" $'orca\x1f''terminal'$'\x1f''close' \
     "Orca spawn should not close a terminal when no handle was recorded"
@@ -682,7 +691,7 @@ test_spawn_preserves_orca_metadata_when_abort_cleanup_fails() {
   orca_case cleanup-fail
   printf '1\n' > "$RESP/1.exit"
   printf '{"ok":true,"result":{"repo":{"id":"repo-cleanup-fail"}}}\n' > "$RESP/2.out"
-  printf '{"ok":true,"result":{"worktree":{"id":"wt-cleanup-fail","path":"%s"}}}\n' "$wt" > "$RESP/3.out"
+  printf '{"ok":true,"result":{"worktree":{"id":"%s","path":"%s"}}}\n' "$(orca_composite_id "$wt")" "$wt" > "$RESP/3.out"
   printf '1\n' > "$RESP/4.exit"
   printf '1\n' > "$RESP/5.exit"
   out=$( HOME="$SPAWN_HOME" CLAUDE_CONFIG_DIR='' PATH="$FB:$PATH" FM_ORCA_LOG="$LOG" FM_ORCA_RESPONSES="$RESP" \
@@ -691,12 +700,12 @@ test_spawn_preserves_orca_metadata_when_abort_cleanup_fails() {
     "$ROOT/bin/fm-spawn.sh" "$id" "$proj" claude --mode no-mistakes --yolo off --backend orca 2>&1 )
   status=$?
   [ "$status" -ne 0 ] || fail "Orca spawn should fail when terminal creation and abort cleanup fail"
-  assert_contains "$(cat "$LOG")" $'orca\x1f''worktree'$'\x1f''rm'$'\x1f''--worktree'$'\x1f''id:wt-cleanup-fail'$'\x1f''--force'$'\x1f''--json' \
+  assert_contains "$(cat "$LOG")" $'orca\x1f''worktree'$'\x1f''rm'$'\x1f''--worktree'$'\x1f'"id:$(orca_composite_id "$wt")"$'\x1f''--force'$'\x1f''--json' \
     "Orca spawn should attempt helper cleanup before preserving metadata"
   assert_present "$state/$id.meta" "failed Orca abort cleanup should preserve metadata"
   assert_grep "window=fm-$id" "$state/$id.meta" "preserved metadata missing stable window alias"
   assert_grep "backend=orca" "$state/$id.meta" "preserved metadata missing backend=orca"
-  assert_grep "orca_worktree_id=wt-cleanup-fail" "$state/$id.meta" "preserved metadata missing Orca worktree id"
+  assert_grep "orca_worktree_id=$(orca_composite_id "$wt")" "$state/$id.meta" "preserved metadata missing Orca worktree id"
   assert_no_grep "terminal=" "$state/$id.meta" "preserved metadata should not invent a terminal handle"
   pass "fm-spawn.sh --backend orca: preserves metadata when abort cleanup fails"
 }
@@ -715,7 +724,7 @@ test_spawn_releases_orca_resources_when_metadata_write_fails() {
   orca_case meta-fail
   printf '1\n' > "$RESP/1.exit"
   printf '{"ok":true,"result":{"repo":{"id":"repo-meta-fail"}}}\n' > "$RESP/2.out"
-  printf '{"ok":true,"result":{"worktree":{"id":"wt-meta-fail","path":"%s"}}}\n' "$wt" > "$RESP/3.out"
+  printf '{"ok":true,"result":{"worktree":{"id":"%s","path":"%s"}}}\n' "$(orca_composite_id "$wt")" "$wt" > "$RESP/3.out"
   printf '{"ok":true,"result":{"terminal":{"handle":"term-meta-fail"}}}\n' > "$RESP/4.out"
   out=$( HOME="$SPAWN_HOME" CLAUDE_CONFIG_DIR='' PATH="$FB:$PATH" FM_ORCA_LOG="$LOG" FM_ORCA_RESPONSES="$RESP" \
     FM_ROOT_OVERRIDE="$ROOT" FM_STATE_OVERRIDE="$state" FM_DATA_OVERRIDE="$data" FM_CONFIG_OVERRIDE="$config" \
@@ -727,7 +736,7 @@ test_spawn_releases_orca_resources_when_metadata_write_fails() {
     "spawn should report metadata publication failure without relying on platform-specific mv output"
   assert_contains "$(cat "$LOG")" $'orca\x1f''terminal'$'\x1f''close'$'\x1f''--terminal'$'\x1f''term-meta-fail'$'\x1f''--json' \
     "Orca spawn should close the recorded terminal when a later abort occurs"
-  assert_contains "$(cat "$LOG")" $'orca\x1f''worktree'$'\x1f''rm'$'\x1f''--worktree'$'\x1f''id:wt-meta-fail'$'\x1f''--force'$'\x1f''--json' \
+  assert_contains "$(cat "$LOG")" $'orca\x1f''worktree'$'\x1f''rm'$'\x1f''--worktree'$'\x1f'"id:$(orca_composite_id "$wt")"$'\x1f''--force'$'\x1f''--json' \
     "Orca spawn should remove the recorded worktree when a later abort occurs"
   [ ! -f "$state/$id.meta" ] || fail "metadata-write abort should not publish a regular metadata file"
   pass "fm-spawn.sh --backend orca: releases terminal and worktree on later aborts"
@@ -831,10 +840,10 @@ test_scout_teardown_removes_orca_worktree_via_helper() {
   fm_write_meta "$state/$id.meta" \
     "window=fm-$id" "endpoint_task_id=$id" "terminal=term-teardown" "worktree=$wt" "project=$proj" \
     "harness=claude" "kind=scout" "mode=no-mistakes" "yolo=off" \
-    "backend=orca" "orca_worktree_id=wt-teardown" \
+    "backend=orca" "orca_worktree_id=$(orca_composite_id "$wt")" \
     "decisions_reviewed=1" "decision_keys="
   orca_case teardown
-  printf '{"ok":true,"result":{"worktree":{"id":"wt-teardown","path":"%s"}}}\n' "$wt" > "$RESP/1.out"
+  printf '{"ok":true,"result":{"worktree":{"id":"%s","path":"%s"}}}\n' "$(orca_composite_id "$wt")" "$wt" > "$RESP/1.out"
   neutral=$(neutral_fm_root "$CASE_DIR/neutral")
   set +e
   out=$( PATH="$FB:$PATH" FM_ORCA_LOG="$LOG" FM_ORCA_RESPONSES="$RESP" \
@@ -845,7 +854,7 @@ test_scout_teardown_removes_orca_worktree_via_helper() {
   expect_code 0 "$rc" "Orca scout teardown should succeed once report exists"$'\n'"$out"
   assert_contains "$(cat "$LOG")" $'orca\x1f''terminal'$'\x1f''close'$'\x1f''--terminal'$'\x1f''term-teardown'$'\x1f''--json' \
     "teardown did not close the recorded Orca terminal"
-  assert_contains "$(cat "$LOG")" $'orca\x1f''worktree'$'\x1f''rm'$'\x1f''--worktree'$'\x1f''id:wt-teardown'$'\x1f''--force'$'\x1f''--json' \
+  assert_contains "$(cat "$LOG")" $'orca\x1f''worktree'$'\x1f''rm'$'\x1f''--worktree'$'\x1f'"id:$(orca_composite_id "$wt")"$'\x1f''--force'$'\x1f''--json' \
     "teardown did not remove the Orca worktree through orca worktree rm"
   assert_absent "$state/$id.meta" "teardown should remove task metadata"
   pass "fm-teardown.sh backend=orca: scout report gate then helper-backed worktree removal"
@@ -868,10 +877,10 @@ test_scout_teardown_refuses_orca_id_path_mismatch() {
   fm_write_meta "$state/$id.meta" \
     "window=fm-$id" "endpoint_task_id=$id" "terminal=term-scout-mismatch" "worktree=$wt" "project=$proj" \
     "harness=claude" "kind=scout" "mode=no-mistakes" "yolo=off" \
-    "backend=orca" "orca_worktree_id=wt-scout-mismatch" \
+    "backend=orca" "orca_worktree_id=$(orca_composite_id "$wt")" \
     "decisions_reviewed=1" "decision_keys="
   orca_case scout-mismatch
-  printf '{"ok":true,"result":{"worktree":{"id":"wt-scout-mismatch","path":"%s"}}}\n' "$other_wt" > "$RESP/1.out"
+  printf '{"ok":true,"result":{"worktree":{"id":"%s","path":"%s"}}}\n' "$(orca_composite_id "$wt")" "$other_wt" > "$RESP/1.out"
   neutral=$(neutral_fm_root "$CASE_DIR/neutral")
   set +e
   out=$( PATH="$FB:$PATH" FM_ORCA_LOG="$LOG" FM_ORCA_RESPONSES="$RESP" \
@@ -904,7 +913,7 @@ test_teardown_removes_orca_worktree_when_path_missing() {
   fm_write_meta "$state/$id.meta" \
     "window=fm-$id" "endpoint_task_id=$id" "terminal=term-missing-path" "worktree=$wt" "project=$proj" \
     "harness=claude" "kind=scout" "mode=no-mistakes" "yolo=off" \
-    "backend=orca" "orca_worktree_id=wt-missing-path" \
+    "backend=orca" "orca_worktree_id=$(orca_composite_id "$wt")" \
     "decisions_reviewed=1" "decision_keys="
   orca_case missing-path
   neutral=$(neutral_fm_root "$CASE_DIR/neutral")
@@ -917,7 +926,7 @@ test_teardown_removes_orca_worktree_when_path_missing() {
   expect_code 0 "$rc" "Orca teardown should release helpers even when the path is absent"$'\n'"$out"
   assert_contains "$(cat "$LOG")" $'orca\x1f''terminal'$'\x1f''close'$'\x1f''--terminal'$'\x1f''term-missing-path'$'\x1f''--json' \
     "teardown did not close the recorded Orca terminal when the path was absent"
-  assert_contains "$(cat "$LOG")" $'orca\x1f''worktree'$'\x1f''rm'$'\x1f''--worktree'$'\x1f''id:wt-missing-path'$'\x1f''--force'$'\x1f''--json' \
+  assert_contains "$(cat "$LOG")" $'orca\x1f''worktree'$'\x1f''rm'$'\x1f''--worktree'$'\x1f'"id:$(orca_composite_id "$wt")"$'\x1f''--force'$'\x1f''--json' \
     "teardown did not remove the recorded Orca worktree when the path was absent"
   assert_absent "$state/$id.meta" "successful helper cleanup should remove task metadata"
   pass "fm-teardown.sh backend=orca: releases terminal/worktree when path is absent"
@@ -937,7 +946,7 @@ test_teardown_preserves_metadata_when_orca_remove_error_json() {
   fm_write_meta "$state/$id.meta" \
     "window=fm-$id" "endpoint_task_id=$id" "terminal=term-remove-error" "worktree=$wt" "project=$proj" \
     "harness=claude" "kind=scout" "mode=no-mistakes" "yolo=off" \
-    "backend=orca" "orca_worktree_id=wt-remove-error" \
+    "backend=orca" "orca_worktree_id=$(orca_composite_id "$wt")" \
     "decisions_reviewed=1" "decision_keys="
   orca_case remove-error-teardown
   printf '{"ok":true,"result":{}}\n' > "$RESP/1.out"
@@ -968,7 +977,7 @@ test_scout_teardown_refuses_orca_missing_report_when_path_missing() {
   fm_write_meta "$state/$id.meta" \
     "window=fm-$id" "endpoint_task_id=$id" "terminal=term-missing-report" "worktree=$wt" "project=$proj" \
     "harness=claude" "kind=scout" "mode=no-mistakes" "yolo=off" \
-    "backend=orca" "orca_worktree_id=wt-missing-report"
+    "backend=orca" "orca_worktree_id=$(orca_composite_id "$wt")"
   orca_case missing-report
   neutral=$(neutral_fm_root "$CASE_DIR/neutral")
   set +e
@@ -998,7 +1007,7 @@ test_ship_teardown_refuses_orca_missing_worktree_path() {
   fm_write_meta "$state/$id.meta" \
     "window=fm-$id" "endpoint_task_id=$id" "terminal=term-missing-ship" "worktree=$wt" "project=$proj" \
     "harness=claude" "kind=ship" "mode=no-mistakes" "yolo=off" \
-    "backend=orca" "orca_worktree_id=wt-missing-ship"
+    "backend=orca" "orca_worktree_id=$(orca_composite_id "$wt")"
   orca_case missing-ship-path
   neutral=$(neutral_fm_root "$CASE_DIR/neutral")
   set +e
@@ -1029,9 +1038,9 @@ test_ship_teardown_removes_orca_worktree_when_id_path_matches() {
   fm_write_meta "$state/$id.meta" \
     "window=fm-$id" "endpoint_task_id=$id" "terminal=term-ship-match" "worktree=$wt" "project=$proj" \
     "harness=claude" "kind=ship" "mode=local-only" "yolo=off" \
-    "backend=orca" "orca_worktree_id=wt-ship-match"
+    "backend=orca" "orca_worktree_id=$(orca_composite_id "$wt")"
   orca_case ship-match
-  printf '{"ok":true,"result":{"worktree":{"id":"wt-ship-match","path":"%s"}}}\n' "$wt" > "$RESP/1.out"
+  printf '{"ok":true,"result":{"worktree":{"id":"%s","path":"%s"}}}\n' "$(orca_composite_id "$wt")" "$wt" > "$RESP/1.out"
   neutral=$(neutral_fm_root "$CASE_DIR/neutral")
   set +e
   out=$( PATH="$FB:$PATH" FM_ORCA_LOG="$LOG" FM_ORCA_RESPONSES="$RESP" \
@@ -1040,11 +1049,11 @@ test_ship_teardown_removes_orca_worktree_when_id_path_matches() {
   rc=$?
   set -e
   expect_code 0 "$rc" "Orca ship teardown should succeed when the id path matches the inspected worktree"$'\n'"$out"
-  assert_contains "$(cat "$LOG")" $'orca\x1f''worktree'$'\x1f''show'$'\x1f''--worktree'$'\x1f''id:wt-ship-match'$'\x1f''--json' \
+  assert_contains "$(cat "$LOG")" $'orca\x1f''worktree'$'\x1f''show'$'\x1f''--worktree'$'\x1f'"id:$(orca_composite_id "$wt")"$'\x1f''--json' \
     "teardown did not resolve the Orca worktree id before removal"
   assert_contains "$(cat "$LOG")" $'orca\x1f''terminal'$'\x1f''close'$'\x1f''--terminal'$'\x1f''term-ship-match'$'\x1f''--json' \
     "teardown did not close the matched Orca terminal"
-  assert_contains "$(cat "$LOG")" $'orca\x1f''worktree'$'\x1f''rm'$'\x1f''--worktree'$'\x1f''id:wt-ship-match'$'\x1f''--force'$'\x1f''--json' \
+  assert_contains "$(cat "$LOG")" $'orca\x1f''worktree'$'\x1f''rm'$'\x1f''--worktree'$'\x1f'"id:$(orca_composite_id "$wt")"$'\x1f''--force'$'\x1f''--json' \
     "teardown did not remove the matched Orca worktree"
   assert_absent "$state/$id.meta" "successful matched teardown should remove task metadata"
   pass "fm-teardown.sh backend=orca: ship teardown requires a matching Orca id path"
@@ -1064,7 +1073,7 @@ test_ship_teardown_refuses_orca_unresolvable_worktree_id() {
   fm_write_meta "$state/$id.meta" \
     "window=fm-$id" "endpoint_task_id=$id" "terminal=term-ship-unresolved" "worktree=$wt" "project=$proj" \
     "harness=claude" "kind=ship" "mode=local-only" "yolo=off" \
-    "backend=orca" "orca_worktree_id=wt-ship-unresolved"
+    "backend=orca" "orca_worktree_id=$(orca_composite_id "$wt")"
   orca_case ship-unresolved
   printf '1\n' > "$RESP/1.exit"
   neutral=$(neutral_fm_root "$CASE_DIR/neutral")
@@ -1075,9 +1084,9 @@ test_ship_teardown_refuses_orca_unresolvable_worktree_id() {
   rc=$?
   set -e
   [ "$rc" -ne 0 ] || fail "Orca ship teardown should refuse when the worktree id cannot be resolved"
-  assert_contains "$out" "cannot resolve Orca worktree id wt-ship-unresolved" \
+  assert_contains "$out" "cannot resolve Orca worktree id $(orca_composite_id "$wt")" \
     "unresolvable Orca worktree id refusal should explain the fail-closed check"
-  assert_contains "$(cat "$LOG")" $'orca\x1f''worktree'$'\x1f''show'$'\x1f''--worktree'$'\x1f''id:wt-ship-unresolved'$'\x1f''--json' \
+  assert_contains "$(cat "$LOG")" $'orca\x1f''worktree'$'\x1f''show'$'\x1f''--worktree'$'\x1f'"id:$(orca_composite_id "$wt")"$'\x1f''--json' \
     "teardown did not attempt to resolve the Orca worktree id"
   assert_not_contains "$(cat "$LOG")" $'orca\x1f''terminal'$'\x1f''close' \
     "refused unresolved Orca ship teardown should not close terminals"
@@ -1103,9 +1112,9 @@ test_ship_teardown_refuses_orca_id_path_mismatch() {
   fm_write_meta "$state/$id.meta" \
     "window=fm-$id" "endpoint_task_id=$id" "terminal=term-ship-mismatch" "worktree=$wt" "project=$proj" \
     "harness=claude" "kind=ship" "mode=local-only" "yolo=off" \
-    "backend=orca" "orca_worktree_id=wt-ship-mismatch"
+    "backend=orca" "orca_worktree_id=$(orca_composite_id "$wt")"
   orca_case ship-mismatch
-  printf '{"ok":true,"result":{"worktree":{"id":"wt-ship-mismatch","path":"%s"}}}\n' "$other_wt" > "$RESP/1.out"
+  printf '{"ok":true,"result":{"worktree":{"id":"%s","path":"%s"}}}\n' "$(orca_composite_id "$wt")" "$other_wt" > "$RESP/1.out"
   neutral=$(neutral_fm_root "$CASE_DIR/neutral")
   set +e
   out=$( PATH="$FB:$PATH" FM_ORCA_LOG="$LOG" FM_ORCA_RESPONSES="$RESP" \
@@ -1116,7 +1125,7 @@ test_ship_teardown_refuses_orca_id_path_mismatch() {
   [ "$rc" -ne 0 ] || fail "Orca ship teardown should refuse when the id path differs from worktree="
   assert_contains "$out" "not inspected worktree" \
     "mismatched Orca worktree path refusal should name the mismatch"
-  assert_contains "$(cat "$LOG")" $'orca\x1f''worktree'$'\x1f''show'$'\x1f''--worktree'$'\x1f''id:wt-ship-mismatch'$'\x1f''--json' \
+  assert_contains "$(cat "$LOG")" $'orca\x1f''worktree'$'\x1f''show'$'\x1f''--worktree'$'\x1f'"id:$(orca_composite_id "$wt")"$'\x1f''--json' \
     "teardown did not resolve the mismatched Orca worktree id"
   assert_not_contains "$(cat "$LOG")" $'orca\x1f''terminal'$'\x1f''close' \
     "refused mismatched Orca ship teardown should not close terminals"
@@ -1172,7 +1181,7 @@ test_teardown_refuses_orca_worktree_without_terminal_handle() {
   fm_write_meta "$state/$id.meta" \
     "window=fm-$id" "endpoint_task_id=$id" "worktree=$wt" "project=$proj" \
     "harness=claude" "kind=scout" "mode=no-mistakes" "yolo=off" \
-    "backend=orca" "orca_worktree_id=wt-no-terminal" \
+    "backend=orca" "orca_worktree_id=$(orca_composite_id "$wt")" \
     "decisions_reviewed=1" "decision_keys="
   orca_case no-terminal
   neutral=$(neutral_fm_root "$CASE_DIR/neutral")
@@ -1209,10 +1218,10 @@ test_secondmate_force_teardown_removes_orca_child_via_orca() {
     "window=fm-$child_id" "endpoint_task_id=$child_id" \
     "terminal=term-child-cleanup" "worktree=$childwt" "project=$childproj" \
     "harness=claude" "kind=ship" "mode=no-mistakes" "yolo=off" \
-    "backend=orca" "orca_worktree_id=wt-child-cleanup"
+    "backend=orca" "orca_worktree_id=$(orca_composite_id "$childwt")"
   orca_case secondmate-child-cleanup
-  printf '{"ok":true,"result":{"worktree":{"id":"wt-child-cleanup","path":"%s"}}}\n' "$childwt" > "$RESP/1.out"
-  printf '{"ok":true,"result":{"worktree":{"id":"wt-child-cleanup","path":"%s"}}}\n' "$childwt" > "$RESP/2.out"
+  printf '{"ok":true,"result":{"worktree":{"id":"%s","path":"%s"}}}\n' "$(orca_composite_id "$childwt")" "$childwt" > "$RESP/1.out"
+  printf '{"ok":true,"result":{"worktree":{"id":"%s","path":"%s"}}}\n' "$(orca_composite_id "$childwt")" "$childwt" > "$RESP/2.out"
   printf '{"ok":true,"result":{}}\n' > "$RESP/3.out"
   printf '{"ok":true,"result":{}}\n' > "$RESP/4.out"
   add_tmux_fake "$FB"
@@ -1225,7 +1234,7 @@ test_secondmate_force_teardown_removes_orca_child_via_orca() {
   expect_code 0 "$rc" "forced secondmate teardown should remove Orca child work through Orca"$'\n'"$out"
   assert_contains "$(cat "$LOG")" $'orca\x1f''terminal'$'\x1f''close'$'\x1f''--terminal'$'\x1f''term-child-cleanup'$'\x1f''--json' \
     "child cleanup did not close the recorded Orca terminal"
-  assert_contains "$(cat "$LOG")" $'orca\x1f''worktree'$'\x1f''rm'$'\x1f''--worktree'$'\x1f''id:wt-child-cleanup'$'\x1f''--force'$'\x1f''--json' \
+  assert_contains "$(cat "$LOG")" $'orca\x1f''worktree'$'\x1f''rm'$'\x1f''--worktree'$'\x1f'"id:$(orca_composite_id "$childwt")"$'\x1f''--force'$'\x1f''--json' \
     "child cleanup did not remove the Orca worktree through orca worktree rm"
   assert_not_contains "$(cat "$LOG")" $'orca\x1f''terminal'$'\x1f''close'$'\x1f''--terminal'$'\x1f'"fm-$child_id" \
     "child cleanup closed the stable alias instead of the Orca terminal"
@@ -1255,9 +1264,9 @@ test_secondmate_force_teardown_refuses_orca_child_id_path_mismatch() {
     "window=fm-$child_id" "endpoint_task_id=$child_id" \
     "terminal=term-child-mismatch" "worktree=$childwt" "project=$childproj" \
     "harness=claude" "kind=ship" "mode=no-mistakes" "yolo=off" \
-    "backend=orca" "orca_worktree_id=wt-child-mismatch"
+    "backend=orca" "orca_worktree_id=$(orca_composite_id "$childwt")"
   orca_case secondmate-child-mismatch
-  printf '{"ok":true,"result":{"worktree":{"id":"wt-child-mismatch","path":"%s"}}}\n' "$other_wt" > "$RESP/1.out"
+  printf '{"ok":true,"result":{"worktree":{"id":"%s","path":"%s"}}}\n' "$(orca_composite_id "$childwt")" "$other_wt" > "$RESP/1.out"
   add_tmux_fake "$FB"
   neutral=$(neutral_fm_root "$CASE_DIR/neutral")
   set +e
@@ -1296,7 +1305,7 @@ test_secondmate_force_teardown_refuses_partial_orca_child() {
     "window=fm-$child_id" "endpoint_task_id=$child_id" \
     "worktree=$childwt" "project=$childproj" \
     "harness=claude" "kind=ship" "mode=no-mistakes" "yolo=off" \
-    "backend=orca" "orca_worktree_id=wt-partial-child"
+    "backend=orca" "orca_worktree_id=$(orca_composite_id "$childwt")"
   orca_case secondmate-partial-child-cleanup
   add_tmux_fake "$FB"
   neutral=$(neutral_fm_root "$CASE_DIR/neutral")

--- a/tests/fm-control.test.sh
+++ b/tests/fm-control.test.sh
@@ -398,7 +398,7 @@ test_orca_refuses_an_escape_harness_interrupt() {
   {
     cat "$dir/home/state/t1.meta"
     echo "terminal=term-1"
-    echo "orca_worktree_id=wt-1"
+    echo "orca_worktree_id=4ed83d32-9f01-49a2-808a-966c2035339e::$dir/wt-t1"
   } > "$dir/home/state/t1.meta.new"
   sed 's|^window=.*|window=fm-t1|' "$dir/home/state/t1.meta.new" > "$dir/home/state/t1.meta"
   out=$(run_control "$dir" t1 interrupt); rc=$?

--- a/tests/fm-teardown-endpoint-safety.test.sh
+++ b/tests/fm-teardown-endpoint-safety.test.sh
@@ -8,6 +8,10 @@ set -u
 TEARDOWN="$ROOT/bin/fm-teardown.sh"
 TMP_ROOT=$(fm_test_tmproot fm-teardown-endpoint-safety)
 REAL_TMUX=$(command -v tmux || true)
+# Orca worktree ids are natively composite - <repo id>::<absolute worktree path>
+# (docs/orca-backend.md "Task shape and metadata") - so Orca fixtures here carry
+# that real shape rather than a simple atom.
+ORCA_REPO_ID=4ed83d32-9f01-49a2-808a-966c2035339e
 
 make_case() {  # <name>
   local dir=$1
@@ -273,7 +277,8 @@ test_supported_backend_endpoint_records_validate() {
   id=orca-task
   fm_write_meta "$dir/home/state/$id.meta" \
     "window=fm-$id" "endpoint_task_id=$id" "terminal=term-7" \
-    "worktree=$dir/worktree" "project=$dir/project" "backend=orca" "orca_worktree_id=worktree-9"
+    "worktree=$dir/worktree" "project=$dir/project" "backend=orca" \
+    "orca_worktree_id=$ORCA_REPO_ID::$dir/worktree"
   fm_backend_validate_task_endpoint "$dir/home/state/$id.meta" "$id" || fail "valid Orca endpoint refused"
   [ "$FM_BACKEND_VALIDATED_TARGET" = term-7 ] || fail "Orca validation did not select its terminal"
 
@@ -825,11 +830,111 @@ test_remote_layout_homes_serialize_on_one_project_lock() {
   pass "Treehouse project locking still serializes two homes across the remote-seeded boundary"
 }
 
+# Orca's composite worktree id is validated by its own structural rule, not by
+# the shared endpoint-atom character class every other backend's atoms use.
+# Each case below is the whole reason for that split: the real shape must be
+# accepted, and every structural defect must still refuse and preserve state.
+test_orca_composite_worktree_id_validation() {
+  local dir id meta out rc
+  dir=$(make_case orca-composite-id)
+  # shellcheck source=/dev/null
+  . "$ROOT/bin/fm-backend.sh"
+
+  write_orca_meta() {  # <meta> <task-id> <orca_worktree_id>
+    fm_write_meta "$1" \
+      "window=fm-$2" "endpoint_task_id=$2" "terminal=term-7" \
+      "worktree=$dir/worktree" "project=$dir/project" "backend=orca" \
+      "orca_worktree_id=$3"
+  }
+
+  refuses_orca_id() {  # <label> <orca_worktree_id> <expected-reason>
+    local label=$1 value=$2 reason=$3
+    write_orca_meta "$dir/home/state/refuse.meta" refuse-task "$value"
+    # Deliberately NOT a command substitution: the published-target assertion
+    # below reads globals the validator sets in the CURRENT shell.
+    set +e
+    fm_backend_validate_task_endpoint "$dir/home/state/refuse.meta" refuse-task \
+      > "$dir/refuse.out" 2>&1
+    rc=$?
+    set -e
+    out=$(cat "$dir/refuse.out")
+    [ "$rc" -ne 0 ] || fail "Orca id with $label was accepted"
+    assert_contains "$out" "$reason" "refusal for $label did not name its concrete reason"
+    assert_contains "$out" "preserving task state" "refusal for $label did not preserve task state"
+    [ -z "$FM_BACKEND_VALIDATED_TARGET" ] || fail "refused Orca id with $label still published a target"
+  }
+
+  # The exact shape a real `orca worktree create --json` returns.
+  id=orca-real-composite
+  meta="$dir/home/state/$id.meta"
+  write_orca_meta "$meta" "$id" "$ORCA_REPO_ID::$dir/worktree"
+  fm_backend_validate_task_endpoint "$meta" "$id" \
+    || fail "Orca's real composite worktree id was refused"
+  [ "$FM_BACKEND_VALIDATED_BACKEND" = orca ] || fail "composite Orca id did not validate as orca"
+  [ "$FM_BACKEND_VALIDATED_TARGET" = term-7 ] || fail "composite Orca id did not select the recorded terminal"
+
+  # A path half naming any other directory is the cross-record check this
+  # format's own structure makes possible, and the reason it is strictly
+  # stronger than a character class.
+  refuses_orca_id "a path half that is not the recorded worktree" \
+    "$ORCA_REPO_ID::$dir/project" "not the recorded worktree"
+  refuses_orca_id "a path half differing only by a trailing slash" \
+    "$ORCA_REPO_ID::$dir/worktree/" "not the recorded worktree"
+  refuses_orca_id "no :: separator at all" \
+    "$ORCA_REPO_ID" "is not <repo id>::<absolute worktree path>"
+  refuses_orca_id "a single colon instead of ::" \
+    "$ORCA_REPO_ID:$dir/worktree" "is not <repo id>::<absolute worktree path>"
+  refuses_orca_id "a relative path half" \
+    "$ORCA_REPO_ID::relative/worktree" "not absolute"
+  refuses_orca_id "an empty repo id half" \
+    "::$dir/worktree" "empty repository id or worktree path half"
+  refuses_orca_id "an empty path half" \
+    "$ORCA_REPO_ID::" "empty repository id or worktree path half"
+  refuses_orca_id "a tab in the path half" \
+    "$ORCA_REPO_ID::$(printf '%s\tx' "$dir/worktree")" "control character"
+  refuses_orca_id "a carriage return in the path half" \
+    "$ORCA_REPO_ID::$(printf '%s\rx' "$dir/worktree")" "control character"
+
+  # The repo id half stays bound by the shared endpoint-atom rule, so widening
+  # the composite format did not open the left half up.
+  refuses_orca_id "a slash in the repo id half" \
+    "bad/repo::$dir/worktree" "repository id half with unsupported characters"
+  refuses_orca_id "a space in the repo id half" \
+    "bad repo::$dir/worktree" "repository id half with unsupported characters"
+  # shellcheck disable=SC2016 # The un-expanded literal IS the hostile input under test.
+  refuses_orca_id "a shell metacharacter in the repo id half" \
+    'r$(touch /tmp/fm-orca-pwn)::'"$dir/worktree" "repository id half with unsupported characters"
+
+  pass "Orca composite worktree ids validate structurally: real shape accepted, every defect refused"
+}
+
+# The composite rule is Orca's alone. This pins the shared endpoint-atom rule
+# every other backend depends on, so an Orca-driven change can never quietly
+# teach tmux, Herdr, Zellij, or cmux atoms to accept a path or a separator.
+test_shared_endpoint_atom_rule_is_unchanged() {
+  local atom
+  # shellcheck source=/dev/null
+  . "$ROOT/bin/fm-backend.sh"
+
+  for atom in term-7 term_2830d9d8-c4bb-4d30-88c2-74085f45cf0c w1 lab 7 a.b_c%d@e+f; do
+    fm_backend_endpoint_atom_valid "$atom" || fail "endpoint atom rule rejected the still-valid atom '$atom'"
+  done
+  # shellcheck disable=SC2016 # These literals are the rejected inputs, not expressions to expand.
+  for atom in '' '/abs/path' 'a::b' 'a:b' 'a b' 'a/b' 'a;b' 'a$b' 'a*b' "$(printf 'a\tb')" "$(printf 'a\nb')"; do
+    ! fm_backend_endpoint_atom_valid "$atom" \
+      || fail "endpoint atom rule now accepts '$atom'; another backend's endpoint safety was weakened"
+  done
+
+  pass "shared endpoint-atom rule still refuses paths, separators, and control characters for every other backend"
+}
+
 test_invalid_endpoint_records_refuse_before_mutation
 test_control_lock_contention_refuses_before_mutation
 test_non_pool_teardown_ignores_task_set_lock
 test_metadata_lock_serializes_destructive_cleanup
 test_supported_backend_endpoint_records_validate
+test_orca_composite_worktree_id_validation
+test_shared_endpoint_atom_rule_is_unchanged
 test_tmux_empty_target_refuses_without_invocation
 test_recorded_process_identity_cleanup_is_exact
 test_isolated_tmux_invalid_and_valid_cleanup

--- a/tests/fm-teardown-endpoint-safety.test.sh
+++ b/tests/fm-teardown-endpoint-safety.test.sh
@@ -861,6 +861,16 @@ test_orca_composite_worktree_id_validation() {
     [ "$rc" -ne 0 ] || fail "Orca id with $label was accepted"
     assert_contains "$out" "$reason" "refusal for $label did not name its concrete reason"
     assert_contains "$out" "preserving task state" "refusal for $label did not preserve task state"
+    # A refused id is by definition malformed, so the refusal must still be
+    # self-diagnosing: it names the offending id and the worktree it failed
+    # against, rendered printable so a control byte cannot reach the terminal.
+    assert_contains "$out" "id '$(printf '%s' "$value" | tr '[:cntrl:]' '?')'" \
+      "refusal for $label did not name the offending Orca worktree id"
+    assert_contains "$out" "recorded worktree '$dir/worktree'" \
+      "refusal for $label did not name the recorded worktree"
+    case $out in
+      *[[:cntrl:]]*) fail "refusal for $label leaked a raw control byte into its message" ;;
+    esac
     [ -z "$FM_BACKEND_VALIDATED_TARGET" ] || fail "refused Orca id with $label still published a target"
   }
 
@@ -894,6 +904,8 @@ test_orca_composite_worktree_id_validation() {
     "$ORCA_REPO_ID::$(printf '%s\tx' "$dir/worktree")" "control character"
   refuses_orca_id "a carriage return in the path half" \
     "$ORCA_REPO_ID::$(printf '%s\rx' "$dir/worktree")" "control character"
+  refuses_orca_id "an ANSI escape in the path half" \
+    "$ORCA_REPO_ID::$(printf '%s\033[31mx' "$dir/worktree")" "control character"
 
   # The repo id half stays bound by the shared endpoint-atom rule, so widening
   # the composite format did not open the left half up.


### PR DESCRIPTION
## Problem

`bin/fm-teardown.sh` refuses **every** Orca-backed task:

```
REFUSED: Orca endpoint metadata for task <id> is malformed or inconsistent; preserving task state.
```

Orca's worktree ids are natively composite, `<repo id>::<absolute worktree path>`, but `fm_backend_endpoint_atom_valid` accepts only `[A-Za-z0-9._@%+-]`. The `::` and `/` present in every real Orca id fail that check, so no Orca task can ever be torn down. Completed workers strand, holding a terminal and a worktree, and an idle finished worker keeps raising stale wakes.

The recorded metadata was always correct: `bin/fm-spawn.sh`'s `parse_orca_worktree_result` faithfully stores what `orca worktree create --json` returns. The validator was the wrong half.

This shipped because every Orca fixture used a fabricated simple id (`wt-teardown`, `wt-spawn`, `worktree-9`). None exercised the shape Orca actually returns, so the suite passed against a fiction.

## Fix

The shared atom class is **not** widened. It guards the tmux, Herdr, Zellij, and cmux endpoint atoms, and loosening it to admit `:` and `/` would weaken every other backend to fix one.

Instead the composite id gets its own structural rule, `fm_backend_orca_worktree_id_valid`:

1. splits on the first `::` into two non-empty halves;
2. the repo half must still pass `fm_backend_endpoint_atom_valid` (reused, not re-implemented);
3. the path half must be absolute and free of control characters;
4. the path half must equal the task's recorded `worktree=`.

Point 4 is a cross-record consistency check the character class could never express: a record whose id names a different directory than the task's own worktree now refuses, where previously the check was simply unreachable. The result is strictly stronger than what it replaces. Every failure mode remains a refusal that preserves task state, and each names its concrete reason and the offending value.

## Tests

Fixtures across `tests/fm-backend-orca.test.sh`, `tests/fm-teardown-endpoint-safety.test.sh`, and `tests/fm-control.test.sh` are converted from fabricated atoms to the real composite shape. New cases cover a valid id accepted, a mismatched path half, a missing `::`, a relative path half, empty halves, control characters, and the repo half still bound by the atom rule, plus a companion case pinning the shared atom class as unchanged.

Verified: the new tests fail against the old validator and pass against the new one. Full regression sweep green across all five backends. `bin/fm-lint.sh` exits 0 (ShellCheck 0.11.0, actionlint 1.7.12). The pipeline's test step independently reproduced the defect on the base commit, confirmed the fix, and ran a hostile-id matrix with zero destructive Orca calls.

No same-class defect exists in the other backends: Herdr pre-strips colons, and cmux and Zellij ids are uuid/numeric and pass the atom class unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017f1DofkK6VLYWvtXwyk53a
