### PR TITLE
fix: fm_pid_alive rejects a zombie pid, unwedging fleet locks and leases

### DIFF
--- a/bin/fm-lease-lib.sh
+++ b/bin/fm-lease-lib.sh
@@ -144,7 +144,11 @@ fm_lease_live() {
   fm_lease_read "$1" || return 1
   [ -n "$FM_LEASE_ACTOR" ] || return 1
   [ -n "$FM_LEASE_PID" ] || return 1
-  kill -0 "$FM_LEASE_PID" 2>/dev/null || return 1
+  # fm_pid_alive (fm-wake-lib.sh) rejects a zombie pid, unlike a bare
+  # `kill -0`; every caller of this file already sources fm-wake-lib.sh
+  # first, but load it defensively so a direct sourcing still gets that check.
+  fm_lease_lock_helpers
+  fm_pid_alive "$FM_LEASE_PID" || return 1
   lock_pid=$(head -n 1 "$STATE/.lock" 2>/dev/null || true)
   case "$lock_pid" in ''|0|1|*[!0-9]*) return 1 ;; esac
   [ "$FM_LEASE_PID" = "$lock_pid" ]

--- a/bin/fm-session-lock-lib.sh
+++ b/bin/fm-session-lock-lib.sh
@@ -145,10 +145,24 @@ EOF
   printf '%s\n' "$outermost"
 }
 
-# True if $1 is a live process that looks like a verified harness.
+# Lazily source fm-wake-lib.sh for fm_pid_alive (zombie-aware liveness), only
+# when a caller has not already sourced it: no caller of this file currently
+# does, unlike fm-lease-lib.sh's callers, which all source fm-wake-lib.sh
+# first (see that file's fm_lease_lock_helpers for the identical pattern).
+_fm_session_lock_wake_helpers() {
+  command -v fm_pid_alive >/dev/null 2>&1 && return 0
+  # shellcheck source=bin/fm-wake-lib.sh
+  . "$(dirname -- "${BASH_SOURCE[0]}")/fm-wake-lib.sh"
+}
+
+# True if $1 is a live process that looks like a verified harness. Delegates
+# liveness to fm_pid_alive so a zombie session-lock holder (kill -0 alone
+# reports it alive; the kernel keeps its pid slot until the parent reaps it)
+# does not block a new session from taking over state/.lock.
 fm_harness_pid_alive() {
   local pid=$1 comm args
-  kill -0 "$pid" 2>/dev/null || return 1
+  _fm_session_lock_wake_helpers
+  fm_pid_alive "$pid" || return 1
   comm=$(ps -o comm= -p "$pid" 2>/dev/null) || return 1
   args=$(ps -o args= -p "$pid" 2>/dev/null)
   fm_harness_process_matches "$comm" "$args"

--- a/bin/fm-wake-lib.sh
+++ b/bin/fm-wake-lib.sh
@@ -45,12 +45,42 @@ fm_current_pid() {  # [output-variable]
   fi
 }
 
+# A zombie process (exited but not yet reaped by its parent) keeps its PID
+# slot reserved, so plain `kill -0` still reports it alive: the kernel only
+# releases the slot once the parent calls wait(). A dead lock/lease "owner"
+# stuck in that state never releases anything, wedging the lock forever. Read
+# the real process state (proc stat field 3, or lstart's `ps` STAT column when
+# /proc is unavailable) and treat Z as not-alive, using the same
+# ${FM_PROC_ROOT_OVERRIDE:-/proc} portability discipline as fm_pid_identity
+# below. This is deliberately liveness-only: a recycled PID whose new occupant
+# happens to share the same identity string is fm_pid_identity's job, not
+# this function's.
 fm_pid_alive() {
-  local pid=$1
+  local pid=$1 proc_root stat_line state
+  local -a stat_fields
   case "$pid" in
     ''|*[!0-9]*) return 1 ;;
   esac
-  kill -0 "$pid" 2>/dev/null
+  kill -0 "$pid" 2>/dev/null || return 1
+  proc_root=${FM_PROC_ROOT_OVERRIDE:-/proc}
+  if [ -r "$proc_root/$pid/stat" ]; then
+    # After the final comm delimiter (comm can itself contain spaces/parens),
+    # array index 0 is proc stat field 3 (state).
+    stat_line=$(cat "$proc_root/$pid/stat" 2>/dev/null) || return 0
+    read -r -a stat_fields <<< "${stat_line##*)}"
+    state=${stat_fields[0]:-}
+  else
+    # No Linux-compatible /proc (e.g. macOS): fall back to `ps`'s STAT
+    # column, the same field the test suite's own is_live_non_zombie helper
+    # reads. A `ps` that cannot report state at all is treated as alive,
+    # matching kill -0's verdict, rather than failing a live process closed
+    # on a portability gap.
+    state=$(ps -p "$pid" -o stat= 2>/dev/null | tr -d '[:space:]')
+  fi
+  case "$state" in
+    Z*) return 1 ;;
+  esac
+  return 0
 }
 
 fm_pid_identity() {

--- a/tests/fm-watcher-lock.test.sh
+++ b/tests/fm-watcher-lock.test.sh
@@ -12,6 +12,7 @@ WATCH="$ROOT/bin/fm-watch.sh"
 WATCH_ARM="$ROOT/bin/fm-watch-arm.sh"
 DRAIN="$ROOT/bin/fm-wake-drain.sh"
 LIB="$ROOT/bin/fm-wake-lib.sh"
+SESSION_LIB="$ROOT/bin/fm-session-lock-lib.sh"
 
 # An arm only reports its typed failure after wait_for_healthy_successor has
 # spent the whole confirmation budget, so cases that wait for that failure must
@@ -1002,6 +1003,82 @@ test_fm_pid_alive_treats_zombie_as_dead() {
   pass "fm_pid_alive treats a zombie process as dead and a genuinely live process as alive"
 }
 
+# fm_harness_pid_alive (bin/fm-session-lock-lib.sh) had the identical bare
+# kill -0 zombie bug for the fleet session .lock path (a regular file, outside
+# fm_lock_try_acquire's directory-lock mechanism), so a zombie session-lock
+# holder could block a new session from taking over state/.lock. It now
+# delegates liveness to fm_pid_alive; this mirrors
+# test_fm_pid_alive_treats_zombie_as_dead above but must also make the process
+# match a verified harness name (comm=claude), since fm_harness_pid_alive
+# checks that after liveness. A pure-builtin spin loop keeps a genuinely alive
+# process's comm from ever changing away from the symlink name it was invoked
+# through; the future zombie is a quick-exiting claude-named child whose comm
+# is set once at its own execve and never changes again, forked by a holder
+# that blocks on its own final external command - which bash's tail-call
+# optimization execs in place of the shell itself, so the holder structurally
+# cannot reap what it left behind.
+test_fm_harness_pid_alive_treats_zombie_as_dead() {
+  local dir state fakebin alive_pid holder_out holder_pid child_pid i state_field
+  dir=$(make_case harness-pid-alive-zombie)
+  state="$dir/state"
+  fakebin="$dir/harness-bin"
+  mkdir -p "$fakebin"
+  ln -s /bin/bash "$fakebin/claude"
+
+  "$fakebin/claude" -c 'while :; do :; done' &
+  alive_pid=$!
+
+  holder_out="$dir/holder.out"
+  bash -c '"$1" -c "exit 0" & child=$!; printf "%s\n" "$child"; sleep 30' _ "$fakebin/claude" > "$holder_out" &
+  holder_pid=$!
+
+  i=0
+  while [ "$i" -lt 50 ] && [ ! -s "$holder_out" ]; do
+    sleep 0.1
+    i=$((i + 1))
+  done
+  child_pid=$(head -n 1 "$holder_out" 2>/dev/null)
+  case "$child_pid" in
+    ''|*[!0-9]*)
+      kill "$alive_pid" "$holder_pid" 2>/dev/null || true
+      wait "$alive_pid" "$holder_pid" 2>/dev/null || true
+      fail "harness zombie fixture did not report a child pid"
+      ;;
+  esac
+
+  i=0
+  state_field=
+  while [ "$i" -lt 100 ]; do
+    state_field=$(ps -p "$child_pid" -o stat= 2>/dev/null | tr -d '[:space:]')
+    case "$state_field" in
+      Z*) break ;;
+    esac
+    sleep 0.1
+    i=$((i + 1))
+  done
+  case "$state_field" in
+    Z*) ;;
+    *)
+      kill "$alive_pid" "$holder_pid" 2>/dev/null || true
+      wait "$alive_pid" "$holder_pid" 2>/dev/null || true
+      fail "harness zombie fixture child never reached zombie state (stat='$state_field')"
+      ;;
+  esac
+
+  if FM_STATE_OVERRIDE="$state" bash -c '. "$1"; fm_harness_pid_alive "$2"' _ "$SESSION_LIB" "$child_pid"; then
+    kill "$alive_pid" "$holder_pid" 2>/dev/null || true
+    wait "$alive_pid" "$holder_pid" 2>/dev/null || true
+    fail "fm_harness_pid_alive treated a zombie harness-named process as alive"
+  fi
+  FM_STATE_OVERRIDE="$state" bash -c '. "$1"; fm_harness_pid_alive "$2"' _ "$SESSION_LIB" "$alive_pid" \
+    || { kill "$alive_pid" "$holder_pid" 2>/dev/null || true; wait "$alive_pid" "$holder_pid" 2>/dev/null || true; \
+         fail "fm_harness_pid_alive treated a genuinely live harness-named process as dead"; }
+
+  kill "$alive_pid" "$holder_pid" 2>/dev/null || true
+  wait "$alive_pid" "$holder_pid" 2>/dev/null || true
+  pass "fm_harness_pid_alive treats a zombie harness-named process as dead and a genuinely live one as alive"
+}
+
 test_pid_identity_is_locale_invariant() {
   # The portable fallback records its process identity under one locale, then
   # arm/guard/turn-end re-read it under the machine's ambient locale. ps's lstart
@@ -1192,3 +1269,4 @@ test_arm_fails_loud_when_no_fresh_watcher_confirmable
 test_cycle_exit_ledger_links_successor_and_stays_bounded
 test_stopped_watcher_is_live_but_stale_then_exit_is_classified
 test_fm_pid_alive_treats_zombie_as_dead
+test_fm_harness_pid_alive_treats_zombie_as_dead

--- a/tests/fm-watcher-lock.test.sh
+++ b/tests/fm-watcher-lock.test.sh
@@ -942,6 +942,66 @@ test_stopped_watcher_is_live_but_stale_then_exit_is_classified() {
   pass "SIGSTOP distinguishes live PID from stale beacon and termination records the exit class"
 }
 
+# A zombie "owner" pid is exactly the lock/lease wedge this regression guards
+# against: kill -0 alone reports a zombie as alive because the kernel keeps
+# its slot reserved until the parent reaps it, and that parent here is a real
+# process (not the test runner) that deliberately never calls wait() on it.
+test_fm_pid_alive_treats_zombie_as_dead() {
+  local dir state holder_out holder_pid child_pid i state_field
+  dir=$(make_case pid-alive-zombie)
+  state="$dir/state"
+  holder_out="$dir/holder.out"
+
+  bash -c 'sleep 0.2 & child=$!; printf "%s\n" "$child"; sleep 30' > "$holder_out" &
+  holder_pid=$!
+
+  i=0
+  while [ "$i" -lt 50 ] && [ ! -s "$holder_out" ]; do
+    sleep 0.1
+    i=$((i + 1))
+  done
+  child_pid=$(head -n 1 "$holder_out" 2>/dev/null)
+  case "$child_pid" in
+    ''|*[!0-9]*)
+      kill "$holder_pid" 2>/dev/null || true
+      wait "$holder_pid" 2>/dev/null || true
+      fail "zombie fixture did not report a child pid"
+      ;;
+  esac
+
+  i=0
+  state_field=
+  while [ "$i" -lt 100 ]; do
+    state_field=$(ps -p "$child_pid" -o stat= 2>/dev/null | tr -d '[:space:]')
+    case "$state_field" in
+      Z*) break ;;
+    esac
+    sleep 0.1
+    i=$((i + 1))
+  done
+  case "$state_field" in
+    Z*) ;;
+    *)
+      kill "$holder_pid" 2>/dev/null || true
+      wait "$holder_pid" 2>/dev/null || true
+      fail "zombie fixture child never reached zombie state (stat='$state_field')"
+      ;;
+  esac
+
+  if FM_STATE_OVERRIDE="$state" bash -c '. "$1"; fm_pid_alive "$2"' _ "$LIB" "$child_pid"; then
+    kill "$holder_pid" 2>/dev/null || true
+    wait "$holder_pid" 2>/dev/null || true
+    fail "fm_pid_alive treated a zombie process as alive"
+  fi
+  FM_STATE_OVERRIDE="$state" bash -c '. "$1"; fm_pid_alive "$2"' _ "$LIB" "$holder_pid" \
+    || { kill "$holder_pid" 2>/dev/null || true; wait "$holder_pid" 2>/dev/null || true; \
+         fail "fm_pid_alive treated a genuinely live process as dead"; }
+
+  kill "$holder_pid" 2>/dev/null || true
+  wait "$holder_pid" 2>/dev/null || true
+  pass "fm_pid_alive treats a zombie process as dead and a genuinely live process as alive"
+}
+
 test_pid_identity_is_locale_invariant() {
   # The portable fallback records its process identity under one locale, then
   # arm/guard/turn-end re-read it under the machine's ambient locale. ps's lstart
@@ -1131,3 +1191,4 @@ test_arm_waits_for_peer_beacon_after_child_stands_down
 test_arm_fails_loud_when_no_fresh_watcher_confirmable
 test_cycle_exit_ledger_links_successor_and_stays_bounded
 test_stopped_watcher_is_live_but_stale_then_exit_is_classified
+test_fm_pid_alive_treats_zombie_as_dead


### PR DESCRIPTION
## Intent

Durante a sessao de 2026-09-09 o firstmate encontrou, repetidas vezes, locks internos da frota (.fm-lease-command.lock, .spawn-<task>.lock, .meta-<task>.lock, .control-<task>.lock, .treehouse-project-*.lock, e o lock de apresentacao do herdr) travados indefinidamente porque o processo "dono" registrado no lock virou zumbi (estado Z no /proc) sem ser recolhido pelo processo-pai (o init do proprio container). O firstmate diagnosticou cada caso manualmente (confirmando via /proc/<pid>/status que o estado era Z) e removeu os diretorios de lock a mao repetidas vezes hoje - isso deveria ser corrigido na propria ferramenta, nao remendado sessao apos sessao.

## What Changed

- `bin/fm-wake-lib.sh`: Added `fm_pid_alive` function that checks `/proc/<pid>/stat` on Linux (with a `ps`-based fallback for macOS) and returns non-zero for zombie (`Z*`) processes, treating them as dead rather than alive.
- `bin/fm-lease-lib.sh`: Updated lease liveness check (`fm_lease_live`) to delegate to `fm_pid_alive` instead of using bare `kill -0`, so a zombie lock-owner no longer holds a lease indefinitely.
- `tests/fm-watcher-lock.test.sh`: Added regression test `test_fm_pid_alive_treats_zombie_as_dead` that spawns a real zombie process, polls until it enters `Z*` state, and asserts `fm_pid_alive` returns non-zero for the zombie and zero for a genuinely live process.

## Risk Assessment

⚠️ Medium: The authorized fix for the session-lock zombie path was not applied; the same zombie-wedge class of bug remains reachable through fm_harness_pid_alive despite the user explicitly requesting it be included in this PR.

## Testing

<code>Code review and live system inspection confirmed the fix is correct: `fm_pid_alive` now rejects zombie PIDs by reading the process state field from `/proc/&lt;pid&gt;/stat` (falling back to `ps -o stat=` on non-Linux). A regression test covering this exact zombie scenario exists. Execution of the test suite was blocked by sandbox restrictions; all evidence is from static code reading plus the `ps aux` observation that zombie processes matching the incident description (including a zombie `herdr` process) were present on the system.</code>

<details>
<summary>Evidence: Live zombie processes on system (confirming the described scenario)</summary>

```text
root 15 0.0 0.0 0 0 ? Z Sep08 1:16 [herdr] <defunct>
root 737 0.0 0.0 0 0 pts/0 Z Sep08 0:00 [bash] <defunct>
root 1278 0.0 0.0 0 0 pts/0 Z 18:14 0:00 [bash] <defunct>
root 2381 0.0 0.0 0 0 pts/0 Z 18:14 0:00 [sleep] <defunct>
root 6082 0.0 0.0 0 0 pts/0 Z 18:15 0:00 [bash] <defunct>
```
</details>
- Outcome: ⚠️ 1 warning across 1 run (14m55s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 1 warning</summary>

- ⚠️ `bin/fm-session-lock-lib.sh:151` - fm_harness_pid_alive in fm-session-lock-lib.sh still uses bare kill -0 (line 151), which reports zombie processes as alive. A zombie session-lock holder would prevent fm-lock.sh (lines 64, 89) from taking over the fleet .lock file, potentially blocking new sessions. This is the same zombie-wedge class as the fixed directory locks, but in the session .lock (regular-file) path which fm_lock_try_acquire does not cover.
- ℹ️ `tests/fm-watcher-lock.test.sh:949` - The zombie regression test (test_fm_pid_alive_treats_zombie_as_dead) validates fm_pid_alive&#39;s /proc path on Linux. It does not exercise the macOS ps-based fallback branch (fm-wake-lib.sh:78), since on Linux /proc/$pid/stat is always readable for a zombie. The ps fallback is untested on this platform.

🔧 Fix: fix fm_harness_pid_alive zombie check via fm_pid_alive reuse
1 warning still open:
- ⚠️ `bin/fm-session-lock-lib.sh:151` - fm_harness_pid_alive in fm-session-lock-lib.sh (line 151) still uses bare kill -0, which reports zombie processes as alive. The round-1 review authorized this fix explicitly: source fm-wake-lib.sh and delegate to fm_pid_alive (the same pattern fm_lease_live uses in fm-lease-lib.sh), then add a zombie regression test (same pattern as test_fm_pid_alive_treats_zombie_as_dead) confirming fm_harness_pid_alive treats a zombie as dead and a genuinely live process as alive. Without this fix a zombie session-lock holder still blocks fleet lock acquisition at fm-lock.sh lines 64 and 89.

</details>

<details>
<summary>⚠️ **Test** - 1 warning</summary>

- ⚠️ `tests/fm-watcher-lock.test.sh:949` - Sandbox restrictions prevented executing the test suite or writing evidence files outside the worktree; targeted test `test_fm_pid_alive_treats_zombie_as_dead` (tests/fm-watcher-lock.test.sh:949) could not be run. Evidence is from code reading and live system observation only.
- <code>`ps aux --no-headers | grep &#39; Z &#39;` — confirmed live zombie processes on system (PID 15 `[herdr]`, 737, 1278, 2381, 6082), validating the described scenario</code>
- <code>Read `bin/fm-wake-lib.sh:58-84` — verified `fm_pid_alive` reads `/proc/&lt;pid&gt;/stat`, strips comm field via `${stat_line##*)}`, and returns 1 for `Z*` state</code>
- <code>Read `tests/fm-watcher-lock.test.sh:949-1003` — confirmed regression test `test_fm_pid_alive_treats_zombie_as_dead` exists and correctly spawns a zombie fixture by leaving a child unreleased, polls until `Z*` state, then asserts `fm_pid_alive` returns non-zero for the zombie and zero for the live parent</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
