### PR TITLE
fix(bin): only claim a task's PR from meta or a ready-signal line

### DIFF
--- a/bin/fm-inactive-reconcile.sh
+++ b/bin/fm-inactive-reconcile.sh
@@ -311,15 +311,19 @@ meta_incarnation() { # <meta>
   printf 'legacy-%s\n' "$(sha256_text "$identity")"
 }
 
-pr_for_task() { # <meta> <status> [preferred-line]
-  local meta=$1 status=$2 preferred=${3:-} value
+# The task's delivered PR. Recorded meta pr= is the only authoritative source;
+# the fallback scrape accepts only a preferred terminal line in a mode's
+# ready-signal shape (`done: PR <url>` or `done: PR <url> checks green`), so a
+# PR a worker merely mentioned in prose is never claimed as the delivery.
+# A scout never delivers a PR, so it never carries one.
+pr_for_task() { # <meta> [preferred-line]
+  local meta=$1 preferred=${2:-} value
+  [ "$(meta_field "$meta" kind)" != scout ] || return 0
   value=$(meta_field "$meta" pr)
   if [ -z "$value" ] && [ -n "$preferred" ]; then
     value=$(printf '%s\n' "$preferred" \
-      | grep -Eo 'https?://[^[:space:])"]+/pull/[0-9]+' | head -1 || true)
-  fi
-  if [ -z "$value" ] && [ -f "$status" ]; then
-    value=$(grep -Eo 'https?://[^[:space:])"]+/pull/[0-9]+' "$status" 2>/dev/null | tail -1 || true)
+      | sed -nE 's|^done: PR (https?://[^[:space:])"]+/pull/[0-9]+)( checks green)?$|\1|p' \
+      | head -1 || true)
   fi
   clean_field "$value"
 }
@@ -398,7 +402,7 @@ report_child_ledger_locked() { # <id> <meta>
   status="$STATE/$id.status"
   last=$(child_terminal_ledger_line "$status") || return 0
   state=$(status_line_verb "$last")
-  pr=$(pr_for_task "$meta" "$status" "$last")
+  pr=$(pr_for_task "$meta" "$last")
   incarnation=$(meta_incarnation "$meta")
   fingerprint=$(sha256_text "$incarnation|$id|$state|ledger|$last")
   previous=$(grep -v '^[[:space:]]*$' "$status" 2>/dev/null \
@@ -496,7 +500,7 @@ reconcile_direct_child_locked() { # <id> <meta> <secondmate-id-or-empty> <timeou
     'state: failed '*) state='failed' ;;
     *) return 0 ;;
   esac
-  pr=$(pr_for_task "$meta" "$status")
+  pr=$(pr_for_task "$meta")
   incarnation=$(meta_incarnation "$meta")
   fingerprint=$(sha256_text "$incarnation|$id|$state|$pr|$(clean_field "$last")")
   if [ -n "$self" ]; then

--- a/tests/fm-inactive-reconcile.test.sh
+++ b/tests/fm-inactive-reconcile.test.sh
@@ -233,7 +233,7 @@ test_secondmate_ledger_delivery_carries_report_and_failure() {
   mkdir -p "$MATE/data/scout"
   printf '# findings\n' > "$MATE/data/scout/report.md"
   write_child "$MATE" boom 'failed: build broke'
-  write_child "$MATE" replaced-pr $'working: old PR https://example.test/owner/repo/pull/11\ndone: replacement PR https://example.test/owner/repo/pull/22'
+  write_child "$MATE" replaced-pr $'working: old PR https://example.test/owner/repo/pull/11\ndone: PR https://example.test/owner/repo/pull/22'
   awk '$0 !~ /^pr=/' "$MATE/state/replaced-pr.meta" > "$MATE/state/replaced-pr.meta.tmp"
   mv "$MATE/state/replaced-pr.meta.tmp" "$MATE/state/replaced-pr.meta"
   FM_FAKE_CREW_STATE='unknown' run_reconcile "$MATE"
@@ -244,8 +244,8 @@ test_secondmate_ledger_delivery_carries_report_and_failure() {
     "$MAIN/state/mate.status" || fail "scout delivery lost its report pointer: $(cat "$MAIN/state/mate.status")"
   grep -Fxq "failed [key=$boom_key]: child boom failed: build broke pr=https://example.test/owner/repo/pull/1 mode=no-mistakes yolo=off" \
     "$MAIN/state/mate.status" || fail "failed line was not delivered under the failed verb: $(cat "$MAIN/state/mate.status")"
-  grep -Fxq "done [key=$replaced_key]: child replaced-pr done: replacement PR https://example.test/owner/repo/pull/22 pr=https://example.test/owner/repo/pull/22 mode=no-mistakes yolo=off" \
-    "$MAIN/state/mate.status" || fail "ledger fallback did not prefer the terminal line PR: $(cat "$MAIN/state/mate.status")"
+  grep -Fxq "done [key=$replaced_key]: child replaced-pr done: PR https://example.test/owner/repo/pull/22 pr=https://example.test/owner/repo/pull/22 mode=no-mistakes yolo=off" \
+    "$MAIN/state/mate.status" || fail "ledger fallback did not prefer the terminal ready line PR: $(cat "$MAIN/state/mate.status")"
   printf 'working: retrying\ndone: fixed on retry\n' >> "$MATE/state/boom.status"
   FM_FAKE_CREW_STATE='unknown' run_reconcile "$MATE"
   boom_key=$(reported_outcome_key "$MATE" boom 'done') || fail "recovered receipt key missing"
@@ -254,6 +254,38 @@ test_secondmate_ledger_delivery_carries_report_and_failure() {
   [ "$(grep -c 'child-outcome-boom-' "$MAIN/state/mate.status")" = 2 ] \
     || fail "recovery delivered the wrong number of lines: $(cat "$MAIN/state/mate.status")"
   pass "ledger delivery carries the report pointer, the failed verb, and each new terminal line"
+}
+
+# A PR URL a worker only ever mentioned in prose is never claimed as the
+# task's delivered PR: without a recorded PR, only a terminal line in the
+# ready-signal shape carries one, and a scout never carries one at all.
+test_pr_field_requires_recorded_pr_or_ready_signal_line() {
+  local id prose_key ready_key scout_key
+  make_world pr-provenance; bind_secondmate local
+  write_child "$MATE" prose $'working: context in https://example.test/other/repo/pull/33\ndone: cleanup finished'
+  write_child "$MATE" ready 'done: PR https://example.test/owner/repo/pull/44 checks green'
+  write_child "$MATE" lookout 'done: PR https://example.test/owner/repo/pull/55'
+  for id in prose ready; do
+    awk '$0 !~ /^pr=/' "$MATE/state/$id.meta" > "$MATE/state/$id.meta.tmp"
+    mv "$MATE/state/$id.meta.tmp" "$MATE/state/$id.meta"
+  done
+  awk '{ sub(/^kind=ship$/, "kind=scout"); print }' "$MATE/state/lookout.meta" \
+    > "$MATE/state/lookout.meta.tmp"
+  mv "$MATE/state/lookout.meta.tmp" "$MATE/state/lookout.meta"
+  FM_FAKE_CREW_STATE='unknown' run_reconcile "$MATE"
+  prose_key=$(reported_outcome_key "$MATE" prose 'done') || fail "prose receipt key missing"
+  ready_key=$(reported_outcome_key "$MATE" ready 'done') || fail "ready receipt key missing"
+  scout_key=$(reported_outcome_key "$MATE" lookout 'done') || fail "scout receipt key missing"
+  grep -Fxq "done [key=$prose_key]: child prose done: cleanup finished mode=no-mistakes yolo=off" \
+    "$MAIN/state/mate.status" \
+    || fail "a PR mentioned only in prose was claimed as the delivery: $(cat "$MAIN/state/mate.status")"
+  grep -Fxq "done [key=$ready_key]: child ready done: PR https://example.test/owner/repo/pull/44 checks green pr=https://example.test/owner/repo/pull/44 mode=no-mistakes yolo=off" \
+    "$MAIN/state/mate.status" \
+    || fail "a ready-signal terminal line did not carry its PR: $(cat "$MAIN/state/mate.status")"
+  grep -Fxq "done [key=$scout_key]: child lookout done: PR https://example.test/owner/repo/pull/55 mode=no-mistakes yolo=off" \
+    "$MAIN/state/mate.status" \
+    || fail "a scout's ready-looking line carried a PR claim: $(cat "$MAIN/state/mate.status")"
+  pass "pr= requires the recorded PR or a ready-signal terminal line, and never a scout"
 }
 
 # If a terminal ledger line lands while the authoritative state read is in
@@ -790,6 +822,7 @@ test_main_direct_terminal_presentation_receipt
 test_local_secondmate_delivers_terminal_ledger_line
 test_busy_child_does_not_starve_later_ledger_outcomes
 test_secondmate_ledger_delivery_carries_report_and_failure
+test_pr_field_requires_recorded_pr_or_ready_signal_line
 test_terminal_line_during_state_read_yields_to_ledger_delivery
 test_terminal_line_after_inactive_delivery_is_not_reported_twice
 test_progress_after_inactive_delivery_starts_a_new_event


### PR DESCRIPTION
## Intent

Captain, 2026-09-10: the effort-impact triage (data/fm-issue-triage-effort-impact-2/report.md) picked three upstream issues and the captain ruled "pick 3 issues and get them done in the firstmate repo": ship this one as a PR to kunchenguid/firstmate. The hard rule from that triage: touch NO hot file (bin/fm-spawn.sh, bin/fm-test-run.sh, bin/fm-teardown.sh, bin/fm-watch.sh, bin/fm-bootstrap.sh, bin/fm-brief.sh, bin/fm-wake-lib.sh, tests/fm-brief.test.sh, tests/fm-teardown.test.sh, docs/scripts.md, docs/configuration.md, AGENTS.md, docs/architecture.md), add no new script and change no documented interface, so the PR cannot deadlock on rebases the way https://github.com/kunchenguid/firstmate/pull/2839 did. Load firstmate-coding-guidelines before editing. The upstream repo requires the no-mistakes attestation on every PR, and its "Behavior portable parallel" shards time out at their 10-minute cap until https://github.com/kunchenguid/firstmate/pull/4123 merges; if that shard is the only red check, close the gate on the evidence that its tests passed and say so in the PR. PR body: "Fixes #<n>" lines, the reproduction, and the test evidence. No co-author. This pick: upstream issue #4099. In bin/fm-inactive-reconcile.sh, pr_for_task (around lines 315-326) reads meta pr= first, then scrapes a PR URL from the preferred line, then falls back to grepping the WHOLE status log with tail -1, so any PR URL a worker ever mentioned in prose, including a scout citing someone else's PR, becomes "the task's delivered PR" in the parent-channel terminal report (embedded as pr=<url> around lines 331-337). Task kind is available in the same script (around line 475) for a scout carve-out.

## What Changed

- Tightened `pr_for_task` in `bin/fm-inactive-reconcile.sh` so a task's delivered PR comes only from the recorded `pr=` meta field or a preferred terminal line in a mode's ready-signal shape (`done: PR <url>` / `done: PR <url> checks green`); removed the fallback that grepped the whole status log with `tail -1`, so a PR URL merely mentioned in prose is never reported as the delivery.
- Added a scout carve-out: `pr_for_task` returns nothing for a `kind=scout` task, so a scout citing someone else's PR never surfaces one in the parent-channel terminal report. Dropped the now-unused `<status>` argument at both call sites.
- Added `test_pr_field_requires_recorded_pr_or_ready_signal_line` and updated the existing ledger-delivery test to assert the new `done: PR <url>` shape.

## Risk Assessment

✅ Low: A tightly scoped fix to a single shared helper that stops prose-mentioned PR URLs from being claimed as deliveries; it matches the DoD-instructed done-line shapes exactly, both call sites are correctly updated, no forbidden hot files are touched, and the change conforms to the authoritative intent.

## Testing

Ran the smallest relevant suite, tests/fm-inactive-reconcile.test.sh, which exercises the reconcile pipeline end-to-end and asserts the actual parent-channel terminal report content rather than source text. All tests pass on the target commit. I confirmed the new test is a true regression by running it against the pre-fix base, where it fails exactly as upstream #4099 describes (a prose-mentioned PR URL and a scout URL both claimed as the delivered PR), then passes after restoring the fix. No screenshot applies: this is a shell/CLI status-log behavior change with no rendered UI surface; the evidence is a CLI before/after transcript.

<details>
<summary>Evidence: pr_for_task provenance before/after transcript</summary>

Source: [pr_for_task provenance before/after transcript](https://github.com/karotkriss/firstmate/blob/f6299bdb8285562d084a02a0e1d9726125e8e90a/.no-mistakes/evidence/fm/fm-inactive-reconcile-prose-pr/pr-provenance-e2e.txt)

<code>BEFORE FIX (base 869ae90): not ok - a PR mentioned only in prose was claimed as the delivery: done [...]: child prose done: cleanup finished pr=https://example.test/other/repo/pull/33 ... (scout lookout line got pr=.../pull/1)&#10;AFTER FIX (target 33727ac): ok - pr= requires the recorded PR or a ready-signal terminal line, and never a scout</code>

```text
=== fm-inactive-reconcile pr_for_task provenance: end-to-end behavior ===

Bug (upstream #4099): pr_for_task scraped a PR URL from the whole status log,
so any URL a worker mentioned in prose (e.g. a scout citing someone else's PR)
became pr=<url> in the parent-channel terminal report.

--- BEFORE FIX (base 869ae90): new regression test fails ---
not ok - a PR mentioned only in prose was claimed as the delivery: done [key=child-outcome-lookout-done-773f04e9]: child lookout done: PR https://example.test/owner/repo/pull/55 pr=https://example.test/owner/repo/pull/1 mode=no-mistakes yolo=off
done [key=child-outcome-prose-done-2d18f95c]: child prose done: cleanup finished pr=https://example.test/other/repo/pull/33 mode=no-mistakes yolo=off

--- AFTER FIX (target 33727ac): same test passes; prose URL dropped, scout carries none, ready-signal keeps its PR ---
ok - pr= requires the recorded PR or a ready-signal terminal line, and never a scout
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"33727ac5ebb0d01d2d3fac1fe714ed5d20dbaea2","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`bash tests/fm-inactive-reconcile.test.sh` on target commit 33727ac - all inactive reconciliation tests pass, including `test_pr_field_requires_recorded_pr_or_ready_signal_line`</code>
- `Regression confirmation: replaced bin/fm-inactive-reconcile.sh with the pre-fix base (869ae90) version and reran the file - the new test fails, wrongly claiming a prose-mentioned URL (pr=.../pull/33) and a stray scout PR; restoring the fix makes it pass`
- `Verified worktree left clean (git status --short empty) after tests`
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>⚠️ **Lint** - 1 warning</summary>

- ⚠️ linter found issues (exit code 1)
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
