### PR TITLE
feat(skills): add PR review and dependency bump procedures

### DIFF
--- a/.agents/skills/dependency-bump-triage/SKILL.md
+++ b/.agents/skills/dependency-bump-triage/SKILL.md
@@ -12,7 +12,8 @@ metadata:
 # dependency-bump-triage
 
 This skill is the single owner of the Dependabot and Renovate bump-triage procedure.
-It is written so a firstmate can apply it directly or paste it unchanged into a crewmate brief.
+A firstmate uses it to scope, brief, and verify the triage, while project-specific inspection and any lockfile regeneration remain delegated under `AGENTS.md` section 1.
+The procedure below is written to paste unchanged into a crewmate brief.
 Merge authority remains owned by `AGENTS.md` section 7.
 Load `pr-review-cycle` with this skill and apply its common exact-head review cycle to every bump.
 Only its independent Codex scout may be omitted under the narrow exception below.

--- a/.agents/skills/dependency-bump-triage/SKILL.md
+++ b/.agents/skills/dependency-bump-triage/SKILL.md
@@ -1,0 +1,144 @@
+---
+name: dependency-bump-triage
+description: >-
+  Agent-only procedure for reviewing Dependabot and Renovate dependency bumps.
+  Load before triaging, reviewing, or briefing an automated dependency-version PR.
+  Owns lockfile and pin verification, imported-symbol impact analysis, upstream comparison, security and CI-gap checks, risk escalation, and the final bump verdict.
+user-invocable: false
+metadata:
+  internal: true
+---
+
+# dependency-bump-triage
+
+This skill is the single owner of the Dependabot and Renovate bump-triage procedure.
+It is written so a firstmate can apply it directly or paste it unchanged into a crewmate brief.
+Merge authority remains owned by `AGENTS.md` section 7.
+
+## Establish the exact bump
+
+Set the repository and pull request explicitly, then capture the immutable head and complete changed-file list.
+
+```sh
+OWNER=<owner>
+REPO=<repo>
+PR=<number>
+gh-axi api "/repos/$OWNER/$REPO/pulls/$PR" --jq '{url:.html_url,author:.user.login,draft,headRef:.head.ref,headSha:.head.sha,baseRef:.base.ref}'
+gh-axi api "/repos/$OWNER/$REPO/pulls/$PR/files?per_page=100" --paginate --jq '.[] | [.filename,.status,.additions,.deletions] | @tsv'
+gh-axi pr diff "$PR" -R "$OWNER/$REPO" --full
+```
+
+Confirm from the full diff that the change contains only dependency manifest pins, generated lockfiles, and automation metadata directly required for the version bump.
+Generated lockfile transitive changes must be explainable by the selected package version.
+Any source, build logic, test logic, workflow behavior, vendored implementation, install script, patch file, or unrelated dependency change makes the PR non-routine and requires the normal `pr-review-cycle`.
+
+Record the package, ecosystem, exact old version, exact new version, and upstream source repository.
+Do not infer those values from the PR title when the manifest or lockfile disagrees.
+
+## Find the project's actual dependency surface
+
+Search the whole project for the package name before excluding generated dependency files.
+
+```sh
+PACKAGE=<package-name>
+rg -n --hidden --glob '!.git/**' --glob '!vendor/**' --glob '!node_modules/**' --glob '!dist/**' --glob '!build/**' "$PACKAGE" .
+```
+
+Read every import, require, include, feature flag, command invocation, configuration key, type reference, and wrapper found by that search.
+List every symbol or executable surface the project actually uses from the package.
+Run focused searches for each imported symbol so aliases, re-exports, fixtures, and runtime construction sites are included.
+
+```sh
+SYMBOL=<imported-symbol-or-command>
+rg -n --hidden --glob '!.git/**' --glob '!vendor/**' --glob '!node_modules/**' --glob '!dist/**' --glob '!build/**' "$SYMBOL" .
+```
+
+An empty source-usage result is a fact to report, not permission to skip upstream and security checks.
+
+## Compare upstream changes to local usage
+
+Fetch the authoritative upstream comparison for the exact released versions.
+
+```sh
+UPSTREAM_OWNER=<upstream-owner>
+UPSTREAM_REPO=<upstream-repo>
+OLD_VERSION=<old-tag-or-sha>
+NEW_VERSION=<new-tag-or-sha>
+gh-axi api "/repos/$UPSTREAM_OWNER/$UPSTREAM_REPO/compare/$OLD_VERSION...$NEW_VERSION" --full --jq '{status,ahead_by,behind_by,total_commits,commits:[.commits[] | {sha:.sha,message:.commit.message}],files:[.files[] | {filename,status,additions,deletions,patch}]}'
+```
+
+Verify tag naming in the upstream repository when the package uses prefixes such as `v`, package-scoped tags, or monorepo release tags.
+Inspect every changed upstream file that defines, exports, documents, tests, or calls a symbol or executable surface used by the project.
+Check signatures, defaults, return types, error behavior, feature gates, platform support, and transitive native or protocol changes rather than relying on release-note labels.
+If GitHub truncates a patch or the compare response, fetch the named file or commit diff separately before deciding.
+
+## Check advisories and risk amplifiers
+
+Inspect both the target repository's Dependabot alerts and the upstream repository's published advisories when access permits.
+
+```sh
+gh-axi api "/repos/$OWNER/$REPO/dependabot/alerts?state=open&per_page=100" --paginate --full
+gh-axi api "/repos/$UPSTREAM_OWNER/$UPSTREAM_REPO/security-advisories?per_page=100" --paginate --full
+```
+
+Record an authorization failure as an evidence gap rather than claiming there are no advisories.
+Read the bump PR body, release notes, changelog, and upstream compare for security fixes or newly disclosed vulnerabilities affecting either version.
+
+Never rubber-stamp any of these cases:
+
+- A TLS, fingerprinting, anti-bot, browser-impersonation, proxy, or transport client.
+- An authentication, authorization, session, token, password, cryptography, WebAuthn, TOTP, HOTP, OTP, or recovery-code library.
+- A major-version bump or any release with documented breaking behavior.
+- A release associated with a security advisory, security fix, withdrawn version, compromised package, or changed trust boundary.
+- An upstream change touching a locally imported symbol, its signature, its defaults, or its transitive protocol behavior.
+
+These cases require targeted review and tests appropriate to the affected boundary even when the repository diff itself is lockfile-only.
+
+## Account for CI gaps
+
+Read every check on the exact PR head and inspect workflow conditions that can skip work for bot-authored pull requests.
+
+```sh
+gh-axi pr checks "$PR" -R "$OWNER/$REPO"
+rg -n --hidden 'dependabot|renovate|github\.actor|pull_request_target|if:' .github/workflows
+```
+
+For every skipped or absent job, state what behavior it normally validates and whether another result covers that behavior on this head.
+A green subset is not equivalent to a green normal-PR matrix.
+Run or request the smallest missing targeted validation when the skipped coverage intersects the package's actual use.
+
+## Apply the review exception narrowly
+
+A hand-verified bump may skip the independent Codex scout only when all of these are true:
+
+- The repository diff is exclusively the one manifest pin and its mechanically generated lockfile or automation metadata.
+- The bump is not in any risk-amplifier class above.
+- The upstream compare does not touch any locally used symbol, signature, default, or transitive behavior.
+- No relevant security advisory or unresolved evidence gap exists.
+- CI covers the affected install, build, test, and runtime surface without an unexplained bot-only skip.
+
+If any condition is false, load and run `pr-review-cycle` in full.
+The exception removes only the local Codex scout; it does not waive thread inspection, CI reading, bot findings, or exact-head verification required by the standing PR policy.
+
+## Report shape
+
+Report this compact evidence block:
+
+```text
+PR: <full URL>
+Head: <full SHA>
+Bump: <package> <old version> -> <new version> (<ecosystem>)
+Repository diff: <exactly which manifest, lockfile, or other files changed>
+Local use: <every imported symbol or executable surface, or none>
+Upstream impact: <whether changed upstream files touch local use and how>
+Security: <relevant advisories or explicit evidence gap>
+CI: <all checks and any bot-only skipped coverage>
+Review path: <hand-verified exception or full pr-review-cycle>
+Verdict: routine | targeted review required | needs fixes
+Reason: <one plain sentence naming the decisive fact>
+```
+
+Use `routine` only when every exception condition is proven.
+Use `targeted review required` when risk or missing coverage needs deeper evidence but no defect is established.
+Use `needs fixes` when the proposed version or PR is demonstrably unsafe or incomplete.
+Never merge as part of triage; follow `AGENTS.md` section 7 for merge authority.

--- a/.agents/skills/dependency-bump-triage/SKILL.md
+++ b/.agents/skills/dependency-bump-triage/SKILL.md
@@ -40,9 +40,11 @@ After regeneration, require no unexplained change in the manifest and lockfile s
 
 ```sh
 <project lockfile regeneration or frozen-lock command>
-git diff --exit-code -- <dependency manifests and lockfiles>
+git diff --exit-code
+test -z "$(git status --porcelain=v1)"
 ```
 
+Require the entire checkout to remain clean, including package-manager metadata and untracked generated outputs, rather than checking only the expected manifest and lockfile paths.
 If the project has no deterministic regeneration or frozen-lock validation path, record that evidence gap and do not use the independent-review exception.
 
 Record the package, ecosystem, exact old version, exact new version, and upstream source repository.

--- a/.agents/skills/dependency-bump-triage/SKILL.md
+++ b/.agents/skills/dependency-bump-triage/SKILL.md
@@ -71,8 +71,8 @@ rg -n --hidden --glob '!.git/**' --glob '!vendor/**' --glob '!node_modules/**' -
 An empty source-usage result is a fact to report, not permission to skip upstream and security checks.
 
 Inventory every old-to-new package delta introduced by the lockfile change, including transitive packages.
-For every runtime-relevant delta, repeat the upstream comparison, locally used-surface search, advisory check, and risk-amplifier classification below.
-Record development-only transitive deltas and the evidence that they cannot enter build, release, test infrastructure, or runtime paths.
+For every build-, release-, test-infrastructure-, or runtime-relevant delta, repeat the upstream comparison, locally used-surface search, advisory check, and risk-amplifier classification below.
+Record exempt development-only transitive deltas and the evidence that they cannot enter any build, release, test-infrastructure, generated-output, or runtime path.
 An unexplained transitive delta makes the bump non-routine.
 
 ## Compare upstream changes to local usage
@@ -144,7 +144,7 @@ A hand-verified bump may skip the independent Codex scout only when all of these
 - The repository diff is exclusively one dependency-version change represented by its manifest pin, its mechanically generated lockfile, or both, plus any automation metadata.
 - Deterministic regeneration or frozen-lock validation succeeds with no unexplained manifest or lockfile diff.
 - The bump is not in any risk-amplifier class above.
-- Every direct and runtime-relevant transitive delta has been inventoried, and its upstream compare does not touch any locally used symbol, signature, default, or transitive behavior.
+- Every direct and build-, release-, test-infrastructure-, or runtime-relevant transitive delta has been inventoried, and its upstream compare does not touch any locally used symbol, signature, default, or transitive behavior.
 - No relevant security advisory or unresolved evidence gap exists.
 - CI covers the affected install, build, test, and runtime surface without an unexplained bot-only skip.
 

--- a/.agents/skills/dependency-bump-triage/SKILL.md
+++ b/.agents/skills/dependency-bump-triage/SKILL.md
@@ -124,7 +124,7 @@ Run or request the smallest missing targeted validation when the skipped coverag
 
 A hand-verified bump may skip the independent Codex scout only when all of these are true:
 
-- The repository diff is exclusively the one manifest pin and its mechanically generated lockfile or automation metadata.
+- The repository diff is exclusively one dependency-version change represented by its manifest pin, its mechanically generated lockfile, or both, plus any automation metadata.
 - The bump is not in any risk-amplifier class above.
 - The upstream compare does not touch any locally used symbol, signature, default, or transitive behavior.
 - No relevant security advisory or unresolved evidence gap exists.

--- a/.agents/skills/dependency-bump-triage/SKILL.md
+++ b/.agents/skills/dependency-bump-triage/SKILL.md
@@ -14,6 +14,8 @@ metadata:
 This skill is the single owner of the Dependabot and Renovate bump-triage procedure.
 It is written so a firstmate can apply it directly or paste it unchanged into a crewmate brief.
 Merge authority remains owned by `AGENTS.md` section 7.
+Load `pr-review-cycle` with this skill and apply its common exact-head review cycle to every bump.
+Only its independent Codex scout may be omitted under the narrow exception below.
 
 ## Establish the exact bump
 
@@ -23,7 +25,7 @@ Set the repository and pull request explicitly, then capture the immutable head 
 OWNER=<owner>
 REPO=<repo>
 PR=<number>
-gh-axi api "/repos/$OWNER/$REPO/pulls/$PR" --jq '{url:.html_url,author:.user.login,draft,headRef:.head.ref,headSha:.head.sha,baseRef:.base.ref}'
+gh-axi api "/repos/$OWNER/$REPO/pulls/$PR" --jq '{url:.html_url,author:.user.login,authorType:.user.type,authorAssociation:.author_association,draft,headRef:.head.ref,headSha:.head.sha,baseRef:.base.ref}'
 gh-axi api "/repos/$OWNER/$REPO/pulls/$PR/files?per_page=100" --paginate --jq '.[] | [.filename,.status,.additions,.deletions] | @tsv'
 gh-axi pr diff "$PR" -R "$OWNER/$REPO" --full
 ```
@@ -34,6 +36,8 @@ Any source, build logic, test logic, workflow behavior, vendored implementation,
 
 Record the package, ecosystem, exact old version, exact new version, and upstream source repository.
 Do not infer those values from the PR title when the manifest or lockfile disagrees.
+Verify that the author is the repository's configured Dependabot or Renovate bot, that GitHub reports its actor type as `Bot`, and that the head branch matches that automation's configured namespace.
+Route a human author, an unrecognized bot, or an identity mismatch through the full `pr-review-cycle` with no shortcut.
 
 ## Find the project's actual dependency surface
 
@@ -117,8 +121,9 @@ A hand-verified bump may skip the independent Codex scout only when all of these
 - No relevant security advisory or unresolved evidence gap exists.
 - CI covers the affected install, build, test, and runtime surface without an unexplained bot-only skip.
 
-If any condition is false, load and run `pr-review-cycle` in full.
-The exception removes only the local Codex scout; it does not waive thread inspection, CI reading, bot findings, or exact-head verification required by the standing PR policy.
+If any condition is false, run `pr-review-cycle` in full, including its independent Codex scout.
+If every condition is true, continue the common `pr-review-cycle` while marking only its independent Codex scout not applicable with this evidence.
+The exception does not waive thread inspection, CI reading, bot findings, or exact-head verification required by the common cycle.
 
 ## Report shape
 

--- a/.agents/skills/dependency-bump-triage/SKILL.md
+++ b/.agents/skills/dependency-bump-triage/SKILL.md
@@ -26,7 +26,7 @@ OWNER=<owner>
 REPO=<repo>
 PR=<number>
 gh-axi api "/repos/$OWNER/$REPO/pulls/$PR" --jq '{url:.html_url,author:.user.login,authorType:.user.type,authorAssociation:.author_association,draft,headRef:.head.ref,headSha:.head.sha,baseRef:.base.ref}'
-gh-axi api "/repos/$OWNER/$REPO/pulls/$PR/files?per_page=100" --paginate --jq '.[] | [.filename,.status,.additions,.deletions] | @tsv'
+gh-axi api "/repos/$OWNER/$REPO/pulls/$PR/files?per_page=100" --paginate --full --jq '.[] | [.filename,.status,.additions,.deletions] | @tsv'
 gh-axi pr diff "$PR" -R "$OWNER/$REPO" --full
 ```
 
@@ -68,13 +68,22 @@ UPSTREAM_OWNER=<upstream-owner>
 UPSTREAM_REPO=<upstream-repo>
 OLD_VERSION=<old-tag-or-sha>
 NEW_VERSION=<new-tag-or-sha>
-gh-axi api "/repos/$UPSTREAM_OWNER/$UPSTREAM_REPO/compare/$OLD_VERSION...$NEW_VERSION" --full --jq '{status,ahead_by,behind_by,total_commits,commits:[.commits[] | {sha:.sha,message:.commit.message}],files:[.files[] | {filename,status,additions,deletions,patch}]}'
+gh-axi api "/repos/$UPSTREAM_OWNER/$UPSTREAM_REPO/compare/$OLD_VERSION...$NEW_VERSION" --full --jq '{status,ahead_by,behind_by,total_commits,returned_commits:(.commits|length),returned_files:(.files|length),commits:[.commits[] | {sha:.sha,message:.commit.message}],files:[.files[] | {filename,status,additions,deletions,patch}]}'
 ```
 
 Verify tag naming in the upstream repository when the package uses prefixes such as `v`, package-scoped tags, or monorepo release tags.
 Inspect every changed upstream file that defines, exports, documents, tests, or calls a symbol or executable surface used by the project.
 Check signatures, defaults, return types, error behavior, feature gates, platform support, and transitive native or protocol changes rather than relying on release-note labels.
 If GitHub truncates a patch or the compare response, fetch the named file or commit diff separately before deciding.
+If `returned_commits` is smaller than `total_commits`, or `returned_files` reaches GitHub's 300-file compare cap, the API response is not a complete change inventory.
+In that case, use an isolated upstream checkout with both exact tags fetched and inspect the complete local comparison before deciding.
+
+```sh
+UPSTREAM_CHECKOUT=<isolated-upstream-checkout>
+git -C "$UPSTREAM_CHECKOUT" fetch --tags origin
+git -C "$UPSTREAM_CHECKOUT" diff --name-status "$OLD_VERSION" "$NEW_VERSION"
+git -C "$UPSTREAM_CHECKOUT" diff "$OLD_VERSION" "$NEW_VERSION" -- <every-file-that-touches-a-locally-used-symbol>
+```
 
 ## Check advisories and risk amplifiers
 

--- a/.agents/skills/dependency-bump-triage/SKILL.md
+++ b/.agents/skills/dependency-bump-triage/SKILL.md
@@ -34,6 +34,16 @@ Confirm from the full diff that the change contains only dependency manifest pin
 Generated lockfile transitive changes must be explainable by the selected package version.
 Any source, build logic, test logic, workflow behavior, vendored implementation, install script, patch file, or unrelated dependency change makes the PR non-routine and requires the normal `pr-review-cycle`.
 
+In an isolated clean checkout at `REVIEW_HEAD`, run the project's documented lockfile regeneration or frozen-lock validation with the repository's pinned package-manager version.
+After regeneration, require no unexplained change in the manifest and lockfile surface.
+
+```sh
+<project lockfile regeneration or frozen-lock command>
+git diff --exit-code -- <dependency manifests and lockfiles>
+```
+
+If the project has no deterministic regeneration or frozen-lock validation path, record that evidence gap and do not use the independent-review exception.
+
 Record the package, ecosystem, exact old version, exact new version, and upstream source repository.
 Do not infer those values from the PR title when the manifest or lockfile disagrees.
 Verify that the author is the repository's configured Dependabot or Renovate bot, that GitHub reports its actor type as `Bot`, and that the head branch matches that automation's configured namespace.
@@ -41,11 +51,12 @@ Route a human author, an unrecognized bot, or an identity mismatch through the f
 
 ## Find the project's actual dependency surface
 
-Search the whole project for the package name before excluding generated dependency files.
+Read the dependency metadata or lockfile entry for its exported module names, executables, plugin identifiers, and configuration names.
+Search the whole project for the package name and each of those literal identifiers before excluding generated dependency files.
 
 ```sh
-PACKAGE=<package-name>
-rg -n --hidden --glob '!.git/**' --glob '!vendor/**' --glob '!node_modules/**' --glob '!dist/**' --glob '!build/**' "$PACKAGE" .
+IDENTIFIER=<package-name-export-module-binary-or-plugin-identifier>
+rg -n -F --hidden --glob '!.git/**' --glob '!vendor/**' --glob '!node_modules/**' --glob '!dist/**' --glob '!build/**' "$IDENTIFIER" .
 ```
 
 Read every import, require, include, feature flag, command invocation, configuration key, type reference, and wrapper found by that search.
@@ -58,6 +69,11 @@ rg -n --hidden --glob '!.git/**' --glob '!vendor/**' --glob '!node_modules/**' -
 ```
 
 An empty source-usage result is a fact to report, not permission to skip upstream and security checks.
+
+Inventory every old-to-new package delta introduced by the lockfile change, including transitive packages.
+For every runtime-relevant delta, repeat the upstream comparison, locally used-surface search, advisory check, and risk-amplifier classification below.
+Record development-only transitive deltas and the evidence that they cannot enter build, release, test infrastructure, or runtime paths.
+An unexplained transitive delta makes the bump non-routine.
 
 ## Compare upstream changes to local usage
 
@@ -87,7 +103,7 @@ git -C "$UPSTREAM_CHECKOUT" diff "$OLD_VERSION" "$NEW_VERSION" -- <every-file-th
 
 ## Check advisories and risk amplifiers
 
-Inspect both the target repository's Dependabot alerts and the upstream repository's published advisories when access permits.
+Inspect the target repository's Dependabot alerts, the upstream repository's published advisories, and an authoritative ecosystem or cross-ecosystem advisory source for both exact versions when access permits.
 
 ```sh
 gh-axi api "/repos/$OWNER/$REPO/dependabot/alerts?state=open&per_page=100" --paginate --full
@@ -95,6 +111,7 @@ gh-axi api "/repos/$UPSTREAM_OWNER/$UPSTREAM_REPO/security-advisories?per_page=1
 ```
 
 Record an authorization failure as an evidence gap rather than claiming there are no advisories.
+Record unavailable ecosystem advisory coverage the same way and do not use the independent-review exception.
 Read the bump PR body, release notes, changelog, and upstream compare for security fixes or newly disclosed vulnerabilities affecting either version.
 
 Never rubber-stamp any of these cases:
@@ -125,8 +142,9 @@ Run or request the smallest missing targeted validation when the skipped coverag
 A hand-verified bump may skip the independent Codex scout only when all of these are true:
 
 - The repository diff is exclusively one dependency-version change represented by its manifest pin, its mechanically generated lockfile, or both, plus any automation metadata.
+- Deterministic regeneration or frozen-lock validation succeeds with no unexplained manifest or lockfile diff.
 - The bump is not in any risk-amplifier class above.
-- The upstream compare does not touch any locally used symbol, signature, default, or transitive behavior.
+- Every direct and runtime-relevant transitive delta has been inventoried, and its upstream compare does not touch any locally used symbol, signature, default, or transitive behavior.
 - No relevant security advisory or unresolved evidence gap exists.
 - CI covers the affected install, build, test, and runtime surface without an unexplained bot-only skip.
 
@@ -143,9 +161,11 @@ PR: <full URL>
 Head: <full SHA>
 Bump: <package> <old version> -> <new version> (<ecosystem>)
 Repository diff: <exactly which manifest, lockfile, or other files changed>
-Local use: <every imported symbol or executable surface, or none>
-Upstream impact: <whether changed upstream files touch local use and how>
-Security: <relevant advisories or explicit evidence gap>
+Lock validation: <exact regeneration or frozen-lock command and clean-diff result>
+Dependency deltas: <direct and transitive old-to-new inventory>
+Local use: <every package, module, binary, plugin identifier, imported symbol, or executable surface, or none>
+Upstream impact: <whether changed upstream files for each relevant delta touch local use and how>
+Security: <repository, upstream, and ecosystem advisory evidence or explicit gap>
 CI: <all checks and any bot-only skipped coverage>
 Review path: <hand-verified exception or full pr-review-cycle>
 Verdict: routine | targeted review required | needs fixes

--- a/.agents/skills/pr-review-cycle/SKILL.md
+++ b/.agents/skills/pr-review-cycle/SKILL.md
@@ -178,7 +178,7 @@ Fetch the PR again and verify all of the following against one unchanged head:
 - When CodeRabbit is configured, its latest summary covers the exact head and is clean, or an explicit rate-limit reply is recorded and the exact-head Codex fallback is clean.
 - When the Claude Review Bot is configured, its latest checklist covers the exact head and its final verdict is clean.
 - Every other configured automated reviewer has a current clean result for the exact head or a documented integration-specific fallback authorized by its owning contract.
-- The independent Codex report covers the exact head and ends `Verdict: ready`.
+- The independent Codex report covers the exact head and ends `Verdict: ready`, unless `dependency-bump-triage` proves and records its narrow scout exception for this head.
 - Every valid finding was fixed and every declined finding has a visible reason before its thread was resolved.
 
 Use this query to bind the check rollup to the current commit rather than trusting a worker's copied terminal output:

--- a/.agents/skills/pr-review-cycle/SKILL.md
+++ b/.agents/skills/pr-review-cycle/SKILL.md
@@ -12,8 +12,12 @@ metadata:
 # pr-review-cycle
 
 This skill is the single owner of the review-to-clean procedure for every pull request.
-It is written so a firstmate can apply it directly or paste the relevant sections unchanged into a crewmate brief.
+A firstmate uses it for intake, briefing, and independent read-only verification, while project-specific inspection and fixes remain delegated under `AGENTS.md` section 1.
+The review and fix briefs below are written to paste unchanged into a crewmate brief.
 Merge authority is not part of this procedure and remains owned by `AGENTS.md` section 7.
+
+Loading this skill for a review-only request grants no authority to edit code, push, change draft state, post comments, or resolve threads.
+In that case, run only the read-only inspection and report findings; enter the mutation steps only when the authorized task includes taking the PR to clean.
 
 ## Pin the review target
 
@@ -169,7 +173,7 @@ Report the full PR URL, final head SHA, check rollup, reviewer verdict evidence,
 Never accept a worker's `done:` or ready claim without a fresh firstmate-side read.
 Fetch the PR again and verify all of the following against one unchanged head:
 
-- The current full head SHA equals the SHA the worker reported.
+- The current full head SHA still equals the captured `REVIEW_HEAD`; when a worker also reported a SHA, it equals both.
 - The current base repository and ref equal `BASE_REPO` and `BASE_REF`; after fetching its current tip, `git merge-base <current-base-tip> "$REVIEW_HEAD"` still equals `MERGE_BASE`.
 - The pull request is open, non-draft, and `MERGEABLE`, its active `reviewDecision` has no change request, and every required approval is present.
 - `statusCheckRollup` and `gh-axi pr checks` show every current CI context and no pending, skipped-without-explanation, cancelled, or failing required work.

--- a/.agents/skills/pr-review-cycle/SKILL.md
+++ b/.agents/skills/pr-review-cycle/SKILL.md
@@ -62,6 +62,10 @@ If the GraphQL result reports `pageInfo.hasNextPage: true`, the `--paginate` com
 
 ## Interpret automated reviewers
 
+First identify which automated reviewers are configured from the repository workflows, app configuration, and recent PR check or comment history.
+Require a current result only from configured integrations, and record an unconfigured integration as not applicable with the evidence used to determine that status.
+The absence of an expected configured reviewer is not a clean result.
+
 CodeRabbit's clean result is a summary issue comment, not a GitHub review object.
 Read the latest CodeRabbit summary in full and verify that the commit range named in that comment ends at `REVIEW_HEAD` before accepting its clean verdict.
 CodeRabbit skips draft PRs, so a draft-skip message is not a review result.
@@ -93,8 +97,10 @@ Detach or use a disposable worktree at `REVIEW_HEAD`, verify `git rev-parse HEAD
 
 ```sh
 test "$(git rev-parse HEAD)" = "$REVIEW_HEAD"
-codex exec review --base "$BASE_SHA" --ephemeral '<adversarial review brief>'
+codex exec --sandbox read-only --ephemeral '<adversarial review brief>'
 ```
+
+The brief itself supplies `BASE_SHA` and `REVIEW_HEAD` because the installed Codex CLI rejects a custom prompt combined with `codex exec review --base`.
 
 Use this brief verbatim after filling in the placeholders:
 
@@ -139,17 +145,18 @@ Fetch the PR again and verify all of the following against one unchanged head:
 - The current full head SHA equals the SHA the worker reported.
 - `statusCheckRollup` and `gh-axi pr checks` show every current CI context and no pending, skipped-without-explanation, cancelled, or failing required work.
 - The paginated GraphQL query reports zero unresolved review threads.
-- The latest CodeRabbit summary covers the exact head and is clean, or an explicit rate-limit reply is recorded and the exact-head Codex fallback is clean.
-- The latest Claude Review Bot checklist covers the exact head and its final verdict is clean.
+- When CodeRabbit is configured, its latest summary covers the exact head and is clean, or an explicit rate-limit reply is recorded and the exact-head Codex fallback is clean.
+- When the Claude Review Bot is configured, its latest checklist covers the exact head and its final verdict is clean.
 - The independent Codex report covers the exact head and ends `Verdict: ready`.
 - Every valid finding was fixed and every declined finding has a visible reason before its thread was resolved.
 
 Use this query to bind the check rollup to the current commit rather than trusting a worker's copied terminal output:
 
 ```sh
-gh-axi api POST graphql --field query="query { repository(owner: \"$OWNER\", name: \"$REPO\") { pullRequest(number: $PR) { headRefOid commits(last: 1) { nodes { commit { oid statusCheckRollup { state contexts(first: 100) { nodes { __typename ... on CheckRun { name status conclusion detailsUrl } ... on StatusContext { context state targetUrl } } pageInfo { hasNextPage endCursor } } } } } } } } }"
+gh-axi api POST graphql --paginate --field query="query(\$endCursor: String) { repository(owner: \"$OWNER\", name: \"$REPO\") { pullRequest(number: $PR) { headRefOid commits(last: 1) { nodes { commit { oid statusCheckRollup { state contexts(first: 100, after: \$endCursor) { nodes { __typename ... on CheckRun { name status conclusion detailsUrl } ... on StatusContext { context state targetUrl } } pageInfo { hasNextPage endCursor } } } } } } } } }"
 ```
 
+Require every page when the context query reports `pageInfo.hasNextPage: true`.
 If the head changes during verification, discard the partial result and restart the cycle at the new head.
 The PR is ready only when all items are clean at the same exact head.
 Follow `AGENTS.md` section 7 after readiness is established; this skill grants no merge authority.

--- a/.agents/skills/pr-review-cycle/SKILL.md
+++ b/.agents/skills/pr-review-cycle/SKILL.md
@@ -26,8 +26,9 @@ PR=<number>
 gh-axi api "/repos/$OWNER/$REPO/pulls/$PR" --jq '{url:.html_url,draft,headRef:.head.ref,headRepo:.head.repo.full_name,headCloneUrl:.head.repo.clone_url,headSha:.head.sha,baseRef:.base.ref,baseRepo:.base.repo.full_name,baseCloneUrl:.base.repo.clone_url,baseSha:.base.sha}'
 ```
 
-Use the returned head SHA as `REVIEW_HEAD` and the returned current base-branch tip as `BASE_SHA`.
-Every review result, check result, and ready claim is stale if the PR head no longer equals `REVIEW_HEAD`.
+Use the returned head SHA as `REVIEW_HEAD` and the returned current base repository, ref, and tip as `BASE_REPO`, `BASE_REF`, and `BASE_SHA`.
+Record the computed merge base as `MERGE_BASE` when preparing the independent review.
+Every review result, check result, and ready claim is stale if the PR head, base target, or merge base no longer equals the recorded identity.
 
 ## Read the complete review surface
 
@@ -154,6 +155,7 @@ Never accept a worker's `done:` or ready claim without a fresh firstmate-side re
 Fetch the PR again and verify all of the following against one unchanged head:
 
 - The current full head SHA equals the SHA the worker reported.
+- The current base repository and ref equal `BASE_REPO` and `BASE_REF`; after fetching its current tip, `git merge-base <current-base-tip> "$REVIEW_HEAD"` still equals `MERGE_BASE`.
 - The pull request is open, non-draft, and `MERGEABLE`, its active `reviewDecision` has no change request, and every required approval is present.
 - `statusCheckRollup` and `gh-axi pr checks` show every current CI context and no pending, skipped-without-explanation, cancelled, or failing required work.
 - The paginated GraphQL query reports zero unresolved review threads.
@@ -166,10 +168,10 @@ Fetch the PR again and verify all of the following against one unchanged head:
 Use this query to bind the check rollup to the current commit rather than trusting a worker's copied terminal output:
 
 ```sh
-gh-axi api POST graphql --paginate --full --field query="query(\$endCursor: String) { repository(owner: \"$OWNER\", name: \"$REPO\") { pullRequest(number: $PR) { state isDraft mergeable reviewDecision headRefOid commits(last: 1) { nodes { commit { oid statusCheckRollup { state contexts(first: 100, after: \$endCursor) { nodes { __typename ... on CheckRun { name status conclusion detailsUrl } ... on StatusContext { context state targetUrl } } pageInfo { hasNextPage endCursor } } } } } } } } }"
+gh-axi api POST graphql --paginate --full --field query="query(\$endCursor: String) { repository(owner: \"$OWNER\", name: \"$REPO\") { pullRequest(number: $PR) { state isDraft mergeable reviewDecision headRefOid baseRefName baseRefOid baseRepository { nameWithOwner url } commits(last: 1) { nodes { commit { oid statusCheckRollup { state contexts(first: 100, after: \$endCursor) { nodes { __typename ... on CheckRun { name status conclusion detailsUrl } ... on StatusContext { context state targetUrl } } pageInfo { hasNextPage endCursor } } } } } } } } }"
 ```
 
 Require every page when the context query reports `pageInfo.hasNextPage: true`.
-If the head changes during verification, discard the partial result and restart the cycle at the new head.
+If the head, base target, or merge base changes during verification, discard the partial result and restart the cycle at the new identity.
 The PR is ready only when all items are clean at the same exact head.
 Follow `AGENTS.md` section 7 after readiness is established; this skill grants no merge authority.

--- a/.agents/skills/pr-review-cycle/SKILL.md
+++ b/.agents/skills/pr-review-cycle/SKILL.md
@@ -3,7 +3,7 @@ name: pr-review-cycle
 description: >-
   Agent-only procedure for taking any pull request from review intake to independently verified clean.
   Load before reviewing, fixing, or declaring a PR ready, and before accepting a worker's PR-ready or done claim.
-  Owns exact-head adversarial Codex review briefs, CI and bot review inspection, review-thread disposition, existing-PR fix briefs, and final independent verification.
+  Owns exact-head adversarial Codex review briefs, CI and configured-reviewer inspection, review-thread disposition, existing-PR fix briefs, and final independent verification.
 user-invocable: false
 metadata:
   internal: true
@@ -22,6 +22,9 @@ In that case, run only the read-only inspection and report findings; enter the m
 ## Pin the review target
 
 Set the repository and pull request explicitly, then record the current head before reviewing anything.
+The command blocks in this skill are the concrete GitHub implementation.
+For another supported forge, use its native CLI and API to collect the equivalent immutable head, base, checks, conversations, reviews, inline comments, discussion threads, and reviewer rerun evidence.
+The evidence requirements and completion gates do not change by forge; report a gap when the forge cannot supply one rather than skipping it or forcing a GitHub command onto that pull request.
 
 ```sh
 OWNER=<owner>
@@ -80,37 +83,36 @@ gh-axi api POST graphql --field query='mutation($thread: ID!) { resolveReviewThr
 
 Count unresolved nodes across every complete response page.
 If the GraphQL result reports `pageInfo.hasNextPage: true`, the `--paginate --full` command must return the later pages before the enumeration is complete.
+On another forge, enumerate and resolve its equivalent discussion-thread collection through the native API, including every pagination page.
 
-## Interpret automated reviewers
+## Interpret configured reviewers
 
-First identify which automated reviewers are configured from the repository workflows, app configuration, and recent PR check or comment history.
-Require a current result only from configured integrations, and record an unconfigured integration as not applicable with the evidence used to determine that status.
+First identify every human and automated reviewer the project configures or requests from repository workflows, app configuration, review requests, ownership rules, branch rules, and recent comparable PR history.
+For each configured reviewer, determine where it reports findings and verdicts, whether and how that evidence binds to a commit, what causes it to skip or defer, and how the project requests a rerun or renewed approval.
+Require a current result only from configured reviewers, and record an unconfigured integration as not applicable with the evidence used to determine that status.
 The absence of an expected configured reviewer is not a clean result.
-
-CodeRabbit's clean result is a summary issue comment, not a GitHub review object.
-Read the latest CodeRabbit summary in full and verify that the commit range named in that comment ends at `REVIEW_HEAD` before accepting its clean verdict.
-CodeRabbit skips draft PRs, so a draft-skip message is not a review result.
-Make the PR ready through the authorized workflow and request or await review before claiming clean.
-CodeRabbit reports rate limiting in a reply comment.
-When that explicit rate-limit reply applies to `REVIEW_HEAD`, record the comment URL and use the independent Codex adversarial review as the fallback required by the captain's directive instead of waiting indefinitely or inventing a CodeRabbit verdict.
-
-The Claude Review Bot from `anthropics/claude-code-action` posts a checklist comment after each push.
-Read the latest checklist comment in full, treat its last section as the verdict, and verify that it belongs to `REVIEW_HEAD` or to the review run triggered by that push.
-An older clean checklist cannot cover a newer head.
-
-After each push, wait for the push-triggered CI.
-When the Claude Review Bot is configured, also wait for its new checklist.
-When CodeRabbit is configured, request a fresh pass if one did not start automatically.
-
-```sh
-gh-axi pr comment "$PR" -R "$OWNER/$REPO" --body '@coderabbitai review'
-```
-
-Do not repeatedly summon CodeRabbit after its explicit rate-limit reply.
-If a configured Claude workflow does not run on the new head, inspect its workflow trigger and report the missing review instead of treating the old checklist as current.
-
+Read all findings even when an earlier summary or review submission says the review is clean.
 Identify automated comments by their author and content together because app login display names can change.
-Read all findings even when an earlier summary says the review is clean.
+
+After each push, capture the new `REVIEW_HEAD`, wait for push-triggered CI, and rerun, re-request, or refresh every configured reviewer through the project's own mechanism.
+Do not accept an older verdict for a newer head.
+If a configured reviewer does not run, inspect its trigger, eligibility, and explicit skip or deferral messages.
+Report missing review coverage instead of treating silence, a skip, or an unrelated old result as clean.
+Use a fallback only when the project's or captain's governing contract explicitly authorizes one for that reviewer and record the evidence that activated it.
+
+### Worked examples for common bot reviewers
+
+These examples describe one project's reviewer setup and are not requirements for projects that do not configure these integrations.
+
+- CodeRabbit's clean verdict can appear as a summary issue comment rather than a GitHub review object.
+  Read its latest summary in full and verify that the commit range named in the comment ends at `REVIEW_HEAD`.
+  A draft-skip message is not a review result; make the PR ready through the authorized workflow before requesting or awaiting its review.
+  CodeRabbit reports rate limiting in a reply comment.
+  When that explicit reply applies to `REVIEW_HEAD`, record its URL and use the independent adversarial review only when the governing directive authorizes that fallback.
+  Request a fresh pass after a push with `gh-axi pr comment "$PR" -R "$OWNER/$REPO" --body '@coderabbitai review'` when it does not start automatically, but do not repeatedly summon it after an explicit rate-limit reply.
+- The Claude review action from `anthropics/claude-code-action` can post a checklist comment after each push.
+  Read the latest checklist in full, treat its last section as the verdict, and verify that it belongs to `REVIEW_HEAD` or to the review run triggered by that push.
+  If the configured workflow does not run on the new head, inspect its workflow trigger and report the missing review instead of treating an older checklist as current.
 
 ## Independent Codex adversarial review
 
@@ -164,8 +166,8 @@ Read every CI result, review, issue comment, inline comment, and review thread.
 Fix valid findings with focused tests, reply to each thread with the fix evidence, and resolve it only after the fix is pushed.
 For every declined finding, reply with the concrete reason and resolve the thread.
 Commit and push only to the existing PR branch.
-After every push, capture the new exact head and rerun the independent Codex adversarial review plus every configured automated reviewer.
-Repeat until the exact head has all CI checks green, no actionable independent Codex or configured automated-reviewer findings, and zero unresolved review threads.
+After every push, capture the new exact head and rerun the independent Codex adversarial review plus every configured human or automated reviewer through the project's review mechanism.
+Repeat until the exact head has all CI checks green, no actionable independent Codex or configured-reviewer findings, and zero unresolved review threads.
 Do not merge.
 Report the full PR URL, final head SHA, check rollup, reviewer verdict evidence, and unresolved-thread count.
 ```
@@ -180,10 +182,10 @@ Fetch the PR again and verify all of the following against one unchanged head:
 - The pull request is open, non-draft, and `MERGEABLE`, its active `reviewDecision` has no change request, and every required approval is present.
 - `statusCheckRollup` and `gh-axi pr checks` show every current CI context and no pending, skipped-without-explanation, cancelled, or failing required work.
 - Every context expected from branch protection, applicable rules, and workflow-trigger analysis exists on `REVIEW_HEAD`; no required workflow is silently absent.
-- The paginated GraphQL query reports zero unresolved review threads.
-- When CodeRabbit is configured, its latest summary covers the exact head and is clean, or an explicit rate-limit reply is recorded and the exact-head Codex fallback is clean.
-- When the Claude Review Bot is configured, its latest checklist covers the exact head and its final verdict is clean.
-- Every other configured automated reviewer has a current clean result for the exact head or a documented integration-specific fallback authorized by its owning contract.
+- The forge's complete paginated thread or discussion query reports zero unresolved review threads.
+- Every configured automated reviewer that emits a head-bound verdict has a current clean result covering the exact head, or a documented reviewer-specific fallback explicitly authorized by its governing contract is satisfied for that head.
+- Every requested human review and every other reviewer surface has been inspected, all findings have a recorded disposition, and any approval or renewed-approval rule the project applies to the current head is satisfied.
+- The latest reviewer comments and verdict surfaces have been read in full, and none contains an actionable finding that is absent from the thread count.
 - The independent Codex report covers the exact head and ends `Verdict: ready`, unless `dependency-bump-triage` proves and records its narrow scout exception for this head.
 - Every valid finding was fixed and every declined finding has a visible reason before its thread was resolved.
 

--- a/.agents/skills/pr-review-cycle/SKILL.md
+++ b/.agents/skills/pr-review-cycle/SKILL.md
@@ -77,14 +77,16 @@ The Claude Review Bot from `anthropics/claude-code-action` posts a checklist com
 Read the latest checklist comment in full, treat its last section as the verdict, and verify that it belongs to `REVIEW_HEAD` or to the review run triggered by that push.
 An older clean checklist cannot cover a newer head.
 
-After each push, wait for the push-triggered CI and Claude checklist and request a fresh CodeRabbit pass when it did not start automatically.
+After each push, wait for the push-triggered CI.
+When the Claude Review Bot is configured, also wait for its new checklist.
+When CodeRabbit is configured, request a fresh pass if one did not start automatically.
 
 ```sh
 gh-axi pr comment "$PR" -R "$OWNER/$REPO" --body '@coderabbitai review'
 ```
 
 Do not repeatedly summon CodeRabbit after its explicit rate-limit reply.
-If the Claude workflow does not run on the new head, inspect its workflow trigger and report the missing review instead of treating the old checklist as current.
+If a configured Claude workflow does not run on the new head, inspect its workflow trigger and report the missing review instead of treating the old checklist as current.
 
 Identify automated comments by their author and content together because app login display names can change.
 Read all findings even when an earlier summary says the review is clean.
@@ -94,6 +96,7 @@ Read all findings even when an earlier summary says the review is clean.
 Run a fresh local Codex review against the exact checked-out PR head after the implementation is committed.
 The reviewer must not be the worker that authored or fixed the change.
 Detach or use a disposable worktree at `REVIEW_HEAD`, verify `git rev-parse HEAD` equals it, and run Codex read-only against the PR base.
+The narrow scout omission for a hand-verified dependency bump is owned only by `dependency-bump-triage`; every other part of this cycle still applies.
 
 ```sh
 test "$(git rev-parse HEAD)" = "$REVIEW_HEAD"
@@ -105,7 +108,7 @@ The brief itself supplies `BASE_SHA` and `REVIEW_HEAD` because the installed Cod
 Use this brief verbatim after filling in the placeholders:
 
 ```text
-Review pull request <full URL> adversarially at exact head <full SHA> against base <base ref>.
+Review pull request <full URL> adversarially at exact head <full SHA> against base <full base SHA from BASE_SHA>.
 Do not modify files.
 Read the complete diff and the surrounding implementation, tests, contracts, and relevant history.
 Focus on correctness, regressions, unsafe state transitions, concurrency or recovery gaps, security boundaries, compatibility, and missing user-visible behavior.
@@ -153,7 +156,7 @@ Fetch the PR again and verify all of the following against one unchanged head:
 Use this query to bind the check rollup to the current commit rather than trusting a worker's copied terminal output:
 
 ```sh
-gh-axi api POST graphql --paginate --field query="query(\$endCursor: String) { repository(owner: \"$OWNER\", name: \"$REPO\") { pullRequest(number: $PR) { headRefOid commits(last: 1) { nodes { commit { oid statusCheckRollup { state contexts(first: 100, after: \$endCursor) { nodes { __typename ... on CheckRun { name status conclusion detailsUrl } ... on StatusContext { context state targetUrl } } pageInfo { hasNextPage endCursor } } } } } } } } }"
+gh-axi api POST graphql --paginate --full --field query="query(\$endCursor: String) { repository(owner: \"$OWNER\", name: \"$REPO\") { pullRequest(number: $PR) { headRefOid commits(last: 1) { nodes { commit { oid statusCheckRollup { state contexts(first: 100, after: \$endCursor) { nodes { __typename ... on CheckRun { name status conclusion detailsUrl } ... on StatusContext { context state targetUrl } } pageInfo { hasNextPage endCursor } } } } } } } } }"
 ```
 
 Require every page when the context query reports `pageInfo.hasNextPage: true`.

--- a/.agents/skills/pr-review-cycle/SKILL.md
+++ b/.agents/skills/pr-review-cycle/SKILL.md
@@ -116,6 +116,8 @@ Read all findings even when an earlier summary says the review is clean.
 
 Run a fresh local Codex review against the exact checked-out PR head after the implementation is committed.
 The reviewer must not be the worker that authored or fixed the change.
+Firstmate dispatches this independent review as a managed scout under the existing spawn and harness contracts; it does not fetch, create a worktree, or audit project code itself.
+The following preparation commands and brief belong to that scout in its isolated worktree.
 Fetch both immutable commits before entering the read-only review, then detach or use a disposable worktree at `REVIEW_HEAD` and verify every prerequisite before invoking Codex.
 The narrow scout omission for a hand-verified dependency bump is owned only by `dependency-bump-triage`; every other part of this cycle still applies.
 

--- a/.agents/skills/pr-review-cycle/SKILL.md
+++ b/.agents/skills/pr-review-cycle/SKILL.md
@@ -23,7 +23,7 @@ Set the repository and pull request explicitly, then record the current head bef
 OWNER=<owner>
 REPO=<repo>
 PR=<number>
-gh-axi api "/repos/$OWNER/$REPO/pulls/$PR" --jq '{url:.html_url,draft,headRef:.head.ref,headRepo:.head.repo.full_name,headSha:.head.sha,baseRef:.base.ref,baseSha:.base.sha}'
+gh-axi api "/repos/$OWNER/$REPO/pulls/$PR" --jq '{url:.html_url,draft,headRef:.head.ref,headRepo:.head.repo.full_name,headCloneUrl:.head.repo.clone_url,headSha:.head.sha,baseRef:.base.ref,baseRepo:.base.repo.full_name,baseCloneUrl:.base.repo.clone_url,baseSha:.base.sha}'
 ```
 
 Use the returned head SHA as `REVIEW_HEAD` and the returned base SHA as `BASE_SHA`.
@@ -95,11 +95,15 @@ Read all findings even when an earlier summary says the review is clean.
 
 Run a fresh local Codex review against the exact checked-out PR head after the implementation is committed.
 The reviewer must not be the worker that authored or fixed the change.
-Detach or use a disposable worktree at `REVIEW_HEAD`, verify `git rev-parse HEAD` equals it, and run Codex read-only against the PR base.
+Fetch both immutable commits before entering the read-only review, then detach or use a disposable worktree at `REVIEW_HEAD` and verify every prerequisite before invoking Codex.
 The narrow scout omission for a hand-verified dependency bump is owned only by `dependency-bump-triage`; every other part of this cycle still applies.
 
 ```sh
-test "$(git rev-parse HEAD)" = "$REVIEW_HEAD"
+git fetch --no-tags "$BASE_CLONE_URL" "$BASE_SHA"
+git fetch --no-tags "$HEAD_CLONE_URL" "$REVIEW_HEAD"
+test "$(git rev-parse HEAD)" = "$REVIEW_HEAD" || exit 1
+git cat-file -e "$BASE_SHA^{commit}" || exit 1
+git cat-file -e "$REVIEW_HEAD^{commit}" || exit 1
 codex exec --sandbox read-only --ephemeral '<adversarial review brief>'
 ```
 
@@ -135,7 +139,7 @@ Fix valid findings with focused tests, reply to each thread with the fix evidenc
 For every declined finding, reply with the concrete reason and resolve the thread.
 Commit and push only to the existing PR branch.
 After every push, capture the new exact head and rerun the independent Codex adversarial review plus every configured automated reviewer.
-Repeat until the exact head has all CI checks green, no actionable Codex, CodeRabbit, or Claude Review Bot findings, and zero unresolved review threads.
+Repeat until the exact head has all CI checks green, no actionable independent Codex or configured automated-reviewer findings, and zero unresolved review threads.
 Do not merge.
 Report the full PR URL, final head SHA, check rollup, reviewer verdict evidence, and unresolved-thread count.
 ```
@@ -150,6 +154,7 @@ Fetch the PR again and verify all of the following against one unchanged head:
 - The paginated GraphQL query reports zero unresolved review threads.
 - When CodeRabbit is configured, its latest summary covers the exact head and is clean, or an explicit rate-limit reply is recorded and the exact-head Codex fallback is clean.
 - When the Claude Review Bot is configured, its latest checklist covers the exact head and its final verdict is clean.
+- Every other configured automated reviewer has a current clean result for the exact head or a documented integration-specific fallback authorized by its owning contract.
 - The independent Codex report covers the exact head and ends `Verdict: ready`.
 - Every valid finding was fixed and every declined finding has a visible reason before its thread was resolved.
 

--- a/.agents/skills/pr-review-cycle/SKILL.md
+++ b/.agents/skills/pr-review-cycle/SKILL.md
@@ -26,7 +26,7 @@ PR=<number>
 gh-axi api "/repos/$OWNER/$REPO/pulls/$PR" --jq '{url:.html_url,draft,headRef:.head.ref,headRepo:.head.repo.full_name,headCloneUrl:.head.repo.clone_url,headSha:.head.sha,baseRef:.base.ref,baseRepo:.base.repo.full_name,baseCloneUrl:.base.repo.clone_url,baseSha:.base.sha}'
 ```
 
-Use the returned head SHA as `REVIEW_HEAD` and the returned base SHA as `BASE_SHA`.
+Use the returned head SHA as `REVIEW_HEAD` and the returned current base-branch tip as `BASE_SHA`.
 Every review result, check result, and ready claim is stale if the PR head no longer equals `REVIEW_HEAD`.
 
 ## Read the complete review surface
@@ -104,17 +104,20 @@ git fetch --no-tags "$HEAD_CLONE_URL" "$REVIEW_HEAD"
 test "$(git rev-parse HEAD)" = "$REVIEW_HEAD" || exit 1
 git cat-file -e "$BASE_SHA^{commit}" || exit 1
 git cat-file -e "$REVIEW_HEAD^{commit}" || exit 1
+MERGE_BASE=$(git merge-base "$BASE_SHA" "$REVIEW_HEAD") || exit 1
+git cat-file -e "$MERGE_BASE^{commit}" || exit 1
 codex exec --sandbox read-only --ephemeral '<adversarial review brief>'
 ```
 
-The brief itself supplies `BASE_SHA` and `REVIEW_HEAD` because the installed Codex CLI rejects a custom prompt combined with `codex exec review --base`.
+Review the three-dot PR change from `BASE_SHA...REVIEW_HEAD`, whose left side Git resolves to `MERGE_BASE`, so base-branch commits made after the PR diverged are not misclassified as reversions in the PR.
+The brief itself supplies `BASE_SHA`, `MERGE_BASE`, and `REVIEW_HEAD` because the installed Codex CLI rejects a custom prompt combined with `codex exec review --base`.
 
 Use this brief verbatim after filling in the placeholders:
 
 ```text
-Review pull request <full URL> adversarially at exact head <full SHA> against base <full base SHA from BASE_SHA>.
+Review pull request <full URL> adversarially at exact head <full SHA from REVIEW_HEAD> against the exact three-dot change <full BASE_SHA>...<full REVIEW_HEAD>, whose verified merge base is <full MERGE_BASE>.
 Do not modify files.
-Read the complete diff and the surrounding implementation, tests, contracts, and relevant history.
+Read the complete `git diff <full BASE_SHA>...<full REVIEW_HEAD>` and the surrounding implementation, tests, contracts, and relevant history.
 Focus on correctness, regressions, unsafe state transitions, concurrency or recovery gaps, security boundaries, compatibility, and missing user-visible behavior.
 For changed tests, judge their negative controls: identify whether each test would fail under the plausible broken implementation it is meant to exclude, and call out vacuous, mock-only, or same-implementation assertions.
 Do not request unrelated cleanup or speculative scope expansion.

--- a/.agents/skills/pr-review-cycle/SKILL.md
+++ b/.agents/skills/pr-review-cycle/SKILL.md
@@ -1,0 +1,155 @@
+---
+name: pr-review-cycle
+description: >-
+  Agent-only procedure for taking any pull request from review intake to independently verified clean.
+  Load before reviewing, fixing, or declaring a PR ready, and before accepting a worker's PR-ready or done claim.
+  Owns exact-head adversarial Codex review briefs, CI and bot review inspection, review-thread disposition, existing-PR fix briefs, and final independent verification.
+user-invocable: false
+metadata:
+  internal: true
+---
+
+# pr-review-cycle
+
+This skill is the single owner of the review-to-clean procedure for every pull request.
+It is written so a firstmate can apply it directly or paste the relevant sections unchanged into a crewmate brief.
+Merge authority is not part of this procedure and remains owned by `AGENTS.md` section 7.
+
+## Pin the review target
+
+Set the repository and pull request explicitly, then record the current head before reviewing anything.
+
+```sh
+OWNER=<owner>
+REPO=<repo>
+PR=<number>
+gh-axi api "/repos/$OWNER/$REPO/pulls/$PR" --jq '{url:.html_url,draft,headRef:.head.ref,headRepo:.head.repo.full_name,headSha:.head.sha,baseRef:.base.ref,baseSha:.base.sha}'
+```
+
+Use the returned head SHA as `REVIEW_HEAD` and the returned base SHA as `BASE_SHA`.
+Every review result, check result, and ready claim is stale if the PR head no longer equals `REVIEW_HEAD`.
+
+## Read the complete review surface
+
+Read every check and the complete PR conversation, review submission, inline comment, and current review thread.
+
+```sh
+gh-axi pr checks "$PR" -R "$OWNER/$REPO"
+gh-axi pr view "$PR" -R "$OWNER/$REPO" --full --comments --reviews
+gh-axi api "/repos/$OWNER/$REPO/issues/$PR/comments" --paginate --full
+gh-axi api "/repos/$OWNER/$REPO/pulls/$PR/reviews" --paginate --full
+gh-axi api "/repos/$OWNER/$REPO/pulls/$PR/comments" --paginate --full
+gh-axi api "/repos/$OWNER/$REPO/commits/$REVIEW_HEAD/check-runs?per_page=100" --paginate --full
+gh-axi api "/repos/$OWNER/$REPO/commits/$REVIEW_HEAD/statuses?per_page=100" --paginate --full
+gh-axi api POST graphql --paginate --field query="query(\$endCursor: String) { repository(owner: \"$OWNER\", name: \"$REPO\") { pullRequest(number: $PR) { reviewThreads(first: 100, after: \$endCursor) { nodes { id isResolved isOutdated comments(first: 100) { nodes { databaseId url path line body author { login } createdAt } } } pageInfo { hasNextPage endCursor } } } } }"
+```
+
+Do not treat an outdated thread as resolved.
+Classify every unresolved thread as valid, already fixed, or declined.
+Fix valid findings, reply with the commit or concrete correction, and resolve the thread only after the fix is present on the PR head.
+For an already-fixed finding, reply with the exact evidence and resolve it.
+For a declined finding, reply with the specific reason it does not apply or would violate the accepted contract, then resolve it.
+Reply to an inline comment before resolving its thread when a disposition is not already visible in the conversation.
+
+```sh
+COMMENT_ID=<database-id-from-thread>
+gh-axi api POST "/repos/$OWNER/$REPO/pulls/$PR/comments/$COMMENT_ID/replies" --field body='<specific disposition and evidence>'
+THREAD_ID=<graphql-review-thread-id>
+gh-axi api POST graphql --field query='mutation($thread: ID!) { resolveReviewThread(input: {threadId: $thread}) { thread { id isResolved } } }' --field thread="$THREAD_ID"
+```
+
+If the GraphQL result reports `pageInfo.hasNextPage: true`, the `--paginate` command must return the later pages before the enumeration is complete.
+
+## Interpret automated reviewers
+
+CodeRabbit's clean result is a summary issue comment, not a GitHub review object.
+Read the latest CodeRabbit summary in full and verify that the commit range named in that comment ends at `REVIEW_HEAD` before accepting its clean verdict.
+CodeRabbit skips draft PRs, so a draft-skip message is not a review result.
+Make the PR ready through the authorized workflow and request or await review before claiming clean.
+CodeRabbit reports rate limiting in a reply comment.
+When that explicit rate-limit reply applies to `REVIEW_HEAD`, record the comment URL and use the independent Codex adversarial review as the fallback required by the captain's directive instead of waiting indefinitely or inventing a CodeRabbit verdict.
+
+The Claude Review Bot from `anthropics/claude-code-action` posts a checklist comment after each push.
+Read the latest checklist comment in full, treat its last section as the verdict, and verify that it belongs to `REVIEW_HEAD` or to the review run triggered by that push.
+An older clean checklist cannot cover a newer head.
+
+After each push, wait for the push-triggered CI and Claude checklist and request a fresh CodeRabbit pass when it did not start automatically.
+
+```sh
+gh-axi pr comment "$PR" -R "$OWNER/$REPO" --body '@coderabbitai review'
+```
+
+Do not repeatedly summon CodeRabbit after its explicit rate-limit reply.
+If the Claude workflow does not run on the new head, inspect its workflow trigger and report the missing review instead of treating the old checklist as current.
+
+Identify automated comments by their author and content together because app login display names can change.
+Read all findings even when an earlier summary says the review is clean.
+
+## Independent Codex adversarial review
+
+Run a fresh local Codex review against the exact checked-out PR head after the implementation is committed.
+The reviewer must not be the worker that authored or fixed the change.
+Detach or use a disposable worktree at `REVIEW_HEAD`, verify `git rev-parse HEAD` equals it, and run Codex read-only against the PR base.
+
+```sh
+test "$(git rev-parse HEAD)" = "$REVIEW_HEAD"
+codex exec review --base "$BASE_SHA" --ephemeral '<adversarial review brief>'
+```
+
+Use this brief verbatim after filling in the placeholders:
+
+```text
+Review pull request <full URL> adversarially at exact head <full SHA> against base <base ref>.
+Do not modify files.
+Read the complete diff and the surrounding implementation, tests, contracts, and relevant history.
+Focus on correctness, regressions, unsafe state transitions, concurrency or recovery gaps, security boundaries, compatibility, and missing user-visible behavior.
+For changed tests, judge their negative controls: identify whether each test would fail under the plausible broken implementation it is meant to exclude, and call out vacuous, mock-only, or same-implementation assertions.
+Do not request unrelated cleanup or speculative scope expansion.
+Report only actionable findings grouped as P1, P2, or P3, each with file and line, concrete failure mode, evidence, and smallest valid correction.
+End with exactly `Verdict: ready` when there are no actionable findings, or `Verdict: needs-fixes` when any finding remains.
+```
+
+Treat the report as evidence, not authority.
+Validate each finding against the accepted intent and route any genuinely ambiguous scope decision through the existing decision owner rather than silently expanding the PR.
+
+## Existing-PR fix brief
+
+Use this brief verbatim after filling in the placeholders:
+
+```text
+Fix the actionable findings on existing pull request <full URL>.
+Work on that PR's own head branch <head branch> in its head repository <head repository>.
+Do not create a new branch or a new pull request.
+Before editing, verify the checked-out branch and head SHA against the PR.
+Read every CI result, review, issue comment, inline comment, and review thread.
+Fix valid findings with focused tests, reply to each thread with the fix evidence, and resolve it only after the fix is pushed.
+For every declined finding, reply with the concrete reason and resolve the thread.
+Commit and push only to the existing PR branch.
+After every push, capture the new exact head and rerun the independent Codex adversarial review plus every configured automated reviewer.
+Repeat until the exact head has all CI checks green, no actionable Codex, CodeRabbit, or Claude Review Bot findings, and zero unresolved review threads.
+Do not merge.
+Report the full PR URL, final head SHA, check rollup, reviewer verdict evidence, and unresolved-thread count.
+```
+
+## Verify a ready claim independently
+
+Never accept a worker's `done:` or ready claim without a fresh firstmate-side read.
+Fetch the PR again and verify all of the following against one unchanged head:
+
+- The current full head SHA equals the SHA the worker reported.
+- `statusCheckRollup` and `gh-axi pr checks` show every current CI context and no pending, skipped-without-explanation, cancelled, or failing required work.
+- The paginated GraphQL query reports zero unresolved review threads.
+- The latest CodeRabbit summary covers the exact head and is clean, or an explicit rate-limit reply is recorded and the exact-head Codex fallback is clean.
+- The latest Claude Review Bot checklist covers the exact head and its final verdict is clean.
+- The independent Codex report covers the exact head and ends `Verdict: ready`.
+- Every valid finding was fixed and every declined finding has a visible reason before its thread was resolved.
+
+Use this query to bind the check rollup to the current commit rather than trusting a worker's copied terminal output:
+
+```sh
+gh-axi api POST graphql --field query="query { repository(owner: \"$OWNER\", name: \"$REPO\") { pullRequest(number: $PR) { headRefOid commits(last: 1) { nodes { commit { oid statusCheckRollup { state contexts(first: 100) { nodes { __typename ... on CheckRun { name status conclusion detailsUrl } ... on StatusContext { context state targetUrl } } pageInfo { hasNextPage endCursor } } } } } } } } }"
+```
+
+If the head changes during verification, discard the partial result and restart the cycle at the new head.
+The PR is ready only when all items are clean at the same exact head.
+Follow `AGENTS.md` section 7 after readiness is established; this skill grants no merge authority.

--- a/.agents/skills/pr-review-cycle/SKILL.md
+++ b/.agents/skills/pr-review-cycle/SKILL.md
@@ -41,7 +41,7 @@ gh-axi api "/repos/$OWNER/$REPO/pulls/$PR/reviews" --paginate --full
 gh-axi api "/repos/$OWNER/$REPO/pulls/$PR/comments" --paginate --full
 gh-axi api "/repos/$OWNER/$REPO/commits/$REVIEW_HEAD/check-runs?per_page=100" --paginate --full
 gh-axi api "/repos/$OWNER/$REPO/commits/$REVIEW_HEAD/statuses?per_page=100" --paginate --full
-gh-axi api POST graphql --paginate --field query="query(\$endCursor: String) { repository(owner: \"$OWNER\", name: \"$REPO\") { pullRequest(number: $PR) { reviewThreads(first: 100, after: \$endCursor) { nodes { id isResolved isOutdated comments(first: 100) { nodes { databaseId url path line body author { login } createdAt } } } pageInfo { hasNextPage endCursor } } } } }"
+gh-axi api POST graphql --paginate --full --field query="query(\$endCursor: String) { repository(owner: \"$OWNER\", name: \"$REPO\") { pullRequest(number: $PR) { reviewThreads(first: 100, after: \$endCursor) { nodes { id isResolved isOutdated comments(first: 100) { nodes { databaseId url path line body author { login } createdAt } } } pageInfo { hasNextPage endCursor } } } } }"
 ```
 
 Do not treat an outdated thread as resolved.
@@ -58,7 +58,8 @@ THREAD_ID=<graphql-review-thread-id>
 gh-axi api POST graphql --field query='mutation($thread: ID!) { resolveReviewThread(input: {threadId: $thread}) { thread { id isResolved } } }' --field thread="$THREAD_ID"
 ```
 
-If the GraphQL result reports `pageInfo.hasNextPage: true`, the `--paginate` command must return the later pages before the enumeration is complete.
+Count unresolved nodes across every complete response page.
+If the GraphQL result reports `pageInfo.hasNextPage: true`, the `--paginate --full` command must return the later pages before the enumeration is complete.
 
 ## Interpret automated reviewers
 
@@ -153,6 +154,7 @@ Never accept a worker's `done:` or ready claim without a fresh firstmate-side re
 Fetch the PR again and verify all of the following against one unchanged head:
 
 - The current full head SHA equals the SHA the worker reported.
+- The pull request is open, non-draft, and `MERGEABLE`, its active `reviewDecision` has no change request, and every required approval is present.
 - `statusCheckRollup` and `gh-axi pr checks` show every current CI context and no pending, skipped-without-explanation, cancelled, or failing required work.
 - The paginated GraphQL query reports zero unresolved review threads.
 - When CodeRabbit is configured, its latest summary covers the exact head and is clean, or an explicit rate-limit reply is recorded and the exact-head Codex fallback is clean.
@@ -164,7 +166,7 @@ Fetch the PR again and verify all of the following against one unchanged head:
 Use this query to bind the check rollup to the current commit rather than trusting a worker's copied terminal output:
 
 ```sh
-gh-axi api POST graphql --paginate --full --field query="query(\$endCursor: String) { repository(owner: \"$OWNER\", name: \"$REPO\") { pullRequest(number: $PR) { headRefOid commits(last: 1) { nodes { commit { oid statusCheckRollup { state contexts(first: 100, after: \$endCursor) { nodes { __typename ... on CheckRun { name status conclusion detailsUrl } ... on StatusContext { context state targetUrl } } pageInfo { hasNextPage endCursor } } } } } } } } }"
+gh-axi api POST graphql --paginate --full --field query="query(\$endCursor: String) { repository(owner: \"$OWNER\", name: \"$REPO\") { pullRequest(number: $PR) { state isDraft mergeable reviewDecision headRefOid commits(last: 1) { nodes { commit { oid statusCheckRollup { state contexts(first: 100, after: \$endCursor) { nodes { __typename ... on CheckRun { name status conclusion detailsUrl } ... on StatusContext { context state targetUrl } } pageInfo { hasNextPage endCursor } } } } } } } } }"
 ```
 
 Require every page when the context query reports `pageInfo.hasNextPage: true`.

--- a/.agents/skills/pr-review-cycle/SKILL.md
+++ b/.agents/skills/pr-review-cycle/SKILL.md
@@ -42,9 +42,24 @@ gh-axi api "/repos/$OWNER/$REPO/pulls/$PR/reviews" --paginate --full
 gh-axi api "/repos/$OWNER/$REPO/pulls/$PR/comments" --paginate --full
 gh-axi api "/repos/$OWNER/$REPO/commits/$REVIEW_HEAD/check-runs?per_page=100" --paginate --full
 gh-axi api "/repos/$OWNER/$REPO/commits/$REVIEW_HEAD/statuses?per_page=100" --paginate --full
-gh-axi api POST graphql --paginate --full --field query="query(\$endCursor: String) { repository(owner: \"$OWNER\", name: \"$REPO\") { pullRequest(number: $PR) { reviewThreads(first: 100, after: \$endCursor) { nodes { id isResolved isOutdated comments(first: 100) { nodes { databaseId url path line body author { login } createdAt } } } pageInfo { hasNextPage endCursor } } } } }"
+gh-axi api POST graphql --paginate --full --field query="query(\$endCursor: String) { repository(owner: \"$OWNER\", name: \"$REPO\") { pullRequest(number: $PR) { reviewThreads(first: 100, after: \$endCursor) { nodes { id isResolved isOutdated comments(first: 1) { nodes { databaseId url } } } pageInfo { hasNextPage endCursor } } } } }"
 ```
 
+Inventory the checks that should exist before judging the observed rollup.
+
+```sh
+gh-axi api "/repos/$OWNER/$REPO/branches/$BASE_REF/protection/required_status_checks" --full
+gh-axi api "/repos/$OWNER/$REPO/rules/branches/$BASE_REF" --full
+rg -n --hidden 'pull_request|pull_request_target|workflow_run|paths:|paths-ignore:|if:' .github/workflows
+```
+
+Use branch protection, applicable rules, workflow triggers, and recent comparable PR runs to name every expected context.
+Treat an unreadable protection or ruleset source as an evidence gap unless another authoritative source establishes the complete expected set.
+An expected workflow that never creates a context because of path, actor, fork, event, or conditional logic is missing validation, not a clean or skipped check.
+
+Treat the paginated REST inline-comment response as the complete comment body source.
+Group it into threads by each comment's `id` and `in_reply_to_id`, then associate each group with the GraphQL thread through its first comment's `databaseId`.
+This join keeps a thread with more than 100 replies complete without relying on a nested unpaginated GraphQL connection.
 Do not treat an outdated thread as resolved.
 Classify every unresolved thread as valid, already fixed, or declined.
 Fix valid findings, reply with the commit or concrete correction, and resolve the thread only after the fix is present on the PR head.
@@ -158,6 +173,7 @@ Fetch the PR again and verify all of the following against one unchanged head:
 - The current base repository and ref equal `BASE_REPO` and `BASE_REF`; after fetching its current tip, `git merge-base <current-base-tip> "$REVIEW_HEAD"` still equals `MERGE_BASE`.
 - The pull request is open, non-draft, and `MERGEABLE`, its active `reviewDecision` has no change request, and every required approval is present.
 - `statusCheckRollup` and `gh-axi pr checks` show every current CI context and no pending, skipped-without-explanation, cancelled, or failing required work.
+- Every context expected from branch protection, applicable rules, and workflow-trigger analysis exists on `REVIEW_HEAD`; no required workflow is silently absent.
 - The paginated GraphQL query reports zero unresolved review threads.
 - When CodeRabbit is configured, its latest summary covers the exact head and is clean, or an explicit rate-limit reply is recorded and the exact-head Codex fallback is clean.
 - When the Claude Review Bot is configured, its latest checklist covers the exact head and its final verdict is clean.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -334,11 +334,11 @@ Supervise all live work under section 8.
 
 ### Selected delivery path and merge authority
 
-The selected delivery path owns its own rigor.
-When no-mistakes is selected, no-mistakes alone owns review, fixes, tests, documentation, push, PR, and CI; otherwise follow the faster path without adding an independent reviewer.
-Never hold work outside no-mistakes for a manual clean verdict, stack serial manual reviews, or infer authority for one from security, architecture, or risk alone.
-A separate review or audit is allowed only when the captain explicitly requests that deliverable or the authorized task is a knowledge-only review; one named question remains scoped to that question.
-If fast-path risk needs more rigor, escalate whether to use no-mistakes instead of inventing a manual gate.
+The selected delivery path owns implementation and pre-PR rigor.
+When no-mistakes is selected, no-mistakes alone owns review, fixes, tests, documentation, push, PR, and CI through its initial green PR; otherwise follow the faster path through initial PR creation without adding an ad hoc reviewer.
+Every PR then passes the exact-head review-to-clean cycle owned by `pr-review-cycle` before firstmate calls it ready; that standing cycle is not a delivery mode and does not change merge authority.
+A separate review or audit beyond that cycle is allowed only when the captain explicitly requests that deliverable or the authorized task is a knowledge-only review; one named question remains scoped to that question.
+If pre-PR fast-path risk needs more rigor, escalate whether to use no-mistakes instead of inventing another gate.
 The path's worker, automated gates, and captain approval remain authoritative:
 
 - **no-mistakes** runs the full pipeline through a PR, then waits for the configured merge authority.
@@ -381,9 +381,9 @@ The worker reports the PR when CI first becomes green rather than waiting for me
 
 ### PR ready, landing, and teardown
 
-For PR-based ship tasks, the ready signal depends on mode: `no-mistakes` reports `done: PR <url> checks green` after CI is green, while `direct-PR` reports `done: PR <url>` after opening the PR.
-Run `bin/fm-pr-check.sh <id> <PR url>` with the URL copied from that ready signal - it records `pr=` and the forge's `pr_head=` when available in the task's meta and arms the watcher's merge poll.
-Tell the captain the PR's full `https://...` URL copied from the worker's ready line or the task's `pr=` metadata, a concise outcome summary, and the no-mistakes risk level when applicable.
+For PR-based ship tasks, the initial PR signal depends on mode: `no-mistakes` reports `done: PR <url> checks green` after CI is green, while `direct-PR` reports `done: PR <url>` after opening the PR.
+Treat that signal as intake to `pr-review-cycle`, independently pass its exact-head completion gate, then run `bin/fm-pr-check.sh <id> <PR url>` with the copied URL; the script records `pr=` and the forge's `pr_head=` when available in the task's meta and arms the watcher merge poll.
+Only after that cycle is clean, tell the captain the PR's full `https://...` URL copied from the worker's signal or the task's `pr=` metadata, a concise outcome summary, and the no-mistakes risk level when applicable.
 A captain instruction to merge is explicit authority; `yolo` is the only standing routine merge authority.
 For any custom `state/<id>.check.sh` you write yourself, keep it an ordinary single-link mode-`0700` file, print one line only when firstmate should wake, print nothing otherwise, finish before `FM_CHECK_TIMEOUT`, then bind its current bytes with `bin/fm-check-register.sh <id>` before the watcher may execute it.
 Retire a custom check only through `bin/fm-check-unregister.sh <id>` (or `bin/fm-teardown.sh` for a spawned task); never hand-compose an `rm` with `$STATE`/`$ID`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -572,6 +572,8 @@ These skills are not captain-invocable; load them only at their precise triggers
 - `fmx-respond` - load on an `x-mention <request_id>` `check:` wake to handle the mention, on an `x-mode-error ...` `check:` wake to report the Relay configuration blocker, on a `public-followup ...` `check:` wake or a startup-surfaced public commitment, and on any milestone or terminal wake for a Relay-linked task before posting its completion follow-up; relevant only when Relay is on.
 - `firstmate-codexapp` - load before coordinating a visible Codex Desktop thread, evaluating a Codex App backend request, or reconciling Codex Desktop host-tool smoke evidence for Firstmate work.
 - `firstmate-coding-guidelines` - load before changing firstmate's shared, tracked material, as defined by section 1's list, whether editing directly or briefing a crewmate for a firstmate-repo task.
+- `pr-review-cycle` - load before reviewing, fixing, or declaring any PR ready, and before accepting a worker's PR-ready or done claim.
+- `dependency-bump-triage` - load before triaging, reviewing, or briefing a Dependabot or Renovate dependency-version PR.
 
 ## 14. Relay
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -383,6 +383,7 @@ The worker reports the PR when CI first becomes green rather than waiting for me
 
 For PR-based ship tasks, the initial PR signal depends on mode: `no-mistakes` reports `done: PR <url> checks green` after CI is green, while `direct-PR` reports `done: PR <url>` after opening the PR.
 Treat that signal as intake to `pr-review-cycle`, independently pass its exact-head completion gate, then run `bin/fm-pr-check.sh <id> <PR url>` with the copied URL; the script records `pr=` and the forge's `pr_head=` when available in the task's meta and arms the watcher merge poll.
+Read back the recorded `pr_head=` and the live PR head, require both to equal the reviewed SHA, and restart the review-to-clean cycle on any mismatch before reporting readiness.
 Only after that cycle is clean, tell the captain the PR's full `https://...` URL copied from the worker's signal or the task's `pr=` metadata, a concise outcome summary, and the no-mistakes risk level when applicable.
 A captain instruction to merge is explicit authority; `yolo` is the only standing routine merge authority.
 For any custom `state/<id>.check.sh` you write yourself, keep it an ordinary single-link mode-`0700` file, print one line only when firstmate should wake, print nothing otherwise, finish before `FM_CHECK_TIMEOUT`, then bind its current bytes with `bin/fm-check-register.sh <id>` before the watcher may execute it.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -383,7 +383,7 @@ The worker reports the PR when CI first becomes green rather than waiting for me
 
 For PR-based ship tasks, the initial PR signal depends on mode: `no-mistakes` reports `done: PR <url> checks green` after CI is green, while `direct-PR` reports `done: PR <url>` after opening the PR.
 Treat that signal as intake to `pr-review-cycle`, independently pass its exact-head completion gate, then run `bin/fm-pr-check.sh <id> <PR url>` with the copied URL; the script records `pr=` and the forge's `pr_head=` when available in the task's meta and arms the watcher merge poll.
-Read back the recorded `pr_head=` and the live PR head, require both to equal the reviewed SHA, and restart the review-to-clean cycle on any mismatch before reporting readiness.
+Read back the live forge head and require it to equal the reviewed SHA; when `pr_head=` was recorded, require that value to match too, and restart the review-to-clean cycle on any mismatch before reporting readiness.
 Only after that cycle is clean, tell the captain the PR's full `https://...` URL copied from the worker's signal or the task's `pr=` metadata, a concise outcome summary, and the no-mistakes risk level when applicable.
 A captain instruction to merge is explicit authority; `yolo` is the only standing routine merge authority.
 For any custom `state/<id>.check.sh` you write yourself, keep it an ordinary single-link mode-`0700` file, print one line only when firstmate should wake, print nothing otherwise, finish before `FM_CHECK_TIMEOUT`, then bind its current bytes with `bin/fm-check-register.sh <id>` before the watcher may execute it.

--- a/docs/documentation-audiences.json
+++ b/docs/documentation-audiences.json
@@ -141,6 +141,10 @@
       "audience": "agent-runtime"
     },
     {
+      "path": ".agents/skills/dependency-bump-triage/SKILL.md",
+      "audience": "agent-runtime"
+    },
+    {
       "path": ".agents/skills/firstmate-codexapp/SKILL.md",
       "audience": "agent-runtime"
     },
@@ -226,6 +230,10 @@
     },
     {
       "path": ".agents/skills/project-management/SKILL.md",
+      "audience": "agent-runtime"
+    },
+    {
+      "path": ".agents/skills/pr-review-cycle/SKILL.md",
       "audience": "agent-runtime"
     },
     {


### PR DESCRIPTION
## Summary

- Add the internal `pr-review-cycle` skill as the single owner for exact-head adversarial review, configured human and automated reviewer inspection, thread disposition, existing-PR fix briefs, and independent readiness verification.
- Keep the normative review cycle reviewer-agnostic and place CodeRabbit and `anthropics/claude-code-action` behavior in a clearly labelled worked-examples section that does not require either integration.
- Preserve equivalent evidence requirements for supported non-GitHub forges while providing concrete GitHub commands.
- Add the internal `dependency-bump-triage` skill for lockfile/pin verification, imported-symbol analysis, upstream compares, advisory checks, bot-CI gaps, risk escalation, and concise verdicts.
- Register precise section 13 triggers and classify both agent-runtime prose surfaces in the documentation catalogue.

## Maintainer verification

- `bin/fm-doc-audience-check.sh` passed with 99 surfaces and 366 local links.
- `bin/fm-test-run.sh tests/fm-documentation-audiences.test.sh` passed all catalogue, classification, owner-pointer, and local-link checks earlier on this branch; the current head reran the repository checker successfully.
- `npx --yes skills add . --list` validated the local catalogue and exposed only the public `stow` skill, confirming the new `metadata.internal: true` skills remain hidden from installer discovery.
- `bin/fm-lint.sh` passed with pinned ShellCheck 0.11.0 and actionlint 1.7.12; there were no changed shell targets and all 3 workflows were valid.
- Independent local Codex adversarial review at exact head `b54727445c2eec9e21f9c3d800c0c975e55238bf` returned `Verdict: ready` after the valid cross-forge compatibility finding was fixed.
- The review declined a readiness-publication race concern because a secondmate event reaches only its parent and the parent must independently pass the same exact-head cycle before reporting readiness to the captain.

The upstream fork workflows are awaiting maintainer approval to run.
No merge performed.
