### PR TITLE
fix(spawn): reject worktree slots another live task already claims

### DIFF
--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -3136,6 +3136,7 @@ elif [ "$KIND" != secondmate ] && [ "$BACKEND" != orca ]; then
   # looping forever.
   SLOT_CONFLICT_RETRIES=${FM_SPAWN_SLOT_CONFLICT_RETRIES:-3}
   slot_attempt=0
+  rejected_wt_real=""
   while :; do
     slot_attempt=$((slot_attempt + 1))
     spawn_send_text_line "$WT_TARGET" 'treehouse get'
@@ -3172,7 +3173,19 @@ elif [ "$KIND" != secondmate ] && [ "$BACKEND" != orca ]; then
     # misconfiguration would need machinery this path does not want - so the
     # refusal has to be self-explaining instead: carry the last path seen and the
     # reason it was rejected, and report both at the deadline.
+    #
+    # On a retry, the pane starts out still sitting in the just-rejected
+    # worktree from the previous attempt, and that worktree is itself a real,
+    # isolated git worktree - it would pass the same two-consecutive-reads
+    # check before the newly resent 'treehouse get' has actually run, since
+    # spawn_send_text_line returns as soon as the keys are injected, not once
+    # the shell has interpreted them. Require more consecutive agreeing reads
+    # before re-accepting a candidate that matches the just-rejected slot, so
+    # a couple of stale immediate reads can't be mistaken for the new
+    # 'treehouse get' having already settled back into the same place.
+    SLOT_REJECT_CONFIRM_READS=5
     candidate=""
+    candidate_reads=0
     last_seen=""
     last_reason="the pane reported no path"
     WT=""
@@ -3181,14 +3194,26 @@ elif [ "$KIND" != secondmate ] && [ "$BACKEND" != orca ]; then
       [ -z "$p" ] || last_seen="$p"
       if [ -n "$p" ] && spawn_worktree_isolated "$p"; then
         p_real=$(real_path_or_raw "$p")
-        last_reason="it is an isolated worktree, but no second read agreed with it"
-        if [ -n "$candidate" ] && [ "$p_real" = "$candidate" ]; then
+        if [ "$p_real" = "$candidate" ]; then
+          candidate_reads=$((candidate_reads + 1))
+        else
+          candidate="$p_real"
+          candidate_reads=1
+        fi
+        if [ -n "$rejected_wt_real" ] && [ "$p_real" = "$rejected_wt_real" ]; then
+          required_reads=$SLOT_REJECT_CONFIRM_READS
+          last_reason="it is the same worktree slot rejected on the previous attempt, and has not yet re-agreed enough times to trust it as genuinely settled"
+        else
+          required_reads=2
+          last_reason="it is an isolated worktree, but no second read agreed with it"
+        fi
+        if [ "$candidate_reads" -ge "$required_reads" ]; then
           WT="$p"
           break
         fi
-        candidate="$p_real"
       else
         candidate=""
+        candidate_reads=0
         [ -z "$p" ] || last_reason=$SPAWN_WT_REASON
       fi
       sleep 1
@@ -3211,6 +3236,7 @@ elif [ "$KIND" != secondmate ] && [ "$BACKEND" != orca ]; then
     fi
     SLOT_CONFLICT_ID=${SLOT_CONFLICT%% *}
     SLOT_CONFLICT_FIELD=${SLOT_CONFLICT#* }
+    rejected_wt_real=$(real_path_or_raw "$WT")
     echo "warning: treehouse handed task $ID the worktree slot '$WT', but task $SLOT_CONFLICT_ID's recorded $SLOT_CONFLICT_FIELD already claims it; requesting another slot (attempt $slot_attempt/$SLOT_CONFLICT_RETRIES)" >&2
     if [ "$slot_attempt" -ge "$SLOT_CONFLICT_RETRIES" ]; then
       echo "error: treehouse kept handing task $ID a worktree slot another live task's meta already records after $SLOT_CONFLICT_RETRIES attempts (last: '$WT', claimed by task $SLOT_CONFLICT_ID's $SLOT_CONFLICT_FIELD); refusing to launch into a contested slot; inspect window $T" >&2

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -3179,13 +3179,12 @@ elif [ "$KIND" != secondmate ] && [ "$BACKEND" != orca ]; then
     # isolated git worktree - it would pass the same two-consecutive-reads
     # check before the newly resent 'treehouse get' has actually run, since
     # spawn_send_text_line returns as soon as the keys are injected, not once
-    # the shell has interpreted them. Require more consecutive agreeing reads
-    # before re-accepting a candidate that matches the just-rejected slot, so
-    # a couple of stale immediate reads can't be mistaken for the new
-    # 'treehouse get' having already settled back into the same place.
-    SLOT_REJECT_CONFIRM_READS=5
+    # the shell has interpreted them. A candidate matching the just-rejected
+    # slot is never accepted as settled, no matter how many reads agree on
+    # it: the wait keeps polling (still bounded by this loop's own deadline)
+    # until the pane reports a genuinely different isolated path, since only
+    # a different path proves the new 'treehouse get' actually ran.
     candidate=""
-    candidate_reads=0
     last_seen=""
     last_reason="the pane reported no path"
     WT=""
@@ -3194,26 +3193,18 @@ elif [ "$KIND" != secondmate ] && [ "$BACKEND" != orca ]; then
       [ -z "$p" ] || last_seen="$p"
       if [ -n "$p" ] && spawn_worktree_isolated "$p"; then
         p_real=$(real_path_or_raw "$p")
-        if [ "$p_real" = "$candidate" ]; then
-          candidate_reads=$((candidate_reads + 1))
-        else
-          candidate="$p_real"
-          candidate_reads=1
-        fi
         if [ -n "$rejected_wt_real" ] && [ "$p_real" = "$rejected_wt_real" ]; then
-          required_reads=$SLOT_REJECT_CONFIRM_READS
-          last_reason="it is the same worktree slot rejected on the previous attempt, and has not yet re-agreed enough times to trust it as genuinely settled"
-        else
-          required_reads=2
-          last_reason="it is an isolated worktree, but no second read agreed with it"
-        fi
-        if [ "$candidate_reads" -ge "$required_reads" ]; then
+          candidate=""
+          last_reason="it is the same worktree slot rejected on the previous attempt"
+        elif [ -n "$candidate" ] && [ "$p_real" = "$candidate" ]; then
           WT="$p"
           break
+        else
+          last_reason="it is an isolated worktree, but no second read agreed with it"
+          candidate="$p_real"
         fi
       else
         candidate=""
-        candidate_reads=0
         [ -z "$p" ] || last_reason=$SPAWN_WT_REASON
       fi
       sleep 1

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -184,6 +184,18 @@
 #   itself a linked worktree of the project repository still launches. A pane
 #   that never reaches an isolated worktree refuses at the end of that wait,
 #   naming the last path seen and why it was rejected.
+#   A worktree `treehouse get` hands back is also cross-checked against every
+#   locally registered Firstmate home's state/*.meta before it is accepted: if
+#   another task's own recorded worktree or home already canonicalizes to the
+#   same slot, that slot is contested rather than exclusively this task's, and
+#   proceeding could run two workers in one working copy or, on that other
+#   task's later teardown, have its worktree hard-reset out from under this one
+#   (spawn_worktree_slot_conflict_task; bin/fm-teardown.sh's
+#   require_exclusive_worktree_slot_record is the teardown-side half of the
+#   same guard). A contested slot sends `treehouse get` again into the same
+#   pane rather than adopting it, bounded by FM_SPAWN_SLOT_CONFLICT_RETRIES
+#   (default 3); exhausting every attempt on a contested slot refuses the
+#   launch rather than proceeding, naming the task already holding it.
 #   That placement is proven only at launch. Every ship or scout pane therefore
 #   also receives `export FM_TASK_ID=<task-id>` before the launch command, on
 #   the same channel as GOTMPDIR, and bin/fm-test-run.sh refuses to execute the
@@ -3025,6 +3037,76 @@ rovo_endpoint_cleanup() {
   fm_backend_kill "$BACKEND" "$T" "$tab_id" "fm-$ID" 2>/dev/null || true
 }
 
+canonical_existing_dir() {  # <path>
+  local target=$1
+  [ -n "$target" ] || return 1
+  [ -d "$target" ] || return 1
+  (CDPATH='' cd -- "$target" && pwd -P)
+}
+
+# Treehouse's own pool bookkeeping can hand a fresh spawn the same slot path a
+# still-live OTHER task's state/<id>.meta already records - the collision
+# bin/fm-teardown.sh's require_exclusive_worktree_slot_record guards from the
+# teardown side by refusing to return a slot another live task's meta claims
+# (AGENTS.md's worktree-pool-collision guard pair). This fresh task has no
+# meta of its own yet, so every locally registered Firstmate home's *.meta is
+# a candidate other owner. Prints "<other-task-id> <field>" and returns 0 on a
+# genuine collision; returns 1 with nothing printed when the slot is
+# exclusively ours, including when $1 itself no longer resolves (nothing left
+# to compare against); returns 2 when a local Firstmate registry could not be
+# read or resolved, so the caller cannot trust the scan was complete.
+spawn_worktree_slot_conflict_task() {  # <candidate-worktree>
+  local candidate=$1 slot root home reg line child known existing i=0
+  local -a homes states
+  slot=$(canonical_existing_dir "$candidate") || return 1
+  root=$(fm_firstmate_root_home "$FM_HOME") || return 2
+  homes=("$root")
+  states=("$STATE")
+  while [ "$i" -lt "${#homes[@]}" ]; do
+    home=${homes[$i]}
+    i=$((i + 1))
+    known=0
+    for existing in "${states[@]}"; do
+      [ "$existing" != "$home/state" ] || known=1
+    done
+    [ "$known" = 1 ] || states+=("$home/state")
+    reg="$home/data/secondmates.md"
+    [ ! -e "$reg" ] && [ ! -L "$reg" ] && continue
+    [ -f "$reg" ] && [ ! -L "$reg" ] || return 2
+    while IFS= read -r line || [ -n "$line" ]; do
+      case "$line" in
+        "- "*)
+          secondmate_registry_parse_line "$line" || return 2
+          [ "$SECONDMATE_REGISTRY_REMOTE" -eq 0 ] || continue
+          child=$(canonical_existing_dir "$SECONDMATE_REGISTRY_HOME") || return 2
+          known=0
+          for existing in "${homes[@]}"; do
+            [ "$existing" != "$child" ] || known=1
+          done
+          [ "$known" = 1 ] || homes+=("$child")
+          ;;
+      esac
+    done < "$reg"
+  done
+  local state_dir meta_file meta_id field meta_path meta_slot
+  for state_dir in "${states[@]}"; do
+    for meta_file in "$state_dir"/*.meta; do
+      [ -f "$meta_file" ] && [ ! -L "$meta_file" ] || continue
+      meta_id=$(basename "$meta_file" .meta)
+      [ "$meta_id" != "$ID" ] || continue
+      for field in worktree home; do
+        meta_path=$(fm_meta_get "$meta_file" "$field")
+        [ -n "$meta_path" ] || continue
+        meta_slot=$(canonical_existing_dir "$meta_path") || continue
+        [ "$meta_slot" = "$slot" ] || continue
+        printf '%s %s\n' "$meta_id" "$field"
+        return 0
+      done
+    done
+  done
+  return 1
+}
+
 if [ "$RELAUNCH" -eq 1 ]; then
   # No worktree is acquired: the recorded one is reused as-is. What must be
   # proven instead is that the adopted endpoint's shell is actually sitting in
@@ -3043,66 +3125,98 @@ if [ "$RELAUNCH" -eq 1 ]; then
   fi
   [ "$KIND" = secondmate ] || validate_spawn_worktree "relaunch" "$T"
 elif [ "$KIND" != secondmate ] && [ "$BACKEND" != orca ]; then
-  spawn_send_text_line "$WT_TARGET" 'treehouse get'
+  # A slot treehouse hands back can still collide with another live task's
+  # recorded worktree (see spawn_worktree_slot_conflict_task above); on a
+  # collision, send 'treehouse get' again into the same pane rather than
+  # adopting the contested slot. treehouse nests a fresh subshell inside the
+  # current one and hands out a different worktree, so the abandoned
+  # contested slot is left with one harmless idle nested shell rather than
+  # anything of this task's ever being recorded or touched there. Bounded so
+  # a pool stuck handing out only contested slots fails loudly instead of
+  # looping forever.
+  SLOT_CONFLICT_RETRIES=${FM_SPAWN_SLOT_CONFLICT_RETRIES:-3}
+  slot_attempt=0
+  while :; do
+    slot_attempt=$((slot_attempt + 1))
+    spawn_send_text_line "$WT_TARGET" 'treehouse get'
 
-  # Wait for the treehouse subshell: the pane's cwd moves from the project to the worktree.
-  # Target the stable window id, not the name: if the name is ever lost (e.g. an
-  # automatic-rename slips through), display-message -t <bad-name> falls back to the
-  # active client's window, which would misread firstmate's OWN pane path as the
-  # worktree and tangle a hook into the primary checkout. The window id never lies.
-  # The project comparison is physical: spawn_worktree_isolated screens each
-  # read against PROJ_ABS_REAL, not PROJ_ABS, because a symlinked project prefix
-  # would otherwise make the pane's OS-level cwd read differ from PROJ_ABS on
-  # the very first poll, before the pane has actually moved.
-  #
-  # A single read that already looks isolated is not proof the pane settled
-  # there: on some tmux/WSL setups a brand-new window's pane_current_path
-  # transiently reports an unrelated stale path (seen live as another real git
-  # checkout entirely) before the shell catches up with treehouse get's cd. That
-  # stale path passes spawn_worktree_isolated too (it resolves to a real,
-  # distinct worktree top-level), so accepting it on one read alone silently
-  # records the wrong worktree= in state/<id>.meta. Require two consecutive
-  # reads to agree on the same isolated path before accepting it; a mismatch
-  # just becomes the new candidate rather than resetting the wait, so a pane
-  # that is already settled by the first real read only costs the one existing
-  # inter-poll sleep as confirmation, not a whole extra cycle on top.
-  #
-  # Every candidate is screened with the isolation guard's own predicate, so a
-  # read of the project itself or of the repository primary checkout is treated
-  # as the transient it is and the wait continues, instead of being adopted and
-  # then refused by the guard.
-  # A candidate the screen rejects is never adopted, so a host where the pane
-  # never reaches an isolated worktree spends the whole window before refusing.
-  # That wait is deliberate - telling a transient apart from a terminal
-  # misconfiguration would need machinery this path does not want - so the
-  # refusal has to be self-explaining instead: carry the last path seen and the
-  # reason it was rejected, and report both at the deadline.
-  candidate=""
-  last_seen=""
-  last_reason="the pane reported no path"
-  for _ in $(seq 1 60); do
-    p=$(spawn_current_path "$WT_TARGET" || true)
-    [ -z "$p" ] || last_seen="$p"
-    if [ -n "$p" ] && spawn_worktree_isolated "$p"; then
-      p_real=$(real_path_or_raw "$p")
-      last_reason="it is an isolated worktree, but no second read agreed with it"
-      if [ -n "$candidate" ] && [ "$p_real" = "$candidate" ]; then
-        WT="$p"
-        break
+    # Wait for the treehouse subshell: the pane's cwd moves from the project to the worktree.
+    # Target the stable window id, not the name: if the name is ever lost (e.g. an
+    # automatic-rename slips through), display-message -t <bad-name> falls back to the
+    # active client's window, which would misread firstmate's OWN pane path as the
+    # worktree and tangle a hook into the primary checkout. The window id never lies.
+    # The project comparison is physical: spawn_worktree_isolated screens each
+    # read against PROJ_ABS_REAL, not PROJ_ABS, because a symlinked project prefix
+    # would otherwise make the pane's OS-level cwd read differ from PROJ_ABS on
+    # the very first poll, before the pane has actually moved.
+    #
+    # A single read that already looks isolated is not proof the pane settled
+    # there: on some tmux/WSL setups a brand-new window's pane_current_path
+    # transiently reports an unrelated stale path (seen live as another real git
+    # checkout entirely) before the shell catches up with treehouse get's cd. That
+    # stale path passes spawn_worktree_isolated too (it resolves to a real,
+    # distinct worktree top-level), so accepting it on one read alone silently
+    # records the wrong worktree= in state/<id>.meta. Require two consecutive
+    # reads to agree on the same isolated path before accepting it; a mismatch
+    # just becomes the new candidate rather than resetting the wait, so a pane
+    # that is already settled by the first real read only costs the one existing
+    # inter-poll sleep as confirmation, not a whole extra cycle on top.
+    #
+    # Every candidate is screened with the isolation guard's own predicate, so a
+    # read of the project itself or of the repository primary checkout is treated
+    # as the transient it is and the wait continues, instead of being adopted and
+    # then refused by the guard.
+    # A candidate the screen rejects is never adopted, so a host where the pane
+    # never reaches an isolated worktree spends the whole window before refusing.
+    # That wait is deliberate - telling a transient apart from a terminal
+    # misconfiguration would need machinery this path does not want - so the
+    # refusal has to be self-explaining instead: carry the last path seen and the
+    # reason it was rejected, and report both at the deadline.
+    candidate=""
+    last_seen=""
+    last_reason="the pane reported no path"
+    WT=""
+    for _ in $(seq 1 60); do
+      p=$(spawn_current_path "$WT_TARGET" || true)
+      [ -z "$p" ] || last_seen="$p"
+      if [ -n "$p" ] && spawn_worktree_isolated "$p"; then
+        p_real=$(real_path_or_raw "$p")
+        last_reason="it is an isolated worktree, but no second read agreed with it"
+        if [ -n "$candidate" ] && [ "$p_real" = "$candidate" ]; then
+          WT="$p"
+          break
+        fi
+        candidate="$p_real"
+      else
+        candidate=""
+        [ -z "$p" ] || last_reason=$SPAWN_WT_REASON
       fi
-      candidate="$p_real"
-    else
-      candidate=""
-      [ -z "$p" ] || last_reason=$SPAWN_WT_REASON
+      sleep 1
+    done
+    if [ -z "$WT" ]; then
+      echo "error: treehouse get did not enter an isolated worktree within 60s (last seen '${last_seen:-none}': $last_reason; spawning project '$PROJ_ABS'); inspect window $T" >&2
+      exit 1
     fi
-    sleep 1
-  done
-  if [ -z "$WT" ]; then
-    echo "error: treehouse get did not enter an isolated worktree within 60s (last seen '${last_seen:-none}': $last_reason; spawning project '$PROJ_ABS'); inspect window $T" >&2
-    exit 1
-  fi
 
-  validate_spawn_worktree "treehouse get" "$T"
+    validate_spawn_worktree "treehouse get" "$T"
+
+    SLOT_CONFLICT_RC=0
+    SLOT_CONFLICT=$(spawn_worktree_slot_conflict_task "$WT") || SLOT_CONFLICT_RC=$?
+    if [ "$SLOT_CONFLICT_RC" -eq 2 ]; then
+      echo "error: could not verify worktree slot '$WT' is exclusive to task $ID (a local Firstmate registry could not be read or resolved); refusing to launch into a potentially contested slot; inspect window $T" >&2
+      exit 1
+    fi
+    if [ "$SLOT_CONFLICT_RC" -ne 0 ]; then
+      break
+    fi
+    SLOT_CONFLICT_ID=${SLOT_CONFLICT%% *}
+    SLOT_CONFLICT_FIELD=${SLOT_CONFLICT#* }
+    echo "warning: treehouse handed task $ID the worktree slot '$WT', but task $SLOT_CONFLICT_ID's recorded $SLOT_CONFLICT_FIELD already claims it; requesting another slot (attempt $slot_attempt/$SLOT_CONFLICT_RETRIES)" >&2
+    if [ "$slot_attempt" -ge "$SLOT_CONFLICT_RETRIES" ]; then
+      echo "error: treehouse kept handing task $ID a worktree slot another live task's meta already records after $SLOT_CONFLICT_RETRIES attempts (last: '$WT', claimed by task $SLOT_CONFLICT_ID's $SLOT_CONFLICT_FIELD); refusing to launch into a contested slot; inspect window $T" >&2
+      exit 1
+    fi
+  done
 fi
 if [ "$RELAUNCH" -eq 0 ] && [ "$KIND" != secondmate ]; then
   freshen_spawn_worktree_base "$WT" || exit 1

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -217,8 +217,8 @@ Codex App support is recorded in `docs/codex-app-backend.md`; it is not selectab
 ## Worktrees, not branches in your checkout
 
 Crewmates never intentionally touch your project clone; [treehouse](https://github.com/kunchenguid/treehouse) pools clean worktrees for tmux, herdr, zellij, and cmux tasks, while Orca creates its own worktrees for `backend=orca`.
-The [`fm-spawn.sh` header](../bin/fm-spawn.sh) owns ship/scout worktree isolation and fresh-base refusal rules, including spawns from linked homes.
-Portable regressions live in [`tests/fm-spawn-pool-base-freshen.test.sh`](../tests/fm-spawn-pool-base-freshen.test.sh) for spawn isolation and base freshness, and [`tests/fm-control-relaunch.test.sh`](../tests/fm-control-relaunch.test.sh) for preserving the recorded copy on relaunch.
+The [`fm-spawn.sh` header](../bin/fm-spawn.sh) owns ship/scout worktree isolation and fresh-base refusal rules, including spawns from linked homes, and the spawn-side half of the worktree-pool-slot-collision guard: a slot treehouse hands back is rejected and re-requested, up to `FM_SPAWN_SLOT_CONFLICT_RETRIES` times, when another live task's `state/*.meta` already records it as that task's own worktree or home; [`bin/fm-teardown.sh`](../bin/fm-teardown.sh)'s slot-ownership proof below is the teardown-side half of the same guard.
+Portable regressions live in [`tests/fm-spawn-pool-base-freshen.test.sh`](../tests/fm-spawn-pool-base-freshen.test.sh) for spawn isolation and base freshness, [`tests/fm-spawn-worktree-slot-collision.test.sh`](../tests/fm-spawn-worktree-slot-collision.test.sh) for the spawn-side slot-collision guard, and [`tests/fm-control-relaunch.test.sh`](../tests/fm-control-relaunch.test.sh) for preserving the recorded copy on relaunch.
 
 The firstmate repo has one extra exposure because it can dispatch crewmates to work on itself.
 Its operating checkout (`FM_ROOT`) and the disposable crewmate worktrees are all linked git worktrees of the same repository, so the valid discriminator is branch state, not whether the checkout is linked.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1019,6 +1019,7 @@ FM_FLEET_PRUNE=1        # set to 0 to skip pruning local branches whose upstream
 FM_STALE_WORKTREE_LOCK_AGE_SECS=30       # min mtime age before fm-teardown.sh treats a leftover worktree git index.lock as provably stale
 FM_TREEHOUSE_RETURN_LOCK_RETRIES=3        # retries after a treehouse return fails on the transient git index.lock signature
 FM_TREEHOUSE_RETURN_LOCK_RETRY_WAIT_SECS=1 # seconds fm-teardown.sh waits before each retry after that signature
+FM_SPAWN_SLOT_CONFLICT_RETRIES=3          # fm-spawn.sh 'treehouse get' resends after treehouse hands back a slot another live task's state/*.meta already records as its worktree or home; exhausting every attempt refuses the launch
 FM_STALE_WORKTREE_LOCK_RETRY_WAIT_SECS=   # legacy alias for FM_TREEHOUSE_RETURN_LOCK_RETRY_WAIT_SECS when the new variable is unset
 FM_FLEET_SYNC_PACKED_REFS_LOCK_RETRIES=3        # fetch retries after fm-fleet-sync.sh hits the orphaned .git/packed-refs.lock signature
 FM_FLEET_SYNC_PACKED_REFS_LOCK_RETRY_WAIT_SECS=1 # seconds fm-fleet-sync.sh waits before each of those retries

--- a/tests/fm-spawn-dispatch-profile.test.sh
+++ b/tests/fm-spawn-dispatch-profile.test.sh
@@ -52,6 +52,64 @@ SH
   printf '%s\n' "$fakebin"
 }
 
+# make_two_slot_spawn_fakebin <dir>: like make_spawn_fakebin, but
+# #{pane_current_path} hands back FM_FAKE_PANE_PATH_1 for the first two reads
+# (enough for fm-spawn's settle loop to accept it) then FM_FAKE_PANE_PATH_2
+# forever after, via FM_FAKE_PANE_COUNTFILE. Batch dispatch re-execs
+# fm-spawn.sh once per id=repo pair; real treehouse never hands a later call
+# the same slot an earlier call's still-running task occupies, so a batch test
+# that spawns two ids against one project needs two genuinely distinct slots
+# or fm-spawn's worktree-pool-slot-collision guard rejects the second as
+# contested - a real production collision, just not the one this case tests.
+make_two_slot_spawn_fakebin() {
+  local dir=$1 fakebin
+  fakebin=$(make_spawn_fakebin "$dir")
+  cat > "$fakebin/tmux" <<'SH'
+#!/usr/bin/env bash
+set -u
+case "$*" in
+  *"#{pane_current_path}"*)
+    countfile="${FM_FAKE_PANE_COUNTFILE:?FM_FAKE_PANE_COUNTFILE unset}"
+    n=0
+    [ -f "$countfile" ] && n=$(cat "$countfile")
+    n=$((n + 1))
+    printf '%s\n' "$n" > "$countfile"
+    if [ "$n" -le 2 ]; then
+      printf '%s\n' "${FM_FAKE_PANE_PATH_1:-}"
+    else
+      printf '%s\n' "${FM_FAKE_PANE_PATH_2:-}"
+    fi
+    exit 0
+    ;;
+esac
+case "${1:-}" in
+  display-message) printf 'firstmate\n'; exit 0 ;;
+  list-windows)
+    if [ -n "${FM_FAKE_DUPLICATE_WINDOW:-}" ]; then
+      printf '%s\n' "$FM_FAKE_DUPLICATE_WINDOW"
+    fi
+    exit 0
+    ;;
+  has-session|new-session|new-window|kill-window|set-window-option) exit 0 ;;
+  send-keys)
+    if [ -n "${FM_FAKE_LAUNCH_LOG:-}" ]; then
+      prev=
+      for a in "$@"; do
+        if [ "$prev" = "-l" ]; then
+          printf '%s\n' "$a" >> "$FM_FAKE_LAUNCH_LOG"
+        fi
+        prev=$a
+      done
+    fi
+    exit 0
+    ;;
+esac
+exit 0
+SH
+  chmod +x "$fakebin/tmux"
+  printf '%s\n' "$fakebin"
+}
+
 make_spawn_case() {
   local name=$1 harness=$2 case_dir home proj wt fakebin launchlog id
   shift 2
@@ -207,6 +265,11 @@ test_home_defaults_preserve_absolute_or_resolve_relative_paths() {
     "relative FM_HOME leaked into Pi's default cross-process extension path"
   assert_contains "$launch" "< '$home_real/data/$relative_id/launch-brief.md'" \
     "relative FM_HOME leaked into the default cross-process brief path"
+
+  # This fixture reuses the same fake pane path for the next spawn below; drop
+  # the just-published meta first so fm-spawn's worktree-pool-slot-collision
+  # guard does not read the reused path as a second live task's own worktree.
+  rm -f "$home_real/state/$relative_id.meta"
 
   linked_home="$CASE_DIR/home-link"
   ln -s "$HOME_DIR" "$linked_home"
@@ -630,11 +693,16 @@ test_native_pi_ultra_is_explicit_and_model_scoped() {
 }
 
 test_batch_preserves_native_ultra() {
-  local rec id1=ultra-batch-a id2=ultra-batch-b out launch
+  local rec id1=ultra-batch-a id2=ultra-batch-b out launch wt2 countfile
   rec=$(make_spawn_case ultra-batch pi "$id1" "$id2")
   read_case_record "$rec"
   enable_dispatch_profile "$HOME_DIR"
-  out=$(run_ship_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" \
+  wt2="$CASE_DIR/wt-2"
+  git -C "$PROJ_DIR" worktree add --quiet --detach "$wt2" "$(git -C "$PROJ_DIR" rev-parse HEAD)"
+  countfile="$CASE_DIR/pane-call-count"
+  FAKEBIN_DIR=$(make_two_slot_spawn_fakebin "$CASE_DIR/fake2")
+  out=$(FM_FAKE_PANE_PATH_1="$WT_DIR" FM_FAKE_PANE_PATH_2="$wt2" FM_FAKE_PANE_COUNTFILE="$countfile" \
+    run_ship_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" \
     "$id1=$PROJ_DIR" "$id2=$PROJ_DIR" --harness pi --model codex-native/gpt-6-astra --effort ultra)
   expect_code 0 "$?" "native Ultra batch failed: $out"
   assert_meta_profile "$HOME_DIR/state/$id1.meta" pi codex-native/gpt-6-astra ultra
@@ -787,14 +855,19 @@ test_pi_signed_persistent_secondmate_uses_pi_extensions_and_identity() {
 }
 
 test_batch_forwards_shared_profile_flags() {
-  local rec id1 id2 out status
+  local rec id1 id2 out status wt2 countfile
   id1=profile-batch-a-z9
   id2=profile-batch-b-z10
   rec=$(make_spawn_case profile-batch claude "$id1" "$id2")
   read_case_record "$rec"
   enable_dispatch_profile "$HOME_DIR"
+  wt2="$CASE_DIR/wt-2"
+  git -C "$PROJ_DIR" worktree add --quiet --detach "$wt2" "$(git -C "$PROJ_DIR" rev-parse HEAD)"
+  countfile="$CASE_DIR/pane-call-count"
+  FAKEBIN_DIR=$(make_two_slot_spawn_fakebin "$CASE_DIR/fake2")
 
-  out=$(run_ship_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" \
+  out=$(FM_FAKE_PANE_PATH_1="$WT_DIR" FM_FAKE_PANE_PATH_2="$wt2" FM_FAKE_PANE_COUNTFILE="$countfile" \
+    run_ship_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" \
     "$id1=$PROJ_DIR" "$id2=$PROJ_DIR" --harness codex --model gpt-5 --effort high)
   status=$?
   expect_code 0 "$status" "batch spawn with shared profile flags should succeed"

--- a/tests/fm-spawn-pool-base-freshen.test.sh
+++ b/tests/fm-spawn-pool-base-freshen.test.sh
@@ -183,6 +183,12 @@ test_stale_pool_base_refreshes_before_branching() {
       "$branch_head" "$current" "$(cat "$POOL_DIR/advanced-main.txt")"
   fi
 
+  # The first task is done with this fixture's single pooled worktree; drop
+  # its meta before reusing the same POOL_DIR for a second spawn below, or
+  # fm-spawn's worktree-pool-slot-collision guard reads the reused path as a
+  # second live task's own worktree and refuses it as contested.
+  rm -f "$HOME_DIR/state/pool-current-base-r1.meta"
+
   id='pool-current-base-repeat-r1'
   fm_test_spawn_brief "$HOME_DIR" "$id"
   out=$(run_spawn "$id" --mode no-mistakes --yolo off)
@@ -528,6 +534,10 @@ strand_submodule_pin_via_spawn() {  # <seed-id>
     || fail "the first spawn did not move the pooled base across the moved submodule pin"
   [ "$(git -C "$POOL_DIR/ui" rev-parse HEAD)" = "$SUBPIN1" ] \
     || fail "the first spawn did not strand the submodule on the pin the old base recorded"
+  # This seed task is done with the pool; every caller immediately reuses
+  # POOL_DIR for the id under test, which would otherwise read as a live
+  # collision to fm-spawn's worktree-pool-slot-collision guard.
+  rm -f "$HOME_DIR/state/$id.meta"
 }
 
 test_stale_submodule_pin_explains_itself() {

--- a/tests/fm-spawn-worktree-slot-collision.test.sh
+++ b/tests/fm-spawn-worktree-slot-collision.test.sh
@@ -59,6 +59,55 @@ SH
   printf '%s\n' "$fakebin"
 }
 
+# make_staged_pane_fakebin <dir>: a fake tmux whose `#{pane_current_path}`
+# query walks an ordered list of "path count" stages given in
+# FM_FAKE_PANE_STAGES (one per line), returning each stage's path for that
+# many consecutive reads before moving to the next, and repeating the last
+# stage's path forever once every stage is consumed. Lets a single test model
+# an arbitrary sequence of pane reads, including several worktree slots in a
+# row, rather than the two-value collide/clean shape make_collision_fakebin
+# is limited to.
+make_staged_pane_fakebin() {
+  local dir=$1 fakebin
+  fakebin=$(fm_fakebin "$dir")
+  cat > "$fakebin/tmux" <<'SH'
+#!/usr/bin/env bash
+set -u
+case "$*" in
+  *"#{pane_current_path}"*)
+    countfile="${FM_FAKE_PANE_COUNTFILE:?FM_FAKE_PANE_COUNTFILE unset}"
+    n=0
+    [ -f "$countfile" ] && n=$(cat "$countfile")
+    n=$((n + 1))
+    printf '%s\n' "$n" > "$countfile"
+    stages="${FM_FAKE_PANE_STAGES:?FM_FAKE_PANE_STAGES unset}"
+    chosen=""
+    cum=0
+    while IFS=' ' read -r stage_path stage_count; do
+      [ -n "$stage_path" ] || continue
+      chosen="$stage_path"
+      cum=$((cum + stage_count))
+      [ "$n" -gt "$cum" ] || break
+    done <<STAGES
+$stages
+STAGES
+    printf '%s\n' "$chosen"
+    exit 0
+    ;;
+esac
+case "${1:-}" in
+  display-message) printf 'firstmate\n'; exit 0 ;;
+  list-windows) exit 0 ;;
+  has-session|new-session|new-window|kill-window) exit 0 ;;
+  send-keys) exit 0 ;;
+esac
+exit 0
+SH
+  chmod +x "$fakebin/tmux"
+  fm_fake_exit0 "$fakebin" treehouse
+  printf '%s\n' "$fakebin"
+}
+
 # make_collision_case <name>: one project repo with two pool-shaped detached
 # worktrees (a contested slot and a clean one) and a home ready to spawn into.
 make_collision_case() {
@@ -99,6 +148,22 @@ run_collision_spawn() {
     "$SPAWN" "$id" "$PROJECT_DIR" --mode no-mistakes --yolo off "$@" 2>&1
 }
 
+# run_staged_collision_spawn <id> [extra fm-spawn args...]: like
+# run_collision_spawn, but drives make_staged_pane_fakebin's arbitrary
+# FM_FAKE_PANE_STAGES sequence instead of the two-value collide/clean shape.
+run_staged_collision_spawn() {
+  local id=$1
+  shift
+  FM_ROOT_OVERRIDE='' FM_HOME="$HOME_DIR" \
+    FM_STATE_OVERRIDE="$HOME_DIR/state" FM_DATA_OVERRIDE="$HOME_DIR/data" \
+    FM_PROJECTS_OVERRIDE="$HOME_DIR/projects" FM_CONFIG_OVERRIDE="$HOME_DIR/config" \
+    FM_SPAWN_NO_GUARD=1 TMUX="fake,1,0" \
+    FM_FAKE_PANE_STAGES="$FM_FAKE_PANE_STAGES" \
+    FM_FAKE_PANE_COUNTFILE="$COUNTFILE" \
+    PATH="$FAKEBIN_DIR:$PATH" \
+    "$SPAWN" "$id" "$PROJECT_DIR" --mode no-mistakes --yolo off "$@" 2>&1
+}
+
 # A slot treehouse hands back that another live task's meta already claims
 # must never be adopted: fm-spawn.sh should reject it and request another
 # slot, landing the new task on the clean one instead.
@@ -125,28 +190,100 @@ test_contested_slot_is_rejected_and_a_clean_slot_is_adopted() {
   pass "fm-spawn: a contested treehouse slot is rejected and a clean slot is adopted instead"
 }
 
-# When treehouse keeps handing back only the contested slot, fm-spawn.sh must
-# fail loudly and bounded rather than adopt the collision or loop forever.
+# When treehouse keeps handing back only contested slots (a different one
+# each retry, but each one already claimed by some other live task), fm-spawn.sh
+# must fail loudly and bounded rather than adopt a collision or loop forever.
 test_persistently_contested_slot_fails_bounded() {
-  local rec other=live-holder-b2 id=collide-stuck-a2 out status
+  local rec other_a=live-holder-b2 other_b=live-holder-b2x id=collide-stuck-a2 out status
+  local collide_2
   rec=$(make_collision_case retry-exhausted)
   read_collision_record "$rec"
-  FAKEBIN_DIR=$(make_collision_fakebin "$TMP_ROOT/retry-exhausted/fake")
+  collide_2="$TMP_ROOT/retry-exhausted/pool-collide-2"
+  git -C "$PROJECT_DIR" worktree add --quiet --detach "$collide_2" HEAD
+  FAKEBIN_DIR=$(make_staged_pane_fakebin "$TMP_ROOT/retry-exhausted/fake")
+  fm_test_fake_sleep_noop "$FAKEBIN_DIR"
   COUNTFILE="$TMP_ROOT/retry-exhausted/pane-call-count"
+
+  fm_write_meta "$HOME_DIR/state/$other_a.meta" \
+    "window=firstmate:fm-$other_a" "worktree=$COLLIDE_DIR" "project=$PROJECT_DIR" "kind=ship"
+  fm_write_meta "$HOME_DIR/state/$other_b.meta" \
+    "window=firstmate:fm-$other_b" "worktree=$collide_2" "project=$PROJECT_DIR" "kind=ship"
+  fm_test_spawn_brief "$HOME_DIR" "$id"
+
+  FM_FAKE_PANE_STAGES="$COLLIDE_DIR 2
+$collide_2 100000"
+  out=$(FM_SPAWN_SLOT_CONFLICT_RETRIES=2 run_staged_collision_spawn "$id")
+  status=$?
+  [ "$status" -ne 0 ] || fail "spawn succeeded after treehouse kept handing back only contested slots"$'\n'"$out"
+  assert_contains "$out" "refusing to launch into a contested slot" \
+    "refusal did not explain the contested-slot exhaustion"
+  assert_contains "$out" "$other_b" "refusal did not name the task holding the last contested slot"
+  assert_contains "$out" "2" "refusal did not report the configured retry bound"
+  [ ! -e "$HOME_DIR/state/$id.meta" ] || fail "refused spawn published task metadata"
+  pass "fm-spawn: a persistently contested treehouse slot fails loudly instead of looping or adopting it"
+}
+
+# The settle loop must never treat a pane still reporting the just-rejected
+# worktree as having settled there again: if treehouse's resent 'treehouse
+# get' never actually moves the pane (a genuinely stuck pane, not merely a
+# slow one), fm-spawn.sh must fail at the settle deadline rather than
+# silently re-adopting the same contested slot as if it were freshly handed
+# out - the exact race tests/fm-spawn-worktree-slot-collision previously left
+# unexercised.
+test_pane_stuck_on_rejected_slot_fails_at_settle_deadline() {
+  local rec other=live-holder-b2y id=collide-stuck-forever-a2 out status
+  rec=$(make_collision_case retry-stuck-forever)
+  read_collision_record "$rec"
+  FAKEBIN_DIR=$(make_staged_pane_fakebin "$TMP_ROOT/retry-stuck-forever/fake")
+  fm_test_fake_sleep_noop "$FAKEBIN_DIR"
+  COUNTFILE="$TMP_ROOT/retry-stuck-forever/pane-call-count"
 
   fm_write_meta "$HOME_DIR/state/$other.meta" \
     "window=firstmate:fm-$other" "worktree=$COLLIDE_DIR" "project=$PROJECT_DIR" "kind=ship"
   fm_test_spawn_brief "$HOME_DIR" "$id"
 
-  out=$(FM_FAKE_PANE_COLLIDE_READS=100000 FM_SPAWN_SLOT_CONFLICT_RETRIES=2 run_collision_spawn "$id")
+  FM_FAKE_PANE_STAGES="$COLLIDE_DIR 100000"
+  out=$(run_staged_collision_spawn "$id")
   status=$?
-  [ "$status" -ne 0 ] || fail "spawn succeeded after treehouse kept handing back only the contested slot"$'\n'"$out"
-  assert_contains "$out" "refusing to launch into a contested slot" \
-    "refusal did not explain the contested-slot exhaustion"
-  assert_contains "$out" "$other" "refusal did not name the task holding the contested slot"
-  assert_contains "$out" "2" "refusal did not report the configured retry bound"
+  [ "$status" -ne 0 ] || fail "spawn succeeded even though the pane never left the rejected slot"$'\n'"$out"
+  assert_contains "$out" "did not enter an isolated worktree within" \
+    "refusal did not explain the settle deadline was reached"
+  assert_contains "$out" "same worktree slot rejected on the previous attempt" \
+    "refusal did not explain the pane never left the rejected slot"
   [ ! -e "$HOME_DIR/state/$id.meta" ] || fail "refused spawn published task metadata"
-  pass "fm-spawn: a persistently contested treehouse slot fails loudly instead of looping or adopting it"
+  pass "fm-spawn: a pane stuck on the just-rejected slot fails at the settle deadline instead of re-adopting it"
+}
+
+# A pane that transiently keeps reporting the just-rejected slot for a few
+# reads after the resent 'treehouse get' - the realistic shape of the race in
+# spawn-retry-stale-path-reaccept, since spawn_send_text_line returns before
+# the shell has interpreted the resend - must not be mistaken for having
+# settled there again; once treehouse's cd actually lands the pane on a
+# genuinely different, uncontested slot, the spawn must still succeed.
+test_transient_stale_rejected_reads_do_not_block_a_genuine_settle() {
+  local rec other=live-holder-b2z id=collide-transient-a2 out status
+  rec=$(make_collision_case retry-transient-stale)
+  read_collision_record "$rec"
+  FAKEBIN_DIR=$(make_staged_pane_fakebin "$TMP_ROOT/retry-transient-stale/fake")
+  fm_test_fake_sleep_noop "$FAKEBIN_DIR"
+  COUNTFILE="$TMP_ROOT/retry-transient-stale/pane-call-count"
+
+  fm_write_meta "$HOME_DIR/state/$other.meta" \
+    "window=firstmate:fm-$other" "worktree=$COLLIDE_DIR" "project=$PROJECT_DIR" "kind=ship"
+  fm_test_spawn_brief "$HOME_DIR" "$id"
+
+  FM_FAKE_PANE_STAGES="$COLLIDE_DIR 6
+$CLEAN_DIR 2"
+  out=$(run_staged_collision_spawn "$id")
+  status=$?
+  expect_code 0 "$status" \
+    "spawn should succeed once the pane genuinely moves off the rejected slot"$'\n'"$out"
+  assert_contains "$out" "spawned $id" "spawn did not report success"
+  assert_grep "worktree=$CLEAN_DIR" "$HOME_DIR/state/$id.meta" \
+    "meta did not record the clean slot handed out once the pane genuinely settled there"
+  assert_no_grep "worktree=$COLLIDE_DIR" "$HOME_DIR/state/$id.meta" \
+    "meta wrongly recorded the slot rejected on the previous attempt"
+  pass "fm-spawn: transient stale reads of the rejected slot do not block a genuine settle on a clean one"
 }
 
 # The same collision, but the live holder's meta lives in a different, locally
@@ -185,6 +322,8 @@ test_cross_home_contested_slot_is_rejected() {
 
 test_contested_slot_is_rejected_and_a_clean_slot_is_adopted
 test_persistently_contested_slot_fails_bounded
+test_pane_stuck_on_rejected_slot_fails_at_settle_deadline
+test_transient_stale_rejected_reads_do_not_block_a_genuine_settle
 test_cross_home_contested_slot_is_rejected
 
 echo "# all fm-spawn-worktree-slot-collision tests passed"

--- a/tests/fm-spawn-worktree-slot-collision.test.sh
+++ b/tests/fm-spawn-worktree-slot-collision.test.sh
@@ -1,0 +1,190 @@
+#!/usr/bin/env bash
+# Regression tests for fm-spawn's treehouse worktree-pool-slot collision guard
+# (bin/fm-spawn.sh, spawn_worktree_slot_conflict_task).
+#
+# A live incident: a treehouse pool handed a fresh spawn a slot another
+# still-live task's state/<id>.meta already recorded as its own worktree. This
+# is the spawn-side half of the worktree-pool-collision guard pair -
+# bin/fm-teardown.sh's require_exclusive_worktree_slot_record is the
+# teardown-side half, refusing to return a slot another live task's meta
+# claims, and is already covered by tests/fm-teardown-endpoint-safety.test.sh.
+# These tests simulate the same collision on the spawn side: two state/*.meta
+# files recording the same worktree path, one belonging to the fresh spawn's
+# would-be slot and one to an already-live task.
+set -u
+
+# shellcheck source=tests/fixtures.sh
+. "$(dirname "${BASH_SOURCE[0]}")/fixtures.sh"
+
+SPAWN="$ROOT/bin/fm-spawn.sh"
+TMP_ROOT=$(fm_test_tmproot fm-spawn-worktree-slot-collision)
+
+# make_collision_fakebin <dir>: a fake tmux whose `#{pane_current_path}` query
+# returns FM_FAKE_PANE_COLLIDE for the first FM_FAKE_PANE_COLLIDE_READS calls,
+# then FM_FAKE_PANE_CLEAN forever after - modeling treehouse handing back the
+# contested slot on the first `treehouse get`, then a different slot once
+# fm-spawn.sh resends 'treehouse get' after detecting the collision. Mirrors
+# tests/fm-spawn-worktree-settle.test.sh's staged-pane technique.
+make_collision_fakebin() {
+  local dir=$1 fakebin
+  fakebin=$(fm_fakebin "$dir")
+  cat > "$fakebin/tmux" <<'SH'
+#!/usr/bin/env bash
+set -u
+case "$*" in
+  *"#{pane_current_path}"*)
+    countfile="${FM_FAKE_PANE_COUNTFILE:?FM_FAKE_PANE_COUNTFILE unset}"
+    n=0
+    [ -f "$countfile" ] && n=$(cat "$countfile")
+    n=$((n + 1))
+    printf '%s\n' "$n" > "$countfile"
+    if [ "$n" -le "${FM_FAKE_PANE_COLLIDE_READS:-0}" ]; then
+      printf '%s\n' "${FM_FAKE_PANE_COLLIDE:-}"
+    else
+      printf '%s\n' "${FM_FAKE_PANE_CLEAN:-}"
+    fi
+    exit 0
+    ;;
+esac
+case "${1:-}" in
+  display-message) printf 'firstmate\n'; exit 0 ;;
+  list-windows) exit 0 ;;
+  has-session|new-session|new-window|kill-window) exit 0 ;;
+  send-keys) exit 0 ;;
+esac
+exit 0
+SH
+  chmod +x "$fakebin/tmux"
+  fm_fake_exit0 "$fakebin" treehouse
+  printf '%s\n' "$fakebin"
+}
+
+# make_collision_case <name>: one project repo with two pool-shaped detached
+# worktrees (a contested slot and a clean one) and a home ready to spawn into.
+make_collision_case() {
+  local name=$1 case_dir home project collide clean initial
+  case_dir="$TMP_ROOT/$name"
+  home="$case_dir/home"
+  project="$case_dir/project"
+  collide="$case_dir/pool-collide"
+  clean="$case_dir/pool-clean"
+  fm_test_spawn_home "$home" codex
+  git init --quiet "$project"
+  printf 'base\n' > "$project/README.md"
+  git -C "$project" add README.md
+  git -C "$project" -c user.name='Firstmate Tests' -c user.email='tests@example.invalid' commit -qm initial
+  initial=$(git -C "$project" rev-parse HEAD)
+  git -C "$project" worktree add --quiet --detach "$collide" "$initial"
+  git -C "$project" worktree add --quiet --detach "$clean" "$initial"
+  printf '%s\n' "$case_dir|$home|$project|$collide|$clean"
+}
+
+read_collision_record() {
+  IFS='|' read -r _ HOME_DIR PROJECT_DIR COLLIDE_DIR CLEAN_DIR <<EOF
+$1
+EOF
+}
+
+run_collision_spawn() {
+  local id=$1
+  shift
+  FM_ROOT_OVERRIDE='' FM_HOME="$HOME_DIR" \
+    FM_STATE_OVERRIDE="$HOME_DIR/state" FM_DATA_OVERRIDE="$HOME_DIR/data" \
+    FM_PROJECTS_OVERRIDE="$HOME_DIR/projects" FM_CONFIG_OVERRIDE="$HOME_DIR/config" \
+    FM_SPAWN_NO_GUARD=1 TMUX="fake,1,0" \
+    FM_FAKE_PANE_COLLIDE="$COLLIDE_DIR" FM_FAKE_PANE_CLEAN="$CLEAN_DIR" \
+    FM_FAKE_PANE_COLLIDE_READS="${FM_FAKE_PANE_COLLIDE_READS:-2}" \
+    FM_FAKE_PANE_COUNTFILE="$COUNTFILE" \
+    PATH="$FAKEBIN_DIR:$PATH" \
+    "$SPAWN" "$id" "$PROJECT_DIR" --mode no-mistakes --yolo off "$@" 2>&1
+}
+
+# A slot treehouse hands back that another live task's meta already claims
+# must never be adopted: fm-spawn.sh should reject it and request another
+# slot, landing the new task on the clean one instead.
+test_contested_slot_is_rejected_and_a_clean_slot_is_adopted() {
+  local rec other=live-holder-b1 id=collide-retry-a1 out status
+  rec=$(make_collision_case retry-succeeds)
+  read_collision_record "$rec"
+  FAKEBIN_DIR=$(make_collision_fakebin "$TMP_ROOT/retry-succeeds/fake")
+  COUNTFILE="$TMP_ROOT/retry-succeeds/pane-call-count"
+
+  fm_write_meta "$HOME_DIR/state/$other.meta" \
+    "window=firstmate:fm-$other" "worktree=$COLLIDE_DIR" "project=$PROJECT_DIR" "kind=ship"
+  fm_test_spawn_brief "$HOME_DIR" "$id"
+
+  out=$(run_collision_spawn "$id")
+  status=$?
+  expect_code 0 "$status" "spawn should succeed once a clean slot is handed out"$'\n'"$out"
+  assert_contains "$out" "spawned $id" "spawn did not report success"
+  assert_contains "$out" "$other" "the collision warning did not name the task already holding the slot"
+  assert_grep "worktree=$CLEAN_DIR" "$HOME_DIR/state/$id.meta" \
+    "meta did not record the clean slot handed out on retry"
+  assert_no_grep "worktree=$COLLIDE_DIR" "$HOME_DIR/state/$id.meta" \
+    "meta wrongly recorded the slot another live task's meta already claims"
+  pass "fm-spawn: a contested treehouse slot is rejected and a clean slot is adopted instead"
+}
+
+# When treehouse keeps handing back only the contested slot, fm-spawn.sh must
+# fail loudly and bounded rather than adopt the collision or loop forever.
+test_persistently_contested_slot_fails_bounded() {
+  local rec other=live-holder-b2 id=collide-stuck-a2 out status
+  rec=$(make_collision_case retry-exhausted)
+  read_collision_record "$rec"
+  FAKEBIN_DIR=$(make_collision_fakebin "$TMP_ROOT/retry-exhausted/fake")
+  COUNTFILE="$TMP_ROOT/retry-exhausted/pane-call-count"
+
+  fm_write_meta "$HOME_DIR/state/$other.meta" \
+    "window=firstmate:fm-$other" "worktree=$COLLIDE_DIR" "project=$PROJECT_DIR" "kind=ship"
+  fm_test_spawn_brief "$HOME_DIR" "$id"
+
+  out=$(FM_FAKE_PANE_COLLIDE_READS=100000 FM_SPAWN_SLOT_CONFLICT_RETRIES=2 run_collision_spawn "$id")
+  status=$?
+  [ "$status" -ne 0 ] || fail "spawn succeeded after treehouse kept handing back only the contested slot"$'\n'"$out"
+  assert_contains "$out" "refusing to launch into a contested slot" \
+    "refusal did not explain the contested-slot exhaustion"
+  assert_contains "$out" "$other" "refusal did not name the task holding the contested slot"
+  assert_contains "$out" "2" "refusal did not report the configured retry bound"
+  [ ! -e "$HOME_DIR/state/$id.meta" ] || fail "refused spawn published task metadata"
+  pass "fm-spawn: a persistently contested treehouse slot fails loudly instead of looping or adopting it"
+}
+
+# The same collision, but the live holder's meta lives in a different, locally
+# registered Firstmate home (a secondmate's own clone) rather than this home's
+# own state/ - mirroring the cross-home shape
+# tests/fm-teardown-endpoint-safety.test.sh already proves on the teardown side.
+test_cross_home_contested_slot_is_rejected() {
+  local rec other=live-holder-b3 id=collide-retry-cross-a3 out status
+  local second_home second_project
+  rec=$(make_collision_case cross-home)
+  read_collision_record "$rec"
+  FAKEBIN_DIR=$(make_collision_fakebin "$TMP_ROOT/cross-home/fake")
+  COUNTFILE="$TMP_ROOT/cross-home/pane-call-count"
+
+  second_home="$TMP_ROOT/cross-home/secondmate-home"
+  second_project="$second_home/projects/project"
+  mkdir -p "$second_home/projects" "$second_home/state" "$second_home/data"
+  git clone -q "$PROJECT_DIR" "$second_project"
+  printf '%s\n' "- mate - fixture (home: $second_home; scope: test; projects: project; added 2026-01-01)" \
+    > "$HOME_DIR/data/secondmates.md"
+  fm_write_meta "$second_home/state/$other.meta" \
+    "window=firstmate:fm-$other" "worktree=$COLLIDE_DIR" "project=$second_project" "kind=ship"
+  fm_test_spawn_brief "$HOME_DIR" "$id"
+
+  out=$(run_collision_spawn "$id")
+  status=$?
+  expect_code 0 "$status" "spawn should succeed once a clean slot is handed out"$'\n'"$out"
+  assert_contains "$out" "spawned $id" "spawn did not report success"
+  assert_contains "$out" "$other" "the collision warning did not name the cross-home task holding the slot"
+  assert_grep "worktree=$CLEAN_DIR" "$HOME_DIR/state/$id.meta" \
+    "meta did not record the clean slot handed out on retry"
+  assert_no_grep "worktree=$COLLIDE_DIR" "$HOME_DIR/state/$id.meta" \
+    "meta wrongly recorded the slot another firstmate home's live task already claims"
+  pass "fm-spawn: a slot contested by another locally registered home's live task is rejected"
+}
+
+test_contested_slot_is_rejected_and_a_clean_slot_is_adopted
+test_persistently_contested_slot_fails_bounded
+test_cross_home_contested_slot_is_rejected
+
+echo "# all fm-spawn-worktree-slot-collision tests passed"


### PR DESCRIPTION
Fixes #2754
Fixes #3075

## Intent

This fixes a real worktree-pool collision bug (matches GitHub issues #2754 and #3075 on this repo) that firstmate hit twice while dispatching Astro project work. The implementation is DONE and already committed on branch fm/fm-worktree-slot-collision (commit af1db08c) - a spawn-side collision guard in bin/fm-spawn.sh plus regression tests, with the teardown-side half already covered by a separately-merged PR (#3837). This task is a fresh restart after the previous worker's environment hit an unrelated usage-limit disruption; nothing about the implementation itself was in question.

## What Changed

- `bin/fm-spawn.sh`: adds `spawn_worktree_slot_conflict_task`, which cross-checks a worktree `treehouse get` hands back against every locally registered Firstmate home's `state/*.meta`, and rejects a slot when another live task's recorded `worktree` or `home` field already resolves to that same path.
- On a detected collision, the ship/scout spawn path resends `treehouse get` into the same pane instead of adopting the contested slot, tracking the previously-rejected slot so it isn't re-accepted once the pane briefly re-reports it before the new command runs; retries are bounded by the new `FM_SPAWN_SLOT_CONFLICT_RETRIES` (default 3), and exhausting all attempts refuses the launch and names the task already holding the slot. A registry that can't be read or resolved also refuses the launch rather than proceeding blind.
- `docs/architecture.md` and `docs/configuration.md` document the new spawn-side half of the worktree-pool-slot-collision guard (pairing with `fm-teardown.sh`'s existing teardown-side guard) and the new `FM_SPAWN_SLOT_CONFLICT_RETRIES` variable.
- Adds `tests/fm-spawn-worktree-slot-collision.test.sh` covering the new collision detection/retry behavior, and extends `tests/fm-spawn-dispatch-profile.test.sh` and `tests/fm-spawn-pool-base-freshen.test.sh` for the changed spawn flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Risk Assessment

✅ Low: This fix-round change replaces the fixed-read-count confirmation heuristic with an unconditional rule (never accept a candidate equal to the just-rejected slot; only accept a genuinely different isolated path confirmed by two consecutive reads), which is exactly the durable remedy round 2's finding recommended, remains bounded by the existing 60s/60-iteration settle deadline, and is covered by new tests that execute the real settle loop and assert observable exit codes, stderr text, and meta file contents for the stuck-forever, transient-stale-then-settle, and multi-retry scenarios.

## Testing

Ran the three targeted test files touched by this change (fm-spawn-worktree-slot-collision, fm-spawn-dispatch-profile, fm-spawn-pool-base-freshen); all pass on the target commit. Additionally confirmed the two new regression tests are genuine reproductions of the round-2 review findings by temporarily swapping in the prior fixed-read-count implementation (commit 8c2228b) and observing the settle-deadline test fail as expected, then restored the target commit's file (working tree left clean).

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"ad94c512b861926f6d6d5704523a2d2505ea0268","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed (2) ✅</summary>

- 🚨 `bin/fm-spawn.sh:3175` - The slot-conflict retry loop can re-accept the just-rejected contested worktree instead of waiting for treehouse to hand out a new one. On the very first `treehouse get` (fresh window), the pane starts at PROJ_ABS, which always fails `spawn_worktree_isolated`, so the settle loop&#39;s &#34;two consecutive isolated reads agree&#34; heuristic only locks onto a path once the pane has genuinely moved. On a retry (bin/fm-spawn.sh:3141, after a collision was detected), the pane is already sitting in the previously-accepted, just-rejected worktree WT1, which is itself a real, isolated git worktree and still passes `spawn_worktree_isolated`. `spawn_send_text_line` (bin/backends/tmux.sh:114, `tmux send-keys ... Enter`) returns as soon as keys are injected, with no wait for the shell to interpret or execute the command. The first poll in the settle loop (bin/fm-spawn.sh:3179) runs immediately after the send, before any sleep, so it will almost always still read WT1; the second poll one second later frequently will too, since real `treehouse get` work (git worktree operations) commonly exceeds 1s. Two consecutive WT1 reads satisfy the settle check and set WT=WT1 again (bin/fm-spawn.sh:3184-3186) before the new `treehouse get` has done anything. `spawn_worktree_slot_conflict_task` (called at bin/fm-spawn.sh:3204) then re-detects the identical collision, consuming a retry attempt without ever actually escaping the contested slot. With the default of 3 retries (FM_SPAWN_SLOT_CONFLICT_RETRIES), this race can exhaust the bound and refuse the launch (bin/fm-spawn.sh:3211) even though a genuinely clean slot exists and would have been handed out had the loop waited for the pane to actually move — a new spurious-failure mode versus the pre-fix behavior. None of the new tests exercise this: the fake tmux in tests/fm-spawn-worktree-slot-collision.test.sh and tests/fm-spawn-dispatch-profile.test.sh switches pane paths purely by read-count, not by whether the resent command has actually executed, so it cannot reproduce the race. Fix should be local to the settle loop (e.g. remember the WT rejected on the previous attempt and refuse to accept a matching candidate as settled, forcing the loop to keep polling until the pane genuinely differs) rather than any new subsystem.

🔧 Fix: fix(spawn): require extra settle confirmation for a just-rejected worktree slot
2 issues (1 error, 1 warning) still open:

- 🚨 `bin/fm-spawn.sh:3193` - The retry settle loop (fixing round-1 finding spawn-retry-stale-path-reaccept) still lets a slow `treehouse get` re-trigger the identical race, just with a bigger window. `spawn_send_text_line` returns as soon as keys are injected, not once the shell interprets them, so after a resend the pane still reports the just-rejected worktree (`rejected_wt_real`) until the new `treehouse get`&#39;s cd actually executes. The fix now requires 5 consecutive matching reads (`SLOT_REJECT_CONFIRM_READS=5`, ~5s of polling at 1s/iteration) before accepting a candidate equal to `rejected_wt_real`, instead of the previous 2. That only raises the bar from &#39;stall &gt;1s&#39; to &#39;stall &gt;~5s&#39; — it does not close the invariant. If the real `treehouse get` (git worktree add + cd, plausibly slower on the WSL/network-filesystem setups this code&#39;s own comments cite as the origin of the underlying staleness) takes longer than ~5s, all 5 polls still read the stale, already-rejected slot, `WT` is re-set to the same contested path, `spawn_worktree_slot_conflict_task` re-detects the identical collision, and a retry attempt is burned on a slot that was never actually re-requested from treehouse — exactly the round-1 failure mode, reproducible with a larger but still real delay. A durable fix (as round 1 itself suggested) is to never treat a candidate equal to `rejected_wt_real` as converged at all — keep polling (still bounded by the existing 60-iteration/60s cap) until the pane reports a genuinely different isolated path — rather than gating on a fixed read count that assumes real work always finishes within it.
- ⚠️ `bin/fm-spawn.sh:3199` - This fix round (1ddfc72..8c2228b) touches only bin/fm-spawn.sh and adds zero test changes. None of the existing tests (tests/fm-spawn-worktree-slot-collision.test.sh&#39;s fake tmux switches pane path purely by a global read counter, defaulting to switching away from the contested path after 2 reads, or forever staying on it for the bounded-exhaustion case) exercise the specific scenario this round&#39;s SLOT_REJECT_CONFIRM_READS logic exists to handle: the pane transiently re-reporting the just-rejected slot for a few reads after a retry&#39;s &#39;treehouse get&#39; is sent, before genuinely settling on a new slot. Without a test that stages, e.g., 4 stale reads of the rejected path followed by a switch to a clean one, a regression that drops the confirmation-read count back toward 2 (or removes it entirely) would pass every existing test.

🔧 Fix: fix(spawn): never re-accept the just-rejected worktree as settled
✅ Re-checked - no issues remain.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`bash tests/fm-spawn-worktree-slot-collision.test.sh` — all 5 tests pass on target commit ad94c51, including the two new regression tests (test_pane_stuck_on_rejected_slot_fails_at_settle_deadline, test_transient_stale_rejected_reads_do_not_block_a_genuine_settle) added specifically to cover the round-2 race</code>
- `Reproduction check: swapped bin/fm-spawn.sh to the pre-fix commit 8c2228b (fixed-read-count SLOT_REJECT_CONFIRM_READS=5 approach) while keeping ad94c51's test file, confirmed test_pane_stuck_on_rejected_slot_fails_at_settle_deadline fails as expected (spawn wrongly succeeds by re-accepting the rejected slot after 5 stale reads), then restored bin/fm-spawn.sh to the target commit's version and re-verified all tests pass with a clean working tree`
- <code>`bash tests/fm-spawn-dispatch-profile.test.sh` — all tests pass (covers the crew-dispatch profile changes in the same diff)</code>
- <code>`bash tests/fm-spawn-pool-base-freshen.test.sh` — all tests pass (covers the pool-base-freshen changes in the same diff)</code>
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>

