### PR TITLE
fix(herdr): reconcile stale Pi registrations on recovery

### DIFF
--- a/bin/backends/herdr.sh
+++ b/bin/backends/herdr.sh
@@ -142,6 +142,17 @@ FM_BACKEND_HERDR_SECONDMATE_MARKER=".fm-secondmate-home"
 # No send, capture, Treehouse, or general task-ownership path reads it.
 FM_BACKEND_HERDR_PRESENTATION_JOURNAL_SUFFIX=".herdr-presentation"
 
+# Recovery-grade stale-Pi reconciliation (issue #4115) is owned by
+# fm_backend_herdr_recovery_live_state. Callers that hold the per-task
+# control lock (fm-control exit, fm-spawn --relaunch) export
+# FM_BACKEND_HERDR_CONTROL_LOCK to that lock directory and
+# FM_BACKEND_HERDR_RECONCILE_STALE_PI=1 so a proven worktree shell chain
+# may release only source=herdr:pi / agent=pi. Interrupt, husk detection,
+# and every other reader leave those unset, so a stale registration stays
+# unreadable rather than released. FM_BACKEND_HERDR_STALE_PI_PROOF_POLLS
+# bounds the process-tree settle (default 10). FM_HERDR_PS_BIN overrides
+# the process-list binary in tests.
+
 # The config item a home writes to opt out of, or explicitly in to, the
 # projection.
 FM_BACKEND_HERDR_PRESENTATION_CONFIG="herdr-presentation-spaces"
@@ -2070,6 +2081,295 @@ fm_backend_herdr_server_running_state() {  # <session>
   ' 2>/dev/null || printf 'unknown'
 }
 
+# fm_backend_herdr_process_basename: the executable basename of a comm, argv0,
+# or command string, with a leading login dash stripped.
+fm_backend_herdr_process_basename() {  # <raw>
+  local s=$1
+  s=$(printf '%s' "$s" | tr -d '\n')
+  s=${s#"${s%%[![:space:]]*}"}
+  s=${s%%[[:space:]]*}
+  s=${s#-}
+  s=${s##*/}
+  printf '%s' "$s"
+}
+
+fm_backend_herdr_process_is_pi() {  # <basename>
+  case "$1" in pi|Pi|pi-signed|pi-launcher) return 0 ;; esac
+  return 1
+}
+
+# A crew pane's preserved worktree chain is treehouse (the worktree holder)
+# plus a recognized interactive shell. Anything else is not this chain.
+fm_backend_herdr_process_is_shell_chain() {  # <basename>
+  case "$1" in sh|bash|zsh|dash|ksh|fish|treehouse) return 0 ;; esac
+  return 1
+}
+
+# True only when this process (or an ancestor) owns the control lock named by
+# FM_BACKEND_HERDR_CONTROL_LOCK. Release of a stale Pi registration is gated
+# on that hold so a replacement cannot race a live agent.
+fm_backend_herdr_control_lock_held() {
+  local lock=${FM_BACKEND_HERDR_CONTROL_LOCK:-} owner me hops=0 ppid
+  [ -n "$lock" ] || return 1
+  owner=$(cat "$lock/pid" 2>/dev/null) || return 1
+  case "$owner" in ''|*[!0-9]*) return 1 ;; esac
+  me=${BASHPID:-$$}
+  while [ "$hops" -lt 32 ]; do
+    case "$me" in ''|*[!0-9]*) return 1 ;; esac
+    [ "$me" = "$owner" ] && return 0
+    ppid=$(ps -o ppid= -p "$me" 2>/dev/null | tr -d '[:space:]')
+    case "$ppid" in ''|*[!0-9]*) return 1 ;; esac
+    [ "$ppid" -gt 1 ] || return 1
+    me=$ppid
+    hops=$((hops + 1))
+  done
+  return 1
+}
+
+# One process-info + OS-descendant snapshot for a recovery-grade Pi liveness
+# proof. Prints pi-live, shell-chain, or unreadable. Descendant-aware on
+# purpose: a crew pane holds a treehouse get subshell, so the top-shell-only
+# idle-shell proof is not sufficient and is not used here.
+fm_backend_herdr_pane_pi_process_tree_sample() {  # <session> <pane-id>
+  local session=$1 pane=$2 info shell_pid fg_kind tree_kind name argv0 argv_first base
+  local ps_bin rows
+  info=$(fm_backend_herdr_cli "$session" pane process-info --pane "$pane" 2>/dev/null) || {
+    printf 'unreadable'
+    return 0
+  }
+  printf '%s' "$info" | jq -e --arg pane "$pane" '
+    .result.type == "pane_process_info"
+    and .result.process_info.pane_id == $pane
+    and (.result.process_info.foreground_processes | type) == "array"
+  ' >/dev/null 2>&1 || {
+    printf 'unreadable'
+    return 0
+  }
+  shell_pid=$(printf '%s' "$info" | jq -er \
+    '.result.process_info.shell_pid | select(type == "number" and . > 1) | floor' 2>/dev/null) || {
+    printf 'unreadable'
+    return 0
+  }
+  fg_kind=empty
+  while IFS=$'\t' read -r name argv0 argv_first; do
+    [ -n "$name$argv0$argv_first" ] || continue
+    for raw in "$name" "$argv0" "$argv_first"; do
+      [ -n "$raw" ] || continue
+      base=$(fm_backend_herdr_process_basename "$raw")
+      [ -n "$base" ] || continue
+      if fm_backend_herdr_process_is_pi "$base"; then
+        printf 'pi-live'
+        return 0
+      fi
+      if fm_backend_herdr_process_is_shell_chain "$base"; then
+        [ "$fg_kind" = other ] || fg_kind=shell
+      else
+        fg_kind=other
+      fi
+    done
+  done < <(printf '%s' "$info" | jq -r '
+    .result.process_info.foreground_processes[]?
+    | [(.name // ""), (.argv0 // ""), ((.argv[0] // "") | tostring)] | @tsv
+  ' 2>/dev/null)
+  [ "$fg_kind" = shell ] || {
+    printf 'unreadable'
+    return 0
+  }
+
+  ps_bin=${FM_HERDR_PS_BIN:-ps}
+  command -v "$ps_bin" >/dev/null 2>&1 || {
+    printf 'unreadable'
+    return 0
+  }
+  rows=$("$ps_bin" -axo pid=,ppid=,command= 2>/dev/null) || {
+    printf 'unreadable'
+    return 0
+  }
+  tree_kind=$(printf '%s\n' "$rows" | awk -v shell="$shell_pid" '
+    function base(cmd,    a, n, s) {
+      sub(/^[[:space:]]+/, "", cmd)
+      n = split(cmd, a, /[[:space:]]+/)
+      if (n < 1) return ""
+      s = a[1]
+      sub(/^-/, "", s)
+      sub(/.*\//, "", s)
+      return s
+    }
+    function is_pi(s) {
+      return s == "pi" || s == "Pi" || s == "pi-signed" || s == "pi-launcher"
+    }
+    function is_shell(s) {
+      return s == "sh" || s == "bash" || s == "zsh" || s == "dash" || s == "ksh" || s == "fish" || s == "treehouse"
+    }
+    {
+      pid = $1 + 0
+      ppid = $2 + 0
+      $1 = ""
+      $2 = ""
+      sub(/^ +/, "")
+      pids[pid] = 1
+      parent[pid] = ppid
+      cmd[pid] = $0
+    }
+    END {
+      if (!(shell in pids)) {
+        print "unreadable"
+        exit
+      }
+      nq = 1
+      q[1] = shell
+      seen[shell] = 1
+      for (i = 1; i <= nq; i++) {
+        cur = q[i]
+        b = base(cmd[cur])
+        if (is_pi(b)) {
+          print "pi-live"
+          exit
+        }
+        if (!is_shell(b)) {
+          print "unreadable"
+          exit
+        }
+        for (pid in parent) {
+          if (parent[pid] == cur && !seen[pid]) {
+            nq++
+            q[nq] = pid
+            seen[pid] = 1
+          }
+        }
+      }
+      print "shell-chain"
+    }
+  ') || {
+    printf 'unreadable'
+    return 0
+  }
+  case "$tree_kind" in
+    pi-live|shell-chain|unreadable) printf '%s' "$tree_kind" ;;
+    *) printf 'unreadable' ;;
+  esac
+}
+
+# Bounded settle wrapper around the instantaneous Pi process-tree sample.
+# An idle shell can host a short-lived prompt helper for a few samples; a
+# genuinely busy or ambiguous pane fails every sample and stays unreadable.
+fm_backend_herdr_pane_pi_process_tree_verdict() {  # <session> <pane-id>
+  local attempt=0 max_attempts=${FM_BACKEND_HERDR_STALE_PI_PROOF_POLLS:-10} verdict
+  while :; do
+    verdict=$(fm_backend_herdr_pane_pi_process_tree_sample "$1" "$2")
+    case "$verdict" in
+      pi-live|shell-chain)
+        printf '%s' "$verdict"
+        return 0
+        ;;
+    esac
+    attempt=$((attempt + 1))
+    [ "$attempt" -lt "$max_attempts" ] || break
+    sleep 0.1
+  done
+  printf 'unreadable'
+}
+
+# Print pane_id, agent, status, revision, and state_change_seq from one
+# agent-get body, tab-separated. Missing optional fields stay empty.
+fm_backend_herdr_pi_agent_identity_line() {  # <agent-get-json>
+  printf '%s' "$1" | jq -r '
+    .result.agent as $a
+    | select(($a | type) == "object")
+    | [
+        ($a.pane_id // ""),
+        ($a.agent // ""),
+        ($a.agent_status // ""),
+        (if ($a.revision | type) == "number" then ($a.revision | floor | tostring) else "" end),
+        (if ($a.state_change_seq | type) == "number" then ($a.state_change_seq | floor | tostring) else "" end)
+      ] | @tsv
+  ' 2>/dev/null
+}
+
+# Recovery-grade handling of a husk-classifier `live` pane. A registered Pi
+# that is idle, done, or blocked is checked against the pane's descendant
+# process tree. A real Pi stays alive. A preserved worktree shell chain may
+# be released only under the control lock, and only for source=herdr:pi /
+# agent=pi, and only when agent get then reports agent_not_found. Any
+# ambiguity, identity change, active non-chain process, missing lock, or
+# failed release stays unreadable and never releases. Working Pi is never
+# a stale-registration candidate. fm_backend_herdr_pane_agent_state stays
+# strict: this widening does not license closing the pane.
+fm_backend_herdr_recovery_live_state() {  # <session> <pane-id>
+  local session=$1 pane=$2 out ident pane_id agent status revision seq
+  local ident2 pane_id2 agent2 status2 revision2 seq2 verdict
+  local -a release_args
+  out=$(fm_backend_herdr_cli "$session" agent get "$pane" 2>/dev/null) || {
+    printf 'unreadable'
+    return 0
+  }
+  ident=$(fm_backend_herdr_pi_agent_identity_line "$out") || ident=
+  IFS=$'\t' read -r pane_id agent status revision seq <<< "$ident"
+  if [ "$agent" != pi ] || [ "$pane_id" != "$pane" ]; then
+    printf 'alive'
+    return 0
+  fi
+  case "$status" in
+    idle|done|blocked) ;;
+    *)
+      printf 'alive'
+      return 0
+      ;;
+  esac
+  verdict=$(fm_backend_herdr_pane_pi_process_tree_verdict "$session" "$pane")
+  case "$verdict" in
+    pi-live)
+      printf 'alive'
+      return 0
+      ;;
+    shell-chain) ;;
+    *)
+      printf 'unreadable'
+      return 0
+      ;;
+  esac
+  if [ "${FM_BACKEND_HERDR_RECONCILE_STALE_PI:-}" != 1 ] \
+     || ! fm_backend_herdr_control_lock_held; then
+    printf 'unreadable'
+    return 0
+  fi
+  out=$(fm_backend_herdr_cli "$session" agent get "$pane" 2>/dev/null) || {
+    printf 'unreadable'
+    return 0
+  }
+  ident2=$(fm_backend_herdr_pi_agent_identity_line "$out") || ident2=
+  IFS=$'\t' read -r pane_id2 agent2 status2 revision2 seq2 <<< "$ident2"
+  if [ "$pane_id2" != "$pane_id" ] || [ "$agent2" != "$agent" ] \
+     || [ "$status2" != "$status" ] || [ "$revision2" != "$revision" ] \
+     || [ "$seq2" != "$seq" ]; then
+    printf 'unreadable'
+    return 0
+  fi
+  case "$status2" in
+    idle|done|blocked) ;;
+    *)
+      printf 'unreadable'
+      return 0
+      ;;
+  esac
+  release_args=(pane release-agent --source herdr:pi --agent pi)
+  case "$seq2" in
+    ''|*[!0-9]*) ;;
+    *) release_args+=(--seq "$seq2") ;;
+  esac
+  release_args+=("$pane")
+  if ! fm_backend_herdr_cli "$session" "${release_args[@]}" >/dev/null 2>&1; then
+    printf 'unreadable'
+    return 0
+  fi
+  out=$(fm_backend_herdr_cli "$session" agent get "$pane" 2>&1)
+  if [ "$(printf '%s' "$out" | jq -r '.error.code // empty' 2>/dev/null)" != agent_not_found ]; then
+    printf 'unreadable'
+    return 0
+  fi
+  printf 'dead'
+}
+
 # fm_backend_herdr_agent_state: recovery-grade state for the same session-start
 # sweep as the tmux classifier. It reuses the husk classifier rather than
 # creating a second Herdr state machine: a structurally gone pane is `missing`,
@@ -2083,6 +2383,13 @@ fm_backend_herdr_server_running_state() {  # <session>
 # `unreadable` stranded tasks with no sanctioned recovery (issue #4091), so a
 # positively stopped server reads `missing` instead.
 #
+# A second recovery-only exception (issue #4115): a registered Pi that is
+# idle, done, or blocked is not taken as alive from the registry alone.
+# fm_backend_herdr_recovery_live_state owns the descendant-aware process proof
+# and the locked, identity-checked herdr:pi / pi release. The husk classifier
+# under this function still reports that pane `live`, so nothing that can
+# close a pane treats a stale registration as a husk.
+#
 # Only this recovery-grade read is widened. fm_backend_herdr_pane_agent_state
 # and the presence classifier under it stay strict, so husk detection, duplicate
 # prevention, rollback, and teardown - which can DESTROY things - keep refusing
@@ -2095,7 +2402,7 @@ fm_backend_herdr_agent_state() {  # <target>
   case "$(fm_backend_herdr_pane_agent_state "$FM_BACKEND_HERDR_SESSION" "$FM_BACKEND_HERDR_PANE")" in
     dead) printf 'missing' ;;
     no-agent) printf 'dead' ;;
-    live) printf 'alive' ;;
+    live) fm_backend_herdr_recovery_live_state "$FM_BACKEND_HERDR_SESSION" "$FM_BACKEND_HERDR_PANE" ;;
     *)
       case "$(fm_backend_herdr_server_running_state "$FM_BACKEND_HERDR_SESSION")" in
         stopped) printf 'missing' ;;

--- a/bin/fm-control.sh
+++ b/bin/fm-control.sh
@@ -84,6 +84,11 @@
 #     than reported as successful blind.
 #   - An ambiguous or unreadable endpoint state refuses; only a positively
 #     classified state acts.
+#   - On Herdr, `exit` may reconcile a stale idle/done/blocked Pi registration
+#     under this plane's per-task lock (bin/backends/herdr.sh
+#     fm_backend_herdr_recovery_live_state). Interrupt never does: its
+#     postcondition requires the agent still alive. There is no general force
+#     flag. Ambiguity stays unreadable and does not release.
 #
 # Environment knobs (all bounded waits, seconds):
 #   FM_CONTROL_POLL              poll interval for postcondition waits (0.5)
@@ -449,6 +454,11 @@ retire_busy_incarnation() {
 do_exit() {
   local state cmd verdict cancel interrupt_result=not-needed
   require_state_verified_backend exit
+  if [ "$BACKEND" = herdr ]; then
+    FM_BACKEND_HERDR_CONTROL_LOCK=$CONTROL_LOCK
+    FM_BACKEND_HERDR_RECONCILE_STALE_PI=1
+    export FM_BACKEND_HERDR_CONTROL_LOCK FM_BACKEND_HERDR_RECONCILE_STALE_PI
+  fi
   state=$(agent_state)
   case "$state" in
     dead)

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -40,7 +40,10 @@
 #   ordinary relaunch. It refuses unless the recorded endpoint is positively
 #   agent-free on a backend with a recovery-grade agent-state classifier (tmux
 #   or herdr), and clears the previous harness's per-task wiring before arming
-#   the new incarnation. The replacement still never starts outside the copy
+#   the new incarnation. On Herdr that dead-check may reconcile a stale
+#   idle/done/blocked Pi registration under this spawn's per-task lock, as
+#   owned by bin/backends/herdr.sh; there is no general force flag.
+#   The replacement still never starts outside the copy
 #   holding the work: a Herdr shell that has drifted out of the recorded
 #   worktree is told once to return, and only a shell that will not go refuses.
 #   --harness <name> is the explicit per-spawn harness/profile adapter. The old
@@ -1282,6 +1285,11 @@ if [ "$RELAUNCH" -eq 1 ]; then
     echo "error: backend '$BACKEND' has no recovery-grade agent-state classifier, so a relaunch cannot prove the previous agent exited; refusing rather than risking two agents in one endpoint" >&2
     exit 1
   }
+  if [ "$BACKEND" = herdr ]; then
+    FM_BACKEND_HERDR_CONTROL_LOCK=$SPAWN_CONTROL_LOCK
+    FM_BACKEND_HERDR_RECONCILE_STALE_PI=1
+    export FM_BACKEND_HERDR_CONTROL_LOCK FM_BACKEND_HERDR_RECONCILE_STALE_PI
+  fi
   RELAUNCH_STATE=$(fm_backend_agent_state "$BACKEND" "$RELAUNCH_TARGET")
   [ "$RELAUNCH_STATE" = dead ] || {
     echo "error: task $ID's endpoint reads '$RELAUNCH_STATE'; a relaunch requires a positively agent-free endpoint (stop the agent first with bin/fm-control.sh $ID exit)" >&2

--- a/docs/agent-control.md
+++ b/docs/agent-control.md
@@ -101,6 +101,7 @@ Switching harness is therefore one ordinary relaunch rather than a separate mech
   Only a positively classified state acts.
 - `fm-spawn --relaunch` independently refuses unless the recorded endpoint is positively agent-free, so a replacement can never join a live agent.
   It also requires the shell to be in the recorded worktree: tmux refuses immediately when it is not, while Herdr sends one `cd` to the recorded path and refuses unless a subsequent path read confirms the move.
+  On Herdr, `exit` and that spawn dead-check reconcile a stale idle Pi registration only under this plane's per-task lock, as owned by [`docs/herdr-backend.md`](herdr-backend.md) "Restart and liveness behavior".
 
 ## Capability matrix
 

--- a/docs/herdr-backend.md
+++ b/docs/herdr-backend.md
@@ -278,10 +278,17 @@ A restored same-labeled tab with a missing pane or no registered agent is a husk
 Create replaces only a confidently dead or no-agent husk, creates the replacement before closing the old tab, and refuses live or unknown states.
 This prevents closing the workspace's last tab before a replacement exists.
 
-The generic Herdr agent-liveness probe reuses the same pane classifier, then applies one recovery-only exception.
+The generic Herdr agent-liveness probe reuses the same pane classifier, then applies two recovery-only exceptions.
 A structurally gone pane or a pane read from a session positively reported as having no running server becomes `missing`, a restored agent-less shell becomes `dead`, a registered agent becomes `alive`, and every other unexpected read becomes `unreadable`.
 The stopped-server exception does not widen husk detection or any close authority; those paths still refuse an unreadable pane.
 Unlike tmux process-name inspection, native registration can classify Pi without guessing from a generic interpreter name.
+
+A registered Pi that is idle, done, or blocked is not treated as alive from the registry alone.
+The recovery-grade read also consults pane process-info and attributes processes to the pane's descendant tree, because a crew pane holds a `treehouse get` subshell and the top-shell-only idle-shell proof is not sufficient.
+A real Pi descendant stays `alive`.
+A pane that holds only the preserved worktree shell chain may be released, only under the control plane's per-task lock, and only for matching `source=herdr:pi` / `agent=pi` authority, and only after a follow-up `agent get` reports `agent_not_found`.
+Any ambiguity, identity change between the proof and the release, an active non-chain process, a process-info failure, or a failed release stays `unreadable` and does not release.
+Herdr should send `pane.release_agent` on Pi TUI shutdown so this reconciliation is not required; that handler is an upstream Herdr concern.
 
 The session-start sweep uses this probe.
 Mid-session secondmate agent-process liveness is not implemented because idle secondmates are deliberately exempt from stale-pane escalation and need a separate periodic identity signal.

--- a/docs/verification/runtime-backends.md
+++ b/docs/verification/runtime-backends.md
@@ -1072,6 +1072,36 @@ ok - real herdr: a drifted agent-free shell returns to its worktree and reuses t
 `tests/fm-control-relaunch.test.sh` drives a tmux stub and proves that tmux retains its prior refusal without sending `cd` or any other input to the pane.
 The Herdr refusal when a shell accepts the command but does not move is not exercised in this change.
 
+### Stale Pi registration
+
+Measured 2026-09-10 on macOS aarch64 against Herdr 0.9.0 (protocol 22) in an isolated `fm-lab-` session.
+
+A live Pi in a pane reports `agent=pi`, `agent_status=idle`, and process-info lists `pi` / `pi-launcher` (argv0 `pi` / `pi-signed`) as descendants of the pane shell.
+`fm_backend_herdr_pane_agent_state` classifies that registry row `live` without consulting processes, and `fm_backend_herdr_agent_state` previously mapped any such row to `alive`.
+A clean `/quit` on this Herdr version dropped the registration (`agent_not_found`) and left the pane shell; `herdr pane report-agent --source herdr:pi` is reserved and does not stick, while `herdr pane release-agent --source herdr:pi --agent pi` against a still-running Pi is a no-op.
+
+The recovery-grade read now proves descendant liveness before trusting an idle, done, or blocked Pi, and may release only that `herdr:pi` / `pi` authority under the control lock.
+Portable coverage is `tests/fm-backend-herdr.test.sh` (stale treehouse-to-bash chain, live Pi descendant, process-info failure, identity change, uncommitted work, missing lock, working Pi).
+The husk classifier is unchanged and still refuses to close a registered idle Pi.
+
+Refresh the portable half with:
+
+```sh
+bin/fm-test-run.sh tests/fm-backend-herdr.test.sh
+```
+
+```
+ok - herdr recovery-grade read: stale idle Pi over a treehouse->bash chain reconciles to dead
+ok - herdr recovery-grade read: a real idle Pi stays alive and is not released
+ok - herdr recovery-grade read: process-info failure stays unreadable and does not release
+ok - herdr recovery-grade read: identity change between proof and release refuses
+ok - herdr recovery-grade read: uncommitted work survives the reconciliation that unblocks relaunch
+ok - herdr recovery-grade read: without the control lock a stale Pi is unreadable and not released
+ok - herdr recovery-grade read: working Pi is never a stale-registration candidate
+```
+
+`tests/fm-control-herdr-smoke.test.sh` on the same date proved an uncommitted worktree file survived a real Herdr relaunch of an agent-free pane in an isolated lab session (Herdr 0.9.0).
+
 ### Away-mode transport
 
 The away daemon is no longer launched on Pi; the away posture there is the record `bin/fm-afk-contract.sh` owns.

--- a/tests/fm-backend-herdr.test.sh
+++ b/tests/fm-backend-herdr.test.sh
@@ -411,6 +411,307 @@ test_recovery_grade_read_widens_only_at_its_own_boundary() {
   pass "herdr recovery-grade read: a stopped server means missing there, and nowhere else"
 }
 
+# --- stale Pi registration (issue #4115) ------------------------------------
+#
+# The husk classifier treats any registered agent_status as live. Recovery
+# must not: an idle/done/blocked Pi whose pane holds only the worktree shell
+# chain is a stale hook, and a real idle Pi must never be released. These
+# cases drive the real recovery function with real descendant processes and a
+# canned Herdr registry, so they pin behavior rather than source text.
+# shellcheck disable=SC2016
+
+make_stale_pi_herdr() {  # <dir> -> fakebin
+  local dir=$1 fb="$1/fakebin"
+  mkdir -p "$fb" "$dir/state"
+  : > "$dir/log"
+  printf '0\n' > "$dir/state/agent-gets"
+  cat > "$fb/herdr" <<'SH'
+#!/usr/bin/env bash
+set -u
+DIR=${FM_STALE_PI_DIR:?}
+{
+  printf 'HERDR_SESSION=%s' "${HERDR_SESSION:-}"
+  for a in "$@"; do printf '\x1f%s' "$a"; done
+  printf '\n'
+} >> "$DIR/log"
+if [ "${1:-}" = status ] && [ "${2:-}" = --json ]; then
+  printf '{"client":{"version":"0.9.0","protocol":22},"server":{"running":true}}\n'
+  exit 0
+fi
+case "${1:-} ${2:-}" in
+  "pane get")
+    cat "$DIR/pane-get.json"
+    exit 0
+    ;;
+  "agent get")
+    n=$(( $(cat "$DIR/state/agent-gets" 2>/dev/null || echo 0) + 1 ))
+    echo "$n" > "$DIR/state/agent-gets"
+    if [ -f "$DIR/agent-reread.json" ] && [ "$n" -ge 3 ]; then
+      cat "$DIR/agent-reread.json"
+    else
+      cat "$DIR/agent.json"
+    fi
+    exit 0
+    ;;
+  "pane process-info")
+    if [ -f "$DIR/process-info.fail" ]; then
+      echo 'Error: process-info unavailable' >&2
+      exit 1
+    fi
+    cat "$DIR/process-info.json"
+    exit 0
+    ;;
+  "pane release-agent")
+    source_id= agent_label=
+    while [ $# -gt 0 ]; do
+      case "$1" in
+        --source) source_id=${2:-}; shift 2 ;;
+        --agent) agent_label=${2:-}; shift 2 ;;
+        --seq) shift 2 ;;
+        *) shift ;;
+      esac
+    done
+    printf '%s\t%s\n' "$source_id" "$agent_label" >> "$DIR/state/releases"
+    if [ "$source_id" = herdr:pi ] && [ "$agent_label" = pi ]; then
+      printf '{"error":{"code":"agent_not_found","message":"agent target released"}}\n' > "$DIR/agent.json"
+      rm -f "$DIR/agent-reread.json"
+      exit 0
+    fi
+    exit 0
+    ;;
+esac
+exit 0
+SH
+  chmod +x "$fb/herdr"
+  printf '%s\n' "$fb"
+}
+
+write_present_pane() {  # <dir> <pane>
+  printf '{"result":{"pane":{"pane_id":"%s"}}}\n' "$2" > "$1/pane-get.json"
+}
+
+write_pi_agent() {  # <dir> <pane> <status> [revision] [seq]
+  printf '{"result":{"agent":{"agent":"pi","agent_status":"%s","pane_id":"%s","revision":%s,"state_change_seq":%s},"type":"agent_info"}}\n' \
+    "$3" "$2" "${4:-3}" "${5:-1}" > "$1/agent.json"
+}
+
+write_process_info() {  # <file> <pane> <shell_pid> <fg_pid> <fg_name>
+  printf '{"result":{"type":"pane_process_info","process_info":{"pane_id":"%s","shell_pid":%s,"foreground_process_group_id":%s,"foreground_processes":[{"pid":%s,"name":"%s","argv0":"%s","argv":["%s"]}]}}}\n' \
+    "$2" "$3" "$3" "$4" "$5" "$5" "$5" > "$1"
+}
+
+start_treehouse_bash_chain() {  # <dir>
+  local dir=$1
+  mkdir -p "$dir/bin"
+  ln -sf "$(command -v bash)" "$dir/bin/treehouse"
+  mkfifo "$dir/outer.fifo" "$dir/inner.fifo"
+  # shellcheck disable=SC2016
+  "$dir/bin/treehouse" --noprofile --norc -c '
+    printf "%s\n" "$$" > "$1/shell.pid"
+    bash --noprofile --norc -c "printf \"%s\\n\" \"\$\$\" > \"\$0/child.pid\"; exec 3<>\"\$0/inner.fifo\"; read -u 3" "$1" &
+    exec 3<>"$1/outer.fifo"
+    read -u 3
+  ' bash "$dir" &
+  printf '%s\n' "$!" > "$dir/outer.pid"
+  local i=0
+  while [ "$i" -lt 50 ]; do
+    if [ -s "$dir/shell.pid" ] && [ -s "$dir/child.pid" ]; then
+      return 0
+    fi
+    sleep 0.02
+    i=$((i + 1))
+  done
+  return 1
+}
+
+start_bash_with_pi_child() {  # <dir>
+  local dir=$1
+  mkdir -p "$dir/bin"
+  cat > "$dir/bin/pi" <<'SH'
+#!/usr/bin/env bash
+sleep 3600
+SH
+  chmod +x "$dir/bin/pi"
+  mkfifo "$dir/outer.fifo"
+  bash --noprofile --norc -c '
+    printf "%s\n" "$$" > "$1/shell.pid"
+    "$1/bin/pi" 3600 &
+    printf "%s\n" "$!" > "$1/pi.pid"
+    exec 3<>"$1/outer.fifo"
+    read -u 3
+  ' bash "$dir" &
+  printf '%s\n' "$!" > "$dir/outer.pid"
+  local i=0
+  while [ "$i" -lt 50 ]; do
+    if [ -s "$dir/shell.pid" ] && [ -s "$dir/pi.pid" ]; then
+      kill -0 "$(cat "$dir/pi.pid")" 2>/dev/null && return 0
+    fi
+    sleep 0.02
+    i=$((i + 1))
+  done
+  return 1
+}
+
+stop_chain() {  # <dir>
+  local pid
+  while IFS= read -r pid; do
+    [ -n "$pid" ] || continue
+    kill "$pid" 2>/dev/null || true
+  done < <(cat "$1/outer.pid" "$1/pi.pid" "$1/child.pid" "$1/shell.pid" 2>/dev/null)
+}
+
+run_stale_pi_state() {  # <dir> <body>
+  local dir=$1 body=$2 fb
+  fb=$(make_stale_pi_herdr "$dir")
+  # shellcheck disable=SC2016
+  FM_STALE_PI_DIR="$dir" PATH="$fb:$PATH" \
+    FM_BACKEND_HERDR_STALE_PI_PROOF_POLLS=1 \
+    FM_STALE_PI_LOCK="$dir/control.lock" \
+    FM_STALE_PI_BODY="$body" \
+    bash -c '
+      . "$0/bin/backends/herdr.sh"
+      if [ "${FM_STALE_PI_NO_LOCK:-}" != 1 ]; then
+        mkdir -p "$FM_STALE_PI_LOCK"
+        printf "%s\n" "${BASHPID:-$$}" > "$FM_STALE_PI_LOCK/pid"
+        FM_BACKEND_HERDR_CONTROL_LOCK=$FM_STALE_PI_LOCK
+        FM_BACKEND_HERDR_RECONCILE_STALE_PI=1
+        export FM_BACKEND_HERDR_CONTROL_LOCK FM_BACKEND_HERDR_RECONCILE_STALE_PI
+      fi
+      eval "$FM_STALE_PI_BODY"
+    ' "$ROOT"
+}
+
+test_stale_idle_pi_over_treehouse_bash_reconciles_to_dead() {
+  local dir log out husk
+  dir="$TMP_ROOT/stale-pi-shell-chain"
+  mkdir -p "$dir"
+  log="$dir/log"
+  start_treehouse_bash_chain "$dir" \
+    || fail "could not start a treehouse->bash descendant chain"
+  write_present_pane "$dir" w1:p2
+  write_pi_agent "$dir" w1:p2 idle
+  write_process_info "$dir/process-info.json" w1:p2 "$(cat "$dir/shell.pid")" "$(cat "$dir/child.pid")" bash
+  out=$(run_stale_pi_state "$dir" 'fm_backend_herdr_agent_state fmtest:w1:p2')
+  stop_chain "$dir"
+  [ "$out" = dead ] || fail "a stale idle Pi over a treehouse->bash chain must reconcile to dead, got '$out'"
+  [ -f "$dir/state/releases" ] || fail "the stale chain must release the matching herdr:pi / pi authority"
+  [ "$(cat "$dir/state/releases")" = $'herdr:pi\tpi' ] \
+    || fail "release must name source=herdr:pi and agent=pi, got '$(cat "$dir/state/releases")'"
+  assert_contains "$(cat "$log")" $'\x1f''release-agent' "the stale chain never called pane release-agent"
+  husk=$(
+    # Husk classifier must still see live and refuse to close.
+    printf '{"result":{"pane":{"pane_id":"w1:p2"}}}\n' > "$dir/pane-get.json"
+    write_pi_agent "$dir" w1:p2 idle
+    run_stale_pi_state "$dir" 'fm_backend_herdr_pane_agent_state fmtest w1:p2; printf " "; fm_backend_herdr_tab_is_husk fmtest w1:p2 && printf husk || printf refused'
+  )
+  [ "$husk" = "live refused" ] \
+    || fail "the husk classifier must still refuse to close a registered idle Pi, got '$husk'"
+  pass "herdr recovery-grade read: stale idle Pi over a treehouse->bash chain reconciles to dead"
+}
+
+test_real_idle_pi_stays_alive_without_release() {
+  local dir out
+  dir="$TMP_ROOT/stale-pi-live"
+  mkdir -p "$dir"
+  start_bash_with_pi_child "$dir" \
+    || fail "could not start a real Pi-named descendant"
+  write_present_pane "$dir" w1:p2
+  write_pi_agent "$dir" w1:p2 idle
+  write_process_info "$dir/process-info.json" w1:p2 "$(cat "$dir/shell.pid")" "$(cat "$dir/pi.pid")" pi
+  out=$(run_stale_pi_state "$dir" 'fm_backend_herdr_agent_state fmtest:w1:p2')
+  stop_chain "$dir"
+  [ "$out" = alive ] || fail "a real idle Pi descendant must stay alive, got '$out'"
+  [ ! -f "$dir/state/releases" ] || fail "a real idle Pi must never be released"
+  assert_not_contains "$(cat "$dir/log")" $'\x1f''release-agent' "a real idle Pi called pane release-agent"
+  pass "herdr recovery-grade read: a real idle Pi stays alive and is not released"
+}
+
+test_stale_pi_process_info_failure_stays_unreadable() {
+  local dir out
+  dir="$TMP_ROOT/stale-pi-procfail"
+  mkdir -p "$dir"
+  write_present_pane "$dir" w1:p2
+  write_pi_agent "$dir" w1:p2 idle
+  : > "$dir/process-info.fail"
+  out=$(run_stale_pi_state "$dir" 'fm_backend_herdr_agent_state fmtest:w1:p2')
+  [ "$out" = unreadable ] || fail "a process-info failure must stay unreadable, got '$out'"
+  [ ! -f "$dir/state/releases" ] || fail "a process-info failure must never release"
+  assert_not_contains "$(cat "$dir/log")" $'\x1f''release-agent' "a process-info failure called pane release-agent"
+  pass "herdr recovery-grade read: process-info failure stays unreadable and does not release"
+}
+
+test_stale_pi_identity_change_refuses_release() {
+  local dir out
+  dir="$TMP_ROOT/stale-pi-identity"
+  mkdir -p "$dir"
+  start_treehouse_bash_chain "$dir" \
+    || fail "could not start a treehouse->bash descendant chain"
+  write_present_pane "$dir" w1:p2
+  write_pi_agent "$dir" w1:p2 idle 3 1
+  write_process_info "$dir/process-info.json" w1:p2 "$(cat "$dir/shell.pid")" "$(cat "$dir/child.pid")" bash
+  printf '{"result":{"agent":{"agent":"pi","agent_status":"idle","pane_id":"w1:p2","revision":4,"state_change_seq":2},"type":"agent_info"}}\n' \
+    > "$dir/agent-reread.json"
+  out=$(run_stale_pi_state "$dir" 'fm_backend_herdr_agent_state fmtest:w1:p2')
+  stop_chain "$dir"
+  [ "$out" = unreadable ] || fail "an identity change between proof and release must stay unreadable, got '$out'"
+  [ ! -f "$dir/state/releases" ] || fail "an identity change must never release"
+  assert_not_contains "$(cat "$dir/log")" $'\x1f''release-agent' "an identity change called pane release-agent"
+  pass "herdr recovery-grade read: identity change between proof and release refuses"
+}
+
+test_stale_pi_reconciliation_preserves_uncommitted_work() {
+  local dir out repo wt
+  dir="$TMP_ROOT/stale-pi-uncommitted"
+  mkdir -p "$dir"
+  repo="$dir/repo"
+  wt="$dir/wt"
+  fm_git_worktree "$repo" "$wt" stale-pi-branch
+  printf 'keep me\n' > "$wt/uncommitted.txt"
+  start_treehouse_bash_chain "$dir" \
+    || fail "could not start a treehouse->bash descendant chain"
+  write_present_pane "$dir" w1:p2
+  write_pi_agent "$dir" w1:p2 idle
+  write_process_info "$dir/process-info.json" w1:p2 "$(cat "$dir/shell.pid")" "$(cat "$dir/child.pid")" bash
+  out=$(run_stale_pi_state "$dir" 'fm_backend_herdr_agent_state fmtest:w1:p2')
+  stop_chain "$dir"
+  [ "$out" = dead ] || fail "reconciliation that precedes relaunch must report dead, got '$out'"
+  [ -f "$wt/uncommitted.txt" ] || fail "uncommitted work must survive the reconciliation that unblocks relaunch"
+  [ "$(cat "$wt/uncommitted.txt")" = "keep me" ] \
+    || fail "uncommitted work content must be unchanged by reconciliation"
+  assert_not_contains "$(cat "$dir/log")" $'\x1f''pane'$'\x1f''close' "reconciliation closed the pane that holds the work"
+  assert_not_contains "$(cat "$dir/log")" $'\x1f''tab'$'\x1f''close' "reconciliation closed the tab that holds the work"
+  pass "herdr recovery-grade read: uncommitted work survives the reconciliation that unblocks relaunch"
+}
+
+test_stale_pi_without_control_lock_does_not_release() {
+  local dir out
+  dir="$TMP_ROOT/stale-pi-nolock"
+  mkdir -p "$dir"
+  start_treehouse_bash_chain "$dir" \
+    || fail "could not start a treehouse->bash descendant chain"
+  write_present_pane "$dir" w1:p2
+  write_pi_agent "$dir" w1:p2 idle
+  write_process_info "$dir/process-info.json" w1:p2 "$(cat "$dir/shell.pid")" "$(cat "$dir/child.pid")" bash
+  out=$(FM_STALE_PI_NO_LOCK=1 run_stale_pi_state "$dir" 'fm_backend_herdr_agent_state fmtest:w1:p2')
+  stop_chain "$dir"
+  [ "$out" = unreadable ] || fail "a proven-stale Pi without the control lock must stay unreadable, got '$out'"
+  [ ! -f "$dir/state/releases" ] || fail "a read without the control lock must never release"
+  pass "herdr recovery-grade read: without the control lock a stale Pi is unreadable and not released"
+}
+
+test_working_pi_is_not_a_stale_candidate() {
+  local dir out
+  dir="$TMP_ROOT/stale-pi-working"
+  mkdir -p "$dir"
+  write_present_pane "$dir" w1:p2
+  write_pi_agent "$dir" w1:p2 working
+  out=$(run_stale_pi_state "$dir" 'fm_backend_herdr_agent_state fmtest:w1:p2')
+  [ "$out" = alive ] || fail "a working Pi must stay alive without a stale-registration proof, got '$out'"
+  assert_not_contains "$(cat "$dir/log")" $'\x1f''process-info' "a working Pi consulted process-info"
+  assert_not_contains "$(cat "$dir/log")" $'\x1f''release-agent' "a working Pi called pane release-agent"
+  pass "herdr recovery-grade read: working Pi is never a stale-registration candidate"
+}
+
 test_agent_state_bypasses_a_stale_client_shadowing_a_compatible_one() {
   local dir out err
   dir="$TMP_ROOT/client-pair-bypass"; make_herdr_client_pair "$dir"
@@ -4726,6 +5027,13 @@ test_workspace_label_different_secondmates_get_different_labels
 test_cli_helper_sets_env_and_appends_trailing_session_flag
 test_agent_state_bypasses_a_stale_client_shadowing_a_compatible_one
 test_recovery_grade_read_widens_only_at_its_own_boundary
+test_stale_idle_pi_over_treehouse_bash_reconciles_to_dead
+test_real_idle_pi_stays_alive_without_release
+test_stale_pi_process_info_failure_stays_unreadable
+test_stale_pi_identity_change_refuses_release
+test_stale_pi_reconciliation_preserves_uncommitted_work
+test_stale_pi_without_control_lock_does_not_release
+test_working_pi_is_not_a_stale_candidate
 test_cli_caches_the_selected_client_within_a_process
 test_cli_scopes_the_selected_client_to_its_session
 test_cli_unrelated_failure_never_triggers_reselection

--- a/tests/fm-control-herdr-smoke.test.sh
+++ b/tests/fm-control-herdr-smoke.test.sh
@@ -171,6 +171,7 @@ done
 [ "$(fm_backend_herdr_current_path "$SESSION:$PANE_ID" 2>/dev/null || true)" = "$PROJ_REAL" ] \
   || fail "the real Herdr pane did not drift out of its recorded worktree"
 
+printf 'scratch\n' > "$WT/uncommitted.txt"
 OUT=$(env FM_HOME="$HOME_DIR" HERDR_SESSION="$SESSION" FM_SPAWN_NO_GUARD=1 \
   "$ROOT/bin/fm-spawn.sh" hsmoke --relaunch --harness codex) \
   || fail "a drifted, agent-free Herdr pane should be re-homed and relaunched: $OUT"
@@ -183,6 +184,8 @@ done
   || fail "the relaunched Herdr shell did not end up in its recorded worktree"
 [ "$(sed -n 's/^window=//p' "$HOME_DIR/state/hsmoke.meta" | tail -1)" = "$SESSION:$PANE_ID" ] \
   || fail "the Herdr relaunch replaced its endpoint instead of reusing it"
+[ -f "$WT/uncommitted.txt" ] || fail "uncommitted work must survive a Herdr relaunch"
+[ "$(cat "$WT/uncommitted.txt")" = scratch ] || fail "uncommitted work content must survive a Herdr relaunch"
 herdr pane get "$PANE_ID" --session "$SESSION" >/dev/null 2>&1 \
   || fail "the Herdr relaunch removed the endpoint it was required to reuse"
 awk -F= '$1 == "harness" {$0="harness=claude"} {print}' "$HOME_DIR/state/hsmoke.meta" \

--- a/tests/fm-secondmate-liveness.test.sh
+++ b/tests/fm-secondmate-liveness.test.sh
@@ -165,7 +165,7 @@ test_herdr_agent_state_preserves_husk_classifier() {
   for row in 'dead missing' 'no-agent dead' 'live alive' 'unknown unreadable'; do
     pane_state=${row%% *}
     expected=${row#* }
-    out=$(FM_TEST_PANE_STATE="$pane_state" bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_pane_agent_state() { printf "%s" "$FM_TEST_PANE_STATE"; }; fm_backend_herdr_agent_state "sess:p1"' "$ROOT")
+    out=$(FM_TEST_PANE_STATE="$pane_state" bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_pane_agent_state() { printf "%s" "$FM_TEST_PANE_STATE"; }; fm_backend_herdr_recovery_live_state() { printf alive; }; fm_backend_herdr_server_running_state() { printf unknown; }; fm_backend_herdr_agent_state "sess:p1"' "$ROOT")
     [ "$out" = "$expected" ] || fail "Herdr pane state $pane_state should map to $expected, got '$out'"
   done
 
@@ -187,7 +187,7 @@ test_agent_state_dispatcher_and_compatibility() {
   out=$(PATH="$fb:$BASE_PATH" bash -c '. "$0/bin/fm-backend.sh"; fm_backend_agent_state tmux sess:win' "$ROOT")
   [ "$out" = alive ] || fail "detailed dispatcher should route tmux, got '$out'"
 
-  out=$(bash -c '. "$0/bin/fm-backend.sh"; fm_backend_source herdr; fm_backend_herdr_pane_agent_state() { printf "live"; }; fm_backend_agent_state herdr sess:p1' "$ROOT")
+  out=$(bash -c '. "$0/bin/fm-backend.sh"; fm_backend_source herdr; fm_backend_herdr_pane_agent_state() { printf "live"; }; fm_backend_herdr_recovery_live_state() { printf alive; }; fm_backend_agent_state herdr sess:p1' "$ROOT")
   [ "$out" = alive ] || fail "detailed dispatcher should route Herdr, got '$out'"
 
   out=$(bash -c '. "$0/bin/fm-backend.sh"; fm_backend_agent_state zellij sess:7' "$ROOT")


### PR DESCRIPTION
Fixes #4115.

When a Pi crew exits to a shell, Herdr can keep `agent=pi` / `agent_status=idle` registered on the still-present pane with no Pi OS process. The recovery-grade classifier treated any registered status as live, so `fm-control` relaunch sent `/quit` into a dead shell and `fm-spawn --relaunch` refused the positively-dead precondition.

This change keeps the husk classifier strict (closing a pane still refuses a registered idle Pi). Only the recovery-grade read proves descendant-aware process liveness:

- A real Pi descendant stays alive.
- A treehouse-to-shell worktree chain may release only matching `source=herdr:pi` / `agent=pi` authority, and only under the control plane's per-task lock, and only after `agent get` reports `agent_not_found`.
- Any ambiguity, identity change, process-info failure, missing lock, or failed release stays unreadable and does not release.

There is no general force-override. Sending `pane.release_agent` on Pi TUI shutdown remains an upstream Herdr concern.

## Test plan

- [x] Stale idle registration over a treehouse->bash descendant chain reconciles to dead
- [x] A real idle Pi stays alive (no false release)
- [x] Process-info read failure stays unreadable (no release)
- [x] Identity change between the liveness proof and the release refuses (no release)
- [x] Preserved uncommitted work survives the reconciliation, and a real Herdr relaunch of an agent-free pane keeps the worktree file
- [x] `bin/fm-test-run.sh tests/fm-backend-herdr.test.sh tests/fm-secondmate-liveness.test.sh tests/fm-control.test.sh tests/fm-control-relaunch.test.sh tests/fm-control-herdr-smoke.test.sh`