### PR TITLE
feat(bin): start Pi workers in a worktree subdirectory across relaunch

### DIFF
--- a/.agents/skills/harness-adapters/references/harness/pi.md
+++ b/.agents/skills/harness-adapters/references/harness/pi.md
@@ -14,6 +14,7 @@ Verified on 2026-07-27 with Pi and Pi-signed 0.82.0 unless a fact gives another 
 | Model flag | `--model <model>`. |
 | Effort flag | `--thinking <low\|medium\|high\|xhigh\|max>`; both identities expose the same levels and completed the same model-qualified max-thinking smoke. |
 | Model discovery | Run the selected executable as `<executable> --list-models [search]`; Pi's installed `docs/models.md` owns how built-in, extension-registered, and custom provider/model entries reach that list. |
+| Start directory | `--start-dir <relative-directory>` starts a Pi or Pi-signed ship or scout inside a subdirectory of its worktree on tmux or Herdr, so a monorepo game's own instructions load; `../../../bin/fm-spawn.sh --help` owns the contract, and relaunch preserves the recorded choice. |
 
 Native Codex sessions may request `ultra` through the native extension flag described by `../../../bin/fm-spawn.sh`; it is separate from Pi's thinking levels.
 Pi has no permission system, so workers are always autonomous.

--- a/bin/fm-control-lib.sh
+++ b/bin/fm-control-lib.sh
@@ -142,10 +142,12 @@ fm_control_start_dir_resolve() {  # <worktree> <start-dir>
   case "$path" in
     "$root"|"$root"/*) ;;
     *)
+      # shellcheck disable=SC2034 # Output globals read by sourcing callers.
       FM_CONTROL_START_DIR_REASON="'$start_dir' physically escapes worktree '$worktree'"
       return 1
       ;;
   esac
+  # shellcheck disable=SC2034 # Output globals read by sourcing callers.
   FM_CONTROL_START_DIR_PATH=$path
 }
 

--- a/bin/fm-control-lib.sh
+++ b/bin/fm-control-lib.sh
@@ -109,6 +109,46 @@ fm_control_harness_supports_kind() {  # <harness> <kind>
   return 0
 }
 
+# The start-directory contract (bin/fm-spawn.sh --help) has one owner here so
+# the launch owner and the relaunch transaction apply the same rule: the
+# launch refuses with it, and a relaunch asks it on the pre-stop side so a
+# running agent is never stopped for a launch that must then be refused. The
+# axes are the canonical adapter, session backend, and task kind; a raw launch
+# command is the launch owner's own extra refusal.
+fm_control_start_dir_axes_supported() {  # <harness> <backend> <kind>
+  case "${1-}:${2-}:${3-}" in
+    pi:tmux:ship|pi:tmux:scout|pi:herdr:ship|pi:herdr:scout) return 0 ;;
+    pi-signed:tmux:ship|pi-signed:tmux:scout|pi-signed:herdr:ship|pi-signed:herdr:scout) return 0 ;;
+  esac
+  return 1
+}
+
+# Resolves <start-dir> inside <worktree> to FM_CONTROL_START_DIR_PATH, its
+# physical directory. Returns 1, with FM_CONTROL_START_DIR_REASON naming the
+# cause, when it is not an accessible directory or its physical path leaves the
+# worktree root. Both results are variables, not output, so a caller keeps
+# them without a subshell.
+FM_CONTROL_START_DIR_PATH=
+FM_CONTROL_START_DIR_REASON=
+fm_control_start_dir_resolve() {  # <worktree> <start-dir>
+  local worktree=${1-} start_dir=${2-} path root
+  FM_CONTROL_START_DIR_PATH=
+  FM_CONTROL_START_DIR_REASON=
+  if ! path=$(CDPATH='' cd -- "$worktree/$start_dir" 2>/dev/null && pwd -P); then
+    FM_CONTROL_START_DIR_REASON="'$start_dir' is not an accessible directory in '$worktree'"
+    return 1
+  fi
+  root=$(CDPATH='' cd -- "$worktree" 2>/dev/null && pwd -P) || root=$worktree
+  case "$path" in
+    "$root"|"$root"/*) ;;
+    *)
+      FM_CONTROL_START_DIR_REASON="'$start_dir' physically escapes worktree '$worktree'"
+      return 1
+      ;;
+  esac
+  FM_CONTROL_START_DIR_PATH=$path
+}
+
 # The key that cancels a running turn. Escape for every adapter except grok,
 # whose Esc only moves focus to the scrollback; grok cancels on Ctrl+C.
 # gemini names its own key in the running turn's status row

--- a/bin/fm-control.sh
+++ b/bin/fm-control.sh
@@ -42,6 +42,11 @@
 #              already recorded for it.
 #              A prefixed raw-command basename cannot reconstruct its launch
 #              command, so relaunch requires an explicit --harness for it.
+#              A recorded start_dir must still satisfy bin/fm-spawn.sh --help's
+#              start-directory contract (supported harness/backend/kind, an
+#              accessible directory inside the worktree) before the old agent
+#              is stopped, so a launch that owner must refuse never costs the
+#              running agent.
 #              --note is required for a ship or scout, whose replacement
 #              inherits the local copy but none of the conversation; a
 #              secondmate reconciles its own home's records at startup, so its

--- a/bin/fm-control.sh
+++ b/bin/fm-control.sh
@@ -304,6 +304,7 @@ LABEL="fm-$ID"
 RECORDED_HARNESS=$(fm_meta_get "$META" harness)
 KIND=$(fm_meta_get "$META" kind)
 WT=$(fm_meta_get "$META" worktree)
+START_DIR=
 [ -n "$KIND" ] || KIND=ship
 
 HARNESS=$(fm_control_harness_family "$RECORDED_HARNESS") \
@@ -661,6 +662,11 @@ resolve_relaunch_profile() {
   # transaction, where nothing has changed yet.
   fm_control_harness_supports_kind "$TARGET_HARNESS" "$KIND" \
     || die "'$TARGET_HARNESS' is not verified to run a $KIND task, so relaunching $ID onto it would stop the running agent for a launch that must be refused; choose an adapter verified for this kind"
+  START_DIR=$(fm_meta_get "$META" start_dir)
+  if [ -n "$START_DIR" ]; then
+    fm_control_start_dir_axes_supported "$TARGET_HARNESS" "$BACKEND" "$KIND" \
+      || die "task $ID records start_dir '$START_DIR', which only canonical Pi/Pi-signed ship/scout launches on tmux or herdr support, so relaunching it onto $TARGET_HARNESS/$BACKEND would stop the running agent for a launch that must be refused; relaunch onto pi or pi-signed"
+  fi
   # A model or effort chosen for the previous harness does not transfer to a
   # different one, so an explicit harness change resets both axes unless the
   # caller names them too.
@@ -703,6 +709,10 @@ safe_checkpoint() {
   wt_top_real=$(cd "$wt_top" 2>/dev/null && pwd -P) || wt_top_real=$wt_top
   [ "$wt_real" = "$wt_top_real" ] \
     || die "task $ID's recorded worktree $WT is not a worktree root (root is $wt_top); refusing to relaunch against an ambiguous checkout"
+  if [ -n "$START_DIR" ]; then
+    fm_control_start_dir_resolve "$WT" "$START_DIR" \
+      || die "task $ID's recorded start_dir $FM_CONTROL_START_DIR_REASON; the replacement must start there, so restore that directory before relaunching rather than stopping the agent for a launch that must be refused"
+  fi
   if head=$(git -C "$WT" rev-parse --verify HEAD 2>/dev/null); then
     :
   elif head_ref=$(git -C "$WT" symbolic-ref -q HEAD 2>/dev/null); then

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -34,6 +34,9 @@
 #   allocation/refresh and physically resolve inside that root (symlinks may
 #   not escape). start_dir= in metadata preserves the relative choice; absence
 #   keeps legacy root startup. Relaunch revalidates it and refuses overrides.
+#   A fresh launch refused after its slot was allocated returns that still-clean
+#   slot and closes its new endpoint; a relaunch refusal leaves the recorded
+#   endpoint and worktree untouched.
 #   Only the harness runs in a subshell at that directory; its exit returns to
 #   the unchanged root shell. Allocation, hooks, ownership, and teardown still
 #   use worktree=. A launch-time physical-path check refuses directory retargeting.
@@ -1237,12 +1240,6 @@ if [ "$RELAUNCH" -eq 0 ]; then
     BACKEND=$BACKEND_ARG
   else
     BACKEND=$(fm_backend_name)
-  fi
-  if [ "$START_DIR_SET" -eq 1 ]; then
-    case "$BACKEND" in
-      tmux|herdr) ;;
-      *) echo "error: --start-dir supports only canonical Pi/Pi-signed ship/scout launches on tmux or herdr" >&2; exit 1 ;;
-    esac
   fi
   fm_backend_validate_spawn "$BACKEND" || exit 1
   fm_backend_source "$BACKEND" || exit 1
@@ -3055,20 +3052,40 @@ rovo_wait_for_delivery() {
 rovo_spawn_fail() {  # <detail>
   printf 'failed: %s\n' "$1" >> "$STATE/$ID.status"
   echo "error: $1; inspect window $T" >&2
-  rovo_endpoint_cleanup
+  spawn_endpoint_cleanup
 }
 
-# No task record is ever published on this failure path, so nothing else
+# No task record is ever published on these failure paths, so nothing else
 # (teardown, the watcher) will ever learn this endpoint exists to close it:
-# without this, the already-launched --yolo rovo process keeps running as an
+# without this, an already-launched --yolo rovo process keeps running as an
 # orphaned autonomous agent outside task control. Mirrors fm-teardown.sh's own
 # generic non-orca kill call; orca's worktree+terminal are owned by the
 # separate ORCA_ABORT_CLEANUP trap path and are out of scope here.
-rovo_endpoint_cleanup() {
+spawn_endpoint_cleanup() {
   [ "$BACKEND" = orca ] && return 0
   local tab_id=
   [ "$BACKEND" = zellij ] && tab_id=$ZELLIJ_TAB_ID
   fm_backend_kill "$BACKEND" "$T" "$tab_id" "fm-$ID" 2>/dev/null || true
+}
+
+# A fresh launch refused after `treehouse get` already allocated its slot owns
+# exactly two things nothing else will ever find: the endpoint this process
+# created and the slot it just proved clean and reset. Only those are retired,
+# and the slot is rechecked first so work that appeared in between is never
+# discarded; anything less certain is left in place with the remedy named.
+spawn_fresh_allocation_retire() {
+  local status out
+  if ! status=$(git -C "$WT" -c core.quotePath=false status --porcelain 2>/dev/null) || [ -n "$status" ]; then
+    echo "error: pooled worktree '$WT' can no longer be proven clean; leaving it and window $T in place for inspection" >&2
+    return 1
+  fi
+  if ! out=$( (cd "$PROJ_ABS" && treehouse return --force "$WT") 2>&1 ); then
+    [ -z "$out" ] || printf '%s\n' "$out" >&2
+    echo "error: could not return pooled worktree '$WT'; leaving it and window $T in place (return it with: cd '$PROJ_ABS' && treehouse return --force '$WT')" >&2
+    return 1
+  fi
+  spawn_endpoint_cleanup
+  echo "returned pooled worktree '$WT' and closed window $T" >&2
 }
 
 if [ "$RELAUNCH" -eq 1 ]; then
@@ -3156,14 +3173,21 @@ fi
 
 START_PATH=
 if [ "$START_DIR_SET" -eq 1 ]; then
-  START_PATH=$(CDPATH='' cd -- "$WT/$START_DIR" 2>/dev/null && pwd -P) || {
-    echo "error: --start-dir '$START_DIR' is not an accessible directory in '$WT'" >&2; exit 1
-  }
-  start_root=$(real_path_or_raw "$WT")
-  case "$START_PATH" in
-    "$start_root"|"$start_root"/*) ;;
-    *) echo "error: --start-dir '$START_DIR' physically escapes worktree '$WT'" >&2; exit 1 ;;
-  esac
+  start_dir_error=
+  if ! START_PATH=$(CDPATH='' cd -- "$WT/$START_DIR" 2>/dev/null && pwd -P); then
+    start_dir_error="--start-dir '$START_DIR' is not an accessible directory in '$WT'"
+  else
+    start_root=$(real_path_or_raw "$WT")
+    case "$START_PATH" in
+      "$start_root"|"$start_root"/*) ;;
+      *) start_dir_error="--start-dir '$START_DIR' physically escapes worktree '$WT'" ;;
+    esac
+  fi
+  if [ -n "$start_dir_error" ]; then
+    echo "error: $start_dir_error" >&2
+    [ "$RELAUNCH" -eq 1 ] || spawn_fresh_allocation_retire || true
+    exit 1
+  fi
 fi
 
 # Pre-register Claude's workspace trust for the worktree, at the first point the
@@ -3955,7 +3979,7 @@ if [ "$START_DIR_SET" -eq 1 ]; then
   # Keep the endpoint shell at the root for ordinary recovery. Recheck the
   # physical destination in the same subshell that starts Pi, before any brief
   # expansion or harness execution, so a changed symlink cannot misroute it.
-  LAUNCH="(CDPATH='' cd -- $(shell_quote "$WT/$START_DIR") && { [ \"\$(pwd -P)\" = $(shell_quote "$START_PATH") ] || { echo 'error: start directory changed before launch' >&2; exit 1; }; } && $LAUNCH)"
+  LAUNCH="(CDPATH='' cd -- $(shell_quote "$WT/$START_DIR") && [ \"\$(pwd -P)\" = $(shell_quote "$START_PATH") ] || { echo 'error: start directory changed before launch' >&2; exit 1; }; $LAUNCH)"
 fi
 sleep 0.3
 spawn_send_literal "$T" "$LAUNCH"

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -34,9 +34,12 @@
 #   allocation/refresh and physically resolve inside that root (symlinks may
 #   not escape). start_dir= in metadata preserves the relative choice; absence
 #   keeps legacy root startup. Relaunch revalidates it and refuses overrides.
-#   A fresh launch refused after its slot was allocated returns that still-clean
-#   slot and closes its new endpoint; a relaunch refusal leaves the recorded
-#   endpoint and worktree untouched.
+#   A fresh launch refused after its slot was allocated returns that slot and
+#   closes its new endpoint only with proof the slot is its own and untouched:
+#   the endpoint still sits in it, HEAD is still the origin base it was reset
+#   to, and the tree is clean. Otherwise both stay in place with the remedy
+#   named. A relaunch refusal leaves the recorded endpoint and worktree
+#   untouched.
 #   Only the harness runs in a subshell at that directory; its exit returns to
 #   the unchanged root shell. Allocation, hooks, ownership, and teardown still
 #   use worktree=. A launch-time physical-path check refuses directory retargeting.
@@ -889,6 +892,7 @@ SPAWN_META_LOCK=
 SPAWN_META_LOCK_HELD=0
 SPAWN_META_PUBLISH_STARTED=0
 SPAWN_FRESH_COMMIT_PENDING=0
+SPAWN_FRESH_BASE_COMMIT=
 SPAWN_TASK_SET_LOCK=
 SPAWN_TASK_SET_LOCK_HELD=0
 SPAWN_TREEHOUSE_PROJECT_LOCK=
@@ -2519,6 +2523,7 @@ freshen_spawn_worktree_base() {  # <worktree>
     echo "error: pooled worktree '$worktree' is at '${actual:-unknown}', not current '$target' ('$expected'); refusing to launch" >&2
     return 1
   fi
+  SPAWN_FRESH_BASE_COMMIT=$expected
 }
 
 herdr_projection_meta_field_exact() {  # <meta> <key>
@@ -3070,13 +3075,32 @@ spawn_endpoint_cleanup() {
 
 # A fresh launch refused after `treehouse get` already allocated its slot owns
 # exactly two things nothing else will ever find: the endpoint this process
-# created and the slot it just proved clean and reset. Only those are retired,
-# and the slot is rechecked first so work that appeared in between is never
-# discarded; anything less certain is left in place with the remedy named.
+# created and the slot it just reset to origin's default branch. Retiring them
+# needs positive proof, taken now, that both are still exactly that - the
+# endpoint sitting in the slot, HEAD at the recorded base, a clean tree - so a
+# slot that was never reset, gained work, or is no longer this endpoint's is
+# left in place with the remedy named. A projected Herdr pane is not closed
+# here: the armed abort cleanup closes it under the presentation lock this
+# process still holds, and taking that lock again from here would release it
+# before the cleanup ran.
 spawn_fresh_allocation_retire() {
-  local status out
+  local status head seen out
+  if [ -z "$SPAWN_FRESH_BASE_COMMIT" ]; then
+    echo "error: pooled worktree '$WT' was never reset to an origin base, so its commits cannot be proven landed; leaving it and window $T in place (inspect it, then return it with: cd '$PROJ_ABS' && treehouse return --force '$WT')" >&2
+    return 1
+  fi
+  head=$(git -C "$WT" rev-parse --verify --quiet HEAD 2>/dev/null || true)
+  if [ "$head" != "$SPAWN_FRESH_BASE_COMMIT" ]; then
+    echo "error: pooled worktree '$WT' is at '${head:-unknown}', not the base '$SPAWN_FRESH_BASE_COMMIT' it was reset to; leaving it and window $T in place for inspection" >&2
+    return 1
+  fi
   if ! status=$(git -C "$WT" -c core.quotePath=false status --porcelain 2>/dev/null) || [ -n "$status" ]; then
     echo "error: pooled worktree '$WT' can no longer be proven clean; leaving it and window $T in place for inspection" >&2
+    return 1
+  fi
+  seen=$(spawn_current_path "$WT_TARGET" || true)
+  if [ -z "$seen" ] || [ "$(real_path_or_raw "$seen")" != "$(real_path_or_raw "$WT")" ]; then
+    echo "error: window $T is in '${seen:-unknown}', not pooled worktree '$WT', so that slot cannot be proven this launch's own; leaving both in place for inspection" >&2
     return 1
   fi
   if ! out=$( (cd "$PROJ_ABS" && treehouse return --force "$WT") 2>&1 ); then
@@ -3084,8 +3108,12 @@ spawn_fresh_allocation_retire() {
     echo "error: could not return pooled worktree '$WT'; leaving it and window $T in place (return it with: cd '$PROJ_ABS' && treehouse return --force '$WT')" >&2
     return 1
   fi
-  spawn_endpoint_cleanup
-  echo "returned pooled worktree '$WT' and closed window $T" >&2
+  if [ "$HERDR_PROJECTION_ABORT_CLEANUP" = 1 ]; then
+    echo "returned pooled worktree '$WT'; projected herdr pane $T is closed by this launch's abort cleanup" >&2
+  else
+    spawn_endpoint_cleanup
+    echo "returned pooled worktree '$WT' and asked $BACKEND to close window $T" >&2
+  fi
 }
 
 if [ "$RELAUNCH" -eq 1 ]; then

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -1688,10 +1688,9 @@ if [ "$START_DIR_SET" -eq 1 ]; then
   if [ "$(printf '%s' "$START_DIR" | LC_ALL=C tr -d '[:cntrl:]')" != "$START_DIR" ]; then
     echo "error: --start-dir cannot contain control characters" >&2; exit 1
   fi
-  case "$HARNESS:$BACKEND:$KIND:$RAW_LAUNCH" in
-    pi:tmux:ship:0|pi:tmux:scout:0|pi:herdr:ship:0|pi:herdr:scout:0|pi-signed:tmux:ship:0|pi-signed:tmux:scout:0|pi-signed:herdr:ship:0|pi-signed:herdr:scout:0) ;;
-    *) echo "error: --start-dir supports only canonical Pi/Pi-signed ship/scout launches on tmux or herdr (got $HARNESS/$BACKEND/$KIND raw=$RAW_LAUNCH)" >&2; exit 1 ;;
-  esac
+  if [ "$RAW_LAUNCH" -ne 0 ] || ! fm_control_start_dir_axes_supported "$HARNESS" "$BACKEND" "$KIND"; then
+    echo "error: --start-dir supports only canonical Pi/Pi-signed ship/scout launches on tmux or herdr (got $HARNESS/$BACKEND/$KIND raw=$RAW_LAUNCH)" >&2; exit 1
+  fi
 fi
 
 case "$HARNESS" in
@@ -3201,21 +3200,12 @@ fi
 
 START_PATH=
 if [ "$START_DIR_SET" -eq 1 ]; then
-  start_dir_error=
-  if ! START_PATH=$(CDPATH='' cd -- "$WT/$START_DIR" 2>/dev/null && pwd -P); then
-    start_dir_error="--start-dir '$START_DIR' is not an accessible directory in '$WT'"
-  else
-    start_root=$(real_path_or_raw "$WT")
-    case "$START_PATH" in
-      "$start_root"|"$start_root"/*) ;;
-      *) start_dir_error="--start-dir '$START_DIR' physically escapes worktree '$WT'" ;;
-    esac
-  fi
-  if [ -n "$start_dir_error" ]; then
-    echo "error: $start_dir_error" >&2
+  if ! fm_control_start_dir_resolve "$WT" "$START_DIR"; then
+    echo "error: --start-dir $FM_CONTROL_START_DIR_REASON" >&2
     [ "$RELAUNCH" -eq 1 ] || spawn_fresh_allocation_retire || true
     exit 1
   fi
+  START_PATH=$FM_CONTROL_START_DIR_PATH
 fi
 
 # Pre-register Claude's workspace trust for the worktree, at the first point the

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -500,7 +500,7 @@ for a in "$@"; do
   case "$a" in
     --scout) KIND=scout; KIND_SET=1 ;;
     --secondmate) KIND=secondmate; KIND_SET=1 ;;
-    --start-dir) want_value=start-dir ;;
+    --start-dir) want_value='start-dir' ;;
     --start-dir=*) START_DIR=${a#--start-dir=}; START_DIR_SET=1 ;;
     --relaunch) RELAUNCH=1 ;;
     --harness) want_value=harness ;;

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 # Spawn a direct report: a crewmate in a treehouse or Orca worktree, or a
 # secondmate in its isolated firstmate home.
-# Usage: fm-spawn.sh <task-id> <project-dir> --mode <no-mistakes|direct-PR|local-only> --yolo <on|off> [--harness <name>|harness|launch-command] [--model <name>] [--effort <level>] [--backend <name>]
-#        fm-spawn.sh <task-id> <project-dir> --scout [--harness <name>|harness|launch-command] [--model <name>] [--effort <level>] [--backend <name>]
+# Usage: fm-spawn.sh <task-id> <project-dir> --mode <no-mistakes|direct-PR|local-only> --yolo <on|off> [--harness <name>|harness|launch-command] [--model <name>] [--effort <level>] [--backend <name>] [--start-dir <relative-directory>]
+#        fm-spawn.sh <task-id> <project-dir> --scout [--harness <name>|harness|launch-command] [--model <name>] [--effort <level>] [--backend <name>] [--start-dir <relative-directory>]
 #        fm-spawn.sh <task-id> [<firstmate-home>] [--harness <name>|harness|launch-command] [--model <name>] [--effort <level>] [--backend <name>] --secondmate
 #   --mode and --yolo are this task's delivery contract, REQUIRED for every ship
 #   spawn and refused on --scout and --secondmate spawns. Firstmate resolves both
@@ -26,6 +26,17 @@
 #   Ship/scout launches always supply fm-dod-lib.sh's current worker role scope
 #   using the same private launch-brief overlay. This never rewrites a project's
 #   instruction files or a secondmate's charter.
+#   --start-dir <relative-directory> starts a canonical Pi or Pi-signed ship/scout
+#   inside its isolated worktree on tmux or Herdr. Other harnesses, raw commands,
+#   secondmates, and other backends refuse this option until verified.
+#   The value must be non-empty and relative, with no .. component or control
+#   characters; . selects the root. The directory must exist after worktree
+#   allocation/refresh and physically resolve inside that root (symlinks may
+#   not escape). start_dir= in metadata preserves the relative choice; absence
+#   keeps legacy root startup. Relaunch revalidates it and refuses overrides.
+#   Only the harness runs in a subshell at that directory; its exit returns to
+#   the unchanged root shell. Allocation, hooks, ownership, and teardown still
+#   use worktree=. A launch-time physical-path check refuses directory retargeting.
 #        fm-spawn.sh <task-id> --relaunch [--harness <name>] [--model <name>] [--effort <level>]
 #   --relaunch launches a replacement agent for an EXISTING task into that
 #   task's own recorded endpoint and worktree instead of creating either. It is
@@ -457,6 +468,8 @@ MODE_SET=0
 YOLO_SET=0
 TRACEPARENT_SET=0
 RELAUNCH=0
+START_DIR=
+START_DIR_SET=0
 POS=()
 want_value=
 for a in "$@"; do
@@ -465,6 +478,7 @@ for a in "$@"; do
       --*) echo "error: --$want_value requires a value" >&2; exit 1 ;;
     esac
     case "$want_value" in
+      start-dir) START_DIR=$a; START_DIR_SET=1 ;;
       harness) HARNESS_ARG=$a; HARNESS_SET=1 ;;
       model) MODEL=$a; MODEL_SET=1 ;;
       effort) EFFORT=$a; EFFORT_SET=1 ;;
@@ -480,6 +494,8 @@ for a in "$@"; do
   case "$a" in
     --scout) KIND=scout; KIND_SET=1 ;;
     --secondmate) KIND=secondmate; KIND_SET=1 ;;
+    --start-dir) want_value=start-dir ;;
+    --start-dir=*) START_DIR=${a#--start-dir=}; START_DIR_SET=1 ;;
     --relaunch) RELAUNCH=1 ;;
     --harness) want_value=harness ;;
     --harness=*) HARNESS_ARG=${a#--harness=}; HARNESS_SET=1 ;;
@@ -529,6 +545,7 @@ esac
 # task's own durable record below. Contradicting it on the command line is a
 # refusal rather than a silently-ignored flag.
 if [ "$RELAUNCH" -eq 1 ]; then
+  [ "$START_DIR_SET" -eq 0 ] || { echo "error: --relaunch reuses recorded start_dir; --start-dir cannot override it" >&2; exit 1; }
   [ "$BACKEND_SET" -eq 0 ] || { echo "error: --relaunch reuses the task's recorded backend; --backend cannot override it" >&2; exit 1; }
   [ "$KIND_SET" -eq 0 ] || { echo "error: --relaunch reuses the task's recorded kind; --scout/--secondmate cannot override it" >&2; exit 1; }
   [ "$MODE_SET" -eq 0 ] || { echo "error: --relaunch reuses the task's recorded delivery mode; --mode cannot override it" >&2; exit 1; }
@@ -1097,6 +1114,7 @@ if [ "${#POS[@]}" -gt 0 ] && [ "${POS[0]}" != "$idpart" ] && case "$idpart" in *
   fi
   rc=0
   shared_args=()
+  [ "$START_DIR_SET" -eq 0 ] || shared_args+=(--start-dir "$START_DIR")
   [ -z "$HARNESS_ARG" ] || shared_args+=(--harness "$HARNESS_ARG")
   [ -z "$MODEL" ] || shared_args+=(--model "$MODEL")
   [ -z "$EFFORT" ] || shared_args+=(--effort "$EFFORT")
@@ -1195,6 +1213,10 @@ if [ "$RELAUNCH" -eq 0 ]; then
   fi
   SPAWN_TASK_SET_LOCK_HELD=1
 fi
+if [ "$START_DIR_SET" -eq 1 ] && [ "$KIND" = secondmate ]; then
+  echo "error: --start-dir supports only canonical Pi/Pi-signed ship/scout launches, not secondmates" >&2
+  exit 1
+fi
 if [ "$KIND" = secondmate ]; then
   if spawn_remote_secondmate "$ID"; then
     exit 0
@@ -1215,6 +1237,12 @@ if [ "$RELAUNCH" -eq 0 ]; then
     BACKEND=$BACKEND_ARG
   else
     BACKEND=$(fm_backend_name)
+  fi
+  if [ "$START_DIR_SET" -eq 1 ]; then
+    case "$BACKEND" in
+      tmux|herdr) ;;
+      *) echo "error: --start-dir supports only canonical Pi/Pi-signed ship/scout launches on tmux or herdr" >&2; exit 1 ;;
+    esac
   fi
   fm_backend_validate_spawn "$BACKEND" || exit 1
   fm_backend_source "$BACKEND" || exit 1
@@ -1290,6 +1318,10 @@ if [ "$RELAUNCH" -eq 1 ]; then
   [ -n "$KIND" ] || KIND=ship
   MODE=$(fm_meta_get "$RELAUNCH_META" mode)
   YOLO=$(fm_meta_get "$RELAUNCH_META" yolo)
+  if grep -q '^start_dir=' "$RELAUNCH_META"; then
+    START_DIR=$(fm_meta_get "$RELAUNCH_META" start_dir)
+    START_DIR_SET=1
+  fi
   RELAUNCH_WT=$(fm_meta_get "$RELAUNCH_META" worktree)
   [ -n "$RELAUNCH_WT" ] && [ -d "$RELAUNCH_WT" ] || {
     echo "error: task $ID's recorded worktree '${RELAUNCH_WT:-none}' is missing; refusing to relaunch without the local copy its work lives in" >&2
@@ -1645,6 +1677,20 @@ fi
 if [ "$KIND" = secondmate ] && [ "$HARNESS" = rovo ]; then
   echo "error: rovo is a verified crewmate/scout adapter only and cannot run a secondmate; it has no primary supervision protocol. Select a harness verified for secondmates." >&2
   exit 1
+fi
+
+if [ "$START_DIR_SET" -eq 1 ]; then
+  case "$START_DIR" in
+    ''|/*|..|../*|*/..|*/../*)
+      echo "error: --start-dir must be a non-empty contained relative directory without .. components" >&2; exit 1 ;;
+  esac
+  if [ "$(printf '%s' "$START_DIR" | LC_ALL=C tr -d '[:cntrl:]')" != "$START_DIR" ]; then
+    echo "error: --start-dir cannot contain control characters" >&2; exit 1
+  fi
+  case "$HARNESS:$BACKEND:$KIND:$RAW_LAUNCH" in
+    pi:tmux:ship:0|pi:tmux:scout:0|pi:herdr:ship:0|pi:herdr:scout:0|pi-signed:tmux:ship:0|pi-signed:tmux:scout:0|pi-signed:herdr:ship:0|pi-signed:herdr:scout:0) ;;
+    *) echo "error: --start-dir supports only canonical Pi/Pi-signed ship/scout launches on tmux or herdr (got $HARNESS/$BACKEND/$KIND raw=$RAW_LAUNCH)" >&2; exit 1 ;;
+  esac
 fi
 
 case "$HARNESS" in
@@ -3108,6 +3154,18 @@ if [ "$RELAUNCH" -eq 0 ] && [ "$KIND" != secondmate ]; then
   freshen_spawn_worktree_base "$WT" || exit 1
 fi
 
+START_PATH=
+if [ "$START_DIR_SET" -eq 1 ]; then
+  START_PATH=$(CDPATH='' cd -- "$WT/$START_DIR" 2>/dev/null && pwd -P) || {
+    echo "error: --start-dir '$START_DIR' is not an accessible directory in '$WT'" >&2; exit 1
+  }
+  start_root=$(real_path_or_raw "$WT")
+  case "$START_PATH" in
+    "$start_root"|"$start_root"/*) ;;
+    *) echo "error: --start-dir '$START_DIR' physically escapes worktree '$WT'" >&2; exit 1 ;;
+  esac
+fi
+
 # Pre-register Claude's workspace trust for the worktree, at the first point the
 # worktree is known and before any per-task state is created below. The dialog
 # gates the pane before the brief is ever read, and it also gates loading the
@@ -3596,7 +3654,7 @@ SPAWN_META_PATH=$SPAWN_META_TMP
 preserve_relaunch_meta() {
   awk -F= '
     BEGIN {
-      split("window endpoint_task_id worktree project harness kind mode yolo tasktmp model effort busy_gen spawn_gen traceparent backend herdr_session herdr_workspace_id herdr_tab_id herdr_pane_id zellij_session zellij_tab_id zellij_pane_id orca_worktree_id terminal cmux_workspace_id cmux_surface_id home projects control_relaunch_tx", keys, " ")
+      split("window endpoint_task_id worktree start_dir project harness kind mode yolo tasktmp model effort busy_gen spawn_gen traceparent backend herdr_session herdr_workspace_id herdr_tab_id herdr_pane_id zellij_session zellij_tab_id zellij_pane_id orca_worktree_id terminal cmux_workspace_id cmux_surface_id home projects control_relaunch_tx", keys, " ")
       for (i in keys) owned[keys[i]] = 1
     }
     !($1 in owned)
@@ -3606,6 +3664,7 @@ preserve_relaunch_meta() {
   echo "window=$META_WINDOW"
   echo "endpoint_task_id=$ID"
   echo "worktree=$WT"
+  [ "$START_DIR_SET" -eq 0 ] || echo "start_dir=$START_DIR"
   echo "project=$PROJ_ABS"
   echo "harness=$HARNESS"
   echo "kind=$KIND"
@@ -3891,6 +3950,12 @@ if [ "$LAUNCH_ENV_ENABLED" = 1 ]; then
     LAUNCH_ENV_PREFIX="$LAUNCH_ENV_PREFIX "'${TRACEPARENT+"TRACEPARENT=$TRACEPARENT"}'
   fi
   LAUNCH="$LAUNCH_ENV_PREFIX /bin/sh -c $(shell_quote "$LAUNCH")"
+fi
+if [ "$START_DIR_SET" -eq 1 ]; then
+  # Keep the endpoint shell at the root for ordinary recovery. Recheck the
+  # physical destination in the same subshell that starts Pi, before any brief
+  # expansion or harness execution, so a changed symlink cannot misroute it.
+  LAUNCH="(CDPATH='' cd -- $(shell_quote "$WT/$START_DIR") && { [ \"\$(pwd -P)\" = $(shell_quote "$START_PATH") ] || { echo 'error: start directory changed before launch' >&2; exit 1; }; } && $LAUNCH)"
 fi
 sleep 0.3
 spawn_send_literal "$T" "$LAUNCH"

--- a/docs/agent-control.md
+++ b/docs/agent-control.md
@@ -63,6 +63,7 @@ It is not deterministic across the verified adapters: codex, grok, and gemini re
    A harness change resets model and effort unless they are named too, because a model chosen for one adapter does not transfer to another.
 2. **Safe checkpoint.**
    The recorded worktree must exist and be a worktree root; its head and dirty state are recorded.
+   A recorded `start_dir=` must still be an accessible directory whose physical path stays inside that worktree, by the same rule the launch owner applies, so a lost or escaping start directory refuses here rather than after the agent is stopped.
    For a `kind=secondmate` task, the home's identity marker must match and its child records must be readable, so a relaunch can never strand child work behind an unreadable home.
    A secondmate's own crewmates run in their own endpoints and outlive its relaunch; the relaunched secondmate reconciles them from its home's durable records at startup.
 3. **Record the note.**
@@ -93,6 +94,7 @@ Switching harness is therefore one ordinary relaunch rather than a separate mech
 - An implicit relaunch from a prefixed raw-command basename is refused before the agent or durable state is touched because its original launch command cannot be reconstructed.
 - An adapter that is not verified for this task's kind is refused **before** the running agent is stopped, not after.
   Muse is a crewmate and scout adapter only, so relaunching a secondmate onto it refuses while its agent is still up rather than leaving that secondmate with no agent when the launch owner refuses.
+- A task that records `start_dir=` refuses a target harness, backend, or kind outside the start-directory contract owned by `bin/fm-spawn.sh --help` before the running agent is stopped, and `--start-dir` cannot be overridden on relaunch.
 - A backend that cannot deliver the harness's interrupt key, or the composer clear that key needs, is refused rather than sent a different key.
   Orca's terminal API exposes only an interrupt and an Enter, so it can deliver neither Escape nor Ctrl+U.
 - `exit` and `relaunch` require a backend with a recovery-grade agent-state classifier - tmux and herdr - because without one the "the agent stopped" postcondition cannot be proven.

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -56,7 +56,7 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-remote-home-seed.sh` | Register and provision a whole secondmate home on an SSH-reachable host              |
 | `fm-remote-readiness-lib.sh` | Shared remote second-mate readiness gate: check and, when needed, repair then re-check through `fm-remote-doctor.sh` |
 | [`fm-project-origin-lib.sh`](../bin/fm-project-origin-lib.sh) | Accepted origin-form owner shared by both remote provisioning boundaries |
-| `fm-spawn.sh`            | Spawn crewmates, scouts, `id=repo` batches, and secondmates on the resolved harness and runtime backend |
+| `fm-spawn.sh`            | Spawn crewmates, scouts, `id=repo` batches, and secondmates; its `--help` owns the Pi `--start-dir` contract |
 | `fm-backend.sh`          | Runtime-backend selection, meta helpers, selector resolution, and operation dispatch |
 | `fm-backend-hometag-lib.sh` | Shared per-installation home-tag derivation for zellij tab and cmux workspace titles |
 | `fm-composer-lib.sh`     | Single fleet-wide owner of composer shapes, capability-aware screen classification, and verdicts |

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -115,7 +115,7 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-lease.sh`            | Claim, release, inspect, and sweep per-task supervision leases                       |
 | `fm-lease-lib.sh`        | One owner of the supervision lease contract and the main-only role-partition guards  |
 | `fm-control.sh`          | Agent lifecycle control plane: allowlisted `interrupt`, `exit`, and transactional `relaunch` verbs for an exact task id ([agent-control.md](agent-control.md)) |
-| `fm-control-lib.sh`      | One executable owner of the control-plane verb allowlist, per-harness interrupt/exit mechanics, and per-backend capability |
+| `fm-control-lib.sh`      | One executable owner of the control-plane verb allowlist, per-harness interrupt/exit mechanics, per-backend capability, and the start-directory checks shared by launch and relaunch |
 | `fm-busy-lib.sh`         | Single owner of the semantic busy-state contract: verdicts, source attribution, and per-harness sources |
 | `fm-busy-event.sh`       | The only writer of a task's semantic busy-state record and native-harness progress marker; arms an incarnation and applies lifecycle events |
 | `fm-tmux-lib.sh`         | Shared tmux pane primitives for composer capture, verified submit, and the submit-time busy check |

--- a/docs/verification/runtime-backends.md
+++ b/docs/verification/runtime-backends.md
@@ -1549,3 +1549,36 @@ A throwaway scout was spawned through `bin/fm-spawn.sh --scout --harness omp --m
 6. `bin/fm-control.sh <id> exit` stopped the agent and `bin/fm-teardown.sh` returned the worktree and closed the item.
 
 `FM_OMP_LIVE_E2E=1 tests/fm-omp-primary-live-e2e.test.sh` refreshes the primary evidence; the worker path above is refreshed by repeating the scout dispatch after any omp upgrade.
+
+### Pi worker startup below the worktree root
+
+Verified on 2026-09-09 with Pi 0.85.1, `pi-codex-native` 0.2.1, and Herdr 0.8.2 protocol 20.
+A credentialed disposable game fixture used a fresh named Herdr lab through `fm-herdr-lab.sh`, worker-only storage directories, and the normal spawn, steering, and control entrypoints.
+Pi and both native thread starts reported the same game subdirectory, with native `gpt-6-astra` and `high` effort.
+The worker followed a game-local instruction sentinel, read a game-local resource, acknowledged a durable steering message, and repeated the instruction proof after ordinary relaunch.
+The generated worker extension emitted busy, settled, turn-end, and native-progress signals; relaunch changed both generation tokens while preserving the endpoint, `worktree`, and `start_dir` fields.
+Guarded teardown succeeded and the default-session tripwire was identical before and after.
+The fixture allocator entered a preallocated linked worktree containing the committed default base; this verifies the launch and lifecycle contract, not Treehouse allocation itself.
+The command entrypoints were:
+
+```sh
+bin/fm-spawn.sh native-smoke "$fixture_project" --scout --harness pi --model codex-native/gpt-6-astra --effort high --backend herdr --start-dir games/demo
+bin/fm-send.sh native-smoke "$fixture_steering_instruction"
+bin/fm-control.sh native-smoke relaunch --note "$fixture_relaunch_instruction"
+bin/fm-control.sh native-smoke exit
+```
+
+Refresh portable command execution, containment, root identity, and relaunch coverage with:
+
+```sh
+bin/fm-test-run.sh tests/fm-spawn-dispatch-profile.test.sh
+```
+
+```text
+ok - explicit root and batch startup work; a launch-time symlink retarget refuses before harness execution
+ok - Pi/Pi-signed nested startup executes in contained cwd, preserves root shell and metadata through relaunch
+ok - invalid directories and unsupported start-directory axes fail explicitly without task publication
+```
+
+Those portable cases execute the delivered shell command against an argv/cwd capture executable; they do not claim a live Pi-signed or tmux model run.
+The supported startup-directory contract and explicit unsupported-axis refusals are owned by `bin/fm-spawn.sh --help`.

--- a/docs/verification/runtime-backends.md
+++ b/docs/verification/runtime-backends.md
@@ -1576,8 +1576,8 @@ bin/fm-test-run.sh tests/fm-spawn-dispatch-profile.test.sh
 
 ```text
 ok - explicit root and batch startup work; a launch-time symlink retarget refuses before harness execution
-ok - Pi/Pi-signed nested startup executes in contained cwd, preserves root shell and metadata through relaunch
-ok - invalid directories and unsupported start-directory axes fail explicitly without task publication
+ok - Pi/Pi-signed nested startup executes in contained cwd, preserves root shell and metadata through relaunch, and never starts without its directory
+ok - invalid directories and unsupported start-directory axes fail explicitly without task publication; refused fresh allocations are returned
 ```
 
 Those portable cases execute the delivered shell command against an argv/cwd capture executable; they do not claim a live Pi-signed or tmux model run.

--- a/docs/verification/runtime-backends.md
+++ b/docs/verification/runtime-backends.md
@@ -1578,7 +1578,9 @@ bin/fm-test-run.sh tests/fm-spawn-dispatch-profile.test.sh
 ok - explicit root and batch startup work; a launch-time symlink retarget refuses before harness execution
 ok - Pi/Pi-signed nested startup executes in contained cwd, preserves root shell and metadata through relaunch, and never starts without its directory
 ok - invalid directories and unsupported start-directory axes fail explicitly without task publication; refused fresh allocations are returned only with ownership proof
+ok - a projected herdr start-directory refusal returns its slot and leaves its pane to the locked abort cleanup
 ```
 
-Those portable cases execute the delivered shell command against an argv/cwd capture executable; they do not claim a live Pi-signed or tmux model run.
+Those portable cases execute the delivered shell command against an argv/cwd capture executable and drive a projected Herdr spawn against a stateful fake CLI; they do not claim a live Pi-signed, tmux, or Herdr model run.
+`tests/fm-control-relaunch.test.sh` proves a relaunch refuses a missing, escaping, or unsupported recorded start directory before the running worker is sent anything.
 The supported startup-directory contract and explicit unsupported-axis refusals are owned by `bin/fm-spawn.sh --help`.

--- a/docs/verification/runtime-backends.md
+++ b/docs/verification/runtime-backends.md
@@ -1502,6 +1502,41 @@ It verifies native `ultra` on initial and operational turns and after restart, s
 Its native App Server peer and watcher-close process are deterministic fixtures; it does not claim a real backend or a live model was tested by that command.
 `tests/fm-busy-state.test.sh`, `tests/fm-busy-adapter-wiring.test.sh`, and `tests/fm-watch-triage.test.sh` cover separate progress notification, unchanged semantic busy state, rejection of a superseded worker's events, and progress refreshing the busy-age bound without fabricating a completed turn.
 
+### Pi worker startup below the worktree root
+
+Verified on 2026-09-09 with Pi 0.85.1, `pi-codex-native` 0.2.1, and Herdr 0.8.2 protocol 20.
+A credentialed disposable game fixture used a fresh named Herdr lab through `fm-herdr-lab.sh`, worker-only storage directories, and the normal spawn, steering, and control entrypoints.
+Pi and both native thread starts reported the same game subdirectory, with native `gpt-6-astra` and `high` effort.
+The worker followed a game-local instruction sentinel, read a game-local resource, acknowledged a durable steering message, and repeated the instruction proof after ordinary relaunch.
+The generated worker extension emitted busy, settled, turn-end, and native-progress signals; relaunch changed both generation tokens while preserving the endpoint, `worktree`, and `start_dir` fields.
+Guarded teardown succeeded and the default-session tripwire was identical before and after.
+The fixture allocator entered a preallocated linked worktree containing the committed default base; this verifies the launch and lifecycle contract, not Treehouse allocation itself.
+The command entrypoints were:
+
+```sh
+bin/fm-spawn.sh native-smoke "$fixture_project" --scout --harness pi --model codex-native/gpt-6-astra --effort high --backend herdr --start-dir games/demo
+bin/fm-send.sh native-smoke "$fixture_steering_instruction"
+bin/fm-control.sh native-smoke relaunch --note "$fixture_relaunch_instruction"
+bin/fm-control.sh native-smoke exit
+```
+
+Refresh portable command execution, containment, root identity, and relaunch coverage with:
+
+```sh
+bin/fm-test-run.sh tests/fm-spawn-dispatch-profile.test.sh
+```
+
+```text
+ok - explicit root and batch startup work; a launch-time symlink retarget refuses before harness execution
+ok - Pi/Pi-signed nested startup executes in contained cwd, preserves root shell and metadata through relaunch, and never starts without its directory
+ok - invalid directories and unsupported start-directory axes fail explicitly without task publication; refused fresh allocations are returned only with ownership proof
+ok - a projected herdr start-directory refusal returns its slot and leaves its pane to the locked abort cleanup
+```
+
+Those portable cases execute the delivered shell command against an argv/cwd capture executable and drive a projected Herdr spawn against a stateful fake CLI; they do not claim a live Pi-signed, tmux, or Herdr model run.
+`tests/fm-control-relaunch.test.sh` proves a relaunch refuses a missing, escaping, or unsupported recorded start directory before the running worker is sent anything.
+The supported startup-directory contract and explicit unsupported-axis refusals are owned by `bin/fm-spawn.sh --help`.
+
 ## Oh My Pi (omp)
 
 omp runs crewmate, scout, secondmate, and primary work; [`supervision.md`](supervision.md#omp-oh-my-pi-native-delivery-2026-09-05) owns the primary evidence.
@@ -1549,38 +1584,3 @@ A throwaway scout was spawned through `bin/fm-spawn.sh --scout --harness omp --m
 6. `bin/fm-control.sh <id> exit` stopped the agent and `bin/fm-teardown.sh` returned the worktree and closed the item.
 
 `FM_OMP_LIVE_E2E=1 tests/fm-omp-primary-live-e2e.test.sh` refreshes the primary evidence; the worker path above is refreshed by repeating the scout dispatch after any omp upgrade.
-
-### Pi worker startup below the worktree root
-
-Verified on 2026-09-09 with Pi 0.85.1, `pi-codex-native` 0.2.1, and Herdr 0.8.2 protocol 20.
-A credentialed disposable game fixture used a fresh named Herdr lab through `fm-herdr-lab.sh`, worker-only storage directories, and the normal spawn, steering, and control entrypoints.
-Pi and both native thread starts reported the same game subdirectory, with native `gpt-6-astra` and `high` effort.
-The worker followed a game-local instruction sentinel, read a game-local resource, acknowledged a durable steering message, and repeated the instruction proof after ordinary relaunch.
-The generated worker extension emitted busy, settled, turn-end, and native-progress signals; relaunch changed both generation tokens while preserving the endpoint, `worktree`, and `start_dir` fields.
-Guarded teardown succeeded and the default-session tripwire was identical before and after.
-The fixture allocator entered a preallocated linked worktree containing the committed default base; this verifies the launch and lifecycle contract, not Treehouse allocation itself.
-The command entrypoints were:
-
-```sh
-bin/fm-spawn.sh native-smoke "$fixture_project" --scout --harness pi --model codex-native/gpt-6-astra --effort high --backend herdr --start-dir games/demo
-bin/fm-send.sh native-smoke "$fixture_steering_instruction"
-bin/fm-control.sh native-smoke relaunch --note "$fixture_relaunch_instruction"
-bin/fm-control.sh native-smoke exit
-```
-
-Refresh portable command execution, containment, root identity, and relaunch coverage with:
-
-```sh
-bin/fm-test-run.sh tests/fm-spawn-dispatch-profile.test.sh
-```
-
-```text
-ok - explicit root and batch startup work; a launch-time symlink retarget refuses before harness execution
-ok - Pi/Pi-signed nested startup executes in contained cwd, preserves root shell and metadata through relaunch, and never starts without its directory
-ok - invalid directories and unsupported start-directory axes fail explicitly without task publication; refused fresh allocations are returned only with ownership proof
-ok - a projected herdr start-directory refusal returns its slot and leaves its pane to the locked abort cleanup
-```
-
-Those portable cases execute the delivered shell command against an argv/cwd capture executable and drive a projected Herdr spawn against a stateful fake CLI; they do not claim a live Pi-signed, tmux, or Herdr model run.
-`tests/fm-control-relaunch.test.sh` proves a relaunch refuses a missing, escaping, or unsupported recorded start directory before the running worker is sent anything.
-The supported startup-directory contract and explicit unsupported-axis refusals are owned by `bin/fm-spawn.sh --help`.

--- a/docs/verification/runtime-backends.md
+++ b/docs/verification/runtime-backends.md
@@ -1577,7 +1577,7 @@ bin/fm-test-run.sh tests/fm-spawn-dispatch-profile.test.sh
 ```text
 ok - explicit root and batch startup work; a launch-time symlink retarget refuses before harness execution
 ok - Pi/Pi-signed nested startup executes in contained cwd, preserves root shell and metadata through relaunch, and never starts without its directory
-ok - invalid directories and unsupported start-directory axes fail explicitly without task publication; refused fresh allocations are returned
+ok - invalid directories and unsupported start-directory axes fail explicitly without task publication; refused fresh allocations are returned only with ownership proof
 ```
 
 Those portable cases execute the delivered shell command against an argv/cwd capture executable; they do not claim a live Pi-signed or tmux model run.

--- a/tests/fm-control-relaunch.test.sh
+++ b/tests/fm-control-relaunch.test.sh
@@ -646,6 +646,57 @@ test_native_ultra_relaunch_preserves_profile_and_rejects_before_stop() {
   pass "native Ultra relaunch preserves its profile and rejects an unsupported model before stopping"
 }
 
+# A recorded start directory is part of what the replacement needs, so every
+# way it can make fm-spawn --relaunch refuse is asked here first, before the
+# running agent is sent anything.
+test_relaunch_refuses_a_lost_or_unsupported_start_directory_before_stop() {
+  local dir out rc id=rl-startdir
+  dir=$(new_case startdir "$id")
+  add_ship_task "$dir" "$id" pi
+  printf pi > "$dir/fake/command"
+  printf pi > "$dir/fake/becomes"
+  printf '#!/usr/bin/env bash\nprintf "Options: --tui-mode\\n"\n' > "$dir/fakebin/pi"
+  chmod +x "$dir/fakebin/pi"
+  printf 'start_dir=games/demo\n' >> "$dir/home/state/$id.meta"
+  cp "$dir/home/state/$id.meta" "$dir/meta.before"
+  mkdir -p "$dir/wt/games/demo"
+
+  out=$(run_control "$dir" "$id" relaunch --harness codex --note "switch runtime"); rc=$?
+  expect_code 1 "$rc" "a start-directory task relaunched onto codex should refuse: $out"
+  assert_contains "$out" "start_dir 'games/demo'" "the refusal should name the recorded start directory"
+  assert_contains "$out" "only canonical Pi" "the refusal should name the supported axes"
+  [ "$(cat "$dir/fake/command")" = pi ] || fail "an unsupported start-directory harness switch stopped the running agent"
+  [ ! -s "$dir/fake/literal" ] || fail "an unsupported start-directory harness switch sent lifecycle input"
+  cmp -s "$dir/meta.before" "$dir/home/state/$id.meta" || fail "an unsupported harness switch changed the task record"
+
+  rmdir "$dir/wt/games/demo"
+  out=$(run_control "$dir" "$id" relaunch --note "directory gone"); rc=$?
+  expect_code 1 "$rc" "a missing start directory should refuse before stopping: $out"
+  assert_contains "$out" "not an accessible directory" "the refusal should say the directory is gone"
+  [ "$(cat "$dir/fake/command")" = pi ] || fail "a missing start directory stopped the running agent"
+  [ ! -s "$dir/fake/literal" ] || fail "a missing start directory sent lifecycle input"
+  cmp -s "$dir/meta.before" "$dir/home/state/$id.meta" || fail "a missing start directory changed the task record"
+
+  rmdir "$dir/wt/games"
+  mkdir -p "$dir/outside/demo"
+  ln -s "$dir/outside" "$dir/wt/games"
+  printf 'games\n' >> "$(git -C "$dir/wt" rev-parse --git-path info/exclude)"
+  out=$(run_control "$dir" "$id" relaunch --note "directory escaped"); rc=$?
+  expect_code 1 "$rc" "an escaping start directory should refuse before stopping: $out"
+  assert_contains "$out" "physically escapes" "the refusal should say the directory left the worktree"
+  [ "$(cat "$dir/fake/command")" = pi ] || fail "an escaping start directory stopped the running agent"
+  [ ! -s "$dir/fake/literal" ] || fail "an escaping start directory sent lifecycle input"
+  cmp -s "$dir/meta.before" "$dir/home/state/$id.meta" || fail "an escaping start directory changed the task record"
+
+  rm "$dir/wt/games"
+  mkdir -p "$dir/wt/games/demo"
+  out=$(run_control "$dir" "$id" relaunch --note "directory restored"); rc=$?
+  expect_code 0 "$rc" "a restored start directory should relaunch: $out"
+  [ "$(meta_field "$dir" "$id" start_dir)" = games/demo ] || fail "relaunch dropped the recorded start directory"
+  assert_contains "$(cat "$dir/fake/literal")" "cd -- '$dir/wt/games/demo'" "the replacement was not launched into the recorded start directory"
+  pass "fm-control relaunch: a lost, escaping, or unsupported start directory refuses before the agent is stopped"
+}
+
 test_explicit_model_wins_over_the_recorded_one() {
   local dir out rc
   dir=$(new_case explicit rl7)
@@ -1608,5 +1659,6 @@ test_spawn_relaunch_refuses_a_pending_authoritative_close
 test_spawn_relaunch_refuses_contradicting_flags
 test_spawn_relaunch_refuses_an_unrecorded_task
 test_spawn_relaunch_refuses_a_pane_outside_the_worktree
+test_relaunch_refuses_a_lost_or_unsupported_start_directory_before_stop
 test_relaunch_reverifies_an_already_in_flight_item_instead_of_rewriting_it
 test_relaunch_moves_a_drifted_item_back_in_flight

--- a/tests/fm-spawn-dispatch-profile.test.sh
+++ b/tests/fm-spawn-dispatch-profile.test.sh
@@ -1203,6 +1203,25 @@ SH
   pass "fm-spawn: actual ship/scout launch commands deliver the worker role contract"
 }
 
+# Record every backend retirement a spawn performs: window kills and treehouse
+# invocations, the latter with the physical directory they ran from.
+arm_retire_log() {
+  RETIRE_LOG="$CASE_DIR/retire.log"
+  export FM_RETIRE_LOG="$RETIRE_LOG"
+  : > "$RETIRE_LOG"
+  mv "$FAKEBIN_DIR/tmux" "$FAKEBIN_DIR/tmux-unlogged"
+  cat > "$FAKEBIN_DIR/tmux" <<'SH'
+#!/bin/bash
+[ "${1:-}" != kill-window ] || printf 'tmux %s\n' "$*" >> "$FM_RETIRE_LOG"
+exec "$(dirname "$0")/tmux-unlogged" "$@"
+SH
+  cat > "$FAKEBIN_DIR/treehouse" <<'SH'
+#!/bin/bash
+printf 'treehouse %s in %s\n' "$*" "$(pwd -P)" >> "$FM_RETIRE_LOG"
+SH
+  chmod +x "$FAKEBIN_DIR/tmux" "$FAKEBIN_DIR/treehouse"
+}
+
 # Run the delivered command, not just its spelling: Pi's process cwd changes,
 # while the invoking endpoint shell and durable worktree identity stay rooted.
 test_pi_start_directory_contract() {
@@ -1211,6 +1230,7 @@ test_pi_start_directory_contract() {
     id="start-$harness"
     rec=$(make_spawn_case "$id" "$harness" "$id")
     read_case_record "$rec"
+    arm_retire_log
     mkdir -p "$WT_DIR/games/a b's"
     out=$(run_ship_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" \
       "$id" "$PROJ_DIR" --start-dir "games/a b's" --model codex-native/gpt-6-astra --effort high)
@@ -1257,28 +1277,59 @@ TMUX
     out=$(FM_START_ID="$id" run_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" "$id" --relaunch --harness codex)
     expect_code 1 "$?" "relaunch into unsupported harness accepted: $out"
     assert_contains "$out" 'supports only canonical Pi' "relaunch did not explain unsupported harness"
+    # The relaunch command carries its own `;`-separated prefix; a directory
+    # that vanished after spawn must still end the subshell before Pi runs.
     rm -d "$WT_DIR/games/a b's"
+    out=$(cd "$WT_DIR" && FM_START_CAPTURE="$CASE_DIR/relaunch-missing" sh -c "$launch" 2>&1)
+    expect_code 1 "$?" "relaunch command ran without its start directory: $out"
+    assert_contains "$out" 'start directory changed before launch' 'missing-directory launch refusal absent'
+    [ ! -f "$CASE_DIR/relaunch-missing" ] || fail 'harness executed after its start directory vanished'
     out=$(FM_START_ID="$id" run_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" "$id" --relaunch)
     expect_code 1 "$?" "relaunch accepted missing start directory: $out"
     assert_contains "$out" 'not an accessible directory' "missing relaunch directory diagnostic absent"
+    assert_no_grep 'kill-window' "$RETIRE_LOG" "relaunch refusal closed the task's own endpoint"
+    assert_no_grep 'treehouse return' "$RETIRE_LOG" "relaunch refusal returned the task's own worktree"
+    assert_grep "start_dir=games/a b's" "$HOME_DIR/state/$id.meta" "relaunch refusal dropped the recorded start directory"
+    assert_grep "worktree=$WT_DIR" "$HOME_DIR/state/$id.meta" "relaunch refusal changed root identity"
   done
-  pass 'Pi/Pi-signed nested startup executes in contained cwd, preserves root shell and metadata through relaunch'
+  pass 'Pi/Pi-signed nested startup executes in contained cwd, preserves root shell and metadata through relaunch, and never starts without its directory'
 }
 
 test_start_directory_refusals() {
-  local rec out value axis
+  local rec out value axis proj_real
   rec=$(make_spawn_case start-refusals pi refused)
   read_case_record "$rec"
+  arm_retire_log
+  proj_real=$(cd "$PROJ_DIR" && pwd -P)
   mkdir -p "$WT_DIR/games" "$CASE_DIR/outside"
   ln -s "$CASE_DIR/outside" "$WT_DIR/escape"
   printf 'escape\n' >> "$(git -C "$WT_DIR" rev-parse --git-path info/exclude)"
   mkdir -p "$WT_DIR/a"$'\n'"b"
-  for value in '' /tmp .. games/../../outside "a"$'\n'"b" missing escape; do
+  for value in '' /tmp .. games/../../outside "a"$'\n'"b"; do
     out=$(run_ship_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" refused "$PROJ_DIR" --start-dir="$value")
     expect_code 1 "$?" "invalid directory was accepted: $value: $out"
     assert_contains "$out" '--start-dir' "directory refusal is unexplained"
     [ ! -f "$HOME_DIR/state/refused.meta" ] || fail "invalid directory published metadata"
+    [ ! -s "$RETIRE_LOG" ] || fail "refusal before allocation retired a resource: $(cat "$RETIRE_LOG")"
   done
+  # These are only refusable once `treehouse get` has produced the slot, so the
+  # refusal must give back that clean slot and close its window itself.
+  for value in missing escape; do
+    : > "$RETIRE_LOG"
+    out=$(run_ship_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" refused "$PROJ_DIR" --start-dir="$value")
+    expect_code 1 "$?" "invalid directory was accepted: $value: $out"
+    assert_contains "$out" '--start-dir' "directory refusal is unexplained"
+    [ ! -f "$HOME_DIR/state/refused.meta" ] || fail "invalid directory published metadata"
+    assert_contains "$out" "returned pooled worktree '$WT_DIR'" "post-allocation refusal did not report retiring its slot"
+    assert_grep "treehouse return --force $WT_DIR in $proj_real" "$RETIRE_LOG" "allocated slot was not returned from the project for $value"
+    assert_grep 'kill-window' "$RETIRE_LOG" "new window was not closed for $value"
+    assert_grep 'fm-refused' "$RETIRE_LOG" "a window other than the refused launch's own was closed for $value"
+  done
+  cat > "$FAKEBIN_DIR/orca" <<'SH'
+#!/bin/sh
+printf '%s\n' '{"ok":true,"result":{"runtime":{"reachable":true,"state":"ready"}}}'
+SH
+  chmod +x "$FAKEBIN_DIR/orca"
   for axis in claude codex opencode grok kimi cursor muse gemini rovo omp; do
     out=$(run_ship_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" refused "$PROJ_DIR" --harness "$axis" --start-dir .)
     expect_code 1 "$?" "unsupported $axis accepted: $out"
@@ -1298,7 +1349,8 @@ test_start_directory_refusals() {
   out=$(run_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" refused "$PROJ_DIR" --secondmate --start-dir .)
   expect_code 1 "$?" "secondmate accepted start directory: $out"
   assert_contains "$out" 'not secondmates' 'secondmate refusal missing'
-  pass 'invalid directories and unsupported start-directory axes fail explicitly without task publication'
+  [ ! -f "$HOME_DIR/state/refused.meta" ] || fail "an unsupported axis published metadata"
+  pass 'invalid directories and unsupported start-directory axes fail explicitly without task publication; refused fresh allocations are returned'
 }
 
 

--- a/tests/fm-spawn-dispatch-profile.test.sh
+++ b/tests/fm-spawn-dispatch-profile.test.sh
@@ -376,7 +376,7 @@ test_active_dispatch_profile_allows_raw_launch_command() {
   out=$(run_ship_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" \
     "$id" "$PROJ_DIR" "custom-agent --flag")
   status=$?
-  expect_code 0 "$status" "raw launch command should satisfy active dispatch-profile requirement"
+  expect_code 0 "$status" "raw launch command should satisfy active dispatch-profile requirement: $out"
   assert_contains "$out" "spawned $id harness=custom-agent" "spawn did not report raw command harness"
   assert_meta_profile "$HOME_DIR/state/$id.meta" custom-agent default default
   launch=$(cat "$LAUNCH_LOG")
@@ -1202,6 +1202,147 @@ SH
   done
   pass "fm-spawn: actual ship/scout launch commands deliver the worker role contract"
 }
+
+# Run the delivered command, not just its spelling: Pi's process cwd changes,
+# while the invoking endpoint shell and durable worktree identity stay rooted.
+test_pi_start_directory_contract() {
+  local rec id out launch expected before harness
+  for harness in pi pi-signed; do
+    id="start-$harness"
+    rec=$(make_spawn_case "$id" "$harness" "$id")
+    read_case_record "$rec"
+    mkdir -p "$WT_DIR/games/a b's"
+    out=$(run_ship_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" \
+      "$id" "$PROJ_DIR" --start-dir "games/a b's" --model codex-native/gpt-6-astra --effort high)
+    expect_code 0 "$?" "nested $harness spawn failed: $out"
+    assert_grep "worktree=$WT_DIR" "$HOME_DIR/state/$id.meta" "root identity changed"
+    assert_grep "start_dir=games/a b's" "$HOME_DIR/state/$id.meta" "relative directory was not persisted"
+    assert_meta_profile "$HOME_DIR/state/$id.meta" "$harness" codex-native/gpt-6-astra high
+    launch=$(cat "$LAUNCH_LOG")
+    cat > "$FAKEBIN_DIR/$harness" <<'CAPTURE'
+#!/bin/sh
+if [ "${1:-}" = --help ]; then exit 0; fi
+pwd -P > "$FM_START_CAPTURE"
+printf '%s\n' "$@" >> "$FM_START_CAPTURE"
+CAPTURE
+    chmod +x "$FAKEBIN_DIR/$harness"
+    expected=$(cd "$WT_DIR/games/a b's" && pwd -P)
+    (cd "$WT_DIR" && FM_START_CAPTURE="$CASE_DIR/capture" sh -c "$launch" && pwd -P > "$CASE_DIR/after") || fail "nested launch failed"
+    assert_grep "$expected" "$CASE_DIR/capture" "Pi did not start in nested directory"
+    assert_grep 'codex-native/gpt-6-astra' "$CASE_DIR/capture" "native model lost"
+    assert_grep 'high' "$CASE_DIR/capture" "effort lost"
+    assert_grep "$HOME_DIR/state/$id.pi-ext.ts" "$CASE_DIR/capture" "absolute worker extension lost"
+    [ "$(cat "$CASE_DIR/after")" = "$(cd "$WT_DIR" && pwd -P)" ] || fail "endpoint shell left root"
+
+    # A fake stopped endpoint supplies only the backend inputs; actual relaunch
+    # performs the same metadata adoption and isolated-root checks as production.
+    mv "$FAKEBIN_DIR/tmux" "$FAKEBIN_DIR/tmux-base"
+    cat > "$FAKEBIN_DIR/tmux" <<'TMUX'
+#!/bin/bash
+case "$*" in
+  *'#{pane_current_command}'*) echo zsh; exit 0 ;;
+  'list-windows '*) printf '%s\n' "fm-$FM_START_ID"; exit 0 ;;
+esac
+exec "$(dirname "$0")/tmux-base" "$@"
+TMUX
+    chmod +x "$FAKEBIN_DIR/tmux"
+    before=$(sed -n 's/^spawn_gen=//p' "$HOME_DIR/state/$id.meta")
+    out=$(FM_START_ID="$id" run_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" "$id" --relaunch)
+    expect_code 0 "$?" "relaunch failed: $out"
+    [ "$before" != "$(sed -n 's/^spawn_gen=//p' "$HOME_DIR/state/$id.meta")" ] || fail "relaunch did not replace generation"
+    launch=$(cat "$LAUNCH_LOG")
+    (cd "$WT_DIR" && FM_START_CAPTURE="$CASE_DIR/relaunch" sh -c "$launch") || fail "relaunch command failed"
+    assert_grep "$expected" "$CASE_DIR/relaunch" "relaunch lost start directory"
+    assert_grep "worktree=$WT_DIR" "$HOME_DIR/state/$id.meta" "relaunch changed root identity"
+    out=$(FM_START_ID="$id" run_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" "$id" --relaunch --harness codex)
+    expect_code 1 "$?" "relaunch into unsupported harness accepted: $out"
+    assert_contains "$out" 'supports only canonical Pi' "relaunch did not explain unsupported harness"
+    rm -d "$WT_DIR/games/a b's"
+    out=$(FM_START_ID="$id" run_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" "$id" --relaunch)
+    expect_code 1 "$?" "relaunch accepted missing start directory: $out"
+    assert_contains "$out" 'not an accessible directory' "missing relaunch directory diagnostic absent"
+  done
+  pass 'Pi/Pi-signed nested startup executes in contained cwd, preserves root shell and metadata through relaunch'
+}
+
+test_start_directory_refusals() {
+  local rec out value axis
+  rec=$(make_spawn_case start-refusals pi refused)
+  read_case_record "$rec"
+  mkdir -p "$WT_DIR/games" "$CASE_DIR/outside"
+  ln -s "$CASE_DIR/outside" "$WT_DIR/escape"
+  printf 'escape\n' >> "$(git -C "$WT_DIR" rev-parse --git-path info/exclude)"
+  mkdir -p "$WT_DIR/a"$'\n'"b"
+  for value in '' /tmp .. games/../../outside "a"$'\n'"b" missing escape; do
+    out=$(run_ship_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" refused "$PROJ_DIR" --start-dir="$value")
+    expect_code 1 "$?" "invalid directory was accepted: $value: $out"
+    assert_contains "$out" '--start-dir' "directory refusal is unexplained"
+    [ ! -f "$HOME_DIR/state/refused.meta" ] || fail "invalid directory published metadata"
+  done
+  for axis in claude codex opencode grok kimi cursor muse gemini rovo omp; do
+    out=$(run_ship_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" refused "$PROJ_DIR" --harness "$axis" --start-dir .)
+    expect_code 1 "$?" "unsupported $axis accepted: $out"
+    assert_contains "$out" 'supports only canonical Pi' "unsupported harness not explicitly refused"
+  done
+  for axis in orca zellij cmux; do
+    out=$(run_ship_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" refused "$PROJ_DIR" --backend "$axis" --start-dir .)
+    expect_code 1 "$?" "unsupported $axis accepted: $out"
+    assert_contains "$out" 'supports only canonical Pi' "unsupported backend not explicitly refused"
+  done
+  out=$(run_ship_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" refused "$PROJ_DIR" 'pi --model custom' --start-dir .)
+  expect_code 1 "$?" "raw launch accepted: $out"
+  assert_contains "$out" 'supports only canonical Pi' "raw launch not explicitly refused"
+  out=$(run_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" refused --relaunch --start-dir .)
+  expect_code 1 "$?" "relaunch override accepted: $out"
+  assert_contains "$out" 'cannot override' "relaunch override diagnostic missing"
+  out=$(run_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" refused "$PROJ_DIR" --secondmate --start-dir .)
+  expect_code 1 "$?" "secondmate accepted start directory: $out"
+  assert_contains "$out" 'not secondmates' 'secondmate refusal missing'
+  pass 'invalid directories and unsupported start-directory axes fail explicitly without task publication'
+}
+
+
+test_start_directory_root_batch_and_retarget() {
+  local rec out launch id
+  rec=$(make_spawn_case start-root-batch pi start-root start-a start-b)
+  read_case_record "$rec"
+  mkdir -p "$WT_DIR/game" "$CASE_DIR/outside"
+  ln -s game "$WT_DIR/game-link"
+  printf 'game-link\n' >> "$(git -C "$WT_DIR" rev-parse --git-path info/exclude)"
+  out=$(run_ship_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" start-root "$PROJ_DIR" --start-dir .)
+  expect_code 0 "$?" "explicit root failed: $out"
+  launch=$(cat "$LAUNCH_LOG")
+  cat > "$FAKEBIN_DIR/pi" <<'CAPTURE'
+#!/bin/sh
+[ "${1:-}" != --help ] || exit 0
+pwd -P > "$FM_START_CAPTURE"
+CAPTURE
+  (cd "$WT_DIR" && FM_START_CAPTURE="$CASE_DIR/root" sh -c "$launch") || fail 'explicit root launch failed'
+  [ "$(cat "$CASE_DIR/root")" = "$(cd "$WT_DIR" && pwd -P)" ] || fail 'explicit root changed cwd'
+  out=$(run_ship_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" "start-a=$PROJ_DIR" "start-b=$PROJ_DIR" --harness pi --start-dir game-link)
+  expect_code 0 "$?" "batch failed: $out"
+  for id in start-a start-b; do
+    assert_grep 'start_dir=game-link' "$HOME_DIR/state/$id.meta" "batch dropped relative directory"
+    assert_grep "worktree=$WT_DIR" "$HOME_DIR/state/$id.meta" "batch changed root identity"
+  done
+  # Execute the contained symlink first, then retarget the same delivered command.
+  launch=$(tail -n 1 "$LAUNCH_LOG")
+  (cd "$WT_DIR" && FM_START_CAPTURE="$CASE_DIR/contained" sh -c "$launch") || fail 'contained symlink launch failed'
+  [ "$(cat "$CASE_DIR/contained")" = "$(cd "$WT_DIR/game" && pwd -P)" ] || fail 'contained symlink did not resolve to game'
+  rm "$WT_DIR/game-link"
+  ln -s "$CASE_DIR/outside" "$WT_DIR/game-link"
+  out=$(cd "$WT_DIR" && FM_START_CAPTURE="$CASE_DIR/escaped" sh -c "$launch" 2>&1)
+  expect_code 1 "$?" "retargeted directory ran the harness: $out"
+  assert_contains "$out" 'start directory changed before launch' 'retarget refusal missing'
+  [ ! -f "$CASE_DIR/escaped" ] || fail 'harness executed after symlink escape'
+  pass 'explicit root and batch startup work; a launch-time symlink retarget refuses before harness execution'
+}
+
+
+test_start_directory_root_batch_and_retarget
+
+test_pi_start_directory_contract
+test_start_directory_refusals
 
 test_worker_launch_delivers_role_scope
 test_no_profile_keeps_claude_profile_defaults

--- a/tests/fm-spawn-dispatch-profile.test.sh
+++ b/tests/fm-spawn-dispatch-profile.test.sh
@@ -1213,6 +1213,14 @@ arm_retire_log() {
   cat > "$FAKEBIN_DIR/tmux" <<'SH'
 #!/bin/bash
 [ "${1:-}" != kill-window ] || printf 'tmux %s\n' "$*" >> "$FM_RETIRE_LOG"
+if [ -n "${FM_FAKE_PANE_DRIFT:-}" ]; then
+  case "$*" in
+    *'#{pane_current_path}'*)
+      n=$(( $(cat "$FM_RETIRE_LOG.reads" 2>/dev/null || echo 0) + 1 ))
+      echo "$n" > "$FM_RETIRE_LOG.reads"
+      if [ "$n" -gt "$FM_FAKE_PANE_DRIFT_AFTER" ]; then printf '%s\n' "$FM_FAKE_PANE_DRIFT"; exit 0; fi ;;
+  esac
+fi
 exec "$(dirname "$0")/tmux-unlogged" "$@"
 SH
   cat > "$FAKEBIN_DIR/treehouse" <<'SH'
@@ -1320,11 +1328,23 @@ test_start_directory_refusals() {
     expect_code 1 "$?" "invalid directory was accepted: $value: $out"
     assert_contains "$out" '--start-dir' "directory refusal is unexplained"
     [ ! -f "$HOME_DIR/state/refused.meta" ] || fail "invalid directory published metadata"
-    assert_contains "$out" "returned pooled worktree '$WT_DIR'" "post-allocation refusal did not report retiring its slot"
+    assert_contains "$out" "returned pooled worktree '$WT_DIR' and asked tmux to close window" "post-allocation refusal did not report retiring its slot"
     assert_grep "treehouse return --force $WT_DIR in $proj_real" "$RETIRE_LOG" "allocated slot was not returned from the project for $value"
     assert_grep 'kill-window' "$RETIRE_LOG" "new window was not closed for $value"
     assert_grep 'fm-refused' "$RETIRE_LOG" "a window other than the refused launch's own was closed for $value"
   done
+  # Ownership is proven at retirement time, not assumed: an endpoint that no
+  # longer sits in the slot after the two discovery reads means the slot is
+  # not provably this launch's own, so nothing is returned or closed.
+  : > "$RETIRE_LOG"
+  out=$(FM_FAKE_PANE_DRIFT="$CASE_DIR/outside" FM_FAKE_PANE_DRIFT_AFTER=2 \
+    run_ship_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" refused "$PROJ_DIR" --start-dir=missing)
+  expect_code 1 "$?" "drifted endpoint refusal did not fail: $out"
+  assert_contains "$out" 'not an accessible directory' 'directory refusal is unexplained after endpoint drift'
+  assert_contains "$out" "cannot be proven this launch's own" 'drifted endpoint was not named as the reason to keep the slot'
+  [ ! -s "$RETIRE_LOG" ] || fail "unproven slot was retired after endpoint drift: $(cat "$RETIRE_LOG")"
+  [ ! -f "$HOME_DIR/state/refused.meta" ] || fail "drifted refusal published metadata"
+  rm -f "$RETIRE_LOG.reads"
   cat > "$FAKEBIN_DIR/orca" <<'SH'
 #!/bin/sh
 printf '%s\n' '{"ok":true,"result":{"runtime":{"reachable":true,"state":"ready"}}}'
@@ -1350,7 +1370,21 @@ SH
   expect_code 1 "$?" "secondmate accepted start directory: $out"
   assert_contains "$out" 'not secondmates' 'secondmate refusal missing'
   [ ! -f "$HOME_DIR/state/refused.meta" ] || fail "an unsupported axis published metadata"
-  pass 'invalid directories and unsupported start-directory axes fail explicitly without task publication; refused fresh allocations are returned'
+  # Without an origin the slot is never reset to a base, so a clean tree still
+  # cannot prove its commits landed; the refusal keeps slot and window and
+  # names the manual return.
+  git -C "$PROJ_DIR" remote remove origin
+  git -C "$WT_DIR" -c user.name='Firstmate Tests' -c user.email='tests@example.invalid' commit -q --allow-empty -m unlanded
+  : > "$RETIRE_LOG"
+  out=$(run_ship_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" refused "$PROJ_DIR" --start-dir=missing)
+  expect_code 1 "$?" "origin-less refusal did not fail: $out"
+  assert_contains "$out" 'not an accessible directory' 'directory refusal is unexplained for an origin-less slot'
+  assert_contains "$out" 'cannot be proven landed' 'origin-less slot was not named as unprovable'
+  assert_contains "$out" "treehouse return --force '$WT_DIR'" 'origin-less refusal did not name the manual return'
+  [ ! -s "$RETIRE_LOG" ] || fail "origin-less slot with an unlanded commit was retired: $(cat "$RETIRE_LOG")"
+  [ ! -f "$HOME_DIR/state/refused.meta" ] || fail "origin-less refusal published metadata"
+  [ "$(git -C "$WT_DIR" log -1 --format=%s)" = unlanded ] || fail 'origin-less refusal discarded the unlanded commit'
+  pass 'invalid directories and unsupported start-directory axes fail explicitly without task publication; refused fresh allocations are returned only with ownership proof'
 }
 
 

--- a/tests/fm-spawn-dispatch-profile.test.sh
+++ b/tests/fm-spawn-dispatch-profile.test.sh
@@ -1387,6 +1387,117 @@ SH
   pass 'invalid directories and unsupported start-directory axes fail explicitly without task publication; refused fresh allocations are returned only with ownership proof'
 }
 
+# A stateful herdr stand-in for a projected spawn: workspaces and tabs carry
+# focus, `pane get` reports the pane's cwd until the pane is closed and a
+# pane_not_found body afterwards, and every call records who holds the
+# presentation lock at that moment, so lock discipline is observable.
+make_spawn_herdr_statefake() {  # <fakebin> <state-file>
+  local fakebin=$1 state=$2
+  printf '%s\n' '{"next":3,"workspaces":[{"workspace_id":"w1","label":"firstmate","focused":true,"active_tab_id":"w1:t2"}],"tabs":[{"tab_id":"w1:t2","label":"1","workspace_id":"w1","pane_id":"w1:p2","focused":true}]}' > "$state"
+  cat > "$fakebin/herdr" <<'SH'
+#!/usr/bin/env bash
+set -u
+STATE=$FM_FAKE_HERDR_STATE
+holder=$(cat "$FM_FAKE_HERDR_LOCK/pid" 2>/dev/null || echo none)
+{ printf 'lock=%s' "$holder"; for a in "$@"; do printf '\x1f%s' "$a"; done; printf '\n'; } >> "$FM_HERDR_LOG"
+jq_state() { jq "$@" "$STATE"; }
+save() { local tmp="$STATE.tmp.$$"; cat > "$tmp" && mv "$tmp" "$STATE"; }
+cmd=${1:-}; sub=${2:-}
+ws=""; label=""
+args=("$@")
+for ((i=0; i<${#args[@]}; i++)); do
+  case "${args[$i]}" in
+    --workspace) ws=${args[$((i+1))]:-} ;;
+    --label) label=${args[$((i+1))]:-} ;;
+  esac
+done
+case "$cmd $sub" in
+  "status --json") printf '{"client":{"version":"0.8.2","protocol":20},"server":{"running":true}}\n' ;;
+  "session list") printf '{"sessions":[{"name":"default","running":true,"socket_path":"%s"}]}\n' "$FM_FAKE_HERDR_SOCKET" ;;
+  "workspace list") jq_state '{result:{workspaces:.workspaces}}' ;;
+  "workspace create")
+    n=$(jq_state -r '.next'); wsid="w$n"; tabid="w$n:t$((n + 1))"; paneid="w$n:p$((n + 1))"
+    jq_state --arg wsid "$wsid" --arg wlabel "$label" --arg tabid "$tabid" --arg paneid "$paneid" \
+      '.workspaces += [{workspace_id:$wsid, label:$wlabel, focused:false, active_tab_id:$tabid}]
+       | .tabs += [{tab_id:$tabid, label:"1", workspace_id:$wsid, pane_id:$paneid, focused:true}]
+       | .next += 2' | save
+    jq -n --arg wsid "$wsid" --arg wlabel "$label" --arg tabid "$tabid" --arg paneid "$paneid" \
+      '{result:{workspace:{workspace_id:$wsid,label:$wlabel},tab:{tab_id:$tabid},root_pane:{pane_id:$paneid}}}' ;;
+  "tab list") jq_state --arg w "$ws" '{result:{tabs:[.tabs[]|select(.workspace_id==$w)]}}' ;;
+  "tab create")
+    n=$(jq_state -r '.next'); tabid="$ws:t$n"; paneid="$ws:p$n"
+    jq_state --arg w "$ws" --arg wlabel "$label" --arg tabid "$tabid" --arg paneid "$paneid" \
+      '.tabs += [{tab_id:$tabid, label:$wlabel, workspace_id:$w, pane_id:$paneid, focused:false}] | .next += 1' | save
+    jq -n --arg tabid "$tabid" --arg paneid "$paneid" '{result:{tab:{tab_id:$tabid},root_pane:{pane_id:$paneid}}}' ;;
+  "pane list") jq_state --arg w "$ws" '{result:{panes:[.tabs[]|select(.workspace_id==$w)|{pane_id:.pane_id, tab_id:.tab_id}]}}' ;;
+  "pane get")
+    pane=${3:-}
+    row=$(jq_state -c --arg p "$pane" '[.tabs[]|select(.pane_id==$p)][0] // empty')
+    if [ -n "$row" ]; then
+      printf '%s' "$row" | jq --arg cwd "$FM_FAKE_HERDR_CWD" '{result:{pane:{pane_id:.pane_id, tab_id:.tab_id, workspace_id:.workspace_id, foreground_cwd:$cwd}}}'
+    else
+      jq -n --arg p "$pane" '{error:{code:"pane_not_found",message:("pane " + $p + " not found")}}'
+      exit 1
+    fi ;;
+  "pane close")
+    pane=${3:-}
+    jq_state --arg p "$pane" '.tabs |= [.[]|select(.pane_id != $p)]' | save ;;
+  "agent get") printf '{"error":{"code":"agent_not_found","message":"no agent"}}\n' ;;
+  "pane process-info") printf '{"result":{"type":"unavailable"}}\n' ;;
+  *) : ;;
+esac
+exit 0
+SH
+  chmod +x "$fakebin/herdr"
+}
+
+# On projected Herdr the refused launch's pane belongs to the armed abort
+# cleanup, which closes it under the presentation lock this process holds from
+# projection until exit. Closing it directly would re-enter that lock and
+# release it before the cleanup ran.
+test_start_directory_refusal_on_projected_herdr_keeps_the_presentation_lock() {
+  local rec out sock_real key lock proj_real state log
+  rec=$(make_spawn_case start-herdr pi refused)
+  read_case_record "$rec"
+  arm_retire_log
+  mkdir -p "$HOME_DIR/config"
+  printf 'on\n' > "$HOME_DIR/config/herdr-presentation-spaces"
+  state="$CASE_DIR/herdr-state.json"
+  log="$CASE_DIR/herdr.log"
+  : > "$log"
+  make_spawn_herdr_statefake "$FAKEBIN_DIR" "$state"
+  sock_real="$(cd "$CASE_DIR" && pwd -P)/herdr.sock"
+  key=$(printf '%s\0%s' default "$sock_real" | shasum -a 256 | awk '{print $1}')
+  lock="/tmp/firstmate-herdr-presentation/order-${key:0:32}.lock"
+  proj_real=$(cd "$PROJ_DIR" && pwd -P)
+  out=$(
+    unset HERDR_ENV HERDR_PANE_ID HERDR_TAB_ID HERDR_WORKSPACE_ID HERDR_SOCKET_PATH HERDR_SESSION
+    export FM_FAKE_HERDR_STATE="$state" FM_HERDR_LOG="$log" FM_FAKE_HERDR_LOCK="$lock" \
+      FM_FAKE_HERDR_SOCKET="$CASE_DIR/herdr.sock" FM_FAKE_HERDR_CWD="$WT_DIR"
+    run_ship_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" refused "$PROJ_DIR" --backend herdr --start-dir=missing
+  )
+  expect_code 1 "$?" "projected herdr start-directory refusal did not fail: $out"
+  assert_contains "$out" 'not an accessible directory' 'directory refusal is unexplained on projected herdr'
+  assert_contains "$out" "returned pooled worktree '$WT_DIR'; projected herdr pane default:w3:p5 is closed by this launch's abort cleanup" \
+    'projected refusal did not defer its pane to the abort cleanup'
+  assert_grep "treehouse return --force $WT_DIR in $proj_real" "$RETIRE_LOG" 'projected refusal did not return the slot from the project'
+  [ ! -f "$HOME_DIR/state/refused.meta" ] || fail 'projected refusal published metadata'
+  assert_grep $'\x1f''pane'$'\x1f''run'$'\x1f''w3:p5'$'\x1f''treehouse get' "$log" 'the projected task pane never received treehouse get'
+  [ "$(grep -c $'\x1f''pane'$'\x1f''close'$'\x1f''w3:p5'$'\x1f' "$log")" = 1 ] || fail "the task pane was not closed exactly once:"$'\n'"$(cat "$log")"
+  jq -e '[.tabs[] | select(.workspace_id == "w3")] | length == 0' "$state" >/dev/null || fail 'the projected workspace still holds panes after cleanup'
+  # From the moment the lock is first seen held, every later herdr call up to
+  # the last one must still see the same holder: the lock is released only
+  # after the abort cleanup finished.
+  awk -F"$(printf '\037')" '
+    { split($1, kv, "="); holder = kv[2] }
+    holder != "none" && first == "" { first = holder }
+    first != "" && holder != first { bad = NR }
+    END { if (first == "") { print "lock never held"; exit 1 } if (bad) { print "lock released before herdr call " bad; exit 1 } }
+  ' "$log" || fail "presentation lock was not held through the abort cleanup:"$'\n'"$(cat "$log")"
+  [ ! -e "$lock" ] && [ ! -L "$lock" ] || fail 'presentation lock was left held after exit'
+  pass 'a projected herdr start-directory refusal returns its slot and leaves its pane to the locked abort cleanup'
+}
+
 
 test_start_directory_root_batch_and_retarget() {
   local rec out launch id
@@ -1429,6 +1540,7 @@ test_start_directory_root_batch_and_retarget
 
 test_pi_start_directory_contract
 test_start_directory_refusals
+test_start_directory_refusal_on_projected_herdr_keeps_the_presentation_lock
 
 test_worker_launch_delivers_role_scope
 test_no_profile_keeps_claude_profile_defaults


### PR DESCRIPTION
## Intent

Support starting a managed Pi worker inside a repository subdirectory while keeping its isolated worktree as the lifecycle boundary. A game in a monorepo needs its own startup directory so native Codex loads the correct game instructions. Today normal launch starts at the root, and custom shell launch does not preserve this choice on relaunch. Provide one explicit supported start-directory contract that survives recovery without weakening worktree isolation.

Refresh. This change is submitted as https://github.com/kunchenguid/firstmate/pull/4092, and that pull request now conflicts with current main, so it cannot be merged as it stands. Carry the same change onto current main, resolving conflicts without altering the contract described above, validate it again there, and update the same branch and the same pull request. No second pull request and no new issue.

## What Changed

- `bin/fm-spawn.sh` gains `--start-dir <relative-directory>` for canonical Pi/Pi-signed ship and scout launches on tmux or Herdr (including `id=repo` batches). The value must be non-empty, relative, free of `..` components and control characters, and physically resolve inside the allocated worktree; other harnesses, raw launch commands, secondmates, and other backends refuse it. Only the harness runs in a subshell at that directory, with a launch-time `pwd -P` recheck that refuses a retargeted symlink, while the endpoint shell, `worktree=`, hooks, ownership, and teardown stay at the worktree root. A fresh launch refused after slot allocation returns the pooled slot and closes its endpoint only with proof the slot is still its own (endpoint in the slot, HEAD at the recorded origin base, clean tree); otherwise both are left in place with the remedy named. `rovo_endpoint_cleanup` is renamed `spawn_endpoint_cleanup` for that shared use.
- The choice is recorded as `start_dir=` in task metadata and reused on `--relaunch` (which refuses a `--start-dir` override; absence keeps legacy root startup). `bin/fm-control-lib.sh` now owns the shared supported-axes and physical-containment checks, and `bin/fm-control.sh relaunch` applies them before the running agent is stopped, refusing a missing, escaping, or unsupported recorded start directory.
- Tests in `tests/fm-spawn-dispatch-profile.test.sh` and `tests/fm-control-relaunch.test.sh` cover nested startup cwd, metadata preservation through relaunch and Herdr endpoint reclaim, invalid/unsupported refusals without task publication, ownership-proven slot return, and pre-stop relaunch refusal. Docs (`docs/agent-control.md`, `docs/scripts.md`, `docs/verification/runtime-backends.md`, and the Pi harness reference) describe the contract and the recorded verification evidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Risk Assessment

✅ Low: The feature's executable diff is equivalent before and after the merge onto main (only main's formatting style and one comment differ), every new behavior is gated behind --start-dir or a recorded start_dir so legacy launches are untouched, the force-return retire path requires base-commit, clean-tree, and endpoint-in-slot proof and correctly composes with main's new slot-owner claim and Treehouse project lock, and no sibling consumer compares a running agent's cwd to worktree=; only two info-level items remain.

## Testing

I ran the two suites that own the start-directory contract (`tests/fm-spawn-dispatch-profile.test.sh` and `tests/fm-control-relaunch.test.sh`), and both passed with no gate skips, including all six start-directory cases. I then drove the real `bin/fm-spawn.sh` and `bin/fm-control.sh` against a monorepo fixture and sourced the staged launch file under zsh, bash and sh, the way a task pane does. All 61 checks in that transcript passed: nested startup with the game's instructions, legacy root startup, preserved worktree identity, recovery through relaunch, refusals before the agent is stopped, and the isolation refusals. The same driver fails 41 checks on the base commit, and a patch comparison shows the merge left the contract unchanged. There was no live terminal multiplexer run: tmux is not installed here, and the earlier decisions on this branch rule out further live workers. This change has no UI, so the evidence is CLI transcripts.

<details>
<summary>Evidence: End-to-end CLI transcript: spawn with --start-dir, recovery via fm-control relaunch, refusals (61 of 61 checks pass)</summary>

Source: [End-to-end CLI transcript: spawn with --start-dir, recovery via fm-control relaunch, refusals (61 of 61 checks pass)](https://github.com/3264studios/firstmate/blob/fa0a493e579408d48d4c967e5beb80afd15e37ed/.no-mistakes/evidence/fm/fm-pi-game-start-subdirectory/start-dir-e2e-transcript.txt)

```text


==================================================================
0. What is under test
==================================================================
commit:   83f6ace Merge main while preserving Pi startup-directory support
real:     bin/fm-spawn.sh, bin/fm-control.sh, the staged launch file, zsh/bash/sh, git
stand-in: tmux (not installed on this host; repo fixture stubs), treehouse (recorder), pi (cwd/argv capture - no model worker)

Monorepo fixture (committed, with an origin):
  AGENTS.md
  games/demo/AGENTS.md
  games/demo/assets/levels.txt
  games/other/AGENTS.md


==================================================================
1. Legacy launch (no --start-dir): Pi starts at the worktree root
==================================================================
$ fm-spawn.sh sd84664-legacy <monorepo> --mode no-mistakes --yolo off --harness pi
warning: <tmp>~/sd84664-legacy/launch-brief.md records no delivery contract line (scaffolded before ship briefs recorded one); launching on the explicit --mode no-mistakes - confirm its definition of done matches
spawned sd84664-legacy harness=pi kind=ship mode=no-mistakes yolo=off window=firstmate:fm-sd84664-legacy worktree=<tmp>/wt-legacy
  [PASS] legacy spawn succeeds
  [PASS] legacy record carries no start_dir (absence keeps root startup)
pane.shell_cwd_after_harness_exit=<tmp>/wt-legacy
pi.cwd=<tmp>/wt-legacy
pi.nearest_instructions=<tmp>/wt-legacy/AGENTS.md
pi.instruction_sentinel=root
  [PASS] legacy Pi sees the ROOT instructions, not the game's


==================================================================
2. --start-dir games/demo: Pi starts inside the game; the worktree stays the lifecycle boundary
==================================================================
$ fm-spawn.sh sd84664-ship <monorepo> --mode no-mistakes --yolo off --harness pi --model codex-native/gpt-6-astra --effort high --start-dir games/demo
warning: <tmp>~/sd84664-ship/launch-brief.md records no delivery contract line (scaffolded before ship briefs recorded one); launching on the explicit --mode no-mistakes - confirm its definition of done matches
spawned sd84664-ship harness=pi kind=ship mode=no-mistakes yolo=off window=firstmate:fm-sd84664-ship worktree=<tmp>/wt-ship
  [PASS] spawn succeeds

Durable task record (state/sd84664-ship.meta), identity fields:
  window=firstmate:fm-sd84664-ship
  worktree=<tmp>/wt-ship
  start_dir=games/demo
  harness=pi
  kind=ship
  model=codex-native/gpt-6-astra
  effort=high
  [PASS] worktree= is still the isolated worktree ROOT
  [PASS] start_dir= records the RELATIVE choice

Line typed into the task pane:
  . '/tmp/fm-sd84664-ship+eb3304c1800ebaf99a739c6e9fc498e58164e7452e0b11f511027714a330dc9b/launch.s1789958865.85530.21194.sh'

Head of the staged launch file it sources (the start-directory guard):
  (CDPATH='' cd -- '<tmp>/wt-ship/games/demo' && [ "$(pwd -P)" = '<tmp>/wt-ship/games/demo' ] || { echo 'error: start directory changed before launch' >&2; exit 1; }; export COMPAC ...

Pane shell = /bin/zsh, sitting at the worktree root, sources that line:
  pi.cwd=<tmp>/wt-ship/games/demo
  pi.nearest_instructions=<tmp>/wt-ship/games/demo/AGENTS.md
  pi.instruction_sentinel=games/demo
  pi.argv.model=codex-native/gpt-6-astra
  pi.argv.thinking=high
  pane.shell_cwd_after_harness_exit=<tmp>/wt-ship
  [PASS] [/bin/zsh] Pi's cwd is <worktree>/games/demo
  [PASS] [/bin/zsh] Pi finds the GAME's instructions first
  [PASS] [/bin/zsh] native model and effort reach Pi
  [PASS] [/bin/zsh] the pane shell is still at the worktree root after Pi exits

Pane shell = /opt/homebrew/bin/bash, sitting at the worktree root, sources that line:
  pi.cwd=<tmp>/wt-ship/games/demo
  pi.nearest_instructions=<tmp>/wt-ship/games/demo/AGENTS.md
  pi.instruction_sentinel=games/demo
  pi.argv.model=codex-native/gpt-6-astra
  pi.argv.thinking=high
  pane.shell_cwd_after_harness_exit=<tmp>/wt-ship
  [PASS] [/opt/homebrew/bin/bash] Pi's cwd is <worktree>/games/demo
  [PASS] [/opt/homebrew/bin/bash] Pi finds the GAME's instructions first
  [PASS] [/opt/homebrew/bin/bash] native model and effort reach Pi
  [PASS] [/opt/homebrew/bin/bash] the pane shell is still at the worktree root after Pi exits

Pane shell = /bin/sh, sitting at the worktree root, sources that line:
  pi.cwd=<tmp>/wt-ship/games/demo
  pi.nearest_instructions=<tmp>/wt-ship/games/demo/AGENTS.md
  pi.instruction_sentinel=games/demo
  pi.argv.model=codex-native/gpt-6-astra
  pi.argv.thinking=high
  pane.shell_cwd_after_harness_exit=<tmp>/wt-ship
  [PASS] [/bin/sh] Pi's cwd is <worktree>/games/demo
  [PASS] [/bin/sh] Pi finds the GAME's instructions first
  [PASS] [/bin/sh] native model and effort reach Pi
  [PASS] [/bin/sh] the pane shell is still at the worktree root after Pi exits

Scout kind and Pi-signed are the other supported axes:
$ fm-spawn.sh sd84664-scout <monorepo> --scout --harness pi-signed --start-dir games/other
spawned sd84664-scout harness=pi-signed kind=scout window=firstmate:fm-sd84664-scout worktree=<tmp>/wt-scout
  [PASS] scout spawn on pi-signed succeeds
  pi.cwd=<tmp>/wt-scout/games/other
  pi.nearest_instructions=<tmp>/wt-scout/games/other/AGENTS.md
  pi.instruction_sentinel=games/other
  [PASS] scout Pi-signed starts in games/other with that game's instructions


==================================================================
3. Recovery: fm-control relaunch keeps the start directory
==================================================================

Agent in the pane before: pi   spawn_gen=s1789958865.85530.21194
$ fm-control.sh sd84664-ship relaunch --note 'context was exhausted; continue the demo game work'
warning: <tmp>~/sd84664-ship/launch-brief.md records no delivery contract line (scaffolded before ship briefs recorded one); launching on the explicit --mode no-mistakes - confirm its definition of done matches
relaunched sd84664-ship harness=pi from=pi model=codex-native/gpt-6-astra effort=high backend=tmux endpoint=firstmate:fm-sd84664-ship worktree=<tmp>/wt-ship
  [PASS] relaunch succeeds

Record after relaunch:
  window=firstmate:fm-sd84664-ship
  worktree=<tmp>/wt-ship
  start_dir=games/demo
  harness=pi
  model=codex-native/gpt-6-astra
  effort=high
  spawn_gen=s1789958871.88181.12624
  [PASS] a new incarnation was launched (spawn_gen changed)
  [PASS] same endpoint
  [PASS] same worktree root
  [PASS] start_dir survived recovery

What the pane received, in order:
  1:/quit ...
  2:(CDPATH='' cd -- '<tmp>/wt-ship/games/demo' && [ "$(pwd -P)" = '<tmp>/wt-ship/games/demo' ] || { echo 'error: start directory changed befo ...
  pi.cwd=<tmp>/wt-ship/games/demo
  pi.nearest_instructions=<tmp>/wt-ship/games/demo/AGENTS.md
  pi.instruction_sentinel=games/demo
  pi.argv.model=codex-native/gpt-6-astra
  pi.argv.thinking=high
  pane.shell_cwd_after_harness_exit=<tmp>/wt-ship
  [PASS] replacement Pi starts in <worktree>/games/demo again
  [PASS] replacement Pi still loads the game's instructions
  [PASS] replacement keeps native model and effort
  [PASS] pane shell still at the worktree root


==================================================================
4. Recovery refuses BEFORE stopping the agent when the contract cannot hold
==================================================================
$ fm-control.sh sd84664-ship relaunch --harness codex --note switch runtime
  error: task sd84664-ship records start_dir 'games/demo', which only canonical Pi/Pi-signed ship/scout 
  launches on tmux or herdr support, so relaunching it onto codex/tmux would stop the running agent for a 
  launch that must be refused; relaunch onto pi or pi-signed
  [PASS] unsupported harness switch: refused (exit 1)
  [PASS] unsupported harness switch: names the cause
  [PASS] unsupported harness switch: agent still running (pi), nothing typed into its pane
  [PASS] unsupported harness switch: task record untouched
$ fm-control.sh sd84664-ship relaunch --note directory gone
  error: task sd84664-ship's recorded start_dir 'games/demo' is not an accessible directory in '<tmp>/wt-ship'; 
  the replacement must start there, so restore that directory before relaunching rather than stopping the agent 
  for a launch that must be refused
  [PASS] start directory gone: refused (exit 1)
  [PASS] start directory gone: names the cause
  [PASS] start directory gone: agent still running (pi), nothing typed into its pane
  [PASS] start directory gone: task record untouched
$ fm-control.sh sd84664-ship relaunch --note directory escaped
  error: task sd84664-ship's recorded start_dir 'games/demo' physically escapes worktree '<tmp>/wt-ship'; the 
  replacement must start there, so restore that directory before relaunching rather than stopping the agent for 
  a launch that must be refused
  [PASS] start directory now escapes the worktree: refused (exit 1)
  [PASS] start directory now escapes the worktree: names the cause
  [PASS] start directory now escapes the worktree: agent still running (pi), nothing typed into its pane
  [PASS] start directory now escapes the worktree: task record untouched
$ fm-spawn.sh sd84664-ship --relaunch --start-dir games/other
  error: --relaunch reuses recorded start_dir; --start-dir cannot override it
  [PASS] relaunch cannot override the recorded start directory


==================================================================
5. Worktree isolation is not weakened
==================================================================

Refused before anything is allocated:
$ fm-spawn.sh sd84664-refused <monorepo> --mode no-mistakes --yolo off --harness pi --start-dir ../outside
  error: --start-dir must be a non-empty contained relative directory without .. components
  [PASS] parent traversal: refused (exit 1), cause named
  [PASS] parent traversal: no task record published
  [PASS]   nothing was allocated or retired
$ fm-spawn.sh sd84664-refused <monorepo> --mode no-mistakes --yolo off --harness pi --start-dir /tmp
  error: --start-dir must be a non-empty contained relative directory without .. components
  [PASS] absolute path: refused (exit 1), cause named
  [PASS] absolute path: no task record published
$ fm-spawn.sh sd84664-refused <monorepo> --mode no-mistakes --yolo off --harness pi --start-dir games/../../outside
  error: --start-dir must be a non-empty contained relative directory without .. components
  [PASS] inner traversal: refused (exit 1), cause named
  [PASS] inner traversal: no task record published
$ fm-spawn.sh sd84664-refused <monorepo> --mode no-mistakes --yolo off --harness codex --start-dir games/demo
  error: --start-dir supports only canonical Pi/Pi-signed ship/scout launches on tmux or herdr (got 
  codex/tmux/ship raw=0)
  [PASS] other harness: refused (exit 1), cause named
  [PASS] other harness: no task record published
$ fm-spawn.sh sd84664-refused <monorepo> --mode no-mistakes --yolo off pi --model custom --start-dir games/demo
  error: --start-dir supports only canonical Pi/Pi-signed ship/scout launches on tmux or herdr (got 
  pi/tmux/ship raw=1)
  [PASS] raw launch command: refused (exit 1), cause named
  [PASS] raw launch command: no task record published

Refusable only once the slot exists; the refused launch gives back exactly what it took:
$ fm-spawn.sh sd84664-refused <monorepo> --mode no-mistakes --yolo off --harness pi --start-dir games/dmeo
  error: --start-dir 'games/dmeo' is not an accessible directory in '<tmp>/wt-refused'
  returned pooled worktree '<tmp>/wt-refused' and asked tmux to close window firstmate:fm-sd84664-refused
  [PASS] typo (games/dmeo): refused (exit 1), cause named
  [PASS] typo (games/dmeo): no task record published
  retired: treehouse return --force <tmp>/wt-refused   (run from <tmp>/monorepo)
  retired: tmux kill-window -t =firstmate:=fm-sd84664-refused
  [PASS]   the fresh slot was returned and its own window closed
$ fm-spawn.sh sd84664-refused <monorepo> --mode no-mistakes --yolo off --harness pi --start-dir escape
  error: --start-dir 'escape' physically escapes worktree '<tmp>/wt-refused'
  returned pooled worktree '<tmp>/wt-refused' and asked tmux to close window firstmate:fm-sd84664-refused
  [PASS] symlink leaving the worktree: refused (exit 1), cause named
  [PASS] symlink leaving the worktree: no task record published
  retired: treehouse return --force <tmp>/wt-refused   (run from <tmp>/monorepo)
  retired: tmux kill-window -t =firstmate:=fm-sd84664-refused

Launch-time guard: a contained symlink retargeted AFTER spawn cannot misroute Pi:
  [PASS] contained symlink is accepted at spawn
  [PASS]   and Pi starts at its physical target inside the worktree
$ (symlink retargeted outside the worktree; the pane sources the SAME launch line)
  error: start directory changed before launch
  pane.shell_cwd_after_harness_exit=<tmp>/wt-link
  [PASS]   Pi never executed


==================================================================
Result
==================================================================
ALL CHECKS PASSED
```
</details>
<details>
<summary>Evidence: Demo driver that produced the transcript (states what is real and what is a stand-in)</summary>

Source: [Demo driver that produced the transcript (states what is real and what is a stand-in)](https://github.com/3264studios/firstmate/blob/fa0a493e579408d48d4c967e5beb80afd15e37ed/.no-mistakes/evidence/fm/fm-pi-game-start-subdirectory/start-dir-e2e-demo.sh)

```text
#!/usr/bin/env bash
# Evidence driver for the Pi --start-dir contract (no-mistakes test phase).
#
# What is REAL here: bin/fm-spawn.sh, bin/fm-control.sh, the staged launch file
# they write, the shells (zsh/bash/sh) that source that file exactly the way a
# task pane does, git, and the monorepo fixture on disk.
# What is a STAND-IN: the terminal multiplexer (tmux is not installed on this
# host, so the repo's own fixture stubs answer for it), `treehouse` (a recorder,
# so no real pool is touched), and `pi` (a capture executable that reports its
# cwd, the instruction file a harness would find first, and its argv - no model
# worker is started).
#
# Usage: start-dir-e2e-demo.sh <repo-root>
set -u

REPO=${1:?repo root}
# shellcheck source=/dev/null
. "$REPO/tests/fixtures.sh"
unset LAVISH_AXI_HOST HERDR_ENV HERDR_PANE_ID HERDR_TAB_ID HERDR_WORKSPACE_ID HERDR_SOCKET_PATH HERDR_SESSION

TMP_ROOT=$(fm_test_tmproot nm-start-dir-demo)
mkdir -p "$TMP_ROOT"
TMP_ROOT=$(cd "$TMP_ROOT" && pwd -P)
TAG="sd$$"
DEMO_IDS=()
demo_cleanup() {
  local id
  for id in "${DEMO_IDS[@]:-}"; do
    [ -n "$id" ] || continue
    rm -rf "/tmp/fm-$id" /tmp/fm-"$id"+*
  done
  rm -rf "$TMP_ROOT"
}
trap demo_cleanup EXIT

FAILS=0
say()   { printf '\n%s\n' "$*"; }
h1()    { printf '\n\n==================================================================\n%s\n==================================================================\n' "$*"; }
show()  { printf '$ %s\n' "$*"; }
check() {  # <description> <command...>
  local desc=$1; shift
  if "$@"; then printf '  [PASS] %s\n' "$desc"; else printf '  [FAIL] %s\n' "$desc"; FAILS=$((FAILS + 1)); fi
}
# Paths in the transcript are shortened so it reads the same on any host.
short() { sed -e "s|$TMP_ROOT|<tmp>|g" -e "s|$REPO|<repo>|g"; }

HOME_DIR="$TMP_ROOT/home"
PROJ="$TMP_ROOT/monorepo"
FAKEBIN="$TMP_ROOT/fakebin"
FAKE="$TMP_ROOT/fake"
TYPED="$TMP_ROOT/typed.log"
RETIRE="$TMP_ROOT/retire.log"
mkdir -p "$FAKEBIN" "$FAKE" "$TMP_ROOT/user-home" "$TMP_ROOT/outside"
: > "$TYPED"; : > "$RETIRE"

# --- monorepo fixture: a root instruction file and one per game ---------------
mkdir -p "$PROJ/games/demo/assets" "$PROJ/games/other"
git -C "$PROJ" init -q -b main
printf '# Monorepo root instructions\nSENTINEL=root\n' > "$PROJ/AGENTS.md"
printf '# Demo game instructions\nSENTINEL=games/demo\n' > "$PROJ/games/demo/AGENTS.md"
printf 'level-1\n' > "$PROJ/games/demo/assets/levels.txt"
printf '# Other game instructions\nSENTINEL=games/other\n' > "$PROJ/games/other/AGENTS.md"
git -C "$PROJ" add -A
git -C "$PROJ" -c user.name='Firstmate Tests' -c user.email='tests@example.invalid' commit -qm 'monorepo with two games'
fm_git_add_origin "$PROJ" "$PROJ.origin.git"
new_slot() {  # <name> -> echoes a pooled-slot-shaped linked worktree
  git -C "$PROJ" worktree add --quiet -b "slot-$1" "$TMP_ROOT/wt-$1"
  printf '%s\n' "$TMP_ROOT/wt-$1"
}

fm_test_spawn_home "$HOME_DIR" pi

# --- stand-ins ----------------------------------------------------------------
# The repo's spawn-world tmux stub, wrapped so the line actually typed into the
# pane and every window kill are recorded.
fm_test_fake_tmux_spawn "$FAKEBIN"
mv "$FAKEBIN/tmux" "$FAKEBIN/tmux-spawn-stub"
cat > "$FAKEBIN/tmux" <<'SH'
#!/usr/bin/env bash
[ "${1:-}" != kill-window ] || printf 'tmux %s\n' "$*" >> "$FM_DEMO_RETIRE"
if [ "${1:-}" = send-keys ]; then
  prev=
  for a in "$@"; do
    [ "$prev" != -l ] || printf '%s\n' "$a" >> "$FM_DEMO_TYPED"
    prev=$a
  done
fi
exec "$(dirname "$0")/tmux-spawn-stub" "$@"
SH
cat > "$FAKEBIN/treehouse" <<'SH'
#!/usr/bin/env bash
printf 'treehouse %s   (run from %s)\n' "$*" "$(pwd -P)" >> "$FM_DEMO_RETIRE"
SH
# `pi`: answers the version/--help probe fm-spawn makes, otherwise reports what
# a harness started here would see. The instruction file is found the way a
# harness finds project instructions: nearest AGENTS.md walking up from cwd.
cat > "$FAKEBIN/pi" <<'SH'
#!/bin/sh
if [ "${1:-}" = --help ]; then
  printf '%s\n' 'Pi 0.85.1' 'Options: --help --tui-mode <mode>'
  exit 0
fi
[ -n "${FM_START_CAPTURE:-}" ] || exit 0
d=$(pwd -P); found=
while [ -n "$d" ]; do
  if [ -f "$d/AGENTS.md" ]; then found="$d/AGENTS.md"; break; fi
  [ "$d" != / ] || break
  d=$(dirname "$d")
done
{
  printf 'pi.cwd=%s\n' "$(pwd -P)"
  printf 'pi.nearest_instructions=%s\n' "${found:-none}"
  [ -z "$found" ] || printf 'pi.instruction_sentinel=%s\n' "$(sed -n 's/^SENTINEL=//p' "$found")"
  prev=
  for a in "$@"; do
    case "$prev" in
      --model) printf 'pi.argv.model=%s\n' "$a" ;;
      --thinking) printf 'pi.argv.thinking=%s\n' "$a" ;;
    esac
    prev=$a
  done
} > "$FM_START_CAPTURE"
SH
cp "$FAKEBIN/pi" "$FAKEBIN/pi-signed"
chmod +x "$FAKEBIN"/*

spawn() {  # <pane-path> <fm-spawn args...>
  local pane=$1; shift
  FM_ROOT_OVERRIDE='' FM_HOME="$HOME_DIR" HOME="$TMP_ROOT/user-home" CLAUDE_CONFIG_DIR='' \
    FM_SPAWN_NO_GUARD=1 FM_FAKE_PANE_PATH="$pane" TMUX='fake,1,0' GROK_HOME="$TMP_ROOT/grok-home" \
    FM_DEMO_TYPED="$TYPED" FM_DEMO_RETIRE="$RETIRE" FM_FAKE_DIR="$FAKE" \
    PATH="$FAKEBIN:$PATH" "$REPO/bin/fm-spawn.sh" "$@" 2>&1
}
brief() { fm_test_spawn_brief "$HOME_DIR" "$1" "Work on the demo game only."; DEMO_IDS+=("$1"); }
meta()  { grep "^$2=" "$HOME_DIR/state/$1.meta" | tail -1 | cut -d= -f2-; }
# Do what the task pane does: an interactive shell sitting at the worktree root
# sources the typed line. Reports the harness capture and where the pane shell
# is afterwards.
pane_runs() {  # <shell> <worktree> <typed-line> <capture-file>
  local shell=$1 wt=$2 line=$3 cap=$4
  rm -f "$cap"
  (cd "$wt" && PATH="$FAKEBIN:$PATH" FM_START_CAPTURE="$cap" "$shell" -c "$line"'
printf "pane.shell_cwd_after_harness_exit=%s\n" "$(pwd -P)"' 2>&1)
}

h1 "0. What is under test"
printf 'commit:   %s\n' "$(git -C "$REPO" log -1 --format='%h %s')"
printf 'real:     bin/fm-spawn.sh, bin/fm-control.sh, the staged launch file, zsh/bash/sh, git\n'
printf 'stand-in: tmux (not installed on this host; repo fixture stubs), treehouse (recorder), pi (cwd/argv capture - no model worker)\n'
say "Monorepo fixture (committed, with an origin):"
(cd "$PROJ" && find . -path ./.git -prune -o -type f -print | sort | sed 's|^\./|  |')

# ------------------------------------------------------------------------------
h1 "1. Legacy launch (no --start-dir): Pi starts at the worktree root"
ID_LEGACY="$TAG-legacy"; brief "$ID_LEGACY"; WT_LEGACY=$(new_slot legacy)
show "fm-spawn.sh $ID_LEGACY <monorepo> --mode no-mistakes --yolo off --harness pi"
: > "$TYPED"
out=$(spawn "$WT_LEGACY" "$ID_LEGACY" "$PROJ" --mode no-mistakes --yolo off --harness pi --backend tmux); rc=$?
printf '%s\n' "$out" | short | tail -3
check "legacy spawn succeeds" [ "$rc" -eq 0 ]
check "legacy record carries no start_dir (absence keeps root startup)" sh -c "! grep -q '^start_dir=' '$HOME_DIR/state/$ID_LEGACY.meta'"
line=$(tail -n 1 "$TYPED")
pane_runs /bin/zsh "$WT_LEGACY" "$line" "$TMP_ROOT/cap-legacy" | short
short < "$TMP_ROOT/cap-legacy"
check "legacy Pi sees the ROOT instructions, not the game's" grep -qx 'pi.instruction_sentinel=root' "$TMP_ROOT/cap-legacy"

# ------------------------------------------------------------------------------
h1 "2. --start-dir games/demo: Pi starts inside the game; the worktree stays the lifecycle boundary"
ID="$TAG-ship"; brief "$ID"; WT=$(new_slot ship)
show "fm-spawn.sh $ID <monorepo> --mode no-mistakes --yolo off --harness pi --model codex-native/gpt-6-astra --effort high --start-dir games/demo"
: > "$TYPED"
out=$(spawn "$WT" "$ID" "$PROJ" --mode no-mistakes --yolo off --harness pi --backend tmux \
  --model codex-native/gpt-6-astra --effort high --start-dir games/demo); rc=$?
printf '%s\n' "$out" | short | tail -3
check "spawn succeeds" [ "$rc" -eq 0 ]
say "Durable task record (state/$ID.meta), identity fields:"
grep -E '^(window|worktree|start_dir|harness|kind|model|effort|backend)=' "$HOME_DIR/state/$ID.meta" | short | sed 's/^/  /'
check "worktree= is still the isolated worktree ROOT" [ "$(meta "$ID" worktree)" = "$WT" ]
check "start_dir= records the RELATIVE choice" [ "$(meta "$ID" start_dir)" = games/demo ]
line=$(tail -n 1 "$TYPED")
say "Line typed into the task pane:"
printf '  %s\n' "$line" | short
sa

... [2219 bytes truncated] ...

nt} on&&/^}$/{exit}' "$REPO/tests/fm-control-relaunch.test.sh" > "$TMP_ROOT/stub-fn.sh"
# shellcheck source=/dev/null
. "$TMP_ROOT/stub-fn.sh"
mkdir -p "$TMP_ROOT/ctl"
make_tmux_stub "$TMP_ROOT/ctl"
cp "$TMP_ROOT/ctl/fakebin/tmux" "$FAKEBIN/tmux"
cp "$TMP_ROOT/ctl/fakebin/sleep" "$FAKEBIN/sleep"
: > "$FAKE/literal"; : > "$FAKE/keys"
printf pi > "$FAKE/command"; printf pi > "$FAKE/becomes"
printf 'fm-%s\n' "$ID" > "$FAKE/windows"; printf firstmate > "$FAKE/session-name"; printf '%s' "$WT" > "$FAKE/cwd"
control() {
  FM_HOME="$HOME_DIR" HOME="$TMP_ROOT/user-home" CLAUDE_CONFIG_DIR='' FM_FAKE_DIR="$FAKE" \
    FM_SPAWN_NO_GUARD=1 GROK_HOME="$TMP_ROOT/grok-home" TMUX='fake,1,0' \
    FM_CONTROL_POLL=0.01 FM_CONTROL_EXIT_WAIT=0.05 FM_CONTROL_LAUNCH_WAIT=0.05 \
    PATH="$FAKEBIN:$PATH" "$REPO/bin/fm-control.sh" "$@" 2>&1
}
gen_before=$(meta "$ID" spawn_gen); win_before=$(meta "$ID" window)
say "Agent in the pane before: $(cat "$FAKE/command")   spawn_gen=$gen_before"
show "fm-control.sh $ID relaunch --note 'context was exhausted; continue the demo game work'"
out=$(control "$ID" relaunch --note 'context was exhausted; continue the demo game work'); rc=$?
printf '%s\n' "$out" | short | tail -4
check "relaunch succeeds" [ "$rc" -eq 0 ]
say "Record after relaunch:"
grep -E '^(window|worktree|start_dir|harness|model|effort|spawn_gen)=' "$HOME_DIR/state/$ID.meta" | short | sed 's/^/  /'
check "a new incarnation was launched (spawn_gen changed)" [ "$(meta "$ID" spawn_gen)" != "$gen_before" ]
check "same endpoint" [ "$(meta "$ID" window)" = "$win_before" ]
check "same worktree root" [ "$(meta "$ID" worktree)" = "$WT" ]
check "start_dir survived recovery" [ "$(meta "$ID" start_dir)" = games/demo ]
say "What the pane received, in order:"
grep -n -E "^/(exit|quit)$|^\(CDPATH=" "$FAKE/literal" | short | cut -c1-140 | sed -e 's/^/  /' -e 's/$/ .../'
relaunch_cmd=$(tail -n 1 "$FAKE/literal")
printf '%s\n' "$relaunch_cmd" > "$TMP_ROOT/relaunch.sh"
pane_runs /bin/zsh "$WT" ". '$TMP_ROOT/relaunch.sh'" "$TMP_ROOT/cap-relaunch" > "$TMP_ROOT/pane.out"
short < "$TMP_ROOT/cap-relaunch" | sed 's/^/  /'; short < "$TMP_ROOT/pane.out" | sed 's/^/  /'
check "replacement Pi starts in <worktree>/games/demo again" grep -qx "pi.cwd=$WT/games/demo" "$TMP_ROOT/cap-relaunch"
check "replacement Pi still loads the game's instructions" grep -qx 'pi.instruction_sentinel=games/demo' "$TMP_ROOT/cap-relaunch"
check "replacement keeps native model and effort" sh -c "grep -qx 'pi.argv.model=codex-native/gpt-6-astra' '$TMP_ROOT/cap-relaunch' && grep -qx 'pi.argv.thinking=high' '$TMP_ROOT/cap-relaunch'"
check "pane shell still at the worktree root" grep -qx "pane.shell_cwd_after_harness_exit=$WT" "$TMP_ROOT/pane.out"

# ------------------------------------------------------------------------------
h1 "4. Recovery refuses BEFORE stopping the agent when the contract cannot hold"
refuse_before_stop() {  # <label> <expected-text> <control args...>
  local label=$1 want=$2; shift 2
  local lines_before out rc
  lines_before=$(wc -l < "$FAKE/literal" | tr -d ' ')
  cp "$HOME_DIR/state/$ID.meta" "$TMP_ROOT/meta.before"
  show "fm-control.sh $*"
  out=$(control "$@"); rc=$?
  printf '%s\n' "$out" | short | tail -1 | fold -s -w 110 | sed 's/^/  /'
  check "$label: refused (exit $rc)" [ "$rc" -ne 0 ]
  check "$label: names the cause" sh -c "printf '%s' \"\$1\" | grep -q -- \"\$2\"" _ "$out" "$want"
  check "$label: agent still running ($(cat "$FAKE/command")), nothing typed into its pane" \
    sh -c "[ \"\$(cat '$FAKE/command')\" = pi ] && [ \"\$(wc -l < '$FAKE/literal' | tr -d ' ')\" = '$lines_before' ]"
  check "$label: task record untouched" cmp -s "$TMP_ROOT/meta.before" "$HOME_DIR/state/$ID.meta"
}
refuse_before_stop "unsupported harness switch" 'only canonical Pi' "$ID" relaunch --harness codex --note 'switch runtime'
mv "$WT/games/demo" "$WT/games/demo-renamed"
refuse_before_stop "start directory gone" 'not an accessible directory' "$ID" relaunch --note 'directory gone'
ln -s "$TMP_ROOT/outside" "$WT/games/demo"
refuse_before_stop "start directory now escapes the worktree" 'physically escapes' "$ID" relaunch --note 'directory escaped'
rm "$WT/games/demo"; mv "$WT/games/demo-renamed" "$WT/games/demo"
show "fm-spawn.sh $ID --relaunch --start-dir games/other"
out=$(spawn "$WT" "$ID" --relaunch --start-dir games/other); rc=$?
printf '%s\n' "$out" | short | tail -1 | sed 's/^/  /'
check "relaunch cannot override the recorded start directory" sh -c "[ $rc -ne 0 ] && printf '%s' \"\$1\" | grep -q 'cannot override'" _ "$out"

# ------------------------------------------------------------------------------
h1 "5. Worktree isolation is not weakened"
cp "$TMP_ROOT/ctl/fakebin/tmux" "$TMP_ROOT/tmux-lifecycle"
# Back to the spawn-world stub for fresh launches.
cat > "$FAKEBIN/tmux" <<'SH'
#!/usr/bin/env bash
[ "${1:-}" != kill-window ] || printf 'tmux %s\n' "$*" >> "$FM_DEMO_RETIRE"
if [ "${1:-}" = send-keys ]; then
  prev=
  for a in "$@"; do
    [ "$prev" != -l ] || printf '%s\n' "$a" >> "$FM_DEMO_TYPED"
    prev=$a
  done
fi
exec "$(dirname "$0")/tmux-spawn-stub" "$@"
SH
chmod +x "$FAKEBIN/tmux"
ID_R="$TAG-refused"; brief "$ID_R"; WT_R=$(new_slot refused)
ln -s "$TMP_ROOT/outside" "$WT_R/escape"
printf 'escape\n' >> "$(git -C "$WT_R" rev-parse --git-path info/exclude)"
refuse_spawn() {  # <label> <expected-text> <extra fm-spawn args...>
  local label=$1 want=$2; shift 2
  local out rc
  : > "$RETIRE"
  show "fm-spawn.sh $ID_R <monorepo> --mode no-mistakes --yolo off $*"
  out=$(spawn "$WT_R" "$ID_R" "$PROJ" --mode no-mistakes --yolo off --backend tmux "$@"); rc=$?
  printf '%s\n' "$out" | grep -E 'error:|returned pooled' | short | fold -s -w 110 | sed 's/^/  /'
  check "$label: refused (exit $rc), cause named" sh -c "[ $rc -ne 0 ] && printf '%s' \"\$1\" | grep -q -- \"\$2\"" _ "$out" "$want"
  check "$label: no task record published" [ ! -e "$HOME_DIR/state/$ID_R.meta" ]
}
say "Refused before anything is allocated:"
refuse_spawn "parent traversal"  'without .. components' --harness pi --start-dir ../outside
check "  nothing was allocated or retired" [ ! -s "$RETIRE" ]
refuse_spawn "absolute path"     'contained relative directory' --harness pi --start-dir /tmp
refuse_spawn "inner traversal"   'without .. components' --harness pi --start-dir games/../../outside
refuse_spawn "other harness"     'supports only canonical Pi' --harness codex --start-dir games/demo
refuse_spawn "raw launch command" 'supports only canonical Pi' 'pi --model custom' --start-dir games/demo
say "Refusable only once the slot exists; the refused launch gives back exactly what it took:"
refuse_spawn "typo (games/dmeo)" 'not an accessible directory' --harness pi --start-dir games/dmeo
short < "$RETIRE" | sed 's/^/  retired: /'
check "  the fresh slot was returned and its own window closed" sh -c "grep -q 'treehouse return --force $WT_R' '$RETIRE' && grep -q 'kill-window.*fm-$ID_R' '$RETIRE'"
refuse_spawn "symlink leaving the worktree" 'physically escapes' --harness pi --start-dir escape
short < "$RETIRE" | sed 's/^/  retired: /'

say "Launch-time guard: a contained symlink retargeted AFTER spawn cannot misroute Pi:"
ID_L="$TAG-link"; brief "$ID_L"; WT_L=$(new_slot link)
ln -s games/demo "$WT_L/current-game"
printf 'current-game\n' >> "$(git -C "$WT_L" rev-parse --git-path info/exclude)"
: > "$TYPED"
out=$(spawn "$WT_L" "$ID_L" "$PROJ" --mode no-mistakes --yolo off --harness pi --backend tmux --start-dir current-game); rc=$?
check "contained symlink is accepted at spawn" [ "$rc" -eq 0 ]
line=$(tail -n 1 "$TYPED")
pane_runs /bin/zsh "$WT_L" "$line" "$TMP_ROOT/cap-link" >/dev/null
check "  and Pi starts at its physical target inside the worktree" grep -qx "pi.cwd=$WT_L/games/demo" "$TMP_ROOT/cap-link"
rm "$WT_L/current-game"; ln -s "$TMP_ROOT/outside" "$WT_L/current-game"
show "(symlink retargeted outside the worktree; the pane sources the SAME launch line)"
pane_runs /bin/zsh "$WT_L" "$line" "$TMP_ROOT/cap-escaped" | short | sed 's/^/  /'
check "  Pi never executed" [ ! -e "$TMP_ROOT/cap-escaped" ]

h1 "Result"
if [ "$FAILS" -eq 0 ]; then printf 'ALL CHECKS PASSED\n'; else printf '%s CHECK(S) FAILED\n' "$FAILS"; fi
exit "$FAILS"
```
</details>
<details>
<summary>Evidence: Pi starts in the game and loads its instructions; worktree identity unchanged (excerpt, /bin/zsh pane)</summary>

```text
$ fm-spawn.sh sd-ship <monorepo> --mode no-mistakes --yolo off --harness pi --model codex-native/gpt-6-astra --effort high --start-dir games/demo
spawned sd-ship harness=pi kind=ship mode=no-mistakes yolo=off window=firstmate:fm-sd-ship worktree=<tmp>/wt-ship

state/sd-ship.meta:
worktree=<tmp>/wt-ship
start_dir=games/demo
model=codex-native/gpt-6-astra
effort=high

Staged launch file (guard): (CDPATH='' cd -- '<tmp>/wt-ship/games/demo' && [ "$(pwd -P)" = '<tmp>/wt-ship/games/demo' ] || { echo 'error: start directory changed before launch' >&2; exit 1; }; ...

Pane shell /bin/zsh at the worktree root sources it:
pi.cwd=<tmp>/wt-ship/games/demo
pi.nearest_instructions=<tmp>/wt-ship/games/demo/AGENTS.md
pi.instruction_sentinel=games/demo
pi.argv.model=codex-native/gpt-6-astra
pi.argv.thinking=high
pane.shell_cwd_after_harness_exit=<tmp>/wt-ship

Legacy launch without --start-dir, same fixture:
pi.cwd=<tmp>/wt-legacy
pi.instruction_sentinel=root
```
</details>
<details>
<summary>Evidence: Recovery keeps the start directory; refusals happen before the agent is stopped (excerpt)</summary>

```text
$ fm-control.sh sd-ship relaunch --note 'context was exhausted; continue the demo game work'
relaunched sd-ship harness=pi from=pi model=codex-native/gpt-6-astra effort=high backend=tmux endpoint=firstmate:fm-sd-ship worktree=<tmp>/wt-ship
window=firstmate:fm-sd-ship (same endpoint)
worktree=<tmp>/wt-ship (same root)
start_dir=games/demo (survived)
spawn_gen changed (new incarnation)
Pane received: 1:/quit 2:(CDPATH='' cd -- '<tmp>/wt-ship/games/demo' && ...
Replacement: pi.cwd=<tmp>/wt-ship/games/demo pi.instruction_sentinel=games/demo pane.shell_cwd_after_harness_exit=<tmp>/wt-ship

$ fm-control.sh sd-ship relaunch --harness codex --note 'switch runtime'
error: task sd-ship records start_dir 'games/demo', which only canonical Pi/Pi-signed ship/scout launches on tmux or herdr support ... relaunch onto pi or pi-signed
-> agent still running (pi), nothing typed into its pane, task record untouched
$ fm-control.sh sd-ship relaunch --note 'directory gone'
error: ... recorded start_dir 'games/demo' is not an accessible directory in '<tmp>/wt-ship'; ... restore that directory before relaunching ...
-> agent still running (pi), nothing typed into its pane, task record untouched
$ fm-control.sh sd-ship relaunch --note 'directory escaped'
error: ... recorded start_dir 'games/demo' physically escapes worktree '<tmp>/wt-ship' ...
-> agent still running (pi), nothing typed into its pane, task record untouched
$ fm-spawn.sh sd-ship --relaunch --start-dir games/other
error: --relaunch reuses recorded start_dir; --start-dir cannot override it
```
</details>
<details>
<summary>Evidence: Worktree isolation refusals (excerpt)</summary>

```text
--start-dir ../outside -> error: --start-dir must be a non-empty contained relative directory without .. components (nothing allocated, no record)
--start-dir /tmp -> same refusal
--start-dir games/../../outside -> same refusal
--harness codex --start-dir ... -> error: --start-dir supports only canonical Pi/Pi-signed ship/scout launches on tmux or herdr (got codex/tmux/ship raw=0)
'pi --model custom' --start-dir -> same refusal (got pi/tmux/ship raw=1)
--start-dir games/dmeo (typo) -> error: 'games/dmeo' is not an accessible directory in '<tmp>/wt-refused'
returned pooled worktree '<tmp>/wt-refused' and asked tmux to close window firstmate:fm-sd-refused
retired: treehouse return --force <tmp>/wt-refused (run from <tmp>/monorepo); tmux kill-window -t =firstmate:=fm-sd-refused
--start-dir escape (symlink out) -> error: 'escape' physically escapes worktree '<tmp>/wt-refused' (slot returned, no record)
Symlink retargeted outside after spawn; pane sources the SAME launch line:
error: start directory changed before launch -> Pi never executed; pane shell still at the worktree root
```
</details>

- Evidence: [fm-spawn-dispatch-profile suite log](https://github.com/3264studios/firstmate/blob/fa0a493e579408d48d4c967e5beb80afd15e37ed/.no-mistakes/evidence/fm/fm-pi-game-start-subdirectory/fm-spawn-dispatch-profile.log)
- Evidence: [fm-control-relaunch suite log](https://github.com/3264studios/firstmate/blob/fa0a493e579408d48d4c967e5beb80afd15e37ed/.no-mistakes/evidence/fm/fm-pi-game-start-subdirectory/fm-control-relaunch.log)
- Outcome: ⚠️ 1 info across 1 run (10m6s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"83f6ace50863d53840af3d3829a59242cd722135","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>⚠️ **Review** - 2 infos</summary>

- ℹ️ `tests/fm-spawn-dispatch-profile.test.sh:1735` - test_start_directory_refusal_on_projected_herdr_keeps_the_presentation_lock introduces this suite&#39;s first jq dependency (the stateful fake herdr CLI, the herdr adapter itself, and the `jq -e` assertion at 1764) and a hard `shasum` call at 1747, with no skip guard. The base version of this file had zero jq uses, and 45 other test files follow the repo idiom `command -v jq &gt;/dev/null 2&gt;&amp;1 || { echo &#34;skip: jq not found ...&#34;; return 0; }` (the sibling herdr case added in tests/fm-control-relaunch.test.sh uses herdr_case_or_skip for exactly this). Concrete sequence on a host without jq: fm-spawn --backend herdr exits 1 from adapter validation, expect_code 1 passes, then assert_contains &#39;not an accessible directory&#39; fails, so the whole previously jq-free suite fails instead of skipping one case. Production derives the lock key with a shasum-or-sha256sum fallback (bin/backends/herdr.sh:859-865) while the test recomputes it with shasum only. CI is unaffected (jq and shasum are present). Remedy: add the standard jq skip guard at the top of this test and mirror the sha256sum fallback when computing the expected lock path.
- ℹ️ `bin/fm-spawn.sh:3789` - Merge-resolution drift, comment only. Before the merge the branch had rewritten the comment above spawn_endpoint_cleanup to cover its callers (&#39;No task record is ever published on these failure paths ...&#39;). Main independently rewrote that comment for the rovo/agy launch-then-confirm gates, and the merge kept main&#39;s text, which now states the function&#39;s callers &#39;run after the task record is published, when ORCA_ABORT_CLEANUP is already cleared&#39;. That is false for the caller this change adds: spawn_fresh_allocation_retire (3900) invokes it before any record is published, on tmux and flat Herdr. Behavior is correct and the retire function carries its own accurate comment; only the shared helper&#39;s header misdescribes when it runs. Remedy: add one sentence noting the pre-publication start-directory retire caller (tmux/flat Herdr only, never orca).
</details>

<details>
<summary>⚠️ **Test** - 1 info</summary>

- ℹ️ `bin/fm-spawn.sh:3233` - When `fm-spawn.sh &lt;id&gt; --relaunch` reclaims a destroyed Herdr endpoint and the recorded start directory is missing, it is correctly refused and the task record is left unchanged. A replacement tab is created before that refusal and is left behind. This is main&#39;s already-documented limitation (docs/agent-control.md:128, bead fm-herdr-rebind-leak-20260913): any refusal between the new tab being created and the record being republished leaves a stray pane. The start-directory check falls inside that window, so it is a new trigger for an existing, tracked leak rather than a new problem from this change. It was confirmed with a probe through the repo&#39;s fake-Herdr fixture. `fm-control.sh relaunch` is not affected, because it checks the start directory before stopping the agent. No action needed for this change.
- <code>`bin/fm-test-run.sh tests/fm-spawn-dispatch-profile.test.sh` - passed, no gate skips; the four start-directory cases passed (root/batch/retarget, Pi and Pi-signed nested startup through relaunch, refusals with ownership-proven retirement, projected-Herdr refusal keeping the presentation lock)</code>
- <code>`bin/fm-test-run.sh tests/fm-control-relaunch.test.sh` - passed, no gate skips; the two start-directory cases passed (refusal before stop for a lost, escaping or unsupported start directory; destroyed Herdr endpoint reclaim preserving start directory and root identity)</code>
- <code>`bash start-dir-e2e-demo.sh &lt;worktree&gt;` - real `bin/fm-spawn.sh` and `bin/fm-control.sh` against a committed monorepo fixture; staged launch file sourced under /bin/zsh, bash and /bin/sh; 61 of 61 checks passed</code>
- <code>`bash start-dir-e2e-demo.sh &lt;git archive of dee119b&gt;` - same driver against the base commit: 41 checks fail (Pi starts at the root and loads the root instructions), and the legacy section behaves the same on both commits</code>
- <code>Patch comparison `git diff 55d4069 3b3f123` vs `git diff dee119b 83f6ace` over bin, docs, .agents and tests - same file set; the only differences are main&#39;s parser reformatting, merged documentation rows, and the added reclaim test</code>
- <code>Ad-hoc probe through the relaunch test fixture: `fm-spawn.sh &lt;id&gt; --relaunch` on a destroyed Herdr endpoint with the recorded start directory missing - refused with &#39;not an accessible directory&#39;, task record unchanged; a tab was created before the refusal</code>
- <code>Cleanup check: `git status --porcelain` is empty; none of the demo&#39;s or probe&#39;s /tmp/fm-&lt;id&gt; directories or temp roots remain</code>
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
