### PR TITLE
fix(remote): keep fm-remote Herdr servers in the Aqua session

### DIFF
--- a/bin/fm-remote-doctor.sh
+++ b/bin/fm-remote-doctor.sh
@@ -13,9 +13,15 @@
 # fm-remote session. Its account therefore needs the Firstmate-owned Aqua Herdr
 # agent plus the sibling dev.firstmate.remote-job worker that runs normal fm-on
 # commands through the Aqua or Linux job-worker path. On darwin, that Herdr
-# agent starts the server through the remote account's login shell (`-l -c`)
-# so the Aqua login session gets login-shell environment and login-keychain
-# access; exec keeps herdr in the foreground under launchd. Doctor remains
+# agent runs bin/fm-remote-herdr-guard.sh through the remote account's login
+# shell (`-l -c`) so the server inherits the account's own environment; the
+# gui/<uid> launchd domain it is bootstrapped into, not the shell, is what
+# gives the server and its panes the Aqua audit session and login-keychain
+# access. The guard execs the server in the foreground under launchd, leaves an
+# Aqua-born server alone, and takes the session over from a server born
+# outside that session (an SSH remote attach wins the socket at boot), because
+# such a server's panes cannot read the login keychain;
+# bin/fm-remote-herdr-owner-lib.sh owns that birth test. Doctor remains
 # invokable over the plain-SSH bootstrap path to inspect and repair that worker.
 # SSH cannot create an Aqua session, so a host with no GUI login is a human
 # gap rather than something --fix attempts to bypass.
@@ -59,6 +65,8 @@ FM_ROOT="${FM_ROOT_OVERRIDE:-$(CDPATH='' cd "$SCRIPT_DIR/.." && pwd -P)}"
 . "$SCRIPT_DIR/fm-remote-job-lib.sh"
 # shellcheck source=bin/fm-tasks-axi-lib.sh
 . "$SCRIPT_DIR/fm-tasks-axi-lib.sh"
+# shellcheck source=bin/fm-remote-herdr-owner-lib.sh
+. "$SCRIPT_DIR/fm-remote-herdr-owner-lib.sh"
 REQUIRED_TOOLS=(git jq herdr tasks-axi treehouse)
 HARNESS_TOOLS=(claude codex opencode pi pi-signed grok kimi)
 OPTIONAL_TOOLS=(tmux no-mistakes gh)
@@ -152,12 +160,45 @@ herdr_adapter_load() {
   FM_REMOTE_DOCTOR_HERDR_LOADED=1
 }
 
+herdr_server_status_json() {
+  herdr_adapter_load || return 1
+  fm_backend_herdr_cli "$HERDR_SESSION_NAME" status --json 2>/dev/null
+}
+
 herdr_server_running() {
   local running
-  herdr_adapter_load || return 1
-  running=$(fm_backend_herdr_cli "$HERDR_SESSION_NAME" status --json 2>/dev/null \
-    | jq -r '.server.running // false' 2>/dev/null) || return 1
+  running=$(herdr_server_status_json | jq -r '.server.running // false' 2>/dev/null) || return 1
   [ "$running" = true ]
+}
+
+# Birth of the process serving the session, as the guard classifies it:
+# prints "<birth> <pid>" (launchd, worker, ssh, or unknown), "unproven" when
+# no herdr process can be shown to hold the socket, or "nolsof" when lsof does
+# not resolve. bin/fm-remote-herdr-owner-lib.sh owns the markers.
+herdr_server_birth() {
+  local socket owner rc birth
+  socket=$(herdr_server_status_json | jq -r '.server.socket // empty' 2>/dev/null) || socket=
+  owner=$(fm_remote_herdr_socket_owner "$socket"); rc=$?
+  if [ "$rc" -eq 2 ]; then
+    printf 'nolsof\n'
+    return 0
+  fi
+  if [ -z "$owner" ]; then
+    printf 'unproven\n'
+    return 0
+  fi
+  birth=$(fm_remote_herdr_owner_birth "$owner")
+  printf '%s %s\n' "$birth" "$owner"
+}
+
+# On darwin the session is ready only when its server was born in the Aqua
+# login session; elsewhere any running server is.
+herdr_server_aqua_owned() {
+  local birth
+  herdr_server_running || return 1
+  [ "$PLATFORM" = darwin ] || return 0
+  birth=$(herdr_server_birth)
+  fm_remote_herdr_birth_is_aqua "${birth%% *}"
 }
 
 launch_agent_is_aqua() {
@@ -209,14 +250,20 @@ resolve_launch_agent_shell() {
   printf '%s' /bin/sh
 }
 
-# Login-shell command that execs the resolved herdr so launchd keeps one
-# foreground process in the Aqua session (login-keychain access) instead of
-# letting herdr self-daemonize into a Background session. KeepAlive stays
-# unconditionally true: this agent uniquely owns fm-remote, and a
-# SuccessfulExit=false plus busy-socket no-op would change the existing
-# restart-on-any-exit contract.
+# Login-shell command that execs the Firstmate-owned guard, which in turn execs
+# the resolved herdr so launchd keeps one foreground process in the Aqua
+# session, or exits 0 when an Aqua-born server already owns the session.
+# KeepAlive={SuccessfulExit=false} is load-bearing for that exit: an
+# unconditional KeepAlive would respawn the job every throttle interval
+# forever while a foreign server holds the socket, exactly the loop this guard
+# replaces, and would never let the guard's "nothing to do" verdict rest.
+launch_agent_guard_path() {
+  printf '%s/bin/fm-remote-herdr-guard.sh' "$FM_ROOT"
+}
+
 launch_agent_exec_command() { # <resolved-herdr-path>
-  printf 'exec %s server --session %s' \
+  printf 'exec %s %s %s' \
+    "$(launch_agent_shell_quote "$(launch_agent_guard_path)")" \
     "$(launch_agent_shell_quote "$1")" \
     "$(launch_agent_shell_quote "$HERDR_SESSION_NAME")"
 }
@@ -244,7 +291,12 @@ render_launch_agent() { # <resolved-herdr-path> <resolved-login-shell>
 	<key>RunAtLoad</key>
 	<true/>
 	<key>KeepAlive</key>
-	<true/>
+	<dict>
+		<key>SuccessfulExit</key>
+		<false/>
+	</dict>
+	<key>ThrottleInterval</key>
+	<integer>10</integer>
 	<key>StandardOutPath</key>
 	<string>$LAUNCH_AGENT_LOG</string>
 	<key>StandardErrorPath</key>
@@ -278,7 +330,10 @@ launch_agent_loaded_contract_matches() { # <resolved-login-shell>
   [[ "$loaded" == *"$args"* ]] || return 1
   [[ "$loaded" == *"stdoutpath=$log_compact"* ]] || return 1
   [[ "$loaded" == *"stderrpath=$log_compact"* ]] || return 1
-  [[ "$loaded" == *'properties=keepalive|runatload'* ]] || return 1
+  # launchd renders KeepAlive={SuccessfulExit=false} as a successful-exit
+  # semaphore rather than a keepalive property.
+  [[ "$loaded" == *'successfulexit=>0'* ]] || return 1
+  [[ "$loaded" == *'properties=runatload'* ]] || return 1
 }
 
 # --- remote job and tool checks ---------------------------------------------
@@ -609,7 +664,29 @@ check_herdr_server() {
     return 0
   fi
   if herdr_server_running; then
-    record herdr-server "ok: session $HERDR_SESSION_NAME is running"
+    if [ "$PLATFORM" != darwin ]; then
+      record herdr-server "ok: session $HERDR_SESSION_NAME is running"
+      return 0
+    fi
+    local birth
+    birth=$(herdr_server_birth)
+    case "$birth" in
+      launchd\ *|worker\ *)
+        record herdr-server "ok: session $HERDR_SESSION_NAME is running in the Aqua login session (pid ${birth#* }, ${birth%% *})"
+        ;;
+      nolsof)
+        record herdr-server "human: session $HERDR_SESSION_NAME is running but lsof does not resolve, so its server's birth cannot be proven" \
+          "install lsof on that account so the launch agent and this check can tell an Aqua-born server from one started over SSH"
+        ;;
+      unproven)
+        record herdr-server "fixable: session $HERDR_SESSION_NAME is running but no herdr process can be shown to own its socket, so its birth cannot be proven" \
+          "rerun this command with --fix so the launch agent takes the session over (its current panes close and the parent firstmate relaunches its mates)"
+        ;;
+      *)
+        record herdr-server "fixable: session $HERDR_SESSION_NAME is served by pid ${birth#* } born outside the Aqua login session (${birth%% *}), so its panes cannot reach the login keychain" \
+          "rerun this command with --fix so the launch agent takes the session over (its current panes close and the parent firstmate relaunches its mates)"
+        ;;
+    esac
     return 0
   fi
   if [ "$PLATFORM" = darwin ] && ! check_is_ok gui-session; then
@@ -685,7 +762,7 @@ write_launch_agent() { # <resolved-login-shell>
     fix_report launchagent failed "cannot publish $LAUNCH_AGENT_PLIST"
     return 1
   fi
-  fix_report launchagent applied "wrote the Aqua-scoped $LAUNCH_AGENT_LABEL launch agent running $herdr_bin server via $shell -l -c"
+  fix_report launchagent applied "wrote the Aqua-scoped $LAUNCH_AGENT_LABEL launch agent running $(launch_agent_guard_path) for $herdr_bin via $shell -l -c"
 }
 
 # Reload rather than plain bootstrap so a rewritten plist replaces a stale
@@ -711,7 +788,7 @@ reload_launch_agent() { # <check-to-report-under>
     return 1
   fi
   if ! wait_for_herdr_server; then
-    fix_report "$report" failed "the herdr server for session $HERDR_SESSION_NAME did not report running within 10s"
+    fix_report "$report" failed "the herdr server for session $HERDR_SESSION_NAME did not come up inside the Aqua launch agent within 10s"
     return 1
   fi
   fix_report "$report" applied "bootstrapped and started $LAUNCH_AGENT_LABEL in gui/$UID_NUM"
@@ -720,7 +797,7 @@ reload_launch_agent() { # <check-to-report-under>
 wait_for_herdr_server() {
   local i=0
   while [ "$i" -lt 20 ]; do
-    herdr_server_running && return 0
+    herdr_server_aqua_owned && return 0
     i=$((i + 1))
     sleep 0.5
   done

--- a/bin/fm-remote-entrypoint.sh
+++ b/bin/fm-remote-entrypoint.sh
@@ -31,7 +31,7 @@
 set -eu
 
 PROTOCOL=1
-DOCTOR_SHA256=810316fbb621f2ca9cdad0d085dee44a09b70f403b2056c9c6971ac7e767104a
+DOCTOR_SHA256=78efccd6cb7a0123400e49fa323292a64c8e3c7ebd3717151be69f87735302fb
 REAL_SOURCE=$(python3 -c 'import os, sys; print(os.path.realpath(sys.argv[1]))' "${BASH_SOURCE[0]}" 2>/dev/null) ||
   REAL_SOURCE=$(realpath "${BASH_SOURCE[0]}" 2>/dev/null) ||
   REAL_SOURCE=${BASH_SOURCE[0]}

--- a/bin/fm-remote-herdr-guard.sh
+++ b/bin/fm-remote-herdr-guard.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+# launchd exec target for the Firstmate-owned dev.firstmate.herdr.fm-remote
+# launch agent: make the Aqua login session own the fm-remote Herdr server.
+#
+# Usage:
+#   fm-remote-herdr-guard.sh <herdr-path> <session>
+#
+# bin/fm-remote-doctor.sh renders the launch agent as the account's login
+# shell running `exec <this script> <herdr> fm-remote` with
+# LimitLoadToSessionType=Aqua, RunAtLoad, KeepAlive={SuccessfulExit=false},
+# and ThrottleInterval=10, then bootstraps it into gui/<uid>. That domain, not
+# the login shell, is what gives this process and every server it execs the
+# Aqua audit session and login-keychain access; the login shell only gives the
+# server the account's own environment.
+#
+# Decision, made once per launch (exit codes matter under SuccessfulExit=false:
+# 0 tells launchd the job is done until something restarts it, non-zero asks
+# for a retry after the throttle interval):
+#   no server owns the session socket  -> exec `herdr server --session <s>`
+#                                          (foreground, launchd-supervised)
+#   the owner was born in the Aqua session (launchd or the Aqua remote-job
+#   worker)                            -> exit 0, leave it alone
+#   the owner was born anywhere else (an SSH remote attach, a shell over
+#   ssh/mosh, or a birth it cannot prove) -> `herdr server stop`, wait until the
+#                                          socket is released, then exec
+#                                          `herdr server --session <s>` at once
+#                                          so the socket is rebound before a
+#                                          reconnecting SSH attach can start
+#                                          another foreign server
+#   the foreign server does not release the socket in time -> exit 1
+# A takeover closes every pane in that session; the parent firstmate's
+# secondmate liveness sweep relaunches its mates into the Aqua-born server.
+# bin/fm-remote-herdr-owner-lib.sh owns the owner discovery and the birth
+# markers; FM_REMOTE_HERDR_GUARD_STOP_WAIT_TENTHS (default 50) bounds the
+# release wait in tenths of a second. Every decision prints one line to
+# stdout, which launchd routes to the agent's log.
+set -u
+
+SCRIPT_SELF=${BASH_SOURCE[0]}
+SCRIPT_DIR=${SCRIPT_SELF%/*}
+[ "$SCRIPT_DIR" != "$SCRIPT_SELF" ] || SCRIPT_DIR=.
+SCRIPT_DIR=$(CDPATH='' cd -- "$SCRIPT_DIR" && pwd -P)
+# shellcheck source=bin/fm-remote-herdr-owner-lib.sh
+. "$SCRIPT_DIR/fm-remote-herdr-owner-lib.sh"
+
+usage() { sed -n '2,6p' "$0" | sed 's/^# \{0,1\}//'; exit 2; }
+[ "$#" -eq 2 ] || usage
+HERDR_BIN=$1
+SESSION=$2
+[ -n "$HERDR_BIN" ] && [ -x "$HERDR_BIN" ] || { printf 'fm-remote-herdr-guard: herdr is not executable: %s\n' "$HERDR_BIN" >&2; exit 1; }
+[ -n "$SESSION" ] || usage
+command -v jq >/dev/null 2>&1 || { printf 'fm-remote-herdr-guard: jq does not resolve on the launch agent PATH\n' >&2; exit 1; }
+STOP_WAIT_TENTHS=${FM_REMOTE_HERDR_GUARD_STOP_WAIT_TENTHS:-50}
+
+log() { printf 'fm-remote-herdr-guard: %s\n' "$*"; }
+
+herdr_status() { # prints the session's status JSON, empty when herdr fails
+  HERDR_SESSION="$SESSION" "$HERDR_BIN" status --json --session "$SESSION" 2>/dev/null || true
+}
+
+status_running() { # <status-json>
+  [ "$(printf '%s' "$1" | jq -r '.server.running // false' 2>/dev/null)" = true ]
+}
+
+start_server() {
+  log "starting the herdr server for session $SESSION inside this launch agent (pid $$)"
+  exec "$HERDR_BIN" server --session "$SESSION"
+}
+
+STATUS=$(herdr_status)
+if ! status_running "$STATUS"; then
+  log "no server owns session $SESSION"
+  start_server
+fi
+
+SOCKET=$(printf '%s' "$STATUS" | jq -r '.server.socket // empty' 2>/dev/null)
+OWNER=$(fm_remote_herdr_socket_owner "$SOCKET"); OWNER_RC=$?
+if [ "$OWNER_RC" -eq 2 ]; then
+  log "session $SESSION is running but lsof does not resolve, so its server's birth cannot be proven"
+  BIRTH=unknown
+elif [ -z "$OWNER" ]; then
+  log "session $SESSION is running but no herdr process could be proven to own ${SOCKET:-its socket}"
+  BIRTH=unknown
+else
+  BIRTH=$(fm_remote_herdr_owner_birth "$OWNER")
+fi
+
+if fm_remote_herdr_birth_is_aqua "$BIRTH"; then
+  log "session $SESSION is served by pid $OWNER born in the Aqua login session ($BIRTH); nothing to do"
+  exit 0
+fi
+
+log "session $SESSION is served by ${OWNER:+pid }${OWNER:-an unproven process} born outside the Aqua login session ($BIRTH); its panes cannot reach the login keychain, taking the session over"
+HERDR_SESSION="$SESSION" "$HERDR_BIN" server stop --session "$SESSION" >/dev/null 2>&1 \
+  || log "herdr server stop for session $SESSION did not succeed; waiting for the socket anyway"
+i=0
+while [ "$i" -lt "$STOP_WAIT_TENTHS" ]; do
+  if ! status_running "$(herdr_status)"; then
+    log "session $SESSION released its socket after $i tenths of a second"
+    start_server
+  fi
+  sleep 0.1
+  i=$((i + 1))
+done
+log "the foreign server for session $SESSION did not release its socket within $STOP_WAIT_TENTHS tenths of a second; exiting 1 so launchd retries"
+exit 1

--- a/bin/fm-remote-herdr-guard.sh
+++ b/bin/fm-remote-herdr-guard.sh
@@ -12,6 +12,8 @@
 # the login shell, is what gives this process and every server it execs the
 # Aqua audit session and login-keychain access; the login shell only gives the
 # server the account's own environment.
+# `herdr server` stays in the foreground under launchd, as verified in
+# docs/verification/runtime-backends.md under "fm-remote server birth and login-keychain access", so the final exec provides the complete supervision lifecycle.
 #
 # Decision, made once per launch (exit codes matter under SuccessfulExit=false:
 # 0 tells launchd the job is done until something restarts it, non-zero asks

--- a/bin/fm-remote-herdr-owner-lib.sh
+++ b/bin/fm-remote-herdr-owner-lib.sh
@@ -1,0 +1,150 @@
+#!/usr/bin/env bash
+# Who owns a Herdr session socket, and was that process born in the Aqua
+# login session?
+#
+# Source this file; it defines functions only. It is the single owner of the
+# socket-owner discovery and birth classification shared by
+# bin/fm-remote-herdr-guard.sh (the launch agent's exec target) and
+# bin/fm-remote-doctor.sh (the readiness check for that session).
+#
+# Why birth matters: a herdr server, and every pane and agent it later spawns,
+# keeps the macOS audit session of whatever started it. Only the Aqua login
+# session (the gui/<uid> launchd domain) can read the login keychain without a
+# UI prompt. A server started over SSH - herdr's own remote attach does this
+# when it finds no server, and it wins the socket at boot because sshd accepts
+# connections before the login session exists - runs in sshd's audit session,
+# where `security find-generic-password -w` exits 36 (interaction not allowed)
+# and every claude pane silently falls back to a stale plaintext credentials
+# file and reports "Login expired". docs/verification/runtime-backends.md
+# ("fm-remote server birth and login-keychain access") holds the dated
+# evidence for every marker read here.
+#
+# Functions:
+#   fm_remote_herdr_socket_owner <socket-path>
+#     Prints the pid of the herdr process that holds <socket-path>, or nothing
+#     when no herdr process does. Reads `lsof -U -a -c herdr -F pn`; on macOS
+#     `pgrep -f` cannot see the herdr server's argv, so lsof is the owner
+#     source. When several herdr processes list the path, the one whose argv
+#     runs `server` wins. Returns 2, printing nothing, when lsof does not
+#     resolve; the caller decides what an unprovable owner means.
+#   fm_remote_herdr_process_env <pid>
+#     Prints the process environment as NAME=VALUE lines: `ps -Eww` on darwin
+#     (own-uid processes only, and macOS hides the environment of Apple
+#     platform binaries such as /bin/sleep even from the same user; a herdr
+#     server is never one), /proc/<pid>/environ elsewhere.
+#   fm_remote_herdr_process_ancestry <pid>
+#     Prints "<pid> <command>" for <pid> and each ancestor up to pid 1.
+#   fm_remote_herdr_owner_birth <pid>
+#     Prints exactly one word, the strongest marker present:
+#       ssh      SSH_CONNECTION, SSH_CLIENT, or SSH_TTY in the environment, or
+#                an ancestor that is sshd or herdr's remote-client-bridge
+#                (matched on argv[0] and whole arguments only)
+#       launchd  XPC_SERVICE_NAME in the environment (any value): launchd
+#                spawned it, in the domain the job was bootstrapped into
+#       worker   FM_REMOTE_JOB_ACTIVE=1: started by the Aqua
+#                dev.firstmate.remote-job worker under its env -i contract
+#       unknown  none of the above
+#   fm_remote_herdr_birth_is_aqua <birth>
+#     Succeeds only for launchd and worker. `unknown` is deliberately not
+#     Aqua: a server that cannot prove its birth is treated like a foreign one,
+#     because leaving it in place silently reproduces the keychain failure.
+
+fm_remote_herdr_socket_owner() { # <socket-path>
+  local socket=$1 real pid='' line candidates='' candidate cmd
+  [ -n "$socket" ] || return 1
+  command -v lsof >/dev/null 2>&1 || return 2
+  real=$(CDPATH='' cd -- "$(dirname "$socket")" 2>/dev/null && printf '%s/%s' "$(pwd -P)" "$(basename "$socket")") || real=$socket
+  while IFS= read -r line; do
+    case "$line" in
+      p*) pid=${line#p} ;;
+      n*)
+        [ -n "$pid" ] || continue
+        case "${line#n}" in
+          "$socket"|"$real") candidates="${candidates}${pid}"$'\n' ;;
+        esac
+        ;;
+    esac
+  done < <(lsof -U -a -c herdr -F pn 2>/dev/null)
+  [ -n "$candidates" ] || return 0
+  while IFS= read -r candidate; do
+    [ -n "$candidate" ] || continue
+    cmd=$(ps -o command= -p "$candidate" 2>/dev/null || true)
+    case " $cmd " in *' server '*) printf '%s\n' "$candidate"; return 0 ;; esac
+  done <<EOF2
+$candidates
+EOF2
+  printf '%s\n' "${candidates%%$'\n'*}"
+}
+
+fm_remote_herdr_process_env() { # <pid>
+  local pid=$1
+  case "$pid" in ''|*[!0-9]*) return 1 ;; esac
+  if [ -r "/proc/$pid/environ" ]; then
+    tr '\0' '\n' < "/proc/$pid/environ"
+    return 0
+  fi
+  ps -Eww -o command= -p "$pid" 2>/dev/null | tr ' ' '\n' | grep -E '^[A-Za-z_][A-Za-z0-9_]*=' || true
+}
+
+fm_remote_herdr_process_ancestry() { # <pid>
+  local pid=$1 depth=0 line ppid
+  while [ "$depth" -lt 64 ]; do
+    case "$pid" in ''|*[!0-9]*) return 0 ;; esac
+    [ "$pid" -gt 0 ] || return 0
+    line=$(ps -o ppid=,command= -p "$pid" 2>/dev/null) || return 0
+    [ -n "$line" ] || return 0
+    ppid=$(printf '%s' "$line" | awk '{print $1}')
+    printf '%s %s\n' "$pid" "$(printf '%s' "$line" | sed 's/^[[:space:]]*[0-9]*[[:space:]]*//')"
+    [ "$pid" -ne 1 ] || return 0
+    pid=$ppid
+    depth=$((depth + 1))
+  done
+}
+
+fm_remote_herdr_owner_birth() { # <pid>
+  local pid=$1 env
+  env=$(fm_remote_herdr_process_env "$pid") || { printf 'unknown\n'; return 0; }
+  if printf '%s\n' "$env" | grep -q -E '^SSH_(CONNECTION|CLIENT|TTY)='; then
+    printf 'ssh\n'
+    return 0
+  fi
+  if printf '%s\n' "$env" | grep -q -E '^XPC_SERVICE_NAME='; then
+    printf 'launchd\n'
+    return 0
+  fi
+  if printf '%s\n' "$env" | grep -q -E '^FM_REMOTE_JOB_ACTIVE=1$'; then
+    printf 'worker\n'
+    return 0
+  fi
+  if fm_remote_herdr_process_ancestry "$pid" | fm_remote_herdr_ancestry_has_ssh_origin; then
+    printf 'ssh\n'
+    return 0
+  fi
+  printf 'unknown\n'
+}
+
+# Reads "<pid> <command>" ancestry lines on stdin and succeeds when one of
+# them IS sshd (argv[0] sshd or sshd-session, including the "sshd-session:
+# user@notty" process title) or IS herdr's SSH remote attach (argv[0] herdr
+# with the whole-word argument remote-client-bridge). Only argv[0] and whole
+# arguments are matched: an ancestor whose free-text arguments merely mention
+# those words, such as an agent carrying a brief, must not count.
+fm_remote_herdr_ancestry_has_ssh_origin() {
+  awk '
+    {
+      argv0 = $2
+      sub(/.*\//, "", argv0)
+      sub(/:$/, "", argv0)
+      if (argv0 == "sshd" || argv0 == "sshd-session") { found = 1; exit }
+      if (argv0 == "herdr") {
+        for (i = 3; i <= NF; i++) if ($i == "remote-client-bridge") { found = 1; exit }
+      }
+    }
+    END { exit found ? 0 : 1 }
+  '
+}
+
+fm_remote_herdr_birth_is_aqua() { # <birth>
+  case "$1" in launchd|worker) return 0 ;; esac
+  return 1
+}

--- a/bin/fm-remote-herdr-owner-lib.sh
+++ b/bin/fm-remote-herdr-owner-lib.sh
@@ -39,11 +39,12 @@
 #       ssh      SSH_CONNECTION, SSH_CLIENT, or SSH_TTY in the environment, or
 #                an ancestor that is sshd or herdr's remote-client-bridge
 #                (matched on argv[0] and whole arguments only)
-#       launchd  XPC_SERVICE_NAME in the environment (any value): launchd
-#                spawned it, in the domain the job was bootstrapped into
-#       worker   FM_REMOTE_JOB_ACTIVE=1: started by the Aqua
-#                dev.firstmate.remote-job worker under its env -i contract
-#       unknown  none of the above
+#       launchd  XPC_SERVICE_NAME=<label>, with launchctl proving that job is
+#                the owner in gui/<uid> or is loaded only in that domain
+#       worker   FM_REMOTE_JOB_ACTIVE=1, with launchctl proving that
+#                dev.firstmate.remote-job is loaded only in gui/<uid>
+#       unknown  none of the above; XPC_SERVICE_NAME alone, including value 0,
+#                does not prove an Aqua birth
 #   fm_remote_herdr_birth_is_aqua <birth>
 #     Succeeds only for launchd and worker. `unknown` is deliberately not
 #     Aqua: a server that cannot prove its birth is treated like a foreign one,
@@ -101,18 +102,43 @@ fm_remote_herdr_process_ancestry() { # <pid>
   done
 }
 
+fm_remote_herdr_gui_job_proves_owner() { # <uid> <label> <pid>
+  local uid=$1 label=$2 pid=$3 job
+  [ -n "$label" ] && [ "$label" != 0 ] || return 1
+  job=$(launchctl print "gui/$uid/$label" 2>/dev/null) || return 1
+  if printf '%s\n' "$job" | awk -v expected="$pid" '
+    $1 == "pid" && $2 == "=" && $3 == expected { found = 1 }
+    END { exit found ? 0 : 1 }
+  '; then
+    return 0
+  fi
+  ! launchctl print "user/$uid/$label" >/dev/null 2>&1
+}
+
+fm_remote_herdr_gui_job_is_exclusive() { # <uid> <label>
+  local uid=$1 label=$2
+  launchctl print "gui/$uid/$label" >/dev/null 2>&1 \
+    && ! launchctl print "user/$uid/$label" >/dev/null 2>&1
+}
+
 fm_remote_herdr_owner_birth() { # <pid>
-  local pid=$1 env
+  local pid=$1 env uid xpc_line label
   env=$(fm_remote_herdr_process_env "$pid") || { printf 'unknown\n'; return 0; }
   if printf '%s\n' "$env" | grep -q -E '^SSH_(CONNECTION|CLIENT|TTY)='; then
     printf 'ssh\n'
     return 0
   fi
-  if printf '%s\n' "$env" | grep -q -E '^XPC_SERVICE_NAME='; then
+  uid=$(id -u 2>/dev/null) || uid=
+  xpc_line=$(printf '%s\n' "$env" | grep -E '^XPC_SERVICE_NAME=' | head -1 || true)
+  label=${xpc_line#XPC_SERVICE_NAME=}
+  if [ -n "$uid" ] && [ -n "$xpc_line" ] \
+    && fm_remote_herdr_gui_job_proves_owner "$uid" "$label" "$pid"; then
     printf 'launchd\n'
     return 0
   fi
-  if printf '%s\n' "$env" | grep -q -E '^FM_REMOTE_JOB_ACTIVE=1$'; then
+  if printf '%s\n' "$env" | grep -q -E '^FM_REMOTE_JOB_ACTIVE=1$' \
+    && [ -n "$uid" ] \
+    && fm_remote_herdr_gui_job_is_exclusive "$uid" dev.firstmate.remote-job; then
     printf 'worker\n'
     return 0
   fi

--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -297,7 +297,7 @@ family_for_basename() {
       printf '%s\n' real-herdr-gated
       ;;
     fm-backlog-handoff.test.sh|fm-on.test.sh|fm-remote-backlog-handoff.test.sh|\
-    fm-remote-doctor.test.sh|fm-remote-job.test.sh|fm-remote-job-orphan-reap.test.sh|\
+    fm-remote-doctor.test.sh|fm-remote-herdr-guard.test.sh|fm-remote-job.test.sh|fm-remote-job-orphan-reap.test.sh|\
     fm-remote-transport-lanes.test.sh|\
     fm-remote-reply.test.sh|fm-remote-secondmate-lifecycle-e2e.test.sh|\
     fm-remote-secondmate-trace-context.test.sh|\
@@ -670,6 +670,7 @@ tests/fm-quota-choose.test.sh 1461
 tests/fm-remote-backlog-handoff.test.sh 41432
 tests/fm-remote-doctor.test.sh 5198
 tests/fm-remote-entrypoint.test.sh 132
+tests/fm-remote-herdr-guard.test.sh 1500
 tests/fm-remote-job-orphan-reap.test.sh 2972
 tests/fm-remote-job.test.sh 59603
 tests/fm-remote-reply.test.sh 101690

--- a/docs/remote-secondmates.md
+++ b/docs/remote-secondmates.md
@@ -112,7 +112,7 @@ These steps are never automated and are always reported rather than silently att
 - The first console login on that Mac, and automatic login in System Settings > Users & Groups when the machine runs headless and must come back on its own after a reboot.
 - FileVault, which holds a reboot at pre-boot authentication before any login session exists.
 - Installing any missing required tool that no safe wrapper can resolve.
-- The required remote tool set is `git`, `jq`, `herdr`, compatible `tasks-axi`, `treehouse`, and at least one of `claude`, `codex`, `opencode`, `pi`, `pi-signed`, `grok`, or `kimi`.
+- The required remote tool set is `git`, `jq`, `herdr`, compatible `tasks-axi`, `treehouse`, and at least one of `claude`, `codex`, `opencode`, `pi`, `pi-signed`, `grok`, or `kimi`; macOS additionally requires `lsof` so the doctor and guard can prove which process owns the session socket.
 - Each worker runtime's own `/login`, and any keychain password prompt that login needs.
 
 Firstmate never writes an auto-login password, never changes FileVault, and never stores an account password.

--- a/docs/remote-secondmates.md
+++ b/docs/remote-secondmates.md
@@ -98,8 +98,10 @@ bin/fm-on.sh <secondmate-id|ssh-alias> fm-remote-doctor.sh --fix
 ```
 
 Over the plain SSH doctor bootstrap, it writes and reloads the Firstmate-owned `dev.firstmate.remote-job` and `dev.firstmate.herdr.fm-remote` launch agents on macOS, both scoped with `LimitLoadToSessionType=Aqua` and bootstrapped in `gui/<uid>`.
-The Herdr agent starts that server through a shell in login mode with separate `-l` and `-c` arguments, resolving the remote account's executable labeled Directory Services `UserShell`, then an executable `$SHELL`, and finally `/bin/sh`.
-The Aqua login session therefore receives login-shell environment and login-keychain access, while `exec` keeps the server in the foreground under launchd rather than letting it detach into a Background session.
+The Herdr agent runs [`bin/fm-remote-herdr-guard.sh`](../bin/fm-remote-herdr-guard.sh) through a shell in login mode with separate `-l` and `-c` arguments, resolving the remote account's executable labeled Directory Services `UserShell`, then an executable `$SHELL`, and finally `/bin/sh`, so the server inherits the account's own environment.
+The `gui/<uid>` domain, not the login shell, is what gives that server and every pane it spawns the Aqua audit session and login-keychain access; a server born in any other session cannot read the login keychain, and every claude pane under it falls back to a stale plaintext credentials file and reports "Login expired".
+Herdr's own SSH remote attach starts such a server when it finds none, and at boot it wins the `fm-remote` socket because sshd accepts connections before the login session exists, so the guard is what makes the launch agent converge: it execs the server in the foreground under launchd when nothing owns the socket, exits 0 when an Aqua-born server already does, and otherwise stops the foreign server and takes the session over, closing its panes so the parent firstmate relaunches its mates into the Aqua-born server.
+`KeepAlive={SuccessfulExit=false}` lets that exit 0 rest instead of respawning against a held socket; the guard's header owns the decision table and [`bin/fm-remote-herdr-owner-lib.sh`](../bin/fm-remote-herdr-owner-lib.sh) owns the birth markers it reads.
 It starts the same workers directly on Linux, recreates the `~/.local/bin/fm-remote-entrypoint.sh` symlink when it is absent, and creates only Firstmate-owned required-tool wrappers that it can prove resolve to a version-manager target, stopping after one harness satisfies the at-least-one requirement.
 It never installs packages or overwrites a non-Firstmate file at a reserved wrapper path.
 The dedicated Herdr launch agent owns only the remote-secondmate `fm-remote` server and does not inspect, rewrite, start, stop, or require the user's interactive `default` session or its `dev.firstmate.herdr` launch agent.
@@ -265,6 +267,7 @@ bin/fm-test-run.sh tests/fm-crew-state.test.sh
 bin/fm-test-run.sh tests/fm-remote-job.test.sh
 bin/fm-test-run.sh tests/fm-remote-transport-lanes.test.sh
 bin/fm-test-run.sh tests/fm-remote-doctor.test.sh
+bin/fm-test-run.sh tests/fm-remote-herdr-guard.test.sh
 bin/fm-test-run.sh tests/fm-project-origin.test.sh
 bin/fm-test-run.sh tests/fm-secondmate-sync.test.sh
 bin/fm-test-run.sh tests/fm-remote-reply.test.sh
@@ -274,6 +277,7 @@ bin/fm-test-run.sh tests/fm-remote-secondmate-trace-context.test.sh
 ```
 
 The account-level checks the doctor performs - a real Aqua login session, a real `launchctl` domain, and a real herdr server - are only ever exercised against fixtures here, so the readiness gate's behavior on a genuine Mac remains an operator-run smoke test.
+The audit-session facts the guard relies on are recorded with their commands in [runtime backend verification](verification/runtime-backends.md#fm-remote-server-birth-and-login-keychain-access).
 
 For a real-host smoke test, provision a disposable remote account and project, run the doctor and its repair against that account, launch the second mate, send one marked request, verify its correlated reply and structured fleet projection, simulate an unreachable host to confirm unknown-without-failover behavior, then retire only after the remote queue is empty.
 The deterministic suite is automated; real-host validation is still an operator-run smoke test and is not claimed by the repository tests.

--- a/docs/verification/runtime-backends.md
+++ b/docs/verification/runtime-backends.md
@@ -621,15 +621,31 @@ Same user, same `HOME`, same login keychain item, three births, probed with `lau
 
 Claude Code 2.1.266 maps that exit 36 (and 44) to "no keychain data" and reads `~/.claude/.credentials.json` instead; with a stale file it prints `Failed to authenticate: OAuth session expired and could not be refreshed` (interactive: `Login expired · Please run /login`).
 
-Birth markers, read with `ps -Eww -o command= -p <pid>` (own-uid processes; macOS hides the environment of Apple platform binaries such as `/bin/sleep`, and a herdr server is never one):
+Candidate birth markers were read with `ps -Eww -o command= -p <pid>` for own-uid processes, noting that macOS hides the environment of Apple platform binaries such as `/bin/sleep` and that a herdr server is never one.
 
 ```text
 launchd-born herdr server (child of launchd, gui/501):  XPC_SERVICE_NAME=org.nix-community.home.herdr-server  no SSH_*
 SSH-born herdr server (child of `herdr --session fm-remote remote-client-bridge` under `sshd-session: user@notty`):  SSH_CLIENT=... SSH_CONNECTION=...  no XPC_SERVICE_NAME
 ```
 
+`XPC_SERVICE_NAME` identifies a launchd label but does not identify its domain, because the Background `user/501` job also carried that variable while lacking keychain access.
+The owner classifier therefore accepts that label only when `launchctl print gui/<uid>/<label>` identifies the owner pid or the label is loaded in `gui/<uid>` but not `user/<uid>`.
+`XPC_SERVICE_NAME=0`, including a value inherited by a herdr live-handoff child, remains unknown.
+`FM_REMOTE_JOB_ACTIVE=1` proves the Aqua worker only when `dev.firstmate.remote-job` is loaded in `gui/<uid>` but not `user/<uid>`.
+
 The SSH-born row was read on the remote host whose `dev.firstmate.herdr.fm-remote` job showed `state = spawn scheduled`, `runs = 239`, `last exit code = 1` and a log repeating `error: herdr server is already running`: herdr's remote attach had started the session's server as its own child before the login session existed, and launchd's copy lost the socket on every retry.
 `pgrep -f` did not list the herdr server's argv on macOS; `lsof -U -a -c herdr -F pn` named the socket owner.
+
+A separate foreground-supervision check ran on 2026-09-09 on macOS 26 (Darwin 25.6.0) with Herdr 0.9.0 using the throwaway Aqua launch agent `dev.fm-rca.herdr-fg`.
+Its `ProgramArguments` ran `/run/current-system/sw/bin/zsh -l -c "exec /etc/profiles/per-user/kunchen/bin/herdr server --session fm-lab-fg-90381-18985"`, with `KeepAlive={SuccessfulExit=false}` and `ThrottleInterval=10`, after `launchctl bootstrap gui/501 <plist>` and `launchctl kickstart -k gui/501/dev.fm-rca.herdr-fg`.
+`launchctl print gui/501/dev.fm-rca.herdr-fg` reported `state = running` and `pid = 4806`.
+`lsof -U -a -c herdr -F pn` named pid 4806 as the owner of `~/.config/herdr/sessions/fm-lab-fg-90381-18985/herdr.sock`.
+`ps -o pid,ppid,command -p 4806` reported `4806 1 /etc/profiles/per-user/kunchen/bin/herdr server --session fm-lab-fg-90381-18985`, and its environment carried `XPC_SERVICE_NAME=dev.fm-rca.herdr-fg`.
+No other herdr process existed for that session, and after 15 seconds the job remained running with pid 4806.
+After a guarded `herdr session stop`, the job reported `state = not running` and `last exit code = 0`, and it stayed at rest through the throttle interval.
+A second `launchctl kickstart -k gui/501/dev.fm-rca.herdr-fg` started pid 45574, which was also the new socket owner.
+This proves that `herdr server` remains in the foreground as the launchd job, so the guard's final `exec` supplies the intended supervision and the earlier server that survived `launchctl bootout` was the unrelated SSH-bridge-born process.
+
 `bin/fm-test-run.sh tests/fm-remote-herdr-guard.test.sh` pins the resulting decision table against real marker-carrying processes, and `tests/fm-remote-doctor.test.sh` pins the doctor's verdicts on the same markers.
 
 ### Client selection

--- a/docs/verification/runtime-backends.md
+++ b/docs/verification/runtime-backends.md
@@ -607,6 +607,31 @@ The CLI matrix was checked directly:
 All destructive verification used `bin/fm-herdr-lab.sh` with a non-default `fm-lab-` name and a byte-identical default-session tripwire.
 No ambient `herdr server stop` command is a supported test operation.
 
+### fm-remote server birth and login-keychain access
+
+Measured 2026-09-09 on macOS 26 (Darwin 25.6.0) aarch64 with Claude Code 2.1.266 and Herdr 0.9.0, the guarantee behind `bin/fm-remote-herdr-guard.sh` and the doctor's `herdr-server` check: login-keychain access follows the audit session a process was born into, never the launch shape or the shell.
+
+Same user, same `HOME`, same login keychain item, three births, probed with `launchctl managername`, `getaudit_addr` (a compiled probe), `security find-generic-password -a "$USER" -w -s "Claude Code-credentials"` (output withheld), and `claude auth status`:
+
+| Birth | `managername` | audit session | `security ... -w` | `claude auth status` |
+| --- | --- | --- | --- | --- |
+| `gui/501` LaunchAgent, bare `ProgramArguments`, `launchctl bootstrap` + `kickstart -k` mid-session | Aqua | asid 100038 (the `gui/501` asid), `HAS_GRAPHIC_ACCESS HAS_TTY HAS_CONSOLE_ACCESS HAS_AUTHENTICATED` | exit 0 | `loggedIn: true` |
+| `gui/501` LaunchAgent, `zsh -l -c 'exec ...'`, same reload | Aqua | asid 100038, same flags | exit 0 | `loggedIn: true` |
+| `user/501` LaunchAgent (`LimitLoadToSessionType=Background`), same reload | Background | asid 100056, flags `0x0` | exit 36 `User interaction is not allowed.`, item metadata still readable | `loggedIn: false`, `authMethod: none` |
+
+Claude Code 2.1.266 maps that exit 36 (and 44) to "no keychain data" and reads `~/.claude/.credentials.json` instead; with a stale file it prints `Failed to authenticate: OAuth session expired and could not be refreshed` (interactive: `Login expired · Please run /login`).
+
+Birth markers, read with `ps -Eww -o command= -p <pid>` (own-uid processes; macOS hides the environment of Apple platform binaries such as `/bin/sleep`, and a herdr server is never one):
+
+```text
+launchd-born herdr server (child of launchd, gui/501):  XPC_SERVICE_NAME=org.nix-community.home.herdr-server  no SSH_*
+SSH-born herdr server (child of `herdr --session fm-remote remote-client-bridge` under `sshd-session: user@notty`):  SSH_CLIENT=... SSH_CONNECTION=...  no XPC_SERVICE_NAME
+```
+
+The SSH-born row was read on the remote host whose `dev.firstmate.herdr.fm-remote` job showed `state = spawn scheduled`, `runs = 239`, `last exit code = 1` and a log repeating `error: herdr server is already running`: herdr's remote attach had started the session's server as its own child before the login session existed, and launchd's copy lost the socket on every retry.
+`pgrep -f` did not list the herdr server's argv on macOS; `lsof -U -a -c herdr -F pn` named the socket owner.
+`bin/fm-test-run.sh tests/fm-remote-herdr-guard.test.sh` pins the resulting decision table against real marker-carrying processes, and `tests/fm-remote-doctor.test.sh` pins the doctor's verdicts on the same markers.
+
 ### Client selection
 
 Measured 2026-09-08 on a macOS aarch64 host running a Herdr 0.9.0 server (protocol 22) for the `fm-remote` session while `~/.local/bin/herdr` still held the self-updated 0.8.2 client (protocol 20) ahead of the Nix-managed 0.9.0 client on the remote-job `PATH`.

--- a/tests/fm-on.test.sh
+++ b/tests/fm-on.test.sh
@@ -68,7 +68,7 @@ case "\${1:-}:\${2:-}" in
 esac
 SH
 cp "$ROOT/bin/fm-remote-doctor.sh" "$ROOT/bin/fm-tasks-axi-lib.sh" \
-  "$ROOT/bin/fm-backend.sh" "$REMOTE_ROOT/bin/"
+  "$ROOT/bin/fm-remote-herdr-owner-lib.sh" "$ROOT/bin/fm-backend.sh" "$REMOTE_ROOT/bin/"
 mkdir -p "$REMOTE_ROOT/bin/backends"
 cp "$ROOT/bin/backends/herdr.sh" "$REMOTE_ROOT/bin/backends/herdr.sh"
 cat > "$REMOTE_ROOT/bin/fm-mutate.sh" <<'SH'

--- a/tests/fm-remote-doctor.test.sh
+++ b/tests/fm-remote-doctor.test.sh
@@ -2,9 +2,13 @@
 # tests/fm-remote-doctor.test.sh - the remote second-mate readiness gate.
 #
 # Drives the real bin/fm-remote-doctor.sh against a controlled account fixture:
-# a private HOME, a fake launchctl backed by state files, a fake herdr CLI, and
-# a fake uname that selects the platform under test. Nothing here touches the
-# runner's own launch agents, login session, or herdr server.
+# a private HOME, a fake launchctl backed by state files, a fake herdr CLI, a
+# fake lsof that names a real holder process as the fm-remote socket owner, and
+# a fake uname that selects the platform under test. The holders are real
+# non-platform processes (jq blocked on a fifo) whose environment carries the
+# birth markers bin/fm-remote-herdr-owner-lib.sh reads, so the Aqua-versus-SSH
+# verdict is exercised for real. Nothing here touches the runner's own launch
+# agents, login session, or herdr server.
 set -u
 
 # shellcheck source=tests/lib.sh
@@ -20,7 +24,9 @@ TMP_ROOT=$(cd "$TMP_ROOT" && pwd -P)
 JOB_LABEL=dev.firstmate.remote-job
 CASE_N=0
 DOCTOR_WORKER_PID=
-trap 'if [ -n "$DOCTOR_WORKER_PID" ]; then kill "$DOCTOR_WORKER_PID" 2>/dev/null || true; fi; fm_test_cleanup || true' EXIT
+HOLDER_PIDS=()
+trap 'if [ -n "$DOCTOR_WORKER_PID" ]; then kill "$DOCTOR_WORKER_PID" 2>/dev/null || true; fi; if [ "${#HOLDER_PIDS[@]}" -gt 0 ]; then kill "${HOLDER_PIDS[@]}" 2>/dev/null || true; fi; fm_test_cleanup || true' EXIT
+GUARD="$ROOT/bin/fm-remote-herdr-guard.sh"
 
 # A fixture must be able to present a host with NO herdr, so the doctor never
 # sees the runner's own PATH. Only the two required tools are re-exposed, by
@@ -30,6 +36,24 @@ mkdir -p "$TOOLS"
 ln -sf "$(command -v git)" "$TOOLS/git"
 ln -sf "$(command -v jq)" "$TOOLS/jq"
 BASE_PATH="$TOOLS:/usr/bin:/bin:/usr/sbin:/sbin"
+
+# Real socket-owner holders for the Darwin birth check: jq blocked on a fifo
+# this test keeps open, with exactly the marker environment each birth needs.
+JQ=$(command -v jq)
+HOLDER_FD=5
+hold() { # <marker-env...> -> HOLDER_PID
+  local fifo="$TMP_ROOT/holder-$HOLDER_FD.fifo"
+  mkfifo "$fifo"
+  env -i "$@" "$JQ" . "$fifo" &
+  HOLDER_PID=$!
+  HOLDER_PIDS+=("$HOLDER_PID")
+  eval "exec ${HOLDER_FD}>\"\$fifo\""
+  HOLDER_FD=$((HOLDER_FD + 1))
+}
+hold XPC_SERVICE_NAME=dev.firstmate.herdr.fm-remote
+AQUA_HOLDER_PID=$HOLDER_PID
+hold SSH_CONNECTION='100.102.217.78 51234 100.100.1.2 22' SSH_CLIENT='100.102.217.78 51234 22'
+SSH_HOLDER_PID=$HOLDER_PID
 
 # new_case <Darwin|Linux> [with-herdr] [gui] [login-shell]
 # Builds one isolated account fixture and points the module-level CASE_*
@@ -127,13 +151,19 @@ arguments = {
 	$FM_FAKE_LOGIN_SHELL
 	-l
 	-c
-	exec '$FM_FAKE_HERDR_BIN' server --session 'fm-remote'
+	exec '$FM_FAKE_GUARD' '$FM_FAKE_HERDR_BIN' 'fm-remote'
 }
 stdout path = $FM_FAKE_LAUNCH_AGENT_LOG
 stderr path = $FM_FAKE_LAUNCH_AGENT_LOG
-properties = keepalive | runatload | inferred program
+semaphores = {
+	successful exit => 0
+}
+properties = runatload | inferred program
 EOF
-        [ -f "$FM_FAKE_STATE/bootstrap-does-not-start" ] || printf 'true\n' > "$FM_FAKE_HERDR_RUNNING"
+        if [ ! -f "$FM_FAKE_STATE/bootstrap-does-not-start" ]; then
+          printf 'true\n' > "$FM_FAKE_HERDR_RUNNING"
+          printf '%s\n' "$FM_FAKE_AQUA_PID" > "$FM_FAKE_STATE/socket-owner"
+        fi
         ;;
     esac
     exit 0
@@ -143,6 +173,9 @@ EOF
     case "$label" in
       dev.firstmate.remote-job) : ;;
       *)
+        # The real job execs the guard, which stops a foreign server and
+        # becomes the Aqua-born owner; the fixture models that outcome.
+        printf '%s\n' "$FM_FAKE_AQUA_PID" > "$FM_FAKE_STATE/socket-owner"
         if [ -f "$FM_FAKE_STATE/kickstart-delay" ]; then
           cp "$FM_FAKE_STATE/kickstart-delay" "$FM_FAKE_STATE/herdr-delay"
         else
@@ -167,6 +200,17 @@ exit 0
 SH
     chmod +x "$CASE_BIN/$forbidden"
   done
+
+  # The socket owner the birth check sees: the pid in socket-owner, or the
+  # Aqua holder when a case never chose one.
+  cat > "$CASE_BIN/lsof" <<'SH'
+#!/usr/bin/env bash
+pid=$(cat "$FM_FAKE_STATE/socket-owner" 2>/dev/null || printf '%s' "$FM_FAKE_AQUA_PID")
+[ -n "$pid" ] || exit 0
+printf 'p%s\n' "$pid"
+printf 'n%s\n' "$FM_FAKE_HERDR_SOCKET"
+SH
+  chmod +x "$CASE_BIN/lsof"
 
   cat > "$CASE_BIN/dscl" <<'SH'
 #!/usr/bin/env bash
@@ -206,7 +250,7 @@ case "${1:-} ${2:-}" in
         running=true
       fi
     fi
-    printf '{"client":{"version":"0.7.5","protocol":16},"server":{"running":%s}}\n' "$running"
+    printf '{"client":{"version":"0.7.5","protocol":16},"server":{"running":%s,"socket":"%s"}}\n' "$running" "$FM_FAKE_HERDR_SOCKET"
     ;;
   "server "*|"server ")
     printf 'true\n' > "$FM_FAKE_HERDR_RUNNING"
@@ -253,6 +297,9 @@ doctor() {
     FM_FAKE_FORBIDDEN_LOG="$CASE_FORBIDDEN_LOG" \
     FM_FAKE_HERDR_RUNNING="$CASE_HERDR_RUNNING" \
     FM_FAKE_HERDR_BIN="$CASE_BIN/herdr" \
+    FM_FAKE_HERDR_SOCKET="$CASE_STATE/herdr.sock" \
+    FM_FAKE_GUARD="$GUARD" \
+    FM_FAKE_AQUA_PID="$AQUA_HOLDER_PID" \
     FM_FAKE_PLIST="$CASE_PLIST" \
     FM_FAKE_JOB_PLIST="$CASE_JOB_PLIST" \
     FM_FAKE_JOB_WORKER="$ROOT/bin/fm-remote-job-worker.sh" \
@@ -271,8 +318,9 @@ doctor() {
   set -e
 }
 
-write_loaded_contract() { # <herdr-path> [properties]
-  local herdr_bin=$1 properties=${2:-'keepalive | runatload | inferred program'}
+write_loaded_contract() { # <herdr-path> [properties] [exec-command]
+  local herdr_bin=$1 properties=${2:-'runatload | inferred program'} exec_cmd
+  exec_cmd=${3:-"exec '$GUARD' '$herdr_bin' 'fm-remote'"}
   cat > "$CASE_STATE/loaded-$LABEL" <<EOF
 path = $CASE_PLIST
 program = $CASE_LOGIN_SHELL
@@ -280,10 +328,13 @@ arguments = {
 	$CASE_LOGIN_SHELL
 	-l
 	-c
-	exec '$herdr_bin' server --session 'fm-remote'
+	$exec_cmd
 }
 stdout path = $CASE_HOME/Library/Logs/$LABEL.log
 stderr path = $CASE_HOME/Library/Logs/$LABEL.log
+semaphores = {
+	successful exit => 0
+}
 properties = $properties
 EOF
 }
@@ -310,14 +361,16 @@ assert_herdr_launch_agent_contract() { # <plist> <herdr-bin> [login-shell]
   [ "$argv0" = "$expected_shell" ] || fail "ProgramArguments[0] is $argv0, not the resolved login shell $expected_shell"
   [ "$argv1" = -l ] || fail "ProgramArguments[1] is $argv1, not -l"
   [ "$argv2" = -c ] || fail "ProgramArguments[2] is $argv2, not -c"
-  [ "$cmd" = "exec '$herdr_bin' server --session 'fm-remote'" ] \
-    || fail "ProgramArguments[3] is not exec of $herdr_bin for session fm-remote: $cmd"
+  [ "$cmd" = "exec '$GUARD' '$herdr_bin' 'fm-remote'" ] \
+    || fail "ProgramArguments[3] is not exec of the guard with $herdr_bin for session fm-remote: $cmd"
   [ "$(printf '%s' "$json" | jq -r '.LimitLoadToSessionType')" = Aqua ] \
     || fail "LimitLoadToSessionType is not Aqua"
   [ "$(printf '%s' "$json" | jq -r '.RunAtLoad')" = true ] \
     || fail "RunAtLoad is not true"
-  [ "$(printf '%s' "$json" | jq -r '.KeepAlive')" = true ] \
-    || fail "KeepAlive is not true"
+  [ "$(printf '%s' "$json" | jq -r '.KeepAlive.SuccessfulExit')" = false ] \
+    || fail "KeepAlive is not {SuccessfulExit=false}: $(printf '%s' "$json" | jq -c '.KeepAlive')"
+  [ "$(printf '%s' "$json" | jq -r '.ThrottleInterval')" = 10 ] \
+    || fail "ThrottleInterval is not 10"
   [ "$(printf '%s' "$json" | jq -r '.Label')" = "$LABEL" ] \
     || fail "Label is not $LABEL"
 }
@@ -444,7 +497,7 @@ cat > "$CASE_PLIST" <<XML
 </dict>
 </plist>
 XML
-write_loaded_contract /obsolete/bin/herdr 'runatload | inferred program'
+write_loaded_contract /obsolete/bin/herdr 'keepalive | runatload | inferred program' "exec '/obsolete/bin/herdr' server --session 'fm-remote'"
 printf 'true\n' > "$CASE_HERDR_RUNNING"
 doctor
 expect_code 1 "$DOCTOR_RC" "a stale launch-agent contract was reported ready"
@@ -480,7 +533,7 @@ cat > "$CASE_PLIST" <<XML
 </dict>
 </plist>
 XML
-write_loaded_contract /obsolete/bin/herdr 'runatload | inferred program'
+write_loaded_contract /obsolete/bin/herdr 'keepalive | runatload | inferred program' "exec '/obsolete/bin/herdr' server --session 'fm-remote'"
 printf 'true\n' > "$CASE_HERDR_RUNNING"
 touch "$CASE_STATE/bootout-fail"
 doctor --fix
@@ -545,6 +598,51 @@ assert_contains "$DOCTOR_OUT" 'fix herdr-server=applied:' "delayed launchd start
 assert_contains "$DOCTOR_OUT" 'check herdr-server=ok:' "delayed launchd startup was not confirmed"
 assert_absent "$CASE_STATE/herdr-delay" "the readiness poll stopped before the delayed server became reachable"
 pass "launchd failures are reported and delayed server readiness is awaited"
+
+# --- a running session served outside the Aqua login session is not ready ---
+
+new_case Darwin with-herdr gui
+doctor --fix
+expect_code 0 "$DOCTOR_RC" "the Aqua-owner fixture could not be initialized"
+assert_contains "$DOCTOR_OUT" "check herdr-server=ok: session fm-remote is running in the Aqua login session (pid $AQUA_HOLDER_PID, launchd)" \
+  "a launchd-born owner was not reported with its pid and birth"
+printf '%s\n' "$SSH_HOLDER_PID" > "$CASE_STATE/socket-owner"
+: > "$CASE_LAUNCHCTL_LOG"
+doctor
+expect_code 1 "$DOCTOR_RC" "a session served by an SSH-born server was reported ready"
+assert_contains "$DOCTOR_OUT" "check herdr-server=fixable: session fm-remote is served by pid $SSH_HOLDER_PID born outside the Aqua login session (ssh)" \
+  "an SSH-born owner was not tagged fixable with its pid and birth"
+assert_contains "$DOCTOR_OUT" 'cannot reach the login keychain' "the consequence of the foreign birth was not named"
+assert_contains "$DOCTOR_OUT" 'action: herdr-server:' "the foreign-birth gap came with no operator action"
+assert_contains "$DOCTOR_OUT" 'check launchagent-loaded=ok:' "a healthy loaded contract was blamed for the foreign server"
+[ ! -s "$CASE_LAUNCHCTL_LOG" ] || assert_not_contains "$(cat "$CASE_LAUNCHCTL_LOG")" kickstart \
+  "a read-only doctor run restarted the launch agent"
+doctor --fix
+expect_code 0 "$DOCTOR_RC" "--fix did not hand the session back to the launch agent"
+assert_contains "$DOCTOR_OUT" 'fix herdr-server=applied:' "--fix did not report the takeover through the launch agent"
+assert_grep "kickstart -k gui/$(id -u)/$LABEL" "$CASE_LAUNCHCTL_LOG" "the takeover did not go through launchd"
+assert_contains "$DOCTOR_OUT" "check herdr-server=ok: session fm-remote is running in the Aqua login session (pid $AQUA_HOLDER_PID, launchd)" \
+  "the launch-agent-owned server was not confirmed after the takeover"
+assert_no_dangerous_calls "the takeover reached for auto-login, FileVault, or the keychain"
+
+# A RunAtLoad job also runs at bootstrap; hold that back so the takeover
+# depends on the kickstart that is about to fail.
+printf '%s\n' "$SSH_HOLDER_PID" > "$CASE_STATE/socket-owner"
+touch "$CASE_STATE/kickstart-fail" "$CASE_STATE/bootstrap-does-not-start"
+doctor --fix
+expect_code 1 "$DOCTOR_RC" "a failed takeover was reported ready"
+assert_contains "$DOCTOR_OUT" 'fix herdr-server=failed: launchctl kickstart' "the failed takeover was not reported"
+assert_contains "$DOCTOR_OUT" "check herdr-server=fixable: session fm-remote is served by pid $SSH_HOLDER_PID" \
+  "a still-foreign server was reported ready after a failed takeover"
+rm -f "$CASE_STATE/kickstart-fail" "$CASE_STATE/bootstrap-does-not-start"
+
+rm -f "$CASE_STATE/socket-owner"
+: > "$CASE_STATE/socket-owner"
+doctor
+expect_code 1 "$DOCTOR_RC" "a session with no provable owner was reported ready"
+assert_contains "$DOCTOR_OUT" 'check herdr-server=fixable: session fm-remote is running but no herdr process can be shown to own its socket' \
+  "an unprovable owner was not tagged fixable"
+pass "a session served outside the Aqua login session is fixable and --fix retakes it through launchd"
 
 # --- no GUI login session: every dependent gap stays human -------------------
 

--- a/tests/fm-remote-doctor.test.sh
+++ b/tests/fm-remote-doctor.test.sh
@@ -52,6 +52,12 @@ hold() { # <marker-env...> -> HOLDER_PID
 }
 hold XPC_SERVICE_NAME=dev.firstmate.herdr.fm-remote
 AQUA_HOLDER_PID=$HOLDER_PID
+hold XPC_SERVICE_NAME=dev.firstmate.herdr.fm-remote
+BACKGROUND_HOLDER_PID=$HOLDER_PID
+hold XPC_SERVICE_NAME=0
+XPC_ZERO_HOLDER_PID=$HOLDER_PID
+hold FM_REMOTE_JOB_ACTIVE=1
+WORKER_HOLDER_PID=$HOLDER_PID
 hold SSH_CONNECTION='100.102.217.78 51234 100.100.1.2 22' SSH_CLIENT='100.102.217.78 51234 22'
 SSH_HOLDER_PID=$HOLDER_PID
 
@@ -104,6 +110,10 @@ loaded="$FM_FAKE_STATE/loaded-$label"
 case "${1:-}" in
   print)
     case "$domain" in
+      user/*/*)
+        [ -f "$FM_FAKE_STATE/user-loaded-$label" ] || exit 113
+        cat "$FM_FAKE_STATE/user-loaded-$label"
+        ;;
       */dev.firstmate.herdr.fm-remote)
         [ -f "$loaded" ] || exit 113
         cat "$loaded"
@@ -606,6 +616,27 @@ doctor --fix
 expect_code 0 "$DOCTOR_RC" "the Aqua-owner fixture could not be initialized"
 assert_contains "$DOCTOR_OUT" "check herdr-server=ok: session fm-remote is running in the Aqua login session (pid $AQUA_HOLDER_PID, launchd)" \
   "a launchd-born owner was not reported with its pid and birth"
+
+printf '%s\n' "$BACKGROUND_HOLDER_PID" > "$CASE_STATE/socket-owner"
+printf 'background job\n' > "$CASE_STATE/user-loaded-$LABEL"
+doctor
+expect_code 1 "$DOCTOR_RC" "a label loaded in the user domain was reported Aqua-born"
+assert_contains "$DOCTOR_OUT" "check herdr-server=fixable: session fm-remote is served by pid $BACKGROUND_HOLDER_PID born outside the Aqua login session (unknown)" \
+  "the user-domain owner was not tagged fixable"
+rm -f "$CASE_STATE/user-loaded-$LABEL"
+
+printf '%s\n' "$XPC_ZERO_HOLDER_PID" > "$CASE_STATE/socket-owner"
+doctor
+expect_code 1 "$DOCTOR_RC" "an XPC_SERVICE_NAME=0 owner was reported Aqua-born"
+assert_contains "$DOCTOR_OUT" "check herdr-server=fixable: session fm-remote is served by pid $XPC_ZERO_HOLDER_PID born outside the Aqua login session (unknown)" \
+  "the inherited XPC marker was not tagged fixable"
+
+printf '%s\n' "$WORKER_HOLDER_PID" > "$CASE_STATE/socket-owner"
+doctor
+expect_code 0 "$DOCTOR_RC" "the gui-only remote-job worker owner was not reported ready"
+assert_contains "$DOCTOR_OUT" "check herdr-server=ok: session fm-remote is running in the Aqua login session (pid $WORKER_HOLDER_PID, worker)" \
+  "the gui-only worker was not recognized"
+
 printf '%s\n' "$SSH_HOLDER_PID" > "$CASE_STATE/socket-owner"
 : > "$CASE_LAUNCHCTL_LOG"
 doctor

--- a/tests/fm-remote-herdr-guard.test.sh
+++ b/tests/fm-remote-herdr-guard.test.sh
@@ -1,0 +1,293 @@
+#!/usr/bin/env bash
+# tests/fm-remote-herdr-guard.test.sh - the fm-remote launch agent's guard.
+#
+# Drives the real bin/fm-remote-herdr-guard.sh (and the owner library it
+# sources) against a fake herdr CLI, a fake lsof that names a real holder
+# process as the session-socket owner, and real holder processes whose
+# environment and ancestry carry the birth markers the guard reads. It pins
+# the decision table: no server -> start; an Aqua-born owner -> leave it; an
+# SSH-born or unprovable owner -> stop it, wait for the socket, start. Nothing
+# here touches the runner's own herdr servers, launch agents, or login
+# session, and no live harness guard applies: the verdict comes from process
+# environment and ancestry, which are kernel facts rather than vendor output.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+command -v jq >/dev/null 2>&1 || { echo "skip: jq not found (the guard parses herdr's JSON, and jq is the holder process)"; exit 0; }
+command -v mkfifo >/dev/null 2>&1 || { echo "skip: mkfifo not found (holder processes block on a fifo)"; exit 0; }
+
+TMP_ROOT=$(fm_test_tmproot fm-remote-herdr-guard)
+mkdir -p "$TMP_ROOT"
+TMP_ROOT=$(cd "$TMP_ROOT" && pwd -P)
+HOLDER_PIDS=()
+HOLDER_FD=5
+trap 'if [ "${#HOLDER_PIDS[@]}" -gt 0 ]; then kill "${HOLDER_PIDS[@]}" 2>/dev/null || true; fi; fm_test_cleanup || true' EXIT
+
+GUARD="$ROOT/bin/fm-remote-herdr-guard.sh"
+JQ=$(command -v jq)
+SESSION=fm-remote
+
+# The guard must see only the fixture and the system tools it really needs,
+# so a case can also present a host with NO lsof.
+TOOLS="$TMP_ROOT/tools"
+mkdir -p "$TOOLS"
+for tool in ps awk sed grep tr dirname basename sleep cat cp rm env bash sh; do
+  real=$(command -v "$tool") || fail "test host lacks $tool"
+  ln -sf "$real" "$TOOLS/$tool"
+done
+ln -sf "$JQ" "$TOOLS/jq"
+FAKE="$TMP_ROOT/fake"
+mkdir -p "$FAKE"
+cat > "$FAKE/lsof" <<'SH'
+#!/usr/bin/env bash
+# Prints the -F pn shape for every pid listed in the owner file.
+[ -f "$FM_FAKE_SOCKET_OWNER" ] || exit 0
+while IFS= read -r pid; do
+  [ -n "$pid" ] || continue
+  printf 'p%s\n' "$pid"
+  printf 'n%s\n' "$FM_FAKE_HERDR_SOCKET"
+done < "$FM_FAKE_SOCKET_OWNER"
+SH
+cat > "$FAKE/herdr" <<'SH'
+#!/usr/bin/env bash
+set -u
+printf '%s\n' "$*" >> "$FM_FAKE_HERDR_LOG"
+running=$(cat "$FM_FAKE_HERDR_RUNNING" 2>/dev/null || printf 'false')
+case "$*" in
+  "status --json --session "*)
+    if [ -f "$FM_FAKE_STATE/release-after" ]; then
+      left=$(cat "$FM_FAKE_STATE/release-after")
+      if [ "$left" -gt 0 ]; then
+        printf '%s\n' "$((left - 1))" > "$FM_FAKE_STATE/release-after"
+      else
+        rm -f "$FM_FAKE_STATE/release-after"
+        printf 'false\n' > "$FM_FAKE_HERDR_RUNNING"
+        running=false
+      fi
+    fi
+    printf '{"server":{"running":%s,"socket":"%s","version":"0.9.0"},"client":{"version":"0.9.0"}}\n' \
+      "$running" "$FM_FAKE_HERDR_SOCKET"
+    ;;
+  "server stop --session "*)
+    if [ -f "$FM_FAKE_STATE/stop-ignored" ]; then
+      exit 0
+    elif [ -f "$FM_FAKE_STATE/stop-releases-after" ]; then
+      cp "$FM_FAKE_STATE/stop-releases-after" "$FM_FAKE_STATE/release-after"
+    else
+      printf 'false\n' > "$FM_FAKE_HERDR_RUNNING"
+    fi
+    ;;
+  "server --session "*)
+    printf 'pid=%s session=%s\n' "$$" "${3:-}" > "$FM_FAKE_STATE/started"
+    ;;
+esac
+exit 0
+SH
+chmod +x "$FAKE/lsof" "$FAKE/herdr"
+cp "$FAKE/lsof" "$TMP_ROOT/lsof.fake"
+
+# hold <marker-env...> -> HOLDER_PID: a real non-platform process (jq blocked
+# on a fifo this test keeps open) whose environment is exactly the markers.
+hold() {
+  local fifo="$TMP_ROOT/holder-$HOLDER_FD.fifo"
+  rm -f "$fifo"
+  mkfifo "$fifo"
+  # Open read-write so this never blocks on the reader; the holder sees EOF
+  # only when the descriptor closes at exit.
+  eval "exec ${HOLDER_FD}<>\"\$fifo\""
+  env -i "$@" "$JQ" . "$fifo" &
+  HOLDER_PID=$!
+  HOLDER_PIDS+=("$HOLDER_PID")
+  HOLDER_FD=$((HOLDER_FD + 1))
+}
+
+# hold_under <argv0> <arg...> -- : a marker-free holder whose PARENT process
+# carries the given argv[0] and arguments (the ancestry the guard inspects).
+hold_under() {
+  local argv0=$1 fifo="$TMP_ROOT/holder-$HOLDER_FD.fifo" pidfile="$TMP_ROOT/holder-$HOLDER_FD.pid"
+  shift
+  rm -f "$fifo" "$pidfile"
+  mkfifo "$fifo"
+  eval "exec ${HOLDER_FD}<>\"\$fifo\""
+  ( export FM_HOLDER_JQ="$JQ" FM_HOLDER_FIFO="$fifo" FM_HOLDER_PIDFILE="$pidfile"
+    exec -a "$argv0" bash -c 'env -i FM_HOLDER=1 "$FM_HOLDER_JQ" . "$FM_HOLDER_FIFO" & printf "%s\n" "$!" > "$FM_HOLDER_PIDFILE"; wait' "$@" ) &
+  HOLDER_PIDS+=("$!")
+  HOLDER_FD=$((HOLDER_FD + 1))
+  local i=0
+  while [ ! -s "$pidfile" ] && [ "$i" -lt 100 ]; do sleep 0.05; i=$((i + 1)); done
+  [ -s "$pidfile" ] || fail "holder under $argv0 did not report its pid"
+  HOLDER_PID=$(cat "$pidfile")
+  HOLDER_PIDS+=("$HOLDER_PID")
+}
+
+CASE_N=0
+new_case() { # [running|stopped]
+  CASE_N=$((CASE_N + 1))
+  CASE_STATE="$TMP_ROOT/case$CASE_N"
+  mkdir -p "$CASE_STATE"
+  CASE_LOG="$CASE_STATE/herdr.log"
+  : > "$CASE_LOG"
+  CASE_RUNNING="$CASE_STATE/running"
+  printf '%s\n' "$([ "${1:-running}" = running ] && printf true || printf false)" > "$CASE_RUNNING"
+  CASE_OWNER="$CASE_STATE/socket-owner"
+  CASE_SOCKET="$CASE_STATE/herdr.sock"
+  CASE_PATH="$FAKE:$TOOLS"
+}
+
+guard() { # [extra env assignments...]
+  set +e
+  GUARD_OUT=$(
+    env -i PATH="$CASE_PATH" HOME="$TMP_ROOT" \
+      FM_FAKE_STATE="$CASE_STATE" FM_FAKE_HERDR_LOG="$CASE_LOG" FM_FAKE_HERDR_RUNNING="$CASE_RUNNING" \
+      FM_FAKE_SOCKET_OWNER="$CASE_OWNER" FM_FAKE_HERDR_SOCKET="$CASE_SOCKET" \
+      FM_HOLDER_JQ="$JQ" \
+      FM_REMOTE_HERDR_GUARD_STOP_WAIT_TENTHS=8 \
+      "$@" "$GUARD" "$FAKE/herdr" "$SESSION" 2>&1
+  )
+  GUARD_RC=$?
+  set -e
+}
+
+herdr_calls() { cat "$CASE_LOG"; }
+assert_started() { # <msg>
+  [ -f "$CASE_STATE/started" ] || fail "$1"
+  assert_grep "session=$SESSION" "$CASE_STATE/started" "the server was started for the wrong session"
+}
+assert_not_started() { assert_absent "$CASE_STATE/started" "$1"; }
+assert_stop_before_start() {
+  local calls stop_line start_line
+  calls=$(herdr_calls)
+  stop_line=$(printf '%s\n' "$calls" | grep -n "^server stop --session $SESSION$" | head -1 | cut -d: -f1)
+  start_line=$(printf '%s\n' "$calls" | grep -n "^server --session $SESSION$" | head -1 | cut -d: -f1)
+  [ -n "$stop_line" ] || fail "the guard never asked the foreign server to stop"
+  [ -n "$start_line" ] || fail "the guard never started its own server"
+  [ "$stop_line" -lt "$start_line" ] || fail "the guard started its server before stopping the foreign one"
+}
+
+# Prove the holder construction on this host: the environment of a jq holder
+# must be readable, or every marker case would be vacuous.
+hold FM_PROBE_MARKER=1
+PROBE_PID=$HOLDER_PID
+sleep 0.2
+# shellcheck source=bin/fm-remote-herdr-owner-lib.sh
+. "$ROOT/bin/fm-remote-herdr-owner-lib.sh"
+probe_env=$(fm_remote_herdr_process_env "$PROBE_PID")
+case "$probe_env" in
+  *FM_PROBE_MARKER=1*) ;;
+  *) fail "this host does not expose a holder's environment (macOS hides platform-binary environments; jq at $JQ must be a non-platform binary): $probe_env" ;;
+esac
+pass "holder processes expose their environment to the owner library"
+
+# --- no server: the guard becomes the server ---------------------------------
+
+new_case stopped
+guard
+expect_code 0 "$GUARD_RC" "the guard failed when no server owned the session"
+assert_started "the guard did not start the server when none owned the session"
+assert_not_contains "$(herdr_calls)" 'server stop' "the guard stopped something when no server owned the session"
+assert_contains "$GUARD_OUT" "no server owns session $SESSION" "the guard did not report the empty session"
+pass "an empty session is started inside the launch agent"
+
+# --- an Aqua-born owner is left alone ----------------------------------------
+
+hold XPC_SERVICE_NAME=dev.firstmate.herdr.fm-remote
+LAUNCHD_PID=$HOLDER_PID
+hold FM_REMOTE_JOB_ACTIVE=1
+WORKER_PID=$HOLDER_PID
+hold SSH_CONNECTION='100.102.217.78 51234 100.100.1.2 22' SSH_CLIENT='100.102.217.78 51234 22'
+SSH_PID=$HOLDER_PID
+hold FM_NOTHING_TO_SEE=1
+UNMARKED_PID=$HOLDER_PID
+hold_under herdr --session "$SESSION" remote-client-bridge
+BRIDGE_CHILD_PID=$HOLDER_PID
+hold_under 'sshd-session:' kunchen@notty
+SSHD_CHILD_PID=$HOLDER_PID
+sleep 0.3
+
+for aqua in "launchd $LAUNCHD_PID" "worker $WORKER_PID"; do
+  new_case running
+  printf '%s\n' "${aqua#* }" > "$CASE_OWNER"
+  guard
+  expect_code 0 "$GUARD_RC" "the guard did not exit 0 for a ${aqua%% *}-born owner"
+  assert_not_started "the guard started a second server over a ${aqua%% *}-born owner"
+  assert_not_contains "$(herdr_calls)" 'server stop' "the guard stopped a ${aqua%% *}-born owner"
+  assert_contains "$GUARD_OUT" "pid ${aqua#* } born in the Aqua login session (${aqua%% *})" \
+    "the guard did not name the Aqua-born owner and its marker"
+done
+pass "a launchd-born or worker-born owner is left in place with exit 0"
+
+# --- a foreign owner is stopped, then the guard becomes the server -----------
+
+for foreign in "ssh $SSH_PID" "ssh $BRIDGE_CHILD_PID" "ssh $SSHD_CHILD_PID" "unknown $UNMARKED_PID"; do
+  new_case running
+  printf '%s\n' "${foreign#* }" > "$CASE_OWNER"
+  guard
+  expect_code 0 "$GUARD_RC" "the guard failed to take over from a ${foreign%% *} owner (pid ${foreign#* })"
+  assert_stop_before_start
+  assert_started "the guard did not start its own server after the ${foreign%% *} owner released the socket"
+  assert_contains "$GUARD_OUT" "pid ${foreign#* } born outside the Aqua login session (${foreign%% *})" \
+    "the guard did not name the foreign owner and its birth"
+done
+pass "SSH-born, SSH-descended, and unprovable owners are taken over: stop, wait, start"
+
+# --- an owner nobody can prove is treated as foreign -------------------------
+
+new_case running
+guard
+expect_code 0 "$GUARD_RC" "the guard failed when lsof listed no owner"
+assert_contains "$GUARD_OUT" 'no herdr process could be proven to own' "the guard did not report the unprovable owner"
+assert_stop_before_start
+pass "a running session with no provable owner is taken over rather than trusted"
+
+new_case running
+printf '%s\n' "$SSH_PID" > "$CASE_OWNER"
+rm -f "$FAKE/lsof"
+guard
+cp "$TMP_ROOT/lsof.fake" "$FAKE/lsof"
+chmod +x "$FAKE/lsof"
+expect_code 0 "$GUARD_RC" "the guard failed when lsof was absent"
+assert_contains "$GUARD_OUT" 'lsof does not resolve' "the guard did not report the missing lsof"
+assert_stop_before_start
+pass "a host without lsof cannot prove an Aqua birth, so the session is taken over"
+
+# --- a foreign owner that keeps the socket makes the guard fail for a retry --
+
+new_case running
+printf '%s\n' "$SSH_PID" > "$CASE_OWNER"
+touch "$CASE_STATE/stop-ignored"
+guard
+expect_code 1 "$GUARD_RC" "the guard did not exit 1 when the foreign server kept its socket"
+assert_not_started "the guard started a server while the foreign one still held the socket"
+assert_contains "$(herdr_calls)" "server stop --session $SESSION" "the guard never asked the foreign server to stop"
+assert_contains "$GUARD_OUT" 'did not release its socket within 8 tenths' "the guard did not report the bounded wait"
+pass "a foreign server that never releases the socket yields exit 1 so launchd retries"
+
+# --- the release wait is polled, not assumed ---------------------------------
+
+new_case running
+printf '%s\n' "$SSH_PID" > "$CASE_OWNER"
+printf '3\n' > "$CASE_STATE/stop-releases-after"
+guard
+expect_code 0 "$GUARD_RC" "the guard gave up on a server that released its socket after a few polls"
+assert_started "the guard did not start after the delayed release"
+assert_contains "$GUARD_OUT" 'released its socket after' "the guard did not report the observed release"
+[ "$(grep -c "^status --json --session $SESSION$" "$CASE_LOG")" -ge 4 ] \
+  || fail "the guard did not keep polling the session status until the socket was released"
+pass "the guard starts as soon as the foreign server releases the socket"
+
+# --- usage errors never touch a server ---------------------------------------
+
+new_case running
+set +e
+env -i PATH="$CASE_PATH" "$GUARD" "$FAKE/herdr" >/dev/null 2>&1
+rc=$?
+set -e
+expect_code 2 "$rc" "a missing session argument was not a usage error"
+set +e
+env -i PATH="$CASE_PATH" "$GUARD" "$TMP_ROOT/no-such-herdr" "$SESSION" >/dev/null 2>&1
+rc=$?
+set -e
+expect_code 1 "$rc" "a non-executable herdr path was not refused"
+[ ! -s "$CASE_LOG" ] || fail "a refused invocation still called herdr"
+pass "argument errors are refused before any herdr call"

--- a/tests/fm-remote-herdr-guard.test.sh
+++ b/tests/fm-remote-herdr-guard.test.sh
@@ -32,7 +32,7 @@ SESSION=fm-remote
 # so a case can also present a host with NO lsof.
 TOOLS="$TMP_ROOT/tools"
 mkdir -p "$TOOLS"
-for tool in ps awk sed grep tr dirname basename sleep cat cp rm env bash sh; do
+for tool in ps awk sed grep tr dirname basename sleep cat cp rm env bash sh id head; do
   real=$(command -v "$tool") || fail "test host lacks $tool"
   ln -sf "$real" "$TOOLS/$tool"
 done
@@ -48,6 +48,17 @@ while IFS= read -r pid; do
   printf 'p%s\n' "$pid"
   printf 'n%s\n' "$FM_FAKE_HERDR_SOCKET"
 done < "$FM_FAKE_SOCKET_OWNER"
+SH
+cat > "$FAKE/launchctl" <<'SH'
+#!/usr/bin/env bash
+[ "${1:-}" = print ] || exit 0
+domain=${2:-}
+scope=${domain%%/*}
+label=${domain#*/}
+label=${label#*/}
+state="$FM_FAKE_STATE/launchctl-$scope-$label"
+[ -f "$state" ] || exit 113
+cat "$state"
 SH
 cat > "$FAKE/herdr" <<'SH'
 #!/usr/bin/env bash
@@ -84,7 +95,7 @@ case "$*" in
 esac
 exit 0
 SH
-chmod +x "$FAKE/lsof" "$FAKE/herdr"
+chmod +x "$FAKE/lsof" "$FAKE/launchctl" "$FAKE/herdr"
 cp "$FAKE/lsof" "$TMP_ROOT/lsof.fake"
 
 # hold <marker-env...> -> HOLDER_PID: a real non-platform process (jq blocked
@@ -133,6 +144,14 @@ new_case() { # [running|stopped]
   CASE_OWNER="$CASE_STATE/socket-owner"
   CASE_SOCKET="$CASE_STATE/herdr.sock"
   CASE_PATH="$FAKE:$TOOLS"
+}
+
+load_job() { # <gui|user> <label> [pid]
+  if [ -n "${3:-}" ]; then
+    printf 'pid = %s\n' "$3" > "$CASE_STATE/launchctl-$1-$2"
+  else
+    printf 'state = running\n' > "$CASE_STATE/launchctl-$1-$2"
+  fi
 }
 
 guard() { # [extra env assignments...]
@@ -193,6 +212,10 @@ pass "an empty session is started inside the launch agent"
 
 hold XPC_SERVICE_NAME=dev.firstmate.herdr.fm-remote
 LAUNCHD_PID=$HOLDER_PID
+hold XPC_SERVICE_NAME=dev.firstmate.herdr.fm-remote
+BACKGROUND_PID=$HOLDER_PID
+hold XPC_SERVICE_NAME=0
+XPC_ZERO_PID=$HOLDER_PID
 hold FM_REMOTE_JOB_ACTIVE=1
 WORKER_PID=$HOLDER_PID
 hold SSH_CONNECTION='100.102.217.78 51234 100.100.1.2 22' SSH_CLIENT='100.102.217.78 51234 22'
@@ -205,19 +228,46 @@ hold_under 'sshd-session:' kunchen@notty
 SSHD_CHILD_PID=$HOLDER_PID
 sleep 0.3
 
-for aqua in "launchd $LAUNCHD_PID" "worker $WORKER_PID"; do
-  new_case running
-  printf '%s\n' "${aqua#* }" > "$CASE_OWNER"
-  guard
-  expect_code 0 "$GUARD_RC" "the guard did not exit 0 for a ${aqua%% *}-born owner"
-  assert_not_started "the guard started a second server over a ${aqua%% *}-born owner"
-  assert_not_contains "$(herdr_calls)" 'server stop' "the guard stopped a ${aqua%% *}-born owner"
-  assert_contains "$GUARD_OUT" "pid ${aqua#* } born in the Aqua login session (${aqua%% *})" \
-    "the guard did not name the Aqua-born owner and its marker"
-done
-pass "a launchd-born or worker-born owner is left in place with exit 0"
+new_case running
+printf '%s\n' "$LAUNCHD_PID" > "$CASE_OWNER"
+load_job gui dev.firstmate.herdr.fm-remote "$LAUNCHD_PID"
+guard
+expect_code 0 "$GUARD_RC" "the guard did not exit 0 for a gui-domain launchd owner"
+assert_not_started "the guard started a second server over a gui-domain launchd owner"
+assert_not_contains "$(herdr_calls)" 'server stop' "the guard stopped a gui-domain launchd owner"
+assert_contains "$GUARD_OUT" "pid $LAUNCHD_PID born in the Aqua login session (launchd)" \
+  "the guard did not name the launchd owner"
+
+new_case running
+printf '%s\n' "$WORKER_PID" > "$CASE_OWNER"
+load_job gui dev.firstmate.remote-job
+guard
+expect_code 0 "$GUARD_RC" "the guard did not exit 0 for the gui-domain worker owner"
+assert_not_started "the guard started a second server over a gui-domain worker owner"
+assert_not_contains "$(herdr_calls)" 'server stop' "the guard stopped a gui-domain worker owner"
+assert_contains "$GUARD_OUT" "pid $WORKER_PID born in the Aqua login session (worker)" \
+  "the guard did not name the worker owner"
+pass "launchd and worker markers require gui-domain launchctl proof"
 
 # --- a foreign owner is stopped, then the guard becomes the server -----------
+
+new_case running
+printf '%s\n' "$BACKGROUND_PID" > "$CASE_OWNER"
+load_job gui dev.firstmate.herdr.fm-remote
+load_job user dev.firstmate.herdr.fm-remote
+guard
+expect_code 0 "$GUARD_RC" "the guard failed to take over a label also loaded in the user domain"
+assert_stop_before_start
+assert_contains "$GUARD_OUT" "pid $BACKGROUND_PID born outside the Aqua login session (unknown)" \
+  "a user-domain label was trusted as Aqua"
+
+new_case running
+printf '%s\n' "$XPC_ZERO_PID" > "$CASE_OWNER"
+guard
+expect_code 0 "$GUARD_RC" "the guard failed to take over an XPC_SERVICE_NAME=0 owner"
+assert_stop_before_start
+assert_contains "$GUARD_OUT" "pid $XPC_ZERO_PID born outside the Aqua login session (unknown)" \
+  "XPC_SERVICE_NAME=0 was trusted as Aqua"
 
 for foreign in "ssh $SSH_PID" "ssh $BRIDGE_CHILD_PID" "ssh $SSHD_CHILD_PID" "unknown $UNMARKED_PID"; do
   new_case running
@@ -229,7 +279,7 @@ for foreign in "ssh $SSH_PID" "ssh $BRIDGE_CHILD_PID" "ssh $SSHD_CHILD_PID" "unk
   assert_contains "$GUARD_OUT" "pid ${foreign#* } born outside the Aqua login session (${foreign%% *})" \
     "the guard did not name the foreign owner and its birth"
 done
-pass "SSH-born, SSH-descended, and unprovable owners are taken over: stop, wait, start"
+pass "background, inherited-XPC, SSH-born, SSH-descended, and unprovable owners are taken over"
 
 # --- an owner nobody can prove is treated as foreign -------------------------
 


### PR DESCRIPTION
## Intent

Captain's intent: Root-cause, from the facts below, WHY the claude agents in the mac mini's `fm-remote` Herdr session cannot authenticate ("Login expired · Please run /login" / "Not logged in") while claude in the mini's `default` Herdr session authenticates fine on the same machine and same user account. Deliver a report with the actual root cause, backed by evidence, and a recommended durable fix (one that keeps working across reboots). The captain does NOT want a prescribed solution handed to you - dig from the facts and find the real mechanism yourself. Do not assume any prior hypothesis is correct.

FACTS (observations only - not conclusions):
1. The mac mini (SSH host alias `mac-home`, macOS, this same dotfiles setup as the MacBook you run on) hosts persistent Firstmate second-mate agents. Each runs the `claude` CLI inside a Herdr session named `fm-remote`, which is kept alive across reboots by a per-user macOS LaunchAgent `dev.firstmate.herdr.fm-remote`. That LaunchAgent's plist is written/rewritten by `bin/fm-remote-doctor.sh` (function `render_launch_agent`) in the firstmate repo.
2. The captain's private dotfiles (`kunchenguid/dotfiles-private`) define a home-manager LaunchAgent `launchd.agents.herdr-server` (in `home-manager/common.nix`) for the DEFAULT Herdr session. claude under that default-session server AUTHENTICATES CORRECTLY. The captain confirmed the default server is that launch-agent server - he did NOT start it by hand in a terminal.
3. Symptom: after the mini was rebooted, every claude in the `fm-remote` session reports login-expired / not-logged-in and cannot run a turn. The `default` session on the same machine is fine.
4. claude on this setup stores its credential in the macOS login Keychain (captain-confirmed). A `~/.claude/.credentials.json` also exists and was recently modified. (Separately and already RESOLVED: `claude --version` had been hanging earlier due to a wedged `syspolicyd`/`trustd` on the mini; a reboot cleared that. The current problem is ONLY the login-expired auth in `fm-remote`, not a hang.)
5. Firstmate launches the mate's claude with a clean environment - the exact command is `CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false CLAUDE_CODE_SEND_FEEDBACK=0 claude --dangerously-skip-permissions --settings '{...}' <brief>` - with NO `HOME`, `CLAUDE_CONFIG_DIR`, or `XDG_*` override and no `env -i` (see `bin/fm-spawn.sh` claude case). So the mate's claude reads the normal `HOME` and keychain.
6. Herdr 0.9.0 runs a SEPARATE server per session (each with its own socket); `default` and `fm-remote` are distinct servers/sockets.
7. Actions taken and their OBSERVED outcomes (facts, not the cause):
a. The `fm-remote` LaunchAgent was changed (firstmate PR #4061, merged and deployed to the mini) so it now starts the server through a login shell: `/run/current-system/sw/bin/zsh -l -c "exec /etc/profiles/per-user/kunchen/bin/herdr server --session fm-remote"` - matching the login-shell pattern the dotfiles default agent uses. After deploy, login-expired PERSISTED.
b. Restarting the `fm-remote` server mid-session - via `herdr server stop --session fm-remote` then `launchctl kickstart -k gui/501/dev.firstmate.herdr.fm-remote`, and via the doctor's own `launchctl bootout`+`bootstrap`+`kickstart` - did NOT restore auth.
c. A bare `herdr server --session fm-remote` (the old plist form) self-daemonizes/detaches and survives `launchctl bootout`.
d. The `default` agent started at LOGIN (RunAtLoad when the Aqua GUI session came up). The `fm-remote` agent has, so far, only ever been (re)started MID-SESSION via kickstart since the login-shell change - it has not started fresh at a login/boot with the corrected plist.
8. You run on the MacBook, which uses the SAME dotfiles and macOS, so you can reproduce the LaunchAgent / Herdr-server / login-keychain / macOS security-session mechanics locally. Read-only inspection of the mini is available, and the captain can run a specific one-off command on the mini if the investigation needs a datum only obtainable there.

Captain's later words: given the CONFIRMED root cause (the SSH remote-client-bridge auto-spawning a keychain-less fm-remote server that pre-empts the launchd agent), should we REVERT the previous merged PR #4061 - the change to bin/fm-remote-doctor.sh render_launch_agent that made the fm-remote launch agent start the herdr server through a login shell? Assess honestly with evidence whether #4061 is (a) still necessary and correct as part of the real fix, (b) irrelevant/redundant, or (c) actively wrong; if keep, say whether any part should still be adjusted.

The captain authorized implementing the durable fix the report recommends. The substance of that recommendation, in the captain's terms: the fm-remote server that owns the session socket must be the one spawned by launchd in the user's Aqua login session (gui/<uid>), because only that birth carries login-keychain access, and Herdr's SSH remote attach (the captain's saved machine "mini" reconnecting through `herdr --session fm-remote remote-client-bridge`) otherwise starts a keychain-less server first at every boot and within seconds of every stop. The mini's live datum confirmed it: the fm-remote server was a child of the SSH bridge with SSH_CONNECTION in its environment and no XPC_SERVICE_NAME, while launchd's own job sat at "spawn scheduled", 239 runs, last exit code 1, its log repeating "herdr server is already running". The durable fix: the launch agent runs a Firstmate-owned guard through the login shell (keep #4061's `<login-shell> -l -c 'exec ...'` launcher) with KeepAlive={SuccessfulExit=false} and ThrottleInterval=10 instead of unconditional KeepAlive; the guard finds the socket owner, execs the server in the foreground when nothing owns the socket, exits 0 when an Aqua-born server (launchd-born or the Aqua remote-job worker) already owns it, and otherwise stops the foreign server, waits for the socket to be released, and execs the server immediately so the socket is rebound before the SSH attach can start another foreign server; a takeover closes the session's panes and the parent firstmate's liveness sweep relaunches the mates. The doctor must be honest: report a session served by a server born outside the Aqua login session as fixable (naming the pid and birth) and let --fix retake it through launchd, and wait for launchd's own Aqua-born owner rather than for any server that answers. Verdict on #4061: keep it, it is neither cause nor cure - a bare Aqua LaunchAgent and the login-shell form behave identically for the keychain, the login shell only provides environment parity - but change its unconditional KeepAlive to SuccessfulExit=false, exec the guard instead of herdr directly, and correct the comments and docs that claimed the login shell grants login-keychain access. The pre-existing tests/fm-pi-primary-types.test.sh failure also fails on main and is out of scope for this change.

## What Changed

- Add an Aqua-scoped launchd guard that detects the `fm-remote` socket owner, replaces SSH-born servers, and preserves existing Aqua-born owners.
- Update the remote doctor to verify server birth, repair foreign ownership through launchd, and use conditional KeepAlive supervision.
- Document the macOS keychain mechanism and add coverage for owner classification, guard takeover, and doctor diagnostics.

## Risk Assessment

✅ Low: The change is well-bounded, matches the authorized durable takeover design, and the prior Aqua-classification issue is corrected with launchd-domain evidence.

## Testing

Focused fixture tests covered the guard decision table, doctor repair contract, and entrypoint behavior; live Herdr checks demonstrated foreground ownership and SSH-server takeover, while a read-only live doctor run correctly reported the ambient unproven owner as fixable. Actual launchd bootstrap/reboot validation was not performed because this phase may not modify host launchd or user state.

- Live validation: ✅ go - 3 of 5 scenarios driven live against the product

| Scenario | Result | Live | Evidence |
| --- | --- | --- | --- |
| An empty isolated session starts as a foreground Herdr server owned by the guard process | ✅ pass | live | Live guard foreground ownership: the real socket owner equaled the guard PID, and both exited cleanly after `herdr server stop`. |
| A reconnect-style SSH-born server is stopped and immediately replaced by the guard | ✅ pass | live | Live SSH-born Herdr server takeover: real socket ownership changed from SSH-marked PID 45469 to guard-exec PID 45577. |
| The doctor reports a running server whose Aqua birth cannot be proven as fixable and identifies the takeover action | ✅ pass | live | Live read-only fm-remote doctor diagnosis reported PID 92247 as `unknown`, outside the Aqua login session, and exited unready with a `--fix` action. |
| An Aqua-only launchd or remote-worker owner is left running, while a user-domain, inherited-XPC, or unprovable owner is rejected | ⏸️ untested | no | Live validation requires authority to create and bootstrap disposable jobs in `gui/&lt;uid&gt;` and `user/&lt;uid&gt;`, which would modify host launchd state and user LaunchAgents outside the worktree. Provide a… |
| Doctor --fix installs the Aqua-scoped guarded LaunchAgent and remains durable across logout or reboot | ⏸️ untested | no | A live repair/reboot would write under `~/Library/LaunchAgents`, alter launchd state, close ambient fm-remote panes, and require reboot authority, all prohibited in this test phase. Provide a disposab… |

<details>
<summary>Evidence: Live guard foreground ownership</summary>

Source: [Live guard foreground ownership](https://github.com/kunchenguid/firstmate/blob/46bc7f531e176c3128db8b41d5dd1c87b08194e3/.no-mistakes/evidence/fm/fm-remote-agent-keychain-auth-rca-s1/live-guard-empty-session.txt)

```text
scenario=empty isolated session starts under the real guard
session=fm-lab-live-89732
herdr=/etc/profiles/per-user/kunchen/bin/herdr
fm-remote-herdr-guard: no server owns session fm-lab-live-89732
fm-remote-herdr-guard: starting the herdr server for session fm-lab-live-89732 inside this launch agent (pid 89738)
herdr server running; you can use any herdr CLI command in another terminal.
api socket: .nmh/.config/herdr/sessions/fm-lab-live-89732/herdr.sock
client socket: .nmh/.config/herdr/sessions/fm-lab-live-89732/herdr-client.sock
logs: .nmh/.config/herdr/sessions/fm-lab-live-89732/herdr-server.log
did you mean to open the Herdr TUI? run `herdr`; you do not need `herdr server`.
guard_pid=89738
socket=.nmh/.config/herdr/sessions/fm-lab-live-89732/herdr.sock
socket_owner=89738
89738 89732 /etc/profiles/per-user/kunchen/bin/herdr server --session fm-lab-live-89732
guard_exit=0
result=PASS: guard exec remained the foreground Herdr socket owner and exited after server stop
```
</details>
<details>
<summary>Evidence: Live SSH-born Herdr server takeover</summary>

Source: [Live SSH-born Herdr server takeover](https://github.com/kunchenguid/firstmate/blob/46bc7f531e176c3128db8b41d5dd1c87b08194e3/.no-mistakes/evidence/fm/fm-remote-agent-keychain-auth-rca-s1/live-guard-ssh-takeover.txt)

```text
scenario=real SSH-marked server is stopped and atomically replaced by guard
session=fm-lab-takeover-45446
herdr server running; you can use any herdr CLI command in another terminal.
api socket: .nmh/.config/herdr/sessions/fm-lab-takeover-45446/herdr.sock
client socket: .nmh/.config/herdr/sessions/fm-lab-takeover-45446/herdr-client.sock
logs: .nmh/.config/herdr/sessions/fm-lab-takeover-45446/herdr-server.log
did you mean to open the Herdr TUI? run `herdr`; you do not need `herdr server`.
foreign_pid=45469
socket_owner_before=45469
fm-remote-herdr-guard: session fm-lab-takeover-45446 is served by pid 45469 born outside the Aqua login session (ssh); its panes cannot reach the login keychain, taking the session over
fm-remote-herdr-guard: session fm-lab-takeover-45446 released its socket after 0 tenths of a second
fm-remote-herdr-guard: starting the herdr server for session fm-lab-takeover-45446 inside this launch agent (pid 45577)
herdr server running; you can use any herdr CLI command in another terminal.
api socket: .nmh/.config/herdr/sessions/fm-lab-takeover-45446/herdr.sock
client socket: .nmh/.config/herdr/sessions/fm-lab-takeover-45446/herdr-client.sock
logs: .nmh/.config/herdr/sessions/fm-lab-takeover-45446/herdr-server.log
did you mean to open the Herdr TUI? run `herdr`; you do not need `herdr server`.
guard_pid=45577
socket_owner_after=45577
foreign_exit=0
guard_exit=0
result=PASS: real socket ownership transitioned from SSH-marked pid 45469 to guard-exec pid 45577
```
</details>
<details>
<summary>Evidence: Live read-only fm-remote doctor diagnosis</summary>

Source: [Live read-only fm-remote doctor diagnosis](https://github.com/kunchenguid/firstmate/blob/46bc7f531e176c3128db8b41d5dd1c87b08194e3/.no-mistakes/evidence/fm/fm-remote-agent-keychain-auth-rca-s1/live-doctor-readonly.txt)

```text
mode=check
path=~/.pi/agent/bin:~/.local/libexec/pi-launcher/bin:~/.nvm/versions/node/v24.14.1/bin:~/.nix-profile/bin:/nix/var/nix/profiles/default/bin:/opt/homebrew/bin:/opt/homebrew/sbin:~/.local/libexec/pi-launcher/bin:/etc/profiles/per-user/kunchen/bin:/run/current-system/sw/bin:~/.local/bin:~/go/bin:/Library/Frameworks/Python.framework/Versions/3.13/bin:~/.nix-profile/bin:/nix/var/nix/profiles/default/bin:/usr/local/libexec/mosh-signed:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:~/.cargo/bin:~/bin:/usr/local/sbin
entrypoint=no
note: not launched through the fixed remote entrypoint; the reported PATH is this caller environment.
platform=darwin
required git=/etc/profiles/per-user/kunchen/bin/git
required jq=/etc/profiles/per-user/kunchen/bin/jq
required herdr=/etc/profiles/per-user/kunchen/bin/herdr
required tasks-axi=~/.nvm/versions/node/v24.14.1/bin/tasks-axi
required treehouse=/etc/profiles/per-user/kunchen/bin/treehouse
required harness=claude:~/.local/bin/claude
optional tmux=/etc/profiles/per-user/kunchen/bin/tmux
optional no-mistakes=~/.local/bin/no-mistakes
optional gh=/opt/homebrew/bin/gh
check herdr=ok: /etc/profiles/per-user/kunchen/bin/herdr
check gui-session=ok: gui/501
check remote-job-worker=fixable: ~/Library/LaunchAgents/dev.firstmate.remote-job.plist does not match the Firstmate-owned Aqua worker contract
check remote-job-worker-loaded=fixable: dev.firstmate.remote-job is not loaded in gui/501
check remote-job-probe=fixable: the remote job worker has not reported a fresh probe
check launchagent=fixable: no Firstmate herdr launch agent at ~/Library/LaunchAgents/dev.firstmate.herdr.fm-remote.plist
check launchagent-scope=skip: no launch agent is installed yet
check launchagent-loaded=fixable: dev.firstmate.herdr.fm-remote is not loaded into gui/501
check herdr-server=fixable: session fm-remote is served by pid 92247 born outside the Aqua login session (unknown), so its panes cannot reach the login keychain
check entrypoint-link=skip: this run did not come through the fixed remote entrypoint
action: remote-job-worker: rerun this command with --fix to write dev.firstmate.remote-job
action: remote-job-worker-loaded: rerun this command with --fix to bootstrap the worker
action: remote-job-probe: rerun this command with --fix to restart the worker, then rerun through fm-on.sh
action: launchagent: rerun this command with --fix to install it
action: launchagent-loaded: rerun this command with --fix to bootstrap and start it
action: herdr-server: rerun this command with --fix so the launch agent takes the session over (its current panes close and the parent firstmate relaunches its mates)
error: this host is not ready for a remote second mate; unresolved: remote-job-worker remote-job-worker-loaded remote-job-probe launchagent launchagent-loaded herdr-server

exit_code=1
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"30ee198085e78366ca9d2d091aa2af11a4ce99e7","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>🔧 **Review** - 2 issues found → auto-fixed ✅</summary>

- 🚨 `bin/fm-remote-herdr-owner-lib.sh:111` - Any process with XPC_SERVICE_NAME is classified as Aqua-born, but the recorded evidence in docs/verification/runtime-backends.md explicitly shows a user/501 Background LaunchAgent also has an XPC service while keychain access fails with exit 36. A Background-born fm-remote owner therefore reaches fm_remote_herdr_birth_is_aqua, is left running by the guard, and is reported ready by the doctor, preserving the authentication failure. Restrict this shared classifier to markers that actually prove the known gui/&lt;uid&gt; jobs, or inspect the audit session directly.
- 🚨 `bin/fm-remote-herdr-guard.sh:67` - The guard merely execs the same `herdr server --session` command that the supplied evidence says self-daemonizes and survives `launchctl bootout`; exec replaces the guard but cannot prevent Herdr from detaching. Once that launcher exits successfully, KeepAlive={SuccessfulExit=false} rests permanently. If the detached Aqua server later stops, the reconnecting SSH bridge can again create a keychain-less owner with no launchd retry to retake it. This contradicts the required durable, foreground-supervised fix. The remedy needs an authorized foreground mode or additional supervision/retry lifecycle machinery, so confirm that mechanism with the user rather than relying on exec alone.

🔧 Fix applied.
✅ Re-checked - no issues remain.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- Live validation: ✅ go - 3 of 5 scenarios driven live against the product

| Scenario | Result | Live | Evidence |
| --- | --- | --- | --- |
| An empty isolated session starts as a foreground Herdr server owned by the guard process | ✅ pass | live | Live guard foreground ownership: the real socket owner equaled the guard PID, and both exited cleanly after `herdr server stop`. |
| A reconnect-style SSH-born server is stopped and immediately replaced by the guard | ✅ pass | live | Live SSH-born Herdr server takeover: real socket ownership changed from SSH-marked PID 45469 to guard-exec PID 45577. |
| The doctor reports a running server whose Aqua birth cannot be proven as fixable and identifies the takeover action | ✅ pass | live | Live read-only fm-remote doctor diagnosis reported PID 92247 as `unknown`, outside the Aqua login session, and exited unready with a `--fix` action. |
| An Aqua-only launchd or remote-worker owner is left running, while a user-domain, inherited-XPC, or unprovable owner is rejected | ⏸️ untested | no | Live validation requires authority to create and bootstrap disposable jobs in `gui/&lt;uid&gt;` and `user/&lt;uid&gt;`, which would modify host launchd state and user LaunchAgents outside the worktree. Provide a… |
| Doctor --fix installs the Aqua-scoped guarded LaunchAgent and remains durable across logout or reboot | ⏸️ untested | no | A live repair/reboot would write under `~/Library/LaunchAgents`, alter launchd state, close ambient fm-remote panes, and require reboot authority, all prohibited in this test phase. Provide a disposab… |

- `bash tests/fm-remote-herdr-guard.test.sh`
- `bash tests/fm-remote-doctor.test.sh`
- `bash tests/fm-remote-entrypoint.test.sh`
- <code>Started `bin/fm-remote-herdr-guard.sh` with Herdr 0.9.0 in an isolated HOME and verified its PID owned the session socket until clean server shutdown</code>
- <code>Started a real Herdr server carrying `SSH_CONNECTION`, ran the guard, and verified socket ownership transitioned from the foreign PID to the guard-exec PID</code>
- <code>Ran `bin/fm-remote-doctor.sh` read-only against the host&#39;s running fm-remote session and captured its birth/readiness diagnosis</code>
- <code>Confirmed the temporary `.nmh` HOME and isolated Herdr processes were removed</code>
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
