### PR TITLE
fix(bin): rebalance portable parallel test lanes using CI timings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,16 +47,13 @@ jobs:
   tests-portable-parallel-1:
     name: Behavior portable parallel 1
     runs-on: ubuntu-latest
-    # Do not restate the shard wall as a literal here: it was recorded as "~1
-    # min of serial sum", grew past this cap without announcing it, and cancelled
-    # both lanes. `bin/fm-test-run.sh --check-coverage` prints the current
-    # parallel_max_ms, which is the number this cap has to clear.
-    #
-    # On 2026-09-10 that worst lane is ~6.9 min of serial sum, so this 10-minute
-    # cap is still a hang tripwire rather than the expected healthy end of the
-    # lane, but only by about 1.45x. Its sibling serial lane keeps roughly 2x.
-    # Growing the parallel set materially is therefore a trunk decision about
-    # this cap or the lane count, not something a rebalance can absorb again.
+    # This cap is intended as a hang tripwire, but the previous lane 1 reached
+    # it; the former "~1 min of serial sum" estimate no longer applies.
+    # Compare it with the derived hints from fm-test-run.sh --check-coverage
+    # and completed job timings, allowing for setup and runner-speed spread.
+    # A packed hint sum is not a measured job wall time or proof of headroom.
+    # Evidence and refresh procedure: docs/fm-test-portable-shards.md.
+    # Changes to this cap or the lane count require a separate scope decision.
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6
@@ -100,8 +97,7 @@ jobs:
   tests-portable-parallel-2:
     name: Behavior portable parallel 2
     runs-on: ubuntu-latest
-    # Same cap and the same reasoning as shard 1 above. The two lanes are packed
-    # to within a second of each other, so neither is the privileged one.
+    # Same timeout rationale as portable parallel shard 1 above.
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,8 +47,16 @@ jobs:
   tests-portable-parallel-1:
     name: Behavior portable parallel 1
     runs-on: ubuntu-latest
-    # Measured shard wall is ~1 min of serial sum on proven scripts; this cap is
-    # a hang tripwire with margin, not the expected healthy end of the lane.
+    # Do not restate the shard wall as a literal here: it was recorded as "~1
+    # min of serial sum", grew past this cap without announcing it, and cancelled
+    # both lanes. `bin/fm-test-run.sh --check-coverage` prints the current
+    # parallel_max_ms, which is the number this cap has to clear.
+    #
+    # On 2026-09-10 that worst lane is ~6.9 min of serial sum, so this 10-minute
+    # cap is still a hang tripwire rather than the expected healthy end of the
+    # lane, but only by about 1.45x. Its sibling serial lane keeps roughly 2x.
+    # Growing the parallel set materially is therefore a trunk decision about
+    # this cap or the lane count, not something a rebalance can absorb again.
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6
@@ -92,6 +100,8 @@ jobs:
   tests-portable-parallel-2:
     name: Behavior portable parallel 2
     runs-on: ubuntu-latest
+    # Same cap and the same reasoning as shard 1 above. The two lanes are packed
+    # to within a second of each other, so neither is the privileged one.
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6

--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -807,11 +807,7 @@ portable_serial_unhinted() {
   rm -rf "$tmp"
 }
 
-# One scheduling weight lookup for every lane. The parallel hints cover the
-# proven-isolated set and the serial hints cover the remainder, so
-# --list-scheduled ranks a parallel lane on its measured durations instead of
-# handing every one of its scripts the serial default guess.
-script_weight_for() {
+portable_parallel_weight_for() {
   local want=$1 ms
   ms=$(portable_parallel_weight_hints | awk -v want="$want" '$1 == want { print $2; exit }')
   if [ -n "$ms" ]; then
@@ -2023,7 +2019,14 @@ fi
 if [ "$LIST_ONLY" -eq 1 ] || [ "$LIST_SCHEDULED" -eq 1 ]; then
   if [ "$LIST_SCHEDULED" -eq 1 ]; then
     for s in "${SCRIPTS[@]+"${SCRIPTS[@]}"}"; do
-      printf '%s\t%s\n' "$(script_weight_for "$s")" "$s"
+      case "$MODE:$LANE" in
+        lane:portable-parallel-1|lane:portable-parallel-2)
+          printf '%s\t%s\n' "$(portable_parallel_weight_for "$s")" "$s"
+          ;;
+        *)
+          printf '%s\t%s\n' "$(portable_serial_weight_for "$s")" "$s"
+          ;;
+      esac
     done | LC_ALL=C sort -t"$(printf '\t')" -k1,1nr -k2,2 | cut -f2-
   else
     for s in "${SCRIPTS[@]+"${SCRIPTS[@]}"}"; do

--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -36,7 +36,11 @@
 #                   tool this host could not exercise.
 #   --list          print selected script paths (one per line) and exit 0
 #   --list-scheduled
-#                   print selected paths longest-hint-first and exit 0
+#                   print selected paths longest-hint-first and exit 0.
+#                   Only --lane portable-parallel-1 or portable-parallel-2 uses
+#                   parallel hints, falling back to serial weights if missing.
+#                   Every other selection uses serial weights alone.
+#                   Equal weights are ordered by path under LC_ALL=C.
 #   --base <ref>    with --changed, compare against this ref (default: origin/main)
 #   --exclude-family <name>
 #                   drop scripts whose primary family matches <name> after selection
@@ -60,7 +64,7 @@
 #                   family proofs may impose a lower cap. Individually proven
 #                   scripts share one phase; scripts admitted only by a family
 #                   proof run in a separate phase for each family. Concurrent
-#                   phases are ordered longest-hint-first. Unproven stateful
+#                   phases use serial weights, longest-hint-first. Unproven stateful
 #                   scripts run serially after all concurrent phases. Default is
 #                   1 (serial) except for plain --changed and a plain list of
 #                   script paths, which use the bounded automatic scheduler.
@@ -117,9 +121,11 @@
 # owned by bin/fm-test-isolation-proof.sh; portable parallel shards are a
 # duration-balanced partition of that exact set, packed from the measured hints
 # in portable_parallel_weight_hints (see docs/fm-test-portable-shards.md).
-# --check-coverage prints the resulting parallel_max_ms and
-# parallel_imbalance_ms, so what the lanes are balanced to is always a derived
-# number and never a literal in prose that can go stale unnoticed.
+# --check-coverage reports parallel_max_ms (the larger lane hint sum),
+# parallel_imbalance_ms (the absolute difference between the sums), and
+# parallel_unhinted (the number of members missing a parallel hint).
+# These sums exclude unhinted members and are estimates, not measured job wall
+# times. Missing parallel hints are reported without failing this guard.
 #
 # portable-serial stays strictly serial. Its CI shards (portable-serial-<k>of<n>)
 # split it across separate runners, so two of its stateful scripts still never
@@ -467,15 +473,9 @@ tests/fm-x-mode.test.sh
 EOF
 }
 
-# Measured serial duration of every proven-isolated script, one "<path> <ms>"
-# per line, and the single basis the two portable parallel lanes are packed
-# from. The instrument has to match what the lanes actually do: these are
-# serial runs of the real lanes on ubuntu-latest, not the 4-way concurrent
-# local timings in docs/fm-test-isolation-proof.json, which measure isolation
-# rather than lane wall clock. Each value is the slowest of the 2026-09-10 CI
-# runs recorded in docs/fm-test-portable-shards.md, which owns the refresh.
-# --check-coverage derives and prints the resulting lane weights, so the lane
-# duration is a computed number rather than a literal in prose that can rot.
+# Per-script serial CI duration hints, one "<path> <ms>" per line, used to
+# pack only the two portable parallel lanes. Measurement provenance and the
+# refresh procedure are owned by docs/fm-test-portable-shards.md.
 portable_parallel_weight_hints() {
   cat <<'EOF'
 tests/fm-arm-pretool-check.test.sh 30898
@@ -518,8 +518,8 @@ portable_parallel_lane_weight() {
 }
 
 # Portable parallel shard 1: LPT balance of the proven-isolated set over the
-# hints above. Execution order is longest first so wall-clock stays near the
-# balanced sum. tests/fm-pi-primary-types.test.sh belongs to this lane because
+# hints above. Stored order agrees with this lane's --list-scheduled output.
+# tests/fm-pi-primary-types.test.sh belongs to this lane because
 # this is the parallel job that installs the Pi package; moving it needs that
 # workflow step moved with it.
 list_portable_parallel_1() {
@@ -539,9 +539,6 @@ EOF
 }
 
 # Portable parallel shard 2: the complementary LPT half of the proven set.
-# tests/fm-captain-hold-lifecycle.test.sh alone is 36% of the whole parallel
-# set, so it fixes this lane's floor: no two-lane split can run shorter than
-# that one script.
 list_portable_parallel_2() {
   cat <<'EOF'
 tests/fm-captain-hold-lifecycle.test.sh
@@ -1075,10 +1072,8 @@ run_coverage_guard() {
     fi
   fi
 
-  # Report what the two parallel lanes are actually packed to, derived from the
-  # hint table rather than asserted in a comment, so the claim that they are
-  # duration-balanced is a number a reader can re-derive with one command. The
-  # worst lane is what the CI job cap applies to.
+  # Keep these estimates derived from the membership and hint owners; see the
+  # header for the distinction between packed weights and measured job time.
   read -r p1_ms p1_unhinted <<<"$(list_portable_parallel_1 | portable_parallel_lane_weight)"
   read -r p2_ms p2_unhinted <<<"$(list_portable_parallel_2 | portable_parallel_lane_weight)"
   parallel_max_ms=$p1_ms

--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -18,6 +18,7 @@
 #   fm-test-run.sh --list --family <name>
 #   fm-test-run.sh --list --lane portable-parallel-1
 #   fm-test-run.sh --list-scheduled --family <name>
+#   fm-test-run.sh --list-scheduled --lane portable-parallel-1
 #   fm-test-run.sh --list-families
 #   fm-test-run.sh --list-concurrent-safe-families
 #   fm-test-run.sh --concurrent-safe-family-jobs-max <name>
@@ -114,7 +115,11 @@
 # Family labels, the changed-file map, and production portable-shard composition
 # live in this script only (one owner). The proven-isolated candidate set remains
 # owned by bin/fm-test-isolation-proof.sh; portable parallel shards are a
-# duration-balanced partition of that exact set (see docs/fm-test-portable-shards.md).
+# duration-balanced partition of that exact set, packed from the measured hints
+# in portable_parallel_weight_hints (see docs/fm-test-portable-shards.md).
+# --check-coverage prints the resulting parallel_max_ms and
+# parallel_imbalance_ms, so what the lanes are balanced to is always a derived
+# number and never a literal in prose that can go stale unnoticed.
 #
 # portable-serial stays strictly serial. Its CI shards (portable-serial-<k>of<n>)
 # split it across separate runners, so two of its stateful scripts still never
@@ -462,41 +467,96 @@ tests/fm-x-mode.test.sh
 EOF
 }
 
-# Portable parallel shard 1: LPT balance of the proven-isolated set using the
-# current concurrent-proof durations in docs/fm-test-isolation-proof.json.
-# Execution order is longest first so wall-clock stays near the balanced sum.
+# Measured serial duration of every proven-isolated script, one "<path> <ms>"
+# per line, and the single basis the two portable parallel lanes are packed
+# from. The instrument has to match what the lanes actually do: these are
+# serial runs of the real lanes on ubuntu-latest, not the 4-way concurrent
+# local timings in docs/fm-test-isolation-proof.json, which measure isolation
+# rather than lane wall clock. Each value is the slowest of the 2026-09-10 CI
+# runs recorded in docs/fm-test-portable-shards.md, which owns the refresh.
+# --check-coverage derives and prints the resulting lane weights, so the lane
+# duration is a computed number rather than a literal in prose that can rot.
+portable_parallel_weight_hints() {
+  cat <<'EOF'
+tests/fm-arm-pretool-check.test.sh 30898
+tests/fm-backend-herdr.test.sh 22144
+tests/fm-brief.test.sh 1625
+tests/fm-captain-hold-lifecycle.test.sh 296481
+tests/fm-cd-pretool-check.test.sh 16964
+tests/fm-composer-ghost.test.sh 2120
+tests/fm-composer-lib.test.sh 4798
+tests/fm-crew-state.test.sh 11557
+tests/fm-ensure-agents-md.test.sh 901
+tests/fm-grok-harness.test.sh 6563
+tests/fm-herdr-lab.test.sh 6936
+tests/fm-lint.test.sh 164262
+tests/fm-pi-primary-types.test.sh 8624
+tests/fm-pr-merge.test.sh 111145
+tests/fm-review-diff.test.sh 2747
+tests/fm-send-popup-settle.test.sh 4939
+tests/fm-send-settle.test.sh 2051
+tests/fm-send-strict.test.sh 3861
+tests/fm-spawn-batch.test.sh 2265
+tests/fm-supervision-instructions.test.sh 297
+tests/fm-test-run.test.sh 92944
+tests/fm-tmux-submit-busy.test.sh 2477
+tests/fm-transition-lib.test.sh 99
+tests/fm-x-mode.test.sh 31870
+EOF
+}
+
+# Sum the hints above for the scripts read on stdin, and report how many of
+# them had no hint at all, as "<summed_ms> <unhinted_count>".
+portable_parallel_lane_weight() {
+  awk '
+    NR == FNR { if (NF) { hint[$1] = $2 } ; next }
+    NF {
+      if ($1 in hint) { total += hint[$1] } else { unhinted++ }
+    }
+    END { printf "%d %d\n", total + 0, unhinted + 0 }
+  ' <(portable_parallel_weight_hints) -
+}
+
+# Portable parallel shard 1: LPT balance of the proven-isolated set over the
+# hints above. Execution order is longest first so wall-clock stays near the
+# balanced sum. tests/fm-pi-primary-types.test.sh belongs to this lane because
+# this is the parallel job that installs the Pi package; moving it needs that
+# workflow step moved with it.
 list_portable_parallel_1() {
   cat <<'EOF'
-tests/fm-x-mode.test.sh
-tests/fm-cd-pretool-check.test.sh
-tests/fm-captain-hold-lifecycle.test.sh
-tests/fm-test-run.test.sh
-tests/fm-composer-ghost.test.sh
-tests/fm-grok-harness.test.sh
 tests/fm-lint.test.sh
+tests/fm-pr-merge.test.sh
+tests/fm-test-run.test.sh
+tests/fm-cd-pretool-check.test.sh
 tests/fm-pi-primary-types.test.sh
+tests/fm-grok-harness.test.sh
+tests/fm-composer-lib.test.sh
 tests/fm-review-diff.test.sh
+tests/fm-tmux-submit-busy.test.sh
+tests/fm-composer-ghost.test.sh
 tests/fm-brief.test.sh
-tests/fm-transition-lib.test.sh
 EOF
 }
 
 # Portable parallel shard 2: the complementary LPT half of the proven set.
+# tests/fm-captain-hold-lifecycle.test.sh alone is 36% of the whole parallel
+# set, so it fixes this lane's floor: no two-lane split can run shorter than
+# that one script.
 list_portable_parallel_2() {
   cat <<'EOF'
-tests/fm-backend-herdr.test.sh
+tests/fm-captain-hold-lifecycle.test.sh
+tests/fm-x-mode.test.sh
 tests/fm-arm-pretool-check.test.sh
+tests/fm-backend-herdr.test.sh
 tests/fm-crew-state.test.sh
 tests/fm-herdr-lab.test.sh
-tests/fm-pr-merge.test.sh
 tests/fm-send-popup-settle.test.sh
-tests/fm-tmux-submit-busy.test.sh
-tests/fm-send-settle.test.sh
 tests/fm-send-strict.test.sh
 tests/fm-spawn-batch.test.sh
-tests/fm-supervision-instructions.test.sh
+tests/fm-send-settle.test.sh
 tests/fm-ensure-agents-md.test.sh
-tests/fm-composer-lib.test.sh
+tests/fm-supervision-instructions.test.sh
+tests/fm-transition-lib.test.sh
 EOF
 }
 
@@ -747,6 +807,20 @@ portable_serial_unhinted() {
   rm -rf "$tmp"
 }
 
+# One scheduling weight lookup for every lane. The parallel hints cover the
+# proven-isolated set and the serial hints cover the remainder, so
+# --list-scheduled ranks a parallel lane on its measured durations instead of
+# handing every one of its scripts the serial default guess.
+script_weight_for() {
+  local want=$1 ms
+  ms=$(portable_parallel_weight_hints | awk -v want="$want" '$1 == want { print $2; exit }')
+  if [ -n "$ms" ]; then
+    printf '%s\n' "$ms"
+    return 0
+  fi
+  portable_serial_weight_for "$want"
+}
+
 portable_serial_weight_for() {
   local want=$1 path ms
   while read -r path ms; do
@@ -875,6 +949,7 @@ select_lane() {
 
 run_coverage_guard() {
   local tmp missing extra a b shard unhinted serial_total
+  local p1_ms p1_unhinted p2_ms p2_unhinted parallel_max_ms parallel_imbalance_ms
   local -a saved_scripts=()
   tmp=$(mktemp -d "${TMPDIR:-/tmp}/fm-test-coverage.XXXXXX")
 
@@ -1004,9 +1079,23 @@ run_coverage_guard() {
     fi
   fi
 
-  printf 'FM_TEST_COVERAGE ok total=%s parallel=%s serial=%s serial_shards=%s serial_unhinted=%s herdr=%s\n' \
+  # Report what the two parallel lanes are actually packed to, derived from the
+  # hint table rather than asserted in a comment, so the claim that they are
+  # duration-balanced is a number a reader can re-derive with one command. The
+  # worst lane is what the CI job cap applies to.
+  read -r p1_ms p1_unhinted <<<"$(list_portable_parallel_1 | portable_parallel_lane_weight)"
+  read -r p2_ms p2_unhinted <<<"$(list_portable_parallel_2 | portable_parallel_lane_weight)"
+  parallel_max_ms=$p1_ms
+  [ "$p2_ms" -le "$parallel_max_ms" ] || parallel_max_ms=$p2_ms
+  parallel_imbalance_ms=$((p1_ms - p2_ms))
+  [ "$parallel_imbalance_ms" -ge 0 ] || parallel_imbalance_ms=$((-parallel_imbalance_ms))
+
+  printf 'FM_TEST_COVERAGE ok total=%s parallel=%s parallel_max_ms=%s parallel_imbalance_ms=%s parallel_unhinted=%s serial=%s serial_shards=%s serial_unhinted=%s herdr=%s\n' \
     "$(wc -l <"$tmp/all" | tr -d ' ')" \
     "$(wc -l <"$tmp/shards_union" | tr -d ' ')" \
+    "$parallel_max_ms" \
+    "$parallel_imbalance_ms" \
+    "$((p1_unhinted + p2_unhinted))" \
     "$(wc -l <"$tmp/serial" | tr -d ' ')" \
     "$PORTABLE_SERIAL_SHARDS" \
     "$unhinted" \
@@ -1934,7 +2023,7 @@ fi
 if [ "$LIST_ONLY" -eq 1 ] || [ "$LIST_SCHEDULED" -eq 1 ]; then
   if [ "$LIST_SCHEDULED" -eq 1 ]; then
     for s in "${SCRIPTS[@]+"${SCRIPTS[@]}"}"; do
-      printf '%s\t%s\n' "$(portable_serial_weight_for "$s")" "$s"
+      printf '%s\t%s\n' "$(script_weight_for "$s")" "$s"
     done | LC_ALL=C sort -t"$(printf '\t')" -k1,1nr -k2,2 | cut -f2-
   else
     for s in "${SCRIPTS[@]+"${SCRIPTS[@]}"}"; do

--- a/docs/fm-test-portable-shards.md
+++ b/docs/fm-test-portable-shards.md
@@ -5,73 +5,40 @@
 
 ## Verification inputs
 
-Balance hints must be measured on the same instrument the lanes run on, or they describe something other than the lane.
-The lanes were previously packed from the 2026-08-20 concurrent isolation proof in [fm-test-isolation-proof.md](fm-test-isolation-proof.md), which runs 24 candidates across four local workers.
-That record answers whether the candidates are safe to run concurrently, not how long a serial CI lane takes, and by 2026-09-10 the parallel set had grown about 3.2x past it without anything noticing.
-Balance hints now come from serial runs of the real lanes on `ubuntu-latest`.
+Balance hints come from serial runs of the real lanes on `ubuntu-latest`.
+The concurrent isolation proof in [fm-test-isolation-proof.md](fm-test-isolation-proof.md) establishes concurrency safety, not serial CI duration.
+Local timings are not interchangeable with CI timings: platform and machine load can affect each script differently and change their relative weights.
 
-The current hints are the slowest value each script reached across six CI runs on 2026-09-10: [34459949083](https://github.com/kunchenguid/firstmate/actions/runs/34459949083), [34460760299](https://github.com/kunchenguid/firstmate/actions/runs/34460760299), [34462530836](https://github.com/kunchenguid/firstmate/actions/runs/34462530836), [34462758357](https://github.com/kunchenguid/firstmate/actions/runs/34462758357), [34466966385](https://github.com/kunchenguid/firstmate/actions/runs/34466966385), and [34470382458](https://github.com/kunchenguid/firstmate/actions/runs/34470382458).
+The retained hints are the slowest completed value each script reached across six CI runs on 2026-09-10: [34459949083](https://github.com/kunchenguid/firstmate/actions/runs/34459949083), [34460760299](https://github.com/kunchenguid/firstmate/actions/runs/34460760299), [34462530836](https://github.com/kunchenguid/firstmate/actions/runs/34462530836), [34462758357](https://github.com/kunchenguid/firstmate/actions/runs/34462758357), [34466966385](https://github.com/kunchenguid/firstmate/actions/runs/34466966385), and [34470382458](https://github.com/kunchenguid/firstmate/actions/runs/34470382458).
 Shard 2 completed in all six, so its scripts come from the uploaded `fm-test-timing-portable-parallel-2` artifacts.
-Shard 1 was cancelled at its 10-minute cap in five of the six, so its scripts come from the `FM_TEST_END duration_ms=` markers in each cancelled job's log, which record every script that finished before the cancellation, plus the one complete `fm-test-timing-portable-parallel-1` artifact from run 34462758357.
-Taking the slowest of several runs rather than a single run keeps the balance honest on a slow runner.
+Shard 1 was cancelled at its job cap in five of the six, so its scripts come from the `FM_TEST_END duration_ms=` markers in each cancelled job's log, which record every script that finished before the cancellation, plus the one complete `fm-test-timing-portable-parallel-1` artifact from run 34462758357.
+Observed maxima provide conservative packing weights, not an upper bound on future durations.
 
-`n` below is how many of the six runs measured that script; the two scripts at `n=1` are the tail of shard 1 that only the one complete run reached.
+The measurements cover all 24 candidates, with six samples per script except:
 
-| max duration_ms | n | script |
-|---:|---:|---|
-| 296481 | 6 | `tests/fm-captain-hold-lifecycle.test.sh` |
-| 164262 | 4 | `tests/fm-lint.test.sh` |
-| 111145 | 6 | `tests/fm-pr-merge.test.sh` |
-| 92944 | 6 | `tests/fm-test-run.test.sh` |
-| 31870 | 6 | `tests/fm-x-mode.test.sh` |
-| 30898 | 6 | `tests/fm-arm-pretool-check.test.sh` |
-| 22144 | 6 | `tests/fm-backend-herdr.test.sh` |
-| 16964 | 6 | `tests/fm-cd-pretool-check.test.sh` |
-| 11557 | 6 | `tests/fm-crew-state.test.sh` |
-| 8624 | 3 | `tests/fm-pi-primary-types.test.sh` |
-| 6936 | 6 | `tests/fm-herdr-lab.test.sh` |
-| 6563 | 6 | `tests/fm-grok-harness.test.sh` |
-| 4939 | 6 | `tests/fm-send-popup-settle.test.sh` |
-| 4798 | 6 | `tests/fm-composer-lib.test.sh` |
-| 3861 | 6 | `tests/fm-send-strict.test.sh` |
-| 2747 | 3 | `tests/fm-review-diff.test.sh` |
-| 2477 | 6 | `tests/fm-tmux-submit-busy.test.sh` |
-| 2265 | 6 | `tests/fm-spawn-batch.test.sh` |
-| 2120 | 6 | `tests/fm-composer-ghost.test.sh` |
-| 2051 | 6 | `tests/fm-send-settle.test.sh` |
-| 1625 | 1 | `tests/fm-brief.test.sh` |
-| 901 | 6 | `tests/fm-ensure-agents-md.test.sh` |
-| 297 | 6 | `tests/fm-supervision-instructions.test.sh` |
-| 99 | 1 | `tests/fm-transition-lib.test.sh` |
+| Samples | Scripts |
+|---:|---|
+| 4 | `tests/fm-lint.test.sh` |
+| 3 | `tests/fm-pi-primary-types.test.sh`, `tests/fm-review-diff.test.sh` |
+| 1 | `tests/fm-brief.test.sh`, `tests/fm-transition-lib.test.sh` |
 
-Those maxima total 828568 ms, about 13 min 49 s of serial work across the 24 scripts.
-Establish that total before designing a split: a lane cancelled at its cap has no total, only a lower bound, and a split derived from a truncated number describes something other than the lane.
-
-A local run is not a substitute for these hints.
-A 2026-09-10 macOS cross-check of the same scripts, on a developer machine also running other work, came in between 1.7x and 5.0x slower than the runner: `tests/fm-test-run.test.sh` at 157420 ms against 92944 ms, `tests/fm-x-mode.test.sh` at 67217 ms against 31870 ms, and `tests/fm-composer-ghost.test.sh` at 10521 ms against 2120 ms.
-The ratio varies by script, so local timings do not merely scale the lane, they reorder it, and a packing derived from them would balance the wrong thing.
+The two scripts with one sample are the tail of shard 1 that only the complete run reached.
+Collect completed per-script measurements for every member before calculating a split.
+A cancelled lane's elapsed duration is only a lower bound; its unfinished scripts have no completed duration for that invocation.
+The complete historical run supplies tail-script hints, not a completion time for any later cancelled invocation or for the rebalanced jobs.
 
 ## Parallel lanes
 
 The two parallel lanes use longest-processing-time assignment over those hints.
+[`bin/fm-test-run.sh`](../bin/fm-test-run.sh) holds the duration values in `portable_parallel_weight_hints` and the ordered memberships and lane-specific prerequisite constraints beside `list_portable_parallel_1` and `list_portable_parallel_2`.
+Read the derived packing estimates with that runner's `--check-coverage`; its header and `--help` own the output fields and the selection-specific `--list-scheduled` weight rules.
+The largest individual hint sets a lower bound on the estimated duration of any split, regardless of how evenly the remaining work is assigned.
+The CI cap and its rationale are owned by [`.github/workflows/ci.yml`](../.github/workflows/ci.yml).
 
-| Lane | Script count | Packed duration |
-|---|---:|---:|
-| `portable-parallel-1` | 11 | 414269 ms (~6.90 min) |
-| `portable-parallel-2` | 13 | 414299 ms (~6.90 min) |
-| imbalance | | 30 ms |
-
-`bin/fm-test-run.sh` holds the hints in `portable_parallel_weight_hints` and the exact ordered memberships in `list_portable_parallel_1` and `list_portable_parallel_2`.
-Read the current numbers from `bin/fm-test-run.sh --check-coverage`, which prints `parallel_max_ms` and `parallel_imbalance_ms` derived from those lists, rather than trusting the table above.
-
-`tests/fm-pi-primary-types.test.sh` must stay in whichever lane the CI workflow installs the Pi package into, currently `portable-parallel-1`.
-
-Two facts bound any future rebalance of these lanes.
-`tests/fm-captain-hold-lifecycle.test.sh` alone is 296481 ms, 36 percent of the whole set, so no two-lane split can run shorter than that single script.
-Against the 10-minute CI cap, the worst lane at 6.90 min leaves about 1.45x of tripwire margin, where the sibling serial lane keeps roughly 2x, so further growth is a trunk decision about the cap or the lane count rather than something another rebalance absorbs.
-
-Nothing refuses a stale parallel hint the way `PORTABLE_SERIAL_MAX_UNHINTED_PERCENT` bounds the serial lane; `--check-coverage` reports `parallel_unhinted` but does not fail on it.
-Refresh these hints from a green run's `fm-test-timing-portable-parallel-*` artifacts whenever the parallel set gains scripts or a member grows materially.
+[`tests/fm-test-run.test.sh`](../tests/fm-test-run.test.sh), in `test_portable_parallel_lanes_stay_duration_balanced`, requires every parallel member to have a hint and the lane sums to differ by no more than five percent of the larger sum.
+Its scheduling regressions also check stored parallel lane order and preserve serial-weight scheduling for other selections.
+These checks do not detect a script outgrowing an existing hint or establish measured job headroom.
+Refresh `portable_parallel_weight_hints` with the slowest completed `duration_ms` per script from several green CI runs' `fm-test-timing-portable-parallel-*` artifacts whenever the parallel set gains scripts or a member grows materially.
 
 ## Portable serial remainder
 
@@ -151,9 +118,9 @@ Portable shards, each portable serial shard, and the Herdr lane upload runner-ge
 
 | Lane | Bound | Rationale |
 |---|---|---|
-| portable parallel 1/2 | job `timeout-minutes: 10` | The measured shard sums are about three minutes and the timeout is a hang tripwire. |
+| portable parallel 1/2 | See [CI workflow](../.github/workflows/ci.yml) | The workflow owns the parallel cap rationale and its evidence limits. |
 | portable serial 1-5 | job `timeout-minutes: 30` | Current runners can take about 20 minutes; the 30-minute cap remains a hang tripwire while leaving margin for job setup and runner-speed spread. |
 | Herdr | family-run step `timeout-minutes: 20`; job `timeout-minutes: 75` backstop | Healthy runs finished around 7 minutes before this lane gained `fm-backend-herdr-focus-flash-e2e`, which measures about 2 minutes against a real lab locally, so the step bound is still the hang tripwire (cleanup and timing artifacts still upload) while the job cap stays a last-resort backstop. Refresh this figure from the lane's uploaded timing artifact. |
 
-Timeouts are hang tripwires rather than expected healthy durations.
+Timeouts are intended as hang tripwires; a passing coverage guard does not establish a healthy job duration.
 `.github/workflows/ci.yml` owns the exact numbers.

--- a/docs/fm-test-portable-shards.md
+++ b/docs/fm-test-portable-shards.md
@@ -5,47 +5,73 @@
 
 ## Verification inputs
 
-The current candidate timings came from the 2026-08-20 concurrent proof recorded in [fm-test-isolation-proof.md](fm-test-isolation-proof.md).
-The proof ran 24 candidates with four workers and no failures.
+Balance hints must be measured on the same instrument the lanes run on, or they describe something other than the lane.
+The lanes were previously packed from the 2026-08-20 concurrent isolation proof in [fm-test-isolation-proof.md](fm-test-isolation-proof.md), which runs 24 candidates across four local workers.
+That record answers whether the candidates are safe to run concurrently, not how long a serial CI lane takes, and by 2026-09-10 the parallel set had grown about 3.2x past it without anything noticing.
+Balance hints now come from serial runs of the real lanes on `ubuntu-latest`.
 
-| duration_ms | script |
-|---:|---|
-| 45356 | `tests/fm-backend-herdr.test.sh` |
-| 35415 | `tests/fm-x-mode.test.sh` |
-| 35095 | `tests/fm-captain-hold-lifecycle.test.sh` |
-| 27529 | `tests/fm-arm-pretool-check.test.sh` |
-| 20922 | `tests/fm-test-run.test.sh` |
-| 17558 | `tests/fm-crew-state.test.sh` |
-| 16582 | `tests/fm-cd-pretool-check.test.sh` |
-| 9766 | `tests/fm-lint.test.sh` |
-| 9562 | `tests/fm-herdr-lab.test.sh` |
-| 6768 | `tests/fm-grok-harness.test.sh` |
-| 6290 | `tests/fm-pr-merge.test.sh` |
-| 5569 | `tests/fm-composer-ghost.test.sh` |
-| 4563 | `tests/fm-send-popup-settle.test.sh` |
-| 4021 | `tests/fm-tmux-submit-busy.test.sh` |
-| 3544 | `tests/fm-composer-lib.test.sh` |
-| 3025 | `tests/fm-send-strict.test.sh` |
-| 2753 | `tests/fm-send-settle.test.sh` |
-| 2166 | `tests/fm-review-diff.test.sh` |
-| 1315 | `tests/fm-brief.test.sh` |
-| 975 | `tests/fm-spawn-batch.test.sh` |
-| 598 | `tests/fm-pi-primary-types.test.sh` |
-| 513 | `tests/fm-ensure-agents-md.test.sh` |
-| 331 | `tests/fm-supervision-instructions.test.sh` |
-| 99 | `tests/fm-transition-lib.test.sh` |
+The current hints are the slowest value each script reached across six CI runs on 2026-09-10: [34459949083](https://github.com/kunchenguid/firstmate/actions/runs/34459949083), [34460760299](https://github.com/kunchenguid/firstmate/actions/runs/34460760299), [34462530836](https://github.com/kunchenguid/firstmate/actions/runs/34462530836), [34462758357](https://github.com/kunchenguid/firstmate/actions/runs/34462758357), [34466966385](https://github.com/kunchenguid/firstmate/actions/runs/34466966385), and [34470382458](https://github.com/kunchenguid/firstmate/actions/runs/34470382458).
+Shard 2 completed in all six, so its scripts come from the uploaded `fm-test-timing-portable-parallel-2` artifacts.
+Shard 1 was cancelled at its 10-minute cap in five of the six, so its scripts come from the `FM_TEST_END duration_ms=` markers in each cancelled job's log, which record every script that finished before the cancellation, plus the one complete `fm-test-timing-portable-parallel-1` artifact from run 34462758357.
+Taking the slowest of several runs rather than a single run keeps the balance honest on a slow runner.
+
+`n` below is how many of the six runs measured that script; the two scripts at `n=1` are the tail of shard 1 that only the one complete run reached.
+
+| max duration_ms | n | script |
+|---:|---:|---|
+| 296481 | 6 | `tests/fm-captain-hold-lifecycle.test.sh` |
+| 164262 | 4 | `tests/fm-lint.test.sh` |
+| 111145 | 6 | `tests/fm-pr-merge.test.sh` |
+| 92944 | 6 | `tests/fm-test-run.test.sh` |
+| 31870 | 6 | `tests/fm-x-mode.test.sh` |
+| 30898 | 6 | `tests/fm-arm-pretool-check.test.sh` |
+| 22144 | 6 | `tests/fm-backend-herdr.test.sh` |
+| 16964 | 6 | `tests/fm-cd-pretool-check.test.sh` |
+| 11557 | 6 | `tests/fm-crew-state.test.sh` |
+| 8624 | 3 | `tests/fm-pi-primary-types.test.sh` |
+| 6936 | 6 | `tests/fm-herdr-lab.test.sh` |
+| 6563 | 6 | `tests/fm-grok-harness.test.sh` |
+| 4939 | 6 | `tests/fm-send-popup-settle.test.sh` |
+| 4798 | 6 | `tests/fm-composer-lib.test.sh` |
+| 3861 | 6 | `tests/fm-send-strict.test.sh` |
+| 2747 | 3 | `tests/fm-review-diff.test.sh` |
+| 2477 | 6 | `tests/fm-tmux-submit-busy.test.sh` |
+| 2265 | 6 | `tests/fm-spawn-batch.test.sh` |
+| 2120 | 6 | `tests/fm-composer-ghost.test.sh` |
+| 2051 | 6 | `tests/fm-send-settle.test.sh` |
+| 1625 | 1 | `tests/fm-brief.test.sh` |
+| 901 | 6 | `tests/fm-ensure-agents-md.test.sh` |
+| 297 | 6 | `tests/fm-supervision-instructions.test.sh` |
+| 99 | 1 | `tests/fm-transition-lib.test.sh` |
+
+Those maxima total 828568 ms, about 13 min 49 s of serial work across the 24 scripts.
+Establish that total before designing a split: a lane cancelled at its cap has no total, only a lower bound, and a split derived from a truncated number describes something other than the lane.
+
+A local run is not a substitute for these hints.
+A 2026-09-10 macOS cross-check of the same scripts, on a developer machine also running other work, came in between 1.7x and 5.0x slower than the runner: `tests/fm-test-run.test.sh` at 157420 ms against 92944 ms, `tests/fm-x-mode.test.sh` at 67217 ms against 31870 ms, and `tests/fm-composer-ghost.test.sh` at 10521 ms against 2120 ms.
+The ratio varies by script, so local timings do not merely scale the lane, they reorder it, and a packing derived from them would balance the wrong thing.
 
 ## Parallel lanes
 
-The two parallel lanes use longest-processing-time assignment from those measured durations.
+The two parallel lanes use longest-processing-time assignment over those hints.
 
-| Lane | Script count | Estimated duration |
+| Lane | Script count | Packed duration |
 |---|---:|---:|
-| `portable-parallel-1` | 11 | 134295 ms (~134.3 s) |
-| `portable-parallel-2` | 13 | 126020 ms (~126.0 s) |
-| imbalance | | 8275 ms |
+| `portable-parallel-1` | 11 | 414269 ms (~6.90 min) |
+| `portable-parallel-2` | 13 | 414299 ms (~6.90 min) |
+| imbalance | | 30 ms |
 
-`bin/fm-test-run.sh` contains the exact ordered memberships in `list_portable_parallel_1` and `list_portable_parallel_2`.
+`bin/fm-test-run.sh` holds the hints in `portable_parallel_weight_hints` and the exact ordered memberships in `list_portable_parallel_1` and `list_portable_parallel_2`.
+Read the current numbers from `bin/fm-test-run.sh --check-coverage`, which prints `parallel_max_ms` and `parallel_imbalance_ms` derived from those lists, rather than trusting the table above.
+
+`tests/fm-pi-primary-types.test.sh` must stay in whichever lane the CI workflow installs the Pi package into, currently `portable-parallel-1`.
+
+Two facts bound any future rebalance of these lanes.
+`tests/fm-captain-hold-lifecycle.test.sh` alone is 296481 ms, 36 percent of the whole set, so no two-lane split can run shorter than that single script.
+Against the 10-minute CI cap, the worst lane at 6.90 min leaves about 1.45x of tripwire margin, where the sibling serial lane keeps roughly 2x, so further growth is a trunk decision about the cap or the lane count rather than something another rebalance absorbs.
+
+Nothing refuses a stale parallel hint the way `PORTABLE_SERIAL_MAX_UNHINTED_PERCENT` bounds the serial lane; `--check-coverage` reports `parallel_unhinted` but does not fail on it.
+Refresh these hints from a green run's `fm-test-timing-portable-parallel-*` artifacts whenever the parallel set gains scripts or a member grows materially.
 
 ## Portable serial remainder
 

--- a/tests/fm-test-run.test.sh
+++ b/tests/fm-test-run.test.sh
@@ -962,6 +962,63 @@ test_exclude_family() {
   pass "exclude-family drops the named primary family after selection"
 }
 
+test_list_scheduled_proven_isolated_uses_serial_weights() {
+  local tmp
+  tmp=$(fm_test_tmproot fm-test-run-proven-schedule)
+  "$RUNNER" --list --proven-isolated | LC_ALL=C sort >"$tmp/expected"
+  "$RUNNER" --list-scheduled --proven-isolated >"$tmp/actual" \
+    || fail "--list-scheduled --proven-isolated failed"
+  cmp -s "$tmp/expected" "$tmp/actual" \
+    || fail "proven-isolated scheduling must break serial-default ties by path"
+  pass "proven-isolated scheduling ignores parallel hints"
+}
+
+test_list_scheduled_non_lane_selections_use_serial_weights() {
+  local tmp repo script selection
+  local -a scripts=(
+    tests/fm-operational-input.test.sh
+    tests/fm-lint.test.sh
+    tests/fm-muse-harness.test.sh
+    tests/fm-captain-hold-lifecycle.test.sh
+    tests/fm-kimi-harness.test.sh
+    tests/fm-brief.test.sh
+  )
+  tmp=$(fm_test_tmproot fm-test-run-non-lane-schedule)
+  repo="$tmp/repo"
+  mkdir -p "$repo/bin" "$repo/tests"
+  cp "$RUNNER" "$repo/bin/fm-test-run.sh"
+  for script in "${scripts[@]}"; do
+    printf '#!/usr/bin/env bash\nexit 0\n' >"$repo/$script"
+    chmod +x "$repo/$script"
+  done
+  git -C "$repo" init -q
+  git -C "$repo" add .
+  git -C "$repo" -c user.name=test -c user.email=test@example.invalid commit -qm baseline
+  for script in "${scripts[@]}"; do
+    printf '\n' >>"$repo/$script"
+  done
+  printf '%s\n' \
+    tests/fm-muse-harness.test.sh \
+    tests/fm-brief.test.sh \
+    tests/fm-captain-hold-lifecycle.test.sh \
+    tests/fm-lint.test.sh \
+    tests/fm-kimi-harness.test.sh \
+    tests/fm-operational-input.test.sh >"$tmp/expected"
+  for selection in family all changed scripts; do
+    case "$selection" in
+      family) set -- --family pure-contract-unit ;;
+      all) set -- --all ;;
+      changed) set -- --changed --base HEAD ;;
+      scripts) set -- "${scripts[@]}" ;;
+    esac
+    "$repo/bin/fm-test-run.sh" --list-scheduled "$@" >"$tmp/actual" \
+      || fail "--list-scheduled $selection failed"
+    cmp -s "$tmp/expected" "$tmp/actual" \
+      || fail "$selection scheduling must use serial hints and path-ordered default ties"
+  done
+  pass "family, all, changed, and script selections ignore parallel hints"
+}
+
 test_portable_shard_union_and_coverage_guard() {
   local s1 s2 proven serial herdr all_count union_count overlap out lane
   s1=$("$RUNNER" --list --lane portable-parallel-1)
@@ -1627,6 +1684,8 @@ test_a_run_that_ran_records_no_skip_reason
 test_live_guards_expect_a_capability_skip_class
 test_fail_on_gate_skip_token
 test_exclude_family
+test_list_scheduled_proven_isolated_uses_serial_weights
+test_list_scheduled_non_lane_selections_use_serial_weights
 test_portable_shard_union_and_coverage_guard
 test_portable_parallel_lanes_stay_duration_balanced
 test_portable_serial_shards_partition_the_serial_lane

--- a/tests/fm-test-run.test.sh
+++ b/tests/fm-test-run.test.sh
@@ -963,7 +963,7 @@ test_exclude_family() {
 }
 
 test_portable_shard_union_and_coverage_guard() {
-  local s1 s2 proven serial herdr all_count union_count overlap out first
+  local s1 s2 proven serial herdr all_count union_count overlap out lane
   s1=$("$RUNNER" --list --lane portable-parallel-1)
   s2=$("$RUNNER" --list --lane portable-parallel-2)
   proven=$("$RUNNER" --list --proven-isolated)
@@ -991,11 +991,36 @@ test_portable_shard_union_and_coverage_guard() {
   # No duplicates across the four partitions.
   [ "$(printf '%s\n' "$s1" "$s2" "$serial" "$herdr" | LC_ALL=C sort | uniq -d | wc -l | tr -d ' ')" = "0" ] \
     || fail "lanes must not duplicate scripts"
-  # LPT order: first script of shard 1 is the longest proven script.
-  first=$(printf '%s\n' "$s1" | head -n 1)
-  [ "$first" = "tests/fm-x-mode.test.sh" ] \
-    || fail "shard 1 must start with the longest proven script, got $first"
+  # LPT execution order, asserted against the runner's own measured schedule
+  # rather than against a script name: naming the current longest script here is
+  # what let the recorded lane duration go stale unnoticed in the first place.
+  for lane in portable-parallel-1 portable-parallel-2; do
+    [ "$("$RUNNER" --list --lane "$lane")" = "$("$RUNNER" --list-scheduled --lane "$lane")" ] \
+      || fail "$lane membership must be stored longest-measured-first"
+  done
   pass "portable shard union, disjointness, and coverage guard hold"
+}
+
+# The two parallel lanes are only "duration-balanced" while every member has a
+# measured hint and the packing over those hints stays even. Both halves went
+# unchecked until one lane grew past its CI job cap and was cancelled on every
+# run, so assert them through the guard's own reported numbers.
+test_portable_parallel_lanes_stay_duration_balanced() {
+  local out max imbalance unhinted
+  out=$("$RUNNER" --check-coverage)
+  unhinted=$(printf '%s\n' "$out" | sed -n 's/.*parallel_unhinted=\([0-9]*\).*/\1/p')
+  max=$(printf '%s\n' "$out" | sed -n 's/.*parallel_max_ms=\([0-9]*\).*/\1/p')
+  imbalance=$(printf '%s\n' "$out" | sed -n 's/.*parallel_imbalance_ms=\([0-9]*\).*/\1/p')
+  [ -n "$unhinted" ] && [ -n "$max" ] && [ -n "$imbalance" ] \
+    || fail "coverage guard must report parallel_unhinted, parallel_max_ms, parallel_imbalance_ms: $out"
+  [ "$unhinted" = "0" ] \
+    || fail "$unhinted proven-isolated scripts have no measured parallel hint, so the lanes are packed on a guess"
+  [ "$max" -gt 0 ] || fail "parallel_max_ms must be a positive packed duration, got $max"
+  # 5% of the worst lane: wide enough that one script's growth does not trip it,
+  # narrow enough that a lopsided partition cannot call itself balanced.
+  [ "$((imbalance * 20))" -le "$max" ] \
+    || fail "parallel lanes differ by ${imbalance}ms against a ${max}ms worst lane, more than 5%"
+  pass "portable parallel lanes are fully hinted and packed within 5% of each other"
 }
 
 test_portable_serial_shards_partition_the_serial_lane() {
@@ -1603,6 +1628,7 @@ test_live_guards_expect_a_capability_skip_class
 test_fail_on_gate_skip_token
 test_exclude_family
 test_portable_shard_union_and_coverage_guard
+test_portable_parallel_lanes_stay_duration_balanced
 test_portable_serial_shards_partition_the_serial_lane
 test_portable_serial_hint_coverage_is_reported_and_bounded
 test_portable_serial_shard_lane_refusals


### PR DESCRIPTION
## Intent

THE CAPTAIN RULED THIS HIMSELF on 2026-09-10 as a NAMED EXCEPTION to the development pause now in force. His words: "Oui, rééquilibre les voies" - yes, rebalance the lanes. The exception authorises rebalancing the TWO PORTABLE PARALLEL LANES and nothing else. It extends to nothing by analogy and the pause holds everywhere else.

WHAT IT UNBLOCKS, so you know what depends on this: that lane cut BOTH of today's deliveries, and the maintainer's triage says one of them becomes eligible for automatic merge once integration is fully green. A security fix is sitting blocked behind an imbalance in our own configuration.

WHAT IS MEASURED AND YOU DO NOT NEED TO RE-ESTABLISH: across the two requests raised today, parallel lane 2 finished in 3 min 21 s and 3 min 34 s, while parallel lane 1 was CANCELLED at 10 min 16 s and 10 min 18 s against the ten-minute cap the workflow sets for both. Roughly a three-to-one split, on two lanes our own workflow comment documents as "duration-balanced".

READ THAT COMMENT BEFORE YOU START, at .github/workflows/ci.yml around line 44. It says the measured shard wall is about ONE MINUTE of serial sum, and that the ten-minute cap is "a hang tripwire with margin, not the expected healthy end of the lane". Lane 1 now runs at least ten times that. So this is not only an imbalance: a recorded fact stopped being true without announcing it, and a tripwire has quietly become the binding constraint. Both halves belong in what you deliver.

THE TRAP, NAMED IN ADVANCE SO YOU DO NOT FALL INTO IT - and it is the most important instruction here: THE TRUE DURATION OF LANE 1 IS UNKNOWN. It has never finished. All anyone knows is that it exceeds 10 min 16 s. Deriving a split from a TRUNCATED measurement would be precisely the defect this fleet has spent three days extracting - a number that describes something other than what it claims. A cancelled lane also uploads no timing artifact, so the usual evidence does not exist for it.

## What Changed

- Rebalance the two portable parallel lanes using completed per-script CI timing hints, and apply those hints to lane-specific `--list-scheduled` output.
- Add coverage metrics and regressions for hint coverage, lane ordering, a maximum 5% estimated imbalance, and serial-weight scheduling for other selections.
- Correct stale workflow duration claims and document timing provenance, cancellation limits, and hint refresh guidance, distinguishing packing estimates from measured job durations.

## Risk Assessment

✅ Low: The rebalance uses verified complete per-script measurements, preserves coverage and prerequisites, and confines scheduling changes to the two authorized parallel lanes.

## Testing

Focused runner tests, base/head CLI comparisons, adversarial selectors, controlled regression checks, workflow parsing and historical-artifact checks passed; CLI evidence was saved and fixtures removed, while complete Ubuntu lane execution remains untested.

- Live validation: ⚠️ inconclusive - 4 of 5 scenarios driven live against the product

| Scenario | Result | Live | Evidence |
| --- | --- | --- | --- |
| Inspect both parallel lanes and receive the complete candidate partition in duration order | ✅ pass | live | Live scheduling CLI transcript: both lanes’ --list and --list-scheduled outputs match; their disjoint union contains all 24 candidates, with the Pi test retained in lane 1. |
| Run the coverage command and receive computed balance and measurement-coverage values | ✅ pass | live | bin/fm-test-run.sh --check-coverage reports parallel_max_ms=414299, parallel_imbalance_ms=30, parallel_unhinted=0. |
| Schedule selections outside the two parallel lanes and preserve pre-change output | ✅ pass | live | scheduling-results.json: 36 byte-identical base/head comparisons covering every family, proven-isolated, all, changed, explicit paths, serial lanes and retained memberships. |
| Attempt to bypass the two-lane boundary using invalid or combined selectors and receive a refusal | ✅ pass | live | Live scheduling CLI transcript: an unknown third lane and four mixed-selector combinations exit 2 without scheduled output. |
| Execute both complete rebalanced Ubuntu jobs below their ten-minute caps and obtain timing artifacts | ⏸️ untested | no | This phase has no authority to launch CI or execute the lanes’ lint workload. The outer executor must run both target-head Ubuntu jobs and verify completed timing artifacts. |

<details>
<summary>Evidence: Live scheduling CLI transcript</summary>

Source: [Live scheduling CLI transcript](https://github.com/mremond/firstmate/blob/635e7a876fc5d920540bc7f4c94fbe84943d7c37/.no-mistakes/evidence/fm/fm-parallel-lane-cancels-at-its-own-cap/scheduling-cli.log)

```text
$ /bin/bash ~/.no-mistakes/worktrees/acf4a767348a/01M25NFVQ8EEP6P6ZERGFSAPA4/bin/fm-test-run.sh --list-families
pure-contract-unit
watcher-wake-lock
real-herdr-gated
secondmate
session-bootstrap
live-harness-optin
backend-dispatch
pr-forge
afk
snapshot-bearings
cmux
zellij
orca
standalone
unclassified
[exit=0]

$ /bin/bash ~/.no-mistakes/worktrees/acf4a767348a/01M25NFVQ8EEP6P6ZERGFSAPA4/bin/fm-test-run.sh --list-lanes
portable-parallel-1
portable-parallel-2
portable-serial
portable-serial-1of5
portable-serial-2of5
portable-serial-3of5
portable-serial-4of5
portable-serial-5of5
real-herdr-gated
[exit=0]

$ /bin/bash ~/.no-mistakes/worktrees/acf4a767348a/01M25NFVQ8EEP6P6ZERGFSAPA4/bin/.nm-test-base.sh --list-scheduled --proven-isolated
tests/fm-arm-pretool-check.test.sh
tests/fm-backend-herdr.test.sh
tests/fm-brief.test.sh
tests/fm-captain-hold-lifecycle.test.sh
tests/fm-cd-pretool-check.test.sh
tests/fm-composer-ghost.test.sh
tests/fm-composer-lib.test.sh
tests/fm-crew-state.test.sh
tests/fm-ensure-agents-md.test.sh
tests/fm-grok-harness.test.sh
tests/fm-herdr-lab.test.sh
tests/fm-lint.test.sh
tests/fm-pi-primary-types.test.sh
tests/fm-pr-merge.test.sh
tests/fm-review-diff.test.sh
tests/fm-send-popup-settle.test.sh
tests/fm-send-settle.test.sh
tests/fm-send-strict.test.sh
tests/fm-spawn-batch.test.sh
tests/fm-supervision-instructions.test.sh
tests/fm-test-run.test.sh
tests/fm-tmux-submit-busy.test.sh
tests/fm-transition-lib.test.sh
tests/fm-x-mode.test.sh
[exit=0]

$ /bin/bash ~/.no-mistakes/worktrees/acf4a767348a/01M25NFVQ8EEP6P6ZERGFSAPA4/bin/fm-test-run.sh --list-scheduled --proven-isolated
tests/fm-arm-pretool-check.test.sh
tests/fm-backend-herdr.test.sh
tests/fm-brief.test.sh
tests/fm-captain-hold-lifecycle.test.sh
tests/fm-cd-pretool-check.test.sh
tests/fm-composer-ghost.test.sh
tests/fm-composer-lib.test.sh
tests/fm-crew-state.test.sh
tests/fm-ensure-agents-md.test.sh
tests/fm-grok-harness.test.sh
tests/fm-herdr-lab.test.sh
tests/fm-lint.test.sh
tests/fm-pi-primary-types.test.sh
tests/fm-pr-merge.test.sh
tests/fm-review-diff.test.sh
tests/fm-send-popup-settle.test.sh
tests/fm-send-settle.test.sh
tests/fm-send-strict.test.sh
tests/fm-spawn-batch.test.sh
tests/fm-supervision-instructions.test.sh
tests/fm-test-run.test.sh
tests/fm-tmux-submit-busy.test.sh
tests/fm-transition-lib.test.sh
tests/fm-x-mode.test.sh
[exit=0]

$ /bin/bash ~/.no-mistakes/worktrees/acf4a767348a/01M25NFVQ8EEP6P6ZERGFSAPA4/bin/.nm-test-base.sh --list-scheduled --all
tests/fm-watch-triage.test.sh
tests/fm-remote-secondmate-lifecycle-e2e.test.sh
tests/fm-public-followup.test.sh
tests/fm-pr-check-security.test.sh
tests/fm-backlog-atomicity.test.sh
tests/fm-session-start.test.sh
tests/fm-secondmate-harness.test.sh
tests/fm-secondmate-restart.test.sh
tests/fm-bearings-snapshot.test.sh
tests/fm-remote-reply.test.sh
tests/fm-teardown.test.sh
tests/fm-watcher-lock.test.sh
tests/fm-pending-reply.test.sh
tests/fm-inactive-reconcile.test.sh
tests/fm-procevent.test.sh
tests/fm-watch-arm.test.sh
tests/fm-remote-secondmate-trace-context.test.sh
tests/fm-sessionstart-nudge.test.sh
tests/fm-spawn-dispatch-profile.test.sh
tests/fm-remote-transport-lanes.test.sh
tests/fm-secondmate-reconcile.test.sh
tests/fm-startup-network.test.sh
tests/fm-claude-stop-autoarm.test.sh
tests/fm-omp-harness.test.sh
tests/fm-remote-job.test.sh
tests/fm-watch-recovery-loop.test.sh
tests/fm-secondmate-safety.test.sh
tests/fm-wake-queue.test.sh
tests/fm-muse-harness.test.sh
tests/fm-cursor-primary.test.sh
tests/fm-control.test.sh
tests/fm-backlog-handoff.test.sh
tests/fm-busy-adapter-wiring.test.sh
tests/fm-control-relaunch.test.sh
tests/fm-trace-context-spawn.test.sh
tests/fm-vendor-auth-probe.test.sh
tests/fm-pi-watch-extension.test.sh
tests/fm-turnend-guard.test.sh
tests/fm-remote-backlog-handoff.test.sh
tests/fm-send-inbox.test.sh
tests/fm-classify-corr-token.test.sh
tests/fm-fleet-sync.test.sh
tests/fm-afk-inject-e2e.test.sh
tests/fm-wake-drain-unread-status.test.sh
tests/fm-spawn-pool-base-freshen.test.sh
tests/fm-home-summary-refresh.test.sh
tests/fm-on.test.sh
tests/fm-guard-stale-banner.test.sh
tests/fm-cursor-harness.test.sh
tests/fm-remote-secondmate-parent-binding.test.sh
tests/fm-voice-relay.test.sh
tests/fm-send-remote-delivery.test.sh
tests/fm-afk-inject-herdr-e2e.test.sh
tests/fm-afk-launch.test.sh
tests/fm-arm-pretool-check.test.sh
tests/fm-backend-autodetect-smoke.test.sh
tests/fm-backend-herdr-eventwait-smoke.test.sh
tests/fm-backend-herdr-focus-flash-e2e.test.sh
tests/fm-backend-herdr-launcher-workspace-e2e.test.sh
tests/fm-backend-herdr-presentation-e2e.test.sh
tests/fm-backend-herdr-prune-safety-e2e.test.sh
tests/fm-backend-herdr-respawn-idem-e2e.test.sh
tests/fm-backend-herdr-smoke.test.sh
tests/fm-backend-herdr-workspace-per-home-e2e.test.sh
tests/fm-backend-herdr.test.sh
tests/fm-bearings-board-lavish-live-e2e.test.sh
tests/fm-brief.test.sh
tests/fm-captain-hold-lifecycle.test.sh
tests/fm-cd-pretool-check.test.sh
tests/fm-claude-trust.test.sh
tests/fm-composer-ghost.test.sh
tests/fm-composer-lib.test.sh
tests/fm-control-herdr-smoke.test.sh
tests/fm-crew-state.test.sh
tests/fm-ensure-agents-md.test.sh
tests/fm-gemini-harness.test.sh
tests/fm-grok-harness.test.sh
tests/fm-herdr-lab.test.sh
tests/fm-herdr-session-cleanup-e2e.test.sh
tests/fm-lint.test.sh
tests/fm-mail-check.test.sh
tests/fm-mail.test.sh
tests/fm-nm-test-contract.test.sh
tests/fm-omp-primary-live-e2e.test.sh
tests/fm-pi-codex-native.test.sh
tests/fm-pi-primary-types.test.sh
tests/fm-pr-merge.test.sh
tests/fm-review-diff.test.sh
tests/fm-rovo-harness.test.sh
tests/fm-rovo-signals-live-e2e.test.sh
tests/fm-send-popup-settle.test.sh
tests/fm-send-settle.test.sh
tests/fm-send-strict.test.sh
tests/fm-spawn-batch.test.sh
tests/fm-stat-shadowing.test.sh
tests/fm-supervision-instructions.test.sh
tests/fm-test-run.test.sh
tests/fm-tmux-submit-busy.test.sh
tests/fm-transition-lib.test.sh
tests/fm-x-mode.test.sh
tests/fm-daemon.test.sh
tests/fm-task-inbox.test.sh
tests/fm-bootstrap.test.sh
tests/fm-pi-branch-extension.test.sh
tests/fm-wake-drain-open-decisions-cursor.test.sh
tests/fm-backend.test.sh
tests/fm-send-resolve-key.test.sh
tests/fm-backend-orca.test.sh
tests/fm-secondmate-liveness.test.sh
tests/fm-kimi-harness.test.sh
tests/fm-procevent-when.test.sh
tests/fm-secondmate-sync.test.sh
tests/fm-wake-drain-outcome-backstop.test.sh
tests/fm-tool-update-check.test.sh
tests/fm-tangle-guard.test.sh
tests/fm-backend-zellij.test.sh
tests/fm-secondmate-lifecycle-e2e.test.sh
tests/fm-fleet-snapshot-view.test.sh
tests/fm-bootstrap-network-parallel.test.sh
tests/fm-extension-binding.test.sh
tests/fm-wake-daemon-lifecycle-e2e.test.sh
tests/fm-startup-memory-budget.test.sh
tests/fm-herdr-session-cleanup.test.sh
tests/fm-send-secondmate-marker.test.sh
tests/fm-wake-drain-open-decisions.test.sh
tests/fm-shared-captain-inheritance.test.sh
tests/fm-live-gate.test.sh
tests/fm-task-delivery.test.sh
tests/fm-watch-checkpoint.test.sh
tests/fm-branch-supervision.test.sh
tests/fm-spawn-worktree-settle.test.sh
tests/fm-update.test.sh
tests/fm-remote-doctor.test.sh
tests/fm-pi-windows-shell-invocation.test.sh
tests/fm-gate-refuse.test.sh
tests/fm-teardown-endpoint-safety.test.sh
tests/fm-bearings-board.test.sh
tests/fm-backend-cmux.test.sh
tests/fm-stow-cascade.test.sh
tests/fm-afk-contract.test.sh
tests/fm-remote-job-orphan-reap.test.sh
tests/fm-busy-state.test.sh
tests/fm-test-isolation-proof.test.sh
tests/fm-procevent-quota.test.sh
tests/fm-afk-return.test.sh
tests/fm-bearings-board-render.test.sh
tests/fm-tmux-agent-liveness.test.sh
tests/fm-remote-herdr-guard.test.sh
tests/fm-quota-choose.test.sh
tests/fm-session-lock-ancestry.test.sh
tests/fm-gotmp.test.sh
tests/fm-classify-decision-key.test.sh
tests/fm-subagent-pretool-check.test.sh
tests/fm-peek-remote.test.sh
tests/fm-test-fixture-cleanup.test.sh
tests/fm-lint-workflows.test.sh
tests/fm-documentation-audiences.test.sh
tests/fm-supervision-events.test.sh
tests/fm-check-unregister.test.sh
tests/fm-backend-tmux-smoke.test.sh
tests/fm-no-mistakes-required.test.sh
tests/fm-calm-pi-extension.test.sh
tests/fm-operational-input.t

... [97507 bytes truncated] ...

4/bin/fm-test-run.sh --list --lane portable-serial-5of5
tests/fm-backlog-atomicity.test.sh
tests/fm-session-start.test.sh
tests/fm-watcher-lock.test.sh
tests/fm-remote-secondmate-trace-context.test.sh
tests/fm-startup-network.test.sh
tests/fm-secondmate-safety.test.sh
tests/fm-control-relaunch.test.sh
tests/fm-vendor-auth-probe.test.sh
tests/fm-classify-corr-token.test.sh
tests/fm-cursor-harness.test.sh
tests/fm-voice-relay.test.sh
tests/fm-mail-check.test.sh
tests/fm-rovo-harness.test.sh
tests/fm-bootstrap.test.sh
tests/fm-secondmate-sync.test.sh
tests/fm-secondmate-lifecycle-e2e.test.sh
tests/fm-extension-binding.test.sh
tests/fm-wake-drain-open-decisions.test.sh
tests/fm-watch-checkpoint.test.sh
tests/fm-remote-doctor.test.sh
tests/fm-afk-contract.test.sh
tests/fm-test-isolation-proof.test.sh
tests/fm-session-lock-ancestry.test.sh
tests/fm-test-fixture-cleanup.test.sh
tests/fm-backend-tmux-smoke.test.sh
tests/fm-calm-pi-extension.test.sh
tests/fm-ask-user-authority.test.sh
tests/fm-send-secondmate-marker-herdr-e2e.test.sh
tests/fm-herdr-version-floor-live-e2e.test.sh
tests/fm-codex-continuity-live-e2e.test.sh
tests/fm-pi-branch-responsiveness-live-e2e.test.sh
tests/fm-sessionstart-hook-live-e2e.test.sh
[exit=0]

$ /bin/bash ~/.no-mistakes/worktrees/acf4a767348a/01M25NFVQ8EEP6P6ZERGFSAPA4/bin/.nm-test-base.sh --list --lane real-herdr-gated
tests/fm-afk-inject-herdr-e2e.test.sh
tests/fm-afk-launch.test.sh
tests/fm-backend-autodetect-smoke.test.sh
tests/fm-backend-herdr-eventwait-smoke.test.sh
tests/fm-backend-herdr-focus-flash-e2e.test.sh
tests/fm-backend-herdr-launcher-workspace-e2e.test.sh
tests/fm-backend-herdr-presentation-e2e.test.sh
tests/fm-backend-herdr-prune-safety-e2e.test.sh
tests/fm-backend-herdr-respawn-idem-e2e.test.sh
tests/fm-backend-herdr-smoke.test.sh
tests/fm-backend-herdr-workspace-per-home-e2e.test.sh
tests/fm-control-herdr-smoke.test.sh
tests/fm-herdr-session-cleanup-e2e.test.sh
[exit=0]

$ /bin/bash ~/.no-mistakes/worktrees/acf4a767348a/01M25NFVQ8EEP6P6ZERGFSAPA4/bin/fm-test-run.sh --list --lane real-herdr-gated
tests/fm-afk-inject-herdr-e2e.test.sh
tests/fm-afk-launch.test.sh
tests/fm-backend-autodetect-smoke.test.sh
tests/fm-backend-herdr-eventwait-smoke.test.sh
tests/fm-backend-herdr-focus-flash-e2e.test.sh
tests/fm-backend-herdr-launcher-workspace-e2e.test.sh
tests/fm-backend-herdr-presentation-e2e.test.sh
tests/fm-backend-herdr-prune-safety-e2e.test.sh
tests/fm-backend-herdr-respawn-idem-e2e.test.sh
tests/fm-backend-herdr-smoke.test.sh
tests/fm-backend-herdr-workspace-per-home-e2e.test.sh
tests/fm-control-herdr-smoke.test.sh
tests/fm-herdr-session-cleanup-e2e.test.sh
[exit=0]

$ /bin/bash ~/.no-mistakes/worktrees/acf4a767348a/01M25NFVQ8EEP6P6ZERGFSAPA4/bin/fm-test-run.sh --list --lane portable-parallel-1
tests/fm-lint.test.sh
tests/fm-pr-merge.test.sh
tests/fm-test-run.test.sh
tests/fm-cd-pretool-check.test.sh
tests/fm-pi-primary-types.test.sh
tests/fm-grok-harness.test.sh
tests/fm-composer-lib.test.sh
tests/fm-review-diff.test.sh
tests/fm-tmux-submit-busy.test.sh
tests/fm-composer-ghost.test.sh
tests/fm-brief.test.sh
[exit=0]

$ /bin/bash ~/.no-mistakes/worktrees/acf4a767348a/01M25NFVQ8EEP6P6ZERGFSAPA4/bin/fm-test-run.sh --list-scheduled --lane portable-parallel-1
tests/fm-lint.test.sh
tests/fm-pr-merge.test.sh
tests/fm-test-run.test.sh
tests/fm-cd-pretool-check.test.sh
tests/fm-pi-primary-types.test.sh
tests/fm-grok-harness.test.sh
tests/fm-composer-lib.test.sh
tests/fm-review-diff.test.sh
tests/fm-tmux-submit-busy.test.sh
tests/fm-composer-ghost.test.sh
tests/fm-brief.test.sh
[exit=0]

$ /bin/bash ~/.no-mistakes/worktrees/acf4a767348a/01M25NFVQ8EEP6P6ZERGFSAPA4/bin/fm-test-run.sh --list-scheduled --lane=portable-parallel-1
tests/fm-lint.test.sh
tests/fm-pr-merge.test.sh
tests/fm-test-run.test.sh
tests/fm-cd-pretool-check.test.sh
tests/fm-pi-primary-types.test.sh
tests/fm-grok-harness.test.sh
tests/fm-composer-lib.test.sh
tests/fm-review-diff.test.sh
tests/fm-tmux-submit-busy.test.sh
tests/fm-composer-ghost.test.sh
tests/fm-brief.test.sh
[exit=0]

$ /bin/bash ~/.no-mistakes/worktrees/acf4a767348a/01M25NFVQ8EEP6P6ZERGFSAPA4/bin/fm-test-run.sh --list --lane portable-parallel-2
tests/fm-captain-hold-lifecycle.test.sh
tests/fm-x-mode.test.sh
tests/fm-arm-pretool-check.test.sh
tests/fm-backend-herdr.test.sh
tests/fm-crew-state.test.sh
tests/fm-herdr-lab.test.sh
tests/fm-send-popup-settle.test.sh
tests/fm-send-strict.test.sh
tests/fm-spawn-batch.test.sh
tests/fm-send-settle.test.sh
tests/fm-ensure-agents-md.test.sh
tests/fm-supervision-instructions.test.sh
tests/fm-transition-lib.test.sh
[exit=0]

$ /bin/bash ~/.no-mistakes/worktrees/acf4a767348a/01M25NFVQ8EEP6P6ZERGFSAPA4/bin/fm-test-run.sh --list-scheduled --lane portable-parallel-2
tests/fm-captain-hold-lifecycle.test.sh
tests/fm-x-mode.test.sh
tests/fm-arm-pretool-check.test.sh
tests/fm-backend-herdr.test.sh
tests/fm-crew-state.test.sh
tests/fm-herdr-lab.test.sh
tests/fm-send-popup-settle.test.sh
tests/fm-send-strict.test.sh
tests/fm-spawn-batch.test.sh
tests/fm-send-settle.test.sh
tests/fm-ensure-agents-md.test.sh
tests/fm-supervision-instructions.test.sh
tests/fm-transition-lib.test.sh
[exit=0]

$ /bin/bash ~/.no-mistakes/worktrees/acf4a767348a/01M25NFVQ8EEP6P6ZERGFSAPA4/bin/fm-test-run.sh --list-scheduled --lane=portable-parallel-2
tests/fm-captain-hold-lifecycle.test.sh
tests/fm-x-mode.test.sh
tests/fm-arm-pretool-check.test.sh
tests/fm-backend-herdr.test.sh
tests/fm-crew-state.test.sh
tests/fm-herdr-lab.test.sh
tests/fm-send-popup-settle.test.sh
tests/fm-send-strict.test.sh
tests/fm-spawn-batch.test.sh
tests/fm-send-settle.test.sh
tests/fm-ensure-agents-md.test.sh
tests/fm-supervision-instructions.test.sh
tests/fm-transition-lib.test.sh
[exit=0]

$ /bin/bash ~/.no-mistakes/worktrees/acf4a767348a/01M25NFVQ8EEP6P6ZERGFSAPA4/bin/fm-test-run.sh --list --proven-isolated
tests/fm-arm-pretool-check.test.sh
tests/fm-backend-herdr.test.sh
tests/fm-brief.test.sh
tests/fm-captain-hold-lifecycle.test.sh
tests/fm-cd-pretool-check.test.sh
tests/fm-composer-ghost.test.sh
tests/fm-composer-lib.test.sh
tests/fm-crew-state.test.sh
tests/fm-ensure-agents-md.test.sh
tests/fm-grok-harness.test.sh
tests/fm-herdr-lab.test.sh
tests/fm-lint.test.sh
tests/fm-pi-primary-types.test.sh
tests/fm-pr-merge.test.sh
tests/fm-review-diff.test.sh
tests/fm-send-popup-settle.test.sh
tests/fm-send-settle.test.sh
tests/fm-send-strict.test.sh
tests/fm-spawn-batch.test.sh
tests/fm-supervision-instructions.test.sh
tests/fm-test-run.test.sh
tests/fm-tmux-submit-busy.test.sh
tests/fm-transition-lib.test.sh
tests/fm-x-mode.test.sh
[exit=0]

$ /bin/bash ~/.no-mistakes/worktrees/acf4a767348a/01M25NFVQ8EEP6P6ZERGFSAPA4/bin/fm-test-run.sh --check-coverage
FM_TEST_COVERAGE ok total=194 parallel=24 parallel_max_ms=414299 parallel_imbalance_ms=30 parallel_unhinted=0 serial=157 serial_shards=5 serial_unhinted=11 herdr=13
[exit=0]

$ /bin/bash ~/.no-mistakes/worktrees/acf4a767348a/01M25NFVQ8EEP6P6ZERGFSAPA4/bin/fm-test-run.sh --list-scheduled --lane portable-parallel-3
fm-test-run: unknown lane 'portable-parallel-3' (see --list-lanes)
[exit=2]

$ /bin/bash ~/.no-mistakes/worktrees/acf4a767348a/01M25NFVQ8EEP6P6ZERGFSAPA4/bin/fm-test-run.sh --list-scheduled --lane portable-parallel-1 --proven-isolated
fm-test-run: only one selection mode is allowed
[exit=2]

$ /bin/bash ~/.no-mistakes/worktrees/acf4a767348a/01M25NFVQ8EEP6P6ZERGFSAPA4/bin/fm-test-run.sh --list-scheduled --proven-isolated --lane portable-parallel-1
fm-test-run: only one selection mode is allowed
[exit=2]

$ /bin/bash ~/.no-mistakes/worktrees/acf4a767348a/01M25NFVQ8EEP6P6ZERGFSAPA4/bin/fm-test-run.sh --list-scheduled --lane portable-parallel-1 --family pure-contract-unit
fm-test-run: only one selection mode is allowed
[exit=2]

$ /bin/bash ~/.no-mistakes/worktrees/acf4a767348a/01M25NFVQ8EEP6P6ZERGFSAPA4/bin/fm-test-run.sh --list-scheduled --lane portable-parallel-1 tests/fm-brief.test.sh
fm-test-run: script paths cannot be combined with --lane
[exit=2]
```
</details>

- Evidence: [Base/head output comparisons and lane memberships](https://github.com/mremond/firstmate/blob/635e7a876fc5d920540bc7f4c94fbe84943d7c37/.no-mistakes/evidence/fm/fm-parallel-lane-cancels-at-its-own-cap/scheduling-results.json)

<details>
<summary>Evidence: Historical timing completeness and prediction limits</summary>

Source: [Historical timing completeness and prediction limits](https://github.com/mremond/firstmate/blob/635e7a876fc5d920540bc7f4c94fbe84943d7c37/.no-mistakes/evidence/fm/fm-parallel-lane-cancels-at-its-own-cap/historical-completeness.json)

```text
{
  "run_id": 34462758357,
  "historical_only": true,
  "enclosing_job_success_not_claimed": true,
  "lanes": [
    {
      "lane": "portable-parallel-1",
      "all_base_members_completed": true,
      "total": 11,
      "invocation_duration_ms": 598225,
      "script_sum_ms": 597834
    },
    {
      "lane": "portable-parallel-2",
      "all_base_members_completed": true,
      "total": 13,
      "invocation_duration_ms": 192939,
      "script_sum_ms": 192522
    }
  ],
  "new_membership_sums_using_this_complete_historical_sample_ms": [
    388449,
    401907
  ],
  "limitation": "Historical timings validate complete inputs; these recomputed sums are predictions, not actual target-head execution times."
}
```
</details>
- Outcome: ⚠️ 1 warning across 1 run (8m40s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"ee6afa74f5494cc4ba6e25bf06da3f5410f9a867","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed ✅</summary>

- ⚠️ `bin/fm-test-run.sh:2026` - The intent authorizes “TWO PORTABLE PARALLEL LANES and nothing else”, but replacing `$(portable_serial_weight_for &#34;$s&#34;)` with `$(script_weight_for &#34;$s&#34;)` changes every --list-scheduled selection. The separate isolation-proof runner consumes --list-scheduled --proven-isolated at bin/fm-test-isolation-proof.sh:352, so its default worker queue now starts with captain-hold/lint/pr-merge/test-run instead of arm-pretool/backend-herdr/brief/captain-hold. This generalization exceeds the named exception. Remove its application to non-lane selections; restrict the new lookup to the two portable parallel lanes.

🔧 Fix applied.
✅ Re-checked - no issues remain.
</details>

<details>
<summary>⚠️ **Test** - 1 warning</summary>

- ⚠️ live validation verdict: inconclusive (4 of 5 scenarios were driven live against the product); untested: Execute both complete rebalanced Ubuntu jobs below their ten-minute caps and obtain timing artifacts
- Live validation: ⚠️ inconclusive - 4 of 5 scenarios driven live against the product

| Scenario | Result | Live | Evidence |
| --- | --- | --- | --- |
| Inspect both parallel lanes and receive the complete candidate partition in duration order | ✅ pass | live | Live scheduling CLI transcript: both lanes’ --list and --list-scheduled outputs match; their disjoint union contains all 24 candidates, with the Pi test retained in lane 1. |
| Run the coverage command and receive computed balance and measurement-coverage values | ✅ pass | live | bin/fm-test-run.sh --check-coverage reports parallel_max_ms=414299, parallel_imbalance_ms=30, parallel_unhinted=0. |
| Schedule selections outside the two parallel lanes and preserve pre-change output | ✅ pass | live | scheduling-results.json: 36 byte-identical base/head comparisons covering every family, proven-isolated, all, changed, explicit paths, serial lanes and retained memberships. |
| Attempt to bypass the two-lane boundary using invalid or combined selectors and receive a refusal | ✅ pass | live | Live scheduling CLI transcript: an unknown third lane and four mixed-selector combinations exit 2 without scheduled output. |
| Execute both complete rebalanced Ubuntu jobs below their ten-minute caps and obtain timing artifacts | ⏸️ untested | no | This phase has no authority to launch CI or execute the lanes’ lint workload. The outer executor must run both target-head Ubuntu jobs and verify completed timing artifacts. |

- <code>`bin/fm-test-run.sh --jobs 1 --json ~/.no-mistakes/evidence/01M25NFVQ8EEP6P6ZERGFSAPA4/runner-regression.json tests/fm-test-run.test.sh` with isolated temporary and home directories.</code>
- <code>`python3 ~/.no-mistakes/evidence/01M25NFVQ8EEP6P6ZERGFSAPA4/validate-scheduling.py` — base/head CLI comparisons, lane partition, coverage values and invalid-selector probes.</code>
- <code>`python3 ~/.no-mistakes/evidence/01M25NFVQ8EEP6P6ZERGFSAPA4/regression-red-green.py` — both new regressions pass on base, fail before R1, and pass on target.</code>
- <code>`ruby -ryaml -rjson -e &#39;puts JSON.generate(YAML.load(STDIN.read))&#39;` — normalized base/head workflow comparison.</code>
- <code>`gh-axi run view 34462758357` and targeted downloads of its two parallel timing artifacts; verified every historical lane member completed.</code>
- `Removed phase fixtures and verified a clean worktree at ec5b37133d40d607cd39042940f0d0d831c38f37.`
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
