### PR TITLE
fix(claude-trust): register the canonical git root beside the task worktree

### DIFF
--- a/.agents/skills/harness-adapters/references/common/control-and-recovery.md
+++ b/.agents/skills/harness-adapters/references/common/control-and-recovery.md
@@ -17,7 +17,7 @@ Select only its documented trust choice from the active Firstmate home, binding 
 No observed dialog proves only that launch.
 
 Each supported harness handles its folder-trust gate differently, and the tool reference owns the detail.
-Claude gates a fresh worktree and cannot be answered by key, so the spawn pre-registers the path in Claude's own store.
+Claude gates a fresh worktree and cannot be answered by key, so the spawn pre-registers the worktree and its canonical git root in Claude's own store; `../harness/claude.md` owns why both paths matter.
 Cursor suppresses its dialog with launch-time `--trust`, and Muse suppresses its own with `--yolo`.
 Grok dodges its gate instead of granting trust, because its project picker appears only outside a project and the spawn starts in the isolated git root.
 Pi gates the fresh-worktree case too, but unlike Claude its dialog is answered with Enter, and `references/harness/pi.md` owns that recipe and where the decision persists.

--- a/.agents/skills/harness-adapters/references/harness/claude.md
+++ b/.agents/skills/harness-adapters/references/harness/claude.md
@@ -22,7 +22,7 @@ A ship or scout spawn therefore pre-registers the worktree before launch, and th
 
 The canonical root matters because Claude Code 2.1.266 (read from its bundle on 2026-09-09) keys a second trust check on it.
 When the project's `.claude/settings.json` or `settings.local.json` carries `permissions.allow` rules or `additionalDirectories`, a gated-grants backstop renders the dialog in its "This folder pre-approves N tool permissions in .claude/settings.json" variant and looks up trust under the canonical git root, the primary checkout a linked worktree's `.git` file points at, rather than the worktree path the plain check accepts.
-For a firstmate worker that root is normally `projects/<name>`, so a worker parked on that variant on 2026-09-09 even though its worktree entry was recorded.
+For a firstmate worker that root is normally `projects/<name>`, the primary checkout the script refuses as a worktree, so registering the worktree alone leaves such a worker parked on that variant.
 The script derives the root from git's own main-working-tree listing rather than from the project argument, so a spawn from a linked spawning home registers the repository's main checkout and not the home; the script's header owns the registration rationale and the owner proof.
 
 Never try to answer the trust dialog with a key.

--- a/.agents/skills/harness-adapters/references/harness/claude.md
+++ b/.agents/skills/harness-adapters/references/harness/claude.md
@@ -18,11 +18,18 @@ Busy hooks verified 2026-07-28 on Claude Code 2.1.220.
 Claude gates a folder it has never seen behind an interactive workspace-trust dialog, so every fresh task worktree would hit it.
 `--dangerously-skip-permissions` does not cover that gate: `claude --help` records that the dialog is skipped only in non-interactive mode, through `-p` or a non-TTY stdout, and a crewmate pane is interactive.
 A ship or scout spawn therefore pre-registers the worktree before launch, and the dialog does not appear.
-`../../../bin/fm-claude-trust.sh` records `hasTrustDialogAccepted` for that worktree path in `${CLAUDE_CONFIG_DIR:-$HOME}/.claude.json`, and `../../../bin/fm-spawn.sh` refuses the spawn when the write fails rather than launching a worker that would wedge.
+`../../../bin/fm-claude-trust.sh` records `hasTrustDialogAccepted` for that worktree path and for its canonical git root in `${CLAUDE_CONFIG_DIR:-$HOME}/.claude.json`, and `../../../bin/fm-spawn.sh` refuses the spawn when the write fails rather than launching a worker that would wedge.
+
+The canonical root matters because Claude Code 2.1.266 (read from its bundle on 2026-09-09) keys a second trust check on it.
+When the project's `.claude/settings.json` or `settings.local.json` carries `permissions.allow` rules or `additionalDirectories`, a gated-grants backstop renders the dialog in its "This folder pre-approves N tool permissions in .claude/settings.json" variant and looks up trust under the canonical git root, the primary checkout a linked worktree's `.git` file points at, rather than the worktree path the plain check accepts.
+For a firstmate worker that root is normally `projects/<name>`, so a worker parked on that variant on 2026-09-09 even though its worktree entry was recorded.
+The script derives the root from git's own main-working-tree listing rather than from the project argument, so a spawn from a linked spawning home registers the repository's main checkout and not the home; the script's header owns the registration rationale and the owner proof.
 
 Never try to answer the trust dialog with a key.
-Firstmate's key plane carries only Enter, Escape, and C-c with no arrow navigation, so it cannot move a dialog's selection at all, and the observed rendering starts on `No, exit`, which means a sent Enter ends the session instead of accepting.
-A visible trust dialog means pre-registration did not take effect, so inspect the store and the spawn's error output rather than sending keys.
+Firstmate's key plane carries only Enter, Escape, and C-c with no arrow navigation, so it cannot move a dialog's selection at all, and every observed rendering starts on the `No` row, which means a sent Enter selects that row instead of accepting.
+On the plain variant that row is `No, exit`, and Enter ends the session.
+On the gated-grants variant with trust already accepted that row is `No, continue without these permissions`, and Escape takes the same path: the session continues without the project's allow rules and does not exit, so `../../../bin/fm-control.sh <id> interrupt` dismisses it and the worker keeps running with only the permissions its launch flags grant.
+A visible trust dialog means pre-registration did not take effect for the path Claude checked, so inspect the store for both the worktree and canonical-root entries and the spawn's error output rather than sending keys.
 
 The once-per-machine bypass-permissions confirmation is a separate dialog, scoped to the machine rather than the path, and pre-registration does not address it.
 Never send Enter to that one either: it was observed rendering in the same shape as the trust dialog, with the selection on `No, exit` and the footer `Enter to confirm . Esc to cancel`, so Enter ends the session rather than accepting.

--- a/bin/fm-claude-trust.sh
+++ b/bin/fm-claude-trust.sh
@@ -182,9 +182,14 @@ PROJ_COMMON=$(common_dir_of "$PROJ_REAL") || true
 
 # The canonical root, derived from the accepted worktree through git rather than
 # taken from either argument: the repository's main working tree is the first
-# entry git lists, and a bare repository lists it as `bare` with no path.
+# record git lists. A bare repository still lists its own directory first, with
+# a `bare` line inside that record, so the whole first record is read and a bare
+# one yields no root.
 ROOT_LISTED=$(git -C "$WT_REAL" worktree list --porcelain 2>/dev/null | awk '
-  NR == 1 && /^worktree / { sub(/^worktree /, ""); print; exit }
+  /^worktree / && root == "" { root = substr($0, 10); next }
+  /^bare$/ { bare = 1 }
+  /^$/ { exit }
+  END { if (!bare) print root }
 ') || true
 [ -n "$ROOT_LISTED" ] || refuse "'$WT_REAL' has no main working tree to serve as its canonical root (a bare repository has none)"
 ROOT_REAL=$(real_dir "$ROOT_LISTED") || true

--- a/bin/fm-claude-trust.sh
+++ b/bin/fm-claude-trust.sh
@@ -6,7 +6,8 @@
 # Usage: fm-claude-trust.sh <worktree> <project>
 #   <worktree>  the isolated task worktree this spawn launches into
 #   <project>   the primary checkout that worktree belongs to
-# Prints one line naming what it registered; refuses loudly on anything else.
+# Records trust for BOTH paths and prints one line naming them; refuses loudly
+# on anything else.
 #
 # WHY THIS EXISTS. Claude Code gates a folder it has never seen behind an
 # interactive workspace-trust dialog, and --dangerously-skip-permissions does
@@ -19,6 +20,25 @@
 # it ever reads the brief. Registering the trust before launch is the only
 # control that reaches an interactive pane.
 #
+# WHY THE CANONICAL ROOT IS REGISTERED TOO. Claude Code 2.1.266 (read from its
+# bundle on 2026-09-09) runs two trust checks. The plain one walks up from cwd
+# and accepts the worktree's own entry. The second is a backstop shown when the
+# project's .claude/settings.json (or settings.local.json) carries
+# permissions.allow rules or additionalDirectories - the "This folder
+# pre-approves N tool permissions in .claude/settings.json" variant - and it
+# keys trust on the CANONICAL git root: the main checkout a linked worktree's
+# `.git` file points at, which for a firstmate worker is projects/<name>.
+# Registering the worktree alone therefore left such a worker parked on that
+# variant, and a primary checkout is exactly the path the scope test below
+# refuses as a <worktree>. So a spawn records hasTrustDialogAccepted for the
+# canonical root as well, UNCONDITIONALLY rather than only when the project's
+# settings currently carry gated grants: Claude keys the gate on the canonical
+# root regardless of which file supplies the grants, a settings file can gain
+# them between this registration and the launch or on the task branch itself,
+# and the entry is harmless for a project without them. With trust accepted,
+# that dialog's Escape ("No, continue without these permissions") continues the
+# session without the project's allow rules instead of exiting.
+#
 # THE SCOPE TEST IS THE SAFETY PROPERTY, and it is STRUCTURAL rather than a
 # path policy. <worktree> must be a LINKED git worktree - its own git dir,
 # sharing <project>'s common dir - whose top level is exactly the resolved
@@ -27,6 +47,24 @@
 # unrelated repo, a subdirectory of a worktree, a plain directory, and a home
 # directory are each refused. Refusal is a non-zero exit, never a warning and
 # never a silent skip.
+#
+# The canonical-root registration is an ADDITION derived from that validated
+# pair, never a relaxation of it, and it is never the <project> argument taken
+# on its own word. The root is what git itself names as the repository's main
+# working tree for the already-accepted worktree (the first entry of
+# `git worktree list --porcelain`, run inside it), and it is written only after
+# it is proven to be the common-dir OWNER: its own top level is exactly that
+# resolved path, its git dir IS the shared common dir, and it is neither the
+# home nor the Claude config directory. In the ordinary spawn <project> is that
+# root. A LINKED SPAWNING HOME (fm-spawn.sh's header: a firstmate home that is
+# itself a linked worktree of the project repository) is not, and Claude keys
+# its backstop on the repository's main checkout rather than on that home, so
+# the main checkout is what gets registered and the home's own path never is.
+# A repository with no main working tree (bare) has no canonical root and
+# refuses. A caller cannot register an arbitrary primary checkout this way,
+# because the worktree argument must independently pass as a linked worktree
+# of <project>'s repository first and the root then comes from git, not from
+# any argument.
 #
 # The test is deliberately NOT a treehouse or orca path prefix. Treehouse's
 # root is configurable (--root, TREEHOUSE_ROOT, config, and a relative
@@ -45,10 +83,11 @@
 # opt-in guard family (FM_*_LIVE_E2E=1) and record the result in
 # docs/verification/runtime-backends.md, rather than assuming the shape here.
 #
-# Only the launching user's own store is written: the projects entry for the
-# worktree path in ${CLAUDE_CONFIG_DIR:-$HOME}/.claude.json, which must be a
-# regular file this uid owns. Every unrelated key and project entry is
-# preserved, and the replacement is atomic. fm-spawn.sh forwards CLAUDE_CONFIG_DIR
+# Only the launching user's own store is written: the projects entries for the
+# worktree path and its canonical root in ${CLAUDE_CONFIG_DIR:-$HOME}/.claude.json,
+# which must be a regular file this uid owns. Every unrelated key and project
+# entry is preserved, including the other keys of an existing canonical-root
+# entry, and the replacement is atomic. fm-spawn.sh forwards CLAUDE_CONFIG_DIR
 # onto the claude launch verbatim rather than resolving it, and the worker's pane
 # starts in the task worktree, so only an absolute value names the same store on
 # both sides; a relative one is refused below rather than guessed at.
@@ -141,6 +180,28 @@ PROJ_COMMON=$(common_dir_of "$PROJ_REAL") || true
 [ -n "$PROJ_COMMON" ] || refuse "project '$PROJ_REAL' is not inside a git repository"
 [ "$WT_COMMON" = "$PROJ_COMMON" ] || refuse "'$WT_REAL' is not a worktree of project '$PROJ_REAL'"
 
+# The canonical root, derived from the accepted worktree through git rather than
+# taken from either argument: the repository's main working tree is the first
+# entry git lists, and a bare repository lists it as `bare` with no path.
+ROOT_LISTED=$(git -C "$WT_REAL" worktree list --porcelain 2>/dev/null | awk '
+  NR == 1 && /^worktree / { sub(/^worktree /, ""); print; exit }
+') || true
+[ -n "$ROOT_LISTED" ] || refuse "'$WT_REAL' has no main working tree to serve as its canonical root (a bare repository has none)"
+ROOT_REAL=$(real_dir "$ROOT_LISTED") || true
+[ -n "$ROOT_REAL" ] || refuse "the main working tree '$ROOT_LISTED' of '$WT_REAL' is not an accessible directory"
+# The owner proof: the listed root must be the primary checkout that OWNS the
+# shared common dir, and it must be a checkout root rather than a subdirectory.
+# The home and config guards apply to it for the same reason they apply to the
+# worktree: neither is ever a project checkout worth a standing trust entry.
+[ "$ROOT_REAL" != "$CONFIG_DIR_REAL" ] || refuse "canonical root '$ROOT_REAL' is the Claude config directory, not a project checkout"
+[ "$ROOT_REAL" != "${HOME_REAL:-}" ] || refuse "canonical root '$ROOT_REAL' is the home directory, not a project checkout"
+ROOT_TOP=$(git -C "$ROOT_REAL" rev-parse --show-toplevel 2>/dev/null) || true
+ROOT_TOP_REAL=$(real_dir "${ROOT_TOP:-/nonexistent}") || true
+[ "$ROOT_TOP_REAL" = "$ROOT_REAL" ] || refuse "canonical root '$ROOT_REAL' is not a checkout root (its root is '${ROOT_TOP_REAL:-unresolvable}')"
+ROOT_GIT_DIR=$(git -C "$ROOT_REAL" rev-parse --absolute-git-dir 2>/dev/null) || true
+ROOT_GIT_DIR=$(real_dir "${ROOT_GIT_DIR:-/nonexistent}") || true
+[ "$ROOT_GIT_DIR" = "$WT_COMMON" ] || refuse "canonical root '$ROOT_REAL' does not own the common git directory of '$WT_REAL'"
+
 # The store write needs node, and a missing interpreter refuses like every other
 # failure here. Degrading instead would launch a worker straight into the dialog
 # this registration exists to remove, which is the one outcome the whole control
@@ -190,11 +251,11 @@ fi
 # attempts, and it must fail loudly rather than report a trust it did not leave.
 # ponytail: fingerprint-and-refuse, not a lock; flock is absent on macOS and
 # cannot stop a vendor session's own rewrite anyway.
-if ! node - "$STORE" "$WT_REAL" <<'NODE'
+if ! node - "$STORE" "$WT_REAL" "$ROOT_REAL" <<'NODE'
 const fs = require("node:fs");
 const path = require("node:path");
 const crypto = require("node:crypto");
-const [store, worktree] = process.argv.slice(2);
+const [store, ...targets] = process.argv.slice(2);
 const readStore = () => {
   try {
     return fs.readFileSync(store);
@@ -223,12 +284,17 @@ const attempt = () => {
   if (projects === null || typeof projects !== "object" || Array.isArray(projects)) {
     throw new Error(`${store} has a non-object "projects" value`);
   }
-  let entry = projects[worktree];
-  if (entry === undefined || entry === null || typeof entry !== "object" || Array.isArray(entry)) {
-    entry = {};
+  // Both the worktree and its canonical root, in one replacement: an existing
+  // entry keeps every other key it carries (allowedTools, history, and the
+  // rest of what Claude records per project), and only the trust flag is set.
+  for (const target of targets) {
+    let entry = projects[target];
+    if (entry === undefined || entry === null || typeof entry !== "object" || Array.isArray(entry)) {
+      entry = {};
+    }
+    entry.hasTrustDialogAccepted = true;
+    projects[target] = entry;
   }
-  entry.hasTrustDialogAccepted = true;
-  projects[worktree] = entry;
   // Unpredictable name plus an exclusive create: the config directory may be
   // writable by another local account, and a predictable path could be
   // pre-created there as a symlink that a plain write would follow into some
@@ -250,7 +316,9 @@ const attempt = () => {
     if (!renamed) fs.rmSync(tmp, { force: true });
   }
   const back = JSON.parse(fs.readFileSync(store, "utf8"));
-  return back.projects?.[worktree]?.hasTrustDialogAccepted === true ? "recorded" : "dropped";
+  return targets.every((target) => back.projects?.[target]?.hasTrustDialogAccepted === true)
+    ? "recorded"
+    : "dropped";
 };
 try {
   for (let i = 0; i < 3; i += 1) {
@@ -265,11 +333,13 @@ try {
   console.error(`error: ${err.message}`);
   process.exit(1);
 }
-console.error(`error: ${store} did not retain trust for ${worktree} after 3 attempts`);
+console.error(`error: ${store} did not retain trust for ${targets.join(" and ")} after 3 attempts`);
 process.exit(1);
 NODE
 then
-  refuse "could not record trust for '$WT_REAL' in '$STORE'"
+  refuse "could not record trust for '$WT_REAL' and its canonical root '$ROOT_REAL' in '$STORE'"
 fi
 
-echo "trusted: $WT_REAL"
+# Both registered paths, so a spawn log shows exactly what Claude's two checks
+# will find.
+echo "trusted: $WT_REAL (canonical root: $ROOT_REAL)"

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -284,10 +284,10 @@
 # park owns that home's supervision (docs/supervision-protocols/cursor.md).
 # claude is the one harness whose pre-launch setup can REFUSE the spawn: before
 # any per-task state exists, and before its worktree .claude/settings.local.json
-# hooks are written, a non-secondmate claude launch pre-registers the worktree in
-# the launching user's own Claude trust store through bin/fm-claude-trust.sh,
-# because Claude's interactive workspace-trust dialog gates a fresh worktree and
-# firstmate cannot answer it. That helper's header owns the structural scope test
+# hooks are written, a non-secondmate claude launch pre-registers the worktree
+# and its canonical git root in the launching user's own Claude trust store
+# through bin/fm-claude-trust.sh, because Claude's interactive workspace-trust
+# dialog gates a fresh worktree and firstmate cannot answer it. That helper's header owns the structural scope test
 # and every refusal; a failed registration stops this spawn rather than launching
 # a worker that would wedge on the dialog. A --secondmate launch never runs it,
 # so a claude secondmate home keeps its own one-time trust decision.
@@ -3109,11 +3109,11 @@ if [ "$RELAUNCH" -eq 0 ] && [ "$KIND" != secondmate ]; then
   freshen_spawn_worktree_base "$WT" || exit 1
 fi
 
-# Pre-register Claude's workspace trust for the worktree, at the first point the
-# worktree is known and before any per-task state is created below. The dialog
-# gates the pane before the brief is ever read, and it also gates loading the
-# project settings written further down, so nothing armed below takes effect
-# without it. bin/fm-claude-trust.sh owns the structural scope test and refuses
+# Pre-register Claude's workspace trust for the worktree and its canonical git
+# root, at the first point the worktree is known and before any per-task state
+# is created below. The dialog gates the pane before the brief is ever read, and
+# it also gates loading the project settings written further down, so nothing
+# armed below takes effect without it. bin/fm-claude-trust.sh owns the structural scope test and refuses
 # any path that is not this project's own isolated worktree; a refusal blocks the
 # spawn rather than launching a worker that would wedge on a dialog firstmate
 # cannot answer. Refusing here rather than beside the arm keeps this in the same

--- a/docs/verification/runtime-backends.md
+++ b/docs/verification/runtime-backends.md
@@ -300,7 +300,8 @@ That warning rendered in the same shape as the trust dialog, with the selection 
 That gate is not a production blocker, because a normal environment has already accepted it and the treatment arm above ran against the real config and saw neither dialog.
 This change does not address that warning and does not claim to.
 
-`bin/fm-spawn.sh` therefore pre-registers the task worktree through `bin/fm-claude-trust.sh` before launch, and `tests/fm-claude-trust.test.sh` pins both halves of the scope contract: a fresh worktree is trusted, and an out-of-scope path is refused.
+`bin/fm-spawn.sh` therefore pre-registers the task worktree, and since 2026-09-09 its canonical git root as well, through `bin/fm-claude-trust.sh` before launch, and `tests/fm-claude-trust.test.sh` pins both halves of the scope contract: a fresh worktree and its canonical root are trusted, and an out-of-scope path is refused.
+The arms above predate the canonical-root registration, so their success line names only the worktree and they observed only the plain dialog variant; the gated-grants variant that keys on the canonical root, owned by `.agents/skills/harness-adapters/references/harness/claude.md`, has no live suppression arm recorded here yet.
 That automated spawn case runs against a fake claude, so it asserts the store entry and the launch command and nothing more; the live arms above are what establish that the entry actually suppresses the dialog.
 The composer-classification record below observes the same gate from the other side, where an untrusted worktree left Claude, Grok, and Muse unverified because the guard reads a first-launch trust dialog as an unreadable composer.
 

--- a/tests/fm-claude-trust.test.sh
+++ b/tests/fm-claude-trust.test.sh
@@ -2,9 +2,10 @@
 # Behavior tests for bin/fm-claude-trust.sh and the claude spawn that calls it.
 #
 # Both halves of the contract are load-bearing and both are proven here: a
-# legitimate fresh task worktree is trusted so a claude worker reaches its
-# brief with no human, and every out-of-scope path is REFUSED rather than
-# warned about or quietly skipped.
+# legitimate fresh task worktree AND its canonical root (the primary checkout
+# Claude's gated-grants backstop keys trust on) are trusted so a claude worker
+# reaches its brief with no human, and every out-of-scope path is REFUSED
+# rather than warned about or quietly skipped.
 set -u
 
 # shellcheck source=tests/fixtures.sh
@@ -86,6 +87,12 @@ test_fresh_worktree_is_trusted() {
   expect_code 0 $? "a fresh linked worktree must be trusted: $out"
   assert_contains "$out" "trusted:" "registration did not report what it trusted"
   assert_trusted "$CONFIG/.claude.json" "$WT" "the worktree was not recorded as trusted"
+  # Claude's gated-grants backstop keys trust on the canonical git root, the
+  # primary checkout a linked worktree's .git file points at, so the worktree
+  # entry alone leaves a worker parked on that dialog variant.
+  assert_trusted "$CONFIG/.claude.json" "$PROJ" "the worktree's canonical root was not recorded as trusted"
+  assert_contains "$out" "$WT" "the success line did not name the worktree"
+  assert_contains "$out" "$PROJ" "the success line did not name the canonical root"
   # The staged write is renamed into place, so no temporary store may survive it.
   [ -z "$(find "$CONFIG" -maxdepth 1 -name '.claude.json.fm-trust.*' -print -quit)" ] \
     || fail "a temporary store file was left behind in the config directory"
@@ -101,6 +108,8 @@ test_registration_is_idempotent() {
   expect_code 0 $? "a repeat registration must succeed: $out"
   count=$(trusted_paths "$CONFIG/.claude.json" | grep -Fxc "$WT")
   [ "$count" = 1 ] || fail "a repeat registration duplicated the entry ($count)"
+  count=$(trusted_paths "$CONFIG/.claude.json" | grep -Fxc "$PROJ")
+  [ "$count" = 1 ] || fail "a repeat registration duplicated the canonical-root entry ($count)"
   pass "fm-claude-trust.sh: repeat registration is idempotent"
 }
 
@@ -262,6 +271,101 @@ test_worktree_subdirectory_is_refused() {
   assert_contains "$out" "is not a worktree root" "the refusal did not name the non-root path"
   assert_not_trusted "$CONFIG/.claude.json" "$sub" "a worktree subdirectory was trusted"
   pass "fm-claude-trust.sh: refuses a subdirectory of the worktree"
+}
+
+# The canonical root Claude's backstop keys on is the repository's MAIN
+# checkout, which is not always the project argument: a linked spawning home
+# (fm-spawn.sh's header) is a firstmate home that is itself a linked worktree
+# of the project repository, and spawns from it must keep launching. The
+# registered root must then be the main checkout, and the home's own path must
+# never be written, because Claude does not look there.
+test_linked_spawning_home_registers_the_repository_main_checkout() {
+  local rec out home_wt
+  rec=$(make_case linked-home)
+  read_case "$rec"
+  home_wt="$CASE_DIR/linked-home"
+  git -C "$PROJ" worktree add --quiet --detach "$home_wt" HEAD
+  out=$(run_trust "$CONFIG" "$WT" "$home_wt")
+  expect_code 0 $? "a spawn from a linked spawning home must still register: $out"
+  assert_trusted "$CONFIG/.claude.json" "$WT" "the worktree was not recorded for a linked spawning home"
+  assert_trusted "$CONFIG/.claude.json" "$PROJ" "the repository main checkout was not recorded as the canonical root"
+  assert_not_trusted "$CONFIG/.claude.json" "$home_wt" "the linked spawning home itself was trusted although Claude never keys on it"
+  assert_contains "$out" "$PROJ" "the success line did not name the main checkout as the canonical root"
+  pass "fm-claude-trust.sh: a linked spawning home registers the repository main checkout, not itself"
+}
+
+# The root is derived from git, never from the project argument's path: a
+# subdirectory of the primary shares its common dir and passes the project
+# check, and what gets written is still the checkout root.
+test_primary_subdirectory_as_project_registers_the_checkout_root() {
+  local rec out sub
+  rec=$(make_case subdir-project)
+  read_case "$rec"
+  sub="$PROJ/sub"
+  mkdir -p "$sub"
+  out=$(run_trust "$CONFIG" "$WT" "$sub")
+  expect_code 0 $? "a subdirectory of the primary named as the project must still register: $out"
+  assert_trusted "$CONFIG/.claude.json" "$PROJ" "the checkout root was not recorded as the canonical root"
+  assert_not_trusted "$CONFIG/.claude.json" "$sub" "the project argument's subdirectory was trusted instead of the checkout root"
+  pass "fm-claude-trust.sh: the canonical root comes from git, not from the project argument's path"
+}
+
+# A home directory that happens to hold the main checkout is still never a
+# standing trust grant, for the same reason it is refused as a worktree.
+test_home_directory_as_canonical_root_is_refused() {
+  local rec out home wt
+  rec=$(make_case home-root)
+  read_case "$rec"
+  home="$CASE_DIR/home-repo"
+  wt="$CASE_DIR/home-repo-wt"
+  fm_git_worktree "$home" "$wt" wt-home-root
+  out=$(run_trust "$CONFIG" "$wt" "$home" "$home")
+  expect_code 1 $? "a home directory as the canonical root must be refused: $out"
+  assert_contains "$out" "home directory" "the refusal did not name the home directory"
+  assert_not_trusted "$CONFIG/.claude.json" "$home" "the home directory was trusted as the canonical root"
+  assert_not_trusted "$CONFIG/.claude.json" "$wt" "the worktree was trusted although its canonical root was refused"
+  # The same pair is acceptable once the root is not HOME, so the home guard is
+  # what refused rather than an unrelated failure.
+  out=$(run_trust "$CONFIG" "$wt" "$home" "$CASE_DIR/elsewhere-home")
+  expect_code 0 $? "the same pair must be acceptable once the root is not HOME: $out"
+  assert_trusted "$CONFIG/.claude.json" "$home" "the canonical root was not recorded once it was no longer HOME"
+  pass "fm-claude-trust.sh: refuses a home directory as the canonical root"
+}
+
+# A bare repository has linked worktrees but no main checkout, so there is no
+# canonical root for Claude's backstop to find and nothing safe to guess at.
+test_bare_repository_worktree_is_refused() {
+  local rec out bare wt
+  rec=$(make_case bare)
+  read_case "$rec"
+  bare="$CASE_DIR/bare.git"
+  wt="$CASE_DIR/bare-wt"
+  git clone --quiet --bare "$PROJ" "$bare"
+  git -C "$bare" worktree add --quiet --detach "$wt" HEAD
+  out=$(run_trust "$CONFIG" "$wt" "$bare")
+  expect_code 1 $? "a worktree of a bare repository must be refused: $out"
+  assert_contains "$out" "bare" "the refusal did not say the repository has no main working tree"
+  assert_not_trusted "$CONFIG/.claude.json" "$wt" "a bare repository's worktree was trusted without a canonical root"
+  pass "fm-claude-trust.sh: refuses a worktree whose repository has no main checkout"
+}
+
+# A canonical-root entry usually already exists: firstmate itself opens the
+# primary checkout in Claude, and Claude records per-project state there.
+# Registration must only set the trust flag and leave every other key alone.
+test_existing_canonical_root_entry_keeps_its_other_keys() {
+  local rec store
+  rec=$(make_case preserve-root)
+  read_case "$rec"
+  store="$CONFIG/.claude.json"
+  node -e 'const [store, proj] = process.argv.slice(1); require("node:fs").writeFileSync(store, JSON.stringify({numStartups: 4, projects: {[proj]: {hasTrustDialogAccepted: false, allowedTools: ["Bash"], history: [{display: "hello"}], hasCompletedProjectOnboarding: true}}}) + "\n");' "$store" "$PROJ"
+  run_trust "$CONFIG" "$WT" "$PROJ" >/dev/null || fail "registration failed against a store holding the canonical root"
+  assert_trusted "$store" "$PROJ" "an existing canonical-root entry was not flipped to trusted"
+  assert_trusted "$store" "$WT" "the worktree was not recorded beside an existing canonical-root entry"
+  assert_store_value "$store" '["Bash"]' "the canonical root's allowedTools were lost" projects "$PROJ" allowedTools
+  assert_store_value "$store" '[{"display":"hello"}]' "the canonical root's history was lost" projects "$PROJ" history
+  assert_store_value "$store" true "the canonical root's onboarding flag was lost" projects "$PROJ" hasCompletedProjectOnboarding
+  assert_store_value "$store" 4 "an unrelated top-level value was changed" numStartups
+  pass "fm-claude-trust.sh: an existing canonical-root entry keeps its other keys"
 }
 
 test_unrelated_store_content_is_preserved() {
@@ -428,6 +532,8 @@ test_claude_spawn_pretrusts_its_worktree_and_reaches_the_brief() {
   expect_code 0 $? "the claude spawn must succeed: $out"
   assert_trusted "$config/.claude.json" "$wt" \
     "the claude spawn did not pre-register trust for its worktree"
+  assert_trusted "$config/.claude.json" "$proj" \
+    "the claude spawn did not pre-register trust for the worktree's canonical root"
   assert_present "$launch_log" "the claude spawn sent no launch command"
   assert_grep 'claude --dangerously-skip-permissions' "$launch_log" \
     "the launch command was not the claude worker launch"
@@ -452,6 +558,11 @@ test_non_git_directory_is_refused
 test_missing_directory_is_refused
 test_foreign_project_worktree_is_refused
 test_worktree_subdirectory_is_refused
+test_linked_spawning_home_registers_the_repository_main_checkout
+test_primary_subdirectory_as_project_registers_the_checkout_root
+test_home_directory_as_canonical_root_is_refused
+test_bare_repository_worktree_is_refused
+test_existing_canonical_root_entry_keeps_its_other_keys
 test_unrelated_store_content_is_preserved
 test_symlinked_store_to_a_foreign_owned_target_is_refused
 test_symlinked_store_to_an_owned_target_is_accepted

--- a/tests/fm-claude-trust.test.sh
+++ b/tests/fm-claude-trust.test.sh
@@ -344,7 +344,7 @@ test_bare_repository_worktree_is_refused() {
   git -C "$bare" worktree add --quiet --detach "$wt" HEAD
   out=$(run_trust "$CONFIG" "$wt" "$bare")
   expect_code 1 $? "a worktree of a bare repository must be refused: $out"
-  assert_contains "$out" "bare" "the refusal did not say the repository has no main working tree"
+  assert_contains "$out" "has no main working tree" "the refusal did not say the repository has no main working tree"
   assert_not_trusted "$CONFIG/.claude.json" "$wt" "a bare repository's worktree was trusted without a canonical root"
   pass "fm-claude-trust.sh: refuses a worktree whose repository has no main checkout"
 }


### PR DESCRIPTION
## Summary

`bin/fm-claude-trust.sh` now records `hasTrustDialogAccepted` for the task worktree AND its canonical git root, so a claude worker no longer parks on Claude Code's gated-grants workspace-trust prompt.

## The finding

Claude Code 2.1.266 runs two workspace-trust checks. The plain one walks up from cwd and accepts the worktree's own entry. The second is a backstop shown when the project's `.claude/settings.json` (or `settings.local.json`) carries `permissions.allow` rules or `additionalDirectories`, rendered as "This folder pre-approves N tool permissions in .claude/settings.json". It keys trust on the canonical git root: the main checkout a linked worktree's `.git` file points at, which for a firstmate worker is `projects/<name>`. That is exactly the path the script refuses as a worktree, so a worker whose worktree was pre-registered still parked on that variant. With trust accepted, that dialog's Escape ("No, continue without these permissions") continues the session without the project's allow rules rather than exiting.

## What changed

- The canonical root is registered unconditionally, not only when gated grants are present: Claude keys the gate on the root regardless of which file supplies the grants, a settings file can gain them between registration and launch, and the entry is harmless otherwise. The header records the reason.
- The root is derived from git's own main-working-tree listing for the already-validated worktree, never from an argument, and is written only after an owner proof: its top level is itself, its git dir is the shared common dir, and it is neither HOME nor the Claude config directory. The worktree scope test is unchanged. A linked spawning home (a firstmate home that is itself a linked worktree of the project repository, which `fm-spawn.sh` supports) registers the repository's main checkout rather than itself. A bare repository has no root and refuses.
- The success line names both registered paths. Atomic replacement and preservation of every unrelated key, including an existing canonical-root entry's other keys, are unchanged.
- `.agents/skills/harness-adapters/references/harness/claude.md` records the canonical-root keying, the dialog variant's wording, and that with trust accepted Escape means "continue without these permissions", so `fm-control interrupt` dismisses it. The "never answer the dialog with Enter" rule stays since the selection still starts on the No row.

## Validation

- `tests/fm-claude-trust.test.sh`: 25/25, including new cases for both entries recorded, an existing canonical-root entry keeping its other keys, the linked-spawning-home and subdirectory derivations, the HOME-as-root refusal, and the bare-repository refusal; the spawn test asserts both paths.
- `tests/fm-control-relaunch.test.sh` (53), `tests/fm-backlog-atomicity.test.sh` (87), `tests/fm-spawn-dispatch-profile.test.sh` (49), `tests/fm-trace-context-spawn.test.sh` (12): all pass.
- `bin/fm-lint.sh` clean with pinned ShellCheck 0.11.0 and actionlint 1.7.12; `bin/fm-doc-audience-check.sh` clean.
- no-mistakes v1.73.0 pipeline: review, test, and document passed with zero findings; the lint step was approved manually because the daemon host lacks ShellCheck on PATH while the pinned lint passes locally on this head. The pipeline's own commits are included (bare-repo detection from the full first porcelain record, and two documentation commits).
- Pushed from a fork because the pipeline's push credential has no upstream push access.
