### PR TITLE
fix(bin): send no-mistakes workers straight from commit into validation

### DIFF
--- a/bin/fm-dod-lib.sh
+++ b/bin/fm-dod-lib.sh
@@ -218,9 +218,8 @@ EOF
       cat <<EOF
 # Definition of done
 Delivery contract: mode=no-mistakes
-The task is complete only when committed on your branch.
-When you believe it is complete, append \`done: {summary}\` to the status file and stop.
-Firstmate will then instruct you to run /no-mistakes to validate and ship a PR.
+The task is complete only when committed on your branch, validated through /no-mistakes, and delivered as a PR with CI green.
+After your implementation commit, start /no-mistakes yourself, immediately, with the \`--intent\` contract below - do not stop, wait for a firstmate instruction, or append any status line for the unvalidated commit.
 
 You drive no-mistakes by responding to its gates, not by implementing fixes.
 Follow the guidance no-mistakes itself provides for the mechanics: it loads when you invoke /no-mistakes, and \`no-mistakes axi run --help\` plus the \`help\` lines in each \`axi\` response are authoritative and version-matched to the installed binary.

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -260,7 +260,7 @@ test_ship_mode_is_explicit_not_registry() {
   brief="$home/data/brief-explicit-a5/brief.md"
   grep -qx "Delivery contract: mode=no-mistakes" "$brief" \
     || fail "registered direct-PR posture overrode the explicit --mode"
-  assert_grep "Firstmate will then instruct you to run /no-mistakes" "$brief" \
+  assert_grep "start /no-mistakes yourself, immediately" "$brief" \
     "explicit no-mistakes brief did not render the pipeline definition of done"
 
   # An unregistered project is not a blocker either, because nothing is looked up.

--- a/tests/fm-dod-lib.test.sh
+++ b/tests/fm-dod-lib.test.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# Behavioral regressions for fm_dod_block's generated Definition of done.
+# The no-mistakes arm must send the worker straight from its implementation
+# commit into the pipeline: no pre-validation done instruction, and exactly one
+# terminal `done:` form (`done: PR {url} checks green`). The direct-PR and
+# local-only arms are pinned against fixtures so a no-mistakes-arm change
+# cannot silently drift them.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+# shellcheck source=bin/fm-dod-lib.sh
+. "$ROOT/bin/fm-dod-lib.sh"
+
+TMP_ROOT=$(fm_test_tmproot fm-dod-lib)
+
+test_no_mistakes_arm_has_no_pre_validation_done() {
+  local block="$TMP_ROOT/no-mistakes.block"
+  fm_dod_block no-mistakes dod-fixture > "$block" \
+    || fail "fm_dod_block refused the no-mistakes mode"
+  grep -qx 'Delivery contract: mode=no-mistakes' "$block" \
+    || fail "no-mistakes arm lost its machine-readable contract line"
+  # shellcheck disable=SC2016 # Backticks are literal generated Markdown.
+  assert_no_grep 'done: {summary}' "$block" \
+    "no-mistakes arm still tells the worker to report done before validation"
+  assert_no_grep 'Firstmate will then instruct' "$block" \
+    "no-mistakes arm still parks the worker to wait for a firstmate instruction"
+  [ "$(grep -c 'done:' "$block")" -eq 1 ] \
+    || fail "no-mistakes arm must carry exactly one terminal done: form"
+  # shellcheck disable=SC2016 # Backticks are literal generated Markdown.
+  assert_grep 'append `done: PR {url} checks green` and stop' "$block" \
+    "no-mistakes arm lost its terminal CI-green done: form"
+  # shellcheck disable=SC2016 # Backticks are literal generated Markdown.
+  assert_grep 'pass `--intent`' "$block" \
+    "no-mistakes arm no longer carries the --intent contract in the same block"
+  pass "no-mistakes arm goes straight into validation with one terminal done: form"
+}
+
+test_direct_pr_and_local_only_arms_are_unchanged() {
+  local block="$TMP_ROOT/arm.block" expect="$TMP_ROOT/arm.expected"
+
+  fm_dod_block direct-PR dod-fixture > "$block" \
+    || fail "fm_dod_block refused the direct-PR mode"
+  cat > "$expect" <<'EOF'
+# Definition of done
+Delivery contract: mode=direct-PR
+This task ships **direct-PR**: you raise the PR yourself, without the no-mistakes pipeline.
+The task is complete only when committed on your branch.
+When it is implemented and committed, push your branch and open a PR with `gh-axi`, then append `done: PR {url}` to the status file and stop.
+Do NOT run /no-mistakes. The configured merge authority decides whether to merge the PR; firstmate relays the outcome.
+EOF
+  diff -u "$expect" "$block" >&2 || fail "direct-PR arm drifted from its fixture"
+
+  fm_dod_block local-only dod-fixture > "$block" \
+    || fail "fm_dod_block refused the local-only mode"
+  cat > "$expect" <<'EOF'
+# Definition of done
+Delivery contract: mode=local-only
+This task ships **local-only**: no remote, no PR, no pipeline.
+The task is complete only when committed on your branch `fm/dod-fixture`. Do NOT push, do NOT open a PR, do NOT merge.
+Keep your branch a clean fast-forward onto the current default branch - if `main` has advanced, rebase onto it so the eventual merge stays a fast-forward.
+When it is implemented and committed, append `done: ready in branch fm/dod-fixture` to the status file and stop.
+The configured merge authority approves the ready branch, then firstmate merges it into local `main` through the guarded fast-forward path.
+EOF
+  diff -u "$expect" "$block" >&2 || fail "local-only arm drifted from its fixture"
+
+  pass "direct-PR and local-only arms match their pinned fixtures"
+}
+
+test_no_mistakes_arm_has_no_pre_validation_done
+test_direct_pr_and_local_only_arms_are_unchanged


### PR DESCRIPTION
## Intent

Pick 3 issues and get them done in the firstmate repo.
This pick: upstream issues #99, #1033 and #3141 (one defect, three reports). The generated no-mistakes definition of done in bin/fm-dod-lib.sh (fm_dod_block, no-mistakes arm) tells the worker to append a done line and stop as soon as it believes the work is complete, while the same block later requires the done line only after the PR's checks are green. A worker that obeys the first instruction stops before validation, and done is overloaded for an unvalidated commit and a delivered PR. No test asserts the wording.

Fixes #99
Fixes #1033
Fixes #3141

## What Changed

- Rewrote the no-mistakes arm of `fm_dod_block` in `bin/fm-dod-lib.sh` so "done" means committed, validated through `/no-mistakes`, and delivered as a PR with CI green; the worker is now told to start `/no-mistakes` itself immediately after its implementation commit instead of appending a done line and stopping to wait for a firstmate instruction.
- Removed the pre-validation `done: {summary}` instruction, leaving a single terminal `done [at=<epoch>]: PR {url} checks green` form in the generated block.
- Added `tests/fm-dod-lib.test.sh` asserting the arm keeps its contract line, carries the `--intent` reference, drops both the pre-validation done line and the "Firstmate will then instruct" wait, and emits exactly one terminal done form; updated `tests/fm-brief.test.sh` to match the new wording.

## Risk Assessment

✅ Low: A well-bounded prompt-wording change to one delivery-contract arm plus behavioral tests that correctly fail-before/pass-after; the prior fix rounds' work (epoch stamp, snapshot-test removal) is verified correct and no source, correctness, or policy issues remain.

## Testing

<code>I derived the scenarios from the intent (worker must proceed from commit straight into validation; done must not be overloaded onto an unvalidated commit; exactly one terminal done form) and drove the real product surface - the fm_dod_block shell function and its bin/fm-brief.sh emitter - not just source reads. The emitted no-mistakes DoD block now instructs the worker to start /no-mistakes immediately and explicitly &#34;do not stop, wait for a firstmate instruction, or append any status line for the unvalidated commit,&#34; and carries exactly one terminal `done [at=&lt;epoch&gt;]: PR {url} checks green` line. I confirmed the regression by running the behavioral test against the base lib (fails) versus the target lib (passes), and the full fm-brief.sh emitter suite passes end-to-end. This surface is generated worker-facing text (an intentional generated interface), so the captured block itself is the reviewer-visible artifact; there is no graphical UI. Worktree restored clean after the base/target swap.</code>

- Live validation: ✅ go - 5 of 5 scenarios driven live against the product

| Scenario | Result | Live | Evidence |
| --- | --- | --- | --- |
| no-mistakes worker is sent straight from its implementation commit into validation, with no pre-validation done/stop instruction | ✅ pass | live | Emitted block (no-mistakes-dod-block.txt) states &#39;start /no-mistakes yourself, immediately ... do not stop, wait for a firstmate instruction, or append any status line for the unvalidated commit&#39;; `ba… |
| the no-mistakes arm carries exactly one terminal done form, `done [at=&lt;epoch&gt;]: PR {url} checks green` | ✅ pass | live | grep -Fc &#39;done [at=&lt;epoch&gt;]:&#39; over the emitted block returns 1, matching only the terminal CI-green line; asserted by tests/fm-dod-lib.test.sh |
| regression reproduces: the pre-fix wording (base dee119b) is caught and the fix clears it | ✅ pass | live | Running tests/fm-dod-lib.test.sh against base lib fails (&#39;still parks the worker to wait for a firstmate instruction&#39;, exit 1); against target lib it passes (exit 0) |
| the real emitter bin/fm-brief.sh renders a no-mistakes brief containing the fixed straight-into-validation wording | ✅ pass | live | `bash tests/fm-brief.test.sh` runs fm-brief.sh to scaffold a brief.md and asserts it contains &#39;start /no-mistakes yourself, immediately&#39;; whole suite passes (exit 0) |
| adversarial: removing the premature done must not also drop the --intent contract from the same block | ✅ pass | live | Emitted block still contains the `--intent` contract paragraphs; tests/fm-dod-lib.test.sh asserts `pass \`--intent\`` present and passes |

<details>
<summary>Evidence: Emitted no-mistakes Definition-of-done block (as a worker receives it)</summary>

Source: [Emitted no-mistakes Definition-of-done block (as a worker receives it)](https://github.com/karotkriss/firstmate/blob/d13b01a61ca68a2e9787c885f1ff649a2d534245/.no-mistakes/evidence/fm/fm-dod-done-before-validation/no-mistakes-dod-block.txt)

```text
# Definition of done
Delivery contract: mode=no-mistakes
The task is complete only when committed on your branch, validated through /no-mistakes, and delivered as a PR with CI green.
After your implementation commit, start /no-mistakes yourself, immediately, with the `--intent` contract below - do not stop, wait for a firstmate instruction, or append any status line for the unvalidated commit.

You drive no-mistakes by responding to its gates, not by implementing fixes.
Follow the guidance no-mistakes itself provides for the mechanics: it loads when you invoke /no-mistakes, and `no-mistakes axi run --help` plus the `help` lines in each `axi` response are authoritative and version-matched to the installed binary.
When starting no-mistakes, pass `--intent` as only this brief's `## Captain's intent` subsection body, not its heading, plus any later words the captain actually said.
Preserve the actual words without adding speaker labels or direct address; the subsection heading supplies provenance outside the pipeline input.
For a legacy brief with no such subsection, include only words on lines marked `[captain] `, excluding that metadata prefix; never copy its mixed `# Task` wholesale.
If it has no provenance-marked captain words, stop and ask firstmate instead of starting no-mistakes.
Do not include `## Firstmate spec`, later Firstmate build constraints, or your own decisions and tradeoffs.
The `--intent` string you pass must be self-sufficient: that string plus the codebase must let a reader reconstruct roughly the same specification, without depending on a separate report, a PR, or context that lives only in this conversation.
When the captain's intent refers to a report, decision, or PR ("do items 1, 2, 3, and 7 of the report"), write the substance of the referenced items into `--intent` in the captain's terms, not only the pointer; that substance is the captain's ask by reference, while Firstmate's build instructions and your own decisions still stay out.
This replaces the no-mistakes skill's advice to enrich `--intent` with decisions and tradeoffs; that advice does not apply to Firstmate-dispatched work.
Do not hand-edit, commit, or fix findings yourself while a run is active - the pipeline applies every fix.

One drive call blocks until the next gate or outcome, which routinely outlives what your harness lets a single command run: Claude Code kills a command at ten minutes maximum, while one fix round is capped around thirty minutes and up to three rounds chain.
So background the drive call and poll `no-mistakes axi status` from a separate call instead of sitting in one blocking hold your harness will kill.
Where a harness's own command limit is not established, assume it bounds commands and use that same background-and-poll shape.
A killed or timed-out call is never evidence the daemon died: the daemon accepts your response immediately and runs the round in the background, so the call was only ever waiting for a read while the run kept working.
Reattach and keep going rather than reporting the pipeline blocked; rule 7 owns the checks that decide when a pipeline block is real.

Two firstmate-specific rules layer on top of that guidance:
- ask-user findings are never yours to answer: escalate to firstmate using rule 6's ask-user format and stop.
  Firstmate applies `ask-user-authority` and obtains any required captain decision.
  When the decision comes back, feed it to the gate with `no-mistakes axi respond` and let the pipeline apply it - do not route the question to "the user" or implement the fix yourself.
- NEVER pass `--yes` (or `-y`) to `no-mistakes axi run` or `no-mistakes axi respond`. It is banned fleet-wide.
  It auto-resolves every gate including ask-user findings with no escalation, and answering your own ask-user finding is a hard rule violation.

After /no-mistakes reports CI green (the CI-ready return point - do not wait for it to keep monitoring in the background until merge), append `done [at=<epoch>]: PR {url} checks green` and stop. You are finished.
```
</details>
<details>
<summary>Evidence: Regression: fail-before-fix / pass-after-fix</summary>

```text
===== behavioral test against BASE lib (expect FAIL) =====
not ok - no-mistakes arm still parks the worker to wait for a firstmate instruction
BASE_EXIT=1
===== behavioral test against TARGET lib (expect PASS) =====
ok - no-mistakes arm goes straight into validation with one terminal done: form
TARGET_EXIT=0
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"3cb5d7ab595a127189b2f0475301b91d06b7071d","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}],"live_validation":{"verdict":"go","live":5,"total":5}} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>🔧 **Rebase** - 1 issue found → auto-fixed ✅</summary>

- ⚠️ `bin/fm-dod-lib.sh` - merge conflict rebasing onto origin/main

🔧 Fix applied.
✅ Re-checked - no issues remain.
</details>

<details>
<summary>🔧 **Review** - 2 issues found → auto-fixed (2) ✅</summary>

- 🚨 `tests/fm-dod-lib.test.sh:29` - The new test&#39;s terminal-`done` assertions were never updated for the `[at=&lt;epoch&gt;]` stamp the rebase adopted into bin/fm-dod-lib.sh (lines 261, 263, 299). Against the real generated blocks: `grep -c &#39;done:&#39;` returns 0 not 1 (actual line is `done [at=&lt;epoch&gt;]: PR {url} checks green`), `assert_grep &#39;append `done: PR {url} checks green` and stop&#39;` misses, and the direct-PR/local-only heredoc fixtures diverge from the generated output by the missing stamp - so every function in this new file fails as committed. Verified by generating each block with fm_dod_block and comparing. Auto-fixed by inserting the `[at=&lt;epoch&gt;]` stamp in all four places (line 29 count pattern, line 32 assert_grep, and both fixtures).
- ⚠️ `tests/fm-dod-lib.test.sh:40` - test_direct_pr_and_local_only_arms_are_unchanged pins the direct-PR and local-only arms to exact full-block fixtures. The user intent concerns only the no-mistakes arm (&#39;The generated no-mistakes definition of done ... tells the worker to append a done line and stop&#39;); no requirement needs the two untouched arms guarded, and the exact-snapshot form breaks on any legitimate future wording tweak to those arms. Recommend removing this function (keep only the no-mistakes-arm behavioral test) as the smallest remedy; this is a scope question, not a code fix.

🔧 Fix applied.
1 warning still open:

- ⚠️ `tests/fm-dod-lib.test.sh:40` - test_direct_pr_and_local_only_arms_are_unchanged pins the direct-PR and local-only arms to exact full-block fixtures. The user intent concerns only the no-mistakes arm (&#39;tells the worker to append a done line and stop&#39;); fm_dod_block dispatches by a case statement, so editing the no-mistakes arm cannot alter the sibling arms, meaning this snapshot guards nothing for the stated change while breaking on any legitimate future wording tweak to those untouched arms. No intent requirement needs it. Recommend removing this function (keeping only the no-mistakes-arm behavioral test) as the smallest remedy; this is a scope question, not a code fix.

🔧 Fix applied.
✅ Re-checked - no issues remain.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- Live validation: ✅ go - 5 of 5 scenarios driven live against the product

| Scenario | Result | Live | Evidence |
| --- | --- | --- | --- |
| no-mistakes worker is sent straight from its implementation commit into validation, with no pre-validation done/stop instruction | ✅ pass | live | Emitted block (no-mistakes-dod-block.txt) states &#39;start /no-mistakes yourself, immediately ... do not stop, wait for a firstmate instruction, or append any status line for the unvalidated commit&#39;; `ba… |
| the no-mistakes arm carries exactly one terminal done form, `done [at=&lt;epoch&gt;]: PR {url} checks green` | ✅ pass | live | grep -Fc &#39;done [at=&lt;epoch&gt;]:&#39; over the emitted block returns 1, matching only the terminal CI-green line; asserted by tests/fm-dod-lib.test.sh |
| regression reproduces: the pre-fix wording (base dee119b) is caught and the fix clears it | ✅ pass | live | Running tests/fm-dod-lib.test.sh against base lib fails (&#39;still parks the worker to wait for a firstmate instruction&#39;, exit 1); against target lib it passes (exit 0) |
| the real emitter bin/fm-brief.sh renders a no-mistakes brief containing the fixed straight-into-validation wording | ✅ pass | live | `bash tests/fm-brief.test.sh` runs fm-brief.sh to scaffold a brief.md and asserts it contains &#39;start /no-mistakes yourself, immediately&#39;; whole suite passes (exit 0) |
| adversarial: removing the premature done must not also drop the --intent contract from the same block | ✅ pass | live | Emitted block still contains the `--intent` contract paragraphs; tests/fm-dod-lib.test.sh asserts `pass \`--intent\`` present and passes |

- <code>`bash tests/fm-dod-lib.test.sh` (behavioral, passes on target)</code>
- <code>Swapped in base lib (dee119b) and re-ran `bash tests/fm-dod-lib.test.sh` -&gt; fails with &#39;still parks the worker to wait for a firstmate instruction&#39;; restored target -&gt; passes (fail-before-fix/pass-after-fix)</code>
- <code>Sourced bin/fm-dod-lib.sh and ran `fm_dod_block no-mistakes demo-task-123`, capturing the emitted block and grepping for `done [at=&lt;epoch&gt;]:` occurrences (exactly 1)</code>
- <code>`bash tests/fm-brief.test.sh` (real emitter renders brief.md containing &#39;start /no-mistakes yourself, immediately&#39;)</code>
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>