### PR TITLE
feat(skills): add RevoCall-family local e2e provision/cleanup pair

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -105,6 +105,7 @@ state/               runtime records and signals; gitignored
   <id>.cursor-session  cursor busy-source binding (projects root, task worktree, prior conversations) written by fm-spawn; removed by teardown
   <id>.reconcile-nudged  epoch second of the last inventory-reconcile nudge sent to this secondmate; bin/fm-secondmate-reconcile.sh owns its per-home cooldown window
   <id>.backlog-close  the exact backlog transition a teardown recorded before removing the task's record, so an interrupted cleanup can still be finished at the next session start; bin/fm-backlog-transition-lib.sh owns its format and replay, and a landed transition removes it
+  <id>.e2e-stack     durable record of the local docker stacks a task provisioned for end-to-end testing, so cleanup never has to rediscover them; written only by bin/fm-e2e-stack.sh, which owns the block format and the four ownership gates, and removed by that script's verified `down`
   <id>.inbox/          durable steering inbox: sequenced firstmate instruction records the worker acknowledges by moving them into its handled/ subdirectory; written by fm-send, with ordinary records re-rung and escalated by the watcher while explicit fire-and-forget records are excluded from that ladder, and removed by teardown (bin/fm-task-inbox-lib.sh)
   <id>.meta          task metadata; each producer script's header owns its exact fields and mutation contract, with docs/configuration.md routing operator-facing backend and trace-context details
   <id>.herdr-presentation  quarantinable attempt and restart-binding journal for Herdr's optional visual projection; never task or endpoint authority; see docs/herdr-backend.md "Presentation spaces"
@@ -538,6 +539,7 @@ Keep additions task-specific rather than repeating lifecycle instructions, and a
 
 Every ship brief must retain the worktree-isolation assertion and stop if launched in the primary checkout.
 If a ship task touches firstmate's shared tracked material, explicitly require `firstmate-coding-guidelines` before editing.
+If a task needs a local docker stack for end-to-end testing, name `revocall-e2e-provision` and `revocall-e2e-teardown` in `## Firstmate spec` so the worker provisions a task-scoped stack and removes it, instead of leaving containers whose ownership takes a forensic session to recover; `bin/fm-teardown.sh` releases whatever that pair recorded, so a worker that dies mid-test still gets cleaned up.
 If a task will drive Herdr lifecycle behavior, scaffold with `--herdr-lab`; if that need appears after an unguarded scaffold, stop and regenerate rather than adding commands by hand.
 The generated Herdr contract must use a named non-`default` isolated lab and its guarded helper for every lifecycle action.
 

--- a/README.md
+++ b/README.md
@@ -207,6 +207,8 @@ Firstmate's skills live in two separate places with different audiences:
   Each one is a self-contained skill with no dependency on firstmate's paths, tools, or vocabulary.
   Today that is `skills/stow`, a generic session-knowledge-sweep skill that routes findings by explicit instruction first, then existing local conventions, then a private `.stow-notes.md` fallback, and curates tiered entries through decay, local archival, and user-approved on-demand offload proposals.
   It intentionally shares no code with the firstmate-internal `.agents/skills/stow` it is named after, so the two can evolve independently.
+  Also `skills/revocall-e2e-provision` and `skills/revocall-e2e-teardown`, a pair that brings up a task-scoped local docker stack for one named end-to-end test scenario across the RevoCall-family repos and then removes exactly what it started.
+  Their firstmate-coupled half is `bin/fm-e2e-stack.sh`, which owns the durable record and the ownership gates, and the pre-teardown release in `bin/fm-teardown.sh`; the skills themselves run standalone against `--task` when no firstmate home is present.
 
 ## Documentation
 

--- a/bin/fm-e2e-stack.sh
+++ b/bin/fm-e2e-stack.sh
@@ -1,0 +1,496 @@
+#!/usr/bin/env bash
+# fm-e2e-stack.sh - durable record and guarded removal of a task's local
+# end-to-end test infrastructure (docker compose stacks).
+#
+# Usage:
+#   fm-e2e-stack.sh record <task-id> --project <name> --stack <profile> \
+#     --repo <repo> --scenario <name> --worktree <path> \
+#     [--compose-file <path>]... [--service <name>]... \
+#     [--external-volume <name>]... [--network <name>] [--created-network] \
+#     [--port <NAME=port>]...
+#   fm-e2e-stack.sh read <task-id>
+#   fm-e2e-stack.sh gate <task-id>
+#   fm-e2e-stack.sh down <task-id> [--dry-run]
+#   fm-e2e-stack.sh clear <task-id>
+#   fm-e2e-stack.sh strays
+#
+# WHY THIS EXISTS. A crewmate that provisions a local stack for an end-to-end
+# test and then dies, or simply forgets, leaves containers, volumes and a
+# network running with no record of who owns them. Recovering that ownership by
+# hand costs a forensic session: reading database logs for a last-activity
+# timestamp, testing whether the launching worktree still exists, and grepping
+# old task reports for container names. This script is the durable half of the
+# `revocall-e2e-provision` / `revocall-e2e-teardown` skill pair: the skills own
+# the provisioning and cleanup PROCEDURE, this script owns the record format,
+# the ownership gates, and the removal, so cleanup converges whether the worker
+# runs it, teardown runs it, or a later session runs it.
+#
+# RECORD. state/<task-id>.e2e-stack holds one `key=value` block per provisioned
+# stack, blank-line separated, in the same shape as state/<task-id>.meta. A
+# repeated key is a list. `record` appends; re-recording the same project
+# replaces that block, so a re-provision cannot leave two records of one stack.
+#
+# OWNERSHIP GATES. `gate` and `down` remove nothing until all four pass:
+#   1. Every live container carrying label ai.revolab.fm.task=<task-id> belongs
+#      to a project this record names, and every recorded project's containers
+#      carry that label. A label without a record, or a record without matching
+#      containers, is reported as a divergence and blocks removal.
+#   2. Every recorded project name begins with the `fm-` prefix. Nothing a
+#      person or another tool started is named that way, so a hand-run or
+#      captain-owned stack can never be selected.
+#   3. No OTHER task record in this home names the same project or worktree.
+#      One project claimed by two task records is the collision itself,
+#      whichever record is stale, and is never resolved by guessing.
+#   4. Every recorded external volume name contains the task id. RevoCall's
+#      deploy stack pins six `external: true` volumes to fixed names, and
+#      compose removes external volumes on NO code path, including `down -v`
+#      (verified; docs/verification/local-e2e-infra.md). Removing one whose
+#      name carries no task suffix would destroy the shared local development
+#      data those unsuffixed names hold.
+# --dry-run prints the verdicts and the removal plan and changes nothing.
+# There is no --force: this script's refusals protect OTHER work, and
+# discarding this task's own work is never what they stand in the way of.
+#
+# NOT A SWEEPER. `strays` reports containers whose task record is gone; it
+# never removes them, and it never reports an unlabelled container as
+# removable. An anonymous container can be live work - a no-mistakes pipeline
+# run brings up a project named after its own directory - so removal always
+# needs a record, never an inference.
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FM_ROOT="${FM_ROOT_OVERRIDE:-$(cd "$SCRIPT_DIR/.." && pwd)}"
+FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
+STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
+DOCKER="${FM_DOCKER:-docker}"
+LABEL_TASK=ai.revolab.fm.task
+PROJECT_PREFIX=fm-
+
+# shellcheck source=bin/fm-pr-lib.sh
+. "$SCRIPT_DIR/fm-pr-lib.sh"
+
+die() { printf 'error: %s\n' "$1" >&2; exit 1; }
+# Print the header contract from `# Usage:` onward: the invocation forms plus
+# the record and ownership-gate rules a caller has to know. Extracted by
+# pattern rather than by line number so editing the header above can never
+# silently truncate or misalign --help.
+usage() {
+  awk '/^# Usage:/ {on=1} on && /^#/ {sub(/^# ?/, ""); print; next} on {exit}' "$0" >&2
+  exit 2
+}
+
+# A record field must survive the blank-line-separated key=value block format.
+# A tab or newline would break the block; '=' is safe because every reader
+# splits on the FIRST '=' only. An empty value is refused so an omitted flag
+# can never read back as a recorded value.
+field_valid() {  # <value>
+  local v=${1-}
+  [ -n "$v" ] || return 1
+  case $v in
+    *$'\t'* | *$'\n'*) return 1 ;;
+  esac
+  return 0
+}
+
+# Docker's own project-name charset, so a recorded project can never carry
+# filter or shell syntax into `docker ps --filter label=...=<project>`.
+project_name_valid() {  # <name>
+  case ${1-} in
+    '' ) return 1 ;;
+    [a-z0-9]*) : ;;
+    *) return 1 ;;
+  esac
+  case ${1-} in
+    *[^a-z0-9_-]*) return 1 ;;
+  esac
+  return 0
+}
+
+# Ports are the one field that legitimately contains '=' (NAME=port).
+port_valid() {  # <NAME=port>
+  case ${1-} in
+    [A-Z_]*=[0-9]*) [ "${1#*=}" -ge 1 ] 2>/dev/null && [ "${1#*=}" -le 65535 ] ;;
+    *) return 1 ;;
+  esac
+}
+
+require_state_dir() {
+  [ -d "$STATE" ] && [ ! -L "$STATE" ] || die "state directory is unavailable"
+}
+
+record_path() { printf '%s/%s.e2e-stack\n' "$STATE" "$1"; }
+
+# Print the value(s) of <key> from the block starting at <block-index>.
+block_values() {  # <file> <index> <key>
+  awk -v want="$2" -v key="$3" '
+    BEGIN { idx = 0; started = 0 }
+    /^[[:space:]]*$/ { if (started) { idx++; started = 0 } ; next }
+    { started = 1; if (idx == want) { eq = index($0, "=");
+        if (eq > 1 && substr($0, 1, eq - 1) == key) print substr($0, eq + 1) } }
+  ' "$1"
+}
+
+block_count() {  # <file>
+  [ -f "$1" ] || { printf '0\n'; return 0; }
+  awk '
+    BEGIN { idx = 0; started = 0 }
+    /^[[:space:]]*$/ { if (started) { idx++; started = 0 } ; next }
+    { started = 1 }
+    END { if (started) idx++; print idx }
+  ' "$1"
+}
+
+docker_available() { command -v "$DOCKER" >/dev/null 2>&1 && "$DOCKER" info >/dev/null 2>&1; }
+
+project_containers() {  # <project>
+  "$DOCKER" ps -aq --filter "label=com.docker.compose.project=$1" 2>/dev/null
+}
+
+project_volumes() {  # <project>
+  "$DOCKER" volume ls -q --filter "label=com.docker.compose.project=$1" 2>/dev/null
+}
+
+project_networks() {  # <project>
+  "$DOCKER" network ls -q --filter "label=com.docker.compose.project=$1" 2>/dev/null
+}
+
+labelled_containers() {  # <task-id>
+  "$DOCKER" ps -aq --filter "label=$LABEL_TASK=$1" 2>/dev/null
+}
+
+container_project() {  # <container>
+  "$DOCKER" inspect "$1" --format '{{index .Config.Labels "com.docker.compose.project"}}' 2>/dev/null
+}
+
+container_task() {  # <container>
+  "$DOCKER" inspect "$1" --format "{{index .Config.Labels \"$LABEL_TASK\"}}" 2>/dev/null
+}
+
+# Gate 3: no other task record in this home may name the same project or
+# worktree. Reads only this home's own records, never a shared namespace.
+other_record_claims() {  # <task-id> <project> <worktree>
+  local id=$1 project=$2 worktree=$3 f other
+  for f in "$STATE"/*.e2e-stack; do
+    [ -f "$f" ] || continue
+    other=${f##*/}; other=${other%.e2e-stack}
+    [ "$other" = "$id" ] && continue
+    if grep -qxF "project=$project" "$f" 2>/dev/null; then
+      printf '%s claims project %s\n' "$other" "$project"
+    fi
+    if [ -n "$worktree" ] && grep -qxF "worktree=$worktree" "$f" 2>/dev/null; then
+      printf '%s claims worktree %s\n' "$other" "$worktree"
+    fi
+  done
+}
+
+cmd_record() {
+  local id=${1-}; shift || true
+  fm_pr_task_id_valid "$id" || die "invalid task id"
+  require_state_dir
+  local project='' stack='' repo='' scenario='' worktree='' network=''
+  local created_network=0
+  # Newline-delimited accumulators rather than arrays: bash 3.2 is the system
+  # shell on macOS and expanding an empty array under `set -u` aborts there.
+  # Every value is validated newline-free before it is appended, so the
+  # delimiter can never be ambiguous.
+  local compose_files='' services='' external_volumes='' ports=''
+  while [ "$#" -gt 0 ]; do
+    case $1 in
+      --project)         project=${2-}; shift 2 || die "--project needs a value" ;;
+      --stack)           stack=${2-}; shift 2 || die "--stack needs a value" ;;
+      --repo)            repo=${2-}; shift 2 || die "--repo needs a value" ;;
+      --scenario)        scenario=${2-}; shift 2 || die "--scenario needs a value" ;;
+      --worktree)        worktree=${2-}; shift 2 || die "--worktree needs a value" ;;
+      --network)         network=${2-}; shift 2 || die "--network needs a value" ;;
+      --created-network) created_network=1; shift ;;
+      --compose-file)
+        field_valid "${2-}" || die "invalid --compose-file value"
+        compose_files=$compose_files${2}$'\n'; shift 2 ;;
+      --service)
+        field_valid "${2-}" || die "invalid --service value"
+        services=$services${2}$'\n'; shift 2 ;;
+      --external-volume)
+        field_valid "${2-}" || die "invalid --external-volume value"
+        external_volumes=$external_volumes${2}$'\n'; shift 2 ;;
+      --port)
+        port_valid "${2-}" || die "invalid --port value (want NAME=port): ${2-}"
+        ports=$ports${2}$'\n'; shift 2 ;;
+      *) die "unknown argument: $1" ;;
+    esac
+  done
+  local v
+  for v in "$project" "$stack" "$repo" "$scenario" "$worktree"; do
+    field_valid "$v" \
+      || die "record needs --project, --stack, --repo, --scenario and --worktree, each non-empty and free of tabs and newlines"
+  done
+  project_name_valid "$project" \
+    || die "project name must match docker's own charset [a-z0-9][a-z0-9_-]*: $project"
+  case $project in
+    "$PROJECT_PREFIX"*) : ;;
+    *) die "project name must begin with '$PROJECT_PREFIX' so cleanup can never select a stack this repo did not provision" ;;
+  esac
+  [ -n "$compose_files" ] || die "record needs at least one --compose-file"
+  [ -z "$network" ] || field_valid "$network" || die "invalid network name"
+  # Gate 4 is enforced at write time as well as at removal time, so an
+  # unsuffixed external volume can never enter the record in the first place.
+  while IFS= read -r v; do
+    [ -n "$v" ] || continue
+    case $v in
+      *"$id"*) : ;;
+      *) die "external volume '$v' does not carry the task id; an unsuffixed name is shared local data and is never task-owned" ;;
+    esac
+  done <<EOF
+$external_volumes
+EOF
+
+  local file; file=$(record_path "$id")
+  umask 077
+  local tmp; tmp=$(mktemp "$STATE/.fm-e2e-stack.XXXXXX") || die "cannot stage the record"
+  # shellcheck disable=SC2064 # Expand tmp now: the trap must name this file.
+  trap "rm -f -- '$tmp'" EXIT HUP INT TERM
+  # Re-recording a project replaces its block rather than adding a second one.
+  if [ -f "$file" ]; then
+    awk -v drop="project=$project" '
+      BEGIN { RS = ""; ORS = "\n\n" }
+      { keep = 1
+        n = split($0, lines, "\n")
+        for (i = 1; i <= n; i++) if (lines[i] == drop) keep = 0
+        if (keep && $0 != "") print $0 }
+    ' "$file" > "$tmp" || die "cannot rewrite the record"
+  fi
+  {
+    printf 'schema=fm-e2e-stack.v1\n'
+    printf 'task=%s\n' "$id"
+    printf 'project=%s\n' "$project"
+    printf 'stack=%s\n' "$stack"
+    printf 'repo=%s\n' "$repo"
+    printf 'scenario=%s\n' "$scenario"
+    printf 'created=%s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+    printf 'worktree=%s\n' "$worktree"
+    printf '%s' "$compose_files" | while IFS= read -r v; do
+      [ -n "$v" ] && printf 'compose_file=%s\n' "$v"; done
+    printf '%s' "$services" | while IFS= read -r v; do
+      [ -n "$v" ] && printf 'service=%s\n' "$v"; done
+    printf '%s' "$external_volumes" | while IFS= read -r v; do
+      [ -n "$v" ] && printf 'external_volume=%s\n' "$v"; done
+    [ -z "$network" ] || printf 'network=%s\n' "$network"
+    [ "$created_network" = 1 ] && printf 'created_network=1\n'
+    printf '%s' "$ports" | while IFS= read -r v; do
+      [ -n "$v" ] && printf 'port=%s\n' "$v"; done
+    printf '\n'
+  } >> "$tmp" || die "cannot write the record"
+  chmod 0600 "$tmp" || die "cannot secure the record"
+  mv -f -- "$tmp" "$file" || die "cannot publish the record"
+  trap - EXIT HUP INT TERM
+  printf 'recorded: state/%s.e2e-stack project=%s\n' "$id" "$project"
+}
+
+cmd_read() {
+  local id=${1-}
+  fm_pr_task_id_valid "$id" || die "invalid task id"
+  require_state_dir
+  local file; file=$(record_path "$id")
+  [ -f "$file" ] || { printf 'ABSENT: state/%s.e2e-stack\n' "$id"; return 0; }
+  cat "$file"
+}
+
+# Run the four gates for every recorded stack. Prints one verdict line per
+# gate per stack and returns non-zero when any gate fails.
+run_gates() {  # <task-id>
+  local id=$1 file count i project worktree claims claim cs c ctask cproj vol mismatch
+  file=$(record_path "$id")
+  [ -f "$file" ] || { printf 'gate: ABSENT no record for %s\n' "$id"; return 1; }
+  count=$(block_count "$file")
+  [ "$count" -gt 0 ] || { printf 'gate: EMPTY record for %s\n' "$id"; return 1; }
+  local rc=0 have_docker=1
+  docker_available || have_docker=0
+  [ "$have_docker" = 1 ] || printf 'gate: docker unavailable; container gates cannot be proved\n'
+  i=0
+  while [ "$i" -lt "$count" ]; do
+    project=$(block_values "$file" "$i" project)
+    worktree=$(block_values "$file" "$i" worktree)
+    # Gate 2 first: it is a pure string test and needs no docker.
+    case $project in
+      "$PROJECT_PREFIX"*) printf 'gate2 ok      %s prefix\n' "$project" ;;
+      *) printf 'gate2 REFUSED %s does not begin with %s\n' "$project" "$PROJECT_PREFIX"; rc=1 ;;
+    esac
+    # Gate 3.
+    claims=$(other_record_claims "$id" "$project" "$worktree")
+    if [ -n "$claims" ]; then
+      printf '%s\n' "$claims" | while IFS= read -r claim; do
+        [ -n "$claim" ] && printf 'gate3 REFUSED %s\n' "$claim"
+      done
+      rc=1
+    else
+      printf 'gate3 ok      %s claimed by no other task record\n' "$project"
+    fi
+    # Gate 4.
+    while IFS= read -r vol; do
+      [ -n "$vol" ] || continue
+      case $vol in
+        *"$id"*) printf 'gate4 ok      %s carries the task id\n' "$vol" ;;
+        *) printf 'gate4 REFUSED %s carries no task id; shared local data is never task-owned\n' "$vol"; rc=1 ;;
+      esac
+    done < <(block_values "$file" "$i" external_volume)
+    # Gate 1 needs docker.
+    if [ "$have_docker" = 1 ]; then
+      cs=$(project_containers "$project")
+      mismatch=0
+      for c in $cs; do
+        ctask=$(container_task "$c")
+        if [ "$ctask" != "$id" ]; then
+          printf 'gate1 REFUSED container %s in %s carries task label %s\n' \
+            "$c" "$project" "${ctask:-<none>}"
+          mismatch=1; rc=1
+        fi
+      done
+      if [ -n "$cs" ] && [ "$mismatch" = 0 ]; then
+        printf 'gate1 ok      every container in %s carries task label %s\n' "$project" "$id"
+      fi
+    else
+      rc=1
+    fi
+    i=$((i + 1))
+  done
+  # Gate 1, other direction: a labelled container whose project this record
+  # does not name is a divergence, not a target.
+  if [ "$have_docker" = 1 ]; then
+    for c in $(labelled_containers "$id"); do
+      cproj=$(container_project "$c")
+      if ! grep -qxF "project=$cproj" "$file" 2>/dev/null; then
+        printf 'gate1 REFUSED container %s labels task %s but its project %s is unrecorded\n' \
+          "$c" "$id" "${cproj:-<none>}"; rc=1
+      fi
+    done
+  fi
+  return "$rc"
+}
+
+cmd_gate() {
+  local id=${1-}
+  fm_pr_task_id_valid "$id" || die "invalid task id"
+  require_state_dir
+  run_gates "$id"
+}
+
+cmd_down() {
+  local id=${1-}; shift || true
+  fm_pr_task_id_valid "$id" || die "invalid task id"
+  require_state_dir
+  local dry=0
+  while [ "$#" -gt 0 ]; do
+    case $1 in
+      --dry-run) dry=1; shift ;;
+      *) die "unknown argument: $1" ;;
+    esac
+  done
+  local file; file=$(record_path "$id")
+  [ -f "$file" ] || { printf 'down: nothing recorded for %s\n' "$id"; return 0; }
+  run_gates "$id" || die "ownership gates refused; nothing was removed"
+  local count i project network vol f residue rc=0
+  local -a args
+  count=$(block_count "$file")
+  i=0
+  while [ "$i" -lt "$count" ]; do
+    project=$(block_values "$file" "$i" project)
+    args=(-p "$project")
+    # Read line by line: a recorded path may legitimately contain a space, and
+    # `for f in $(...)` would split one such path into two bogus -f arguments.
+    while IFS= read -r f; do
+      [ -n "$f" ] || continue
+      args+=(-f "$f")
+    done < <(block_values "$file" "$i" compose_file)
+    if [ "$dry" = 1 ]; then
+      printf 'down: would run %s compose %s down -v --remove-orphans\n' "$DOCKER" "${args[*]}"
+    else
+      "$DOCKER" compose "${args[@]}" down -v --remove-orphans --timeout 20 >&2 || rc=1
+      while IFS= read -r vol; do
+        [ -n "$vol" ] || continue
+        "$DOCKER" volume rm -- "$vol" >/dev/null 2>&1 || true
+      done < <(block_values "$file" "$i" external_volume)
+      network=$(block_values "$file" "$i" network)
+      if [ -n "$network" ] && [ "$(block_values "$file" "$i" created_network)" = 1 ]; then
+        "$DOCKER" network rm -- "$network" >/dev/null 2>&1 || true
+      fi
+      # Verify once, over everything this stack owned: a removal that leaves
+      # residue is a failure, not a success, and the record stays for retry.
+      residue=$(project_containers "$project")$(project_volumes "$project")$(project_networks "$project")
+      while IFS= read -r vol; do
+        [ -n "$vol" ] || continue
+        if "$DOCKER" volume inspect "$vol" >/dev/null 2>&1; then
+          residue=$residue$vol
+          printf 'down: RESIDUE external volume %s remains\n' "$vol" >&2
+        fi
+      done < <(block_values "$file" "$i" external_volume)
+      if [ -n "$residue" ]; then
+        printf 'down: RESIDUE remains for %s; the record is preserved for retry\n' "$project" >&2
+        rc=1
+      else
+        printf 'down: %s removed (containers, volumes, network)\n' "$project"
+      fi
+    fi
+    i=$((i + 1))
+  done
+  [ "$dry" = 1 ] && return 0
+  [ "$rc" = 0 ] || return 1
+  cmd_clear "$id"
+}
+
+cmd_clear() {
+  local id=${1-}
+  fm_pr_task_id_valid "$id" || die "invalid task id"
+  require_state_dir
+  local file; file=$(record_path "$id")
+  [ -f "$file" ] && [ ! -L "$file" ] || { printf 'clear: no record for %s\n' "$id"; return 0; }
+  rm -f -- "$file" || die "cannot remove the record"
+  printf 'cleared: state/%s.e2e-stack\n' "$id"
+}
+
+# Read-only report. Never a removal path: an unlabelled container can be live
+# work, so this only says what it saw and who, if anyone, still claims it.
+cmd_strays() {
+  [ "$#" -eq 0 ] || die "strays takes no arguments"
+  # Required, not optional: without the state directory every task's record
+  # reads as absent and the report would claim every container is abandoned.
+  require_state_dir
+  docker_available || { printf 'strays: docker unavailable\n'; return 0; }
+  local c name task proj wd claim live
+  for c in $("$DOCKER" ps -aq 2>/dev/null); do
+    name=$("$DOCKER" inspect "$c" --format '{{.Name}}' 2>/dev/null | tr -d /)
+    task=$(container_task "$c")
+    proj=$(container_project "$c")
+    wd=$("$DOCKER" inspect "$c" --format '{{index .Config.Labels "com.docker.compose.project.working_dir"}}' 2>/dev/null)
+    if [ -n "$task" ]; then
+      claim="task=$task"
+      # The label is written by whoever started the container, so it is never
+      # trusted as a path component: a garbled or hostile value must not send
+      # this probe outside the state directory.
+      if ! fm_pr_task_id_valid "$task"; then
+        live=record=UNREADABLE
+      elif [ -f "$STATE/$task.meta" ]; then
+        live=record=LIVE
+      else
+        live=record=GONE
+      fi
+    else
+      claim=unlabelled; live=record=none
+    fi
+    printf '%s\t%s\t%s\tworkdir=%s\tproject=%s\n' \
+      "$name" "$claim" "$live" \
+      "$([ -n "$wd" ] && { [ -d "$wd" ] && echo EXISTS || echo GONE; } || echo unknown)" \
+      "${proj:-<none>}"
+  done
+}
+
+[ "$#" -ge 1 ] || usage
+SUB=$1; shift
+case $SUB in
+  record) cmd_record "$@" ;;
+  read)   cmd_read "$@" ;;
+  gate)   cmd_gate "$@" ;;
+  down)   cmd_down "$@" ;;
+  clear)  cmd_clear "$@" ;;
+  strays) cmd_strays "$@" ;;
+  -h|--help) usage ;;
+  *) die "unknown subcommand: $SUB" ;;
+esac

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -229,9 +229,10 @@
 #     ownership by hand costs a forensic session. bin/fm-e2e-stack.sh owns the
 #     record format, the four ownership gates, and the removal; this teardown
 #     only invokes its `down`, and only for THIS task's own record. It runs
-#     here rather than later because both the record it reads
-#     (state/<id>.e2e-stack) and the standalone fallback copy a worker may have
-#     written under the per-task tasktmp are removed further down. Best effort: a
+#     here rather than later because `down`'s own `-f` arguments come from the
+#     record's compose_file entries, and the generated override file among
+#     them lives under the per-task tasktmp, which is removed further down;
+#     `docker compose -f` refuses a path that is already gone. Best effort: a
 #     stopped docker daemon, an absent record, or a gate that cannot be proved
 #     leaves the stack in place and says so, and never blocks this teardown -
 #     the stack is reported by the next session start instead.

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -220,6 +220,21 @@
 #     root still exists, so the account's healthy LaunchAgent worker and every
 #     live remote secondmate worker are out of scope. Best effort: a sweep
 #     failure never blocks this teardown.
+#   Fix 4 - release local end-to-end test infrastructure. A crewmate that
+#     provisions a docker stack for a local end-to-end test and then dies
+#     leaves containers, volumes and a network running with no live record of
+#     who owns them (observed 2026-09-10: 15 containers removed by hand, some
+#     5+ days old, most carrying no compose project label at all, plus ~2.0 GB
+#     of dangling volumes and a 55-day-old empty network). Recovering that
+#     ownership by hand costs a forensic session. bin/fm-e2e-stack.sh owns the
+#     record format, the four ownership gates, and the removal; this teardown
+#     only invokes its `down`, and only for THIS task's own record. It runs
+#     here rather than later because both the record it reads
+#     (state/<id>.e2e-stack) and the standalone fallback copy a worker may have
+#     written under the per-task tasktmp are removed further down. Best effort: a
+#     stopped docker daemon, an absent record, or a gate that cannot be proved
+#     leaves the stack in place and says so, and never blocks this teardown -
+#     the stack is reported by the next session start instead.
 set -eu
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -3192,6 +3207,14 @@ fi
 # Fix 3 (see script header): sweep remote job workers abandoned by an already
 # pruned code root. Best effort - a sweep failure never blocks this teardown.
 "$SCRIPT_DIR/fm-remote-job-reap-orphans.sh" >&2 || true
+
+# Fix 4 (see script header): release this task's recorded local end-to-end test
+# infrastructure while its record and tasktmp still exist. Best effort - a
+# refusal or a stopped docker daemon never blocks this teardown.
+if [ "$KIND" != secondmate ] && [ -f "$STATE/$ID.e2e-stack" ]; then
+  "$SCRIPT_DIR/fm-e2e-stack.sh" down "$ID" >&2 \
+    || echo "NOTE: local end-to-end test infrastructure for $ID was not released; run bin/fm-e2e-stack.sh gate $ID to see why." >&2
+fi
 
 # Best-effort: drop the local task branch so the shared repo does not accumulate refs.
 if [ "$BACKEND" = orca ] && [ "$KIND" != secondmate ]; then

--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -624,6 +624,7 @@ tests/fm-cursor-primary-live-e2e.test.sh 21
 tests/fm-cursor-primary.test.sh 54947
 tests/fm-daemon.test.sh 26870
 tests/fm-documentation-audiences.test.sh 732
+tests/fm-e2e-stack.test.sh 2970
 tests/fm-extension-binding.test.sh 7398
 tests/fm-fleet-snapshot-view.test.sh 8547
 tests/fm-fleet-sync.test.sh 37749
@@ -1417,6 +1418,13 @@ families_for_changed_path() {
       printf '%s\n' live-harness-optin
       ;;
     .agents/skills/*/SKILL.md)
+      printf '%s\n' pure-contract-unit
+      ;;
+    skills/*)
+      # The public, installer-facing skill tier. Its behavior lives in the
+      # scripts each skill points at, but every tracked *.md under it must be
+      # classified in the audience inventory, and the repo-wide check that
+      # enforces that runs inside fm-documentation-audiences.test.sh.
       printf '%s\n' pure-contract-unit
       ;;
     .github/workflows/ci.yml|.no-mistakes.yaml)

--- a/docs/documentation-audiences.json
+++ b/docs/documentation-audiences.json
@@ -441,6 +441,10 @@
       "audience": "maintainer-verification"
     },
     {
+      "path": "docs/verification/local-e2e-infra.md",
+      "audience": "maintainer-verification"
+    },
+    {
       "path": "docs/verification/muse.md",
       "audience": "maintainer-verification"
     },
@@ -494,6 +498,26 @@
     },
     {
       "path": "skills/stow/SKILL.md",
+      "audience": "public-product"
+    },
+    {
+      "path": "skills/revocall-e2e-provision/SKILL.md",
+      "audience": "public-product"
+    },
+    {
+      "path": "skills/revocall-e2e-provision/references/profiles.md",
+      "audience": "public-product"
+    },
+    {
+      "path": "skills/revocall-e2e-provision/scenarios/ai-handler/README.md",
+      "audience": "public-product"
+    },
+    {
+      "path": "skills/revocall-e2e-provision/scenarios/revcaf/README.md",
+      "audience": "public-product"
+    },
+    {
+      "path": "skills/revocall-e2e-teardown/SKILL.md",
       "audience": "public-product"
     }
   ]

--- a/docs/verification/local-e2e-infra.md
+++ b/docs/verification/local-e2e-infra.md
@@ -1,0 +1,143 @@
+# Local end-to-end infrastructure verification
+
+Audience: maintainer verification.
+
+This record supports the active guarantees behind [`bin/fm-e2e-stack.sh`](../../bin/fm-e2e-stack.sh) and the crew-facing [`revocall-e2e-provision`](../../skills/revocall-e2e-provision/SKILL.md) and [`revocall-e2e-teardown`](../../skills/revocall-e2e-teardown/SKILL.md) pair.
+Those files own the record format, the ownership gates, and the procedure; this record holds only the empirical container-runtime facts they depend on, each of which a runtime release could change.
+Refresh it with the commands below, and refresh the ownership-gate and removal coverage with `bash tests/fm-e2e-stack.test.sh` plus the three Fix 4 cases in `tests/fm-teardown.test.sh`.
+
+Checked on 2026-09-10 with Docker 29.4.0 (build 9d7ad9f) and Docker Compose v5.1.2 on macOS 24.6.0, arm64, OrbStack.
+
+## `-p` overrides a compose file's own `name:`, but never its `container_name:`
+
+The identity scheme depends on the first half and works around the second.
+
+```
+$ cat base.yml
+name: myproject
+services:
+  db: { image: postgres:17-alpine, container_name: fixed-db-name, ports: ["5432:5432"] }
+
+$ docker compose -f base.yml config | head -1
+name: myproject
+$ docker compose -p rvtest -f base.yml config --format json | jq -r .name
+rvtest
+$ docker compose -p rvtest -f base.yml config --format json | jq -r '.services.db.container_name'
+fixed-db-name
+```
+
+The surviving `container_name` is why the override file must set one explicitly: two stacks of `Conversational-AI-Framework` or `RevoCall-AI-Handler` cannot otherwise coexist, and the project name never reaches `docker ps`.
+
+## `ports:` without `!override` MERGES, leaving the original port published
+
+This is the single most costly detail to get wrong, because the resulting file looks correct.
+
+```
+$ cat override-without-the-tag.yml
+services:
+  db:
+    ports:
+      - "55432:5432"
+
+$ docker compose -p rvtest -f base.yml -f override-without-the-tag.yml config | grep -A 8 'ports:'
+    ports:
+      - {target: 5432, published: "5432"}
+      - {target: 5432, published: "55432"}
+```
+
+With `ports: !override`, only `55432` is published.
+The same tag applies to `volumes:` when an override must drop a mount the base declares.
+
+## A relative path in an override resolves against the project directory
+
+An override generated into a scratch directory therefore does not resolve paths relative to itself.
+
+```
+$ grep -A 2 'volumes' /tmp/.../override.yml
+    volumes: !override
+      - ./init-databases.sh:/docker-entrypoint-initdb.d/init-databases.sh:ro
+
+$ docker compose -p fm-rvfam-verify-revocall \
+    -f deploy/docker-compose.infra.yml -f /tmp/.../override.yml config postgres | grep -A 3 'volumes:'
+    volumes:
+      - type: bind
+        source: /Users/hng/Worksplace/firstmate/projects/RevoCall/deploy/init-databases.sh
+```
+
+The project directory defaults to the directory of the first `-f` file, so the path resolved under `deploy/` rather than under `/tmp`.
+Generated overrides must write absolute paths.
+
+## `down -v` does NOT remove an `external: true` volume
+
+This is why the record carries external volume names and why cleanup removes them itself.
+
+```
+$ docker volume create fmprobe_ext_vol
+$ docker compose -p fmprobe-ext -f ext.yml up -d          # volumes: ext: {external: true, name: fmprobe_ext_vol}
+$ docker compose -p fmprobe-ext -f ext.yml down -v
+ Container fmprobe-ext-db-1 Removed
+ Network fmprobe-ext_default Removed
+$ docker volume ls -q --filter name=fmprobe_ext_vol
+fmprobe_ext_vol
+```
+
+All six of `RevoCall/deploy/docker-compose.infra.yml`'s volumes are declared that way, which is also why gate 4 refuses any whose name carries no task suffix: an unsuffixed name is the shared local development data.
+
+## Compose labels volumes and networks with the project, so the residue check is exact
+
+```
+$ docker compose -p fm-<task>-revcaf -f <base> -f <override> up -d db
+$ docker volume ls  -q --filter "label=com.docker.compose.project=fm-<task>-revcaf"
+fm-<task>-revcaf_db_data
+$ docker network ls -q --filter "label=com.docker.compose.project=fm-<task>-revcaf"
+fm-<task>-revcaf_default
+$ docker compose -p fm-<task>-revcaf -f <base> -f <override> down -v --remove-orphans
+$ # containers 0  volumes 0  networks 0
+```
+
+`docker volume rm --` and `docker network rm --` both accept the end-of-options separator, which is what lets the removal pass names through safely.
+
+## The network is created by infra, so pre-creating it breaks the bring-up
+
+`docker-compose.infra.yml` declares the network while `ai.yml` and `admin.yml` consume it as `external: true`.
+
+```
+$ docker network create fm-rvfam-verify-revocall
+$ NET_NAME=fm-rvfam-verify-revocall docker compose -p fm-rvfam-verify-revocall \
+    -f deploy/docker-compose.infra.yml -f /tmp/.../override.yml up -d postgres
+network fm-rvfam-verify-revocall was found but has incorrect label com.docker.compose.network set to "" (expected: "revocall")
+```
+
+Pre-create the network only when infra is absent from the `-f` chain.
+The six external volumes still need pre-creation in every case.
+
+## The scenario fixture applies against the real migrated schema and refuses loudly
+
+`skills/revocall-e2e-provision/scenarios/revocall/admin-portal-login.sql` was applied to `RevoCall/admin/backend/db/migrations` at head, brought up through the identity scheme above and migrated with the same `migrate/migrate:latest` image `deploy/docker-compose.admin.yml` uses.
+
+```
+$ docker run --rm --network fm-rvfam-verify-revocall \
+    -v "$PWD/admin/backend/db/migrations:/migrations:ro" migrate/migrate:latest \
+    -path /migrations -database "postgresql://postgres:postgres@fm-rvfam-verify-revocall-postgres:5432/admin?sslmode=disable" up
+...
+101/u inbound_call_queue (118.160706ms)
+
+$ docker exec -i <container> psql -U postgres -d admin -q < admin-portal-login.sql            # no -v email
+exit=3
+$ docker exec -i <container> psql -U postgres -d admin -v email="nobody@example.com" -q < admin-portal-login.sql
+ERROR:  admin-portal-login: no user with email nobody@example.com; run seed_superadmin first
+exit=3
+$ docker exec -i <container> psql -U postgres -d admin -tAc \
+    "select count(*) from organization where name like 'ZZ-AdminPortalLogin-%'"
+0
+$ docker exec -i <container> psql -U postgres -d admin -v email="admin@revolab.local" -q < admin-portal-login.sql
+exit=0
+$ docker exec -i <container> psql -U postgres -d admin -tAc "select u.email, o.name, r.name from ..."
+admin@revolab.local|ZZ-AdminPortalLogin-Org|ORGADMIN
+$ # re-applied: exit=0, binding rows = 1
+```
+
+Three properties this run establishes.
+A missing psql variable and an unknown email each abort with a non-zero exit rather than reporting success, which matters because psql's own `\quit` takes no exit code and its default is to continue past a failed statement and still exit 0.
+The refused run creates nothing, because the user check runs before the first insert.
+Re-application is idempotent, so re-provisioning a scenario is a no-op.

--- a/skills/revocall-e2e-provision/SKILL.md
+++ b/skills/revocall-e2e-provision/SKILL.md
@@ -48,7 +48,10 @@ Derive everything from the task id, once, and use it consistently.
 
 ```
 TASK      = $FM_TASK_ID, or --task
-TASK_SLUG = TASK, lowercased, with every character outside [a-z0-9-] replaced by a hyphen
+TASK_SLUG = TASK, lowercased, with every character outside [a-z0-9-] replaced by a hyphen;
+            if that differs from TASK, append -<h>, where <h> is the first 6 hex digits of
+            crc32(TASK) zero-padded to 8 digits (the same hash step 2 derives the port offset
+            from); an already-clean TASK is left unsuffixed
 STACK     = the profile's short name (revcaf, aih, revocall)
 PROJECT   = fm-<TASK_SLUG>-<STACK>
 CONTAINER = <PROJECT>-<service>
@@ -58,6 +61,8 @@ VOLUMES   = <PROJECT>_<volume>, or revocall-infra_<volume>-data-<TASK> for the d
 
 Sanitize before deriving PROJECT.
 `--task`/`FM_TASK_ID` is validated only against the loose `[A-Za-z0-9._-]+` charset, but `bin/fm-e2e-stack.sh`'s `project_name_valid()` accepts only lowercase `[a-z0-9][a-z0-9_-]*`; an uppercase letter or a dot in TASK would otherwise mint a PROJECT the script refuses outright, and standalone mode has no equivalent check before `docker compose up`.
+Plain lowercase-and-hyphenate is lossy on its own: `PR-123` and `pr-123` are two distinct, individually valid raw ids that would otherwise collapse onto one PROJECT, and nothing refuses that at provisioning time — gate 3 only refuses to *tear down* an ambiguous claim, at `gate`/`down` time, so a second `up` could silently land inside the first task's still-live containers.
+The crc32 suffix on any TASK that sanitizing actually changes makes that collision structurally unreachable without a uniqueness registry or any cross-task state; a TASK that is already clean, which is the lowercase-hyphenated form `tasks-axi` mints, is left unsuffixed, so the common case stays exactly as readable in `docker ps` as before.
 TASK_SLUG is what PROJECT, CONTAINER, and the compose-internal NETWORK/VOLUMES are built from.
 TASK itself stays raw everywhere ownership must trace back to the exact id `record`/`down` were given: the `ai.revolab.fm.task` label, the deploy stack's external-volume suffix (gate 4 checks that the volume name contains the raw id), and the task's own `/tmp/fm-<task>` root.
 
@@ -83,11 +88,12 @@ Carry both; neither replaces the other.
 
 1. **Preflight.**
    Confirm `docker info` answers and `docker compose version` is 2.20 or newer, because the override file below needs the `!override` tag.
-   Resolve the task id, stop if neither `FM_TASK_ID` nor `--task` supplies one, then derive `TASK_SLUG` from it (see Identity scheme) once, for every docker name below.
+   Resolve the task id, and stop if neither `FM_TASK_ID` nor `--task` supplies one.
    Read the profile row from `references/profiles.md` and confirm every file it names exists in the checkout.
 
 2. **Derive ports.**
    Take `k` as `1 + (crc32(<task id>) mod 20)` and use `k * 300` as the offset, which is the multiples-of-300 convention `RevoCall/deploy/SLOTS.md` records as verified safe.
+   Derive `TASK_SLUG` from that same `crc32(<task id>)` now too (see Identity scheme), once, for every docker name below.
    For the RevoCall deploy stack, do not compute the ports yourself: run `deploy/gen-slot-env.sh --slot <short-slug> --offset <k*300>` and use its output verbatim.
    That generator already emits every `PORT_*`, `LK_UDP_RANGE`, `VOL_SUFFIX`, `NET_NAME`, `IMG_SUFFIX`, and `COMPOSE_PROJECT_NAME`, and it already refuses an unsafe offset before bring-up.
    Its `--slot` argument must match `^[a-z0-9]+$`, so pass a sanitized short slug rather than a hyphenated task id.

--- a/skills/revocall-e2e-provision/SKILL.md
+++ b/skills/revocall-e2e-provision/SKILL.md
@@ -48,12 +48,18 @@ Derive everything from the task id, once, and use it consistently.
 
 ```
 TASK      = $FM_TASK_ID, or --task
+TASK_SLUG = TASK, lowercased, with every character outside [a-z0-9-] replaced by a hyphen
 STACK     = the profile's short name (revcaf, aih, revocall)
-PROJECT   = fm-<TASK>-<STACK>
+PROJECT   = fm-<TASK_SLUG>-<STACK>
 CONTAINER = <PROJECT>-<service>
 NETWORK   = <PROJECT>_default, or NET_NAME=<PROJECT> for the RevoCall deploy stack
 VOLUMES   = <PROJECT>_<volume>, or revocall-infra_<volume>-data-<TASK> for the deploy stack's external volumes
 ```
+
+Sanitize before deriving PROJECT.
+`--task`/`FM_TASK_ID` is validated only against the loose `[A-Za-z0-9._-]+` charset, but `bin/fm-e2e-stack.sh`'s `project_name_valid()` accepts only lowercase `[a-z0-9][a-z0-9_-]*`; an uppercase letter or a dot in TASK would otherwise mint a PROJECT the script refuses outright, and standalone mode has no equivalent check before `docker compose up`.
+TASK_SLUG is what PROJECT, CONTAINER, and the compose-internal NETWORK/VOLUMES are built from.
+TASK itself stays raw everywhere ownership must trace back to the exact id `record`/`down` were given: the `ai.revolab.fm.task` label, the deploy stack's external-volume suffix (gate 4 checks that the volume name contains the raw id), and the task's own `/tmp/fm-<task>` root.
 
 The `fm-` prefix is load-bearing, not cosmetic.
 Cleanup will only remove a project whose name starts with it, which is what makes it impossible to remove a stack a person or another tool started.
@@ -62,7 +68,7 @@ Attach all six labels to every service:
 
 | Label | Value |
 |---|---|
-| `ai.revolab.fm.task` | the task id |
+| `ai.revolab.fm.task` | the raw task id (TASK, not TASK_SLUG) |
 | `ai.revolab.fm.stack` | the profile's short name |
 | `ai.revolab.fm.repo` | the repo name |
 | `ai.revolab.fm.scenario` | the scenario name |
@@ -77,7 +83,7 @@ Carry both; neither replaces the other.
 
 1. **Preflight.**
    Confirm `docker info` answers and `docker compose version` is 2.20 or newer, because the override file below needs the `!override` tag.
-   Resolve the task id, and stop if neither `FM_TASK_ID` nor `--task` supplies one.
+   Resolve the task id, stop if neither `FM_TASK_ID` nor `--task` supplies one, then derive `TASK_SLUG` from it (see Identity scheme) once, for every docker name below.
    Read the profile row from `references/profiles.md` and confirm every file it names exists in the checkout.
 
 2. **Derive ports.**
@@ -99,7 +105,7 @@ Carry both; neither replaces the other.
    ```yaml
    services:
      db:
-       container_name: fm-<task>-<stack>-db
+       container_name: fm-<task-slug>-<stack>-db
        ports: !override
          - "<derived>:5432"
        labels:
@@ -136,7 +142,7 @@ Carry both; neither replaces the other.
 
    ```bash
    bin/fm-e2e-stack.sh record <task> \
-     --project fm-<task>-<stack> --stack <profile> --repo <repo> \
+     --project fm-<task-slug>-<stack> --stack <profile> --repo <repo> \
      --scenario <scenario> --worktree "$PWD" \
      --compose-file <base compose>... --compose-file <override> \
      --service <name>... --port PORT_POSTGRES=<n>... \
@@ -149,7 +155,7 @@ Carry both; neither replaces the other.
 7. **Bring up only the services the scenario needs.**
 
    ```bash
-   docker compose -p fm-<task>-<stack> \
+   docker compose -p fm-<task-slug>-<stack> \
      -f <base compose> [-f <more base compose>] -f <override> \
      up -d <service>...
    ```
@@ -163,7 +169,7 @@ Carry both; neither replaces the other.
    Then confirm the only clients on the scenario database are your own:
 
    ```bash
-   docker exec -i fm-<task>-<stack>-db psql -U <user> -d postgres \
+   docker exec -i fm-<task-slug>-<stack>-db psql -U <user> -d postgres \
      -tAc "select pid, datname, client_addr, backend_start from pg_stat_activity where backend_type='client backend'"
    ```
 
@@ -189,7 +195,7 @@ Seed in three layers, and apply only as many as the scenario needs.
    A single SQL file under `scenarios/<repo>/<scenario>.sql`, applied through the running container:
 
    ```bash
-   docker exec -i fm-<task>-<stack>-db psql -U <user> -d <db> -v ON_ERROR_STOP=1 -q \
+   docker exec -i fm-<task-slug>-<stack>-db psql -U <user> -d <db> -v ON_ERROR_STOP=1 -q \
      < scenarios/<repo>/<scenario>.sql
    ```
 

--- a/skills/revocall-e2e-provision/SKILL.md
+++ b/skills/revocall-e2e-provision/SKILL.md
@@ -1,0 +1,236 @@
+---
+name: revocall-e2e-provision
+description: >-
+  Provision an isolated local docker stack for one named end-to-end test scenario across the RevoCall-family repos (RevoCall, RevoCall-AI-Handler, Conversational-AI-Framework/RevCAF), seeded with only the data that scenario needs.
+  Use before running any local end-to-end test, integration test, or live driving session that needs a database, Redis, NATS, Qdrant, MinIO, or one of the services, and whenever a test skips because DATABASE_URL or TEST_DATABASE_URL is unset.
+  Names every container after the task that owns it, so `docker ps` alone answers who provisioned it, and records what it started so `revocall-e2e-teardown` can reverse exactly that.
+user-invocable: true
+---
+
+<!-- maintainers: this is the public, installer-facing skill. Keep it standalone: it must work with no firstmate home present, deriving its identity from --task when FM_TASK_ID is absent and treating bin/fm-e2e-stack.sh as an optional durable mirror. The firstmate-coupled half is bin/fm-e2e-stack.sh plus Fix 4 in bin/fm-teardown.sh. -->
+
+# revocall-e2e-provision
+
+Bring up the smallest local stack one named test scenario needs, seed only that scenario's data, and leave a record precise enough that cleanup never has to guess what you started.
+
+Its companion is `revocall-e2e-teardown`.
+Provision and cleanup are one pair: never provision without knowing how the stack will come down.
+
+## Why the identity discipline matters
+
+Three defects in the RevoCall-family compose files make an unmanaged local stack anonymous and unrepeatable.
+
+- Most compose files declare no top-level `name:`, so the compose project name falls back to the directory basename.
+  `admin/backend/docker-compose.yml` becomes project `backend` and yields containers called `backend-postgres-1`; `outbound/service/docker-compose.yml` becomes project `service`.
+  Nothing in those names says which task, repo, or test owns them.
+- `Conversational-AI-Framework/docker-compose.yaml` and `RevoCall-AI-Handler/services/ai-handler/docker-compose.yaml` hardcode `container_name:` (`revcaf-db`, `revocall-ai-handler-db`, and so on).
+  A hardcoded container name survives `docker compose -p`, so two stacks of the same repo cannot run at once and the project name never reaches `docker ps`.
+- Host ports are literals in every per-service compose file.
+  `admin/backend`, `chat`, and `forwarder` all bind 5432; `outbound/service` and `mcp-gateway` both bind 5433; `warehouse`'s ClickHouse binds 9000, which is MinIO's port in the shared deploy stack.
+  `deploy/README.md` manages this with a comment telling you not to run them together.
+
+This skill fixes all three from outside the repos, so no project file is ever modified.
+
+## Inputs
+
+| Input | Required | Meaning |
+|---|---|---|
+| `--repo <name>` | yes | `RevoCall`, `RevoCall-AI-Handler`, or `Conversational-AI-Framework`. |
+| `--scenario <name>` | yes | The test scenario being provisioned for. Keys the seed step and labels the containers. |
+| `--profile <name>` | yes | A row of `references/profiles.md`. Decides which services come up and which schema and seed steps run. |
+| `--task <id>` | when `FM_TASK_ID` is unset | The owning task id. Refuse rather than invent one: the whole identity chain hangs off it. |
+| `--checkout <path>` | for cross-repo profiles | Root whose children are the three repos. Only `revocall-full` needs it. |
+| `--port-base <n>` | no | Overrides the derived port offset. Escape hatch for a collision the probe cannot resolve. |
+
+## Identity scheme
+
+Derive everything from the task id, once, and use it consistently.
+
+```
+TASK      = $FM_TASK_ID, or --task
+STACK     = the profile's short name (revcaf, aih, revocall)
+PROJECT   = fm-<TASK>-<STACK>
+CONTAINER = <PROJECT>-<service>
+NETWORK   = <PROJECT>_default, or NET_NAME=<PROJECT> for the RevoCall deploy stack
+VOLUMES   = <PROJECT>_<volume>, or revocall-infra_<volume>-data-<TASK> for the deploy stack's external volumes
+```
+
+The `fm-` prefix is load-bearing, not cosmetic.
+Cleanup will only remove a project whose name starts with it, which is what makes it impossible to remove a stack a person or another tool started.
+
+Attach all six labels to every service:
+
+| Label | Value |
+|---|---|
+| `ai.revolab.fm.task` | the task id |
+| `ai.revolab.fm.stack` | the profile's short name |
+| `ai.revolab.fm.repo` | the repo name |
+| `ai.revolab.fm.scenario` | the scenario name |
+| `ai.revolab.fm.created` | RFC-3339 UTC timestamp |
+| `ai.revolab.fm.worktree` | absolute path of the checkout this ran from |
+
+The project name is what makes ownership readable from a bare `docker ps`.
+The labels are what make cleanup a precise filter and give a later reader the age and purpose without reading container logs.
+Carry both; neither replaces the other.
+
+## Steps
+
+1. **Preflight.**
+   Confirm `docker info` answers and `docker compose version` is 2.20 or newer, because the override file below needs the `!override` tag.
+   Resolve the task id, and stop if neither `FM_TASK_ID` nor `--task` supplies one.
+   Read the profile row from `references/profiles.md` and confirm every file it names exists in the checkout.
+
+2. **Derive ports.**
+   Take `k` as `1 + (crc32(<task id>) mod 20)` and use `k * 300` as the offset, which is the multiples-of-300 convention `RevoCall/deploy/SLOTS.md` records as verified safe.
+   For the RevoCall deploy stack, do not compute the ports yourself: run `deploy/gen-slot-env.sh --slot <short-slug> --offset <k*300>` and use its output verbatim.
+   That generator already emits every `PORT_*`, `LK_UDP_RANGE`, `VOL_SUFFIX`, `NET_NAME`, `IMG_SUFFIX`, and `COMPOSE_PROJECT_NAME`, and it already refuses an unsafe offset before bring-up.
+   Its `--slot` argument must match `^[a-z0-9]+$`, so pass a sanitized short slug rather than a hyphenated task id.
+   For the two AI repos, whose compose files carry no `PORT_*` variables, compute `default + k*300` per published port.
+
+3. **Probe the ports, and do not trust a free one blindly.**
+   Check each derived port with `lsof -nP -iTCP:<port> -sTCP:LISTEN` and shift the offset by one stride on a collision, up to a few attempts, then stop and name the busy ports.
+   A port with no listener is still not always safe: an orphaned application process from an earlier test can be dialing that exact port on a retry loop and will attach the instant something binds it.
+   Prefer a stride far from both the documented defaults and the known live-test offsets, and see step 8 for the check that catches an unexpected client.
+
+4. **Generate the override compose file.**
+   Write it under the task's own temporary root, never into the checkout.
+   `/tmp/fm-<task>/e2e/override.<stack>.yml` is the location when a firstmate task tmp root exists; otherwise any private scratch directory outside the repo works.
+
+   ```yaml
+   services:
+     db:
+       container_name: fm-<task>-<stack>-db
+       ports: !override
+         - "<derived>:5432"
+       labels:
+         ai.revolab.fm.task: <task>
+         ai.revolab.fm.stack: <stack>
+         ai.revolab.fm.repo: <repo>
+         ai.revolab.fm.scenario: <scenario>
+         ai.revolab.fm.created: "<rfc3339>"
+         ai.revolab.fm.worktree: <abs path>
+       environment:
+         POSTGRES_DB: revcaf_test
+   ```
+
+   **The `!override` tag on `ports:` is load-bearing.**
+   Without it compose MERGES the two port lists and still publishes the original literal, so the remap looks right in the file and the bring-up still fails to bind when the default port is taken.
+   The same tag applies to `volumes:` when the override must drop a mount the base declares.
+
+   **Write every path in the override absolute.**
+   A relative path in an override resolves against the compose PROJECT DIRECTORY, which defaults to the directory of the FIRST `-f` file, not the directory the override itself lives in.
+   An override written to a scratch directory therefore silently picks up files from the repo instead, or fails to find them.
+
+5. **Pre-create external resources, for the RevoCall deploy stack only.**
+   Its six infra volumes are declared `external: true`, so compose does not create them:
+   `docker volume create revocall-infra_<v>-data-<TASK>` for `postgres`, `nats`, `valkey`, `redis-stack`, `qdrant`, and `minio`.
+   The task suffix is mandatory, because an unsuffixed name is the shared local development data and cleanup refuses to remove one.
+
+   The NETWORK is different, and pre-creating it unconditionally breaks the bring-up.
+   `docker-compose.infra.yml` DECLARES the network, while `ai.yml` and `admin.yml` consume it as `external: true`.
+   So create it by hand only when infra is absent from the `-f` chain; with infra present, compose creates it and a hand-made one is refused with `network <name> was found but has incorrect label com.docker.compose.network`.
+
+6. **Record what you are about to start, before you start it.**
+   An interrupted bring-up must still be cleanable.
+   With firstmate present:
+
+   ```bash
+   bin/fm-e2e-stack.sh record <task> \
+     --project fm-<task>-<stack> --stack <profile> --repo <repo> \
+     --scenario <scenario> --worktree "$PWD" \
+     --compose-file <base compose>... --compose-file <override> \
+     --service <name>... --port PORT_POSTGRES=<n>... \
+     [--external-volume <name>...] [--network <name> --created-network]
+   ```
+
+   Standalone, write the same fields to a file beside the override and hand its path to cleanup.
+   Either way the record must name every compose file, because cleanup tears down with the recorded list rather than re-deriving it: a repo file edited after provisioning must not change what comes down.
+
+7. **Bring up only the services the scenario needs.**
+
+   ```bash
+   docker compose -p fm-<task>-<stack> \
+     -f <base compose> [-f <more base compose>] -f <override> \
+     up -d <service>...
+   ```
+
+   Wait on healthchecks, or poll `pg_isready`, with a bounded timeout.
+   Report the ports actually published, not the ones requested.
+
+8. **Apply the schema through the repo's own migration tool.**
+   The profile row names it.
+   Never hand-write DDL and never substitute a metadata `create_all`: RevCAF's own integration fixture records that `create_all` reproduces every table but not the `assistant_config` trigger that lives only in a migration, which makes real code fail against a fake schema.
+   Then confirm the only clients on the scenario database are your own:
+
+   ```bash
+   docker exec -i fm-<task>-<stack>-db psql -U <user> -d postgres \
+     -tAc "select pid, datname, client_addr, backend_start from pg_stat_activity where backend_type='client backend'"
+   ```
+
+   An unexpected client is an orphaned process from an earlier test; stop and report it rather than seeding into a database something else is reading.
+
+9. **Seed the scenario, and only the scenario.**
+   See "Seeding" below.
+
+10. **Hand back the environment and the cleanup command.**
+    Emit an exportable block with `DATABASE_URL`, `TEST_DATABASE_URL`, `REDIS_ADK`, `QDRANT_URL`, `NATS_URL`, and any `E2E_BASE_URL`, `E2E_EMAIL`, `E2E_PASSWORD` the scenario needs.
+    Then print the cleanup command as the final line, because a worker that copies one line cleans up far more reliably than one that reconstructs a compose invocation.
+
+## Seeding
+
+Seed in three layers, and apply only as many as the scenario needs.
+
+1. **Schema.**
+   Always the repo's own tool: `golang-migrate` per database for RevoCall, `alembic upgrade head` for RevCAF and AI-Handler.
+2. **Baseline reference data.**
+   Only RevoCall has any: `cmd/seed_user_management`, `cmd/seed_tiers`, and `cmd/seed_superadmin <email> <password>`, all built on the transactional `internal/seed` runner.
+   RevCAF and AI-Handler have no baseline seeder, and none should be invented for them.
+3. **Scenario delta.**
+   A single SQL file under `scenarios/<repo>/<scenario>.sql`, applied through the running container:
+
+   ```bash
+   docker exec -i fm-<task>-<stack>-db psql -U <user> -d <db> -v ON_ERROR_STOP=1 -q \
+     < scenarios/<repo>/<scenario>.sql
+   ```
+
+   `-v ON_ERROR_STOP=1` is required.
+   Without it psql continues past a failed statement and still exits 0, so a broken fixture reports success.
+
+Four rules keep the delta layer fitting the repos rather than fighting them.
+
+- **Use the `ZZ-<SCENARIO>-<Entity>` naming namespace for every row a RevoCall scenario inserts.**
+  That is this repo's own established convention across dozens of `*_db_test.go` files, and it makes a scenario's rows recognizable, deletable by prefix, and safe if the database is ever shared.
+  Pair it with `ON CONFLICT` so re-provisioning is idempotent.
+- **Reference the fixed role UUIDs rather than looking them up by name.**
+  `admin/backend/internal/seed/roles/roles.go` pins them: ORGADMIN `019400a0-0000-7000-8000-000000000001`, ADMIN `...002`, SUPERADMIN `...003`, LIVEAGENTMANAGER `...004`, LIVEAGENT `...005`, MAKER `...006`, CHECKER `...007`.
+- **Where a repo already expresses the scenario as a test fixture, satisfy that fixture's contract instead of duplicating it.**
+  For RevCAF's `tests/integration`, the whole seed is: create a database whose NAME differs from the application's, hand it over as `TEST_DATABASE_URL`, and let the repo's own `pg_schema` and `seeded` fixtures do the rest.
+  A SQL twin of an in-repo fixture drifts from it.
+- **Every scenario file declares its own preconditions in a header comment**: which layers it assumes, which services must be up, and which database it targets.
+  Validate those before applying rather than failing halfway through.
+
+## Refusals
+
+Stop and report rather than proceeding when any of these holds.
+
+- No task id from either `FM_TASK_ID` or `--task`.
+- `docker info` does not answer, or compose is older than 2.20.
+- A derived port stays busy after the retry stride.
+- A cross-repo profile whose sibling checkouts are absent.
+- A `*-full` profile whose required `config.development.ini` or `config.toml` is missing, since those files are gitignored and a fresh checkout has none.
+  Starting the container anyway produces a boot loop that reads as a code failure.
+- An unexpected client already connected to the scenario database.
+- A scenario naming a database that matches the application's own database name, for RevCAF specifically.
+  Its integration fixture drops the `public` schema and refuses a same-name URL, because that exact mistake once destroyed a developer's `revcaf_db`.
+
+## One dimension this cannot isolate
+
+LiveKit.
+Two stacks sharing one LiveKit Cloud project cross-route calls, because the agent names are hardcoded in AI-Handler and workers register to a project rather than to a key.
+The credentials are also read from a mounted `config.development.ini` or `chat/config.toml`, not from an environment variable, so the override file cannot inject them.
+A LiveKit-touching scenario is therefore not concurrency-safe: serialize it, or require an explicitly named distinct LiveKit project, and say plainly in the report which was done.
+
+## Reference
+
+`references/profiles.md` owns the per-profile service, schema, and seed table plus the per-repo differences the profiles encode.
+`bin/fm-e2e-stack.sh --help` in a firstmate checkout owns the record format and the ownership gates.

--- a/skills/revocall-e2e-provision/references/profiles.md
+++ b/skills/revocall-e2e-provision/references/profiles.md
@@ -1,0 +1,117 @@
+# RevoCall-family local end-to-end stack profiles
+
+Data for `revocall-e2e-provision`.
+Every path is relative to its repo's checkout root.
+
+## Profiles
+
+| Profile | Short name | Repo | Base compose files | Services | Schema step | Baseline seed |
+|---|---|---|---|---|---|---|
+| `revcaf-db` | `revcaf` | Conversational-AI-Framework | `docker-compose.yaml` | `db` | `alembic upgrade head`, or let `tests/integration` build it | none |
+| `revcaf-full` | `revcaf` | Conversational-AI-Framework | `docker-compose.yaml` | `db`, `redis-stack`, `qdrant`, `nats`, `app` | `alembic upgrade head` | none |
+| `aih-db` | `aih` | RevoCall-AI-Handler | `services/ai-handler/docker-compose.yaml` | `db` | `alembic upgrade head` | none |
+| `aih-full` | `aih` | RevoCall-AI-Handler | `services/ai-handler/docker-compose.yaml` | `db`, `redis`, `nats`, `app` | `alembic upgrade head` | none |
+| `revocall-admin-db` | `revocall` | RevoCall | `deploy/docker-compose.infra.yml` | `postgres` | `golang-migrate` on `admin`, `chat`, `outbound` | `seed_user_management`, `seed_tiers`, `seed_superadmin` |
+| `revocall-admin` | `revocall` | RevoCall | `deploy/docker-compose.infra.yml`, `deploy/docker-compose.admin.yml` | infra plus the Go backends and their init containers | the `*-migrate` init containers | the `admin-seed` init container |
+| `revocall-full` | `revocall` | RevoCall | `deploy/docker-compose.infra.yml`, `deploy/docker-compose.ai.yml`, `deploy/docker-compose.admin.yml` | all 26 | every init container | the `admin-seed` init container |
+
+Pick the cheapest profile that answers the question.
+`revcaf-db` alone satisfies every test in RevCAF's `tests/integration`, and `revocall-admin-db` satisfies RevoCall's `*_db_test.go` suites.
+
+## Ports
+
+Default published ports, before the offset.
+
+| Service | RevoCall deploy | Conversational-AI-Framework | RevoCall-AI-Handler |
+|---|---|---|---|
+| Postgres | 5432 | 5433 | 5434 |
+| NATS client / monitor | 4222 / 8222 | 4223 / 8223 | 4222 / 8222 |
+| Valkey | 6379 | not present | not present |
+| Redis | 6380 (redis-stack) | 6379 (redis-stack) | 6380 (plain redis) |
+| Qdrant | 6333 / 6334 | 6333 | not present |
+| OTLP receiver | 4317 / 4318 (jaeger) | 4317 / 4318 | 4333 / 4334 |
+| MinIO | 9000 / 9001 | not present | not present |
+| RevCAF | 9090 / 9093 | 9090 / 9093 | reached over `host.docker.internal` |
+| AI Handler | 9091 / 9092 / 9998 | not present | 9091 / 9092 / 9998 |
+
+`RevoCall/deploy/SLOTS.md` holds the full table of about 31 `PORT_*` variables that `deploy/gen-slot-env.sh` shifts.
+
+## Per-repo differences the profiles encode
+
+Each of these is a real divergence to accommodate, not an inconsistency to normalize away.
+
+1. **Only RevoCall's `deploy/` stack is parameterized.**
+   Its three files take `${PORT_*}`, `NET_NAME`, `VOL_SUFFIX`, and `IMG_SUFFIX`, and `deploy/gen-slot-env.sh` generates a safe set with its own collision self-check.
+   The two AI repos' own compose files hardcode every port and container name, so their overrides must be fully generated.
+
+2. **`deploy/docker-compose.ai.yml` builds from sibling checkouts.**
+   Its build contexts are `../Conversational-AI-Framework`, `../RevoCall-AI-Handler/services/ai-handler`, and `../RevoCall-AI-Handler/services/post-call`.
+   `revocall-full` therefore needs a `--checkout` root whose children are all three repos, and must refuse rather than silently build the wrong tree when a sibling is absent.
+
+3. **Three seeding conventions, one per repo.**
+   RevoCall: `golang-migrate` plus Go seeders plus a `ZZ-<TICKET>-<Entity>` row namespace with `t.Cleanup` deletion, gated on `DATABASE_URL` and skipping when unset.
+   Conversational-AI-Framework: alembic plus `TEST_DATABASE_URL`-gated pytest fixtures that rebuild the schema per test.
+   RevoCall-AI-Handler: in-memory SQLite with `Base.metadata.create_all` and no real-Postgres convention at all.
+   A single fixture format would fit exactly one of the three.
+
+4. **RevCAF's destructive-guard contract is unique and must be honored, not worked around.**
+   Its `tests/integration/conftest.py` drops the `public` schema, and refuses a `TEST_DATABASE_URL` that resolves to the application's database OR merely shares its NAME on any host or port.
+   The recorded reason is that `config.example.ini` says `:5432/revcaf_db` while the real dev database is `:5433/revcaf_db`, the name matched, the guard stood aside, and a developer's database was dropped.
+   Provision `revcaf_test` or `revcaf_test_<slug>`, never `revcaf_db`.
+
+5. **RevoCall-AI-Handler's suite is not green on its own default branch.**
+   Its `AGENTS.md` records a specific failing count and instructs comparing against a clean-tree run before blaming a change.
+   Provisioning success therefore means "the stack is up, migrated, and seeded", never "the tests pass".
+
+6. **Redis is three different things.**
+   RevCAF needs `redis/redis-stack-server` with `--notify-keyspace-events KEA` for its JSON and Search modules plus keyspace events.
+   AI-Handler needs plain `redis:latest`.
+   RevoCall's admin needs `valkey/valkey:8` for login throttling AND redis-stack for RevCAF, on separate ports.
+
+7. **NATS is a three-node cluster in both AI repos' own compose files but a single node in RevoCall's infra.**
+   The cluster publishes three times the ports and is unnecessary for most scenarios; default to the single node and let a scenario opt into the cluster.
+
+8. **RevoCall's infra volumes are `external: true`; the AI repos' are plain.**
+   External volumes must be pre-created before the first `up`, and compose removes them on no code path, `down -v` included.
+   Plain volumes auto-prefix with the project name and are removed by `down -v`.
+   That difference is why cleanup removes external volumes by name and refuses any whose name carries no task suffix.
+
+9. **LiveKit cannot be isolated by port or network.**
+   Agent names are hardcoded in AI-Handler and workers register to a LiveKit project, so two stacks sharing a project cross-route calls.
+   The credentials come from a mounted `config.development.ini` or `chat/config.toml`, not from an environment variable, so no override can inject them.
+
+10. **`config.development.ini` and the Go `config.toml` files are gitignored.**
+    A fresh checkout has none, and the `*-full` profiles bind-mount them.
+    Check before bring-up: a missing config produces a boot loop that reads as a code failure.
+
+11. **Two machine tokens are boot-fatal for the admin stack.**
+    `adminv2_machineauth_chat_token` and `adminv2_machineauth_outbound_token` must equal the `chat` and `outbound` entries in `admin/backend/config.toml`'s `[adminAPI.machineKeys]`, or `chat-backend` and `outbound-service` refuse to boot rather than failing at first call.
+    They are injected as environment variables because the config files are gitignored.
+
+12. **The composed project name comes from the LAST `-f` file's own `name:` unless `-p` is given.**
+    Stacking infra, ai, and admin yields project `revocall-admin`.
+    Always pass `-p`.
+
+13. **`services/post-call` has no compose file of its own.**
+    It exists only inside `deploy/docker-compose.ai.yml`, so an AI-Handler-only profile cannot bring it up.
+
+14. **`scripts/` is absent from AI-Handler's container image.**
+    Its `Dockerfile` copies `src/`, `tests/`, and `assets/` only, so a script-based seed runs on the host with `CONFIG=` and `PYTHONPATH=.`, or through psql.
+
+15. **`warehouse`'s ClickHouse binds 9000, which is MinIO's port in the deploy infra stack.**
+    Never provision both in one scenario without an offset.
+
+## Named scenario targets
+
+Real suites a profile has to satisfy.
+
+| Suite | Profile | Gate | Extra requirement |
+|---|---|---|---|
+| `Conversational-AI-Framework/tests/integration` | `revcaf-db` | `TEST_DATABASE_URL`, skips when unset | database name must differ from the application's |
+| `Conversational-AI-Framework` tests marked `local_only` | `revcaf-full` | the `local_only` marker | Redis, Qdrant, NATS, or a live model |
+| `RevoCall` `admin/backend/**/*_db_test.go` | `revocall-admin-db` | `DATABASE_URL`, skips when unset | `ZZ-` prefixed rows only |
+| `RevoCall/admin/frontend` Playwright specs | `revocall-full` | `E2E_BASE_URL`, `E2E_EMAIL`, `E2E_PASSWORD` | a user WITH an organization, see below |
+
+The Playwright suite's `e2e/auth.setup.ts` asserts a selected organization after sign-in, and the committed seed chain cannot produce one: `cmd/seed_superadmin` inserts `user_role_organization` with `organization_id = NULL`.
+`SLOTS.md` records the same gap from the other side, noting that the superadmin organization and its `ORGADMIN` binding are applied by a staging manifest and do not carry over per slot.
+`scenarios/revocall/admin-portal-login.sql` fills that gap.

--- a/skills/revocall-e2e-provision/scenarios/ai-handler/README.md
+++ b/skills/revocall-e2e-provision/scenarios/ai-handler/README.md
@@ -1,0 +1,20 @@
+# AI-Handler scenario seeds
+
+RevoCall-AI-Handler has no real-Postgres test convention: every DB-touching test in `services/ai-handler/tests/` builds an in-memory SQLite engine with `Base.metadata.create_all` plus JSONB and UUID `@compiles` shims.
+So a provisioned Postgres here is never for the unit suite.
+It is for the paths that genuinely need a real database:
+
+- `scripts/verify_rv2015_breakdown.py`, run as `CONFIG=<ini> PYTHONPATH=. uv run python scripts/verify_rv2015_breakdown.py <organization_id>`.
+- The standalone psql scripts in `scripts/sql/`, which the repo itself documents as runnable against any reachable ai-handler database.
+- Driving the running `app` service for a live end-to-end session.
+
+Two constraints when adding a fixture here.
+
+`scripts/` is not in the container image, because the `Dockerfile` copies only `src/`, `tests/`, and `assets/`.
+A script-based seed therefore runs on the host, or through psql against the published port, never as `docker compose exec app python scripts/...`.
+
+JSONB nulls have two spellings in this schema, and a fixture that ignores the difference asserts nothing.
+`scripts/sql/post_call_replay_diagnose.sql` records why: SQLAlchemy's JSONB type defaults to `none_as_null=False`, so a Python `None` persists as the JSON scalar `'null'` rather than SQL NULL, and `summary IS NULL` matches nothing in production.
+Use `jsonb_typeof(summary) = 'null'` when a scenario needs the un-summarised shape.
+
+Give every file the same preconditions header as `../revocall/admin-portal-login.sql`.

--- a/skills/revocall-e2e-provision/scenarios/revcaf/README.md
+++ b/skills/revocall-e2e-provision/scenarios/revcaf/README.md
@@ -1,0 +1,18 @@
+# RevCAF scenario seeds
+
+There are deliberately no SQL fixtures here for anything `tests/integration` covers.
+
+That suite owns its own seeding.
+`tests/integration/conftest.py` rebuilds the schema per test with `alembic upgrade head` and provides scenario fixtures such as `seeded`, which creates two organizations and one assistant owned by the first.
+A SQL twin of an in-repo pytest fixture drifts from it the moment only one is edited.
+
+For those tests, the provisioning skill's whole job is layer 1 and layer 2 of the seed contract:
+
+1. Bring up `db` under a task-scoped project name.
+2. Create a database whose NAME differs from the application's, for example `revcaf_test`.
+3. Export it as `TEST_DATABASE_URL`.
+
+The suite then does the rest, and refuses if step 2 was skipped.
+
+Add a file here only for a scenario driven through the running application over HTTP or WebSocket, where no pytest fixture exists to satisfy.
+Give it the same preconditions header as `../revocall/admin-portal-login.sql`.

--- a/skills/revocall-e2e-provision/scenarios/revocall/admin-portal-login.sql
+++ b/skills/revocall-e2e-provision/scenarios/revocall/admin-portal-login.sql
@@ -1,0 +1,99 @@
+-- Scenario: admin-portal-login (repo: RevoCall, database: admin)
+--
+-- Preconditions:
+--   layers   schema (golang-migrate on `admin`), baseline (seed_user_management,
+--            seed_tiers, seed_superadmin <email> <password>)
+--   services postgres
+--   target   the `admin` database
+--   variable -v email=<the address seed_superadmin was given>
+--
+-- What this adds and why it is not already in the repo.
+-- `admin/frontend/e2e/auth.setup.ts` signs in and then asserts a SELECTED
+-- ORGANIZATION, reading it from the auth store. The committed seed chain cannot
+-- produce one: `cmd/seed_superadmin` inserts user_role_organization with
+-- organization_id = NULL, a global SUPERADMIN bound to no organization.
+-- `deploy/SLOTS.md` records the same gap from the operations side, noting that
+-- the superadmin organization and its ORGADMIN binding come from a staging
+-- manifest and do not carry over per slot. This file is that missing step, and
+-- nothing more: it never creates the user, because the password is argon2id and
+-- hashing belongs in `cmd/seed_superadmin`, not in SQL.
+--
+-- Rows use the repo's own ZZ-<SCENARIO>-<Entity> namespace so they are
+-- recognizable, deletable by prefix, and safe in a shared database. Every insert
+-- is ON CONFLICT-guarded, so re-provisioning the scenario is a no-op.
+
+\set ON_ERROR_STOP on
+
+-- A missing variable must ABORT, not warn. psql's \quit takes no exit code, so
+-- the refusal is raised as a real error instead: with ON_ERROR_STOP on, that is
+-- what makes the process exit non-zero rather than reporting success.
+\if :{?email}
+\else
+DO $$ BEGIN
+  RAISE EXCEPTION 'admin-portal-login: -v email=<address seed_superadmin created> is required';
+END $$;
+\endif
+
+BEGIN;
+
+-- Bridge the psql variable into the session so the DO blocks below can read it.
+-- A DO block's body is a string literal to psql, so a `:'email'` inside one is
+-- never substituted; set_config is the seam that works for both.
+SELECT set_config('admin_portal_login.email', :'email', false);
+
+-- 1. The named user must already exist. Checked BEFORE any insert, because a
+--    typo in the email would otherwise leave the organization created, no
+--    binding made, and the run reporting success.
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM users WHERE email = current_setting('admin_portal_login.email')) THEN
+    RAISE EXCEPTION 'admin-portal-login: no user with email %; run seed_superadmin first',
+      current_setting('admin_portal_login.email');
+  END IF;
+END $$;
+
+-- 2. A tier for the scenario organization. `organization.tier_id` is NOT NULL.
+INSERT INTO tier (id, name, description)
+VALUES (gen_random_uuid(), 'ZZ-AdminPortalLogin-Tier', 'admin-portal-login scenario')
+ON CONFLICT (name) DO UPDATE SET description = EXCLUDED.description;
+
+-- 3. The organization the portal will select. billing_model defaults to
+--    'legacy', which the organization_billing_model_check constraint accepts.
+INSERT INTO organization (id, name, tier_id)
+SELECT '019400a0-1111-7000-8000-000000000001', 'ZZ-AdminPortalLogin-Org', t.id
+FROM tier t
+WHERE t.name = 'ZZ-AdminPortalLogin-Tier'
+ON CONFLICT (id) DO UPDATE SET name = EXCLUDED.name;
+
+-- 4. Bind that user to that organization as ORGADMIN. The role id is the fixed
+--    constant from admin/backend/internal/seed/roles/roles.go, so this never
+--    depends on a name lookup. uro_user_role_org_unique is a partial unique
+--    index over (user_id, role_id, organization_id) WHERE organization_id IS
+--    NOT NULL, which is the conflict target below.
+INSERT INTO user_role_organization (user_id, role_id, organization_id)
+SELECT u.id, '019400a0-0000-7000-8000-000000000001', '019400a0-1111-7000-8000-000000000001'
+FROM users u
+WHERE u.email = current_setting('admin_portal_login.email')
+ON CONFLICT (user_id, role_id, organization_id) WHERE organization_id IS NOT NULL
+DO NOTHING;
+
+-- 5. Prove THIS user now resolves an organization, rather than proving only
+--    that some binding exists: a leftover binding from an earlier run of this
+--    scenario would satisfy the weaker check for any email at all.
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM user_role_organization uro
+    JOIN users u ON u.id = uro.user_id
+    WHERE u.email = current_setting('admin_portal_login.email')
+      AND uro.role_id = '019400a0-0000-7000-8000-000000000001'
+      AND uro.organization_id = '019400a0-1111-7000-8000-000000000001'
+      AND uro.deleted_at IS NULL
+  ) THEN
+    RAISE EXCEPTION 'admin-portal-login: % still resolves no organization',
+      current_setting('admin_portal_login.email');
+  END IF;
+END $$;
+
+COMMIT;

--- a/skills/revocall-e2e-teardown/SKILL.md
+++ b/skills/revocall-e2e-teardown/SKILL.md
@@ -1,0 +1,117 @@
+---
+name: revocall-e2e-teardown
+description: >-
+  Reverse exactly what revocall-e2e-provision started for one task's local end-to-end test: its containers, volumes, and network, verified gone.
+  Use when local end-to-end testing is finished, before ending a task that provisioned a local stack, and when recovering a task whose worker died mid-test.
+  Verifies ownership through the provisioning record before removing anything, and reports an unattributed container instead of removing it, because an anonymous container can be live work.
+user-invocable: true
+---
+
+<!-- maintainers: this is the public, installer-facing skill. Keep it standalone: it must work with no firstmate home present. The firstmate-coupled half is bin/fm-e2e-stack.sh plus Fix 4 in bin/fm-teardown.sh, which runs this same removal automatically at task cleanup. -->
+
+# revocall-e2e-teardown
+
+Take down the local stack `revocall-e2e-provision` brought up for this task, and prove it is gone.
+
+Run it as soon as the end-to-end test is finished, not at the end of the task.
+In a firstmate checkout, task cleanup also runs the same removal automatically, so this skill and that path converge on one outcome rather than two.
+
+## The rule this skill exists to enforce
+
+**Removal always needs a record. Never an inference.**
+
+An anonymous container is not evidence of abandonment.
+Compose names a project after its own directory when the compose file declares no `name:`, so a live validation pipeline's database can appear as `backend-postgres-1` with nothing tying it to any task.
+That shape is indistinguishable from a stray, and it has been live work in practice.
+So this skill removes only what a provisioning record names, and reports everything else.
+
+## Steps
+
+1. **Read the record.**
+   With firstmate present: `bin/fm-e2e-stack.sh read <task>`.
+   Standalone: the file the provisioning run wrote beside its override.
+   No record means nothing to remove: say so and stop, rather than searching for something to clean.
+
+2. **Run the ownership gates.**
+   `bin/fm-e2e-stack.sh gate <task>` runs all four and prints one verdict per gate.
+   Standalone, check them by hand in this order.
+
+   | Gate | Check | Why |
+   |---|---|---|
+   | 1 | Every container labelled `ai.revolab.fm.task=<task>` sits in a project the record names, and every recorded project's containers carry that label. | Labels and record disagreeing is a divergence to report, not a target to remove. |
+   | 2 | Every recorded project name begins with `fm-`. | Nothing a person or another tool starts is named that way, so a hand-run or pipeline-owned stack can never be selected. |
+   | 3 | No OTHER task's record names the same project or worktree. | One project claimed by two records is the collision itself, whichever record is stale. Never resolved by guessing. |
+   | 4 | Every recorded external volume name contains the task id. | RevoCall's deploy stack pins six `external: true` volumes to fixed names. An unsuffixed name is the shared local development data. |
+
+   A failed gate stops the removal.
+   There is no force flag: these refusals protect OTHER work, and discarding this task's own work is never what they stand in the way of.
+
+3. **Remove, using the recorded compose files.**
+
+   ```bash
+   docker compose -p <recorded project> -f <recorded file>... down -v --remove-orphans --timeout 20
+   ```
+
+   `-v` is required.
+   A plain `down` leaves the project's volumes behind, and volume residue is where the disk actually goes: an unswept machine has been observed holding about 2.0 GB of dangling volumes.
+   Use the RECORDED file list rather than re-deriving it, so a repo file edited since provisioning cannot change what comes down.
+
+4. **Remove what compose will not.**
+   `docker volume rm <name>` for each recorded external volume, only when gate 4 passed.
+   Compose removes an `external: true` volume on no code path, `down -v` included.
+   `docker network rm <name>` when the record says provisioning created the network and it now holds no containers.
+
+5. **Verify, and treat residue as failure.**
+
+   ```bash
+   docker ps -aq      --filter label=com.docker.compose.project=<project>
+   docker volume ls -q --filter label=com.docker.compose.project=<project>
+   docker network ls -q --filter label=com.docker.compose.project=<project>
+   docker volume inspect <each recorded external volume>
+   ```
+
+   All four must come back empty.
+   Anything surviving is a failed removal: report it, keep the record for a retry, and do not clear it.
+
+6. **Reap the host side.**
+   A provisioned stack often has an application process pointed at it, and that process outlives the containers.
+   Kill processes whose working directory is under this task's worktree or its temporary root, and any process holding a socket on a recorded port, verifying identity before signalling.
+   This step is not optional bookkeeping: an orphaned application process has been observed still polling a deleted database more than 25 hours later, reattaching the moment anything bound its port again.
+   Report anything it declines to kill.
+
+7. **Clear the record**, only after step 5 passed.
+   `bin/fm-e2e-stack.sh clear <task>`, or delete the standalone record file.
+   `bin/fm-e2e-stack.sh down <task>` performs steps 2 through 5 and 7 as one guarded, idempotent operation, and is the preferred path when firstmate is present.
+
+## Reporting what you did not remove
+
+`bin/fm-e2e-stack.sh strays` lists every container with its claimed task, whether that task still has a live record, and whether the directory it was launched from still exists.
+
+Two of those signals are for triage only and never authorize a removal.
+
+- A launching directory that no longer exists suggests abandonment.
+- A launching directory that still exists suggests live work, and it is the signal that protects a running pipeline.
+
+Report an unattributed container with its age and launching directory so a human can decide.
+Do not remove it.
+Container start time from `docker inspect --format '{{.State.StartedAt}}'` is the cheap age signal; reading container logs for a last-activity timestamp is the expensive fallback, and needing it means the identity discipline was skipped upstream.
+
+## If the record is gone but the stack is not
+
+This is the recovery case: a worker died before recording, or the record was deleted.
+
+Reconstruct a CANDIDATE set from `docker ps -a --filter label=ai.revolab.fm.task=<task>`, and say plainly in the report that the set was reconstructed.
+Gate 1 cannot be checked in that state, so gates 2, 3, and 4 carry the whole decision: the `fm-` prefix, no competing claimant, and a task-suffixed external volume name.
+If those do not hold, stop and report rather than removing.
+
+## Refusals
+
+- Any ownership gate failing.
+- An unrecorded or unlabelled container, always. It is reported, never removed.
+- An external volume whose name carries no task id, always. That is shared local data.
+- `docker info` not answering. Nothing can be proved, so nothing is removed.
+
+## Reference
+
+`bin/fm-e2e-stack.sh --help` in a firstmate checkout owns the record format, the exact gate semantics, and the removal mechanics.
+`revocall-e2e-provision` owns what gets started and what the record must contain.

--- a/tests/fm-e2e-stack.test.sh
+++ b/tests/fm-e2e-stack.test.sh
@@ -1,0 +1,429 @@
+#!/usr/bin/env bash
+# Behavioral regressions for bin/fm-e2e-stack.sh - the durable record and
+# guarded removal of a task's local end-to-end test infrastructure.
+#
+# Every case drives the real script through a fake `docker` whose whole world is
+# one TSV inventory file, so the ownership gates and the residue verification
+# are exercised for real without a docker daemon.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+E2E="$ROOT/bin/fm-e2e-stack.sh"
+TMP_ROOT=$(fm_test_tmproot fm-e2e-stack)
+
+# make_case <name> -> echoes the case dir. Builds an isolated home plus a fake
+# docker whose inventory starts empty.
+make_case() {
+  local name=$1 case_dir fakebin
+  case_dir="$TMP_ROOT/$name"
+  fakebin="$case_dir/fakebin"
+  mkdir -p "$case_dir/state" "$case_dir/docker" "$fakebin"
+  : > "$case_dir/docker/inv"
+  # Fake docker. Inventory rows are "kind<TAB>name<TAB>project<TAB>task".
+  # It answers only the reads and writes this script actually performs.
+  cat > "$fakebin/docker" <<'SH'
+#!/usr/bin/env bash
+set -u
+S=${FAKE_DOCKER_DIR:?}
+INV=$S/inv
+[ -f "$INV" ] || : > "$INV"
+
+# Value of --filter label=<key>=<value>, if present.
+filter_value() {
+  local k=$1 a; shift
+  for a in "$@"; do
+    case $a in "label=$k="*) printf '%s' "${a#label="$k"=}"; return 0 ;; esac
+  done
+  return 1
+}
+
+# First positional after the subcommand, skipping docker's `--` end-of-options.
+target() {
+  local a
+  for a in "$@"; do
+    case $a in --) continue ;; -*) continue ;; *) printf '%s' "$a"; return 0 ;; esac
+  done
+  return 1
+}
+
+case "${1-}" in
+  info) exit "${FAKE_DOCKER_INFO_RC:-0}" ;;
+  ps)
+    if v=$(filter_value com.docker.compose.project "$@"); then
+      awk -F'\t' -v p="$v" '$1=="container" && $3==p {print $2}' "$INV"
+    elif v=$(filter_value ai.revolab.fm.task "$@"); then
+      awk -F'\t' -v t="$v" '$1=="container" && $4==t {print $2}' "$INV"
+    else
+      awk -F'\t' '$1=="container" {print $2}' "$INV"
+    fi ;;
+  inspect)
+    c=$2; shift 2; fmt=""
+    for a in "$@"; do case $a in --format) : ;; *) fmt=$a ;; esac; done
+    case $fmt in
+      *.Name*) printf '/%s\n' "$c" ;;
+      *com.docker.compose.project.working_dir*) printf '%s\n' "${FAKE_DOCKER_WORKDIR:-}" ;;
+      *com.docker.compose.project*) awk -F'\t' -v c="$c" '$2==c {print $3}' "$INV" ;;
+      *ai.revolab.fm.task*) awk -F'\t' -v c="$c" '$2==c {print $4}' "$INV" ;;
+      *) : ;;
+    esac ;;
+  volume)
+    case ${2-} in
+      ls) if v=$(filter_value com.docker.compose.project "$@"); then
+            awk -F'\t' -v p="$v" '$1=="volume" && $3==p {print $2}' "$INV"
+          else awk -F'\t' '$1=="volume" {print $2}' "$INV"; fi ;;
+      rm) shift 2; n=$(target "$@") || exit 1
+          # Refuse BEFORE mutating, so a simulated failure really leaves it.
+          [ "${FAKE_VOLUME_RM_RC:-0}" = 0 ] || exit "${FAKE_VOLUME_RM_RC}"
+          awk -F'\t' -v n="$n" '!($1=="volume" && $2==n)' "$INV" > "$INV.new" \
+            && mv "$INV.new" "$INV" ;;
+      inspect) shift 2; n=$(target "$@") || exit 1
+          awk -F'\t' -v n="$n" '$1=="volume" && $2==n {f=1} END {exit !f}' "$INV"
+          exit $? ;;
+    esac ;;
+  network)
+    case ${2-} in
+      ls) if v=$(filter_value com.docker.compose.project "$@"); then
+            awk -F'\t' -v p="$v" '$1=="network" && $3==p {print $2}' "$INV"
+          else awk -F'\t' '$1=="network" {print $2}' "$INV"; fi ;;
+      rm) shift 2; n=$(target "$@") || exit 1
+          awk -F'\t' -v n="$n" '!($1=="network" && $2==n)' "$INV" > "$INV.new" \
+            && mv "$INV.new" "$INV" ;;
+    esac ;;
+  compose)
+    printf '%s\n' "$*" >> "$S/compose.log"
+    p=""; prev=""
+    for a in "$@"; do [ "$prev" = "-p" ] && p=$a; prev=$a; done
+    [ "${FAKE_COMPOSE_RC:-0}" = 0 ] && [ -n "$p" ] \
+      && { awk -F'\t' -v p="$p" '$3 != p' "$INV" > "$INV.new" && mv "$INV.new" "$INV"; }
+    exit "${FAKE_COMPOSE_RC:-0}" ;;
+esac
+exit 0
+SH
+  chmod +x "$fakebin/docker"
+  printf '%s\n' "$case_dir"
+}
+
+# inv <case-dir> <kind> <name> <project> <task>: append one inventory row.
+inv() {
+  printf '%s\t%s\t%s\t%s\n' "$2" "$3" "$4" "$5" >> "$1/docker/inv"
+}
+
+# Count of live inventory rows. `grep -c` prints 0 AND exits 1 on no match, so
+# an `|| printf 0` fallback would emit "0" twice.
+inv_rows() {
+  local n
+  n=$(grep -c . "$1/docker/inv" 2>/dev/null) || n=0
+  printf '%s\n' "$n"
+}
+
+# run_e2e <case-dir> <args...>
+run_e2e() {
+  local case_dir=$1; shift
+  FM_ROOT_OVERRIDE="$ROOT" \
+  FM_STATE_OVERRIDE="$case_dir/state" \
+  FM_DOCKER="$case_dir/fakebin/docker" \
+  FAKE_DOCKER_DIR="$case_dir/docker" \
+    "$E2E" "$@"
+}
+
+# record_stack <case-dir> <task> <project> [extra args...]
+record_stack() {
+  local case_dir=$1 task=$2 project=$3; shift 3
+  run_e2e "$case_dir" record "$task" \
+    --project "$project" --stack revcaf-db --repo Conversational-AI-Framework \
+    --scenario org-scope-write-path --worktree "$case_dir/wt" \
+    --compose-file "$case_dir/dc.yaml" "$@"
+}
+
+test_record_round_trips_and_replaces_a_reprovisioned_project() {
+  local c out
+  c=$(make_case record-round-trip)
+  record_stack "$c" t1 fm-t1-revcaf --service db --port PORT_POSTGRES=15433 >/dev/null
+  out=$(run_e2e "$c" read t1)
+  assert_contains "$out" 'schema=fm-e2e-stack.v1' "record omits its schema marker"
+  assert_contains "$out" 'project=fm-t1-revcaf' "record omits the project"
+  assert_contains "$out" 'compose_file=' "record omits the compose file it must tear down with"
+  assert_contains "$out" 'port=PORT_POSTGRES=15433' "record loses a port whose value itself contains '='"
+
+  # Re-provisioning the same project must replace its block, not add a second.
+  run_e2e "$c" record t1 --project fm-t1-revcaf --stack revcaf-full \
+    --repo Conversational-AI-Framework --scenario org-scope-write-path \
+    --worktree "$c/wt" --compose-file "$c/dc.yaml" --service db --service qdrant >/dev/null
+  out=$(run_e2e "$c" read t1)
+  assert_equals 1 "$(printf '%s\n' "$out" | grep -c '^project=fm-t1-revcaf$')" \
+    "re-recording one project left two blocks for it"
+  assert_contains "$out" 'stack=revcaf-full' "re-recording did not replace the stale block"
+  assert_not_contains "$out" 'stack=revcaf-db' "re-recording kept the superseded block"
+
+  # A second, different project coexists.
+  record_stack "$c" t1 fm-t1-revocall >/dev/null
+  out=$(run_e2e "$c" read t1)
+  assert_equals 2 "$(printf '%s\n' "$out" | grep -c '^project=')" \
+    "a task holding two stacks lost one of them"
+  pass "record round-trips its fields, replaces a re-provisioned project, and keeps distinct ones"
+}
+
+test_record_refuses_a_project_cleanup_could_not_safely_own() {
+  local c code
+  c=$(make_case record-refusals)
+
+  # No fm- prefix: this is what protects a hand-run or pipeline-owned stack,
+  # whose project name is its own directory basename.
+  code=0
+  run_e2e "$c" record t1 --project backend --stack s --repo r --scenario s \
+    --worktree "$c/wt" --compose-file "$c/dc.yaml" >/dev/null 2>&1 || code=$?
+  expect_code 1 "$code" "record accepted a project name outside the fm- namespace"
+  assert_contains "$(run_e2e "$c" read t1)" ABSENT "a refused record was written anyway"
+
+  # Not docker's own charset: keeps filter syntax out of `--filter label=...`.
+  code=0
+  run_e2e "$c" record t1 --project 'fm-t1 revcaf' --stack s --repo r --scenario s \
+    --worktree "$c/wt" --compose-file "$c/dc.yaml" >/dev/null 2>&1 || code=$?
+  expect_code 1 "$code" "record accepted a project name outside docker's charset"
+
+  # A missing required field must refuse rather than record an empty value.
+  code=0
+  run_e2e "$c" record t1 --project fm-t1-revcaf --stack s --repo r \
+    --compose-file "$c/dc.yaml" >/dev/null 2>&1 || code=$?
+  expect_code 1 "$code" "record accepted a stack with no scenario or worktree"
+
+  # No compose file means `down` would have nothing to tear down with.
+  code=0
+  run_e2e "$c" record t1 --project fm-t1-revcaf --stack s --repo r --scenario s \
+    --worktree "$c/wt" >/dev/null 2>&1 || code=$?
+  expect_code 1 "$code" "record accepted a stack with no compose file"
+  pass "record refuses every stack whose ownership cleanup could not later prove"
+}
+
+test_record_refuses_an_external_volume_that_is_shared_local_data() {
+  local c code out
+  c=$(make_case record-external-volume)
+
+  # RevoCall's deploy stack pins six external volumes to fixed names; compose
+  # removes an external volume on no code path, so cleanup removes them by
+  # name. An unsuffixed name is the shared local development data.
+  code=0
+  run_e2e "$c" record t1 --project fm-t1-revocall --stack revocall-admin-db \
+    --repo RevoCall --scenario admin-portal-login --worktree "$c/wt" \
+    --compose-file "$c/dc.yaml" --external-volume revocall-infra_postgres-data >/dev/null 2>&1 || code=$?
+  expect_code 1 "$code" "record accepted an external volume carrying no task id"
+
+  run_e2e "$c" record t1 --project fm-t1-revocall --stack revocall-admin-db \
+    --repo RevoCall --scenario admin-portal-login --worktree "$c/wt" \
+    --compose-file "$c/dc.yaml" --external-volume revocall-infra_postgres-data-t1 >/dev/null
+  out=$(run_e2e "$c" read t1)
+  assert_contains "$out" 'external_volume=revocall-infra_postgres-data-t1' \
+    "record rejected a task-suffixed external volume"
+  pass "record admits only external volumes whose names carry the task id"
+}
+
+test_gate_refuses_a_project_another_task_record_claims() {
+  local c out code
+  c=$(make_case gate-collision)
+  record_stack "$c" t1 fm-t1-revcaf >/dev/null
+  # A second task record naming the same project is the collision itself,
+  # whichever record is stale. Never resolved by guessing.
+  cp "$c/state/t1.e2e-stack" "$c/state/t2.e2e-stack"
+
+  code=0
+  out=$(run_e2e "$c" gate t1 2>&1) || code=$?
+  expect_code 1 "$code" "gate passed a project two task records claim"
+  assert_contains "$out" 'gate3 REFUSED' "gate did not name the claim collision"
+  assert_contains "$out" 't2 claims project fm-t1-revcaf' "gate did not name the other claimant"
+  pass "gate refuses a project or worktree another task record also claims"
+}
+
+test_gate_refuses_when_labels_and_the_record_disagree() {
+  local c out code
+  c=$(make_case gate-divergence)
+  record_stack "$c" t1 fm-t1-revcaf >/dev/null
+
+  # A container inside a recorded project carrying someone else's task label.
+  inv "$c" container fm-t1-revcaf-db fm-t1-revcaf other-task
+  code=0
+  out=$(run_e2e "$c" gate t1 2>&1) || code=$?
+  expect_code 1 "$code" "gate passed a container labelled for another task"
+  assert_contains "$out" 'carries task label other-task' "gate did not name the foreign label"
+  assert_not_contains "$out" 'gate1 ok' "gate reported success beside its own refusal"
+
+  # The other direction: a container labelled for this task in a project the
+  # record does not name. Also a divergence, never a removal target.
+  : > "$c/docker/inv"
+  inv "$c" container stray-db someone-else t1
+  code=0
+  out=$(run_e2e "$c" gate t1 2>&1) || code=$?
+  expect_code 1 "$code" "gate passed a labelled container in an unrecorded project"
+  assert_contains "$out" 'is unrecorded' "gate did not name the unrecorded project"
+  pass "gate refuses in both directions when container labels and the record disagree"
+}
+
+test_gate_cannot_pass_without_docker() {
+  local c out code
+  c=$(make_case gate-no-docker)
+  record_stack "$c" t1 fm-t1-revcaf >/dev/null
+  code=0
+  out=$(FAKE_DOCKER_INFO_RC=1 run_e2e "$c" gate t1 2>&1) || code=$?
+  expect_code 1 "$code" "gate passed while the container gates could not be proved"
+  assert_contains "$out" 'docker unavailable' "gate did not say why it could not prove ownership"
+
+  # An absent record is not an implicit pass either.
+  code=0
+  out=$(run_e2e "$c" gate no-such-task 2>&1) || code=$?
+  expect_code 1 "$code" "gate passed with no record at all"
+  pass "gate refuses rather than passing when it cannot prove ownership"
+}
+
+test_down_removes_only_what_the_record_names_then_clears_it() {
+  local c out
+  c=$(make_case down-success)
+  run_e2e "$c" record t1 --project fm-t1-revocall --stack revocall-admin-db \
+    --repo RevoCall --scenario admin-portal-login --worktree "$c/wt" \
+    --compose-file "$c/dc.yaml" --external-volume revocall-infra_postgres-data-t1 \
+    --network fm-t1-revocall --created-network >/dev/null
+  inv "$c" container fm-t1-revocall-postgres fm-t1-revocall t1
+  inv "$c" volume fm-t1-revocall_pgdata fm-t1-revocall t1
+  inv "$c" network fm-t1-revocall_default fm-t1-revocall t1
+  inv "$c" volume revocall-infra_postgres-data-t1 '' ''
+  # A neighbour with no record at all must survive: an anonymous project can be
+  # live work, such as a no-mistakes pipeline run under its own directory name.
+  inv "$c" container backend-postgres-1 backend ''
+
+  out=$(run_e2e "$c" down t1 2>&1) || fail "down refused a stack whose gates all pass"$'\n'"$out"
+  assert_contains "$out" 'removed (containers, volumes, network)' "down did not report the removal"
+  assert_grep 'down -v --remove-orphans' "$c/docker/compose.log" \
+    "down did not remove volumes and orphans with the project's own compose files"
+  assert_equals 1 "$(inv_rows "$c")" "down removed more or less than the record named"
+  assert_grep 'backend-postgres-1' "$c/docker/inv" "down removed an unrecorded neighbour"
+  assert_contains "$(run_e2e "$c" read t1)" ABSENT "a verified removal left its record behind"
+  pass "down removes exactly the recorded stack, spares unrecorded neighbours, then clears the record"
+}
+
+test_down_refuses_and_removes_nothing_when_a_gate_fails() {
+  local c out code before
+  c=$(make_case down-refusal)
+  record_stack "$c" t1 fm-t1-revcaf >/dev/null
+  inv "$c" container fm-t1-revcaf-db fm-t1-revcaf other-task
+  before=$(inv_rows "$c")
+
+  code=0
+  out=$(run_e2e "$c" down t1 2>&1) || code=$?
+  expect_code 1 "$code" "down proceeded past a failed ownership gate"
+  assert_contains "$out" 'nothing was removed' "down did not say it removed nothing"
+  assert_equals "$before" "$(inv_rows "$c")" "a refused down still changed the inventory"
+  assert_contains "$(run_e2e "$c" read t1)" 'project=fm-t1-revcaf' "a refused down cleared the record"
+  assert_absent "$c/docker/compose.log" "a refused down still invoked compose"
+  pass "down refuses on a failed gate, removes nothing, and preserves the record for retry"
+}
+
+test_down_dry_run_changes_nothing() {
+  local c out
+  c=$(make_case down-dry-run)
+  record_stack "$c" t1 fm-t1-revcaf >/dev/null
+  inv "$c" container fm-t1-revcaf-db fm-t1-revcaf t1
+  out=$(run_e2e "$c" down t1 --dry-run 2>&1) || fail "dry run refused a passing stack"$'\n'"$out"
+  assert_contains "$out" 'would run' "dry run did not print the removal plan"
+  assert_equals 1 "$(inv_rows "$c")" "dry run changed the inventory"
+  assert_absent "$c/docker/compose.log" "dry run invoked compose"
+  assert_contains "$(run_e2e "$c" read t1)" 'project=fm-t1-revcaf' "dry run cleared the record"
+  pass "down --dry-run prints the plan and changes nothing"
+}
+
+test_down_treats_surviving_residue_as_failure() {
+  local c out code
+  c=$(make_case down-residue)
+  record_stack "$c" t1 fm-t1-revcaf >/dev/null
+  inv "$c" container fm-t1-revcaf-db fm-t1-revcaf t1
+  code=0
+  out=$(FAKE_COMPOSE_RC=1 run_e2e "$c" down t1 2>&1) || code=$?
+  expect_code 1 "$code" "down reported success while its containers survived"
+  assert_contains "$out" 'RESIDUE remains' "down did not name the surviving residue"
+  assert_contains "$(run_e2e "$c" read t1)" 'project=fm-t1-revcaf' \
+    "down cleared the record of a stack it failed to remove"
+
+  # An external volume that refuses removal is the same kind of failure, and
+  # matters more: compose never removes those, so only this check catches it.
+  c=$(make_case down-residue-external)
+  run_e2e "$c" record t1 --project fm-t1-revocall --stack revocall-admin-db \
+    --repo RevoCall --scenario s --worktree "$c/wt" --compose-file "$c/dc.yaml" \
+    --external-volume revocall-infra_postgres-data-t1 >/dev/null
+  inv "$c" volume revocall-infra_postgres-data-t1 '' ''
+  code=0
+  out=$(FAKE_VOLUME_RM_RC=1 run_e2e "$c" down t1 2>&1) || code=$?
+  expect_code 1 "$code" "down reported success while an external volume survived"
+  assert_contains "$out" 'RESIDUE external volume' "down did not name the surviving external volume"
+  assert_contains "$(run_e2e "$c" read t1)" 'project=fm-t1-revocall' \
+    "down cleared the record of an external volume it failed to remove"
+  pass "down fails loudly and keeps its record when any resource survives removal"
+}
+
+test_strays_reports_and_never_removes() {
+  local c out
+  c=$(make_case strays)
+  : > "$c/state/live-task.meta"
+  inv "$c" container fm-gone-revcaf-db fm-gone-revcaf gone-task
+  inv "$c" container fm-live-revcaf-db fm-live-revcaf live-task
+  inv "$c" container backend-postgres-1 backend ''
+
+  # A label is written by whoever started the container, so a value that is not
+  # a usable task id must be reported as unreadable rather than probed as a path.
+  inv "$c" container fm-evil-db fm-evil '../../etc/passwd'
+
+  out=$(run_e2e "$c" strays 2>&1) || fail "strays failed"$'\n'"$out"
+  assert_contains "$out" 'record=GONE' "strays did not flag a container whose task record is gone"
+  assert_contains "$out" 'record=LIVE' "strays did not spare a container whose task is still live"
+  assert_contains "$out" 'unlabelled' "strays did not report an unattributed container"
+  assert_contains "$out" 'record=UNREADABLE' "strays treated an unusable task label as a task id"
+  assert_equals 4 "$(inv_rows "$c")" "strays removed a container instead of reporting it"
+  assert_absent "$c/docker/compose.log" "strays invoked compose"
+  pass "strays reports ownership without removing anything, and never trusts a label as a path"
+}
+
+test_recorded_paths_survive_a_space() {
+  local c out spaced
+  c=$(make_case spaced-paths)
+  spaced="$c/My Compose/dc.yaml"
+  mkdir -p "$c/My Compose"
+  : > "$spaced"
+  run_e2e "$c" record t1 --project fm-t1-revcaf --stack revcaf-db \
+    --repo Conversational-AI-Framework --scenario org-scope-write-path \
+    --worktree "$c/wt" --compose-file "$spaced" --service db >/dev/null
+  assert_contains "$(run_e2e "$c" read t1)" "compose_file=$spaced" \
+    "a compose path containing a space did not round-trip"
+
+  inv "$c" container fm-t1-revcaf-db fm-t1-revcaf t1
+  out=$(run_e2e "$c" down t1 2>&1) || fail "down failed on a compose path with a space"$'\n'"$out"
+  # One -f, with the whole path intact. Word-splitting the record would have
+  # produced two bogus -f arguments and torn down nothing.
+  assert_grep "-f $spaced " "$c/docker/compose.log" \
+    "down split a spaced compose path into separate -f arguments"
+  assert_equals 1 "$(grep -c -- ' -f ' "$c/docker/compose.log")" \
+    "down passed more -f arguments than the record named"
+  assert_equals 0 "$(inv_rows "$c")" "down left the stack in place"
+  pass "a recorded compose path containing a space reaches compose as one argument"
+}
+
+test_clear_is_idempotent() {
+  local c
+  c=$(make_case clear)
+  record_stack "$c" t1 fm-t1-revcaf >/dev/null
+  run_e2e "$c" clear t1 >/dev/null
+  assert_absent "$c/state/t1.e2e-stack" "clear left the record in place"
+  run_e2e "$c" clear t1 >/dev/null || fail "clear failed on an already-cleared record"
+  pass "clear removes the record and is a no-op on a second run"
+}
+
+test_record_round_trips_and_replaces_a_reprovisioned_project
+test_record_refuses_a_project_cleanup_could_not_safely_own
+test_record_refuses_an_external_volume_that_is_shared_local_data
+test_gate_refuses_a_project_another_task_record_claims
+test_gate_refuses_when_labels_and_the_record_disagree
+test_gate_cannot_pass_without_docker
+test_down_removes_only_what_the_record_names_then_clears_it
+test_down_refuses_and_removes_nothing_when_a_gate_fails
+test_down_dry_run_changes_nothing
+test_down_treats_surviving_residue_as_failure
+test_strays_reports_and_never_removes
+test_clear_is_idempotent
+test_recorded_paths_survive_a_space

--- a/tests/fm-e2e-stack.test.sh
+++ b/tests/fm-e2e-stack.test.sh
@@ -197,6 +197,27 @@ test_record_refuses_a_project_cleanup_could_not_safely_own() {
   pass "record refuses every stack whose ownership cleanup could not later prove"
 }
 
+test_record_accepts_the_sanitized_project_name_derived_from_a_mixed_case_dotted_task_id() {
+  local c code
+  c=$(make_case record-task-id-charset)
+
+  # SKILL.md derives PROJECT from the task id. A caller-supplied --task value
+  # (validated only by the looser [A-Za-z0-9._-]+ charset) can carry an
+  # uppercase letter or a dot; used unsanitized in PROJECT it is refused here,
+  # same as any other char outside docker's own [a-z0-9][a-z0-9_-]* charset.
+  code=0
+  record_stack "$c" 'T1.abc' fm-T1.abc-revcaf >/dev/null 2>&1 || code=$?
+  expect_code 1 "$code" "record accepted a project name carrying the task id's raw uppercase/dot"
+
+  # The skill's TASK_SLUG rule (lowercase, non-[a-z0-9-] -> '-') turns that
+  # same task id into a project name the script accepts.
+  record_stack "$c" 'T1.abc' fm-t1-abc-revcaf >/dev/null \
+    || fail "record refused the sanitized project name the skill derives from a mixed-case dotted task id"
+  assert_contains "$(run_e2e "$c" read 'T1.abc')" 'project=fm-t1-abc-revcaf' \
+    "record did not keep the sanitized project name"
+  pass "a task id with an uppercase letter and a dot sanitizes into a project name the script accepts"
+}
+
 test_record_refuses_an_external_volume_that_is_shared_local_data() {
   local c code out
   c=$(make_case record-external-volume)
@@ -416,6 +437,7 @@ test_clear_is_idempotent() {
 
 test_record_round_trips_and_replaces_a_reprovisioned_project
 test_record_refuses_a_project_cleanup_could_not_safely_own
+test_record_accepts_the_sanitized_project_name_derived_from_a_mixed_case_dotted_task_id
 test_record_refuses_an_external_volume_that_is_shared_local_data
 test_gate_refuses_a_project_another_task_record_claims
 test_gate_refuses_when_labels_and_the_record_disagree

--- a/tests/fm-e2e-stack.test.sh
+++ b/tests/fm-e2e-stack.test.sh
@@ -209,13 +209,39 @@ test_record_accepts_the_sanitized_project_name_derived_from_a_mixed_case_dotted_
   record_stack "$c" 'T1.abc' fm-T1.abc-revcaf >/dev/null 2>&1 || code=$?
   expect_code 1 "$code" "record accepted a project name carrying the task id's raw uppercase/dot"
 
-  # The skill's TASK_SLUG rule (lowercase, non-[a-z0-9-] -> '-') turns that
+  # The skill's TASK_SLUG rule (lowercase, non-[a-z0-9-] -> '-', then a crc32
+  # disambiguator appended because sanitizing this id is lossy) turns that
   # same task id into a project name the script accepts.
-  record_stack "$c" 'T1.abc' fm-t1-abc-revcaf >/dev/null \
+  record_stack "$c" 'T1.abc' fm-t1-abc-30143a-revcaf >/dev/null \
     || fail "record refused the sanitized project name the skill derives from a mixed-case dotted task id"
-  assert_contains "$(run_e2e "$c" read 'T1.abc')" 'project=fm-t1-abc-revcaf' \
+  assert_contains "$(run_e2e "$c" read 'T1.abc')" 'project=fm-t1-abc-30143a-revcaf' \
     "record did not keep the sanitized project name"
   pass "a task id with an uppercase letter and a dot sanitizes into a project name the script accepts"
+}
+
+test_record_disambiguates_distinct_task_ids_that_sanitize_to_one_slug() {
+  local c
+  c=$(make_case record-task-id-collision)
+
+  # pr.123 and pr-123 are two distinct, individually valid raw task ids
+  # (fm_pr_task_id_valid accepts both '.' and '-') that both sanitize to the
+  # same base slug "pr-123" once '.' becomes '-'. Undisambiguated they would
+  # derive one identical PROJECT, and a second task's `up` could silently
+  # land inside the first task's still-live compose project. (Chosen to
+  # differ by punctuation rather than letter case, since macOS's default
+  # case-insensitive filesystem would otherwise collide the two tasks'
+  # *.e2e-stack record files themselves, a separate concern from the
+  # docker-project-name collision this test targets.)
+  record_stack "$c" 'pr.123' fm-pr-123-0e167d-revcaf --worktree "$c/wt-dot" >/dev/null \
+    || fail "record refused the disambiguated project name derived from pr.123"
+  record_stack "$c" 'pr-123' fm-pr-123-revcaf --worktree "$c/wt-hyphen" >/dev/null \
+    || fail "record refused the unsuffixed project name derived from the already-clean pr-123"
+
+  run_e2e "$c" gate 'pr.123' >/dev/null 2>&1 \
+    || fail "gate refused pr.123's record once pr-123's record also existed: their derived projects collided"
+  run_e2e "$c" gate 'pr-123' >/dev/null 2>&1 \
+    || fail "gate refused pr-123's record once pr.123's record also existed: their derived projects collided"
+  pass "distinct raw task ids that sanitize to one slug derive different, individually valid project names"
 }
 
 test_record_refuses_an_external_volume_that_is_shared_local_data() {
@@ -438,6 +464,7 @@ test_clear_is_idempotent() {
 test_record_round_trips_and_replaces_a_reprovisioned_project
 test_record_refuses_a_project_cleanup_could_not_safely_own
 test_record_accepts_the_sanitized_project_name_derived_from_a_mixed_case_dotted_task_id
+test_record_disambiguates_distinct_task_ids_that_sanitize_to_one_slug
 test_record_refuses_an_external_volume_that_is_shared_local_data
 test_gate_refuses_a_project_another_task_record_claims
 test_gate_refuses_when_labels_and_the_record_disagree

--- a/tests/fm-teardown.test.sh
+++ b/tests/fm-teardown.test.sh
@@ -3666,6 +3666,106 @@ EOF
   pass "the run abort and the leaked-process reap both complete before the destructive worktree return"
 }
 
+# --- Fix 4: local end-to-end test infrastructure -------------------------------
+# A hermetic `docker` for the Fix 4 cases. It reports an empty inventory, so
+# the ownership gates pass and the post-removal residue check is satisfied,
+# and it logs every compose invocation so a case can prove the removal ran.
+add_e2e_docker() {  # <case-dir>
+  local case_dir=$1
+  cat > "$case_dir/fakebin/docker" <<EOF
+#!/usr/bin/env bash
+case "\${1-}" in
+  compose) printf '%s\n' "\$*" >> "$case_dir/compose.log" ;;
+esac
+exit 0
+EOF
+  chmod +x "$case_dir/fakebin/docker"
+}
+
+# Record one provisioned stack for task-x1 in the case's own state directory.
+record_e2e_stack() {  # <case-dir> [project]
+  local case_dir=$1 project=${2:-fm-task-x1-revcaf}
+  FM_ROOT_OVERRIDE="$ROOT" FM_STATE_OVERRIDE="$case_dir/state" \
+    "$ROOT/bin/fm-e2e-stack.sh" record task-x1 \
+      --project "$project" --stack revcaf-db --repo Conversational-AI-Framework \
+      --scenario org-scope-write-path --worktree "$case_dir/wt" \
+      --compose-file "$case_dir/dc.yaml" --service db >/dev/null
+}
+
+test_recorded_e2e_stack_is_released_before_the_worktree_return() {
+  local case_dir rc
+  case_dir=$(make_case e2e-stack-released)
+  write_meta "$case_dir" no-mistakes ship
+  land_shippable_commit "$case_dir"
+  add_e2e_docker "$case_dir"
+  record_e2e_stack "$case_dir"
+
+  # Snapshot, at the moment the destructive worktree return runs, whether the
+  # stack was already released. Causal proof of ordering from observed state,
+  # not a source-text correlation. Fix 4 must precede every destructive step
+  # because the record's fallback copy lives under the tasktmp this removes.
+  cat > "$case_dir/fakebin/treehouse" <<EOF
+#!/usr/bin/env bash
+if [ ! -f "$case_dir/state/task-x1.e2e-stack" ]; then
+  echo "e2e-release-already-happened" >> "$case_dir/order.log"
+fi
+exit 0
+EOF
+  chmod +x "$case_dir/fakebin/treehouse"
+
+  rc=0
+  run_teardown "$case_dir" > "$case_dir/stdout" 2> "$case_dir/stderr" || rc=$?
+  expect_code 0 "$rc" "e2e-stack-released: teardown should succeed"
+  assert_grep 'down -v --remove-orphans' "$case_dir/compose.log" \
+    "e2e-stack-released: teardown never released the recorded stack"
+  assert_absent "$case_dir/state/task-x1.e2e-stack" \
+    "e2e-stack-released: the stack record survived a successful release"
+  assert_present "$case_dir/order.log" \
+    "e2e-stack-released: the destructive worktree return was never invoked"
+  assert_grep "e2e-release-already-happened" "$case_dir/order.log" \
+    "e2e-stack-released: the stack was still recorded when the worktree return ran"
+  pass "a recorded local end-to-end stack is released before the destructive worktree return"
+}
+
+test_e2e_stack_refusal_never_blocks_teardown() {
+  local case_dir rc
+  case_dir=$(make_case e2e-stack-refusal)
+  write_meta "$case_dir" no-mistakes ship
+  land_shippable_commit "$case_dir"
+  add_e2e_docker "$case_dir"
+  record_e2e_stack "$case_dir"
+  # A second task record claiming the same project makes the ownership gate
+  # refuse. Cleanup must then leave the stack alone and still finish teardown:
+  # the stack is reported by the next session start instead.
+  cp "$case_dir/state/task-x1.e2e-stack" "$case_dir/state/other-task.e2e-stack"
+
+  rc=0
+  run_teardown "$case_dir" > "$case_dir/stdout" 2> "$case_dir/stderr" || rc=$?
+  expect_code 0 "$rc" "e2e-stack-refusal: a refused stack release must not block teardown"
+  assert_absent "$case_dir/compose.log" \
+    "e2e-stack-refusal: a refused release still invoked compose"
+  assert_present "$case_dir/state/task-x1.e2e-stack" \
+    "e2e-stack-refusal: a refused release removed its own record"
+  assert_grep 'was not released' "$case_dir/stderr" \
+    "e2e-stack-refusal: teardown did not report the stack it left behind"
+  pass "a refused end-to-end stack release is reported and never blocks teardown"
+}
+
+test_teardown_without_an_e2e_record_never_calls_docker() {
+  local case_dir rc
+  case_dir=$(make_case e2e-stack-absent)
+  write_meta "$case_dir" no-mistakes ship
+  land_shippable_commit "$case_dir"
+  add_e2e_docker "$case_dir"
+
+  rc=0
+  run_teardown "$case_dir" > "$case_dir/stdout" 2> "$case_dir/stderr" || rc=$?
+  expect_code 0 "$rc" "e2e-stack-absent: teardown should succeed"
+  assert_absent "$case_dir/compose.log" \
+    "e2e-stack-absent: teardown invoked compose for a task that provisioned nothing"
+  pass "a task that provisioned no local infrastructure reaches no container tooling"
+}
+
 test_local_only_fork_remote_allows
 test_teardown_closes_the_backlog_item_itself
 test_teardown_manual_backend_leaves_the_backlog_to_the_operator
@@ -3750,3 +3850,6 @@ test_process_spawned_during_grace_is_reaped_on_later_pass
 test_persistent_scan_refuses_after_bounded_retries
 test_process_exit_during_identity_lookup_does_not_refuse
 test_run_abort_precedes_process_reap_precedes_worktree_removal
+test_recorded_e2e_stack_is_released_before_the_worktree_return
+test_e2e_stack_refusal_never_blocks_teardown
+test_teardown_without_an_e2e_record_never_calls_docker

--- a/tests/fm-teardown.test.sh
+++ b/tests/fm-teardown.test.sh
@@ -3703,7 +3703,10 @@ test_recorded_e2e_stack_is_released_before_the_worktree_return() {
   # Snapshot, at the moment the destructive worktree return runs, whether the
   # stack was already released. Causal proof of ordering from observed state,
   # not a source-text correlation. Fix 4 must precede every destructive step
-  # because the record's fallback copy lives under the tasktmp this removes.
+  # because its `down` reads compose_file entries - including the generated
+  # override file - from the per-task tasktmp that a later step removes; the
+  # state record itself (state/<id>.e2e-stack) is never removed by anything
+  # else in this script, only by this hook's own successful `down`.
   cat > "$case_dir/fakebin/treehouse" <<EOF
 #!/usr/bin/env bash
 if [ ! -f "$case_dir/state/task-x1.e2e-stack" ]; then


### PR DESCRIPTION
## What this adds

A shared skill pair for standing up and tearing down local Docker stacks used for
end-to-end testing across the RevoCall family (RevoCall, RevoCall-AI-Handler,
Conversational-AI-Framework), plus the deterministic core the pair drives.

- `skills/revocall-e2e-provision` — provisions a task-scoped stack, seeds the
  minimum data for a named scenario, and records what it created.
- `skills/revocall-e2e-teardown` — releases exactly what was recorded.
- `bin/fm-e2e-stack.sh` — the record/gate/down core, with four ownership gates.
- `bin/fm-teardown.sh` — Fix 4 releases any recorded stack, so a worker that dies
  mid-test still gets cleaned up.

## Why

Container leaks from local e2e runs were taking a forensic session to attribute:
most stray containers carried no Compose project label, so recovering ownership
meant reading Postgres logs, checking whether worktrees still existed, and
grepping scout reports. Fifteen such containers were removed by hand before this
work started, some more than five days old.

Root cause was three concrete Compose defects rather than carelessness:
`container_name:` surviving `-p` and hiding project identity; list-valued keys
appending instead of overriding without `!override`; and `external: true` volumes
that Compose neither creates on `up` nor removes on `down -v`.

## Design

Identity comes from the Compose project name (`fm-<task>-<stack>`), so ownership
is readable from a bare `docker ps` with no forensic work; labels serve as
cleanup filters rather than as the identity itself. Isolation uses a generated
override Compose file written into the per-task tmp directory, reusing RevoCall's
existing `gen-slot-env.sh` port-offset scheme — no project repo is modified.

Seeding routes to each repo's own tooling (golang-migrate plus the Go seeder for
RevoCall, Alembic plus pytest fixtures for CAF, in-memory SQLite for AI-Handler)
with a thin per-scenario SQL delta layer on top.

The core safety rule is that **removal always needs a record, never an
inference**. An anonymous container is not evidence of abandonment — during this
work five containers that looked like strays turned out to be live pipeline work
and self-cleaned.

## Verification

The full provision → seed → verify → cleanup cycle was run live against CAF's
real Compose file and RevoCall's real 101-migration schema, with zero residue and
zero collateral damage. `docs/verification/local-e2e-infra.md` records the
procedure.

Tests: 13 new unit cases in `tests/fm-e2e-stack.test.sh` (driven by a fake
`docker` fed from a TSV inventory) and 3 integration cases in
`tests/fm-teardown.test.sh` covering release-before-worktree-return ordering,
refusal never blocking teardown, and no-record never invoking Docker.

## Notes for the reviewer

- Stacks are isolated per task, but LiveKit is not — that caveat is documented in
  the provision skill rather than papered over.
- The design deliberately ships one shared skill pair rather than per-repo
  variants; the reasoning and the 15 real per-repo differences it has to
  accommodate are in `skills/revocall-e2e-provision/references/profiles.md`.
