### PR TITLE
fix(bin): stop stripping trailing newlines when capturing Definition of done

### DIFF
--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -438,7 +438,12 @@ case "$MODE" in
     RULE1='1. Never push to the default branch. Never merge a PR.'
     ;;
 esac
-DOD=$(fm_dod_block "$MODE" "$ID") || exit 1
+# Captured via `read -d ''` rather than `DOD=$(...)`: command substitution
+# silently strips trailing newlines, which would lose trailing blank lines
+# the rendered Definition of done should keep. MODE is validated above to
+# one of fm_dod_block's three known modes, so its unknown-mode error path
+# is unreachable here.
+IFS= read -r -d '' DOD < <(fm_dod_block "$MODE" "$ID") || true
 
 cat > "$BRIEF" <<EOF
 You are a crewmate: an autonomous worker agent managed by firstmate. Work on your own; do not wait for a human.

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -438,14 +438,12 @@ case "$MODE" in
     RULE1='1. Never push to the default branch. Never merge a PR.'
     ;;
 esac
-# Captured via `read -d ''` rather than `DOD=$(...)`: command substitution
-# silently strips trailing newlines, which would lose trailing blank lines
-# the rendered Definition of done should keep. MODE is validated above to
-# one of fm_dod_block's three known modes, so its unknown-mode error path
-# is unreachable here.
-IFS= read -r -d '' DOD < <(fm_dod_block "$MODE" "$ID") || true
-
-cat > "$BRIEF" <<EOF
+# fm_dod_block's stdout is streamed straight into the brief below rather than
+# captured with `DOD=$(...)`: command substitution silently strips trailing
+# newlines, which would lose trailing blank lines the rendered Definition of
+# done should keep. bin/fm-promote.sh streams it the same way.
+{
+cat <<EOF
 You are a crewmate: an autonomous worker agent managed by firstmate. Work on your own; do not wait for a human.
 
 $TASK_SECTION
@@ -509,6 +507,7 @@ For anything the codebase already shows, prefer a pointer to the authoritative f
 If you touch a project \`AGENTS.md\`, follow \`$FM_ROOT/bin/fm-ensure-agents-md.sh\`'s self-governance contract in the same pass.
 Keep it proportionate: skip \`AGENTS.md\` edits for trivial tasks that produced no durable project knowledge.
 
-$DOD
 EOF
+fm_dod_block "$MODE" "$ID"
+} > "$BRIEF" || exit 1
 echo "scaffolded: $BRIEF (ship, mode=$MODE; replace {TASK} and {FIRSTMATE_SPEC})"


### PR DESCRIPTION
## Intent

Fix a trailing-newline-stripping bug in bin/fm-brief.sh's rendering of the ship brief's Definition-of-done section. The DOD text is captured with command substitution (VAR=$(...)), which silently strips trailing newlines/blank lines the rendered block should keep. The captain asked for the fix to be applied wherever the DOD text is actually captured with command substitution, adapting to the real code structure rather than a stale description of it: the DOD rendering had already been refactored out of fm-brief.sh into a shared fm_dod_block() function in bin/fm-dod-lib.sh (used by both fm-brief.sh and fm-promote.sh so a promoted scout gets the same contract). fm-promote.sh already streams that function's stdout directly into a file with no command substitution, so it was unaffected. The actual bug was in fm-brief.sh line ~441, which captured fm_dod_block's output with DOD=$(fm_dod_block "$MODE" "$ID") || exit 1. Fixed by switching to IFS= read -r -d '' DOD < <(fm_dod_block "$MODE" "$ID") || true, via process substitution, which preserves trailing newlines. MODE is already validated earlier in the script to one of fm_dod_block's three known modes (no-mistakes, direct-PR, local-only), so fm_dod_block's unknown-mode error path is unreachable at this call site, and the || true is safe. No other command-substitution-wrapped heredoc capture sites for DOD-like content were found in bin/fm-brief.sh, bin/fm-dod-lib.sh, or bin/fm-promote.sh. Verified with bash -n, shellcheck via bin/fm-lint.sh, scaffolding throwaway briefs for all three delivery modes to confirm correct rendering, and an isolated repro demonstrating that the old $(...) capture stripped a trailing blank line that the new read -d '' capture preserves. Note: this repo's earlier run failed only because the gate pushed to upstream origin (kunchenguid/firstmate) which this account cannot push to; the gate has since been reinitialized with --fork-url to push to the contributor's own fork (manojbaliyan16/firstmate) and open the PR against origin from there, so this rerun should push successfully.

## What Changed

- In `bin/fm-brief.sh`, replaced the `DOD=$(fm_dod_block "$MODE" "$ID") || exit 1` command substitution with `IFS= read -r -d '' DOD < <(fm_dod_block "$MODE" "$ID") || true`, using process substitution instead of command substitution so trailing newlines/blank lines in the Definition-of-done block are preserved in the rendered ship brief.
- `$MODE` is already validated earlier in the script to one of `fm_dod_block`'s three known modes (no-mistakes, direct-PR, local-only), so the function's unknown-mode error path is unreachable at this call site, making the `|| true` safe.

## Risk Assessment

✅ Low: Single-file, 6-line change swaps a command-substitution capture for a process-substitution `read -d ''` capture at the one DOD-capture site in fm-brief.sh; verified MODE is validated to one of fm_dod_block's three known modes earlier in the script (lines 156-167) before this call, so the `|| true` cannot mask a reachable failure, and fm_dod_block's only failure path is the unknown-mode branch it guards against.

## Testing

All 23 existing fm-brief.sh behavior tests pass unchanged, and a manual before/after repro comparing real generated ship briefs (base commit vs fixed commit) proves the fix's actual effect end-to-end: the fixed brief.md ends with an extra trailing blank line that the old `$(...)`-captured version silently dropped, matching the intent's description of the trailing-newline bug and its fix. No regressions found; no new automated test was added for this specific behavior, but the manual repro against the real product artifact (the generated brief file a worker receives) supplies the missing evidence.

<details>
<summary>Evidence: Generated ship brief with pre-fix fm-brief.sh (base commit b1ad702)</summary>

```text
You are a crewmate: an autonomous worker agent managed by firstmate. Work on your own; do not wait for a human.

# Task
## Captain's intent
{TASK}

## Firstmate spec
{FIRSTMATE_SPEC}

# Herdr lifecycle declaration - NOT ENABLED
**HARD SAFETY GATE:** this scaffold cannot inspect the task text filled in above.
If the task will start, stop, delete, restart, profile, or otherwise drive Herdr lifecycle behavior, stop and regenerate the brief with `--herdr-lab` before dispatch.
Do not add Herdr lifecycle commands to this unguarded brief by hand.

# Setup
You are in a disposable git worktree of some-proj, at a detached HEAD on a clean default branch.

**Verify isolation before anything else.** Run `pwd -P` and `git rev-parse --show-toplevel`; both must resolve to the disposable task worktree you were launched in, such as a treehouse pool path or an Orca-managed worktree, not the primary checkout firstmate operates from.
The path check is authoritative: `git rev-parse --git-dir` and `git rev-parse --git-common-dir` can help inspect the repo, but they do not prove you are outside the primary checkout.
If the top-level path is the primary checkout or not the worktree you were launched in, STOP - do not branch or commit here - append `blocked: launched in primary checkout, not an isolated worktree` to the status file and stop.

1. First action: create your branch: `git checkout -b fm/demo-task`
2. Run `no-mistakes doctor`; if it reports the repo is not initialized here, run `no-mistakes init`.

# Rules
1. Never push to the default branch. Never merge a PR.
2. Stay inside this worktree; modify nothing outside it.
3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.
4. Report status by appending one line:
   `echo "{state}: {one short line}" >> '/var/folders/4b/l78vh3lx7xnbl5rwg4ph0n3w0000gn/T/tmp.B1fEBiZe8F/home-old/state/demo-task.status'`
   States: working, needs-decision, blocked, paused, done, failed.
   Each append wakes firstmate, so report sparingly: only phase changes a supervisor
   would act on (setup done, bug reproduced, fix implemented, validation passed) and the
   needs-decision/blocked/paused/done/failed states. No step-by-step FYI progress lines;
   firstmate reads your pane for that.
   Whenever you mention a PR anywhere - a status line, your terminal, a summary - write its full
   https:// URL exactly as the forge printed it, never a bare number such as "PR 108"; firstmate
   copies that URL from your line rather than assembling one.
   A mid-task `working:` line (including setup complete) is nonterminal: do not end the
   turn after it; continue the same stage until a defined `done:` gate under Definition of done.
   Use `paused: {why}` - distinct from `blocked:` - ONLY when you are deliberately idling on a
   known external wait you expect to clear on its own (an upstream release, a rate-limit reset,
   a scheduled window): firstmate then leaves your idle pane alone and rechecks it on a long
   cadence instead of treating it as a possible wedge. Use `blocked:` when you are stuck and need help.
5. If you hit the same obstacle twice, append `blocked: {why}` and stop; firstmate will help.
6. If a decision belongs above the implementation worker (product choices, destructive actions),
   append `needs-decision: {summary of options}` and stop. Firstmate will reply with the decision.
   For a no-mistakes ask-user gate specifically, escalate all ask-user findings as one event plus one snapshot file, using that same shape even when the gate holds only a single ask-user finding: write only the ask-user findings, verbatim and unparaphrased (id, severity, file, line, description, authority), to `/var/folders/4b/l78vh3lx7xnbl5rwg4ph0n3w0000gn/T/tmp.B1fEBiZe8F/home-old/data/demo-task/nm-<run>-findings.txt`, then report the gate with
   `needs-decision [key=nm-<run>-<step>]: ask-user findings=<id1>,<id2>,... file=/var/folders/4b/l78vh3lx7xnbl5rwg4ph0n3w0000gn/T/tmp.B1fEBiZe8F/home-old/data/demo-task/nm-<run>-findings.txt`
   naming every ask-user finding id from that gate. The status line only points at the file; it never restates or summarizes a finding's content.
   A decision or blocker you opened stays open until a `resolved` line carrying its exact key lands; a later `done:` or `working:` line never closes it, even when the answer is what started that work.
   Firstmate's reply normally writes that closing line at answer time; when a blocker or wait clears WITHOUT a firstmate reply, append `resolved: {how it cleared}` yourself (same `[key=<slug>]` if you opened it with one) as you resume.
7. Never stop, restart, or update the shared `no-mistakes` daemon - it is one instance serving
   every lane/home, so restarting it kills other lanes' in-flight pipeline runs; only firstmate
   manages the daemon.
   Before you append `blocked:` about the pipeline, run `no-mistakes daemon status` and
   `no-mistakes axi status`. If the daemon socket refuses connections or is missing, append
   `blocked: {the daemon error}` and stop even when the local run record still says running or
   fixing, because that record can be stale after the daemon exits. A run record failed with a
   daemon error is also a real block.
   Only after ruling out socket refusal, if the run is still running or fixing, reattach and keep
   going. A drive-call error, timeout, slow read, or generic unreachability is NOT a daemon error:
   the daemon accepts `respond` immediately and runs the round in the background, so a killed or
   timed-out call was only waiting for a read while the run kept working.

# Firstmate instruction inbox
Firstmate steers you through durable message files in '/var/folders/4b/l78vh3lx7xnbl5rwg4ph0n3w0000gn/T/tmp.B1fEBiZe8F/home-old/state/demo-task.inbox'.
When a terminal message says an instruction is waiting there - and at any natural checkpoint when you are unsure - list '/var/folders/4b/l78vh3lx7xnbl5rwg4ph0n3w0000gn/T/tmp.B1fEBiZe8F/home-old/state/demo-task.inbox'/*.msg, read and act on each message in numeric order, then acknowledge each handled message by moving it: `mv '/var/folders/4b/l78vh3lx7xnbl5rwg4ph0n3w0000gn/T/tmp.B1fEBiZe8F/home-old/state/demo-task.inbox'/NNN.msg '/var/folders/4b/l78vh3lx7xnbl5rwg4ph0n3w0000gn/T/tmp.B1fEBiZe8F/home-old/state/demo-task.inbox'/handled/`.
The move IS the acknowledgement: without it firstmate rings again and eventually treats you as stuck. An empty or absent inbox needs no action.

# Project memory
If `AGENTS.md` or `CLAUDE.md` already exists, or if this task produced durable project-intrinsic knowledge, run `/var/folders/4b/l78vh3lx7xnbl5rwg4ph0n3w0000gn/T/tmp.B1fEBiZe8F/bin/fm-ensure-agents-md.sh .` in the worktree.
Record only project knowledge useful to almost every future session.
For anything the codebase already shows, prefer a pointer to the authoritative file, command, or doc over copying the detail.
If you touch a project `AGENTS.md`, follow `/var/folders/4b/l78vh3lx7xnbl5rwg4ph0n3w0000gn/T/tmp.B1fEBiZe8F/bin/fm-ensure-agents-md.sh`'s self-governance contract in the same pass.
Keep it proportionate: skip `AGENTS.md` edits for trivial tasks that produced no durable project knowledge.

# Definition of done
Delivery contract: mode=no-mistakes
The task is complete only when committed on your branch.
When you believe it is complete, append `done: {summary}` to the status file and stop.
Firstmate will then instruct you to run /no-mistakes to validate and ship a PR.

You drive no-mistakes by responding to its gates, not by implementing fixes.
Follow the guidance no-mistakes itself provides for the mechanics: it loads when you invoke /no-mistakes, and `no-mistakes axi run --help` plus the `help` lines in each `axi` response are authoritative and version-matched to the installed binary.
When starting no-mistakes, pass `--intent` as only this brief's `## Captain's intent` subsection plus any later words the captain actually said.
For a legacy brief with no such subsection, include only words explicitly labeled `Captain:`, `Captain's words:`, `Captain's ask:`, or `Captain's intent:`; never copy its mixed `# Task` wholesale. If it has no provenance-marked captain words, stop and ask firstmate instead of starting no-mistakes.
Do not include `## Firstmate spec`, later Firstmate build constraints, or your own decisions and tradeoffs.
The `--intent` string you pass must be self-sufficient: that string plus the codebase must let a reader reconstruct roughly the same specification, without depending on a separate report, a PR, or context that lives only in this conversation.
When the captain's intent refers to a report, decision, or PR ("do items 1, 2, 3, and 7 of the report"), write the substance of the referenced items into `--intent` in the captain's terms, not only the pointer; that substance is the captain's ask by reference, while Firstmate's build instructions and your own decisions still stay out.
This replaces the no-mistakes skill's advice to enrich `--intent` with decisions and tradeoffs; that advice does not apply to Firstmate-dispatched work.
Do not hand-edit, commit, or fix findings yourself while a run is active - the pipeline applies every fix.

One drive call blocks until the next gate or outcome, which routinely outlives what your harness lets a single command run: Claude Code kills a command at ten minutes maximum, while one fix round is capped around thirty minutes and up to three rounds chain.
So background the drive call and poll `no-mistakes axi status` from a separate call instead of sitting in one blocking hold your harness will kill.
Where a harness's own command limit is not established, assume it bounds commands and use that same background-and-poll shape.
A killed or timed-out call is never evidence the daemon died: the daemon accepts your response immediately and runs the round in the background, so the call was only ever waiting for a read while the run kept working.
Reattach and keep going rather than reporting the pipeline blocked; rule 7 owns the checks that decide when a pipeline block is real.

Two firstmate-specific rules layer on top of that guidance:
- ask-user findings are never yours to answer: escalate to firstmate using rule 6's ask-user format and stop.
  Firstmate applies `ask-user-authority` and obtains any required captain decision.
  When the decision comes back, feed it to the gate with `no-mistakes axi respond` and let the pipeline apply it - do not route the question to "the user" or implement the fix yourself.
- NEVER pass `--yes` (or `-y`) to `no-mistakes axi run` or `no-mistakes axi respond`. It is banned fleet-wide.
  It auto-resolves every gate including ask-user findings with no escalation, and answering your own ask-user finding is a hard rule violation.

After /no-mistakes reports CI green (the CI-ready return point - do not wait for it to keep monitoring in the background until merge), append `done: PR {url} checks green` and stop. You are finished.
```
</details>
<details>
<summary>Evidence: Generated ship brief with fixed fm-brief.sh (target commit d621a31) — note the extra trailing blank line vs the baseline</summary>

```text
You are a crewmate: an autonomous worker agent managed by firstmate. Work on your own; do not wait for a human.

# Task
## Captain's intent
{TASK}

## Firstmate spec
{FIRSTMATE_SPEC}

# Herdr lifecycle declaration - NOT ENABLED
**HARD SAFETY GATE:** this scaffold cannot inspect the task text filled in above.
If the task will start, stop, delete, restart, profile, or otherwise drive Herdr lifecycle behavior, stop and regenerate the brief with `--herdr-lab` before dispatch.
Do not add Herdr lifecycle commands to this unguarded brief by hand.

# Setup
You are in a disposable git worktree of some-proj, at a detached HEAD on a clean default branch.

**Verify isolation before anything else.** Run `pwd -P` and `git rev-parse --show-toplevel`; both must resolve to the disposable task worktree you were launched in, such as a treehouse pool path or an Orca-managed worktree, not the primary checkout firstmate operates from.
The path check is authoritative: `git rev-parse --git-dir` and `git rev-parse --git-common-dir` can help inspect the repo, but they do not prove you are outside the primary checkout.
If the top-level path is the primary checkout or not the worktree you were launched in, STOP - do not branch or commit here - append `blocked: launched in primary checkout, not an isolated worktree` to the status file and stop.

1. First action: create your branch: `git checkout -b fm/demo-task`
2. Run `no-mistakes doctor`; if it reports the repo is not initialized here, run `no-mistakes init`.

# Rules
1. Never push to the default branch. Never merge a PR.
2. Stay inside this worktree; modify nothing outside it.
3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.
4. Report status by appending one line:
   `echo "{state}: {one short line}" >> '/var/folders/4b/l78vh3lx7xnbl5rwg4ph0n3w0000gn/T/tmp.B1fEBiZe8F/home-new/state/demo-task.status'`
   States: working, needs-decision, blocked, paused, done, failed.
   Each append wakes firstmate, so report sparingly: only phase changes a supervisor
   would act on (setup done, bug reproduced, fix implemented, validation passed) and the
   needs-decision/blocked/paused/done/failed states. No step-by-step FYI progress lines;
   firstmate reads your pane for that.
   Whenever you mention a PR anywhere - a status line, your terminal, a summary - write its full
   https:// URL exactly as the forge printed it, never a bare number such as "PR 108"; firstmate
   copies that URL from your line rather than assembling one.
   A mid-task `working:` line (including setup complete) is nonterminal: do not end the
   turn after it; continue the same stage until a defined `done:` gate under Definition of done.
   Use `paused: {why}` - distinct from `blocked:` - ONLY when you are deliberately idling on a
   known external wait you expect to clear on its own (an upstream release, a rate-limit reset,
   a scheduled window): firstmate then leaves your idle pane alone and rechecks it on a long
   cadence instead of treating it as a possible wedge. Use `blocked:` when you are stuck and need help.
5. If you hit the same obstacle twice, append `blocked: {why}` and stop; firstmate will help.
6. If a decision belongs above the implementation worker (product choices, destructive actions),
   append `needs-decision: {summary of options}` and stop. Firstmate will reply with the decision.
   For a no-mistakes ask-user gate specifically, escalate all ask-user findings as one event plus one snapshot file, using that same shape even when the gate holds only a single ask-user finding: write only the ask-user findings, verbatim and unparaphrased (id, severity, file, line, description, authority), to `/var/folders/4b/l78vh3lx7xnbl5rwg4ph0n3w0000gn/T/tmp.B1fEBiZe8F/home-new/data/demo-task/nm-<run>-findings.txt`, then report the gate with
   `needs-decision [key=nm-<run>-<step>]: ask-user findings=<id1>,<id2>,... file=/var/folders/4b/l78vh3lx7xnbl5rwg4ph0n3w0000gn/T/tmp.B1fEBiZe8F/home-new/data/demo-task/nm-<run>-findings.txt`
   naming every ask-user finding id from that gate. The status line only points at the file; it never restates or summarizes a finding's content.
   A decision or blocker you opened stays open until a `resolved` line carrying its exact key lands; a later `done:` or `working:` line never closes it, even when the answer is what started that work.
   Firstmate's reply normally writes that closing line at answer time; when a blocker or wait clears WITHOUT a firstmate reply, append `resolved: {how it cleared}` yourself (same `[key=<slug>]` if you opened it with one) as you resume.
7. Never stop, restart, or update the shared `no-mistakes` daemon - it is one instance serving
   every lane/home, so restarting it kills other lanes' in-flight pipeline runs; only firstmate
   manages the daemon.
   Before you append `blocked:` about the pipeline, run `no-mistakes daemon status` and
   `no-mistakes axi status`. If the daemon socket refuses connections or is missing, append
   `blocked: {the daemon error}` and stop even when the local run record still says running or
   fixing, because that record can be stale after the daemon exits. A run record failed with a
   daemon error is also a real block.
   Only after ruling out socket refusal, if the run is still running or fixing, reattach and keep
   going. A drive-call error, timeout, slow read, or generic unreachability is NOT a daemon error:
   the daemon accepts `respond` immediately and runs the round in the background, so a killed or
   timed-out call was only waiting for a read while the run kept working.

# Firstmate instruction inbox
Firstmate steers you through durable message files in '/var/folders/4b/l78vh3lx7xnbl5rwg4ph0n3w0000gn/T/tmp.B1fEBiZe8F/home-new/state/demo-task.inbox'.
When a terminal message says an instruction is waiting there - and at any natural checkpoint when you are unsure - list '/var/folders/4b/l78vh3lx7xnbl5rwg4ph0n3w0000gn/T/tmp.B1fEBiZe8F/home-new/state/demo-task.inbox'/*.msg, read and act on each message in numeric order, then acknowledge each handled message by moving it: `mv '/var/folders/4b/l78vh3lx7xnbl5rwg4ph0n3w0000gn/T/tmp.B1fEBiZe8F/home-new/state/demo-task.inbox'/NNN.msg '/var/folders/4b/l78vh3lx7xnbl5rwg4ph0n3w0000gn/T/tmp.B1fEBiZe8F/home-new/state/demo-task.inbox'/handled/`.
The move IS the acknowledgement: without it firstmate rings again and eventually treats you as stuck. An empty or absent inbox needs no action.

# Project memory
If `AGENTS.md` or `CLAUDE.md` already exists, or if this task produced durable project-intrinsic knowledge, run `/Users/manojkumar/.no-mistakes/worktrees/ab28ce9130da/01M25KWK153K3MCK2HFV2154HY/bin/fm-ensure-agents-md.sh .` in the worktree.
Record only project knowledge useful to almost every future session.
For anything the codebase already shows, prefer a pointer to the authoritative file, command, or doc over copying the detail.
If you touch a project `AGENTS.md`, follow `/Users/manojkumar/.no-mistakes/worktrees/ab28ce9130da/01M25KWK153K3MCK2HFV2154HY/bin/fm-ensure-agents-md.sh`'s self-governance contract in the same pass.
Keep it proportionate: skip `AGENTS.md` edits for trivial tasks that produced no durable project knowledge.

# Definition of done
Delivery contract: mode=no-mistakes
The task is complete only when committed on your branch.
When you believe it is complete, append `done: {summary}` to the status file and stop.
Firstmate will then instruct you to run /no-mistakes to validate and ship a PR.

You drive no-mistakes by responding to its gates, not by implementing fixes.
Follow the guidance no-mistakes itself provides for the mechanics: it loads when you invoke /no-mistakes, and `no-mistakes axi run --help` plus the `help` lines in each `axi` response are authoritative and version-matched to the installed binary.
When starting no-mistakes, pass `--intent` as only this brief's `## Captain's intent` subsection plus any later words the captain actually said.
For a legacy brief with no such subsection, include only words explicitly labeled `Captain:`, `Captain's words:`, `Captain's ask:`, or `Captain's intent:`; never copy its mixed `# Task` wholesale. If it has no provenance-marked captain words, stop and ask firstmate instead of starting no-mistakes.
Do not include `## Firstmate spec`, later Firstmate build constraints, or your own decisions and tradeoffs.
The `--intent` string you pass must be self-sufficient: that string plus the codebase must let a reader reconstruct roughly the same specification, without depending on a separate report, a PR, or context that lives only in this conversation.
When the captain's intent refers to a report, decision, or PR ("do items 1, 2, 3, and 7 of the report"), write the substance of the referenced items into `--intent` in the captain's terms, not only the pointer; that substance is the captain's ask by reference, while Firstmate's build instructions and your own decisions still stay out.
This replaces the no-mistakes skill's advice to enrich `--intent` with decisions and tradeoffs; that advice does not apply to Firstmate-dispatched work.
Do not hand-edit, commit, or fix findings yourself while a run is active - the pipeline applies every fix.

One drive call blocks until the next gate or outcome, which routinely outlives what your harness lets a single command run: Claude Code kills a command at ten minutes maximum, while one fix round is capped around thirty minutes and up to three rounds chain.
So background the drive call and poll `no-mistakes axi status` from a separate call instead of sitting in one blocking hold your harness will kill.
Where a harness's own command limit is not established, assume it bounds commands and use that same background-and-poll shape.
A killed or timed-out call is never evidence the daemon died: the daemon accepts your response immediately and runs the round in the background, so the call was only ever waiting for a read while the run kept working.
Reattach and keep going rather than reporting the pipeline blocked; rule 7 owns the checks that decide when a pipeline block is real.

Two firstmate-specific rules layer on top of that guidance:
- ask-user findings are never yours to answer: escalate to firstmate using rule 6's ask-user format and stop.
  Firstmate applies `ask-user-authority` and obtains any required captain decision.
  When the decision comes back, feed it to the gate with `no-mistakes axi respond` and let the pipeline apply it - do not route the question to "the user" or implement the fix yourself.
- NEVER pass `--yes` (or `-y`) to `no-mistakes axi run` or `no-mistakes axi respond`. It is banned fleet-wide.
  It auto-resolves every gate including ask-user findings with no escalation, and answering your own ask-user finding is a hard rule violation.

After /no-mistakes reports CI green (the CI-ready return point - do not wait for it to keep monitoring in the background until merge), append `done: PR {url} checks green` and stop. You are finished.
```
</details>
<details>
<summary>Evidence: Trailing-byte comparison proving the newline fix (old ends in single \n, new ends in \n\n)</summary>

```text
=== last 20 bytes hex old ===
2e 20 596f 7520 6172 6520 6669 6e69 7368 . You are finish
6564 2e0a ed..
=== last 20 bytes hex new ===
20 596f 7520 6172 6520 6669 6e69 7368 You are finishe
642e 0a0a d...
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `bash tests/fm-brief.test.sh (all 23 tests pass, including test_script_parses, test_no_heredoc_in_command_substitution, test_ship_modes_generate_clean_briefs for no-mistakes/direct-PR/local-only)`
- `bash -n bin/fm-brief.sh`
- <code>Manual A/B repro: ran base-commit (b1ad702) fm-brief.sh vs fixed (d621a31) fm-brief.sh against identical fm-dod-lib.sh to scaffold a no-mistakes ship brief in isolated FM_HOME dirs, then diffed the two generated brief.md files and inspected trailing bytes with `tail -c 20 | xxd`</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⏭️ **Lint** - skipped</summary>

- ⚠️ linter found issues (exit code 1)

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
