### PR TITLE
fix(fm-pr): parse task metadata as unordered key-value

### DIFF
--- a/bin/fm-pr-lib.sh
+++ b/bin/fm-pr-lib.sh
@@ -285,8 +285,12 @@ fm_pr_regular_destination_on_device_or_absent() {
   [ ! -e "$path" ] || [ "$(fm_pr_file_device "$path")" = "$device" ]
 }
 
+# Task metadata is an unordered key-value record, so exactly one canonical
+# pr= value defines its PR identity. Callers match that identity against the
+# hashed sidecar and identity-bound registration; pr_head= is validated but is
+# neither positional nor part of the PR identity.
 fm_pr_metadata_identity_parse() {
-  local file=$1 line value pr_count=0 seen_pr=0 post_pr_invalid=0
+  local file=$1 line value pr_count=0 pr_head_invalid=0
   FM_PR_META_PROVIDER=
   FM_PR_META_URL=
   FM_PR_META_HOST=
@@ -307,23 +311,16 @@ fm_pr_metadata_identity_parse() {
           FM_PR_META_PATH=$FM_PR_PATH
           FM_PR_META_NUMBER=$FM_PR_NUMBER
         fi
-        seen_pr=1
         ;;
       pr_head=*)
-        if [ "$seen_pr" -eq 1 ]; then
-          value=${line#pr_head=}
-          fm_pr_head_valid "$value" || post_pr_invalid=1
-        fi
+        value=${line#pr_head=}
+        fm_pr_head_valid "$value" || pr_head_invalid=1
         ;;
-      x_request=*|x_request_ts=*|x_followups=*|x_platform=*|x_reply_max_chars=*)
-        ;;
-      *)
-        [ "$seen_pr" -eq 0 ] || post_pr_invalid=1
-        ;;
+      *) ;;
     esac
   done < "$file"
   [ "$pr_count" -eq 1 ] || return 1
-  [ "$post_pr_invalid" -eq 0 ] || return 1
+  [ "$pr_head_invalid" -eq 0 ] || return 1
   [ -n "$FM_PR_META_URL" ]
 }
 

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -3665,6 +3665,8 @@ preserve_relaunch_meta() {
   if [ "$RELAUNCH" -eq 1 ]; then
     preserve_relaunch_meta
   fi
+  # This transaction marker follows preserved durable fields intentionally;
+  # task metadata consumers must identify fields by key rather than position.
   if [ "$SPAWN_CONTROL_PARENT" = 1 ] && [ -n "${FM_CONTROL_RELAUNCH_TX:-}" ]; then
     echo "control_relaunch_tx=$FM_CONTROL_RELAUNCH_TX"
   fi

--- a/tests/fm-control-relaunch.test.sh
+++ b/tests/fm-control-relaunch.test.sh
@@ -17,6 +17,8 @@
 #   6. fm-spawn --relaunch refuses on its own: a live agent, a contradicting
 #      flag, an extra positional, or a backend that cannot prove the previous
 #      agent exited.
+#   7. An open PR's authenticated merge poll survives the transaction metadata
+#      that a relaunch appends after the preserved PR fields.
 set -u
 
 # shellcheck source=tests/lib.sh
@@ -25,11 +27,15 @@ set -u
 . "$ROOT/bin/fm-control-lib.sh"
 # shellcheck source=/dev/null
 . "$ROOT/bin/fm-trace-context-lib.sh"
+# shellcheck source=/dev/null
+. "$ROOT/bin/fm-pr-lib.sh"
 
 CONTROL="$ROOT/bin/fm-control.sh"
 SPAWN="$ROOT/bin/fm-spawn.sh"
 PROMOTE="$ROOT/bin/fm-promote.sh"
 X_LINK="$ROOT/bin/fm-x-link.sh"
+PR_CHECK="$ROOT/bin/fm-pr-check.sh"
+PR_POLL="$ROOT/bin/fm-pr-poll.sh"
 # fm_test_tmproot's own cleanup trap fires when its command substitution exits,
 # so recreate the root before resolving it and clean it up from this file's trap.
 TMP_ROOT=$(fm_test_tmproot fm-control-relaunch)
@@ -198,6 +204,26 @@ run_spawn() {  # <case-dir> <args...>
     HOME="$dir/user-home" CLAUDE_CONFIG_DIR='' \
     FM_SPAWN_NO_GUARD=1 GROK_HOME="$dir/grokhome" \
     "$SPAWN" "$@" 2>&1
+}
+
+arm_pr_poll() {  # <case-dir> <id> <url>
+  local dir=$1 id=$2 url=$3
+  mkdir -p "$dir/pr-root/bin"
+  cat > "$dir/pr-root/bin/fm-guard.sh" <<'SH'
+#!/usr/bin/env bash
+exit 0
+SH
+  chmod +x "$dir/pr-root/bin/fm-guard.sh"
+  cat > "$dir/fakebin/gh" <<'SH'
+#!/usr/bin/env bash
+case "${1:-} ${2:-}" in
+  'pr view') printf '%s\n' 0123456789abcdef0123456789abcdef01234567 ;;
+  *) exit 1 ;;
+esac
+SH
+  chmod +x "$dir/fakebin/gh"
+  FM_ROOT_OVERRIDE="$dir/pr-root" FM_HOME="$dir/home" PATH="$dir/fakebin:$PATH" \
+    "$PR_CHECK" "$id" "$url" >/dev/null
 }
 
 meta_field() {  # <case-dir> <id> <key>
@@ -384,6 +410,30 @@ test_relaunch_preserves_durable_task_metadata() {
   [ "$(meta_field "$dir" rl19 decisions_reviewed)" = 1 ] \
     || fail "the task decision state must survive relaunch"
   pass "fm-control relaunch: durable task metadata survives replacement launch publication"
+}
+
+test_relaunch_keeps_open_pr_poll_authenticated() {
+  local dir untouched out rc url pr_line tx_line
+  url=https://github.com/example/repo/pull/19
+
+  untouched=$(new_case open-pr-untouched rl43)
+  add_ship_task "$untouched" rl43 claude
+  arm_pr_poll "$untouched" rl43 "$url" || fail "could not arm the untouched PR poll fixture"
+  fm_pr_poll_artifacts_valid "$untouched/home/state" rl43 "$PR_POLL" \
+    || fail "an open PR poll became invalid without a relaunch"
+
+  dir=$(new_case open-pr-relaunch rl44)
+  add_ship_task "$dir" rl44 claude
+  arm_pr_poll "$dir" rl44 "$url" || fail "could not arm the relaunched PR poll fixture"
+  out=$(run_control "$dir" rl44 relaunch --note "continue watching the open PR"); rc=$?
+  expect_code 0 "$rc" "an open-PR task should relaunch successfully"$'\n'"$out"
+  pr_line=$(grep -n '^pr=' "$dir/home/state/rl44.meta" | cut -d: -f1)
+  tx_line=$(grep -n '^control_relaunch_tx=' "$dir/home/state/rl44.meta" | cut -d: -f1)
+  [ -n "$pr_line" ] && [ -n "$tx_line" ] && [ "$tx_line" -gt "$pr_line" ] \
+    || fail "the relaunch fixture did not append its transaction marker after PR metadata"
+  fm_pr_poll_artifacts_valid "$dir/home/state" rl44 "$PR_POLL" \
+    || fail "relaunch invalidated the open PR poll after appending its transaction marker"
+  pass "fm-control relaunch: an appended transaction marker leaves open PR polling authenticated"
 }
 
 test_relaunch_serializes_concurrent_durable_metadata_publication() {
@@ -1561,6 +1611,7 @@ test_relaunch_moves_a_drifted_item_back_in_flight() {
 test_same_harness_relaunch_keeps_identity_and_reuses_the_endpoint
 test_relaunch_from_linked_home_preserves_recorded_worktree
 test_relaunch_preserves_durable_task_metadata
+test_relaunch_keeps_open_pr_poll_authenticated
 test_relaunch_serializes_concurrent_durable_metadata_publication
 test_disabled_relaunch_clears_prior_trace_context
 test_relaunch_appends_the_progress_note_to_the_instructions


### PR DESCRIPTION
## Intent

Nach jedem Neustart eines Vorgangs mit offenem PR ist die Merge-Ueberwachung dieses Vorgangs tot. Der Merge wird dann nicht mehr bemerkt. Gemessen 04.09.2026.

## What Changed
- `bin/fm-pr-lib.sh`: `fm_pr_metadata_identity_parse` no longer requires `pr=` to appear before other keys — it dropped the `seen_pr`/`post_pr_invalid` positional gate that rejected identity when any line followed `pr=`, and now validates `pr_head=` independent of line order.
- `bin/fm-spawn.sh`: relaunched tasks now append `control_relaunch_tx=` after the preserved durable fields, since metadata parsing is no longer position-sensitive.
- `tests/fm-control-relaunch.test.sh`: added coverage for metadata parsing after a control relaunch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Risk Assessment

✅ Low: Small, well-scoped fix to one parsing function; root cause matches stated bug (unwhitelisted key after relaunch broke PR identity parse), no other call sites depend on old strict behavior, test exercises real binaries not string matching.

## Testing

Ran the targeted shell test suite tests/fm-control-relaunch.test.sh on the target commit — all cases pass, including the new test_relaunch_keeps_open_pr_poll_authenticated. Verified the regression is real by copying that same test onto the pre-fix base commit (b1ad702) in a disposable worktree, where it fails with the exact reported symptom (open PR poll invalidated after relaunch appends control_relaunch_tx), confirming the fix addresses the measured bug end-to-end.

<details>
<summary>Evidence: fm-control-relaunch.test.sh: regression test result before vs after fix</summary>

```text
On base b1ad702: not ok - relaunch invalidated the open PR poll after appending its transaction marker
On target 8683322: ok - fm-control relaunch: an appended transaction marker leaves open PR polling authenticated
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"8683322f01fac96c7059009b26f8ca1fabff8e9c","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `bash tests/fm-control-relaunch.test.sh (target 8683322, full file, all ok)`
- `bash tests/fm-control-relaunch.test.sh with only new test copied onto base commit b1ad702 in a scratch worktree: reproduces failure pre-fix`
- `git worktree add/remove scratch verification worktree, cleaned up afterward`
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>🔧 **Lint** - 1 issue found → auto-fixed (2) ✅</summary>

- ⚠️ linter found issues (exit code 1)

🔧 Fix: No lint fixes needed; only actionlint-missing finding, already declined
1 warning still open:

- ⚠️ linter found issues (exit code 1)

🔧 Fix: No lint fixes needed, run now clean with pinned tools
✅ Re-checked - no issues remain.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
