### PR TITLE
fix(herdr): recover gone and drifted worker endpoints

### DIFF
--- a/bin/backends/herdr.sh
+++ b/bin/backends/herdr.sh
@@ -2045,11 +2045,50 @@ fm_backend_herdr_tab_is_husk() {  # <session> <pane_id>
   esac
 }
 
+# fm_backend_herdr_server_running_state: whether the named session has a running
+# server, as running|stopped|unknown, read from `status --json`'s own tri-state
+# `.server.running`. `status` is the one command that answers with a
+# running=false BODY instead of refusing, so it works on exactly the sessions
+# whose operational calls cannot be reached at all.
+#
+# The verdict rests on that field rather than on the `server_not_running` error
+# code an operational call happens to return, because the field is version
+# stable across the supported range while the code is not (verified on 0.8.2
+# protocol 20 and 0.9.0 protocol 22 - docs/verification/runtime-backends.md).
+fm_backend_herdr_server_running_state() {  # <session>
+  local session=$1 status
+  command -v jq >/dev/null 2>&1 || { printf 'unknown'; return 0; }
+  status=$(fm_backend_herdr_cli "$session" status --json 2>/dev/null) || {
+    printf 'unknown'
+    return 0
+  }
+  printf '%s' "$status" | jq -r '
+    if .server.running == true then "running"
+    elif .server.running == false then "stopped"
+    else "unknown"
+    end
+  ' 2>/dev/null || printf 'unknown'
+}
+
 # fm_backend_herdr_agent_state: recovery-grade state for the same session-start
 # sweep as the tmux classifier. It reuses the husk classifier rather than
 # creating a second Herdr state machine: a structurally gone pane is `missing`,
 # a confirmed agent-less pane is `dead`, a registered agent is `alive`, and an
 # unexpected or failed API read is `unreadable`.
+#
+# One exception to that last case, and it is deliberately made HERE rather than
+# in the husk classifier: a read can fail because the recorded session's server
+# is not running at all, which is authoritative absence for every pane in that
+# session rather than an ambiguous answer about one of them. Treating it as
+# `unreadable` stranded tasks with no sanctioned recovery (issue #4091), so a
+# positively stopped server reads `missing` instead.
+#
+# Only this recovery-grade read is widened. fm_backend_herdr_pane_agent_state
+# and the presence classifier under it stay strict, so husk detection, duplicate
+# prevention, rollback, and teardown - which can DESTROY things - keep refusing
+# on exactly the reads they refused on before. A server that is running, or
+# whose state cannot itself be read, still yields `unreadable` here too: absence
+# is claimed only from positive evidence of it.
 fm_backend_herdr_agent_state() {  # <target>
   local target=$1
   fm_backend_herdr_parse_target "$target" || { printf 'unreadable'; return 0; }
@@ -2057,7 +2096,12 @@ fm_backend_herdr_agent_state() {  # <target>
     dead) printf 'missing' ;;
     no-agent) printf 'dead' ;;
     live) printf 'alive' ;;
-    *) printf 'unreadable' ;;
+    *)
+      case "$(fm_backend_herdr_server_running_state "$FM_BACKEND_HERDR_SESSION")" in
+        stopped) printf 'missing' ;;
+        *) printf 'unreadable' ;;
+      esac
+      ;;
   esac
 }
 

--- a/bin/fm-backend.sh
+++ b/bin/fm-backend.sh
@@ -886,8 +886,9 @@ fm_backend_target_exists() {  # <backend> <target> [expected-label]
 #   unverified - this backend has no recovery classifier.
 # Only `dead` and `missing` license recovery. The tmux adapter requires a
 # successful session inventory and returns `missing` only when it omits the
-# exact window; the Herdr adapter reuses its husk
-# classifier. Zellij remains unverified because its secondmate ghost-tab and
+# exact window; the Herdr adapter reuses its strict husk classifier, then maps
+# a positively stopped session server to `missing` only in this recovery-grade
+# view. Zellij remains unverified because its secondmate ghost-tab and
 # agent-process recovery path has not been empirically validated. Orca and cmux
 # do not support secondmate spawns.
 fm_backend_agent_state() {  # <backend> <target>

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -39,9 +39,10 @@
 #   model, and effort may change, which is what makes a harness switch one
 #   ordinary relaunch. It refuses unless the recorded endpoint is positively
 #   agent-free on a backend with a recovery-grade agent-state classifier (tmux
-#   or herdr), refuses unless the endpoint's shell is sitting in the recorded
-#   worktree, and clears the previous harness's per-task wiring before arming
-#   the new incarnation.
+#   or herdr), and clears the previous harness's per-task wiring before arming
+#   the new incarnation. The replacement still never starts outside the copy
+#   holding the work: a shell that has drifted out of the recorded worktree is
+#   told once to return, and only a shell that will not go refuses.
 #   --harness <name> is the explicit per-spawn harness/profile adapter. The old
 #   positional harness arg still works for back-compat.
 #   --model <name> and --effort <low|medium|high|xhigh|max|ultra> are concrete profile
@@ -3033,15 +3034,33 @@ if [ "$RELAUNCH" -eq 1 ]; then
   # than wherever the pane happened to drift.
   relaunch_wt_real=$(real_path_or_raw "$WT")
   relaunch_seen=
-  for _ in $(seq 1 10); do
-    relaunch_seen=$(spawn_current_path "$WT_TARGET" || true)
+  relaunch_rehomed=0
+  while :; do
+    for _ in $(seq 1 10); do
+      relaunch_seen=$(spawn_current_path "$WT_TARGET" || true)
+      [ -z "$relaunch_seen" ] || [ "$(real_path_or_raw "$relaunch_seen")" != "$relaunch_wt_real" ] || break
+      sleep 0.5
+    done
     [ -z "$relaunch_seen" ] || [ "$(real_path_or_raw "$relaunch_seen")" != "$relaunch_wt_real" ] || break
-    sleep 0.5
+    # Drift is recoverable, not disqualifying. An agent's own exit leaves an
+    # ordinary shell behind and that shell wanders - the harness's exit, a `cd`
+    # the previous worker ran, or a login shell that re-homed on restart all
+    # move it out of the worktree while the work itself sits untouched on disk.
+    # Refusing outright left such a task with no sanctioned way back, so the
+    # shell is told once to return and only a shell that will not go refuses.
+    if [ "$relaunch_rehomed" -eq 1 ]; then
+      echo "error: task $ID's endpoint is in '${relaunch_seen:-unknown}' and did not return to its recorded worktree '$WT' when told to; refusing to relaunch an agent outside the copy holding its work" >&2
+      exit 1
+    fi
+    relaunch_rehomed=1
+    # Single-quote the path and escape any embedded quote, so a worktree path
+    # with a space or a quote in it cannot become two words in the pane's shell.
+    relaunch_cd_path=${WT//\'/\'\\\'\'}
+    spawn_send_text_line "$WT_TARGET" "cd -- '$relaunch_cd_path'" || {
+      echo "error: task $ID's endpoint is in '${relaunch_seen:-unknown}' and could not be told to return to its recorded worktree '$WT'; refusing to relaunch an agent outside the copy holding its work" >&2
+      exit 1
+    }
   done
-  if [ -z "$relaunch_seen" ] || [ "$(real_path_or_raw "$relaunch_seen")" != "$relaunch_wt_real" ]; then
-    echo "error: task $ID's endpoint is in '${relaunch_seen:-unknown}', not its recorded worktree '$WT'; refusing to relaunch an agent outside the copy holding its work" >&2
-    exit 1
-  fi
   [ "$KIND" = secondmate ] || validate_spawn_worktree "relaunch" "$T"
 elif [ "$KIND" != secondmate ] && [ "$BACKEND" != orca ]; then
   spawn_send_text_line "$WT_TARGET" 'treehouse get'

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -41,8 +41,8 @@
 #   agent-free on a backend with a recovery-grade agent-state classifier (tmux
 #   or herdr), and clears the previous harness's per-task wiring before arming
 #   the new incarnation. The replacement still never starts outside the copy
-#   holding the work: a shell that has drifted out of the recorded worktree is
-#   told once to return, and only a shell that will not go refuses.
+#   holding the work: a Herdr shell that has drifted out of the recorded
+#   worktree is told once to return, and only a shell that will not go refuses.
 #   --harness <name> is the explicit per-spawn harness/profile adapter. The old
 #   positional harness arg still works for back-compat.
 #   --model <name> and --effort <low|medium|high|xhigh|max|ultra> are concrete profile
@@ -3034,33 +3034,31 @@ if [ "$RELAUNCH" -eq 1 ]; then
   # than wherever the pane happened to drift.
   relaunch_wt_real=$(real_path_or_raw "$WT")
   relaunch_seen=
-  relaunch_rehomed=0
-  while :; do
-    for _ in $(seq 1 10); do
-      relaunch_seen=$(spawn_current_path "$WT_TARGET" || true)
-      [ -z "$relaunch_seen" ] || [ "$(real_path_or_raw "$relaunch_seen")" != "$relaunch_wt_real" ] || break
-      sleep 0.5
-    done
+  for _ in $(seq 1 10); do
+    relaunch_seen=$(spawn_current_path "$WT_TARGET" || true)
     [ -z "$relaunch_seen" ] || [ "$(real_path_or_raw "$relaunch_seen")" != "$relaunch_wt_real" ] || break
-    # Drift is recoverable, not disqualifying. An agent's own exit leaves an
-    # ordinary shell behind and that shell wanders - the harness's exit, a `cd`
-    # the previous worker ran, or a login shell that re-homed on restart all
-    # move it out of the worktree while the work itself sits untouched on disk.
-    # Refusing outright left such a task with no sanctioned way back, so the
-    # shell is told once to return and only a shell that will not go refuses.
-    if [ "$relaunch_rehomed" -eq 1 ]; then
-      echo "error: task $ID's endpoint is in '${relaunch_seen:-unknown}' and did not return to its recorded worktree '$WT' when told to; refusing to relaunch an agent outside the copy holding its work" >&2
+    sleep 0.5
+  done
+  if [ -z "$relaunch_seen" ] || [ "$(real_path_or_raw "$relaunch_seen")" != "$relaunch_wt_real" ]; then
+    if [ "$BACKEND" != herdr ]; then
+      echo "error: task $ID's endpoint is in '${relaunch_seen:-unknown}', not its recorded worktree '$WT'; refusing to relaunch an agent outside the copy holding its work" >&2
       exit 1
     fi
-    relaunch_rehomed=1
-    # Single-quote the path and escape any embedded quote, so a worktree path
-    # with a space or a quote in it cannot become two words in the pane's shell.
     relaunch_cd_path=${WT//\'/\'\\\'\'}
     spawn_send_text_line "$WT_TARGET" "cd -- '$relaunch_cd_path'" || {
       echo "error: task $ID's endpoint is in '${relaunch_seen:-unknown}' and could not be told to return to its recorded worktree '$WT'; refusing to relaunch an agent outside the copy holding its work" >&2
       exit 1
     }
-  done
+    for _ in $(seq 1 10); do
+      relaunch_seen=$(spawn_current_path "$WT_TARGET" || true)
+      [ -z "$relaunch_seen" ] || [ "$(real_path_or_raw "$relaunch_seen")" != "$relaunch_wt_real" ] || break
+      sleep 0.5
+    done
+    if [ -z "$relaunch_seen" ] || [ "$(real_path_or_raw "$relaunch_seen")" != "$relaunch_wt_real" ]; then
+      echo "error: task $ID's endpoint is in '${relaunch_seen:-unknown}' and did not return to its recorded worktree '$WT' when told to; refusing to relaunch an agent outside the copy holding its work" >&2
+      exit 1
+    fi
+  fi
   [ "$KIND" = secondmate ] || validate_spawn_worktree "relaunch" "$T"
 elif [ "$KIND" != secondmate ] && [ "$BACKEND" != orca ]; then
   spawn_send_text_line "$WT_TARGET" 'treehouse get'

--- a/docs/agent-control.md
+++ b/docs/agent-control.md
@@ -99,7 +99,8 @@ Switching harness is therefore one ordinary relaunch rather than a separate mech
   zellij, orca, and cmux are refused rather than reported as successful blind.
 - An ambiguous or unreadable endpoint state refuses.
   Only a positively classified state acts.
-- `fm-spawn --relaunch` independently refuses unless the recorded endpoint is positively agent-free and its shell is sitting in the recorded worktree, so a replacement can never join a live agent or start outside the copy holding the work.
+- `fm-spawn --relaunch` independently refuses unless the recorded endpoint is positively agent-free, so a replacement can never join a live agent.
+  It also requires the shell to be in the recorded worktree: tmux refuses immediately when it is not, while Herdr sends one `cd` to the recorded path and refuses unless a subsequent path read confirms the move.
 
 ## Capability matrix
 

--- a/docs/herdr-backend.md
+++ b/docs/herdr-backend.md
@@ -278,8 +278,9 @@ A restored same-labeled tab with a missing pane or no registered agent is a husk
 Create replaces only a confidently dead or no-agent husk, creates the replacement before closing the old tab, and refuses live or unknown states.
 This prevents closing the workspace's last tab before a replacement exists.
 
-The generic Herdr agent-liveness probe reuses the same classifier.
-A structurally gone pane becomes `missing`, a restored agent-less shell becomes `dead`, a registered agent becomes `alive`, and an unexpected read becomes `unreadable`.
+The generic Herdr agent-liveness probe reuses the same pane classifier, then applies one recovery-only exception.
+A structurally gone pane or a pane read from a session positively reported as having no running server becomes `missing`, a restored agent-less shell becomes `dead`, a registered agent becomes `alive`, and every other unexpected read becomes `unreadable`.
+The stopped-server exception does not widen husk detection or any close authority; those paths still refuse an unreadable pane.
 Unlike tmux process-name inspection, native registration can classify Pi without guessing from a generic interpreter name.
 
 The session-start sweep uses this probe.
@@ -349,6 +350,7 @@ tests/fm-backend-herdr-workspace-per-home-e2e.test.sh
 tests/fm-backend-herdr-launcher-workspace-e2e.test.sh
 tests/fm-backend-herdr-presentation-e2e.test.sh
 tests/fm-backend-herdr-eventwait-smoke.test.sh
+tests/fm-control-herdr-smoke.test.sh
 tests/fm-herdr-session-cleanup.test.sh
 tests/fm-herdr-session-cleanup-e2e.test.sh
 tests/fm-afk-inject-herdr-e2e.test.sh

--- a/docs/verification/runtime-backends.md
+++ b/docs/verification/runtime-backends.md
@@ -1051,7 +1051,7 @@ endpoint in a session with no server missing
 malformed target                     unreadable
 ```
 
-The same run drove `bin/fm-spawn.sh --relaunch` against a real Herdr pane whose shell had been moved to `/`: the shell was told once to return, ended in the recorded worktree, and the replacement was launched into the SAME pane, leaving one task tab.
+The same run drove `bin/fm-spawn.sh --relaunch` against a real Herdr pane whose shell had been moved outside its recorded worktree: the shell was told once to return, ended in the recorded worktree, and the replacement was launched into the SAME pane, leaving one task tab.
 
 Herdr 0.8.x is not installed on this host, so protocol-20 coverage is structural plus the adapter fixture exercising both response shapes; it is not a live result.
 Refresh the live half, which fails naming the installed version, with:
@@ -1064,10 +1064,13 @@ Observed 2026-09-10:
 
 ```text
 ok - real herdr 0.9.0: a gone session reads recoverable while a live pane and a malformed target do not
+ok - real herdr: a drifted agent-free shell returns to its worktree and reuses the same endpoint
 ```
 
 `tests/fm-backend-herdr.test.sh` pins the logic portably by driving the two signals apart - the same failed pane read yields `missing` under a stopped server and `unreadable` under a running one - and asserts that the husk classifier still refuses on that identical read.
-`tests/fm-control-relaunch.test.sh` pins the drifted-shell relaunch: the shell is told to return and the same endpoint is reused, while a shell that will not move still refuses.
+`tests/fm-control-herdr-smoke.test.sh` proves the Herdr-only drift recovery against a real binary in an isolated lab session.
+`tests/fm-control-relaunch.test.sh` drives a tmux stub and proves that tmux retains its prior refusal without sending `cd` or any other input to the pane.
+The Herdr refusal when a shell accepts the command but does not move is not exercised in this change.
 
 ### Away-mode transport
 

--- a/docs/verification/runtime-backends.md
+++ b/docs/verification/runtime-backends.md
@@ -1025,6 +1025,50 @@ ok - real herdr: an agent that does not stop fails closed instead of being repor
 The registry read through `herdr pane report-agent` is the same source `fm_backend_herdr_agent_state` classifies, so registering and not registering an agent on a plain shell pane exercises exactly the gate every lifecycle verb depends on, with no real agent launched.
 That command is the guard that refreshes this record; run it after every Herdr upgrade rather than trusting the version above.
 
+### Endpoint recovery classification
+
+Measured 2026-09-10 on macOS aarch64 against Herdr 0.9.0 (protocol 22) in an isolated `fm-lab-` session.
+
+An endpoint recorded in a session whose server is not running cannot be read by any operational call, and `status` is the one command that answers with a body instead of refusing:
+
+```sh
+herdr pane get w1:p2 --session fm-lab-never-started
+herdr status --json --session fm-lab-never-started | jq -c "{running: .server.running, status: .server.status}"
+```
+
+```text
+{"id":"cli:pane:get","error":{"code":"server_not_running","message":"no herdr server is running at /Users/kunchen/.config/herdr/sessions/fm-lab-never-started/herdr.sock; run `herdr session attach fm-lab-never-started` to start or attach it"}}
+{"running":false,"status":"not_running"}
+```
+
+`fm_backend_herdr_agent_state` therefore settles an uninterpretable pane read with `.server.running` rather than with the `server_not_running` error code, which keeps the verdict working across the supported range: the field is present on 0.8.2 protocol 20 and 0.9.0 protocol 22 alike (measured in "Client selection" above), while the code is not.
+Only that recovery-grade read is widened; the husk classifier under it stays strict, because it licenses closing panes.
+Observed in the lab, in one run:
+
+```text
+live agent-free pane                 dead
+endpoint in a session with no server missing
+malformed target                     unreadable
+```
+
+The same run drove `bin/fm-spawn.sh --relaunch` against a real Herdr pane whose shell had been moved to `/`: the shell was told once to return, ended in the recorded worktree, and the replacement was launched into the SAME pane, leaving one task tab.
+
+Herdr 0.8.x is not installed on this host, so protocol-20 coverage is structural plus the adapter fixture exercising both response shapes; it is not a live result.
+Refresh the live half, which fails naming the installed version, with:
+
+```sh
+tests/fm-control-herdr-smoke.test.sh
+```
+
+Observed 2026-09-10:
+
+```text
+ok - real herdr 0.9.0: a gone session reads recoverable while a live pane and a malformed target do not
+```
+
+`tests/fm-backend-herdr.test.sh` pins the logic portably by driving the two signals apart - the same failed pane read yields `missing` under a stopped server and `unreadable` under a running one - and asserts that the husk classifier still refuses on that identical read.
+`tests/fm-control-relaunch.test.sh` pins the drifted-shell relaunch: the shell is told to return and the same endpoint is reused, while a shell that will not move still refuses.
+
 ### Away-mode transport
 
 The away daemon is no longer launched on Pi; the away posture there is the record `bin/fm-afk-contract.sh` owns.

--- a/tests/fm-backend-herdr.test.sh
+++ b/tests/fm-backend-herdr.test.sh
@@ -353,6 +353,64 @@ run_with_clients() {  # <dir> <path> <body>
     bash -c ". \"\$0/bin/backends/herdr.sh\"; $body" "$ROOT"
 }
 
+# The #4091 widening, and the boundary it is deliberately confined to.
+#
+# A recovery-grade read that cannot confirm the pane is `missing` only when the
+# session's server is POSITIVELY stopped - absence for that whole session -
+# and stays `unreadable` otherwise. The two signals are driven apart here on
+# purpose: the SAME failed pane read is settled two ways by the server state
+# alone, so the case cannot go quietly vacuous if one signal stops being read.
+#
+# The second half matters as much as the first: the widening must not reach the
+# husk classifier under it, because that one licenses CLOSING panes.
+test_recovery_grade_read_widens_only_at_its_own_boundary() {
+  local dir log resp fb gone running husk
+
+  herdr_state_with_server() {  # <dir-suffix> <server-running-json>
+    local dir="$TMP_ROOT/recovery-widen-$1" resp log fb
+    mkdir -p "$dir/responses"; resp="$dir/responses"; log="$dir/log"; : > "$log"
+    # 1: the pane read, failing in a way this parse cannot interpret.
+    printf 'Error: socket unavailable\n' > "$resp/1.out"
+    printf '1\n' > "$resp/1.exit"
+    # 2: the server-state read that settles it.
+    printf '{"client":{"protocol":22},"server":{"running":%s}}\n' "$2" > "$resp/2.out"
+    fb=$(make_herdr_fakebin "$dir")
+    PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" FM_HERDR_SCRIPT_STATUS=1 \
+      bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_agent_state fmtest:w1:p2' "$ROOT"
+  }
+
+  gone=$(herdr_state_with_server gone false)
+  running=$(herdr_state_with_server running true)
+  [ "$gone" = missing ] \
+    || fail "an uninterpretable pane read against a positively stopped server must read missing, got '$gone'"
+  [ "$running" = unreadable ] \
+    || fail "an uninterpretable pane read against a RUNNING server must stay unreadable, got '$running'"
+  [ "$gone" != "$running" ] \
+    || fail "the server-state signal is not being consulted: both verdicts are '$gone'"
+
+  # An unreadable server state is not evidence of absence either.
+  dir="$TMP_ROOT/recovery-widen-unknown"; mkdir -p "$dir/responses"; resp="$dir/responses"; log="$dir/log"; : > "$log"
+  printf 'Error: socket unavailable\n' > "$resp/1.out"; printf '1\n' > "$resp/1.exit"
+  printf 'not json at all\n' > "$resp/2.out"; printf '1\n' > "$resp/2.exit"
+  fb=$(make_herdr_fakebin "$dir")
+  out=$(PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" FM_HERDR_SCRIPT_STATUS=1 \
+    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_agent_state fmtest:w1:p2' "$ROOT")
+  [ "$out" = unreadable ] \
+    || fail "a server state that cannot itself be read must keep the conservative verdict, got '$out'"
+
+  # The confinement: the husk classifier sees the SAME stopped-server read and
+  # must still refuse, because it is what licenses closing a pane.
+  dir="$TMP_ROOT/recovery-widen-husk"; mkdir -p "$dir/responses"; resp="$dir/responses"; log="$dir/log"; : > "$log"
+  printf 'Error: socket unavailable\n' > "$resp/1.out"; printf '1\n' > "$resp/1.exit"
+  printf '{"client":{"protocol":22},"server":{"running":false}}\n' > "$resp/2.out"
+  fb=$(make_herdr_fakebin "$dir")
+  husk=$(PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" FM_HERDR_SCRIPT_STATUS=1 \
+    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_pane_agent_state fmtest w1:p2; printf " "; fm_backend_herdr_tab_is_husk fmtest w1:p2 && printf husk || printf refused' "$ROOT")
+  [ "$husk" = "unknown refused" ] \
+    || fail "the stopped-server rule leaked into the husk classifier, which licenses closing panes: got '$husk'"
+  pass "herdr recovery-grade read: a stopped server means missing there, and nowhere else"
+}
+
 test_agent_state_bypasses_a_stale_client_shadowing_a_compatible_one() {
   local dir out err
   dir="$TMP_ROOT/client-pair-bypass"; make_herdr_client_pair "$dir"
@@ -4667,6 +4725,7 @@ test_workspace_label_empty_marker_falls_back_to_primary
 test_workspace_label_different_secondmates_get_different_labels
 test_cli_helper_sets_env_and_appends_trailing_session_flag
 test_agent_state_bypasses_a_stale_client_shadowing_a_compatible_one
+test_recovery_grade_read_widens_only_at_its_own_boundary
 test_cli_caches_the_selected_client_within_a_process
 test_cli_scopes_the_selected_client_to_its_session
 test_cli_unrelated_failure_never_triggers_reselection

--- a/tests/fm-control-herdr-smoke.test.sh
+++ b/tests/fm-control-herdr-smoke.test.sh
@@ -104,6 +104,44 @@ case "$OUT" in
 esac
 pass "real herdr: exit on a pane with no registered agent is idempotent success"
 
+# --- the recovery-grade read, against the real binary ------------------------
+#
+# The classification that decides whether a task can be recovered at all is read
+# out of what herdr actually answers, so a stub can only confirm the assumption
+# already written into the stub. Its logic is pinned portably in
+# tests/fm-backend-herdr.test.sh; this is the check that notices when the real
+# client stops answering the way that logic expects, and it names the version so
+# a release change is attributed rather than mysterious.
+HERDR_VERSION=$(herdr --version 2>&1 | head -1)
+HERDR_VERSION=${HERDR_VERSION#herdr }
+version_fail() {  # <message>
+  fail "$1 [herdr $HERDR_VERSION]"
+}
+
+STATE=$(fm_backend_agent_state herdr "$SESSION:$PANE_ID")
+[ "$STATE" = dead ] \
+  || version_fail "a real, present, agent-free pane reads '$STATE' rather than 'dead'; every relaunch would be refused"
+
+# `status --json` is the second signal, and the only one that answers for a
+# session whose operational calls cannot be reached at all. A release that drops
+# or renames `.server.running` would silently make every gone endpoint
+# unrecoverable again, so it is asserted by name on both a live and an absent
+# session.
+[ "$(fm_backend_herdr_server_running_state "$SESSION")" = running ] \
+  || version_fail "this run's own live lab session does not report .server.running=true through status --json"
+[ "$(fm_backend_herdr_server_running_state "fm-lab-never-started-$$")" = stopped ] \
+  || version_fail "a session with no server does not report .server.running=false, so authoritative absence can no longer be told from an unreadable read"
+
+# Issue #4091's exact stranding shape: an endpoint recorded in a session whose
+# server is not running used to read `unreadable` and block recovery.
+[ "$(fm_backend_agent_state herdr "fm-lab-never-started-$$:w1:p2")" = missing ] \
+  || version_fail "an endpoint in a session with no running server is not classified as recoverable"
+
+# And the safety direction: an uninterpretable read must never license recovery.
+[ "$(fm_backend_agent_state herdr "no-separator-here")" = unreadable ] \
+  || version_fail "a malformed endpoint target does not stay unreadable"
+pass "real herdr $HERDR_VERSION: a gone session reads recoverable while a live pane and a malformed target do not"
+
 if OUT=$(run_control hsmoke interrupt 2>&1); then
   fail "interrupt should refuse when herdr reports no agent on the pane: $OUT"
 fi

--- a/tests/fm-control-herdr-smoke.test.sh
+++ b/tests/fm-control-herdr-smoke.test.sh
@@ -44,7 +44,14 @@ SCRATCH=$(mktemp -d "${TMPDIR:-/tmp}/fm-control-herdr.XXXXXX")
 SCRATCH=$(cd "$SCRATCH" && pwd)
 HOME_DIR="$SCRATCH/home"
 mkdir -p "$HOME_DIR/state" "$HOME_DIR/data/hsmoke"
-printf '# brief\n' > "$HOME_DIR/data/hsmoke/brief.md"
+cat > "$HOME_DIR/data/hsmoke/brief.md" <<'EOF'
+# Task
+## Captain's intent
+Exercise Herdr lifecycle control safely.
+
+## Firstmate spec
+Keep the isolated endpoint and worktree intact.
+EOF
 
 # A real git worktree so the control plane's checkpoint has a real local copy.
 PROJ="$SCRATCH/proj"
@@ -55,6 +62,8 @@ printf '# proj\n' > "$PROJ/README.md"
 git -C "$PROJ" add README.md
 git -C "$PROJ" -c user.name='Firstmate Tests' -c user.email='tests@example.invalid' commit -qm initial
 git -C "$PROJ" worktree add --quiet -b hsmoke "$WT"
+PROJ_REAL=$(cd "$PROJ" && pwd -P)
+WT_REAL=$(cd "$WT" && pwd -P)
 
 # shellcheck source=/dev/null
 . "$ROOT/bin/fm-backend.sh"
@@ -90,7 +99,7 @@ EOF
 } > "$HOME_DIR/state/hsmoke.meta"
 
 run_control() {
-  env FM_HOME="$HOME_DIR" HERDR_SESSION="$SESSION" \
+  env FM_HOME="$HOME_DIR" HERDR_SESSION="$SESSION" FM_SPAWN_NO_GUARD=1 \
     FM_CONTROL_POLL=0.2 FM_CONTROL_EXIT_WAIT=2 \
     "$ROOT/bin/fm-control.sh" "$@" 2>&1
 }
@@ -141,6 +150,45 @@ STATE=$(fm_backend_agent_state herdr "$SESSION:$PANE_ID")
 [ "$(fm_backend_agent_state herdr "no-separator-here")" = unreadable ] \
   || version_fail "a malformed endpoint target does not stay unreadable"
 pass "real herdr $HERDR_VERSION: a gone session reads recoverable while a live pane and a malformed target do not"
+
+FAKEBIN="$SCRATCH/fakebin"
+mkdir -p "$FAKEBIN"
+cat > "$FAKEBIN/codex" <<EOF
+#!/usr/bin/env bash
+: > "$SCRATCH/codex-launched"
+EOF
+chmod +x "$FAKEBIN/codex"
+printf -v FAKEBIN_Q '%q' "$FAKEBIN"
+printf -v PROJ_Q '%q' "$PROJ"
+fm_backend_herdr_send_text_line "$SESSION:$PANE_ID" "export PATH=$FAKEBIN_Q:\$PATH" \
+  || fail "could not put the inert test harness on the pane PATH"
+fm_backend_herdr_send_text_line "$SESSION:$PANE_ID" "cd -- $PROJ_Q" \
+  || fail "could not move the agent-free pane out of its recorded worktree"
+for _ in $(seq 1 20); do
+  [ "$(fm_backend_herdr_current_path "$SESSION:$PANE_ID" 2>/dev/null || true)" != "$PROJ_REAL" ] || break
+  sleep 0.1
+done
+[ "$(fm_backend_herdr_current_path "$SESSION:$PANE_ID" 2>/dev/null || true)" = "$PROJ_REAL" ] \
+  || fail "the real Herdr pane did not drift out of its recorded worktree"
+
+OUT=$(env FM_HOME="$HOME_DIR" HERDR_SESSION="$SESSION" FM_SPAWN_NO_GUARD=1 \
+  "$ROOT/bin/fm-spawn.sh" hsmoke --relaunch --harness codex) \
+  || fail "a drifted, agent-free Herdr pane should be re-homed and relaunched: $OUT"
+for _ in $(seq 1 20); do
+  [ ! -e "$SCRATCH/codex-launched" ] || break
+  sleep 0.1
+done
+[ -e "$SCRATCH/codex-launched" ] || fail "the replacement harness was not launched"
+[ "$(fm_backend_herdr_current_path "$SESSION:$PANE_ID" 2>/dev/null || true)" = "$WT_REAL" ] \
+  || fail "the relaunched Herdr shell did not end up in its recorded worktree"
+[ "$(sed -n 's/^window=//p' "$HOME_DIR/state/hsmoke.meta" | tail -1)" = "$SESSION:$PANE_ID" ] \
+  || fail "the Herdr relaunch replaced its endpoint instead of reusing it"
+herdr pane get "$PANE_ID" --session "$SESSION" >/dev/null 2>&1 \
+  || fail "the Herdr relaunch removed the endpoint it was required to reuse"
+awk -F= '$1 == "harness" {$0="harness=claude"} {print}' "$HOME_DIR/state/hsmoke.meta" \
+  > "$HOME_DIR/state/hsmoke.meta.tmp"
+mv "$HOME_DIR/state/hsmoke.meta.tmp" "$HOME_DIR/state/hsmoke.meta"
+pass "real herdr: a drifted agent-free shell returns to its worktree and reuses the same endpoint"
 
 if OUT=$(run_control hsmoke interrupt 2>&1); then
   fail "interrupt should refuse when herdr reports no agent on the pane: $OUT"

--- a/tests/fm-control-relaunch.test.sh
+++ b/tests/fm-control-relaunch.test.sh
@@ -83,17 +83,6 @@ case "${1:-}" in
     else
       printf '%s\n' "$payload" >> "$D/keys"
       case "$payload" in
-        # The stub models the pane's shell, so a cd actually moves it: a re-home
-        # has to be observable as a shell that ENDED UP somewhere, not merely as
-        # a line that was typed. FM_FAKE_IGNORE_CD models the opposite pane -
-        # one that accepts the keystroke and stays put.
-        'cd -- '*)
-          [ -z "${FM_FAKE_IGNORE_CD:-}" ] || exit 0
-          target=${payload#cd -- }
-          target=${target#\'}
-          target=${target%\'}
-          printf '%s' "$target" > "$D/cwd"
-          ;;
         'export GOTMPDIR='*)
           if [ -n "${FM_FAKE_TRACE_PREPARE:-}" ]; then
             : > "$FM_FAKE_TRACE_PREPARE"
@@ -189,7 +178,6 @@ run_control() {  # <case-dir> <args...>
     HOME="$dir/user-home" CLAUDE_CONFIG_DIR='' \
     FM_SPAWN_NO_GUARD=1 GROK_HOME="$dir/grokhome" \
     FM_CONTROL_POLL=0.01 FM_CONTROL_EXIT_WAIT=0.05 FM_CONTROL_LAUNCH_WAIT=0.05 \
-    FM_FAKE_IGNORE_CD="${FM_FAKE_IGNORE_CD:-}" \
     FM_REAL_GIT="${FM_REAL_GIT:-}" FM_FAKE_GIT_FAILURE="${FM_FAKE_GIT_FAILURE:-}" \
     FM_REAL_MV="${FM_REAL_MV:-}" FM_FAKE_COMPLETE_JOURNAL_MV_FAIL="${FM_FAKE_COMPLETE_JOURNAL_MV_FAIL:-}" \
     FM_FAKE_META_PUBLISH_MV_FAIL="${FM_FAKE_META_PUBLISH_MV_FAIL:-}" \
@@ -209,7 +197,6 @@ run_spawn() {  # <case-dir> <args...>
   env PATH="$dir/fakebin:$PATH" FM_HOME="$dir/home" FM_FAKE_DIR="$dir/fake" \
     HOME="$dir/user-home" CLAUDE_CONFIG_DIR='' \
     FM_SPAWN_NO_GUARD=1 GROK_HOME="$dir/grokhome" \
-    FM_FAKE_IGNORE_CD="${FM_FAKE_IGNORE_CD:-}" \
     "$SPAWN" "$@" 2>&1
 }
 
@@ -1053,11 +1040,10 @@ test_launch_failure_keeps_the_prior_record_and_reports_it() {
   dir=$(new_case rollback rl13)
   add_ship_task "$dir" rl13 claude
   before=$(cat "$dir/home/state/rl13.meta")
-  # The endpoint's shell is not in the recorded worktree and will not return
-  # when told to, so the launch owner refuses AFTER the previous agent has
-  # already been stopped.
+  # The endpoint's shell is not in the recorded worktree, so the launch owner
+  # refuses AFTER the previous agent has already been stopped.
   printf '%s' "$dir/proj" > "$dir/fake/cwd"
-  out=$(FM_FAKE_IGNORE_CD=1 run_control "$dir" rl13 relaunch --harness codex --note "carry this forward"); rc=$?
+  out=$(run_control "$dir" rl13 relaunch --harness codex --note "carry this forward"); rc=$?
   expect_code 1 "$rc" "a failed launch should fail closed"$'\n'"$out"
   assert_contains "$out" "no agent is running" "the failure should say no agent is running"
   assert_contains "$out" "$dir/wt" "the failure should say where the work is preserved"
@@ -1077,7 +1063,7 @@ test_prepublication_failure_keeps_concurrent_durable_metadata() {
   dir=$(new_case rollback-race rl30)
   add_ship_task "$dir" rl30 claude
   printf '%s' "$dir/proj" > "$dir/fake/cwd"
-  FM_FAKE_CWD_RACE_READY="$dir/cwd-race-ready" FM_FAKE_IGNORE_CD=1 \
+  FM_FAKE_CWD_RACE_READY="$dir/cwd-race-ready" \
     run_control "$dir" rl30 relaunch --harness codex --note "preserve concurrent metadata" \
       > "$dir/control.out" &
   control_pid=$!
@@ -1524,37 +1510,17 @@ test_spawn_relaunch_refuses_an_unrecorded_task() {
   pass "fm-spawn --relaunch: an unrecorded task is refused"
 }
 
-# The reproduced stranding: a task whose agent had exited left its shell sitting
-# somewhere other than the recorded worktree, and the relaunch refused outright,
-# leaving no sanctioned way to put a worker back on that work.
-test_spawn_relaunch_rehomes_a_pane_outside_the_worktree() {
-  local dir out rc=0
-  dir=$(new_case drifted rl18)
+test_spawn_relaunch_refuses_a_pane_outside_the_worktree() {
+  local dir out rc
+  dir=$(new_case wrongcwd rl18)
   add_ship_task "$dir" rl18 claude
   printf 'zsh' > "$dir/fake/command"
   printf '%s' "$dir/proj" > "$dir/fake/cwd"
-  out=$(run_spawn "$dir" rl18 --relaunch --harness claude) || rc=$?
-  expect_code 0 "$rc" "a drifted pane should be re-homed, not refused ($out)"
-  grep -Fqx "cd -- '$dir/wt'" "$dir/fake/keys" \
-    || fail "the relaunch did not tell the drifted shell to return to the recorded worktree"
-  [ "$(cat "$dir/fake/cwd")" = "$dir/wt" ] \
-    || fail "the re-homed shell did not end up in the recorded worktree"
-  [ "$(meta_field "$dir" rl18 window)" = "fmses:fm-rl18" ] \
-    || fail "re-homing must reuse the same endpoint, not replace it"
-  pass "fm-spawn --relaunch: a shell that drifted out of the worktree is told to return, and the same endpoint is reused"
-}
-
-test_spawn_relaunch_refuses_a_pane_that_will_not_return_to_the_worktree() {
-  local dir out rc
-  dir=$(new_case wrongcwd rl41)
-  add_ship_task "$dir" rl41 claude
-  printf 'zsh' > "$dir/fake/command"
-  printf '%s' "$dir/proj" > "$dir/fake/cwd"
-  out=$(FM_FAKE_IGNORE_CD=1 run_spawn "$dir" rl41 --relaunch --harness claude); rc=$?
-  expect_code 1 "$rc" "a pane that will not return to the worktree should refuse"
-  assert_contains "$out" "did not return to its recorded worktree" \
-    "the refusal should name the shell that would not move"
-  pass "fm-spawn --relaunch: refuses to start a replacement outside the copy holding the work"
+  out=$(run_spawn "$dir" rl18 --relaunch --harness claude); rc=$?
+  expect_code 1 "$rc" "a pane outside the worktree should refuse"
+  assert_contains "$out" "not its recorded worktree" "the refusal should name the wrong location"
+  [ ! -s "$dir/fake/keys" ] || fail "a refused tmux relaunch must send nothing to the pane"
+  pass "fm-spawn --relaunch: refuses to start a replacement outside the copy holding its work"
 }
 
 test_relaunch_reverifies_an_already_in_flight_item_instead_of_rewriting_it() {
@@ -1642,7 +1608,6 @@ test_spawn_relaunch_keeps_its_early_meta_lock_continuous
 test_spawn_relaunch_refuses_a_pending_authoritative_close
 test_spawn_relaunch_refuses_contradicting_flags
 test_spawn_relaunch_refuses_an_unrecorded_task
-test_spawn_relaunch_rehomes_a_pane_outside_the_worktree
-test_spawn_relaunch_refuses_a_pane_that_will_not_return_to_the_worktree
+test_spawn_relaunch_refuses_a_pane_outside_the_worktree
 test_relaunch_reverifies_an_already_in_flight_item_instead_of_rewriting_it
 test_relaunch_moves_a_drifted_item_back_in_flight

--- a/tests/fm-control-relaunch.test.sh
+++ b/tests/fm-control-relaunch.test.sh
@@ -83,6 +83,17 @@ case "${1:-}" in
     else
       printf '%s\n' "$payload" >> "$D/keys"
       case "$payload" in
+        # The stub models the pane's shell, so a cd actually moves it: a re-home
+        # has to be observable as a shell that ENDED UP somewhere, not merely as
+        # a line that was typed. FM_FAKE_IGNORE_CD models the opposite pane -
+        # one that accepts the keystroke and stays put.
+        'cd -- '*)
+          [ -z "${FM_FAKE_IGNORE_CD:-}" ] || exit 0
+          target=${payload#cd -- }
+          target=${target#\'}
+          target=${target%\'}
+          printf '%s' "$target" > "$D/cwd"
+          ;;
         'export GOTMPDIR='*)
           if [ -n "${FM_FAKE_TRACE_PREPARE:-}" ]; then
             : > "$FM_FAKE_TRACE_PREPARE"
@@ -178,6 +189,7 @@ run_control() {  # <case-dir> <args...>
     HOME="$dir/user-home" CLAUDE_CONFIG_DIR='' \
     FM_SPAWN_NO_GUARD=1 GROK_HOME="$dir/grokhome" \
     FM_CONTROL_POLL=0.01 FM_CONTROL_EXIT_WAIT=0.05 FM_CONTROL_LAUNCH_WAIT=0.05 \
+    FM_FAKE_IGNORE_CD="${FM_FAKE_IGNORE_CD:-}" \
     FM_REAL_GIT="${FM_REAL_GIT:-}" FM_FAKE_GIT_FAILURE="${FM_FAKE_GIT_FAILURE:-}" \
     FM_REAL_MV="${FM_REAL_MV:-}" FM_FAKE_COMPLETE_JOURNAL_MV_FAIL="${FM_FAKE_COMPLETE_JOURNAL_MV_FAIL:-}" \
     FM_FAKE_META_PUBLISH_MV_FAIL="${FM_FAKE_META_PUBLISH_MV_FAIL:-}" \
@@ -197,6 +209,7 @@ run_spawn() {  # <case-dir> <args...>
   env PATH="$dir/fakebin:$PATH" FM_HOME="$dir/home" FM_FAKE_DIR="$dir/fake" \
     HOME="$dir/user-home" CLAUDE_CONFIG_DIR='' \
     FM_SPAWN_NO_GUARD=1 GROK_HOME="$dir/grokhome" \
+    FM_FAKE_IGNORE_CD="${FM_FAKE_IGNORE_CD:-}" \
     "$SPAWN" "$@" 2>&1
 }
 
@@ -1040,10 +1053,11 @@ test_launch_failure_keeps_the_prior_record_and_reports_it() {
   dir=$(new_case rollback rl13)
   add_ship_task "$dir" rl13 claude
   before=$(cat "$dir/home/state/rl13.meta")
-  # The endpoint's shell is not in the recorded worktree, so the launch owner
-  # refuses AFTER the previous agent has already been stopped.
+  # The endpoint's shell is not in the recorded worktree and will not return
+  # when told to, so the launch owner refuses AFTER the previous agent has
+  # already been stopped.
   printf '%s' "$dir/proj" > "$dir/fake/cwd"
-  out=$(run_control "$dir" rl13 relaunch --harness codex --note "carry this forward"); rc=$?
+  out=$(FM_FAKE_IGNORE_CD=1 run_control "$dir" rl13 relaunch --harness codex --note "carry this forward"); rc=$?
   expect_code 1 "$rc" "a failed launch should fail closed"$'\n'"$out"
   assert_contains "$out" "no agent is running" "the failure should say no agent is running"
   assert_contains "$out" "$dir/wt" "the failure should say where the work is preserved"
@@ -1063,7 +1077,7 @@ test_prepublication_failure_keeps_concurrent_durable_metadata() {
   dir=$(new_case rollback-race rl30)
   add_ship_task "$dir" rl30 claude
   printf '%s' "$dir/proj" > "$dir/fake/cwd"
-  FM_FAKE_CWD_RACE_READY="$dir/cwd-race-ready" \
+  FM_FAKE_CWD_RACE_READY="$dir/cwd-race-ready" FM_FAKE_IGNORE_CD=1 \
     run_control "$dir" rl30 relaunch --harness codex --note "preserve concurrent metadata" \
       > "$dir/control.out" &
   control_pid=$!
@@ -1510,15 +1524,36 @@ test_spawn_relaunch_refuses_an_unrecorded_task() {
   pass "fm-spawn --relaunch: an unrecorded task is refused"
 }
 
-test_spawn_relaunch_refuses_a_pane_outside_the_worktree() {
-  local dir out rc
-  dir=$(new_case wrongcwd rl18)
+# The reproduced stranding: a task whose agent had exited left its shell sitting
+# somewhere other than the recorded worktree, and the relaunch refused outright,
+# leaving no sanctioned way to put a worker back on that work.
+test_spawn_relaunch_rehomes_a_pane_outside_the_worktree() {
+  local dir out rc=0
+  dir=$(new_case drifted rl18)
   add_ship_task "$dir" rl18 claude
   printf 'zsh' > "$dir/fake/command"
   printf '%s' "$dir/proj" > "$dir/fake/cwd"
-  out=$(run_spawn "$dir" rl18 --relaunch --harness claude); rc=$?
-  expect_code 1 "$rc" "a pane outside the worktree should refuse"
-  assert_contains "$out" "not its recorded worktree" "the refusal should name the wrong location"
+  out=$(run_spawn "$dir" rl18 --relaunch --harness claude) || rc=$?
+  expect_code 0 "$rc" "a drifted pane should be re-homed, not refused ($out)"
+  grep -Fqx "cd -- '$dir/wt'" "$dir/fake/keys" \
+    || fail "the relaunch did not tell the drifted shell to return to the recorded worktree"
+  [ "$(cat "$dir/fake/cwd")" = "$dir/wt" ] \
+    || fail "the re-homed shell did not end up in the recorded worktree"
+  [ "$(meta_field "$dir" rl18 window)" = "fmses:fm-rl18" ] \
+    || fail "re-homing must reuse the same endpoint, not replace it"
+  pass "fm-spawn --relaunch: a shell that drifted out of the worktree is told to return, and the same endpoint is reused"
+}
+
+test_spawn_relaunch_refuses_a_pane_that_will_not_return_to_the_worktree() {
+  local dir out rc
+  dir=$(new_case wrongcwd rl41)
+  add_ship_task "$dir" rl41 claude
+  printf 'zsh' > "$dir/fake/command"
+  printf '%s' "$dir/proj" > "$dir/fake/cwd"
+  out=$(FM_FAKE_IGNORE_CD=1 run_spawn "$dir" rl41 --relaunch --harness claude); rc=$?
+  expect_code 1 "$rc" "a pane that will not return to the worktree should refuse"
+  assert_contains "$out" "did not return to its recorded worktree" \
+    "the refusal should name the shell that would not move"
   pass "fm-spawn --relaunch: refuses to start a replacement outside the copy holding the work"
 }
 
@@ -1607,6 +1642,7 @@ test_spawn_relaunch_keeps_its_early_meta_lock_continuous
 test_spawn_relaunch_refuses_a_pending_authoritative_close
 test_spawn_relaunch_refuses_contradicting_flags
 test_spawn_relaunch_refuses_an_unrecorded_task
-test_spawn_relaunch_refuses_a_pane_outside_the_worktree
+test_spawn_relaunch_rehomes_a_pane_outside_the_worktree
+test_spawn_relaunch_refuses_a_pane_that_will_not_return_to_the_worktree
 test_relaunch_reverifies_an_already_in_flight_item_instead_of_rewriting_it
 test_relaunch_moves_a_drifted_item_back_in_flight


### PR DESCRIPTION
## Scope of this change, and what is deliberately not in it

This is a minimal classifier fix. Two things are excluded on purpose, and both are stated here so a reviewer does not have to infer them from the diff.

**`missing`-endpoint RECOVERY is OUT OF SCOPE.** A confirmed-gone endpoint now *classifies* as `missing` rather than `unreadable`, which is issue #4091's literal ask. Actually recovering such a task - recreating an endpoint that no longer exists - is not implemented here: `bin/fm-spawn.sh --relaunch` still accepts only `dead`. That work needs an explicitly designed endpoint-recreation path and is filed as a follow-up, `fm-herdr-missing-endpoint-recreation-r1`. What this PR does unblock is the drifted-shell case, where the pane still exists and reads `dead`.

**The drifted-shell re-home is Herdr-only, and its proof is in the real-Herdr guard.** tmux keeps its prior refusal, unchanged. A Herdr-only behaviour cannot be exercised hermetically, so the re-home is proven against the real binary in `tests/fm-control-herdr-smoke.test.sh` rather than in the portable suite; `tests/fm-control-relaunch.test.sh` covers tmux's retained refusal.

**Herdr 0.8.x (protocol 20) was NOT live-verified.** No 0.8.x binary is installed on this host, so protocol-20 coverage is structural plus the adapter fixture exercising both response shapes. That is a documented limitation, not a live pass, and the scenario table below records it as `untested`. A follow-up will live-verify the endpoint-recovery guard against a real 0.8.x binary when one is available.

---

## Intent

Captain's decision (2026-09-10): fix GitHub issue #4091 with the SMALLEST change that does two things, and nothing more.

(a) Fix #4091 itself: a confirmed-gone or drifted herdr pane must be classified as `missing`/recoverable instead of `unreadable`, so a same-task-id relaunch recovery works. The reported bug is that `bin/fm-spawn.sh <id>` refuses recovery with "it reads 'unreadable' and a relaunch requires a positively agent-free endpoint" for a task whose recorded herdr workspace and pane are verifiably, completely gone from herdr's own inventory - not merely ambiguous. Per bin/fm-backend.sh's own contract, `missing` means the recorded endpoint is authoritatively absent and should license recovery, while `unreadable` means a read failed or contradicted itself and blocks it; authoritative absence must classify as `missing`. This was reproduced across three independent tasks in one home, each with real preserved unlanded work blocked on it.

(b) Be sufficient to relaunch a specific stuck worker (the #4033 reconcile worker) whose herdr pane had drifted off its recorded worktree. That task's `bin/fm-control.sh <id> relaunch` refused with "endpoint is in <home>, not its recorded worktree <path>; refusing to relaunch an agent outside the copy holding its work", and the replacement did not launch, leaving no sanctioned way to relaunch the same task id.

The fix must ALSO remain backwards-compatible across herdr 0.8.x (protocol 20) and 0.9.0 (protocol 22), handling both output and target shapes defensively rather than adapting to 0.9.0 in a way that breaks 0.8.x. This subsumes a separate reported symptom where a recovery-grade state read of a remote second mate returned "unreadable" after that host's herdr upgrade to 0.9.0.

The captain fenced the scope explicitly and wants that discipline held: this is a minimal, mergeable classifier fix, NOT an airtight subsystem. HARD NO on new configuration knobs, on extending the recovery to other backends, on a broad re-home or fresh-checkout subsystem, on new libraries, and on live-0.8.x verification rigging. Fixture plus structural coverage for herdr 0.8.x is accepted as a documented limitation, because no 0.8.x binary is installed on this host; do not build machinery to change that. Any review finding that wants NEW machinery or widens the surface should be declined and parked as a follow-up rather than absorbed. If a round tries to harden newly added machinery, that is a signal of over-scoping and the answer is to narrow, not to harden.

Keep every teardown and unlanded-work safety intact. Turn the reproduced relaunch failure into a regression test.

Delivery is no-mistakes with yolo OFF: the captain owns the merge; never self-merge.

## What Changed

- Classify endpoints in positively stopped Herdr sessions as `missing` and recoverable while keeping ambiguous reads and destructive husk checks fail-closed.
- Re-home drifted Herdr shells to their recorded worktree before relaunch, while preserving the existing refusal behavior for other backends.
- Add regression and compatibility coverage for Herdr 0.8.x/0.9.0 response shapes, stopped-session classification, and same-endpoint drift recovery.

## Risk Assessment

â Low: The remaining changes are narrowly scoped to Herdr, preserve tmux behavior, fail closed on ambiguous reads, and align their tests and verification record with the implemented behavior.

## Testing

Inspected the targeted change, ran the focused adapter and relaunch regressions, exercised real Herdr 0.9.0 classification and same-endpoint drift recovery, verified the destructive classifier remains closed, and confirmed a real tmux pane retains its original refusal without moving or launching; protocol-20 remains fixture-only as explicitly accepted because Herdr 0.8.x is unavailable.

- Live validation: â go - 5 of 6 scenarios driven live against the product

| Scenario | Result | Live | Evidence |
| --- | --- | --- | --- |
| An endpoint recorded in a stopped Herdr session is classified as missing/recoverable | â pass | live | Real Herdr 0.9.0 returned `missing` for an endpoint in a session with no running server; see herdr-live-validation.log. |
| A drifted agent-free Herdr pane returns to its recorded worktree and relaunches in the same endpoint | â pass | live | The isolated real-Herdr lifecycle smoke moved the pane away, invoked relaunch, observed the replacement harness, restored cwd, and retained the same pane; see herdr-live-validation.log. |
| Recovery widening does not authorize destructive cleanup on the same absent-session read | â pass | live | Real Herdr reported `recovery_state=missing destructive_presence=unknown husk=refused`; see herdr-live-safety-boundary.log. |
| A malformed or ambiguous Herdr target remains unreadable rather than licensing recovery | â pass | live | The real-Herdr lifecycle smoke verified a malformed target remains unreadable; see herdr-live-validation.log. |
| A drifted tmux pane retains the original refusal and receives no re-home or replacement launch | â pass | live | Against real tmux 3.6a, fm-spawn exited 1 with the original wrong-worktree refusal, cwd stayed in the project, and the launch marker remained absent; see tmux-live-retained-refusal.log. |
| Herdr protocol 20 and protocol 22 response shapes remain compatible | â¸ï¸ untested | no | Herdr 0.8.x/protocol 20 is not installed on this host. Live coverage would require providing a Herdr 0.8.x binary in an isolated environment; the authoritative intent explicitly accepts fixture plus sâ¦ |

<details>
<summary>Evidence: Real Herdr classification and lifecycle validation</summary>

Source: [Real Herdr classification and lifecycle validation](https://github.com/kunchenguid/firstmate/blob/8843993ca26a6b48a5267ee563ad082bb27f7350/.no-mistakes/evidence/fm/fm-herdr-endpoint-classify-r1/herdr-live-validation.log)

```text
=== Environment ===
herdr: herdr 0.9.0
jq: jq-1.8.1

=== Real Herdr lifecycle smoke ===
ok - real herdr: exit on a pane with no registered agent is idempotent success
ok - real herdr 0.9.0: a gone session reads recoverable while a live pane and a malformed target do not
warning: /var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/fm-control-herdr.zO4gc3/home/data/hsmoke/launch-brief.md records no delivery contract line (scaffolded before ship briefs recorded one); launching on the explicit --mode no-mistakes - confirm its definition of done matches
ok - real herdr: a drifted agent-free shell returns to its worktree and reuses the same endpoint
ok - real herdr: interrupt refuses when herdr's own agent registry reports no agent
ok - real herdr: interrupt delivers the harness's key and proves the agent survived it
ok - real herdr: no control verb removed the endpoint or the task's local copy
ok - real herdr: an agent that does not stop fails closed instead of being reported as stopped
```
</details>
<details>
<summary>Evidence: Real Herdr recovery/destructive safety boundary</summary>

Source: [Real Herdr recovery/destructive safety boundary](https://github.com/kunchenguid/firstmate/blob/8843993ca26a6b48a5267ee563ad082bb27f7350/.no-mistakes/evidence/fm/fm-herdr-endpoint-classify-r1/herdr-live-safety-boundary.log)

```text
=== Real Herdr absent-session safety boundary ===
herdr: herdr 0.9.0
session=fm-lab-husk-absent-47535 recovery_state=missing destructive_presence=unknown husk=refused
```
</details>
<details>
<summary>Evidence: Real tmux retained refusal</summary>

Source: [Real tmux retained refusal](https://github.com/kunchenguid/firstmate/blob/8843993ca26a6b48a5267ee563ad082bb27f7350/.no-mistakes/evidence/fm/fm-herdr-endpoint-classify-r1/tmux-live-retained-refusal.log)

```text
=== Real tmux retained-refusal validation ===
tmux: tmux 3.6a
exit_code: 1
output: warning: /tmp/fm-tmux-live.aLBUX8/home/data/tmxlive/launch-brief.md records no delivery contract line (scaffolded before ship briefs recorded one); launching on the explicit --mode no-mistakes - confirm its definition of done matches
error: task tmxlive's endpoint is in '/private/tmp/fm-tmux-live.aLBUX8/proj', not its recorded worktree '/tmp/fm-tmux-live.aLBUX8/wt'; refusing to relaunch an agent outside the copy holding its work
pane_cwd_after: /private/tmp/fm-tmux-live.aLBUX8/proj
unexpected_launch_marker: absent
```
</details>
<details>
<summary>Evidence: Herdr adapter fixture regression</summary>

Source: [Herdr adapter fixture regression](https://github.com/kunchenguid/firstmate/blob/8843993ca26a6b48a5267ee563ad082bb27f7350/.no-mistakes/evidence/fm/fm-herdr-endpoint-classify-r1/herdr-adapter-regression.log)

```text
ok - fm_backend_herdr_version_check: accepts the current protocol (14)
ok - fm_backend_herdr_version_check: refuses an old protocol loudly
ok - fm_backend_herdr_version_check: refuses loudly when herdr is not installed
ok - fm_backend_herdr_workspace_label: a primary home (no marker) resolves to 'firstmate'
ok - fm_backend_herdr_workspace_label: a secondmate home (.fm-secondmate-home) resolves to '2ndmate-<id>'
ok - fm_backend_herdr_workspace_label: trims whitespace around the marker's secondmate id
ok - fm_backend_herdr_workspace_label: an empty marker file falls back to the primary label 'firstmate'
ok - fm_backend_herdr_workspace_label: two different secondmate homes get two different, non-colliding labels
ok - fm_backend_herdr_cli: sets HERDR_SESSION AND appends a trailing --session flag on every call
ok - herdr client selection: a live pane behind a stale shadowing client reads alive
ok - herdr recovery-grade read: a stopped server means missing there, and nowhere else
ok - herdr client selection: one selected client is reused per process
ok - herdr client selection: selected clients remain scoped to their session
ok - herdr client selection: only protocol_mismatch triggers reselection; other failures pass through untouched
ok - herdr client selection: the happy path makes no extra call
ok - herdr client status: .server.compatible, legacy protocol equality, unknown, and stopped shapes all normalize
ok - fm_backend_herdr_launcher_identity: a firstmate not running inside herdr has no launcher workspace to inherit
ok - fm_backend_herdr_launcher_identity: HERDR_ENV=1 without a pane id selects the backend but binds no parent
ok - fm_backend_herdr_launcher_identity: resolves the launcher's exact workspace even when a same-labeled workspace sorts first
ok - fm_backend_herdr_launcher_identity: refuses a launcher pane that names a different herdr session
ok - fm_backend_herdr_launcher_identity: refuses a claimed pane without exact server identity
ok - fm_backend_herdr_launcher_identity: refuses a launcher pane whose injected socket belongs to another herdr server
ok - fm_backend_herdr_launcher_identity: refuses when the launcher's own pane no longer resolves
ok - fm_backend_herdr_launcher_identity: refuses when the launcher's pane and tab disagree about their workspace
ok - fm_backend_herdr_launcher_identity: refuses when the launcher's workspace is gone from its own session
ok - fm_backend_herdr_workspace_ensure: places a worker in the launcher's exact workspace, not the first same-labeled one
ok - fm_backend_herdr_workspace_ensure: refuses to guess between two same-labeled home workspaces
ok - fm_backend_herdr_workspace_ensure: a --secondmate container resolves that home's own workspace, not the launcher's
ok - fm_backend_herdr_container_ensure: surfaces the exact ambiguous-placement refusal instead of a generic failure
ok - fm_backend_herdr_container_ensure: version-gates, starts the server, ensures the firstmate workspace, echoes session:workspace_id + the seeded default tab id
ok - fm_backend_herdr_server_ensure: scrubs home and harness identity without disturbing unrelated environment or session routing
ok - fm_backend_herdr_container_ensure: reuses an existing firstmate workspace without recreating it, and reports no seeded default tab (adopted, not created)
ok - fm_backend_herdr_container_ensure: workspace create passes --no-focus
ok - fm_backend_herdr_container_ensure: creates the workspace under the SECONDMATE home's own label, not 'firstmate'
ok - fm_backend_herdr_create_task: prunes exactly the seeded default tab container_ensure identified, once the first real task tab exists
ok - herdr repeated spawn/teardown: one persistent firstmate workspace reused, zero orphans, default tab pruned, create ran once
ok - fm_backend_herdr_create_task: an ADOPTED workspace's pre-existing tab is never pruned (the created-vs-adopted gate)
ok - fm_backend_herdr_create_task: the label-collision startup-workspace scenario (2026-07-02 incident) leaves the captain's live tab untouched
ok - fm_backend_herdr_workspace_prune_seeded_default_tab: refuses to close the seeded default tab when its pane reports a working agent (defense in depth)
ok - fm_backend_herdr_create_task: refuses a duplicate tab label (herdr's own tab create has no uniqueness check)
ok - fm_backend_herdr_create_task: a same-labeled tab with a live (even idle) registered agent still refuses exactly as before
ok - fm_backend_herdr_create_task: scans every same-labeled tab and refuses if any duplicate is live
ok - fm_backend_herdr_create_task: closes and replaces a same-labeled tab whose pane is dead (pane_not_found)
ok - fm_backend_herdr_create_task: closes and replaces a same-labeled tab whose pane is alive but hosts no registered agent (a restored plain shell)
ok - fm_backend_herdr_create_task: closes every confirmed same-labeled husk only after creating the replacement
ok - fm_backend_herdr_create_task: refuses success when a preexisting husk tab remains after replacement
ok - fm_backend_herdr_create_task: refuses (fail-safe) rather than guessing when the duplicate's agent state cannot be classified confidently
ok - fm_backend_herdr_create_task: creates the replacement tab BEFORE closing the husk tab, never the reverse
ok - fm_backend_herdr_create_task: creates a tab and parses tab_id/pane_id from the JSON response, prunes nothing when no seeded tab id is given
ok - fm_backend_herdr_create_task: tab create passes --no-focus
ok - herdr presentation: a home that set nothing gets the projection by default at or above the floor
ok - herdr presentation: an unconfigured home below the floor falls back flat with one naming warning
ok - herdr presentation: an unreadable client release falls back flat instead of guessing
ok - herdr presentation: a deliberate opt-in is never silently downgraded below the floor
ok - herdr presentation: an explicit off opts the home out
ok - herdr presentation: an unrecognized value warns and follows the default instead of failing a spawn
ok - herdr presentation: the below-floor warning is one per home per release, not one per spawn
ok - herdr presentation: warning marker publication is atomic, symlink-safe, and fails visible
ok - herdr presentation: client and selected server floors compose conservatively without overriding explicit opt-in
ok - herdr presentation floor: every measured release, and each signal alone, classifies correctly
ok - herdr presentation floor: either signal alone can carry an above verdict, and each divergence is real
ok - herdr presentation: config parsing separates a deliberate choice from an unconfigured default
ok - herdr presentation journal: atomically publishes one non-authoritative 128-bit correlator and refuses overwrite
ok - herdr presentation journal: version 2 binds exact home/endpoint/parent identities and advances atomically
ok - herdr presentation create: exact response IDs yield one normal task pane with no workspace-close authority
ok - herdr presentation create: concurrent same-label tabs are never prune targets
ok - herdr presentation focus: snapshot requires one exact active workspace and tab
ok - herdr presentation focus: exact pane close restores the exact prior workspace and tab
ok - herdr presentation focus: cleanup refuses rather than close the captain's active tab
ok - herdr presentation focus: pane close fails when exact focus restoration fails
ok - herdr presentation reclaim: live agent state at the close boundary refuses mutation
ok - herdr presentation cleanup: emptying close behind focus ends the exact shell without a move or focus change
ok - herdr presentation cleanup: emptying close before focus moves the doomed workspace to the end and ends its exact shell
ok - herdr presentation cleanup: emptying close with the focused workspace last skips the move
ok - herdr presentation cleanup: emptying close of the last workspace skips the move
ok - herdr presentation cleanup: a non-emptying close stays plain with no proof, move, or signal
ok - herdr presentation cleanup: no-move plain close requires structured pane removal
ok - herdr presentation cleanup: an ambiguous workspace layout falls back to the plain close

... [4329 bytes truncated] ...

_backend_herdr_current_path: reads pane foreground_cwd (the live running process), not the frozen creation-time cwd
ok - fm_backend_herdr_busy_state: working -> busy
ok - fm_backend_herdr_busy_state: done -> idle, blocked -> idle (surfaced like a stale pane, not suppressed as busy)
ok - fm_backend_herdr_busy_state: unparseable/absent agent state reports unknown, the regex-fallback cue
ok - fm_backend_herdr_composer_state: a bare 'â¯' composer row reads empty
ok - fm_backend_herdr_composer_state: bright placeholder-like text stays pending rather than being mistaken for an idle ghost
ok - fm_backend_herdr_composer_state: real composer text reads pending
ok - fm_backend_herdr_composer_state: a slash-command popup's argument-hint placeholder still reads pending (the incident fix)
ok - fm_backend_herdr_composer_state: reports unknown when the pane cannot be captured
ok - fm_backend_herdr_composer_state: reports unknown for bare shell prompts with no composer row
ok - fm_backend_herdr_composer_state: a blocked pi pane parked on a prompt is not an empty composer
ok - fm_backend_herdr_composer_state: a native idle Pi separator composer reads empty
ok - fm_backend_herdr_composer_state: real Pi composer text remains pending
ok - fm_backend_herdr_composer_state: an incomplete lower Pi separator cannot inherit a stale empty row
ok - fm_backend_herdr_composer_state: Pi separators never authorize working, non-Pi, unreadable, or over-tall targets
ok - fm_backend_herdr_composer_state: a real-claude unbordered 'â¯' prompt row (no border box in view) reads empty
ok - fm_backend_herdr_composer_state: a real-claude unbordered 'â¯ <text>' prompt row reads pending
ok - fm_backend_herdr_composer_state: a live unbordered prompt row below a stale bordered decorative box still wins (not misread as the box's own row)
ok - fm_backend_herdr_composer_state: claude's dim prompt-suggestion ghost (the overnight wedge shape) reads empty
ok - fm_backend_herdr_composer_state: real typed text on the same claude prompt row still reads pending
ok - fm_backend_herdr_composer_state: grok's dark-truecolor placeholder (the TRUECOLOR gap) reads empty
ok - fm_backend_herdr_composer_state: grok's real bright typed input still reads pending
ok - fm_backend_herdr_composer_state: a real-codex unbordered 'âº' prompt row reads empty
ok - fm_backend_herdr_composer_state: a faint real-codex ghost suggestion reads empty
ok - fm_backend_herdr_composer_state: non-faint codex prompt text still reads pending
ok - fm_backend_herdr_wait_for_working: reports 'busy' immediately on the first poll, without spending the rest of the budget
ok - fm_backend_herdr_wait_for_working: a slow transition landing on a later sample within one window is still caught (robust against the 'slow transition' failure direction)
ok - fm_backend_herdr_wait_for_working: spreads six samples across the full budget endpoint without a final trailing sleep
ok - fm_backend_herdr_send_text_submit: applies the herdr minimum confirmation budget before polling agent-state
ok - fm_backend_herdr_wait_for_working: reports 'idle' (readable, genuinely not yet working) when 'busy' never appears
ok - fm_backend_herdr_wait_for_working: reports 'unknown' (a hard read failure, not a timing race) only when EVERY poll in the window fails
ok - fm_backend_herdr_wait_for_working: treats blocked as submit-active for confirmation without changing watcher busy-state semantics
ok - fm_backend_herdr_send_text_submit: reports 'empty' once agent_status reports working after one Enter, without ever reading the composer
ok - fm_backend_herdr_send_text_submit: reports 'pending' when agent_status stays idle and the composer still holds unsent text after retried Enters (swallowed)
ok - fm_backend_herdr_send_text_submit: a slash-command popup's placeholder fill on Enter #1 never flips agent_status to working, so it does not short-circuit as submitted; Enter #2 is retried and lands it
ok - fm_backend_herdr_send_text_submit: a post-Enter blocked state confirms delivery without retrying into the prompt
ok - fm_backend_herdr_send_text_submit: native working + proven pending after retries reports empty (queued Enter)
ok - fm_backend_herdr_send_text_submit: a failed Enter cannot borrow preexisting working state as queued-delivery proof
ok - fm_backend_herdr_send_text_submit: a failed Enter cannot borrow a later native transition as delivery proof
ok - fm_backend_herdr_send_text_submit: idle native agent-state plus empty composer reports empty (landed Claude turn)
ok - fm_backend_herdr_send_text_submit: idle native baseline uses a rendered busy footer to confirm a queued Enter
ok - fm_backend_herdr_composer_state: cursor's mid-turn placeholder-plus-busy-token row reads pending (why delivery needs a separate signal)
ok - fm_backend_herdr_rendered_busy_state: busy/idle/unknown from the rendered footer, with an unreadable pane never reading idle
ok - fm_backend_herdr_send_text_submit: a rendered-footer idle-to-busy transition confirms delivery when native agent-state never reports idle
ok - fm_backend_herdr_send_text_submit: an already-busy footer baseline is never accepted as proof that this Enter landed
ok - fm_backend_herdr_send_text_submit: confirms submission via native agent-state alone, immune to a codex-style dynamic idle-tip composer that would have misread as 'pending' under the old composer-based confirmation
ok - fm_backend_herdr_composer_state: a faint real-codex dynamic idle-tip composer row reads empty
ok - fm_backend_composer_state (herdr): the pre-injection empty-box guard still refuses a genuinely non-empty composer, unaffected by the submit-confirmation change
ok - fm_backend_herdr_send_text_submit: a slow transition landing on a later sample within one Enter's budget is confirmed WITHOUT sending a needless extra Enter
ok - fm_backend_herdr_send_text_submit: reports 'send-failed' when the literal send-text call itself errors
ok - fm_backend_herdr_send_text_submit: reports 'unknown' when the post-Enter agent-get read fails (never retries past an unreadable target)
ok - fm_backend_herdr_send_text_submit: an unreadable composer stops Enter retries after native status stays idle
ok - fm_backend_validate: herdr is a known backend (P2)
ok - fm_backend_busy_state: tmux (no native primitive) always reports unknown, preserving the P1 regex-only path
error: unknown backend 'bogus' (known: tmux herdr zellij orca cmux)
ok - fm_backend_composer_state dispatches every backend to its named thin classifier, unknown for unrecognized backends
ok - fm-peek/fm-send: explicit stale targets matching metadata use the recorded backend
ok - fm_backend_herdr_normalize_event routes through the shared record with an empty from_status
ok - fm_backend_herdr_escalation_marker keys the dedupe marker exactly like the watcher's .stale-<key>
ok - fm_backend_herdr_apply_transition: blocked dedupe starts only after explicit commit
ok - fm_backend_herdr_apply_transition: a working edge clears the marker so the next ->blocked re-escalates
ok - fm_backend_herdr_clear_transition removes task-owned dedupe state
ok - fm_backend_herdr_apply_transition: idle/done (defer) and unknown/empty (fallback) take no fast action
ok - fm_backend_herdr_wait_transition: a home with no herdr panes falls back to polling (rc 2)
ok - fm_backend_herdr_wait_transition: below-capability protocol/schema falls back to polling (rc 2)
ok - fm_backend_herdr_wait_transition: reconnect level-reconcile returns an uncommitted blocked pane
ok - fm_backend_herdr_wait_transition: subscribes before reconnect level-reconcile
ok - fm_backend_herdr_wait_transition: a still-blocked, already-escalated pane is not re-delivered on reconnect
ok - fm_backend_herdr_wait_transition: a streamed ->blocked edge returns the record sub-poll
ok - fm_backend_herdr_wait_transition: streamed working clears the marker, idle/done are deferred (clean timeout)
ok - fm_backend_herdr_wait_transition: a reader/subscribe failure falls back to polling (rc 2)
ok - fm_backend_herdr_wait_transition: Bash 3.2-safe bad-ack path closes fd 9 and removes its FIFO
ok - fm_backend_herdr_wait_transition: stock macOS Bash clean timeout closes fd 9 and returns 1
```
</details>
<details>
<summary>Evidence: Relaunch boundary regression</summary>

Source: [Relaunch boundary regression](https://github.com/kunchenguid/firstmate/blob/8843993ca26a6b48a5267ee563ad082bb27f7350/.no-mistakes/evidence/fm/fm-herdr-endpoint-classify-r1/relaunch-boundary-regression.log)

```text
ok - fm-control relaunch: a same-harness relaunch replaces the agent in the same endpoint and worktree
ok - fm-control relaunch: a linked spawning home preserves committed and unfinished work in the recorded copy
ok - fm-control relaunch: durable task metadata survives replacement launch publication
ok - fm-control relaunch: delivery and concurrent task metadata publication serialize
ok - fm-control relaunch: disabling tracing clears metadata and pane context
ok - fm-control relaunch: the progress note lands in the instructions the replacement reads
ok - fm-control relaunch: a ship task refuses without the progress note its replacement needs
ok - fm-control relaunch: switching harness is one ordinary relaunch, and the old wiring goes with the old agent
ok - fm-control relaunch: a harness switch resets model and effort unless they are named too
ok - fm-control relaunch: a prefixed recorded harness can switch adapters transactionally
ok - fm-control relaunch: a prefixed command requires an explicit replacement harness
ok - fm-control relaunch: a same-harness relaunch keeps the profile axes it was running with
ok - native Ultra relaunch preserves its profile and rejects an unsupported model before stopping
ok - fm-control relaunch: explicit model and effort win over the recorded ones
ok - fm-control relaunch: refuses to relaunch onto an adapter with no verified mechanics
ok - fm-control relaunch: the retired incarnation's global turn-end token is revoked
ok - fm-control relaunch: wiring cleanup failure refuses replacement arming
ok - fm-control-lib: one owner resolves each harness's turn-end registry entry, and refuses a malformed token
ok - fm-control relaunch: a secondmate relaunch re-resolves its durable configured harness pin
ok - fm-control relaunch: invalid configured effort is ignored before stop
ok - fm-control relaunch: an adapter unverified for this task kind refuses before the agent is stopped
ok - fm-control relaunch: explicit secondmate harness resets unnamed profile axes
ok - fm-control relaunch: a ship task keeps its recorded harness instead of re-reading crew config
ok - fm-spawn --relaunch: with no explicit harness it reuses the task's recorded one, never the crew default
ok - fm-spawn --relaunch: wiring armed under a prefixed harness name is still retired
ok - fm-spawn --relaunch: switching away from muse retires its session binding
ok - fm-spawn --relaunch: switching away from cursor retires its session binding
ok - fm-control relaunch: an unaccountable local copy refuses before the agent is touched
ok - fm-control relaunch: a worker with nothing to work from is never launched
ok - fm-control relaunch: a refusal before the agent is stopped leaves the durable record untouched
ok - fm-control relaunch: checkpoint inspection failures refuse before stopping
ok - fm-control relaunch: a launch failure after the stop keeps the prior record and reports the real state
ok - fm-control relaunch: unpublished rollback keeps concurrent durable metadata
ok - fm-control relaunch: post-publication failure keeps the new durable record
ok - fm-control relaunch: partial stop reconciles actual agent state
ok - fm-control relaunch: failed journal replacement preserves durable phase
ok - fm-spawn relaunch: prepublication abort removes replacement state
ok - fm-control relaunch: the checkpoint records the exact unlanded work it preserved
ok - fm-control relaunch: a secondmate's child work is accounted for and its charter is left alone
ok - fm-control relaunch: a secondmate home that is not this secondmate's is refused
ok - fm-control relaunch: unreadable and untraversable child state fails checkpoint
ok - fm-control relaunch: two control actions on one task serialize instead of interleaving
ok - fm-spawn relaunch: direct entry participates in lifecycle serialization
ok - fm-promote: promotion participates in lifecycle serialization
ok - fm-spawn --relaunch: refuses to launch a second agent into a live endpoint
ok - fm-spawn --relaunch: symlinked records refuse before inspection
ok - fm-spawn --relaunch: keeps its early meta lock continuous
ok - fm-spawn --relaunch: pending closes refuse before replacement begins
ok - fm-spawn --relaunch: every identity axis comes from the record, and a contradicting flag refuses
ok - fm-spawn --relaunch: an unrecorded task is refused
ok - fm-spawn --relaunch: refuses to start a replacement outside the copy holding its work
ok - relaunch re-reads the backlog item instead of blindly re-running the transition
ok - relaunch heals an item that drifted out of In flight while the task stayed live
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"dfafa39086473361c9ab16c4a3a2b9d8d243a8cf","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>â **intent** - passed</summary>

â No issues found.
</details>

<details>
<summary>â **Rebase** - passed</summary>

â No issues found.
</details>

<details>
<summary>ð§ **Review** - 2 issues found â auto-fixed (2) â</summary>

- ð¨ `bin/backends/herdr.sh:2101` - The required same-task-id recovery remains unreachable. A stopped Herdr session now correctly produces `missing`, but `bin/fm-spawn.sh:1286` still accepts only `dead`; the concrete sequence is failed pane read â `.server.running=false` â `missing` â the same ârelaunch requires a positively agent-free endpointâ refusal. This contradicts the requirement that `missing` license recovery and that the reproduced relaunch failure become a regression test. Supporting a missing endpoint requires an explicitly designed endpoint-recreation path, not merely widening the existing adoption gate.
- â ï¸ `bin/fm-spawn.sh:3059` - The new re-home branch is backend-neutral, so verified tmux relaunches also send `cd` and recover drift; the added regression test specifically exercises tmux. This exceeds and contradicts the explicit âHARD NO ... extending the recovery to other backendsâ constraint. Narrow this behavior and its regression test to Herdr, leaving tmuxâs prior refusal intact.

ð§ Fix applied.
1 warning still open:

- â ï¸ `docs/verification/runtime-backends.md:1070` - The verification record still claims `tests/fm-control-relaunch.test.sh` proves drifted-shell re-homing and refusal, but that suite now intentionally covers only tmux refusal and sends no `cd`; the Herdr re-home proof moved to `tests/fm-control-herdr-smoke.test.sh`, which does not exercise the âwill not moveâ case. Update the record to describe the coverage actually present.

ð§ Fix applied.
â Re-checked - no issues remain.
</details>

<details>
<summary>â **Test** - passed</summary>

â No issues found.
- Live validation: â go - 5 of 6 scenarios driven live against the product

| Scenario | Result | Live | Evidence |
| --- | --- | --- | --- |
| An endpoint recorded in a stopped Herdr session is classified as missing/recoverable | â pass | live | Real Herdr 0.9.0 returned `missing` for an endpoint in a session with no running server; see herdr-live-validation.log. |
| A drifted agent-free Herdr pane returns to its recorded worktree and relaunches in the same endpoint | â pass | live | The isolated real-Herdr lifecycle smoke moved the pane away, invoked relaunch, observed the replacement harness, restored cwd, and retained the same pane; see herdr-live-validation.log. |
| Recovery widening does not authorize destructive cleanup on the same absent-session read | â pass | live | Real Herdr reported `recovery_state=missing destructive_presence=unknown husk=refused`; see herdr-live-safety-boundary.log. |
| A malformed or ambiguous Herdr target remains unreadable rather than licensing recovery | â pass | live | The real-Herdr lifecycle smoke verified a malformed target remains unreadable; see herdr-live-validation.log. |
| A drifted tmux pane retains the original refusal and receives no re-home or replacement launch | â pass | live | Against real tmux 3.6a, fm-spawn exited 1 with the original wrong-worktree refusal, cwd stayed in the project, and the launch marker remained absent; see tmux-live-retained-refusal.log. |
| Herdr protocol 20 and protocol 22 response shapes remain compatible | â¸ï¸ untested | no | Herdr 0.8.x/protocol 20 is not installed on this host. Live coverage would require providing a Herdr 0.8.x binary in an isolated environment; the authoritative intent explicitly accepts fixture plus sâ¦ |

- `git diff 269f8fe64a692ebdabd7c9ad205f5aa5c28caadc..b57433df4164d4033b0eec57dc499a86f73a60aa -- bin/backends/herdr.sh bin/fm-spawn.sh tests/... docs/verification/runtime-backends.md`
- <code>`bash tests/fm-control-herdr-smoke.test.sh` against real Herdr 0.9.0</code>
- `bash tests/fm-backend-herdr.test.sh`
- `bash tests/fm-control-relaunch.test.sh`
- `Direct real-Herdr absent-session check of recovery state, destructive presence state, and husk refusal`
- <code>Direct `bin/fm-spawn.sh tmxlive --relaunch --harness codex` against an isolated real tmux 3.6a session with a drifted pane</code>
</details>

<details>
<summary>â **Document** - passed</summary>

â No issues found.
</details>

<details>
<summary>â **Lint** - passed</summary>

â No issues found.
</details>

<details>
<summary>â **Push** - passed</summary>

â No issues found.
</details>
