### PR TITLE
fix: standardize worker PR body scaffolding

### DIFF
--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -49,7 +49,7 @@
 # recorded task metadata cannot drift apart.
 # Ship no-mistakes and direct-PR briefs include a captain-first PR body contract
 # beside the definition of done; local-only, scout, and secondmate briefs omit it.
-# The generated contract owns the section order and tool-owned metadata boundary.
+# bin/fm-dod-lib.sh owns the generated PR body contract.
 # Ship briefs begin with a worktree-isolation assertion before the branch step.
 # --mode is refused on scout and secondmate scaffolds: a scout's deliverable is a
 # report rather than a merge, and a charter is not a delivery contract.
@@ -443,24 +443,6 @@ case "$MODE" in
 esac
 DOD=$(fm_dod_block "$MODE" "$ID") || exit 1
 
-PR_BODY_SECTION=""
-if [ "$MODE" != local-only ]; then
-  IFS= read -r -d '' PR_BODY_SECTION <<'EOF' || true
-# PR body
-Write for the captain first: plain language before evidence, in this section order:
-- `## Intent` - open with a plain-language paragraph of the captain's ask and why it matters to him, then explicit scope (in and out) and acceptance criteria.
-- `## What Changed` - one bullet per changed file saying what changed there.
-- `## Choices made where the spec was silent` - every choice the spec did not settle, least-confident first.
-- `## Risk Assessment` - a severity line with blast-radius reasoning and what was verified unchanged.
-- `## Testing` - reproduce-first evidence on the base commit and after the fix, then lint and test evidence.
-The no-mistakes Pipeline section and attestation stamp are tool-owned: never hand-write or edit them.
-EOF
-  if [ "$MODE" = no-mistakes ]; then
-    PR_BODY_SECTION="$PR_BODY_SECTION
-After the pipeline opens the PR, apply this body with \`gh-axi pr edit <number> --body-file <path>\` (the \`gh pr edit --body-file\` operation), preserving the existing Pipeline section and attestation comment byte-identically."
-  fi
-fi
-
 cat > "$BRIEF" <<EOF
 You are a crewmate: an autonomous worker agent managed by firstmate. Work on your own; do not wait for a human.
 
@@ -526,7 +508,5 @@ If you touch a project \`AGENTS.md\`, follow \`$FM_ROOT/bin/fm-ensure-agents-md.
 Keep it proportionate: skip \`AGENTS.md\` edits for trivial tasks that produced no durable project knowledge.
 
 $DOD
-
-$PR_BODY_SECTION
 EOF
 echo "scaffolded: $BRIEF (ship, mode=$MODE; replace {TASK} and {FIRSTMATE_SPEC})"

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -47,6 +47,9 @@
 # "Delivery contract: mode=<mode>" line. bin/fm-spawn.sh reads that line and refuses
 # to launch a ship task whose explicit --mode disagrees, so an adjusted brief and the
 # recorded task metadata cannot drift apart.
+# Ship no-mistakes and direct-PR briefs include a captain-first PR body contract
+# beside the definition of done; local-only, scout, and secondmate briefs omit it.
+# The generated contract owns the section order and tool-owned metadata boundary.
 # Ship briefs begin with a worktree-isolation assertion before the branch step.
 # --mode is refused on scout and secondmate scaffolds: a scout's deliverable is a
 # report rather than a merge, and a charter is not a delivery contract.
@@ -440,6 +443,24 @@ case "$MODE" in
 esac
 DOD=$(fm_dod_block "$MODE" "$ID") || exit 1
 
+PR_BODY_SECTION=""
+if [ "$MODE" != local-only ]; then
+  IFS= read -r -d '' PR_BODY_SECTION <<'EOF' || true
+# PR body
+Write for the captain first: plain language before evidence, in this section order:
+- `## Intent` - open with a plain-language paragraph of the captain's ask and why it matters to him, then explicit scope (in and out) and acceptance criteria.
+- `## What Changed` - one bullet per changed file saying what changed there.
+- `## Choices made where the spec was silent` - every choice the spec did not settle, least-confident first.
+- `## Risk Assessment` - a severity line with blast-radius reasoning and what was verified unchanged.
+- `## Testing` - reproduce-first evidence on the base commit and after the fix, then lint and test evidence.
+The no-mistakes Pipeline section and attestation stamp are tool-owned: never hand-write or edit them.
+EOF
+  if [ "$MODE" = no-mistakes ]; then
+    PR_BODY_SECTION="$PR_BODY_SECTION
+After the pipeline opens the PR, apply this body with \`gh-axi pr edit <number> --body-file <path>\` (the \`gh pr edit --body-file\` operation), preserving the existing Pipeline section and attestation comment byte-identically."
+  fi
+fi
+
 cat > "$BRIEF" <<EOF
 You are a crewmate: an autonomous worker agent managed by firstmate. Work on your own; do not wait for a human.
 
@@ -505,5 +526,7 @@ If you touch a project \`AGENTS.md\`, follow \`$FM_ROOT/bin/fm-ensure-agents-md.
 Keep it proportionate: skip \`AGENTS.md\` edits for trivial tasks that produced no durable project knowledge.
 
 $DOD
+
+$PR_BODY_SECTION
 EOF
 echo "scaffolded: $BRIEF (ship, mode=$MODE; replace {TASK} and {FIRSTMATE_SPEC})"

--- a/bin/fm-dod-lib.sh
+++ b/bin/fm-dod-lib.sh
@@ -252,4 +252,22 @@ EOF
       echo "error: fm_dod_block: unknown delivery mode '$mode'" >&2
       return 1 ;;
   esac
+  if [ "$mode" != local-only ]; then
+    cat <<'EOF'
+
+# PR body
+Write for the captain first: plain language before evidence, in this section order:
+- `## Intent` - open with a plain-language paragraph of the captain's ask and why it matters to him, then explicit scope (in and out) and acceptance criteria.
+- `## What Changed` - one bullet per changed file saying what changed there.
+- `## Choices made where the spec was silent` - every choice the spec did not settle, least-confident first.
+- `## Risk Assessment` - a severity line with blast-radius reasoning and what was verified unchanged.
+- `## Testing` - reproduce-first evidence on the base commit and after the fix, then lint and test evidence.
+The no-mistakes Pipeline section and attestation stamp are tool-owned: never hand-write or edit them.
+EOF
+    if [ "$mode" = no-mistakes ]; then
+      cat <<'EOF'
+After the pipeline opens the PR, apply this body with `gh-axi pr edit <number> --body-file <path>` (the `gh pr edit --body-file` operation), preserving the existing Pipeline section and attestation comment byte-identically.
+EOF
+    fi
+  fi
 }

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -32,8 +32,8 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-backlog-receive.sh`  | Idempotently ingest one confined remote handoff outbox through tasks-axi             |
 | `fm-captain-hold.sh`     | Hold tasks for the captain, record the captain's answers, gate investigation completion, and report record divergence between the status log and the backlog |
 | `fm-decision-hold.sh`    | One-release compatibility shim mapping the retired decision commands onto fm-captain-hold.sh |
-| `fm-brief.sh`            | Scaffold ship (explicit `--mode`), scout, secondmate-charter, and Herdr-lab briefs, with Captain's intent and Firstmate spec subsections on ship/scout and a PR body contract for PR-opening ships; see `bin/fm-brief.sh --help` |
-| [`fm-dod-lib.sh`](../bin/fm-dod-lib.sh) | Own ship/scout worker role scope, ship definitions of done, and the no-mistakes `--intent` contract |
+| `fm-brief.sh`            | Scaffold ship (explicit `--mode`), scout, secondmate-charter, and Herdr-lab briefs, with Captain's intent and Firstmate spec subsections on ship/scout and the shared [`fm-dod-lib.sh`](../bin/fm-dod-lib.sh) delivery contract for ships; see `bin/fm-brief.sh --help` |
+| [`fm-dod-lib.sh`](../bin/fm-dod-lib.sh) | Own ship/scout worker role scope, ship definitions of done, the PR body contract for ordinary and promoted PR-opening workers, and the no-mistakes `--intent` contract |
 | `fm-herdr-lab.sh`        | Provision and guardedly operate an isolated, never-default Herdr lab session         |
 | `fm-install-herdr.sh`    | Install CI's exact-version Herdr pin with official asset URL, SHA-256, and protocol checks |
 | `fm-install-treehouse.sh`| Install CI's exact-version Treehouse pin for real-Herdr E2E that needs spawn worktrees |

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -32,7 +32,7 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-backlog-receive.sh`  | Idempotently ingest one confined remote handoff outbox through tasks-axi             |
 | `fm-captain-hold.sh`     | Hold tasks for the captain, record the captain's answers, gate investigation completion, and report record divergence between the status log and the backlog |
 | `fm-decision-hold.sh`    | One-release compatibility shim mapping the retired decision commands onto fm-captain-hold.sh |
-| `fm-brief.sh`            | Scaffold ship (explicit `--mode`), scout, secondmate-charter, and Herdr-lab briefs, with Captain's intent and Firstmate spec subsections on ship/scout |
+| `fm-brief.sh`            | Scaffold ship (explicit `--mode`), scout, secondmate-charter, and Herdr-lab briefs, with Captain's intent and Firstmate spec subsections on ship/scout and a PR body contract for PR-opening ships; see `bin/fm-brief.sh --help` |
 | [`fm-dod-lib.sh`](../bin/fm-dod-lib.sh) | Own ship/scout worker role scope, ship definitions of done, and the no-mistakes `--intent` contract |
 | `fm-herdr-lab.sh`        | Provision and guardedly operate an isolated, never-default Herdr lab session         |
 | `fm-install-herdr.sh`    | Install CI's exact-version Herdr pin with official asset URL, SHA-256, and protocol checks |

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -195,7 +195,7 @@ EOF
 # one of these DOD blocks, since a broken heredoc corrupts or empties the
 # generated brief content, not just the script's own syntax.
 test_ship_modes_generate_clean_briefs() {
-  local home id mode brief status
+  local home id mode brief status headings
   home="$TMP_ROOT/ship-home"
   write_registry "$home"
 
@@ -207,6 +207,25 @@ test_ship_modes_generate_clean_briefs() {
     brief="$home/data/$id/brief.md"
     assert_present "$brief" "$id: brief was not scaffolded"
     assert_grep "# Definition of done" "$brief" "$id: brief missing Definition of done section"
+    if [ "$mode" = local-only ]; then
+      assert_no_grep '# PR body' "$brief" "$mode received a PR body contract"
+    else
+      assert_grep '# PR body' "$brief" "$mode omitted the PR body contract"
+      # shellcheck disable=SC2016  # Match literal Markdown backticks in the generated contract.
+      headings=$(sed -n 's/^- `\(## [^`]*\)` -.*/\1/p' "$brief")
+      [ "$headings" = '## Intent
+## What Changed
+## Choices made where the spec was silent
+## Risk Assessment
+## Testing' ] || fail "$mode PR headings are missing, duplicated, or out of order"
+      assert_grep 'never hand-write or edit them' "$brief" "$mode lost the tool-owned metadata boundary"
+      if [ "$mode" = no-mistakes ]; then
+        assert_grep 'gh-axi pr edit <number> --body-file <path>' "$brief" "no-mistakes omitted the post-open body edit"
+        assert_grep 'attestation comment byte-identically' "$brief" "no-mistakes lost byte-preservation"
+      else
+        assert_no_grep 'After the pipeline opens the PR' "$brief" "direct-PR received pipeline-only instructions"
+      fi
+    fi
     grep -qx "Delivery contract: mode=$mode" "$brief" \
       || fail "$id: brief did not record its machine-readable delivery contract line"
     assert_grep "{TASK}" "$brief" "$id: brief missing the {TASK} placeholder"
@@ -258,6 +277,7 @@ test_ship_mode_is_explicit_not_registry() {
   FM_HOME="$home" "$ROOT/bin/fm-brief.sh" brief-explicit-a5 direct-proj --mode no-mistakes >/dev/null 2>&1 \
     || fail "explicit no-mistakes brief on a direct-PR project should scaffold"
   brief="$home/data/brief-explicit-a5/brief.md"
+  assert_grep "# PR body" "$brief" "no-mistakes ship omitted the PR body contract"
   grep -qx "Delivery contract: mode=no-mistakes" "$brief" \
     || fail "registered direct-PR posture overrode the explicit --mode"
   assert_grep "Firstmate will then instruct you to run /no-mistakes" "$brief" \
@@ -501,6 +521,11 @@ test_herdr_lab_omission_is_loud_for_ship_and_scout() {
       FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" firstmate --mode no-mistakes >/dev/null 2>&1
     fi
     brief="$home/data/$id/brief.md"
+    if [ "$kind" = scout ]; then
+      assert_no_grep '# PR body' "$brief" "scout received a PR body contract"
+    else
+      assert_grep '# PR body' "$brief" "ship omitted the PR body contract"
+    fi
     assert_grep "# Herdr lifecycle declaration - NOT ENABLED" "$brief" \
       "$kind brief silently omitted the Herdr declaration"
     assert_grep "regenerate the brief with \`--herdr-lab\` before dispatch" "$brief" \
@@ -530,6 +555,11 @@ test_documented_global_replace_leaves_the_herdr_gate_intact() {
       FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" firstmate --mode no-mistakes >/dev/null 2>&1
     fi
     brief="$home/data/$id/brief.md"
+    if [ "$kind" = scout ]; then
+      assert_no_grep '# PR body' "$brief" "scout received a PR body contract"
+    else
+      assert_grep '# PR body' "$brief" "ship omitted the PR body contract"
+    fi
     assert_present "$brief" "$kind brief was not scaffolded"
     count=$(grep -c -F '{TASK}' "$brief")
     [ "$count" = 1 ] \
@@ -564,6 +594,7 @@ test_secondmate_no_projects_charter() {
     "$ROOT/bin/fm-brief.sh" fdev --secondmate --no-projects >/dev/null 2>&1; status=$?
   expect_code 0 "$status" "--no-projects secondmate brief should exit 0"
   brief="$home/data/fdev/brief.md"
+  assert_no_grep '# PR body' "$brief" "secondmate received a PR body contract"
   assert_present "$brief" "project-less charter was not scaffolded"
   assert_grep "# Project clones" "$brief" "project-less charter dropped the Project clones heading"
   assert_grep "None. This is a project-less domain" "$brief" \
@@ -836,6 +867,7 @@ test_scout_and_secondmate_scaffold() {
     FM_HOME="$BRIEF_HOME" "$ROOT/bin/fm-brief.sh" brief-sm-q6 --secondmate alpha >/dev/null 2>&1 \
     || fail "fm-brief.sh secondmate scaffold exited non-zero"
   brief="$BRIEF_HOME/data/brief-sm-q6/brief.md"
+  assert_no_grep '# PR body' "$brief" "project-bearing secondmate received a PR body contract"
   assert_present "$brief" "secondmate charter was not scaffolded"
   assert_grep "persistent second mate" "$brief" \
     "secondmate charter must declare its role"

--- a/tests/fm-task-delivery.test.sh
+++ b/tests/fm-task-delivery.test.sh
@@ -307,7 +307,7 @@ test_promote_refuses_a_symlinked_task_record() {
 # prints against a capturing fm-send.sh, and asserts on the message the worker would
 # actually receive - for every supported mode.
 test_promotion_delivers_the_real_definition_of_done() {
-  local home meta out sendroot payload mode id brief_dod delivered_dod
+  local home meta out sendroot payload mode id brief_dod delivered_dod headings
   home="$TMP_ROOT/promote-dod/home"
   sendroot="$TMP_ROOT/promote-dod/sendroot"
   mkdir -p "$home/state" "$sendroot/bin"
@@ -337,6 +337,26 @@ STUB
          eval "$(printf '%s\n' "$out" | sed -n 's/^next: //p' | grep 'fm-send\.sh')" ) \
       || fail "$mode: promotion's delivery command did not run"
     assert_present "$payload" "$mode: promotion delivered no message to the worker"
+
+    if [ "$mode" = local-only ]; then
+      assert_no_grep '# PR body' "$payload" "$mode: promoted worker received a PR body contract"
+    else
+      assert_grep '# PR body' "$payload" "$mode: promoted worker omitted the PR body contract"
+      # shellcheck disable=SC2016
+      headings=$(sed -n 's/^- `\(## [^`]*\)` -.*/\1/p' "$payload")
+      [ "$headings" = '## Intent
+## What Changed
+## Choices made where the spec was silent
+## Risk Assessment
+## Testing' ] || fail "$mode: promoted worker PR headings are missing, duplicated, or out of order"
+      assert_grep 'never hand-write or edit them' "$payload" "$mode: promoted worker lost the tool-owned metadata boundary"
+      if [ "$mode" = no-mistakes ]; then
+        assert_grep 'gh-axi pr edit <number> --body-file <path>' "$payload" "$mode: promoted worker omitted the post-open body edit"
+        assert_grep 'attestation comment byte-identically' "$payload" "$mode: promoted worker lost byte-preservation"
+      else
+        assert_no_grep 'After the pipeline opens the PR' "$payload" "$mode: promoted worker received pipeline-only instructions"
+      fi
+    fi
 
     grep -qx "Delivery contract: mode=$mode" "$payload" \
       || fail "$mode: promoted worker did not receive the machine-readable delivery contract"


### PR DESCRIPTION
## Intent

The captain wants PR descriptions to explain the purpose plainly before presenting technical evidence, with the same layout whether delivery uses no-mistakes or opens a PR directly.

Scope: apply the five-section contract to ordinary ship briefs and promoted-scout shipping instructions for both PR-opening modes.
Local-only work, scouts, secondmates, the shape-of-the-change block, chat presentation, and no-mistakes itself are outside this change.
Acceptance criteria: the five sections appear in order, non-PR instructions omit them, and tool-owned metadata stays intact.

## What Changed

- `bin/fm-dod-lib.sh`: owns the shared PR body contract and the no-mistakes post-open editing instruction.
- `bin/fm-brief.sh`: consumes the shared delivery block and documents the contract in help.
- `tests/fm-brief.test.sh`: checks heading order, metadata instructions, both PR modes, and excluded scaffold types.
- `tests/fm-task-delivery.test.sh`: verifies the same contract reaches promoted scouts in both PR modes and excludes local-only promotion.
- `docs/scripts.md`: points to the shared owner and generator help.

## Choices made where the spec was silent

- Use the existing `gh-axi pr edit --body-file` wrapper for post-open editing; installed no-mistakes v1.70.1 exposes no AXI body-input flag.
- Keep one contract in the delivery owner shared by ordinary and promoted workers.

## Risk Assessment

Low: this changes generated instructions, with no change to delivery execution.
Live CLI checks verified the layout on ordinary and promoted PR paths, exclusions for non-PR work, and refusal of invalid mode combinations.
Model compliance with the instructions remains a runtime limitation.

## Testing

The base generator omitted the contract; the new missing-contract assertion failed before the change and passed afterward.
Pipeline testing reproduced the omission on the base commit and passed all five live CLI scenarios on the fixed head, including promotion and exclusions.

- `bin/fm-test-run.sh tests/fm-brief.test.sh`: passed before pipeline validation.
- Pipeline lint: passed on the fixed head.
- `bin/fm-doc-audience-check.sh`: passed.
- The published body was updated through `gh-axi`, retaining the existing Pipeline block byte-for-byte.

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"de05f3f7160510e172e759c6e71e05c9ddadd5bc","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}],"live_validation":{"verdict":"go","live":5,"total":5}} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed ✅</summary>

- 🚨 `bin/fm-brief.sh:446` - The intent requires this layout for “every delivery path that opens a PR,” but the new `PR_BODY_SECTION` exists only in fm-brief.sh. A scout subsequently promoted with `fm-promote.sh &lt;id&gt; --mode direct-PR|no-mistakes --yolo off` receives ship-instructions.md containing only fm_dod_block (fm-promote.sh:190); neither its original scout brief nor its promotion instructions contains the layout. Put the contract in the existing shared delivery owner, fm-dod-lib.sh, so ordinary and promoted workers both receive it.

🔧 Fix applied.
✅ Re-checked - no issues remain.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- Live validation: ✅ go - 5 of 5 scenarios driven live against the product

| Scenario | Result | Live | Evidence |
| --- | --- | --- | --- |
| Generate ordinary worker instructions for both PR modes: all five sections appear once, in order, regardless of project registry posture. | ✅ pass | live | Base and target CLI transcript; Ordinary no-mistakes instructions |
| Promote a scout into either PR mode: generated ship instructions match the ordinary PR contract and preserve captain intent. | ✅ pass | live | Promoted no-mistakes instructions; Promoted direct-PR instructions |
| Generate local-only, scout, and secondmate instructions, including local-only promotion: no PR layout is emitted. | ✅ pass | live | Base and target CLI transcript |
| Generate PR instructions: both modes reserve tool-owned metadata, while only no-mistakes receives post-open editing and byte-preservation instructions. | ✅ pass | live | Promoted no-mistakes instructions; Promoted direct-PR instructions |
| Attempt PR modes on scouts and secondmates, or use the registry-only policy as a task mode: commands refuse without generating a brief. | ✅ pass | live | Excluded-role and invalid-mode refusals |

- <code>`git status --short --branch -uall` and base-to-target diff inspection.</code>
- <code>`git archive 269f8fe64a692ebdabd7c9ad205f5aa5c28caadc bin | tar -x -C .pr-layout-live/base` for isolated baseline execution.</code>
- <code>`python3 ~/.no-mistakes/evidence/01M24RHXJBZYVXGCB0XAB5GHKV/drive-layout.py` executed real `/bin/bash` brief and promotion commands against base and target.</code>
- <code>Manual CLI probes rejected scout/secondmate delivery flags and `--mode no-mistakes-prod-only`, checking that no brief was created.</code>
- `Inspected generated PR instructions, saved CLI transcripts and Markdown outputs, removed temporary test homes and baseline files, and confirmed a clean worktree.`
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
