### PR TITLE
fix(orca): accept composite worktree ids in endpoint validation

### DIFF
--- a/bin/fm-backend.sh
+++ b/bin/fm-backend.sh
@@ -388,6 +388,43 @@ fm_backend_endpoint_atom_valid() {  # <value>
   esac
 }
 
+# fm_backend_orca_worktree_id_valid: validate a recorded Orca worktree
+# identifier. Orca records the composite form `<repo-id>::<absolute-path>`
+# (for example `83cc33e8-...::/Users/me/orca/workspaces/node/fm-task`), so the
+# atom validator alone would reject every real Orca task and block its
+# cleanup. The composite form is accepted only when the repo component is a
+# valid atom and the path component is absolute, non-empty, built exclusively
+# from an allowlist of safe path characters, and free of `..` segments. The
+# allowlist admits the ordinary space that legitimate macOS and POSIX paths
+# carry, because cleanup passes the recorded identifier as one quoted argument
+# and must forward it byte for byte; it still leaves no ASCII control,
+# newline, shell metacharacter, command substitution, or extra delimiter able
+# to reach a runtime command. Bare atom ids stay accepted.
+fm_backend_orca_worktree_id_valid() {  # <value>
+  local value=$1 repo path
+  fm_backend_endpoint_atom_valid "$value" && return 0
+  case "$value" in
+    *'::'*) ;;
+    *) return 1 ;;
+  esac
+  repo=${value%%::*}
+  path=${value#*::}
+  fm_backend_endpoint_atom_valid "$repo" || return 1
+  case "$path" in
+    /*) ;;
+    *) return 1 ;;
+  esac
+  # Space is the only whitespace admitted; a stray colon also rejects a second
+  # `::` delimiter.
+  case "$path" in
+    *[!A-Za-z0-9._@%+/" "-]*) return 1 ;;
+  esac
+  case "$path" in
+    */../*|*/..) return 1 ;;
+  esac
+  return 0
+}
+
 fm_backend_validate_task_endpoint() {  # <meta-file> <task-id>
   local meta=$1 id=$2 backend_count backend window worktree project binding_count binding
   local session pane recorded_session workspace tab terminal worktree_id surface
@@ -508,7 +545,7 @@ fm_backend_validate_task_endpoint() {  # <meta-file> <task-id>
       }
       if [ "$window" != "fm-$id" ] \
         || ! fm_backend_endpoint_atom_valid "$terminal" \
-        || ! fm_backend_endpoint_atom_valid "$worktree_id"; then
+        || ! fm_backend_orca_worktree_id_valid "$worktree_id"; then
         echo "REFUSED: Orca endpoint metadata for task $id is malformed or inconsistent; preserving task state." >&2
         return 1
       fi

--- a/bin/fm-backend.sh
+++ b/bin/fm-backend.sh
@@ -393,13 +393,15 @@ fm_backend_endpoint_atom_valid() {  # <value>
 # (for example `83cc33e8-...::/Users/me/orca/workspaces/node/fm-task`), so the
 # atom validator alone would reject every real Orca task and block its
 # cleanup. The composite form is accepted only when the repo component is a
-# valid atom and the path component is absolute, non-empty, built exclusively
-# from an allowlist of safe path characters, and free of `..` segments. The
-# allowlist admits the ordinary space that legitimate macOS and POSIX paths
-# carry, because cleanup passes the recorded identifier as one quoted argument
-# and must forward it byte for byte; it still leaves no ASCII control,
-# newline, shell metacharacter, command substitution, or extra delimiter able
-# to reach a runtime command. Bare atom ids stay accepted.
+# valid atom and the path component is absolute, non-empty, free of `..`
+# segments, and free of the structural characters that would corrupt a
+# `state/<id>.meta` record or hide a second delimiter: ASCII control
+# characters (NUL, newline, tab included) and any further `::`. Every other
+# ordinary printable path character - Unicode, spaces, parentheses,
+# apostrophes, commas, `#`, `~`, `&` - belongs to legitimate macOS and POSIX
+# paths and is accepted, because cleanup forwards the recorded identifier as
+# one quoted argument byte for byte and never as shell text. Bare atom ids
+# stay accepted.
 fm_backend_orca_worktree_id_valid() {  # <value>
   local value=$1 repo path
   fm_backend_endpoint_atom_valid "$value" && return 0
@@ -414,13 +416,8 @@ fm_backend_orca_worktree_id_valid() {  # <value>
     /*) ;;
     *) return 1 ;;
   esac
-  # Space is the only whitespace admitted; a stray colon also rejects a second
-  # `::` delimiter.
   case "$path" in
-    *[!A-Za-z0-9._@%+/" "-]*) return 1 ;;
-  esac
-  case "$path" in
-    */../*|*/..) return 1 ;;
+    *[[:cntrl:]]*|*'::'*|*/../*|*/..) return 1 ;;
   esac
   return 0
 }

--- a/docs/orca-backend.md
+++ b/docs/orca-backend.md
@@ -36,12 +36,13 @@ The normal isolation and unlanded-work refusal rules still apply.
 backend=orca
 window=fm-<id>
 terminal=<orca terminal handle>
-orca_worktree_id=<orca worktree id>
+orca_worktree_id=<orca worktree id: a plain atom or Orca's composite <repo-id>::<absolute-path>>
 worktree=<absolute Orca worktree path>
 ```
 
 `window=` remains the caller-facing Firstmate alias.
 `terminal=` and `orca_worktree_id=` are the backend authority used by operation and cleanup paths.
+Orca normally records the composite form, for example `83cc33e8-1b52-4eff-9dad-6d3666775361::/Users/me/orca/workspaces/node/fm-task`, and its path component may carry ordinary printable characters such as spaces, Unicode, parentheses, apostrophes, commas, `#`, `~`, and `&`.
 
 ## Current lifecycle and safety
 
@@ -59,6 +60,8 @@ Grok alone retains its isolated rendered-tail fallback.
 Cleanup keeps all shared Firstmate safety checks.
 A scout still requires its report and completed decision inventory.
 A ship still refuses dirty or unlanded work.
+Before any runtime dispatch, cleanup requires the recorded worktree id to be a valid endpoint atom or a composite whose repo component is a valid atom and whose path component is absolute, free of `..` segments, and free of ASCII control characters or a second `::` delimiter that would corrupt the `state/<id>.meta` record.
+An accepted identifier is forwarded to Orca byte for byte as one quoted argument, never escaped or rewritten.
 Before release, cleanup resolves the recorded Orca worktree id and verifies its path matches the recorded worktree path.
 A missing, unreadable, or mismatched identity preserves metadata and stops rather than deleting anything.
 After those checks, Firstmate closes the exact terminal and releases the exact worktree with Orca's worktree command.

--- a/tests/fm-backend-orca.test.sh
+++ b/tests/fm-backend-orca.test.sh
@@ -1189,6 +1189,86 @@ test_teardown_refuses_orca_worktree_without_terminal_handle() {
   pass "fm-teardown.sh backend=orca: refuses incomplete worktree-only endpoint metadata before runtime dispatch"
 }
 
+test_teardown_removes_orca_worktree_with_composite_id() {
+  local proj wt data state config id composite out rc neutral
+  id="orcacompositez1"
+  proj="$TMP_ROOT/composite-project"
+  wt="$TMP_ROOT/composite wt with spaces"
+  data="$TMP_ROOT/composite-data"
+  state="$TMP_ROOT/composite-state"
+  config="$TMP_ROOT/composite-config"
+  composite="83cc33e8-1b52-4eff-9dad-6d3666775361::$wt"
+  fm_git_worktree "$proj" "$wt" "fm/$id"
+  mkdir -p "$data/$id" "$state" "$config"
+  printf 'report\n' > "$data/$id/report.md"
+  touch "$state/.last-watcher-beat"
+  fm_write_meta "$state/$id.meta" \
+    "window=fm-$id" "endpoint_task_id=$id" "terminal=term-composite" "worktree=$wt" "project=$proj" \
+    "harness=claude" "kind=scout" "mode=no-mistakes" "yolo=off" \
+    "backend=orca" "orca_worktree_id=$composite" \
+    "decisions_reviewed=1" "decision_keys="
+  orca_case composite
+  printf '{"ok":true,"result":{"worktree":{"id":"%s","path":"%s"}}}\n' "$composite" "$wt" > "$RESP/1.out"
+  neutral=$(neutral_fm_root "$CASE_DIR/neutral")
+  set +e
+  out=$( PATH="$FB:$PATH" FM_ORCA_LOG="$LOG" FM_ORCA_RESPONSES="$RESP" \
+    FM_ROOT_OVERRIDE="$neutral" FM_STATE_OVERRIDE="$state" FM_DATA_OVERRIDE="$data" FM_CONFIG_OVERRIDE="$config" \
+    "$ROOT/bin/fm-teardown.sh" "$id" 2>&1 )
+  rc=$?
+  set -e
+  expect_code 0 "$rc" "Orca teardown should accept the composite repo-id::path worktree identifier"$'\n'"$out"
+  assert_contains "$(cat "$LOG")" $'orca\x1f''worktree'$'\x1f''rm'$'\x1f''--worktree'$'\x1f'"id:$composite"$'\x1f''--force'$'\x1f''--json' \
+    "teardown did not forward the exact recorded composite id, spaces included, as one argument"
+  assert_absent "$state/$id.meta" "composite-id teardown should remove task metadata"
+  pass "fm-teardown.sh backend=orca: cleans up a real composite <repo-id>::<path> worktree id whose path contains spaces"
+}
+
+test_teardown_refuses_unsafe_orca_worktree_ids() {
+  local proj wt data state config id worktree_id out rc neutral n=0
+  proj="$TMP_ROOT/unsafe-id-project"
+  wt="$TMP_ROOT/unsafe-id-wt"
+  fm_git_worktree "$proj" "$wt" "fm/orcaunsafebase"
+  for worktree_id in \
+    "83cc33e8::$wt \$(touch $TMP_ROOT/pwned)" \
+    "83cc33e8::$wt;touch $TMP_ROOT/pwned2" \
+    "83cc33e8::$wt"$'\t'"tabbed" \
+    "83cc33e8::$wt"$'\v'"vertical" \
+    "83cc33e8::$TMP_ROOT/../etc/passwd" \
+    "83cc33e8::relative/path" \
+    "83cc33e8::$wt::extra" \
+    "83cc33e8::" \
+    "::$wt"
+  do
+    n=$(( n + 1 ))
+    id="orcaunsafez$n"
+    data="$TMP_ROOT/unsafe-id-data-$n"
+    state="$TMP_ROOT/unsafe-id-state-$n"
+    config="$TMP_ROOT/unsafe-id-config-$n"
+    mkdir -p "$data/$id" "$state" "$config"
+    printf 'report\n' > "$data/$id/report.md"
+    touch "$state/.last-watcher-beat"
+    fm_write_meta "$state/$id.meta" \
+      "window=fm-$id" "endpoint_task_id=$id" "terminal=term-unsafe-$n" "worktree=$wt" "project=$proj" \
+      "harness=claude" "kind=scout" "mode=no-mistakes" "yolo=off" \
+      "backend=orca" "orca_worktree_id=$worktree_id" \
+      "decisions_reviewed=1" "decision_keys="
+    orca_case "unsafe-id-$n"
+    neutral=$(neutral_fm_root "$CASE_DIR/neutral")
+    set +e
+    out=$( PATH="$FB:$PATH" FM_ORCA_LOG="$LOG" FM_ORCA_RESPONSES="$RESP" \
+      FM_ROOT_OVERRIDE="$neutral" FM_STATE_OVERRIDE="$state" FM_DATA_OVERRIDE="$data" FM_CONFIG_OVERRIDE="$config" \
+      "$ROOT/bin/fm-teardown.sh" "$id" 2>&1 )
+    rc=$?
+    set -e
+    [ "$rc" -ne 0 ] || fail "Orca teardown accepted unsafe worktree id '$worktree_id'"$'\n'"$out"
+    assert_present "$state/$id.meta" "refused unsafe worktree id '$worktree_id' removed task metadata"
+    [ ! -s "$LOG" ] || fail "unsafe worktree id '$worktree_id' reached an Orca runtime command"
+  done
+  assert_absent "$TMP_ROOT/pwned" "command substitution in a worktree id must never execute"
+  assert_absent "$TMP_ROOT/pwned2" "a shell separator in a worktree id must never execute"
+  pass "fm-teardown.sh backend=orca: refuses malformed and unsafe composite worktree ids before dispatch"
+}
+
 test_secondmate_force_teardown_removes_orca_child_via_orca() {
   local home subhome childproj childwt child_id neutral out rc
   home="$TMP_ROOT/orca-child-parent"
@@ -1371,6 +1451,8 @@ test_ship_teardown_refuses_orca_unresolvable_worktree_id
 test_ship_teardown_refuses_orca_id_path_mismatch
 test_teardown_refuses_orca_missing_worktree_id
 test_teardown_refuses_orca_worktree_without_terminal_handle
+test_teardown_removes_orca_worktree_with_composite_id
+test_teardown_refuses_unsafe_orca_worktree_ids
 test_secondmate_force_teardown_removes_orca_child_via_orca
 test_secondmate_force_teardown_refuses_orca_child_id_path_mismatch
 test_secondmate_force_teardown_refuses_partial_orca_child

--- a/tests/fm-backend-orca.test.sh
+++ b/tests/fm-backend-orca.test.sh
@@ -1334,7 +1334,7 @@ test_orca_worktree_id_validator_structural_boundaries() {
     do
       ! fm_backend_orca_worktree_id_valid "$value" \
         || fail "validator accepted the unsafe Orca worktree id '$value'"
-    done )
+    done ) || fail "fm_backend_orca_worktree_id_valid misclassified a structural boundary case"
   pass "fm_backend_orca_worktree_id_valid: accepts printable composite ids and refuses structural corruption"
 }
 

--- a/tests/fm-backend-orca.test.sh
+++ b/tests/fm-backend-orca.test.sh
@@ -1229,8 +1229,6 @@ test_teardown_refuses_unsafe_orca_worktree_ids() {
   wt="$TMP_ROOT/unsafe-id-wt"
   fm_git_worktree "$proj" "$wt" "fm/orcaunsafebase"
   for worktree_id in \
-    "83cc33e8::$wt \$(touch $TMP_ROOT/pwned)" \
-    "83cc33e8::$wt;touch $TMP_ROOT/pwned2" \
     "83cc33e8::$wt"$'\t'"tabbed" \
     "83cc33e8::$wt"$'\v'"vertical" \
     "83cc33e8::$TMP_ROOT/../etc/passwd" \
@@ -1264,9 +1262,80 @@ test_teardown_refuses_unsafe_orca_worktree_ids() {
     assert_present "$state/$id.meta" "refused unsafe worktree id '$worktree_id' removed task metadata"
     [ ! -s "$LOG" ] || fail "unsafe worktree id '$worktree_id' reached an Orca runtime command"
   done
+  pass "fm-teardown.sh backend=orca: refuses malformed and unsafe composite worktree ids before dispatch"
+}
+
+test_teardown_removes_orca_worktree_with_ordinary_punctuation_paths() {
+  local proj data state config id composite out rc neutral leaf wt n=0
+  for leaf in \
+    "Tài liệu (orca) #1 & 'quotes', ~tilde" \
+    "meta \$(touch $TMP_ROOT/pwned) ;touch $TMP_ROOT/pwned2"
+  do
+    n=$(( n + 1 ))
+    id="orcaprintablez$n"
+    proj="$TMP_ROOT/printable-project-$n"
+    wt="$TMP_ROOT/$leaf"
+    data="$TMP_ROOT/printable-data-$n"
+    state="$TMP_ROOT/printable-state-$n"
+    config="$TMP_ROOT/printable-config-$n"
+    composite="83cc33e8-1b52-4eff-9dad-6d3666775361::$wt"
+    fm_git_worktree "$proj" "$wt" "fm/$id"
+    mkdir -p "$data/$id" "$state" "$config"
+    printf 'report\n' > "$data/$id/report.md"
+    touch "$state/.last-watcher-beat"
+    fm_write_meta "$state/$id.meta" \
+      "window=fm-$id" "endpoint_task_id=$id" "terminal=term-printable-$n" "worktree=$wt" "project=$proj" \
+      "harness=claude" "kind=scout" "mode=no-mistakes" "yolo=off" \
+      "backend=orca" "orca_worktree_id=$composite" \
+      "decisions_reviewed=1" "decision_keys="
+    orca_case "printable-$n"
+    printf '{"ok":true,"result":{"worktree":{"id":"%s","path":"%s"}}}\n' "$composite" "$wt" > "$RESP/1.out"
+    neutral=$(neutral_fm_root "$CASE_DIR/neutral")
+    set +e
+    out=$( PATH="$FB:$PATH" FM_ORCA_LOG="$LOG" FM_ORCA_RESPONSES="$RESP" \
+      FM_ROOT_OVERRIDE="$neutral" FM_STATE_OVERRIDE="$state" FM_DATA_OVERRIDE="$data" FM_CONFIG_OVERRIDE="$config" \
+      "$ROOT/bin/fm-teardown.sh" "$id" 2>&1 )
+    rc=$?
+    set -e
+    expect_code 0 "$rc" "Orca teardown should accept an ordinary printable path in the composite id: $composite"$'\n'"$out"
+    assert_contains "$(cat "$LOG")" $'orca\x1f''worktree'$'\x1f''rm'$'\x1f''--worktree'$'\x1f'"id:$composite"$'\x1f''--force'$'\x1f''--json' \
+      "teardown did not forward '$composite' byte for byte as one argument"
+    assert_absent "$state/$id.meta" "printable-path teardown should remove task metadata"
+  done
   assert_absent "$TMP_ROOT/pwned" "command substitution in a worktree id must never execute"
   assert_absent "$TMP_ROOT/pwned2" "a shell separator in a worktree id must never execute"
-  pass "fm-teardown.sh backend=orca: refuses malformed and unsafe composite worktree ids before dispatch"
+  pass "fm-teardown.sh backend=orca: cleans up composite ids whose path carries Unicode and ordinary punctuation"
+}
+
+test_orca_worktree_id_validator_structural_boundaries() {
+  local value
+  ( . "$ROOT/bin/fm-backend.sh"
+    for value in \
+      "wt-plain-atom" \
+      "83cc33e8::/Users/me/orca/workspaces/node/fm-task" \
+      "83cc33e8::/Users/me/Tài liệu/orca (2)/fm-task #1 & 'x', ~y"
+    do
+      fm_backend_orca_worktree_id_valid "$value" \
+        || fail "validator rejected a legitimate Orca worktree id '$value'"
+    done
+    for value in \
+      "" \
+      "83cc33e8::" \
+      "::/Users/me/wt" \
+      "83cc33e8::relative/path" \
+      "83cc33e8::/Users/me/../etc/passwd" \
+      "83cc33e8::/Users/me/wt/.." \
+      "83cc33e8::/Users/me/wt::extra" \
+      "83cc33e8::/Users/me/wt"$'\n'"/etc/passwd" \
+      "83cc33e8::/Users/me/wt"$'\r'"x" \
+      "83cc33e8::/Users/me/wt"$'\t'"x" \
+      "83cc33e8::/Users/me/wt"$'\001'"x" \
+      "83cc33e8::/Users/me/wt"$'\177'"x"
+    do
+      ! fm_backend_orca_worktree_id_valid "$value" \
+        || fail "validator accepted the unsafe Orca worktree id '$value'"
+    done )
+  pass "fm_backend_orca_worktree_id_valid: accepts printable composite ids and refuses structural corruption"
 }
 
 test_secondmate_force_teardown_removes_orca_child_via_orca() {
@@ -1453,6 +1522,8 @@ test_teardown_refuses_orca_missing_worktree_id
 test_teardown_refuses_orca_worktree_without_terminal_handle
 test_teardown_removes_orca_worktree_with_composite_id
 test_teardown_refuses_unsafe_orca_worktree_ids
+test_teardown_removes_orca_worktree_with_ordinary_punctuation_paths
+test_orca_worktree_id_validator_structural_boundaries
 test_secondmate_force_teardown_removes_orca_child_via_orca
 test_secondmate_force_teardown_refuses_orca_child_id_path_mismatch
 test_secondmate_force_teardown_refuses_partial_orca_child


### PR DESCRIPTION
## Problem

A real Orca spawn records `orca_worktree_id=<repo-id>::<absolute-path>` (for example `83cc33e8-1b52-4eff-9dad-6d3666775361::/Users/me/orca/workspaces/node/fm-task`), but `fm_backend_validate_task_endpoint` applied the atom-only validator, which rejects `:` and `/`. Cleanup was therefore refused for every real Orca task.

## Change

- `bin/fm-backend.sh` gains `fm_backend_orca_worktree_id_valid`, and only Orca worktree-id validation routes through it. Terminal ids and every other runtime identifier keep the unchanged atom validator.
- Bare atom ids stay accepted. The composite form is accepted only when the repository component is a valid atom and the path component is absolute, non-empty, and free of `..` segments.
- The path component uses a structural denylist: ordinary printable UTF-8 path characters are accepted, including Unicode, parentheses, apostrophes, commas, `#`, `~`, `&`, and spaces, because legitimate macOS and POSIX workspace paths contain them. ASCII controls and newlines, empty values, malformed or extra `::` delimiters, and anything that would split the metadata record are still rejected before any runtime command runs.
- The validated identifier is forwarded byte for byte as one quoted argument; it is never escaped or rewritten, and the independent exact resolved-path match before removal is retained.

## Verification

- `tests/fm-backend-orca.test.sh` extended through the executable interface: cleanup of a real composite id whose path contains spaces, representative Unicode and punctuation paths, exact single-argument forwarding, and negative boundaries for ASCII controls, shell syntax, extra `::`, empty path, empty repository, relative paths, and `..` segments, each asserting metadata is preserved and no runtime command is dispatched.
- Full suite, review, documentation, and `bin/fm-lint.sh` (ShellCheck 0.11.0, actionlint 1.7.12) pass through the no-mistakes pipeline.
