### PR TITLE
fix(pi): resolve native Codex transport to the Pi engine as session owner

### DIFF
--- a/.pi/extensions/fm-branch-supervision.ts
+++ b/.pi/extensions/fm-branch-supervision.ts
@@ -61,7 +61,6 @@
 // readonly-variable shell prelude so an accidental override fails loudly
 // inside the branch's own shell. bin/fm-lease-lib.sh documents the grade and
 // its deliberate limits.
-import { spawnSync } from "node:child_process";
 import { createHash, randomUUID } from "node:crypto";
 import { existsSync, mkdirSync, readFileSync, renameSync, rmSync, writeFileSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
@@ -312,18 +311,6 @@ function modelLabel(model: { provider: string; id: string }): string {
   return `${model.provider}/${model.id}`;
 }
 
-async function parentPid(pid: string): Promise<string> {
-  const result = await runCommandAsync("ps", ["-o", "ppid=", "-p", pid]);
-  if (result.status !== 0) return "";
-  return result.stdout.trim();
-}
-
-function parentPidSync(pid: string): string {
-  const result = spawnSync("ps", ["-o", "ppid=", "-p", pid], { encoding: "utf8" });
-  if (result.status !== 0) return "";
-  return result.stdout.trim();
-}
-
 function pidAlive(pid: string): boolean {
   try {
     process.kill(Number(pid), 0);
@@ -335,22 +322,16 @@ function pidAlive(pid: string): boolean {
 
 let ownedLockPid = "";
 
-// Same ownership read as the watcher extension's lockOwnership(): the lock
-// names the harness pid, and this process owns it when that pid appears in
-// its own ancestry.
+// Same ownership read as the watcher and turn-end guard extensions: the lock
+// names the owning harness pid, and this Pi process owns it only when that pid
+// is its own. Shell startup resolves a native Codex transport child to this
+// same Pi pid in bin/fm-session-lock-lib.sh, so no ancestry is walked here and
+// none is accepted: a launcher or an enclosing session holding the lock is
+// another session.
 //
-// The ancestry is walked in full at every boundary that asks, never cached:
-// process ancestry is not immutable (a parent exiting reparents its child,
-// and pid identity is reused), and this answer is an ownership AUTHORITY
-// rather than a hint, so a stale chain would misattribute ownership. Moving
-// delivery off Pi's render thread does not trade that away - it awaits each
-// `ps` instead of shortening the walk.
-//
-// The lock file's own answer and the verdict after the walk are shared by the
-// awaited and synchronous forms below, so the only difference between them
-// stays the wait.
-const LOCK_ANCESTRY_DEPTH = 8;
-
+// The lock is re-read at every boundary that asks, never cached: this answer
+// is an ownership AUTHORITY rather than a hint. The awaited form exists for
+// the call sites that are asynchronous anyway; both forms share one read.
 function readLockPid(): { lockPid: string; verdict: LockOwnership | null } {
   ownedLockPid = "";
   let lockPid = "";
@@ -363,45 +344,22 @@ function readLockPid(): { lockPid: string; verdict: LockOwnership | null } {
   return { lockPid, verdict: null };
 }
 
-function ownershipVerdict(lockPid: string, ancestryMatched: boolean): LockOwnership {
-  if (ancestryMatched) {
+function ownershipVerdict(lockPid: string, owned: boolean): LockOwnership {
+  if (owned) {
     ownedLockPid = lockPid;
     return "owned";
   }
   return pidAlive(lockPid) ? "other" : "missing";
 }
 
-async function lockOwnership(): Promise<LockOwnership> {
-  const { lockPid, verdict } = readLockPid();
-  if (verdict) return verdict;
-  let pid = String(process.pid);
-  for (let i = 0; i < LOCK_ANCESTRY_DEPTH; i += 1) {
-    if (pid === lockPid) {
-      const current = readLockPid();
-      if (current.verdict || current.lockPid !== lockPid) return current.verdict ?? "other";
-      return ownershipVerdict(lockPid, true);
-    }
-    pid = await parentPid(pid);
-    if (!pid || pid === "1") break;
-  }
-  return ownershipVerdict(lockPid, false);
-}
-
-// Pi types its bash spawn hook as a synchronous function
-// (BashSpawnHook: (context) => context), so the guard on the BRANCH's own
-// shell commands cannot await. It keeps the synchronous walk unchanged rather
-// than caching the authority: what blocks there is one branch shell command
-// about to spawn a shell anyway, never an arriving outcome.
 function lockOwnershipSync(): LockOwnership {
   const { lockPid, verdict } = readLockPid();
   if (verdict) return verdict;
-  let pid = String(process.pid);
-  for (let i = 0; i < LOCK_ANCESTRY_DEPTH; i += 1) {
-    if (pid === lockPid) return ownershipVerdict(lockPid, true);
-    pid = parentPidSync(pid);
-    if (!pid || pid === "1") break;
-  }
-  return ownershipVerdict(lockPid, false);
+  return ownershipVerdict(lockPid, lockPid === String(process.pid));
+}
+
+async function lockOwnership(): Promise<LockOwnership> {
+  return lockOwnershipSync();
 }
 
 function textOfContent(content: unknown): string {

--- a/.pi/extensions/fm-primary-pi-watch.ts
+++ b/.pi/extensions/fm-primary-pi-watch.ts
@@ -198,12 +198,6 @@ function positiveInteger(name: string, fallback: number): number {
   return Math.floor(value);
 }
 
-function parentPid(pid: string): string {
-  const result = spawnSync("ps", ["-o", "ppid=", "-p", pid], { encoding: "utf8" });
-  if (result.status !== 0) return "";
-  return result.stdout.trim();
-}
-
 function pidAlive(pid: string): boolean {
   try {
     process.kill(Number(pid), 0);
@@ -221,12 +215,10 @@ function lockOwnership(): LockOwnership {
     return "missing";
   }
   if (!/^[0-9]+$/.test(lockPid) || lockPid === "1") return "other";
-  let pid = String(process.pid);
-  for (let i = 0; i < 8; i += 1) {
-    if (pid === lockPid) return "owned";
-    pid = parentPid(pid);
-    if (!pid || pid === "1") break;
-  }
+  // The Pi engine is the session owner. Shell startup resolves a direct
+  // native Codex transport to this same PID in fm-session-lock-lib.sh.
+  // A launcher or another enclosing session is not this Pi session.
+  if (lockPid === String(process.pid)) return "owned";
   return pidAlive(lockPid) ? "other" : "missing";
 }
 

--- a/.pi/extensions/fm-primary-turnend-guard.ts
+++ b/.pi/extensions/fm-primary-turnend-guard.ts
@@ -22,12 +22,6 @@ const state = process.env.FM_STATE_OVERRIDE || `${fmHome}/state`;
 const marker = `${state}/.pi-turnend-extension-loaded`;
 const extensionVersion = `sha256:${createHash("sha256").update(readFileSync(extensionFile)).digest("hex")}`;
 
-function parentPid(pid: string): string {
-  const result = spawnSync("ps", ["-o", "ppid=", "-p", pid], { encoding: "utf8" });
-  if (result.status !== 0) return "";
-  return result.stdout.trim();
-}
-
 function pidAlive(pid: string): boolean {
   try {
     process.kill(Number(pid), 0);
@@ -45,12 +39,10 @@ function lockOwnership(): LockOwnership {
     return "missing";
   }
   if (!/^[0-9]+$/.test(lockPid) || lockPid === "1") return "other";
-  let pid = String(process.pid);
-  for (let i = 0; i < 8; i += 1) {
-    if (pid === lockPid) return "owned";
-    pid = parentPid(pid);
-    if (!pid || pid === "1") break;
-  }
+  // The Pi engine is the session owner. Shell startup resolves a direct
+  // native Codex transport to this same PID in fm-session-lock-lib.sh.
+  // A launcher or another enclosing session is not this Pi session.
+  if (lockPid === String(process.pid)) return "owned";
   return pidAlive(lockPid) ? "other" : "missing";
 }
 

--- a/bin/fm-session-lock-lib.sh
+++ b/bin/fm-session-lock-lib.sh
@@ -90,6 +90,33 @@ fm_harness_process_matches() {  # <comm> <args>
   return 1
 }
 
+# Pi's native transport is a direct `codex [-c key=value ...] app-server
+# --stdio` child. Only that concrete bridge resolves to its Pi parent; an
+# interactive/exec Codex session, a wrapper, or a gap remains its own session.
+# Use executable basenames and the command prefix, never a prompt substring or
+# inherited environment marker. The parent is read from the kernel each time,
+# so replacing the transport child does not replace the session identity.
+fm_pi_native_owner_pid() {  # <pid> <comm> <args>
+  local pid=$1 comm=$2 args=$3 parent parent_comm argv0
+  local -a words
+  read -r -a words <<< "$args"
+  argv0=${words[0]:-}
+  [ "$(basename -- "$comm")" = codex ] || [ "${argv0##*/}" = codex ] || return 1
+  words=("${words[@]:1}")
+  while [ "${words[0]:-}" = -c ]; do
+    [ "${#words[@]}" -ge 2 ] || return 1
+    words=("${words[@]:2}")
+  done
+  [ "${#words[@]}" -eq 2 ] && [ "${words[0]}" = app-server ] && [ "${words[1]}" = --stdio ] || return 1
+  parent=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d ' ') || return 1
+  case "$parent" in ''|1|*[!0-9]*) return 1 ;; esac
+  parent_comm=$(ps -o comm= -p "$parent" 2>/dev/null) || return 1
+  case "$(basename -- "$parent_comm")" in
+    pi|pi-signed) printf '%s\n' "$parent" ;;
+    *) return 1 ;;
+  esac
+}
+
 # Walk the current process ancestry (up to 16 hops) and print this session's
 # contiguous verified-harness ancestry, innermost pid first.
 #
@@ -99,8 +126,9 @@ fm_harness_process_matches() {  # <comm> <args>
 # into an unrelated harness further up the real process tree - for example the
 # live session that launched a test as its own subprocess.
 #
-# For every harness except Claude the innermost match is the session, which is
-# where e.g. Pi's shared signed-wrapper ancestry actually holds the lock: a
+# Except for the direct Pi/native bridge above and Claude below, the innermost
+# match is the session. Pi's shared signed-wrapper ancestry holds the lock at
+# the inner engine: a
 # "pi-signed" launcher can be the direct parent of the inner "pi" engine pid that
 # owns the lock, and the wrapper pid above it is not that owner. Claude Code
 # instead runs hooks several levels below the session inside its own nested
@@ -109,11 +137,15 @@ fm_harness_process_matches() {  # <comm> <args>
 # session cannot be read off the ancestry at all, so the whole contiguous run is
 # reported and the callers below decide what they need from it.
 fm_harness_ancestry_pids() {
-  local pid=$$ comm args extending=0 printed=0
+  local pid=$$ comm args native_owner extending=0 printed=0
   for _ in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16; do
     comm=$(ps -o comm= -p "$pid" 2>/dev/null) || break
     args=$(ps -o args= -p "$pid" 2>/dev/null)
     if fm_harness_process_matches "$comm" "$args"; then
+      if native_owner=$(fm_pi_native_owner_pid "$pid" "$comm" "$args"); then
+        printf '%s\n' "$native_owner"
+        return 0
+      fi
       printf '%s\n' "$pid"
       printed=1
       [ "$FM_HARNESS_IS_CLAUDE" -eq 1 ] || break

--- a/bin/fm-session-lock-lib.sh
+++ b/bin/fm-session-lock-lib.sh
@@ -90,27 +90,58 @@ fm_harness_process_matches() {  # <comm> <args>
   return 1
 }
 
-# Pi's native transport is a direct `codex [-c key=value ...] app-server
-# --stdio` child. Only that concrete bridge resolves to its Pi parent; an
-# interactive/exec Codex session, a wrapper, or a gap remains its own session.
-# Use executable basenames and the command prefix, never a prompt substring or
-# inherited environment marker. The parent is read from the kernel each time,
-# so replacing the transport child does not replace the session identity.
-fm_pi_native_owner_pid() {  # <pid> <comm> <args>
-  local pid=$1 comm=$2 args=$3 parent parent_comm argv0
+# Pi's native transport is a `codex [-c key=value ...] app-server --stdio`
+# child of the Pi engine, either directly (the ChatGPT.app binary, or an
+# explicit PI_CODEX_NATIVE_BIN) or through exactly one hop of the installed npm
+# launcher: `node .../@openai/codex/bin/codex.js <same command>`, which spawns
+# the vendor binary and stays its parent. Only those two concrete shapes resolve
+# to the Pi parent; an interactive/exec Codex session, any other node process, a
+# wrapper, or a gap remains its own session. The evidence is executable
+# basenames, the launcher's symlink-resolved script path, and the exact command,
+# never a prompt substring or an inherited environment marker. Parents are read
+# from the kernel each time, so replacing the transport child does not replace
+# the session identity.
+fm_pi_native_transport_args() {  # <args> <program-words>
   local -a words
-  read -r -a words <<< "$args"
-  argv0=${words[0]:-}
-  [ "$(basename -- "$comm")" = codex ] || [ "${argv0##*/}" = codex ] || return 1
-  words=("${words[@]:1}")
+  read -r -a words <<< "$1"
+  words=("${words[@]:$2}")
   while [ "${words[0]:-}" = -c ]; do
     [ "${#words[@]}" -ge 2 ] || return 1
+    case "${words[1]}" in *=*) ;; *) return 1 ;; esac
     words=("${words[@]:2}")
   done
-  [ "${#words[@]}" -eq 2 ] && [ "${words[0]}" = app-server ] && [ "${words[1]}" = --stdio ] || return 1
-  parent=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d ' ') || return 1
+  [ "${#words[@]}" -eq 2 ] && [ "${words[0]}" = app-server ] && [ "${words[1]}" = --stdio ]
+}
+
+fm_pi_native_npm_launcher() {  # <args>
+  local -a words
+  local script
+  read -r -a words <<< "$1"
+  [ "${#words[@]}" -ge 2 ] || return 1
+  script=$(fm_cursor_canonical_path "${words[1]}") || return 1
+  case "$script" in */@openai/codex/bin/codex.js) ;; *) return 1 ;; esac
+  fm_pi_native_transport_args "$1" 2
+}
+
+fm_pi_native_parent_pid() {  # <pid>
+  local parent
+  parent=$(ps -o ppid= -p "$1" 2>/dev/null | tr -d ' ') || return 1
   case "$parent" in ''|1|*[!0-9]*) return 1 ;; esac
+  printf '%s\n' "$parent"
+}
+
+fm_pi_native_owner_pid() {  # <pid> <comm> <args>
+  local pid=$1 comm=$2 args=$3 parent parent_comm parent_args
+  [ "$(basename -- "$comm")" = codex ] || return 1
+  fm_pi_native_transport_args "$args" 1 || return 1
+  parent=$(fm_pi_native_parent_pid "$pid") || return 1
   parent_comm=$(ps -o comm= -p "$parent" 2>/dev/null) || return 1
+  if [ "$(basename -- "$parent_comm")" = node ]; then
+    parent_args=$(ps -o args= -p "$parent" 2>/dev/null)
+    fm_pi_native_npm_launcher "$parent_args" || return 1
+    parent=$(fm_pi_native_parent_pid "$parent") || return 1
+    parent_comm=$(ps -o comm= -p "$parent" 2>/dev/null) || return 1
+  fi
   case "$(basename -- "$parent_comm")" in
     pi|pi-signed) printf '%s\n' "$parent" ;;
     *) return 1 ;;
@@ -126,9 +157,9 @@ fm_pi_native_owner_pid() {  # <pid> <comm> <args>
 # into an unrelated harness further up the real process tree - for example the
 # live session that launched a test as its own subprocess.
 #
-# Except for the direct Pi/native bridge above and Claude below, the innermost
-# match is the session. Pi's shared signed-wrapper ancestry holds the lock at
-# the inner engine: a
+# Except for the Pi/native bridge above, which applies only to the first match,
+# and Claude below, the innermost match is the session. Pi's shared
+# signed-wrapper ancestry holds the lock at the inner engine: a
 # "pi-signed" launcher can be the direct parent of the inner "pi" engine pid that
 # owns the lock, and the wrapper pid above it is not that owner. Claude Code
 # instead runs hooks several levels below the session inside its own nested
@@ -142,7 +173,7 @@ fm_harness_ancestry_pids() {
     comm=$(ps -o comm= -p "$pid" 2>/dev/null) || break
     args=$(ps -o args= -p "$pid" 2>/dev/null)
     if fm_harness_process_matches "$comm" "$args"; then
-      if native_owner=$(fm_pi_native_owner_pid "$pid" "$comm" "$args"); then
+      if [ "$printed" -eq 0 ] && native_owner=$(fm_pi_native_owner_pid "$pid" "$comm" "$args"); then
         printf '%s\n' "$native_owner"
         return 0
       fi

--- a/docs/pi-supervision-branch.md
+++ b/docs/pi-supervision-branch.md
@@ -78,7 +78,9 @@ Cancellation is preserved by the generation and lock-ownership rechecks the awai
 
 Two reads stay synchronous because Pi's own API is synchronous there, not as an optimization.
 Pi types its bash spawn hook as a plain function, so the guard on the branch's own shell commands cannot await; and the watcher reads `offer.accepted` the moment its dispatch event returns, so a session that does not own the fleet lock must still refuse a wake without waiting.
-Both read the same uncached ownership authority: the lock's process ancestry is walked in full every time it is asked, never cached, because reparenting and pid reuse can invalidate a remembered chain and this answer decides ownership rather than hinting at it.
+Both read the same uncached ownership authority: `state/.lock` is re-read every time it is asked, never cached, because this answer decides ownership rather than hinting at it.
+The branch owns the lock only when it names this Pi process's own pid, the same exact-pid rule as the watcher and turn-end guard extensions; no ancestry is walked or accepted, so a launcher or an enclosing session holding the lock is another session.
+Shell startup and shell ownership checks resolve a native Codex transport child to that same Pi pid, a boundary owned by `bin/fm-session-lock-lib.sh` and verified in [`verification/runtime-backends.md`](verification/runtime-backends.md#native-codex-through-pi).
 
 ## Lost-wake outcome backstop
 

--- a/docs/verification/runtime-backends.md
+++ b/docs/verification/runtime-backends.md
@@ -1489,17 +1489,22 @@ Those absolute figures are specific to this host and Pi version; the guards asse
 
 ## Native Codex through Pi
 
-Verified on 2026-09-08 with Pi 0.85.1 and the installed `pi-codex-native` 0.2.1 adapter.
+Verified on 2026-09-09 with Pi 0.85.1, Codex CLI 0.153.4, and the installed `pi-codex-native` 0.2.1 adapter.
 Run this token-free guard after updating Pi, Codex, or the adapter:
 
 ```sh
-FM_PI_CODEX_NATIVE_LIVE=1 bash tests/fm-pi-codex-native.test.sh
+FM_PI_CODEX_NATIVE_LIVE=1 FM_NATIVE_CODEX_BIN=/Applications/ChatGPT.app/Contents/Resources/codex bash tests/fm-pi-codex-native.test.sh
 ```
 
 Observed result: `"result": "PASS"`.
 The guard runs the real Pi runtime, native adapter, three FirstMate primary extensions, native MCP transport, and FirstMate's durable outcome scripts in an isolated home.
 It verifies native `ultra` on initial and operational turns and after restart, startup operational input, watcher arming, a notification while main is idle, outcome read and one acknowledgement, refusal of a duplicate acknowledgement, and no reprocessing after restart.
-Its native App Server peer and watcher-close process are deterministic fixtures; it does not claim a real backend or a live model was tested by that command.
+The guard also runs full startup and shell ownership checks through the real Codex `command/exec` protocol, replaces that child under the same Pi process, and verifies the lock continues to name Pi.
+`FM_NATIVE_CODEX_BIN` selects the actual Codex executable for this probe; it defaults to `codex`.
+Model turns and watcher-close events use deterministic peers; this command does not verify a real fleet backend or live model.
+`tests/fm-session-lock-ancestry.test.sh` covers the direct native bridge, real-process child replacement, interactive Codex exclusion, non-harness gaps, and outer-wrapper rejection.
+`tests/fm-pi-watch-extension.test.sh` covers watcher recovery and session replacement, and verifies both Pi primary extensions reject a lock held by an enclosing process.
+The identity boundary is owned by `bin/fm-session-lock-lib.sh`; the extensions compare the resulting owner with their own Pi PID.
 `tests/fm-busy-state.test.sh`, `tests/fm-busy-adapter-wiring.test.sh`, and `tests/fm-watch-triage.test.sh` cover separate progress notification, unchanged semantic busy state, rejection of a superseded worker's events, and progress refreshing the busy-age bound without fabricating a completed turn.
 
 ## Oh My Pi (omp)

--- a/docs/verification/runtime-backends.md
+++ b/docs/verification/runtime-backends.md
@@ -1489,22 +1489,23 @@ Those absolute figures are specific to this host and Pi version; the guards asse
 
 ## Native Codex through Pi
 
-Verified on 2026-09-09 with Pi 0.85.1, Codex CLI 0.153.4, and the installed `pi-codex-native` 0.2.1 adapter.
+Verified on 2026-09-09 with Pi 0.85.1, the ChatGPT.app Codex binary 0.153.4, the npm `@openai/codex` launcher 0.151.0, and the installed `pi-codex-native` 0.2.1 adapter.
 Run this token-free guard after updating Pi, Codex, or the adapter:
 
 ```sh
-FM_PI_CODEX_NATIVE_LIVE=1 FM_NATIVE_CODEX_BIN=/Applications/ChatGPT.app/Contents/Resources/codex bash tests/fm-pi-codex-native.test.sh
+FM_PI_CODEX_NATIVE_LIVE=1 bash tests/fm-pi-codex-native.test.sh
 ```
 
 Observed result: `"result": "PASS"`.
 The guard runs the real Pi runtime, native adapter, three FirstMate primary extensions, native MCP transport, and FirstMate's durable outcome scripts in an isolated home.
 It verifies native `ultra` on initial and operational turns and after restart, startup operational input, watcher arming, a notification while main is idle, outcome read and one acknowledgement, refusal of a duplicate acknowledgement, and no reprocessing after restart.
 The guard also runs full startup and shell ownership checks through the real Codex `command/exec` protocol, replaces that child under the same Pi process, and verifies the lock continues to name Pi.
-`FM_NATIVE_CODEX_BIN` selects the actual Codex executable for this probe; it defaults to `codex`.
+`FM_NATIVE_CODEX_BIN` selects the Codex executable for this probe; by default it mirrors the adapter's own resolution, the ChatGPT.app binary when installed and otherwise PATH `codex`.
+When PATH `codex` is the installed npm launcher and is not already that executable, the probe also runs through the launcher, whose `node .../@openai/codex/bin/codex.js app-server --stdio` process stays the vendor binary's parent; the guard records every Codex version it exercised.
 Model turns and watcher-close events use deterministic peers; this command does not verify a real fleet backend or live model.
-`tests/fm-session-lock-ancestry.test.sh` covers the direct native bridge, real-process child replacement, interactive Codex exclusion, non-harness gaps, and outer-wrapper rejection.
-`tests/fm-pi-watch-extension.test.sh` covers watcher recovery and session replacement, and verifies both Pi primary extensions reject a lock held by an enclosing process.
-The identity boundary is owned by `bin/fm-session-lock-lib.sh`; the extensions compare the resulting owner with their own Pi PID.
+`tests/fm-session-lock-ancestry.test.sh` covers the direct native bridge, the one-hop npm launcher bridge and its rejection of other node scripts, other commands, gaps, and a second hop, real-process child replacement through both shapes, interactive Codex exclusion, outer-wrapper rejection, and a Claude session inside native Codex staying separate from the enclosing Pi.
+`tests/fm-pi-watch-extension.test.sh` covers watcher recovery and session replacement and verifies the watcher and turn-end guard extensions reject a lock held by an enclosing process; `tests/fm-pi-branch-extension.test.sh` verifies the supervision branch rejects a lock held by a sibling or an enclosing live process.
+The identity boundary is owned by `bin/fm-session-lock-lib.sh`; all three Pi extensions compare the lock with their own Pi PID.
 `tests/fm-busy-state.test.sh`, `tests/fm-busy-adapter-wiring.test.sh`, and `tests/fm-watch-triage.test.sh` cover separate progress notification, unchanged semantic busy state, rejection of a superseded worker's events, and progress refreshing the busy-age bound without fabricating a completed turn.
 
 ## Oh My Pi (omp)

--- a/tests/fm-pi-branch-extension.test.sh
+++ b/tests/fm-pi-branch-extension.test.sh
@@ -661,7 +661,7 @@ await eval(`(async () => { ${prelude}; globalThis.__t = { pi, fire, dispatch, se
 const { pi, fire, dispatch, settle, outcomeScript, sentToMain, mainUserMessages, mainTools, renderers, entryRenderers, mainEntries, defaultSessionCtx, home, realRoot } = globalThis.__t;
 import { readFileSync, writeFileSync } from "node:fs";
 
-writeFileSync(`${home}/state/.lock`, `${process.ppid}\n`);
+writeFileSync(`${home}/state/.lock`, `${process.pid}\n`);
 await fire("session_start", {}, defaultSessionCtx);
 
 // 1. An accepted wake reaches the branch session, never main. Keep the
@@ -696,7 +696,7 @@ if (loader.options.systemPrompt.length < 4096) throw new Error("branch prompt is
 const bashTool = session.options.customTools.find((tool) => tool.name === "bash");
 const hooked = bashTool.__options.spawnHook({ command: "true", cwd: "/x", env: { PATH: "/bin" } });
 if (hooked.env.FM_SUPERVISION_ACTOR !== "branch") throw new Error("branch bash does not inject the branch actor");
-if (hooked.env.FM_LEASE_HOLDER_PID !== String(process.ppid)) throw new Error("branch bash does not pin the verified session-lock holder pid");
+if (hooked.env.FM_LEASE_HOLDER_PID !== String(process.pid)) throw new Error("branch bash does not pin the verified session-lock holder pid");
 
 // 3. Shared per-home prompt_cache_key: overrides only payloads that already
 // carry one, stable within the home.
@@ -3679,9 +3679,10 @@ test_secondary_session_stays_inert() {
   home="$TMP_ROOT/secondary-home"
   mkdir -p "$home/state" "$home/config"
   install_pi_branch_extension_fixture "$repo"
-  # The fleet lock is owned by ANOTHER live process that is NOT in the
-  # driver's ancestry (a sibling sleeper), so the driver is a secondary
-  # session: it must accept nothing, write no marker, and release no leases.
+  # The fleet lock is owned by ANOTHER live process: first a sibling sleeper,
+  # then the driver's own live parent. Neither is this Pi process, so the driver
+  # is a secondary session either way: it must accept nothing, write no marker,
+  # and release no leases.
   sleep 60 &
   foreign_pid=$!
   printf 'branch\t%s\t123\n' "$foreign_pid" > "$home/state/.lease-task-x"
@@ -3691,13 +3692,15 @@ const prelude = process.env.DRIVER_PRELUDE;
 await eval(`(async () => { ${prelude}; globalThis.__t = { dispatch, home }; })()`);
 const { dispatch, home } = globalThis.__t;
 import { existsSync, writeFileSync } from "node:fs";
-writeFileSync(`${home}/state/.lock`, `${process.env.FM_TEST_LOCK_PID}\n`);
-if (dispatch("signal: secondary probe").accepted) throw new Error("secondary session accepted a wake it does not own");
-if (existsSync(`${home}/state/.pi-branch-extension-loaded`)) {
-  throw new Error("secondary session wrote the primary's marker");
-}
-if (!existsSync(`${home}/state/.lease-task-x`)) {
-  throw new Error("secondary session released the primary's branch lease");
+for (const [holder, label] of [[process.env.FM_TEST_LOCK_PID, "sibling"], [String(process.ppid), "enclosing"]]) {
+  writeFileSync(`${home}/state/.lock`, `${holder}\n`);
+  if (dispatch(`signal: secondary probe (${label})`).accepted) throw new Error(`secondary session accepted a wake it does not own (${label} holder)`);
+  if (existsSync(`${home}/state/.pi-branch-extension-loaded`)) {
+    throw new Error(`secondary session wrote the primary's marker (${label} holder)`);
+  }
+  if (!existsSync(`${home}/state/.lease-task-x`)) {
+    throw new Error(`secondary session released the primary's branch lease (${label} holder)`);
+  }
 }
 process.exit(0);
 EOF
@@ -3705,7 +3708,7 @@ EOF
   out=$(cat "$TMP_ROOT/node-output")
   kill "$foreign_pid" 2>/dev/null || true
   expect_code 0 "$status" "a secondary session must stay inert: $out"
-  pass "a Pi session that does not own the lock accepts nothing and mutates no branch state"
+  pass "a Pi session whose lock is held by a sibling or an enclosing live process accepts nothing and mutates no branch state"
 }
 
 test_rebind_remirrors_undelivered_dialog_from_durable_cursor() {
@@ -4512,26 +4515,29 @@ EOF
 }
 
 test_session_replacement_during_delivery_neither_loses_nor_duplicates() {
-  local repo home fakebin out status real_ps
+  local repo home fakebin out status real_bash
   repo="$TMP_ROOT/delivery-replacement-root"
   home="$TMP_ROOT/delivery-replacement-home"
   fakebin="$home/fakebin"
-  real_ps=$(command -v ps)
+  real_bash=$(command -v bash)
   mkdir -p "$home/state" "$home/config" "$fakebin"
   install_pi_branch_extension_fixture "$repo"
-  cat > "$fakebin/ps" <<'SH'
+  # Holds the first outcome-store call after arming open until released, so a
+  # delivery already in the queue stays in flight while the session is replaced.
+  cat > "$fakebin/bash" <<'SH'
 #!/bin/sh
-if [ -f "$FM_TEST_PS_ARM" ]; then
-  rm -f "$FM_TEST_PS_ARM"
-  : > "$FM_TEST_PS_ENTERED"
-  while [ ! -f "$FM_TEST_PS_RELEASE" ]; do sleep 0.01; done
+if [ -f "$FM_TEST_STORE_ARM" ] && [ "$1" = "$FM_TEST_OUTCOME_SCRIPT" ]; then
+  rm -f "$FM_TEST_STORE_ARM"
+  : > "$FM_TEST_STORE_ENTERED"
+  while [ ! -f "$FM_TEST_STORE_RELEASE" ]; do sleep 0.01; done
 fi
-exec "$FM_TEST_REAL_PS" "$@"
+exec "$FM_TEST_REAL_BASH" "$@"
 SH
-  chmod +x "$fakebin/ps"
+  chmod +x "$fakebin/bash"
   PATH="$fakebin:$PATH" PLUGIN="$repo/.pi/extensions/fm-branch-supervision.ts" FM_HOME="$home" FM_ROOT_OVERRIDE="$ROOT" \
-    FM_TEST_REAL_PS="$real_ps" FM_TEST_PS_ARM="$home/state/ps-arm" \
-    FM_TEST_PS_ENTERED="$home/state/ps-entered" FM_TEST_PS_RELEASE="$home/state/ps-release" \
+    FM_TEST_REAL_BASH="$real_bash" FM_TEST_OUTCOME_SCRIPT="$ROOT/bin/fm-branch-outcome.sh" \
+    FM_TEST_STORE_ARM="$home/state/store-arm" FM_TEST_STORE_ENTERED="$home/state/store-entered" \
+    FM_TEST_STORE_RELEASE="$home/state/store-release" \
     DRIVER_PRELUDE="$DRIVER_PRELUDE" node --input-type=module > "$TMP_ROOT/node-output" 2>&1 <<'EOF'
 const prelude = process.env.DRIVER_PRELUDE;
 await eval(`(async () => { ${prelude}; globalThis.__t = { fire, dispatch, settle, outcomeScript, sentToMain, mainEntries, home }; })()`);
@@ -4547,10 +4553,7 @@ const secondCtx = {
   sessionManager: { getSessionFile: () => `${home}/second.jsonl`, getEntries: () => secondEntries },
 };
 
-// Use the live parent as lock owner so each ownership check must traverse at
-// least one real ps subprocess; a self-owned lock would return before the
-// asynchronous boundary this regression needs to hold open.
-writeFileSync(`${home}/state/.lock`, `${process.ppid}\n`);
+writeFileSync(`${home}/state/.lock`, `${process.pid}\n`);
 await fire("session_start", {}, firstCtx);
 let finishWakePrompt;
 globalThis.__fmOnBranchPrompt = () => new Promise((resolve) => { finishWakePrompt = resolve; });
@@ -4562,7 +4565,12 @@ const toolGeneration = 1;
 
 // A delivery that is still in flight when the captain replaces the session
 // (/new, /resume, /fork, reload) must stop acting into the replaced session.
-writeFileSync(process.env.FM_TEST_PS_ARM, "");
+// A turn-end reconciliation held open inside its outcome-store call keeps the
+// delivery queue busy, so the report behind it is still in flight, its
+// ownership not yet evaluated, when the replacement happens.
+writeFileSync(process.env.FM_TEST_STORE_ARM, "");
+const heldReconcile = fire("turn_end", {}, firstCtx);
+await settle(() => existsSync(process.env.FM_TEST_STORE_ENTERED), "in-flight outcome-store subprocess");
 const inFlight = report.execute(
   "replaced-mid-delivery",
   { task: "branch-driver", verdict: "captain", summary: "reported as the session was replaced" },
@@ -4570,11 +4578,11 @@ const inFlight = report.execute(
   undefined,
   {},
 );
-await settle(() => existsSync(process.env.FM_TEST_PS_ENTERED), "in-flight ownership subprocess");
 await fire("session_shutdown", {});
 const replacementStart = fire("session_start", {}, secondCtx);
-writeFileSync(process.env.FM_TEST_PS_RELEASE, "");
+writeFileSync(process.env.FM_TEST_STORE_RELEASE, "");
 await replacementStart;
+await heldReconcile;
 const replaced = await inFlight;
 if (!replaced.isError) {
   throw new Error(`a report from the replaced session was accepted: ${JSON.stringify(replaced)}`);

--- a/tests/fm-pi-codex-native.test.sh
+++ b/tests/fm-pi-codex-native.test.sh
@@ -403,7 +403,7 @@ try {
         piVersion,
         adapterVersion,
         ...(process.env.FM_NATIVE_TEST_KEEP === "1" ? { fixture } : {}),
-        versions: { pi: piVersion, "pi-codex-native": adapterVersion, codex: codexVersions },
+        codexVersions,
         checks: [
           "actual Pi runtime and native package",
           "full startup through real Codex command/exec and shell ownership",

--- a/tests/fm-pi-codex-native.test.sh
+++ b/tests/fm-pi-codex-native.test.sh
@@ -9,7 +9,27 @@ set -u
 
 # shellcheck source=tests/lib.sh
 . "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
-fm_live_gate default-on FM_PI_CODEX_NATIVE_LIVE node "${FM_PI_BIN:-pi}" "${FM_NATIVE_CODEX_BIN:-codex}"
+# Mirror the adapter's own executable resolution: the ChatGPT.app binary when
+# installed, else PATH codex. When PATH codex is the installed npm launcher and
+# is not already the probe executable, the ownership probe runs through it too.
+FM_NATIVE_GUI_CODEX=/Applications/ChatGPT.app/Contents/Resources/codex
+if [ -z "${FM_NATIVE_CODEX_BIN:-}" ]; then
+  if [ -x "$FM_NATIVE_GUI_CODEX" ]; then FM_NATIVE_CODEX_BIN=$FM_NATIVE_GUI_CODEX; else FM_NATIVE_CODEX_BIN=codex; fi
+fi
+export FM_NATIVE_CODEX_BIN
+fm_live_gate default-on FM_PI_CODEX_NATIVE_LIVE node "${FM_PI_BIN:-pi}" "$FM_NATIVE_CODEX_BIN"
+# shellcheck source=bin/fm-session-lock-lib.sh
+. "$ROOT/bin/fm-session-lock-lib.sh"
+FM_NATIVE_CODEX_LAUNCHER=$(command -v codex 2>/dev/null || true)
+if [ -n "$FM_NATIVE_CODEX_LAUNCHER" ] && [ "$FM_NATIVE_CODEX_LAUNCHER" != "$(command -v "$FM_NATIVE_CODEX_BIN")" ]; then
+  case "$(fm_cursor_canonical_path "$FM_NATIVE_CODEX_LAUNCHER")" in
+    */@openai/codex/bin/codex.js) ;;
+    *) FM_NATIVE_CODEX_LAUNCHER='' ;;
+  esac
+else
+  FM_NATIVE_CODEX_LAUNCHER=''
+fi
+export FM_NATIVE_CODEX_LAUNCHER
 PI_CODEX_NATIVE_PACKAGE=${PI_CODEX_NATIVE_PACKAGE:-"$HOME/.pi/agent/packages/pi-codex-native"}
 if [ ! -f "$PI_CODEX_NATIVE_PACKAGE/index.ts" ]; then
   if [ "${FM_PI_CODEX_NATIVE_LIVE:-${FM_LIVE:-0}}" = 1 ]; then
@@ -36,7 +56,12 @@ let adapterVersion = "unknown";
 try {
   adapterVersion = JSON.parse(fs.readFileSync(path.join(nativePackage, "package.json"), "utf8")).version || "unknown";
 } catch { /* A source-only adapter may omit package metadata. */ }
-console.log(`Native Codex guard: Pi ${piVersion}, pi-codex-native ${adapterVersion}`);
+const codexExecutables = [process.env.FM_NATIVE_CODEX_BIN, process.env.FM_NATIVE_CODEX_LAUNCHER].filter(Boolean);
+const codexVersions = Object.fromEntries(codexExecutables.map((executable) => [
+  executable,
+  execFileSync(executable, ["--version"], { encoding: "utf8", timeout: 20000 }).trim(),
+]));
+console.log(`Native Codex guard: Pi ${piVersion}, pi-codex-native ${adapterVersion}, Codex ${JSON.stringify(codexVersions)}`);
 const fixture = fs.mkdtempSync(path.join(tmpdir(), "fm-native-primary."));
 const repo = path.join(fixture, "repo"),
   home = path.join(fixture, "home"),
@@ -78,8 +103,9 @@ while :; do
 done
 `,
 );
-// Exercise the installed Codex executable's token-free command/exec under Pi.
-// The protocol peer below cannot establish the real binary's process identity.
+// Exercise each real Codex executable's token-free command/exec under Pi: the
+// adapter's resolved binary and, when installed separately, the npm launcher.
+// The protocol peer below cannot establish a real binary's process identity.
 const own = path.join(fixture, "own-lock.ts");
 const ownershipProbe = path.join(fixture, "ownership-probe.sh");
 fs.writeFileSync(ownershipProbe, `#!/usr/bin/env bash
@@ -100,22 +126,24 @@ import assert from 'node:assert/strict';
 import {CodexAppServer} from ${JSON.stringify(path.join(nativePackage, "app-server.mjs"))};
 export default function(pi) {
  pi.on('session_start', async () => {
-  const children = [];
-  for (let i = 0; i < 2; i++) {
-   const server = new CodexAppServer({cwd:${JSON.stringify(repo)}, executable:process.env.FM_NATIVE_CODEX_BIN || 'codex'});
-   try {
-    await server.start();
-    children.push(server.child.pid);
-    const result = await server.request('command/exec', {
-     command:['bash',${JSON.stringify(ownershipProbe)},${JSON.stringify(repo)},process.env.FM_HOME],
-     cwd:${JSON.stringify(repo)}, sandboxPolicy:{type:'dangerFullAccess'}, timeoutMs:30000,
-    }, 40000);
-    assert.equal(result.exitCode,0,JSON.stringify(result));
-    assert.equal(readFileSync(process.env.FM_HOME+'/state/.lock','utf8').trim(),String(process.pid),JSON.stringify(result));
-   } finally { await server.close(); }
+  for (const executable of ${JSON.stringify(codexExecutables)}) {
+   const children = [];
+   for (let i = 0; i < 2; i++) {
+    const server = new CodexAppServer({cwd:${JSON.stringify(repo)}, executable});
+    try {
+     await server.start();
+     children.push(server.child.pid);
+     const result = await server.request('command/exec', {
+      command:['bash',${JSON.stringify(ownershipProbe)},${JSON.stringify(repo)},process.env.FM_HOME],
+      cwd:${JSON.stringify(repo)}, sandboxPolicy:{type:'dangerFullAccess'}, timeoutMs:30000,
+     }, 40000);
+     assert.equal(result.exitCode,0,executable+': '+JSON.stringify(result));
+     assert.equal(readFileSync(process.env.FM_HOME+'/state/.lock','utf8').trim(),String(process.pid),executable+': '+JSON.stringify(result));
+    } finally { await server.close(); }
+   }
+   assert.notEqual(children[0],children[1]);
+   appendFileSync(process.env.FM_HOME+'/state/ownership-probes',JSON.stringify({executable,owner:process.pid,children})+'\\n');
   }
-  assert.notEqual(children[0],children[1]);
-  appendFileSync(process.env.FM_HOME+'/state/ownership-probes',JSON.stringify({owner:process.pid,children})+'\\n');
  });
  pi.events.on('codex-native:progress', event => appendFileSync(process.env.FM_HOME+'/state/progress-events',JSON.stringify(event)+'\\n'));
 }
@@ -280,6 +308,8 @@ try {
     "first settle",
   );
   assert(fs.existsSync(path.join(state, "ownership-probes")), "real native ownership probe failed: " + child.err);
+  const probed = fs.readFileSync(path.join(state, "ownership-probes"), "utf8").trim().split("\n").map((line) => JSON.parse(line));
+  assert.deepEqual(probed.map((probe) => probe.executable), codexExecutables, "every real Codex executable was probed: " + child.err);
   assert.equal(fs.readFileSync(path.join(state, ".lock"), "utf8").trim(), String(child.pid));
   assert(
     log().some(
@@ -373,10 +403,12 @@ try {
         piVersion,
         adapterVersion,
         ...(process.env.FM_NATIVE_TEST_KEEP === "1" ? { fixture } : {}),
+        versions: { pi: piVersion, "pi-codex-native": adapterVersion, codex: codexVersions },
         checks: [
           "actual Pi runtime and native package",
           "full startup through real Codex command/exec and shell ownership",
           "native child replacement preserves Pi owner",
+          ...(process.env.FM_NATIVE_CODEX_LAUNCHER ? ["installed npm Codex launcher resolves to the same Pi owner"] : []),
           "native Ultra preserved across operational turns and restart",
           "installed native adapter emits observable output progress",
           "actual FirstMate primary extensions",

--- a/tests/fm-pi-codex-native.test.sh
+++ b/tests/fm-pi-codex-native.test.sh
@@ -9,7 +9,7 @@ set -u
 
 # shellcheck source=tests/lib.sh
 . "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
-fm_live_gate default-on FM_PI_CODEX_NATIVE_LIVE node "${FM_PI_BIN:-pi}"
+fm_live_gate default-on FM_PI_CODEX_NATIVE_LIVE node "${FM_PI_BIN:-pi}" "${FM_NATIVE_CODEX_BIN:-codex}"
 PI_CODEX_NATIVE_PACKAGE=${PI_CODEX_NATIVE_PACKAGE:-"$HOME/.pi/agent/packages/pi-codex-native"}
 if [ ! -f "$PI_CODEX_NATIVE_PACKAGE/index.ts" ]; then
   if [ "${FM_PI_CODEX_NATIVE_LIVE:-${FM_LIVE:-0}}" = 1 ]; then
@@ -44,6 +44,7 @@ const repo = path.join(fixture, "repo"),
 fs.mkdirSync(path.join(repo, "bin"), { recursive: true });
 fs.mkdirSync(state, { recursive: true });
 fs.mkdirSync(path.join(home, "config"));
+fs.symlinkSync(path.join(root, "docs"), path.join(repo, "docs"));
 fs.cpSync(
   path.join(root, ".pi/extensions"),
   path.join(repo, ".pi/extensions"),
@@ -61,6 +62,9 @@ script(
   '#!/usr/bin/env bash\nprintf "NATIVE_PRIMARY_STARTUP_SENTINEL\\n"\n',
 );
 script("fm-turnend-guard.sh", "#!/usr/bin/env bash\nexit 0\n");
+// Full startup runs below; external services and fleet work are fixture-only.
+for (const name of ["fm-bootstrap.sh", "fm-startup-network.sh", "fm-wake-drain.sh"])
+  script(name, "#!/usr/bin/env bash\nexit 0\n");
 script(
   "fm-watch-arm.sh",
   `#!/usr/bin/env bash
@@ -74,11 +78,48 @@ while :; do
 done
 `,
 );
+// Exercise the installed Codex executable's token-free command/exec under Pi.
+// The protocol peer below cannot establish the real binary's process identity.
 const own = path.join(fixture, "own-lock.ts");
-fs.writeFileSync(
-  own,
-  `import {writeFileSync,appendFileSync} from 'node:fs'; export default function(pi){pi.on('session_start',()=>writeFileSync(process.env.FM_HOME+'/state/.lock',String(process.pid)+'\\n'));pi.events.on('codex-native:progress',event=>appendFileSync(process.env.FM_HOME+'/state/progress-events',JSON.stringify(event)+'\\n'));}`,
-);
+const ownershipProbe = path.join(fixture, "ownership-probe.sh");
+fs.writeFileSync(ownershipProbe, `#!/usr/bin/env bash
+export FM_ROOT_OVERRIDE="$1" FM_HOME="$2" FM_STATE_OVERRIDE="$2/state"
+"$1/bin/fm-session-start.sh" > "$2/state/native-startup.out" || exit
+if grep -q 'READ-ONLY SESSION' "$2/state/native-startup.out"; then
+  cat "$2/state/native-startup.out"
+  exit 1
+fi
+"$1/bin/fm-lock.sh" || exit
+. "$1/bin/fm-session-lock-lib.sh"
+fm_session_lock_owned_by_self "$2/state" || exit
+cat "$2/state/.lock"
+`, { mode: 0o755 });
+fs.writeFileSync(own, `
+import {appendFileSync,readFileSync} from 'node:fs';
+import assert from 'node:assert/strict';
+import {CodexAppServer} from ${JSON.stringify(path.join(nativePackage, "app-server.mjs"))};
+export default function(pi) {
+ pi.on('session_start', async () => {
+  const children = [];
+  for (let i = 0; i < 2; i++) {
+   const server = new CodexAppServer({cwd:${JSON.stringify(repo)}, executable:process.env.FM_NATIVE_CODEX_BIN || 'codex'});
+   try {
+    await server.start();
+    children.push(server.child.pid);
+    const result = await server.request('command/exec', {
+     command:['bash',${JSON.stringify(ownershipProbe)},${JSON.stringify(repo)},process.env.FM_HOME],
+     cwd:${JSON.stringify(repo)}, sandboxPolicy:{type:'dangerFullAccess'}, timeoutMs:30000,
+    }, 40000);
+    assert.equal(result.exitCode,0,JSON.stringify(result));
+    assert.equal(readFileSync(process.env.FM_HOME+'/state/.lock','utf8').trim(),String(process.pid),JSON.stringify(result));
+   } finally { await server.close(); }
+  }
+  assert.notEqual(children[0],children[1]);
+  appendFileSync(process.env.FM_HOME+'/state/ownership-probes',JSON.stringify({owner:process.pid,children})+'\\n');
+ });
+ pi.events.on('codex-native:progress', event => appendFileSync(process.env.FM_HOME+'/state/progress-events',JSON.stringify(event)+'\\n'));
+}
+`);
 const peer = path.join(fixture, "native-peer.mjs");
 fs.writeFileSync(
   peer,
@@ -184,6 +225,7 @@ async function start(resume) {
     env: {
       ...process.env,
       FM_HOME: home,
+      FM_STATE_OVERRIDE: state,
       FM_ROOT_OVERRIDE: repo,
       PI_CODEX_NATIVE_BIN: peer,
       PI_CODING_AGENT_DIR: path.join(fixture, "pi-config"),
@@ -237,6 +279,8 @@ try {
     () => events.some((e) => e.type === "agent_settled"),
     "first settle",
   );
+  assert(fs.existsSync(path.join(state, "ownership-probes")), "real native ownership probe failed: " + child.err);
+  assert.equal(fs.readFileSync(path.join(state, ".lock"), "utf8").trim(), String(child.pid));
   assert(
     log().some(
       (e) =>
@@ -331,6 +375,8 @@ try {
         ...(process.env.FM_NATIVE_TEST_KEEP === "1" ? { fixture } : {}),
         checks: [
           "actual Pi runtime and native package",
+          "full startup through real Codex command/exec and shell ownership",
+          "native child replacement preserves Pi owner",
           "native Ultra preserved across operational turns and restart",
           "installed native adapter emits observable output progress",
           "actual FirstMate primary extensions",
@@ -342,7 +388,7 @@ try {
           "restart does not reprocess acknowledged outcome",
         ],
         limits: [
-          "native peer and watcher-close process are deterministic fixtures; no live model or backend tested",
+          "model turns and watcher-close process use deterministic peers; no live model or backend tested",
         ],
       },
       null,

--- a/tests/fm-pi-watch-extension.test.sh
+++ b/tests/fm-pi-watch-extension.test.sh
@@ -1874,11 +1874,11 @@ try {
   other.kill("SIGTERM");
 }
 
+writeFileSync(lock, `${process.ppid}\n`);
 const guardHandlers = new Map();
 const guard = await import(new URL("fm-primary-turnend-guard.ts", pathToFileURL(process.env.PLUGIN)).href);
 guard.default({ on(name, handler) { guardHandlers.set(name, handler); } });
 const guardMarker = `${process.env.FM_HOME}/state/.pi-turnend-extension-loaded`;
-writeFileSync(lock, `${process.ppid}\n`);
 guardHandlers.get("session_start")({ reason: "reload" }, {});
 if (existsSync(guardMarker)) throw new Error("guard marked loaded for enclosing foreign session");
 const ancestor = await callArm();

--- a/tests/fm-pi-watch-extension.test.sh
+++ b/tests/fm-pi-watch-extension.test.sh
@@ -1818,6 +1818,7 @@ test_pi_arm_distinguishes_session_lock_ownership() {
   mkdir -p "$repo/bin" "$home/state" "$home/config"
   install_pi_watch_extension_fixture "$repo"
   plugin="$repo/.pi/extensions/fm-primary-pi-watch.ts"
+  cp "$ROOT/.pi/extensions/fm-primary-turnend-guard.ts" "$repo/.pi/extensions/"
   cat > "$repo/bin/fm-watch-arm.sh" <<'SH'
 #!/usr/bin/env bash
 printf 'arm\n' >> "${FM_ARM_LOG:?}"
@@ -1873,8 +1874,23 @@ try {
   other.kill("SIGTERM");
 }
 
+const guardHandlers = new Map();
+const guard = await import(new URL("fm-primary-turnend-guard.ts", pathToFileURL(process.env.PLUGIN)).href);
+guard.default({ on(name, handler) { guardHandlers.set(name, handler); } });
+const guardMarker = `${process.env.FM_HOME}/state/.pi-turnend-extension-loaded`;
+writeFileSync(lock, `${process.ppid}\n`);
+guardHandlers.get("session_start")({ reason: "reload" }, {});
+if (existsSync(guardMarker)) throw new Error("guard marked loaded for enclosing foreign session");
+const ancestor = await callArm();
+if (ancestor.details?.ok !== false || !ancestor.details.message.includes("held by another firstmate session")) {
+  throw new Error(`enclosing process incorrectly treated as Pi owner: ${JSON.stringify(ancestor.details)}`);
+}
+
 if (existsSync(process.env.FM_ARM_LOG)) throw new Error("watcher arm ran without lock ownership");
 writeFileSync(lock, `${process.pid}\n`);
+guardHandlers.get("session_start")({ reason: "reload" }, {});
+if (!existsSync(guardMarker)) throw new Error("guard rejected its own Pi session");
+await guardHandlers.get("session_shutdown")();
 const owned = await callArm();
 if (owned.details?.ok !== true || !owned.details.message.includes("started Pi extension arm child")) {
   throw new Error(`owned lock did not arm: ${JSON.stringify(owned.details)}`);

--- a/tests/fm-session-lock-ancestry.test.sh
+++ b/tests/fm-session-lock-ancestry.test.sh
@@ -491,6 +491,7 @@ const child = spawn(process.env.FM_TEST_VENDOR_CODEX, process.argv.slice(2), { s
 child.on("exit", (code, signal) => process.exit(signal ? 1 : code));
 JS
   chmod +x "$dir/lib/node_modules/@openai/codex/bin/codex.js"
+  printf '{"type":"module"}\n' > "$dir/lib/node_modules/@openai/codex/package.json"
   ln -s ../lib/node_modules/@openai/codex/bin/codex.js "$dir/bin/codex"
   cat > "$dir/pi-session" <<'SH'
 #!/usr/bin/env bash

--- a/tests/fm-session-lock-ancestry.test.sh
+++ b/tests/fm-session-lock-ancestry.test.sh
@@ -357,24 +357,45 @@ test_e2e_daemon_parented_version_named_session_keeps_its_lock() {
 }
 
 # Pin the native bridge without accepting a generic Codex session, a wrapper,
-# a non-harness gap, or a lookalike Pi process as the owning session.
+# a non-harness gap, a lookalike Pi process, or any node process other than the
+# installed npm launcher running the same transport command, one hop deep.
 test_pi_native_owner() {
-  local dir fakebin shape got expected
+  local dir fakebin shape got expected pids
   dir="$TMP_ROOT/pi-native"
   fakebin=$(fm_fakebin "$dir")
-  mkdir -p "$dir/state"
+  mkdir -p "$dir/state" "$dir/bin" "$dir/lib/node_modules/@openai/codex/bin"
+  : > "$dir/lib/node_modules/@openai/codex/bin/codex.js"
+  : > "$dir/other.js"
+  ln -s ../lib/node_modules/@openai/codex/bin/codex.js "$dir/bin/codex"
   cat > "$fakebin/ps" <<'SH'
 #!/usr/bin/env bash
 field=$2 pid=$4
+vendor=/opt/homebrew/lib/node_modules/@openai/codex/node_modules/@openai/codex-darwin-arm64/vendor/aarch64-apple-darwin/bin/codex
+case "$FM_TEST_NATIVE_SHAPE" in npm*) via_launcher=1 ;; *) via_launcher=0 ;; esac
 case "$pid:$field" in
-  700:comm=) echo /Applications/ChatGPT.app/Contents/Resources/codex ;;
+  700:comm=)
+    if [ "$via_launcher" = 1 ]; then echo "$vendor"; else echo /Applications/ChatGPT.app/Contents/Resources/codex; fi ;;
   700:args=)
-    if [ "$FM_TEST_NATIVE_SHAPE" = interactive ]; then echo 'codex exec task';
-    else echo '/Applications/ChatGPT.app/Contents/Resources/codex -c features.code_mode_host=true app-server --stdio'; fi ;;
-  700:ppid=) echo 800 ;;
+    case "$FM_TEST_NATIVE_SHAPE" in
+      interactive) echo 'codex exec task' ;;
+      npm*) echo "$vendor app-server --stdio" ;;
+      *) echo '/Applications/ChatGPT.app/Contents/Resources/codex -c features.code_mode_host=true app-server --stdio' ;;
+    esac ;;
+  700:ppid=) if [ "$via_launcher" = 1 ]; then echo 750; else echo 800; fi ;;
+  750:comm=) echo node ;;
+  750:args=)
+    case "$FM_TEST_NATIVE_SHAPE" in
+      npm-other-script) echo "node $FM_TEST_NATIVE_DIR/other.js app-server --stdio" ;;
+      npm-other-command) echo "node $FM_TEST_NATIVE_DIR/bin/codex exec task" ;;
+      *) echo "node $FM_TEST_NATIVE_DIR/bin/codex app-server --stdio" ;;
+    esac ;;
+  750:ppid=) if [ "$FM_TEST_NATIVE_SHAPE" = npm-double ]; then echo 760; else echo 800; fi ;;
+  760:comm=) echo node ;;
+  760:args=) echo "node $FM_TEST_NATIVE_DIR/bin/codex app-server --stdio" ;;
+  760:ppid=) echo 800 ;;
   800:comm=|800:args=)
     case "$FM_TEST_NATIVE_SHAPE" in
-      gap) echo bash ;; lookalike) echo pi-helper ;; signed) echo pi-signed ;; *) echo pi ;;
+      gap|npm-gap) echo bash ;; lookalike) echo pi-helper ;; signed) echo pi-signed ;; *) echo pi ;;
     esac ;;
   800:ppid=) echo 900 ;;
   900:comm=|900:args=) echo pi-signed ;;
@@ -384,25 +405,72 @@ case "$pid:$field" in
 esac
 SH
   chmod +x "$fakebin/ps"
-  for shape in native signed interactive gap lookalike; do
+  export FM_TEST_NATIVE_DIR="$dir"
+  for shape in native signed interactive gap lookalike npm npm-other-script npm-other-command npm-gap npm-double; do
     expected=700
-    case "$shape" in native|signed) expected=800 ;; esac
+    case "$shape" in native|signed|npm) expected=800 ;; esac
     got=$(FM_TEST_NATIVE_SHAPE="$shape" lib_eval "$fakebin" 'fm_harness_ancestry_pid') || fail "$shape: no owner"
     [ "$got" = "$expected" ] || fail "$shape: owner $got, expected $expected"
+    pids=$(FM_TEST_NATIVE_SHAPE="$shape" lib_eval "$fakebin" 'fm_harness_ancestry_pids')
+    [ "$pids" = "$expected" ] || fail "$shape: ownership set '$pids', expected only $expected"
     printf '%s\n' "$expected" > "$dir/state/.lock"
     FM_TEST_NATIVE_SHAPE="$shape" FM_NATIVE_STATE="$dir/state" lib_eval "$fakebin" 'fm_session_lock_owned_by_self "$FM_NATIVE_STATE"' || fail "$shape: shell rejected canonical owner"
-    printf '900\n' > "$dir/state/.lock"
-    if FM_TEST_NATIVE_SHAPE="$shape" FM_NATIVE_STATE="$dir/state" lib_eval "$fakebin" 'fm_session_lock_owned_by_self "$FM_NATIVE_STATE"'; then
-      fail "$shape: accepted outer wrapper or foreign session"
-    fi
+    for foreign in 750 900; do
+      printf '%s\n' "$foreign" > "$dir/state/.lock"
+      if FM_TEST_NATIVE_SHAPE="$shape" FM_NATIVE_STATE="$dir/state" lib_eval "$fakebin" 'fm_session_lock_owned_by_self "$FM_NATIVE_STATE"'; then
+        fail "$shape: accepted launcher, outer wrapper, or foreign session $foreign"
+      fi
+    done
   done
-  pass "Pi native owner: direct app-server bridge only; shell membership agrees"
+  unset FM_TEST_NATIVE_DIR
+  pass "Pi native owner: direct or one-hop npm-launched app-server bridge only; shell membership agrees"
+}
+
+# A Claude session running inside a native Codex child of Pi is reached first,
+# so it stays its own session: the bridge never promotes the enclosing Pi into
+# a Claude ancestry, and the Claude selection is what it was before the bridge.
+test_claude_inside_native_codex_keeps_its_own_session() {
+  local dir fakebin pids got
+  dir="$TMP_ROOT/claude-in-native"
+  fakebin=$(fm_fakebin "$dir")
+  mkdir -p "$dir/state"
+  cat > "$fakebin/ps" <<'SH'
+#!/usr/bin/env bash
+field=$2 pid=$4
+case "$pid:$field" in
+  600:comm=|600:args=) echo claude ;;
+  600:ppid=) echo 700 ;;
+  700:comm=) echo /Applications/ChatGPT.app/Contents/Resources/codex ;;
+  700:args=) echo '/Applications/ChatGPT.app/Contents/Resources/codex -c features.code_mode_host=true app-server --stdio' ;;
+  700:ppid=) echo 800 ;;
+  800:comm=|800:args=) echo pi ;;
+  800:ppid=) echo 900 ;;
+  900:comm=|900:args=) echo pi-signed ;;
+  900:ppid=) echo 1 ;;
+  *:comm=|*:args=) echo bash ;;
+  *:ppid=) echo 600 ;;
+esac
+SH
+  chmod +x "$fakebin/ps"
+  pids=$(lib_eval "$fakebin" 'fm_harness_ancestry_pids' | tr '\n' ' ')
+  [ "$pids" = "600 700 " ] || fail "Claude inside native Codex: ownership set '$pids', expected '600 700 '"
+  got=$(lib_eval "$fakebin" 'fm_harness_ancestry_pid') || fail "Claude inside native Codex: no owner"
+  [ "$got" = 700 ] || fail "Claude inside native Codex: lock owner $got, expected the outermost Claude-run pid 700"
+  for own in 600 700; do
+    printf '%s\n' "$own" > "$dir/state/.lock"
+    FM_NATIVE_STATE="$dir/state" lib_eval "$fakebin" 'fm_session_lock_owned_by_self "$FM_NATIVE_STATE"' || fail "Claude inside native Codex: rejected its own ancestry pid $own"
+  done
+  printf '800\n' > "$dir/state/.lock"
+  if FM_NATIVE_STATE="$dir/state" lib_eval "$fakebin" 'fm_session_lock_owned_by_self "$FM_NATIVE_STATE"'; then
+    fail "Claude inside native Codex: the enclosing Pi entered the Claude session's ownership set"
+  fi
+  pass "a Claude session inside Pi's native Codex child stays separate from the enclosing Pi"
 }
 
 test_pi_native_real_processes() {
   local dir out
   dir="$TMP_ROOT/pi-native-processes"
-  mkdir -p "$dir/state"
+  mkdir -p "$dir/state" "$dir/bin" "$dir/lib/node_modules/@openai/codex/bin"
   ln -s /bin/bash "$dir/pi"
   ln -s /bin/bash "$dir/codex"
   cat > "$dir/app-server" <<'SH'
@@ -410,23 +478,42 @@ test_pi_native_real_processes() {
 "$FM_NATIVE_ROOT/bin/fm-lock.sh" || exit
 . "$FM_NATIVE_ROOT/bin/fm-session-lock-lib.sh"
 fm_session_lock_owned_by_self "$FM_HOME/state" || exit
-[ "$(cat "$FM_HOME/state/.lock")" = "$PPID" ] || exit 1
+[ "$(cat "$FM_HOME/state/.lock")" = "$FM_TEST_PI_PID" ] || exit 1
 printf '%s\n' "$$" >> "$FM_HOME/state/children"
 SH
+  # The installed npm launcher's shape: a node script reached through a bin
+  # symlink that spawns the vendor binary with its own arguments and stays its
+  # parent.
+  cat > "$dir/lib/node_modules/@openai/codex/bin/codex.js" <<'JS'
+#!/usr/bin/env node
+import { spawn } from "node:child_process";
+const child = spawn(process.env.FM_TEST_VENDOR_CODEX, process.argv.slice(2), { stdio: "inherit" });
+child.on("exit", (code, signal) => process.exit(signal ? 1 : code));
+JS
+  chmod +x "$dir/lib/node_modules/@openai/codex/bin/codex.js"
+  ln -s ../lib/node_modules/@openai/codex/bin/codex.js "$dir/bin/codex"
   cat > "$dir/pi-session" <<'SH'
 #!/usr/bin/env bash
 cd "$FM_HOME" || exit 1
+export FM_TEST_PI_PID=$$ FM_TEST_VENDOR_CODEX="$FM_HOME/codex"
 ./codex app-server --stdio || exit
 ./codex app-server --stdio || exit
+expected=2
+if command -v node >/dev/null 2>&1; then
+  "$FM_HOME/bin/codex" app-server --stdio || exit
+  "$FM_HOME/bin/codex" app-server --stdio || exit
+  expected=4
+fi
 [ "$(cat state/.lock)" = "$$" ] || exit 1
-[ "$(sort -u state/children | wc -l | tr -d ' ')" = 2 ] || exit 1
+[ "$(sort -u state/children | wc -l | tr -d ' ')" = "$expected" ] || exit 1
 SH
   out=$(FM_HOME="$dir" FM_STATE_OVERRIDE="$dir/state" FM_NATIVE_ROOT="$ROOT" "$dir/pi" "$dir/pi-session" 2>&1) || fail "real Pi/native tree: $out"
-  pass "real Pi/native tree: lock acquisition and shell checks survive child replacement"
+  pass "real Pi/native tree: lock acquisition and shell checks survive child replacement, direct and npm-launched"
 }
 
 test_pi_native_real_processes
 test_pi_native_owner
+test_claude_inside_native_codex_keeps_its_own_session
 test_version_named_session_is_identified_on_both_platforms
 test_ordinary_paths_are_never_harness_processes
 test_harness_beyond_a_gap_never_owns_the_lock

--- a/tests/fm-session-lock-ancestry.test.sh
+++ b/tests/fm-session-lock-ancestry.test.sh
@@ -356,6 +356,77 @@ test_e2e_daemon_parented_version_named_session_keeps_its_lock() {
   pass "session-lock e2e: a version-named session under a harness-named daemon keeps its own lock"
 }
 
+# Pin the native bridge without accepting a generic Codex session, a wrapper,
+# a non-harness gap, or a lookalike Pi process as the owning session.
+test_pi_native_owner() {
+  local dir fakebin shape got expected
+  dir="$TMP_ROOT/pi-native"
+  fakebin=$(fm_fakebin "$dir")
+  mkdir -p "$dir/state"
+  cat > "$fakebin/ps" <<'SH'
+#!/usr/bin/env bash
+field=$2 pid=$4
+case "$pid:$field" in
+  700:comm=) echo /Applications/ChatGPT.app/Contents/Resources/codex ;;
+  700:args=)
+    if [ "$FM_TEST_NATIVE_SHAPE" = interactive ]; then echo 'codex exec task';
+    else echo '/Applications/ChatGPT.app/Contents/Resources/codex -c features.code_mode_host=true app-server --stdio'; fi ;;
+  700:ppid=) echo 800 ;;
+  800:comm=|800:args=)
+    case "$FM_TEST_NATIVE_SHAPE" in
+      gap) echo bash ;; lookalike) echo pi-helper ;; signed) echo pi-signed ;; *) echo pi ;;
+    esac ;;
+  800:ppid=) echo 900 ;;
+  900:comm=|900:args=) echo pi-signed ;;
+  900:ppid=) echo 1 ;;
+  *:comm=|*:args=) echo bash ;;
+  *:ppid=) echo 700 ;;
+esac
+SH
+  chmod +x "$fakebin/ps"
+  for shape in native signed interactive gap lookalike; do
+    expected=700
+    case "$shape" in native|signed) expected=800 ;; esac
+    got=$(FM_TEST_NATIVE_SHAPE="$shape" lib_eval "$fakebin" 'fm_harness_ancestry_pid') || fail "$shape: no owner"
+    [ "$got" = "$expected" ] || fail "$shape: owner $got, expected $expected"
+    printf '%s\n' "$expected" > "$dir/state/.lock"
+    FM_TEST_NATIVE_SHAPE="$shape" FM_NATIVE_STATE="$dir/state" lib_eval "$fakebin" 'fm_session_lock_owned_by_self "$FM_NATIVE_STATE"' || fail "$shape: shell rejected canonical owner"
+    printf '900\n' > "$dir/state/.lock"
+    if FM_TEST_NATIVE_SHAPE="$shape" FM_NATIVE_STATE="$dir/state" lib_eval "$fakebin" 'fm_session_lock_owned_by_self "$FM_NATIVE_STATE"'; then
+      fail "$shape: accepted outer wrapper or foreign session"
+    fi
+  done
+  pass "Pi native owner: direct app-server bridge only; shell membership agrees"
+}
+
+test_pi_native_real_processes() {
+  local dir out
+  dir="$TMP_ROOT/pi-native-processes"
+  mkdir -p "$dir/state"
+  ln -s /bin/bash "$dir/pi"
+  ln -s /bin/bash "$dir/codex"
+  cat > "$dir/app-server" <<'SH'
+#!/usr/bin/env bash
+"$FM_NATIVE_ROOT/bin/fm-lock.sh" || exit
+. "$FM_NATIVE_ROOT/bin/fm-session-lock-lib.sh"
+fm_session_lock_owned_by_self "$FM_HOME/state" || exit
+[ "$(cat "$FM_HOME/state/.lock")" = "$PPID" ] || exit 1
+printf '%s\n' "$$" >> "$FM_HOME/state/children"
+SH
+  cat > "$dir/pi-session" <<'SH'
+#!/usr/bin/env bash
+cd "$FM_HOME" || exit 1
+./codex app-server --stdio || exit
+./codex app-server --stdio || exit
+[ "$(cat state/.lock)" = "$$" ] || exit 1
+[ "$(sort -u state/children | wc -l | tr -d ' ')" = 2 ] || exit 1
+SH
+  out=$(FM_HOME="$dir" FM_STATE_OVERRIDE="$dir/state" FM_NATIVE_ROOT="$ROOT" "$dir/pi" "$dir/pi-session" 2>&1) || fail "real Pi/native tree: $out"
+  pass "real Pi/native tree: lock acquisition and shell checks survive child replacement"
+}
+
+test_pi_native_real_processes
+test_pi_native_owner
 test_version_named_session_is_identified_on_both_platforms
 test_ordinary_paths_are_never_harness_processes
 test_harness_beyond_a_gap_never_owns_the_lock


### PR DESCRIPTION
## Intent

Fix issue #4084: one live Pi session running the native Codex transport resolves two different session owners.

Pi's native Codex transport launches shell tools below its `codex app-server --stdio` process. The shell-side session-owner resolver walks up its parent processes, stops at that Codex child because `codex` is a known tool name, and names it the session owner, while Pi's watcher, turn-end guard and supervision-branch extensions identify the session as the Pi engine's own process. Main promises one session owner per home, but for one live Pi session the code resolves two. That session can therefore acquire a session lock its own watcher rejects as another live session, or refuse a lock already held by its own Pi engine. Both processes are alive at once, so this is not a stale-lock case.

The shared shell resolver maps the exact `codex [-c key=value ...] app-server --stdio` transport, including the installed npm launcher's single Node hop, to its direct Pi parent, and anything else keeps its own identity. The three Pi extensions drop their ancestor walk, so ownership means only that the lock names their own process id.

## What Changed

- `bin/fm-session-lock-lib.sh` adds a Pi/native bridge to the shared session-owner resolver: when the innermost harness match is exactly `codex [-c key=value ...] app-server --stdio` whose parent is `pi`/`pi-signed` — directly, or through one hop of the installed npm launcher (`node .../@openai/codex/bin/codex.js <same command>`, matched on its symlink-resolved script path) — `fm_harness_ancestry_pids` reports the Pi engine pid instead of the Codex child. Interactive/exec Codex sessions, other node scripts, wrappers, gaps, a second hop, and a Claude session nested inside the native child keep their existing identity.
- The three Pi extensions (`fm-primary-pi-watch.ts`, `fm-primary-turnend-guard.ts`, `fm-branch-supervision.ts`) drop their 8-hop `ps` ancestor walk: a lock is `owned` only when it names the extension's own `process.pid`, so a launcher or enclosing session holding the lock now reads as another session. The branch extension's async `lockOwnership()` becomes a thin wrapper over the single synchronous lock read, and the now-unused `parentPid` helpers and `spawnSync` import are removed.
- Tests and docs follow the new boundary: `tests/fm-session-lock-ancestry.test.sh` adds bridge cases (direct and one-hop npm launcher, rejection shapes, real-process child replacement, Claude-inside-native-Codex separation) alongside main's newer cases; `tests/fm-pi-codex-native.test.sh` now runs full startup plus shell ownership checks through real Codex `command/exec`, replaces the native child under the same Pi process, probes the npm launcher when installed, and records the Codex versions exercised; the watch and branch extension tests assert a lock held by an enclosing or sibling live process is rejected. `docs/pi-supervision-branch.md` and `docs/verification/runtime-backends.md` describe exact-pid ownership and the updated guard.

## Risk Assessment

✅ Low: The refresh is hunk-for-hunk identical to the original PR #4082 commits (range-diff shows only shifted context, and the conflicted test file is purely additive at +159/-0), the resolver returns the Pi pid when traced against a real live Pi native Codex tree, every rejected shape falls back to the pre-fix identity rather than mis-attributing ownership, and no sibling path on current main reintroduces the two-owner split.

## Testing

<code>Ran the four test files this change touches on the target commit: the session-lock ancestry suite, the Pi watch-extension suite, the Pi branch-extension suite, and the live native Codex guard against the real Pi runtime, the real ChatGPT.app Codex binary, and the real npm Codex launcher; all passed. Proved the regression both ways by re-running the new ancestry tests and the live guard against a temp tree identical to the target except for the base `bin/fm-session-lock-lib.sh`: both fail there, with real Codex startup taking the lock under the Codex child pid and reporting the primary harness as `codex`. Wrote a real-process reproduction (node exec&#39;d as `pi` loading the real watcher extension -&gt; live `codex app-server --stdio` child -&gt; shell tool running the real `fm-lock.sh`) and captured a before/after transcript showing two owners on base and one owner on the target, for both failure modes named in the intent. Because upstream main moved one commit past the base mid-run and touched four overlapping files, also applied the change onto that newest main in an ephemeral clone: no conflicts, and the ancestry and branch-extension suites pass there. No screenshot or rendered artifact applies: this is a shell/process-identity change with no UI surface, so CLI transcripts are the end-user evidence. All temp trees were removed and the worktree is clean.</code>

<details>
<summary>Evidence: Before/after transcript: one live Pi session asked from both sides who owns it (real processes, real fm-lock.sh, real watcher extension)</summary>

Source: [Before/after transcript: one live Pi session asked from both sides who owns it (real processes, real fm-lock.sh, real watcher extension)](https://github.com/3264studios/firstmate/blob/5bcc90ba9475ab34aaf6a34a84bf08fb9ceb91a9/.no-mistakes/evidence/fix/pi-native-session-owner/two-owner-before-after.txt)

<code>BEFORE - base c443d8c (current main)&#10;Scenario 1 - shell tool acquires the lock, then Pi&#39;s watcher is asked to arm&#10;Pi engine pid (what Pi&#39;s extensions call the owner): 91222&#10;codex transport child pid : 91223 [./codex app-server --stdio]&#10;shell resolver names the session owner : 91223&#10;bin/fm-lock.sh (acquire) : exit 0 - lock acquired: harness pid 91223&#10;Pi watcher extension (real), asked to arm : ok=false - watcher: read-only - session lock is held by another firstmate session&#10;Scenario 2 - the Pi engine already holds the lock; a shell tool below a NEW transport child checks in&#10;state/.lock pre-set to the Pi engine pid : 91222&#10;shell resolver names the session owner : 91555&#10;bin/fm-lock.sh (acquire) : exit 1 - error: another live firstmate session holds the lock (pid 91222); operate read-only until resolved&#10;&#10;AFTER - target dcbddce (fix/pi-native-session-owner)&#10;Scenario 1&#10;Pi engine pid (what Pi&#39;s extensions call the owner): 91783&#10;codex transport child pid : 91784 [./codex app-server --stdio]&#10;shell resolver names the session owner : 91783&#10;bin/fm-lock.sh (acquire) : exit 0 - lock acquired: harness pid 91783&#10;Pi watcher extension (real), asked to arm : ok=true - watcher: started Pi extension arm child 1; ...&#10;Scenario 2&#10;state/.lock pre-set to the Pi engine pid : 91783&#10;shell resolver names the session owner : 91783 (new transport child pid 92062)&#10;bin/fm-lock.sh (acquire) : exit 0 - lock acquired: harness pid 91783</code>

```text
# Issue #4084 reproduced with real processes: one live Pi session, asked from both sides who owns it.
# Script: two-owner-repro.sh (same directory). Tree: pi (node exec'd as 'pi', real watcher extension)
#   -> codex app-server --stdio (live transport child) -> bash shell tool (real bin/fm-lock.sh + resolver).

################ BEFORE ################
firstmate tree : /var/folders/b_/gcsh88fj13qf8fwdsns47b9c0000gn/T/fm-base-main.ADVH5l
tree is        : BEFORE - base commit c443d8c (current main), unmodified

Scenario 1 - fresh home: the session's shell tool acquires the lock, then Pi's watcher is asked to arm
  Pi engine pid (what Pi's extensions call the owner): 91222
  codex transport child pid                     : 91223   [./codex app-server --stdio]
  shell resolver names the session owner        : 91223
  bin/fm-lock.sh (acquire)                      : exit 0 - lock acquired: harness pid 91223
  shell: is state/.lock owned by this session?  : yes
  state/.lock now names                         : 91223
  Pi watcher extension (real), asked to arm     : ok=false - watcher: read-only - session lock is held by another firstmate session

Scenario 2 - the Pi engine already holds the lock; a shell tool below a NEW transport child checks in
  state/.lock pre-set to the Pi engine pid      : 91222
  codex transport child pid                     : 91555   [./codex app-server --stdio]
  shell resolver names the session owner        : 91555
  bin/fm-lock.sh (acquire)                      : exit 1 - error: another live firstmate session holds the lock (pid 91222); operate read-only until resolved
  shell: is state/.lock owned by this session?  : NO
  state/.lock afterwards names                  : 91222

################ AFTER #################
firstmate tree : ~/.no-mistakes/worktrees/9b0bfac143a1/01M30F91C1RCST5XSYRPAQN3A8
tree is        : AFTER - target commit dcbddce (fix/pi-native-session-owner)

Scenario 1 - fresh home: the session's shell tool acquires the lock, then Pi's watcher is asked to arm
  Pi engine pid (what Pi's extensions call the owner): 91783
  codex transport child pid                     : 91784   [./codex app-server --stdio]
  shell resolver names the session owner        : 91783
  bin/fm-lock.sh (acquire)                      : exit 0 - lock acquired: harness pid 91783
  shell: is state/.lock owned by this session?  : yes
  state/.lock now names                         : 91783
  Pi watcher extension (real), asked to arm     : ok=true - watcher: started Pi extension arm child 1; future ordinary re-arms are automatic; call fm_watch_arm_pi again only after a later notification says the cycle is missing, failed, or unhealthy

Scenario 2 - the Pi engine already holds the lock; a shell tool below a NEW transport child checks in
  state/.lock pre-set to the Pi engine pid      : 91783
  codex transport child pid                     : 92062   [./codex app-server --stdio]
  shell resolver names the session owner        : 91783
  bin/fm-lock.sh (acquire)                      : exit 0 - lock acquired: harness pid 91783
  shell: is state/.lock owned by this session?  : yes
  state/.lock afterwards names                  : 91783
```
</details>
<details>
<summary>Evidence: Reproduction script used for the before/after transcript</summary>

Source: [Reproduction script used for the before/after transcript](https://github.com/3264studios/firstmate/blob/5bcc90ba9475ab34aaf6a34a84bf08fb9ceb91a9/.no-mistakes/evidence/fix/pi-native-session-owner/two-owner-repro.sh)

```text
#!/usr/bin/env bash
# Reproduces issue #4084 with REAL processes against a given firstmate tree.
#
#   two-owner-repro.sh <firstmate-root>
#
# Process tree it builds (every box is a live OS process; nothing mocks `ps`):
#
#   pi                          <- node, exec'd under the name `pi`; loads the tree's REAL
#   |                              .pi/extensions/fm-primary-pi-watch.ts and asks it to arm
#   +- codex app-server --stdio <- Pi's native Codex transport child (stays alive on stdin)
#      +- bash shell-tool.sh    <- a shell tool launched below the transport; runs the tree's
#                                  REAL bin/fm-lock.sh and bin/fm-session-lock-lib.sh
#
# It prints who each side of that ONE live session says the session owner is.
set -u
root=$(cd "$1" && pwd)
work=$(mktemp -d "${TMPDIR:-/tmp}/fm-two-owner.XXXXXX")
trap 'rm -rf "$work"' EXIT
home="$work/home" repo="$work/repo"
mkdir -p "$home/state" "$home/config" "$repo/bin" "$repo/.pi/extensions/lib" \
  "$repo/node_modules/@earendil-works/pi-coding-agent" "$repo/node_modules/@earendil-works/pi-tui" "$repo/node_modules/typebox"

# The tree's real Pi watcher extension, with the same import stubs its own test suite uses.
cp "$root/.pi/extensions/fm-primary-pi-watch.ts" "$repo/.pi/extensions/"
cp "$root"/.pi/extensions/lib/*.ts "$repo/.pi/extensions/lib/"
cp "$root/bin/fm-operational-input.sh" "$repo/bin/"
printf '#!/usr/bin/env bash\nprintf "arm\\n" >> "$FM_ARM_LOG"\n' > "$repo/bin/fm-watch-arm.sh"
chmod +x "$repo/bin/fm-watch-arm.sh"
printf '{"name":"@earendil-works/pi-coding-agent","type":"module","exports":"./index.js"}\n' > "$repo/node_modules/@earendil-works/pi-coding-agent/package.json"
printf 'export function getMarkdownTheme() { return {}; }\nexport class UserMessageComponent { render() { return []; } invalidate() {} }\n' > "$repo/node_modules/@earendil-works/pi-coding-agent/index.js"
printf '{"name":"@earendil-works/pi-tui","type":"module","exports":"./index.js"}\n' > "$repo/node_modules/@earendil-works/pi-tui/package.json"
printf 'export class Box { addChild() {} clear() {} setBgFn() {} }\nexport class Container {}\nexport class Text {}\n' > "$repo/node_modules/@earendil-works/pi-tui/index.js"
printf '{"name":"typebox","type":"module","exports":"./index.js"}\n' > "$repo/node_modules/typebox/package.json"
printf 'export const Type = { Object(properties) { return { type: "object", properties, additionalProperties: false }; } };\n' > "$repo/node_modules/typebox/index.js"

ln -s "$(command -v node)" "$work/pi"   # the Pi engine
ln -s /bin/bash "$work/codex"           # its native transport child

# The shell tool: what a Pi-native-Codex session's bash tool does at session start.
cat > "$work/shell-tool.sh" <<'SH'
. "$FM_NATIVE_ROOT/bin/fm-session-lock-lib.sh"
printf '  %-46s: %s\n' "shell resolver names the session owner" "$(fm_harness_ancestry_pid)"
out=$("$FM_NATIVE_ROOT/bin/fm-lock.sh" 2>&1); code=$?
printf '  %-46s: exit %s - %s\n' "bin/fm-lock.sh (acquire)" "$code" "$out"
if fm_session_lock_owned_by_self "$FM_HOME/state"; then v=yes; else v=NO; fi
printf '  %-46s: %s\n' "shell: is state/.lock owned by this session?" "$v"
SH
# `./codex app-server --stdio`: run one shell tool, then stay alive like the real transport.
cat > "$work/app-server" <<'SH'
printf '  %-46s: %s   [%s]\n' "codex transport child pid" "$$" "$(ps -o args= -p $$)"
/bin/bash "$FM_HOME/../shell-tool.sh"
echo TOOL_DONE
read -r _
SH

cat > "$work/pi-engine.mjs" <<'JS'
import { spawn } from "node:child_process";
import { existsSync, readFileSync, rmSync, writeFileSync } from "node:fs";
import { pathToFileURL } from "node:url";
const work = process.env.FM_WORK, lock = `${process.env.FM_HOME}/state/.lock`;
const say = (k, v) => console.log(`  ${k.padEnd(46)}: ${v}`);
let tool = null;
const pi = { on() {}, registerCommand() {}, registerTool(c) { if (c.name === "fm_watch_arm_pi") tool = c; }, sendUserMessage: async () => {} };
(await import(pathToFileURL(process.env.PLUGIN).href)).default(pi);

// One live native transport child; resolves once its shell tool finished, child still alive.
function transport() {
  const { FM_ROOT_OVERRIDE, PLUGIN, ...env } = process.env;
  const child = spawn("./codex", ["app-server", "--stdio"], { cwd: work, env, stdio: ["pipe", "pipe", "inherit"] });
  return new Promise((resolve) => {
    let buf = "";
    child.stdout.on("data", (d) => {
      buf += d;
      let i;
      while ((i = buf.indexOf("\n")) >= 0) {
        const line = buf.slice(0, i); buf = buf.slice(i + 1);
        if (line === "TOOL_DONE") resolve(child); else console.log(line);
      }
    });
  });
}
const stop = (child) => new Promise((r) => { child.on("exit", r); child.stdin.end(); });

console.log(`\nScenario 1 - fresh home: the session's shell tool acquires the lock, then Pi's watcher is asked to arm`);
say("Pi engine pid (what Pi's extensions call the owner)", process.pid);
let child = await transport();
say("state/.lock now names", readFileSync(lock, "utf8").trim());
let arm = await tool.execute("repro", {}, undefined, undefined, {});
say("Pi watcher extension (real), asked to arm", `ok=${arm.details?.ok} - ${arm.details?.message}`);
await stop(child);

console.log(`\nScenario 2 - the Pi engine already holds the lock; a shell tool below a NEW transport child checks in`);
rmSync(`${process.env.FM_HOME}/state/.lock-session`, { force: true });
writeFileSync(lock, `${process.pid}\n`);
say("state/.lock pre-set to the Pi engine pid", process.pid);
child = await transport();
say("state/.lock afterwards names", readFileSync(lock, "utf8").trim());
await stop(child);
process.exit(0);
JS

echo "firstmate tree : $root"
echo "tree is        : ${FM_REPRO_LABEL:-unlabelled}"
FM_WORK="$work" FM_HOME="$home" FM_STATE_OVERRIDE="$home/state" FM_NATIVE_ROOT="$root" FM_ROOT_OVERRIDE="$repo" \
  FM_ARM_LOG="$work/arm.log" PLUGIN="$repo/.pi/extensions/fm-primary-pi-watch.ts" NODE_NO_WARNINGS=1 \
  FM_GATE_REFUSE_BYPASS=1 "$work/pi" "$work/pi-engine.mjs"
```
</details>
<details>
<summary>Evidence: Live guard AFTER fix: real Pi + real ChatGPT.app Codex + real npm Codex launcher -&gt; PASS</summary>

Source: [Live guard AFTER fix: real Pi + real ChatGPT.app Codex + real npm Codex launcher -&gt; PASS](https://github.com/3264studios/firstmate/blob/5bcc90ba9475ab34aaf6a34a84bf08fb9ceb91a9/.no-mistakes/evidence/fix/pi-native-session-owner/live-native-guard-after-fix.log)

<code>Native Codex guard: Pi 0.85.1, pi-codex-native 0.2.1, Codex {&#34;/Applications/ChatGPT.app/Contents/Resources/codex&#34;:&#34;codex-cli 0.153.4&#34;,&#34;/opt/homebrew/bin/codex&#34;:&#34;codex-cli 0.151.0&#34;}&#10;&#34;result&#34;: &#34;PASS&#34;&#10;checks include:&#10;&#34;full startup through real Codex command/exec and shell ownership&#34;&#10;&#34;native child replacement preserves Pi owner&#34;&#10;&#34;installed npm Codex launcher resolves to the same Pi owner&#34;&#10;exit=0</code>

```text
Native Codex guard: Pi 0.85.1, pi-codex-native 0.2.1, Codex {"/Applications/ChatGPT.app/Contents/Resources/codex":"codex-cli 0.153.4","/opt/homebrew/bin/codex":"codex-cli 0.151.0"}
{
  "result": "PASS",
  "piVersion": "0.85.1",
  "adapterVersion": "0.2.1",
  "codexVersions": {
    "/Applications/ChatGPT.app/Contents/Resources/codex": "codex-cli 0.153.4",
    "/opt/homebrew/bin/codex": "codex-cli 0.151.0"
  },
  "checks": [
    "actual Pi runtime and native package",
    "full startup through real Codex command/exec and shell ownership",
    "native child replacement preserves Pi owner",
    "installed npm Codex launcher resolves to the same Pi owner",
    "native Ultra preserved across operational turns and restart",
    "installed native adapter emits observable output progress",
    "actual FirstMate primary extensions",
    "startup operational message forwarded",
    "MCP watcher control",
    "idle watcher notification opens native turn",
    "durable completion visible/read/ack once",
    "duplicate acknowledgement refused",
    "restart does not reprocess acknowledged outcome"
  ],
  "limits": [
    "model turns and watcher-close process use deterministic peers; no live model or backend tested"
  ]
}
exit=0
```
</details>
<details>
<summary>Evidence: Live guard BEFORE fix (target tests + base resolver): fails at the real ownership probe</summary>

Source: [Live guard BEFORE fix (target tests + base resolver): fails at the real ownership probe](https://github.com/3264studios/firstmate/blob/5bcc90ba9475ab34aaf6a34a84bf08fb9ceb91a9/.no-mistakes/evidence/fix/pi-native-session-owner/live-native-guard-before-fix.log)

<code>Native Codex guard failed against Pi 0.85.1, pi-codex-native 0.2.1&#10;AssertionError [ERR_ASSERTION]: real native ownership probe failed&#10;exit=1</code>

```text
Native Codex guard: Pi 0.85.1, pi-codex-native 0.2.1, Codex {"/Applications/ChatGPT.app/Contents/Resources/codex":"codex-cli 0.153.4","/opt/homebrew/bin/codex":"codex-cli 0.151.0"}
Native Codex guard failed against Pi 0.85.1, pi-codex-native 0.2.1
Native FirstMate test fixture: /var/folders/b_/gcsh88fj13qf8fwdsns47b9c0000gn/T/fm-native-primary.cIvF7e
node:internal/modules/run_main:107
    triggerUncaughtException(
    ^

AssertionError [ERR_ASSERTION]: real native ownership probe failed: 
    at file:///private/var/folders/b_/gcsh88fj13qf8fwdsns47b9c0000gn/T/fm-before-fix.E5hfHu/[eval1]:268:3 {
  generatedMessage: false,
  code: 'ERR_ASSERTION',
  actual: false,
  expected: true,
  operator: '==',
  diff: 'simple'
}

Node.js v25.6.0
exit=1
```
</details>
<details>
<summary>Evidence: Fixture state left by the BEFORE-fix live run: real Codex startup took the lock as the Codex child and identified the harness as codex</summary>

Source: [Fixture state left by the BEFORE-fix live run: real Codex startup took the lock as the Codex child and identified the harness as codex](https://github.com/3264studios/firstmate/blob/5bcc90ba9475ab34aaf6a34a84bf08fb9ceb91a9/.no-mistakes/evidence/fix/pi-native-session-owner/live-native-guard-before-fix-state.txt)

<code>state/.lock: 42279&#10;LOCK&#10;lock acquired: harness pid 42279&#10;SUPERVISION OPERATING INSTRUCTIONS - primary harness: codex</code>

```text
# Fixture state left by the BEFORE-fix live guard run (target tests + base bin/fm-session-lock-lib.sh)
# state/.lock:
42279
# state/native-startup.out (LOCK section + harness line):

================================================================================
SESSION START - /var/folders/b_/gcsh88fj13qf8fwdsns47b9c0000gn/T/fm-native-primary.cIvF7e/home
================================================================================

LOCK
--------------------------------------------------------------------------------
lock acquired: harness pid 42279

18:SUPERVISION OPERATING INSTRUCTIONS - primary harness: codex
```
</details>
<details>
<summary>Evidence: New ancestry tests against the base resolver: regression reproduces (fails before the fix)</summary>

Source: [New ancestry tests against the base resolver: regression reproduces (fails before the fix)](https://github.com/3264studios/firstmate/blob/5bcc90ba9475ab34aaf6a34a84bf08fb9ceb91a9/.no-mistakes/evidence/fix/pi-native-session-owner/before-fix-ancestry.log)

<code>not ok - real Pi/native tree: lock acquired: harness pid 90853&#10;exit=1</code>

```text
not ok - real Pi/native tree: lock acquired: harness pid 90853
exit=1
```
</details>
<details>
<summary>Evidence: Session-lock ancestry suite on target (fix&#39;s cases alongside main&#39;s newer ones)</summary>

Source: [Session-lock ancestry suite on target (fix&#39;s cases alongside main&#39;s newer ones)](https://github.com/3264studios/firstmate/blob/5bcc90ba9475ab34aaf6a34a84bf08fb9ceb91a9/.no-mistakes/evidence/fix/pi-native-session-owner/session-lock-ancestry.log)

```text
ok - real Pi/native tree: lock acquisition and shell checks survive child replacement, direct and npm-launched
ok - Pi native owner: direct or one-hop npm-launched app-server bridge only; shell membership agrees
ok - a Claude session inside Pi's native Codex child stays separate from the enclosing Pi
ok - session-lock: a version-named Claude Code session is identified from its install path and argv[0]
ok - session-lock: a harness that is pid 1 of its own namespace is examined, not skipped
ok - session-lock: ordinary script paths under a harness directory are not harness processes
ok - session-lock: ownership stops at the first non-harness gap above the contiguous run
ok - session-lock: a live version-named session holding the lock is not mistaken for a stale owner
ok - session-lock: a trusted same-session id keeps owning a recycled background chain, and nothing weaker does
ok - session-lock: a trusted id anchors the lock on the model-loop process, anything else on the outermost pid
ok - session-lock e2e: a version-named session claims the home and arms supervision
ok - session-lock e2e: a session parented by a harness-named daemon claims the home and arms supervision
ok - session-lock e2e: a version-named session under a harness-named daemon keeps its own lock
ok - session-lock e2e: a background session keeps its lock and its supervision across a recycled helper chain
ok - session-lock: a same-session confirmation waits for the claim lock and refreshes a re-keyed id
ok - session-lock: a waiting confirmation does not steal another session's lock
ok - session-lock: a failed lock write restores the previous sidecar
ok - session-lock: a failed lock write removes a newly created sidecar
ok - session-lock: a verified reclaim keeps the new sidecar beside the new pid
```
</details>
<details>
<summary>Evidence: Pi watch-extension suite on target</summary>

Source: [Pi watch-extension suite on target](https://github.com/3264studios/firstmate/blob/5bcc90ba9475ab34aaf6a34a84bf08fb9ceb91a9/.no-mistakes/evidence/fix/pi-native-session-owner/pi-watch-extension.log)

```text
ok - Pi extension reports external healthy watcher output
ok - Pi custom tool exposes repair-only metadata and returns automatic-continuation guidance
ok - Pi redundant tool call returns ownership guidance and spawns no second child
ok - Pi scheduled retry remains extension-owned after another tool call
ok - Pi actionable close starts one successor before wake delivery settles
ok - Pi dispatcher branch offer owns accepted wakes and falls back to main
ok - Pi dispatcher flags a fleet-wide heartbeat offer as branch-eligible
ok - a co-present check row neither vetoes nor rides a heartbeat into main
ok - every main-only check class still reaches main, never the supervision branch
ok - a captain-held signal trigger reaches main with routine rows present
ok - an unread pending-reply escalation keeps later stale aliases on main
ok - a mixed batch of two distinct files - one routine, one needs-decision - routes wholly to main
ok - a co-present needs-decision row neither vetoes nor rides a heartbeat into main
ok - heartbeat restoration failure stays on main
ok - watcher-failure repair stays with main even with a live, accepting branch listener
ok - under the away-posture record every actionable row is offered to the branch while broken-queue wakes and watcher-failure alarms still reach main
ok - Pi refused handling handshake is classified and not swallowed
ok - Pi hung successor falls back to one typed actionable wake
ok - Pi unretired successor falls back without an overlapping retry
ok - Pi late unretired closes resume classified supervision
ok - Pi clean empty close triggers a bounded continuity retry
ok - Pi established clean closes stop at the configured retry limit
ok - Pi close handler verifies session-lock ownership before successor launch
ok - Pi watcher arm distinguishes all session lock ownership states
ok - Pi session transitions auto-arm through a generation owner across /new /resume /fork/reload, stale callbacks, and quit
ok - Pi session replacement auto-arms and carries its in-flight actionable close
ok - Pi replacement replays a streaming follow-up before consumption
ok - Pi streaming-time wake delivery keeps the successor chain and replays only unconsumed wakes
ok - Pi retries a verified successor that failed during wake delivery once that delivery settles
ok - Pi replacement receives actionable closes after retirement timeout
ok - Pi replacement handoff tokens stay unique across fresh modules
ok - Pi replacement persistence failure still stops its arm child
ok - Pi process-exit cleanup listener remains singular across session replacement
ok - Pi process-exit cleanup stops the attached arm child
ok - OpenCode plugins have an explicit ESM boundary even under a typeless parent package
ok - OpenCode watcher plugin uses the effective FM_HOME state
ok - OpenCode watcher plugin sources the effective config
ok - OpenCode watcher plugin requires session lock ownership
ok - OpenCode watcher coordinator respects primary scope
ok - OpenCode watcher plugin starts one successor before wake prompt delivery settles
ok - OpenCode pre-ready actionable close preserves its successor
ok - OpenCode hung successor falls back to one typed actionable wake
ok - OpenCode unretired successor falls back without an overlapping retry
ok - OpenCode late unretired closes resume classified supervision
ok - OpenCode clean empty close triggers a bounded continuity retry
ok - OpenCode established clean closes stop at the configured retry limit
ok - OpenCode close handler verifies session-lock ownership before successor launch
ok - OpenCode watcher plugin coordinates with the turn-end guard
ok - OpenCode healthy arm output does not suppress the turn-end guard
exit=0
```
</details>
<details>
<summary>Evidence: Pi branch-extension suite on target</summary>

Source: [Pi branch-extension suite on target](https://github.com/3264studios/firstmate/blob/5bcc90ba9475ab34aaf6a34a84bf08fb9ceb91a9/.no-mistakes/evidence/fix/pi-native-session-owner/pi-branch-extension.log)

```text
ok - fm_branch_outcomes hides through ToolExecutionComponent while Calm-off and HTML export stay stock
ok - the installed Pi still bounds the picker's list and ranks its search
ok - branch owns accepted wakes with a stable prefix and deterministic verdict-driven delivery
ok - a captain outcome reaches main's model as one typed, sequence-keyed processing request while routine notes stay plain
ok - requested and unsolicited healthy outcomes keep distinct delivery and event ownership
ok - captain outcomes are exact and exactly once across crash, reload, busy main, compaction, and an unrelated assistant response
ok - a captain outcome opens one sequence-keyed processing turn, survives empty and unrelated answers, is re-presented at run end and session start, and closes only on its acknowledgement
ok - scopeForUnreadWake excludes every main-only class without vetoing eligible task-local rows, and writes the eligible snapshot
ok - branch prompt_cache_key is stable per home across sessions and distinct between homes
ok - branch default-on eligibility (task-scoped, heartbeat, legacy flag ignored) binds and a broken branch rejects to watcher fallback
ok - under the away-posture record the wake carries the verbatim read-back tail, claims every row, opens no processing turn, cancels a pending request, and presents the accumulated rows after archive
ok - an accepted away-only wake rejects after archive, while a drained task-local wake stays a quiet no-op
ok - a claimed heartbeat row on a non-heartbeat away wake lifts task scoping for the fleet report
ok - a heartbeat review survives a check row arriving before its drain
ok - fm_branch_report refuses a task the wake did not name, fleet included, while a heartbeat is unscoped
ok - pre-drain eligibility re-check excludes a newly main-owned row without deferring eligible work
ok - a co-present needs-decision row neither vetoes nor falsely settles routine branch delivery
ok - a settled branch turn without a durable outcome falls back and releases its grant for main replay
ok - provider-error latches cool down, re-probe once with backoff, and recover through a durable report
ok - selection changes preserve in-flight transcript ownership and reset provider-error streaks
ok - a stale main claim returns the durable wake to watcher delivery
ok - pre-drain eligibility re-check no-ops an already-drained wake
ok - dialog mirror filters tool and operational traffic, lands before wakes, and keeps a durable cursor
ok - the dialog mirror re-anchors for each session's new branch conversation and stays incremental within it
ok - every main session start begins a new branch conversation while one session keeps its own
ok - the current pin state binds every branch build, and clearing it returns the branch to main's model
ok - unpinned branches follow main model changes live while pinned branches stay fixed
ok - supervision-model command persists the captain's pick and rebinds the live branch
ok - supervision-model opens a bounded searchable list, follow main first, and pins the branch alone
ok - branch model picker keeps follow main first and filters the eligible catalog
ok - the effort pin binds every branch build, and clearing it returns the branch to main's effort
ok - unpinned branches follow main effort changes live while pinned branches stay fixed
ok - an extension-registered provider resolves in the isolated branch runtime
ok - supervision-model runs an effort picker after the model picker and persists both independently
ok - an unusable model pin rejects to watcher fallback and an unparseable one is treated as no pin
ok - replacement activation cleans old branch leases and retries failed cleanup
ok - branch activates on a cold start once the lock is acquired, never before
ok - queued wakes and mirrors stop mutating branch state after lock ownership is lost
ok - stale reports, shells, mirrors, cursors, leases, and prompts perform no side effects
ok - a Pi session whose lock is held by a sibling or an enclosing live process accepts nothing and mutates no branch state
ok - an extension rebind re-mirrors undelivered dialog instead of dropping it
ok - outcome delivery keeps the event loop running and interleaved reports stay ordered and exactly once
ok - a session replaced mid-delivery cancels cleanly and the stored outcome still arrives exactly once
ok - a failing store script surfaces to the branch and its outcome is neither lost nor delivered twice
ok - a failed cursor write re-delivers a routine note exactly once more while a captain outcome stays deduplicated
exit=0
```
</details>
<details>
<summary>Evidence: Ancestry suite on newest upstream main (dee119b) + this change</summary>

Source: [Ancestry suite on newest upstream main (dee119b) + this change](https://github.com/3264studios/firstmate/blob/5bcc90ba9475ab34aaf6a34a84bf08fb9ceb91a9/.no-mistakes/evidence/fix/pi-native-session-owner/on-newest-main-session-lock-ancestry.log)

```text
ok - real Pi/native tree: lock acquisition and shell checks survive child replacement, direct and npm-launched
ok - Pi native owner: direct or one-hop npm-launched app-server bridge only; shell membership agrees
ok - a Claude session inside Pi's native Codex child stays separate from the enclosing Pi
ok - session-lock: a version-named Claude Code session is identified from its install path and argv[0]
ok - session-lock: a harness that is pid 1 of its own namespace is examined, not skipped
ok - session-lock: ordinary script paths under a harness directory are not harness processes
ok - session-lock: ownership stops at the first non-harness gap above the contiguous run
ok - session-lock: a live version-named session holding the lock is not mistaken for a stale owner
ok - session-lock: a trusted same-session id keeps owning a recycled background chain, and nothing weaker does
ok - session-lock: a trusted id anchors the lock on the model-loop process, anything else on the outermost pid
ok - session-lock e2e: a version-named session claims the home and arms supervision
ok - session-lock e2e: a session parented by a harness-named daemon claims the home and arms supervision
ok - session-lock e2e: a version-named session under a harness-named daemon keeps its own lock
ok - session-lock e2e: a background session keeps its lock and its supervision across a recycled helper chain
ok - session-lock: a same-session confirmation waits for the claim lock and refreshes a re-keyed id
ok - session-lock: a waiting confirmation does not steal another session's lock
ok - session-lock: a failed lock write restores the previous sidecar
ok - session-lock: a failed lock write removes a newly created sidecar
ok - session-lock: a verified reclaim keeps the new sidecar beside the new pid
exit=0
```
</details>
<details>
<summary>Evidence: Branch-extension suite on newest upstream main (dee119b) + this change</summary>

Source: [Branch-extension suite on newest upstream main (dee119b) + this change](https://github.com/3264studios/firstmate/blob/5bcc90ba9475ab34aaf6a34a84bf08fb9ceb91a9/.no-mistakes/evidence/fix/pi-native-session-owner/on-newest-main-pi-branch-extension.log)

```text
ok - fm_branch_outcomes hides through ToolExecutionComponent while Calm-off and HTML export stay stock
ok - the installed Pi still bounds the picker's list and ranks its search
ok - branch owns accepted wakes with a stable prefix and deterministic verdict-driven delivery
ok - a captain outcome reaches main's model as one typed, sequence-keyed processing request while routine notes stay plain
ok - requested and unsolicited healthy outcomes keep distinct delivery and event ownership
ok - captain outcomes are exact and exactly once across crash, reload, busy main, compaction, and an unrelated assistant response
ok - a captain outcome opens one sequence-keyed processing turn, survives empty and unrelated answers, is re-presented at run end and session start, and closes only on its acknowledgement
ok - scopeForUnreadWake excludes every main-only class without vetoing eligible task-local rows, and writes the eligible snapshot
ok - branch prompt_cache_key is stable per home across sessions and distinct between homes
ok - branch default-on eligibility (task-scoped, heartbeat, legacy flag ignored) binds and a broken branch rejects to watcher fallback
ok - under the away-posture record the wake carries the verbatim read-back tail, claims every row, opens no processing turn, cancels a pending request, and presents the accumulated rows after archive
ok - an accepted away-only wake rejects after archive, while a drained task-local wake stays a quiet no-op
ok - a claimed heartbeat row on a non-heartbeat away wake lifts task scoping for the fleet report
ok - a heartbeat review survives a check row arriving before its drain
ok - fm_branch_report refuses a task the wake did not name, fleet included, while a heartbeat is unscoped
ok - pre-drain eligibility re-check excludes a newly main-owned row without deferring eligible work
ok - a co-present needs-decision row neither vetoes nor falsely settles routine branch delivery
ok - a settled branch turn without a durable outcome falls back and releases its grant for main replay
ok - provider-error latches cool down, re-probe once with backoff, and recover through a durable report
ok - selection changes preserve in-flight transcript ownership and reset provider-error streaks
ok - a stale main claim returns the durable wake to watcher delivery
ok - pre-drain eligibility re-check no-ops an already-drained wake
ok - dialog mirror filters tool and operational traffic, lands before wakes, and keeps a durable cursor
ok - the dialog mirror re-anchors for each session's new branch conversation and stays incremental within it
ok - every main session start begins a new branch conversation while one session keeps its own
ok - the current pin state binds every branch build, and clearing it returns the branch to main's model
ok - unpinned branches follow main model changes live while pinned branches stay fixed
ok - supervision-model command persists the captain's pick and rebinds the live branch
ok - supervision-model opens a bounded searchable list, follow main first, and pins the branch alone
ok - branch model picker keeps follow main first and filters the eligible catalog
ok - the effort pin binds every branch build, and clearing it returns the branch to main's effort
ok - unpinned branches follow main effort changes live while pinned branches stay fixed
ok - an extension-registered provider resolves in the isolated branch runtime
ok - supervision-model runs an effort picker after the model picker and persists both independently
ok - an unusable model pin rejects to watcher fallback and an unparseable one is treated as no pin
ok - replacement activation cleans old branch leases and retries failed cleanup
ok - branch activates on a cold start once the lock is acquired, never before
ok - queued wakes and mirrors stop mutating branch state after lock ownership is lost
ok - stale reports, shells, mirrors, cursors, leases, and prompts perform no side effects
ok - a Pi session whose lock is held by a sibling or an enclosing live process accepts nothing and mutates no branch state
ok - an extension rebind re-mirrors undelivered dialog instead of dropping it
ok - outcome delivery keeps the event loop running and interleaved reports stay ordered and exactly once
ok - a session replaced mid-delivery cancels cleanly and the stored outcome still arrives exactly once
ok - a failing store script surfaces to the branch and its outcome is neither lost nor delivered twice
ok - a failed cursor write re-delivers a routine note exactly once more while a captain outcome stays deduplicated
exit=0
```
</details>
- Outcome: ⚠️ 1 info across 1 run (8m16s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"43bda1b786a369ee314a2195d9f55cfcc90368ec","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"skipped"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>⏭️ **Rebase** - skipped</summary>

Step was skipped.
</details>

<details>
<summary>⚠️ **Review** - 3 infos</summary>

- ℹ️ `bin/fm-session-lock-lib.sh:111` - fm_pi_native_transport_args splits the `ps -o args=` string on whitespace and skips a fixed number of program words, so a Codex executable path containing a space (an explicit PI_CODEX_NATIVE_BIN such as `~/My Apps/codex`, or an npm prefix under a spaced directory) leaves 3+ trailing words and is rejected. That case keeps the pre-fix identity (the Codex child), i.e. it fails closed to the old behavior rather than mis-attributing ownership. Both shapes the adapter actually launches (`/Applications/ChatGPT.app/Contents/Resources/codex -c features.code_mode_host=true app-server --stdio` and PATH `codex app-server --stdio`) parse correctly; verified against a live Pi native tree on this host, where the resolver returned the Pi pid. No action needed for this refresh; widening the match would go beyond the intent&#39;s exact-shape rule.
- ℹ️ `.pi/extensions/fm-branch-supervision.ts:386` - With the ancestry walk gone, the async `lockOwnership()` is a pure alias for `lockOwnershipSync()` with a single caller (`generationOwnsLock`, line 853). It is harmless: the body runs synchronously, so there is no await window between reading state/.lock and the verdict, which is why the old post-walk lock re-read could be dropped safely. The function pre-exists the change and the intent requires carrying the same fix unchanged, so no action is recommended here.
- ℹ️ `docs/verification/runtime-backends.md:2038` - Upstream main is now one commit past the review base (dee119b, #5076) and that commit touches four files this branch also edits (.pi/extensions/fm-branch-supervision.ts, docs/pi-supervision-branch.md, docs/verification/runtime-backends.md, tests/fm-pi-branch-extension.test.sh). Verified by base-side hunk ranges that none overlap or touch: the closest pair is upstream&#39;s insertion after base line 2035 of runtime-backends.md versus this branch&#39;s edit at line 2038, separated by two unchanged lines. #5076 also adds no reference to the helpers this branch removes (parentPid, parentPidSync, LOCK_ANCESTRY_DEPTH, the spawnSync import) and no new lock-ownership call site, so there is no semantic conflict either. Mergeability on current main holds; noted only because mergeability is the intent&#39;s core requirement.
</details>

<details>
<summary>⚠️ **Test** - 1 info</summary>

- ℹ️ Upstream main advanced from the base commit c443d8c to dee119b (#5076 &#39;act on captain&#39;s away words during AFK supervision&#39;) while this run was in progress. #5076 touches 4 files this change also edits (.pi/extensions/fm-branch-supervision.ts, docs/pi-supervision-branch.md, docs/verification/runtime-backends.md, tests/fm-pi-branch-extension.test.sh). Verified in an ephemeral clone that the full change applies onto dee119b with no conflicts and that the ancestry and branch-extension suites pass on the combined tree, so the PR should still show as mergeable; no rebase is required for mergeability, but the branch&#39;s base is no longer main&#39;s tip.
- <code>`bash tests/fm-session-lock-ancestry.test.sh` on target dcbddce - all pass, including the 3 new Pi-native cases alongside main&#39;s newer cases</code>
- <code>`bash tests/fm-pi-watch-extension.test.sh` on target - all pass, incl. &#39;Pi watcher arm distinguishes all session lock ownership states&#39; (watcher + turn-end guard reject an enclosing-process lock, accept own pid)</code>
- <code>`bash tests/fm-pi-branch-extension.test.sh` on target - all pass, incl. sibling/enclosing lock holder stays inert and mid-delivery session replacement</code>
- <code>`FM_PI_CODEX_NATIVE_LIVE=1 bash tests/fm-pi-codex-native.test.sh` on target - PASS with real Pi 0.85.1, pi-codex-native 0.2.1, ChatGPT.app codex 0.153.4 and npm launcher codex 0.151.0; lock names the Pi pid across child replacement on both executables</code>
- <code>Regression proof: `bash tests/fm-session-lock-ancestry.test.sh` in a temp tree = target + base `bin/fm-session-lock-lib.sh` - FAILS: &#39;real Pi/native tree: lock acquired: harness pid &lt;codex child&gt;&#39;</code>
- <code>Regression proof: `FM_PI_CODEX_NATIVE_LIVE=1 bash tests/fm-pi-codex-native.test.sh` in that same temp tree - FAILS at &#39;real native ownership probe failed&#39;; fixture state shows `lock acquired: harness pid 42279` (the Codex child) and &#39;primary harness: codex&#39;</code>
- <code>Manual end-to-end: `two-owner-repro.sh &lt;tree&gt;` against a `git archive` of base c443d8c (BEFORE) and the target worktree (AFTER) - real process tree pi -&gt; codex app-server --stdio -&gt; shell tool, real `bin/fm-lock.sh`, real `fm-primary-pi-watch.ts` arm tool</code>
- <code>Additive-merge check: `git diff --numstat c443d8c..dcbddce -- tests/fm-session-lock-ancestry.test.sh` = 159 insertions, 0 deletions; base is an ancestor of target</code>
- <code>Current-main check (read-only): upstream main is now dee119b (#5076), one commit past base, touching 4 overlapping files; `git apply --3way` of the full change onto dee119b in an ephemeral shallow clone applied all 10 files cleanly</code>
- <code>On that newest-main + change tree: `bash tests/fm-session-lock-ancestry.test.sh` and `bash tests/fm-pi-branch-extension.test.sh` - all pass</code>
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>

