### PR TITLE
fix: disable Codex memory for crewmates and scouts

### DIFF
--- a/.agents/skills/harness-adapters/references/harness/codex.md
+++ b/.agents/skills/harness-adapters/references/harness/codex.md
@@ -13,6 +13,7 @@ Verified on 2026-06-11 with codex-cli 0.139.0 unless a fact gives a newer versio
 | Resume | `codex resume <session-id>`, using the id printed on quit. |
 | Model flag | `--model <model>`. |
 | Effort flag | `-c 'model_reasoning_effort="<low\|medium\|high\|xhigh>"'`, verified on codex-cli 0.142.1 whose installed schema contains `model_reasoning_effort`, active config uses it, and bundled catalog advertises only these four values while omitting `max`. |
+| Memory | Crewmate and scout launches pass `--disable memories`, while secondmate launches keep the harness default; verified on 2026-09-09 with codex-cli 0.153.4: `codex features list --disable memories` and `codex -c 'features.memories=false' features list` both report `memories stable false`. |
 | Model discovery | Open the current interactive session's `/model` picker. |
 
 A directory trust dialog appears on the first run for a repository root: "Do you trust the contents of this directory?"

--- a/.agents/skills/harness-adapters/references/harness/codex.md
+++ b/.agents/skills/harness-adapters/references/harness/codex.md
@@ -13,7 +13,7 @@ Verified on 2026-06-11 with codex-cli 0.139.0 unless a fact gives a newer versio
 | Resume | `codex resume <session-id>`, using the id printed on quit. |
 | Model flag | `--model <model>`. |
 | Effort flag | `-c 'model_reasoning_effort="<low\|medium\|high\|xhigh>"'`, verified on codex-cli 0.142.1 whose installed schema contains `model_reasoning_effort`, active config uses it, and bundled catalog advertises only these four values while omitting `max`. |
-| Memory | Crewmate and scout launches pass `--disable memories`, while secondmate launches keep the harness default; verified on 2026-09-09 with codex-cli 0.153.4: `codex features list --disable memories` and `codex -c 'features.memories=false' features list` both report `memories stable false`. |
+| Memory | Crewmate and scout launches pass `--disable memories`, while secondmate launches keep the harness default; verified on 2026-09-09 with codex-cli 0.153.4: `codex features list --disable memories` and `codex -c 'features.memories=false' features list` both report `memories stable false`. A raw launch command is passed verbatim by design, so an operator-typed raw Codex launch must carry `--disable memories` itself. |
 | Model discovery | Open the current interactive session's `/model` picker. |
 
 A directory trust dialog appears on the first run for a repository root: "Do you trust the contents of this directory?"

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -1437,11 +1437,14 @@ launch_template() {
     # otherwise run with attribution back on; carrying it per launch keeps the
     # policy in force regardless of which settings scopes end up loaded.
     claude) printf '%s' 'CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false CLAUDE_CODE_SEND_FEEDBACK=0 claude --dangerously-skip-permissions --settings '\''{"feedbackDrafts":"off","attribution":{"commit":"","pr":"","sessionUrl":false}}'\'' __MODELFLAG____EFFORTFLAG__"$(__OPINPUT__ encode launch-brief < __BRIEF__)"' ;;
+    # Crew memory would inject the captain's personal registry into a fresh task
+    # worker and distil worker sessions back into it; disable it per launch,
+    # leaving the captain's own config and secondmate defaults untouched.
     codex)
       if [ "$kind" = secondmate ]; then
         printf '%s' 'codex __MODELFLAG____EFFORTFLAG__--dangerously-bypass-approvals-and-sandbox "$(__OPINPUT__ encode launch-brief < __BRIEF__)"'
       else
-        printf '%s' 'codex __MODELFLAG____EFFORTFLAG__--dangerously-bypass-approvals-and-sandbox -c "notify=[\"bash\",\"-c\",\"touch __TURNEND__\"]" "$(__OPINPUT__ encode launch-brief < __BRIEF__)"'
+        printf '%s' 'codex __MODELFLAG____EFFORTFLAG__--dangerously-bypass-approvals-and-sandbox --disable memories -c "notify=[\"bash\",\"-c\",\"touch __TURNEND__\"]" "$(__OPINPUT__ encode launch-brief < __BRIEF__)"'
       fi
       ;;
     opencode) printf '%s' 'OPENCODE_CONFIG_CONTENT='\''{"permission":{"*":"allow"}}'\'' opencode __MODELFLAG__--prompt "$(__OPINPUT__ encode launch-brief < __BRIEF__)"' ;;

--- a/tests/fm-secondmate-harness.test.sh
+++ b/tests/fm-secondmate-harness.test.sh
@@ -858,6 +858,7 @@ test_spawn_explicit_harness_does_not_inherit_secondmate_harness_tokens() {
   launch=$(cat "$launchlog")
   assert_contains "$launch" "codex --dangerously-bypass-approvals-and-sandbox" \
     "explicit-harness-no-tokens: launch did not use codex"
+  assert_not_contains "$launch" "--disable memories" "secondmate codex launch must keep its memory default"
   assert_not_contains "$launch" "--model" "explicit-harness-no-tokens: launch must not carry a --model flag"
   assert_not_contains "$launch" "model_reasoning_effort" \
     "explicit-harness-no-tokens: launch must not carry a codex effort flag"

--- a/tests/fm-spawn-dispatch-profile.test.sh
+++ b/tests/fm-spawn-dispatch-profile.test.sh
@@ -402,19 +402,27 @@ test_claude_threads_model_and_effort() {
 }
 
 test_codex_threads_model_and_effort() {
-  local rec id out status launch
-  id=profile-codex-z3
-  rec=$(make_spawn_case profile-codex codex "$id")
-  read_case_record "$rec"
+  local rec id out status launch kind
+  for kind in ship scout; do
+    id=profile-codex-$kind-z3
+    rec=$(make_spawn_case profile-codex-$kind codex "$id")
+    read_case_record "$rec"
 
-  out=$(run_ship_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" "$id" "$PROJ_DIR" --model gpt-5 --effort high)
-  status=$?
-  expect_code 0 "$status" "codex spawn with profile flags should succeed"
-  assert_meta_profile "$HOME_DIR/state/$id.meta" codex gpt-5 high
-  launch=$(cat "$LAUNCH_LOG")
-  assert_contains "$launch" "codex --model 'gpt-5' -c 'model_reasoning_effort=\"high\"' --dangerously-bypass-approvals-and-sandbox" \
-    "codex launch did not thread model and reasoning effort config"
-  pass "codex receives --model and model_reasoning_effort profile flags"
+    if [ "$kind" = ship ]; then
+      out=$(run_ship_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" "$id" "$PROJ_DIR" --model gpt-5 --effort high)
+      status=$?
+    else
+      out=$(run_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" "$id" "$PROJ_DIR" --scout --model gpt-5 --effort high)
+      status=$?
+    fi
+    expect_code 0 "$status" "codex spawn with profile flags should succeed"
+    assert_meta_profile "$HOME_DIR/state/$id.meta" codex gpt-5 high
+    launch=$(cat "$LAUNCH_LOG")
+    assert_contains "$launch" "codex --model 'gpt-5' -c 'model_reasoning_effort=\"high\"' --dangerously-bypass-approvals-and-sandbox" \
+      "codex launch did not thread model and reasoning effort config"
+    assert_contains "$launch" "--disable memories" "codex $kind launch must disable memories"
+    pass "codex $kind receives model/effort flags and disables memories"
+  done
 }
 
 test_codex_omits_invalid_max_effort() {


### PR DESCRIPTION
## Intent

Keep personal Codex memory out of disposable task workers by turning memory off for Codex crewmates and scouts at launch.
Personal memory belongs to the interactive user, while an isolated task worker should neither receive that cross-project registry nor feed its temporary work back into it.

Scope includes the canonical Codex crew launch command, its adapter reference, and executable launch-command regressions.
Persistent secondmates and personal Codex settings retain their defaults.
Raw commands remain verbatim; operators must supply the memory flag themselves.
Skill discovery, brief scaffolds, other harnesses, and user configuration are outside this change.

Acceptance criteria:

- Canonical ship and scout launches include `--disable memories`, including when model and effort options are supplied.
- Secondmate launches omit the override, and no personal Codex configuration is changed.
- Raw launch commands remain unmodified, with their memory-setting responsibility documented.
- Tests assert rendered launch commands through the public spawn interface; the targeted scripts and repository lint pass.

## What Changed

- `bin/fm-spawn.sh`: add `--disable memories` only to the canonical Codex crew launch branch and explain the per-launch isolation rationale.
- `.agents/skills/harness-adapters/references/harness/codex.md`: document the memory flag, verification commands, secondmate default, and raw-command exception.
- `tests/fm-spawn-dispatch-profile.test.sh`: exercise ship and scout launches separately and assert the memory flag alongside model and effort options.
- `tests/fm-secondmate-harness.test.sh`: assert that the rendered Codex secondmate launch omits the memory override.

## Choices made where the spec was silent

- Sound, high confidence: extend the existing model/effort test with a ship/scout loop so each worker kind renders its own launch command and must include the flag.
  This tests both routes through the public spawn interface without adding a runner.
- One cosmetic choice: place the memory flag after the existing sandbox option.
  This does not affect the specified behavior.

## Risk Assessment

Low severity: the runtime change adds one flag to the canonical Codex crew branch.
The secondmate command remains unchanged and its exclusion passed the executable regression; live raw-command probes confirmed verbatim behavior, and the isolated personal configuration remained unchanged.
Other harness branches and brief scaffolds are unchanged.
Live secondmate execution and authenticated model-turn behavior remain outside the validation performed.

## Testing

Reproduce-first evidence separates source comparison from runtime behavior: the base-to-head diff (`269f8fe6` to `ace5097c`) shows the canonical crew command lacked `--disable memories` on base and includes it after this change.
Live ship and scout processes then confirmed the new startup flag.
Running Codex `features list` with their exact startup options reported `memories stable false`; removing only the new flag reported `true`, reproducing the prior effective setting without claiming a separate live checkout of the base.

`bin/fm-lint.sh`
```text
fm-lint.sh: ShellCheck 0.11.0 (pinned 0.11.0)
fm-lint.sh: local changed-file mode; ShellCheck source following disabled
fm-lint-workflows.sh: actionlint 1.7.12 (pinned 1.7.12)
fm-lint-workflows.sh: 3 workflow files valid
```

`bin/fm-test-run.sh --jobs 1 tests/fm-spawn-dispatch-profile.test.sh tests/fm-secondmate-harness.test.sh`
```text
FM_TEST_END 2026-09-10T03:29:55Z tests/fm-spawn-dispatch-profile.test.sh exit=0 duration_ms=170819 gate_skip=false
FM_TEST_END 2026-09-10T03:33:07Z tests/fm-secondmate-harness.test.sh exit=0 duration_ms=192001 gate_skip=false
FM_TEST_SUMMARY total=2 failed=0 skipped_gate=0 duration_ms=362914
FM_TEST_SUMMARY_FAMILY family=backend-dispatch count=1 duration_ms=170819 failed=0
FM_TEST_SUMMARY_FAMILY family=secondmate count=1 duration_ms=192001 failed=0
```

Real tmux/Codex launches confirmed the ship/scout startup flag, including model and effort options.
Codex `features list` with those startup flags reported `memories stable false`; removing only the new flag reported `true`.
Raw launches reported `true` by default and `false` with the operator-supplied flag.
The isolated configuration remained unchanged.
No authenticated model turn was submitted; a prompt-content probe was inconclusive.
The secondmate launch exclusion passed the executable regression, but a live secondmate launch was not performed because its required home is outside the permitted worktree.

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"306f34f0033776d5389784de2f66f9a4625f88ae","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"running"},{"step":"pr","status":"pending"},{"step":"ci","status":"pending"}]} -->
