### PR TITLE
fix(teardown): guard empty descendant lock array

### DIFF
--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -2652,7 +2652,7 @@ preflight_descendant_treehouse_slots() {
     }
     held=0
     [ "$TREEHOUSE_PROJECT_LOCK_HELD" != 1 ] || [ "$TREEHOUSE_PROJECT_LOCK" != "$lock_path" ] || held=1
-    for target in "${DESCENDANT_TREEHOUSE_LOCK_PATHS[@]}"; do
+    for target in "${DESCENDANT_TREEHOUSE_LOCK_PATHS[@]+"${DESCENDANT_TREEHOUSE_LOCK_PATHS[@]}"}"; do
       [ "$target" != "$lock_path" ] || held=1
     done
     if [ "$held" = 0 ]; then

--- a/tests/fm-teardown.test.sh
+++ b/tests/fm-teardown.test.sh
@@ -2327,6 +2327,43 @@ configure_secondmate_with_tmux_children() {  # <case-dir>
   done
 }
 
+test_forced_secondmate_treehouse_preflight_accepts_empty_lock_list_on_bash32() {
+  local case_dir home child_wt rc=0 bash_version
+  bash_version=$(/bin/bash -c 'printf "%s.%s\n" "${BASH_VERSINFO[0]}" "${BASH_VERSINFO[1]}"')
+  if [ "$bash_version" != 3.2 ]; then
+    echo "skip: /bin/bash is Bash $bash_version, not Bash 3.2 (empty-array nounset regression)"
+    return 0
+  fi
+
+  case_dir=$(make_case descendant-treehouse-empty-lock-list)
+  write_meta "$case_dir" local-only secondmate
+  home="$case_dir/secondmate-home"
+  child_wt="$case_dir/pool/1/project"
+  mkdir -p "$home/state" "$home/data" "$home/config" "$home/projects" "$(dirname "$child_wt")"
+  printf '%s\n' task-x1 > "$home/.fm-secondmate-home"
+  printf '%s\n' "home=$home" >> "$case_dir/state/task-x1.meta"
+  git -C "$case_dir/project" worktree add -q -b fm/child-pool "$child_wt" main
+  printf '%s\n' '{}' > "$case_dir/pool/treehouse-state.json"
+  fm_write_meta "$home/state/child-pool.meta" \
+    "window=firstmate:fm-child-pool" \
+    "endpoint_task_id=child-pool" \
+    "worktree=$child_wt" \
+    "project=$case_dir/project" \
+    "kind=ship" \
+    "mode=local-only"
+
+  FM_ROOT_OVERRIDE="$ROOT" \
+  FM_STATE_OVERRIDE="$case_dir/state" \
+  FM_DATA_OVERRIDE="$case_dir/data" \
+  FM_CONFIG_OVERRIDE="$case_dir/config" \
+  PATH="$case_dir/fakebin:$PATH" \
+    /bin/bash -u "$TEARDOWN" task-x1 --force \
+    > "$case_dir/stdout" 2> "$case_dir/stderr" || rc=$?
+  expect_code 0 "$rc" \
+    "descendant-treehouse-empty-lock-list: forced teardown failed under Bash 3.2: $(cat "$case_dir/stderr")"
+  pass "forced secondmate Treehouse preflight accepts an initially empty lock list under Bash 3.2 nounset"
+}
+
 test_forced_secondmate_teardown_holds_descendant_lifecycle_locks() {
   local case_dir home lock ready release holder_pid rc waited=0 child
   case_dir=$(make_case descendant-locks)
@@ -3674,6 +3711,7 @@ test_local_only_merged_to_local_main_allows
 test_no_mistakes_origin_remote_allows
 test_no_mistakes_truly_unpushed_refuses
 test_local_only_force_overrides_unpushed
+test_forced_secondmate_treehouse_preflight_accepts_empty_lock_list_on_bash32
 test_secondmate_pr_registration_publishes_ready_line
 test_secondmate_home_teardown_delivers_final_line_or_refuses
 test_teardown_missing_busy_sidecar_completes


### PR DESCRIPTION
## Summary

- Guard the descendant Treehouse lock array expansion with the Bash 3.2-safe nounset idiom already used elsewhere in `bin/`.
- Add a colocated forced-secondmate teardown regression that invokes stock `/bin/bash -u` when it is Bash 3.2 and skips with an explicit reason elsewhere.

## Incident

On 2026-09-10, forced retirement of the Bookie second mate on macOS Bash 3.2.57 crashed in preflight with `DESCENDANT_TREEHOUSE_LOCK_PATHS[@]: unbound variable` before any mutation.
The first descendant Treehouse slot reached the duplicate-lock loop while its lock array was still empty, making forced retirement impossible until the expansion was patched by hand.

## Audit

The other unguarded quoted array expansions in `bin/fm-teardown.sh` are non-empty at their expansion sites: `TREEHOUSE_OWNER_STATES` and `homes` are seeded before iteration, while `child_ids` has an explicit positive-length guard before sorting.

## Verification

Pinned lint completed cleanly:

```text
fm-lint.sh: ShellCheck 0.11.0 (pinned 0.11.0)
fm-lint.sh: local changed-file mode; ShellCheck source following disabled
fm-lint-workflows.sh: actionlint 1.7.12 (pinned 1.7.12)
fm-lint-workflows.sh: 3 workflow files valid
```

The host stock shell and the regression output were:

```text
$ /bin/bash --version | head -1
GNU bash, version 3.2.57(1)-release (x86_64-apple-darwin24)
$ bin/fm-test-run.sh tests/fm-teardown.test.sh
ok - forced secondmate Treehouse preflight accepts an initially empty lock list under Bash 3.2 nounset
```

The regression case invokes `/bin/bash -u "$TEARDOWN" task-x1 --force` directly.
The broader teardown suite later stopped at the unrelated existing `herdr-preflight-missing-adapter` fixture assertion on this host.
Both `/bin/bash -n bin/fm-teardown.sh` and `/bin/bash -n tests/fm-teardown.test.sh` passed.
An independent local Codex adversarial review of exact head `ff59b5cae4c01e70a5b0135017cf48db58938ca1` reported no actionable findings.