### PR TITLE
fix(remote-job): expose account config roots to workers

### DIFF
--- a/bin/fm-discord-live.sh
+++ b/bin/fm-discord-live.sh
@@ -7,6 +7,7 @@
 #   fm-discord-live.sh live-reply --config <json> --request-id <id> --text-file <f> [--nonce <n>]
 #   fm-discord-live.sh live-source --config <json>
 #   fm-discord-live.sh live-roundtrip --config <json> --request-id <id> --text-file <f>
+#   fm-discord-live.sh live-post --config <json> --thread <id> --tag captain|main --text-file <f>
 #
 # Decrypts only the bot token into process memory (never stdout, disk, or
 # logs), talks to Discord API v10, and reuses the core workspace config,

--- a/bin/fm-discord-live.sh
+++ b/bin/fm-discord-live.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# fm-discord-live.sh - bounded live Discord activation layer.
+#
+# Usage:
+#   fm-discord-live.sh health --config <json>
+#   fm-discord-live.sh setup-apply --config <json>
+#   fm-discord-live.sh live-reply --config <json> --request-id <id> --text-file <f> [--nonce <n>]
+#   fm-discord-live.sh live-source --config <json>
+#   fm-discord-live.sh live-roundtrip --config <json> --request-id <id> --text-file <f>
+#
+# Decrypts only the bot token into process memory (never stdout, disk, or
+# logs), talks to Discord API v10, and reuses the core workspace config,
+# receipts, cursors, and external-id inbox seam. Deletion/retirement, voice
+# capture, hosted transcription, webhooks, and arbitrary guilds stay out of
+# scope. Test seams: FM_DISCORD_LIVE_API_BASE and FM_DISCORD_LIVE_SOPS.
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+exec python3 "$SCRIPT_DIR/fm_discord_live.py" "$SCRIPT_DIR" "$@"

--- a/bin/fm-discord-workspace.sh
+++ b/bin/fm-discord-workspace.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# fm-discord-workspace.sh - offline owner for Firstmate's private Discord operations workspace.
+#
+# This script validates non-secret config, renders setup and health dry-runs,
+# plans outbound replies/status/artifacts, records idempotent outbound receipts,
+# links Discord-originated requests to tasks, preserves pending final follow-ups,
+# and safely refuses live setup, live posting, live health, and destructive
+# retirement until a later activation task supplies every required approval.
+#
+# Usage:
+#   fm-discord-workspace.sh sample-config
+#   fm-discord-workspace.sh config-check [--config <json>]
+#   fm-discord-workspace.sh setup --dry-run [--config <json>]
+#   fm-discord-workspace.sh setup --apply [--config <json>]     (refuses in this phase)
+#   fm-discord-workspace.sh health [--local|--secrets|--discord|--transcription|--process-event]
+#   fm-discord-workspace.sh reply --request-id <discord:guild:channel:message> --text-file <file>
+#   fm-discord-workspace.sh status --profile <profile> --text-file <file> [--thread <id>]
+#   fm-discord-workspace.sh artifact --profile <profile> --file <path> --purpose <tag> [--request-id <id>]
+#   fm-discord-workspace.sh publish-artifact --profile <profile> --file <path> --purpose <tag> --url <https-url> --access <mode>
+#   fm-discord-workspace.sh link-task <task-id> --request-id <discord:guild:channel:message>
+#   fm-discord-workspace.sh followup <task-id> [--final] --text-file <file>
+#   fm-discord-workspace.sh guard-work <task-id>
+#   fm-discord-workspace.sh retire [--apply]
+#
+# The config file is local and non-secret: config/discord-workspace.json by
+# default, or --config. It names exactly one operations guild, one Firstmate
+# operations bot identity, captain Discord user ids, ProApplis/Folium/ARFAL
+# categories, exchanges and artifacts forum ids, thread allowlists, forum tag
+# vocabularies, and dry-run-only policy choices. The script never reads .env,
+# never decrypts secret values, never contacts Discord or Groq in this phase,
+# and never creates categories, channels, threads, tags, bots, permissions, or
+# live registrations.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+exec python3 "$SCRIPT_DIR/fm_discord_workspace_lib.py" tool "$SCRIPT_DIR" "$@"

--- a/bin/fm-discord-workspace.sh
+++ b/bin/fm-discord-workspace.sh
@@ -24,7 +24,7 @@
 #
 # The config file is local and non-secret: config/discord-workspace.json by
 # default, or --config. It names exactly one operations guild, one Firstmate
-# operations bot identity, captain Discord user ids, ProApplis/Folium/ARFAL
+# operations bot identity, captain Discord user ids, System / Firstmate, ProApplis, and Folium
 # categories, exchanges and artifacts forum ids, thread allowlists, forum tag
 # vocabularies, and dry-run-only policy choices. The script never reads .env,
 # never decrypts secret values, never contacts Discord or Groq in this phase,

--- a/bin/fm-inbox.sh
+++ b/bin/fm-inbox.sh
@@ -255,9 +255,10 @@ queue_note() {
     lock_held=1
     # shellcheck disable=SC2064
     trap "[ '$lock_held' -eq 0 ] || fm_lock_release '$lock'" RETURN
+    die_locked() { fm_lock_release "$lock"; lock_held=0; trap - RETURN; die "$1"; }
     if [ -f "$map" ] && [ ! -L "$map" ]; then
       existing=$(sed -n 's/^note_id=//p' "$map" | head -1)
-      [ -n "$existing" ] || die "external inbox map is malformed: $map"
+      [ -n "$existing" ] || die_locked "external inbox map is malformed: $map"
       printf 'queued %s\n' "$existing"
       printf '  duplicate external id; no new wake was appended.\n'
       fm_lock_release "$lock"
@@ -265,12 +266,12 @@ queue_note() {
       trap - RETURN
       return 0
     fi
-    [ ! -e "$map" ] && [ ! -L "$map" ] || die "external inbox map is unsafe: $map"
+    [ ! -e "$map" ] && [ ! -L "$map" ] || die_locked "external inbox map is unsafe: $map"
     metadata_dst=""
     if [ -n "$metadata_file" ]; then
       metadata_dst="${map%.map}.metadata.json"
-      cp "$metadata_file" "$metadata_dst" || die "cannot copy metadata file"
-      chmod 600 "$metadata_dst" || die "cannot protect metadata file"
+      cp "$metadata_file" "$metadata_dst" || die_locked "cannot copy metadata file"
+      chmod 600 "$metadata_dst" || die_locked "cannot protect metadata file"
       extra="${extra}${extra:+$'\n'}external_metadata=$metadata_dst"
     fi
     extra="${extra}${extra:+$'\n'}external_source=$source
@@ -284,8 +285,8 @@ external_id=$external_id"
       printf 'note_id=%s\n' "$id"
       [ -z "$metadata_dst" ] || printf 'metadata=%s\n' "$metadata_dst"
     } > "$tmp_map"
-    chmod 600 "$tmp_map" || die "cannot protect external inbox map"
-    mv "$tmp_map" "$map" || die "cannot publish external inbox map"
+    chmod 600 "$tmp_map" || die_locked "cannot protect external inbox map"
+    mv "$tmp_map" "$map" || die_locked "cannot publish external inbox map"
     summary=$(printf '%s' "$body" | tr '\n\t' '  ' | cut -c1-100)
     printf 'queued %s\n' "$id"
     printf '  %s\n' "$summary"

--- a/bin/fm-inbox.sh
+++ b/bin/fm-inbox.sh
@@ -19,7 +19,8 @@
 #           fleet work and must not become fleet work.
 #
 # Usage:
-#   fm-inbox.sh note <text>...          | fm-inbox.sh note -   (body from stdin)
+#   fm-inbox.sh note [--source <name> --external-id <id> [--metadata-file <json>]] <text>...
+#   fm-inbox.sh note [--source <name> --external-id <id> [--metadata-file <json>]] -
 #   fm-inbox.sh say  [<file.wav>]       (default: audio on stdin)
 #   fm-inbox.sh status
 #   fm-inbox.sh ask  <question>...
@@ -54,10 +55,12 @@
 # `note` is also the queueing half of the spoken interface: when the voice agent
 # in bin/fm-voice-relay.py hands real work over to firstmate, it runs this
 # subcommand rather than carrying a second queue of its own. Keep the `note`
-# contract stable for that caller. `status` is the HUMAN view of the records;
-# bin/fm_voice_records.py owns the scope-controlled machine view the voice agent
-# reads, because the voice agent must be able to answer without record free text
-# ever reaching a model.
+# contract stable for that caller. A trusted external intake may add
+# `--source`, `--external-id`, and `--metadata-file`; replaying the same source
+# and upstream id returns the first note id and appends no second wake. `status`
+# is the HUMAN view of the records; bin/fm_voice_records.py owns the
+# scope-controlled machine view the voice agent reads, because the voice agent
+# must be able to answer without record free text ever reaching a model.
 set -euo pipefail
 
 # A non-interactive `ssh host fm-inbox.sh ...` does NOT get a login shell, so it
@@ -134,6 +137,23 @@ need_ask_model() {
 
 need() { command -v "$1" >/dev/null 2>&1 || die "required command not found: $1"; }
 
+source_wake_lib() {
+  local lib="$FM_ROOT/bin/fm-wake-lib.sh"
+  [ -r "$lib" ] || return 1
+  # shellcheck source=/dev/null
+  FM_ROOT_OVERRIDE="$FM_ROOT" FM_HOME="$FM_HOME" STATE="$STATE" . "$lib"
+}
+
+sha256_text() {
+  if command -v shasum >/dev/null 2>&1; then
+    printf '%s' "$1" | shasum -a 256 | awk '{print $1}'
+  elif command -v sha256sum >/dev/null 2>&1; then
+    printf '%s' "$1" | sha256sum | awk '{print $1}'
+  else
+    die "no SHA-256 tool is available"
+  fi
+}
+
 # The profile's credential_process (`ada`) costs a MEASURED ~1030ms on every
 # single call, which is about half the wall time of `say` and `ask`. If real
 # credentials are already in the environment, skip --profile entirely and let the
@@ -154,21 +174,50 @@ aws_call() {
 # disk, so we report the wake failure and still exit non-zero loudly.
 wake_for() {
   local id=$1 summary=$2 lib="$FM_ROOT/bin/fm-wake-lib.sh"
-  if [ ! -r "$lib" ]; then
+  if ! source_wake_lib; then
     printf 'fm-inbox: note saved but NOT announced (missing %s)\n' "$lib" >&2
     return 1
   fi
-  # shellcheck source=/dev/null
-  FM_ROOT_OVERRIDE="$FM_ROOT" FM_HOME="$FM_HOME" STATE="$STATE" . "$lib"
   fm_wake_append check "inbox:$id" "check: captain inbox note $id - $summary"
 }
 
-queue_note() {
-  local source=$1 body=$2 extra=${3:-}
-  [ -n "${body//[[:space:]]/}" ] || die "refusing to queue an empty note"
-  mkdir -p "$INBOX"
+validate_note_source() {
+  case "$1" in
+    ''|*[!A-Za-z0-9._-]*) die "note source must be path-safe" ;;
+  esac
+}
 
-  local tmp id summary staging_name
+validate_external_id() {
+  case "$1" in
+    ''|*[!A-Za-z0-9._:-]*) die "external id must be a bounded non-secret id" ;;
+  esac
+  [ "${#1}" -le 256 ] || die "external id is too long"
+}
+
+validate_metadata_file() {
+  local path=$1 bytes
+  [ -f "$path" ] && [ ! -L "$path" ] || die "metadata file is unavailable or unsafe: $path"
+  bytes=$(wc -c < "$path" | tr -d ' ')
+  case "$bytes" in ''|*[!0-9]*) die "metadata file size is unreadable: $path" ;; esac
+  [ "$bytes" -le 16384 ] || die "metadata file is too large: $path"
+  need python3
+  python3 - "$path" <<'PY'
+import json, sys
+with open(sys.argv[1], encoding="utf-8") as f:
+    data = json.load(f)
+if not isinstance(data, dict):
+    raise SystemExit("metadata root must be a JSON object")
+PY
+}
+
+external_map_path() {  # <source> <external-id>
+  local digest
+  digest=$(sha256_text "$1:$2") || return 1
+  printf '%s/external/%s.map\n' "$INBOX" "$digest"
+}
+
+queue_note_file() {  # <source> <body> <extra>
+  local source=$1 body=$2 extra=${3:-} tmp id staging_name
   tmp=$(mktemp "$INBOX/.staging-XXXXXX")
   staging_name=$(basename "$tmp")
   id="$(date +%s)-${staging_name#.staging-}"
@@ -180,11 +229,83 @@ queue_note() {
     printf -- '--\n'
     printf '%s\n' "$body"
   } >"$tmp"
-
-  # Publish the completed note atomically.
   mv "$tmp" "$INBOX/$id.note"
+  printf '%s\n' "$id"
+}
 
-  # One-line summary for the wake payload; the full body stays in the file.
+queue_note() {
+  local source=$1 body=$2 extra=${3:-} external_id=${4:-} metadata_file=${5:-}
+  [ -n "${body//[[:space:]]/}" ] || die "refusing to queue an empty note"
+  mkdir -p "$INBOX"
+
+  if [ -n "$external_id" ]; then
+    validate_note_source "$source"
+    validate_external_id "$external_id"
+    [ -z "$metadata_file" ] || validate_metadata_file "$metadata_file"
+  fi
+
+  local id summary map lock lock_held=0 metadata_dst tmp_map existing
+  if [ -n "$external_id" ]; then
+    mkdir -p "$INBOX/external"
+    chmod 700 "$INBOX/external" 2>/dev/null || true
+    map=$(external_map_path "$source" "$external_id")
+    lock="$INBOX/.external.lock"
+    source_wake_lib || die "missing wake/lock library: $FM_ROOT/bin/fm-wake-lib.sh"
+    fm_lock_acquire_wait "$lock" || die "cannot lock external inbox map"
+    lock_held=1
+    # shellcheck disable=SC2064
+    trap "[ '$lock_held' -eq 0 ] || fm_lock_release '$lock'" RETURN
+    if [ -f "$map" ] && [ ! -L "$map" ]; then
+      existing=$(sed -n 's/^note_id=//p' "$map" | head -1)
+      [ -n "$existing" ] || die "external inbox map is malformed: $map"
+      printf 'queued %s\n' "$existing"
+      printf '  duplicate external id; no new wake was appended.\n'
+      fm_lock_release "$lock"
+      lock_held=0
+      trap - RETURN
+      return 0
+    fi
+    [ ! -e "$map" ] && [ ! -L "$map" ] || die "external inbox map is unsafe: $map"
+    metadata_dst=""
+    if [ -n "$metadata_file" ]; then
+      metadata_dst="${map%.map}.metadata.json"
+      cp "$metadata_file" "$metadata_dst" || die "cannot copy metadata file"
+      chmod 600 "$metadata_dst" || die "cannot protect metadata file"
+      extra="${extra}${extra:+$'\n'}external_metadata=$metadata_dst"
+    fi
+    extra="${extra}${extra:+$'\n'}external_source=$source
+external_id=$external_id"
+    id=$(queue_note_file "$source" "$body" "$extra")
+    tmp_map=$(mktemp "$INBOX/external/.map-XXXXXX")
+    {
+      printf 'schema=fm-inbox-external-map.v1\n'
+      printf 'source=%s\n' "$source"
+      printf 'external_id=%s\n' "$external_id"
+      printf 'note_id=%s\n' "$id"
+      [ -z "$metadata_dst" ] || printf 'metadata=%s\n' "$metadata_dst"
+    } > "$tmp_map"
+    chmod 600 "$tmp_map" || die "cannot protect external inbox map"
+    mv "$tmp_map" "$map" || die "cannot publish external inbox map"
+    summary=$(printf '%s' "$body" | tr '\n\t' '  ' | cut -c1-100)
+    printf 'queued %s\n' "$id"
+    printf '  %s\n' "$summary"
+    if wake_for "$id" "$summary"; then
+      printf '  firstmate will pick this up at its next check.\n'
+    else
+      rm -f -- "$map" 2>/dev/null || true
+      [ -z "$metadata_dst" ] || rm -f -- "$metadata_dst" 2>/dev/null || true
+      fm_lock_release "$lock"
+      lock_held=0
+      trap - RETURN
+      die "note $id is saved at $INBOX/$id.note but firstmate was NOT woken"
+    fi
+    fm_lock_release "$lock"
+    lock_held=0
+    trap - RETURN
+    return 0
+  fi
+
+  id=$(queue_note_file "$source" "$body" "$extra")
   summary=$(printf '%s' "$body" | tr '\n\t' '  ' | cut -c1-100)
   printf 'queued %s\n' "$id"
   printf '  %s\n' "$summary"
@@ -196,15 +317,44 @@ queue_note() {
 }
 
 cmd_note() {
-  local body
+  local body source=text external_id='' metadata_file=''
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      --source)
+        [ "$#" -ge 2 ] || die "--source needs a value"
+        source=$2
+        shift 2
+        ;;
+      --external-id)
+        [ "$#" -ge 2 ] || die "--external-id needs a value"
+        external_id=$2
+        shift 2
+        ;;
+      --metadata-file)
+        [ "$#" -ge 2 ] || die "--metadata-file needs a value"
+        metadata_file=$2
+        shift 2
+        ;;
+      --)
+        shift
+        break
+        ;;
+      -|*)
+        break
+        ;;
+    esac
+  done
+  if [ -z "$external_id" ] && { [ "$source" != text ] || [ -n "$metadata_file" ]; }; then
+    die "--source or --metadata-file requires --external-id"
+  fi
   if [ "$#" -eq 0 ]; then
-    die "usage: fm-inbox.sh note <text>...   (or: note - to read stdin)"
+    die "usage: fm-inbox.sh note [--source <name> --external-id <id> [--metadata-file <json>]] <text>..."
   elif [ "$1" = "-" ]; then
     body=$(cat)
   else
     body="$*"
   fi
-  queue_note text "$body"
+  queue_note "$source" "$body" "" "$external_id" "$metadata_file"
 }
 
 # ---------------------------------------------------------------- say

--- a/bin/fm-inbox.sh
+++ b/bin/fm-inbox.sh
@@ -216,6 +216,17 @@ external_map_path() {  # <source> <external-id>
   printf '%s/external/%s.map\n' "$INBOX" "$digest"
 }
 
+rewrite_external_map_announced() {  # <map-path> <0|1>
+  local map=$1 announced=$2 tmp
+  tmp=$(mktemp "${map%/*}/.map-XXXXXX") || return 1
+  {
+    sed -n '/^announced=/!p' "$map"
+    printf 'announced=%s\n' "$announced"
+  } > "$tmp" || { rm -f -- "$tmp"; return 1; }
+  chmod 600 "$tmp" || { rm -f -- "$tmp"; return 1; }
+  mv "$tmp" "$map"
+}
+
 queue_note_file() {  # <source> <body> <extra>
   local source=$1 body=$2 extra=${3:-} tmp id staging_name
   tmp=$(mktemp "$INBOX/.staging-XXXXXX")
@@ -259,8 +270,26 @@ queue_note() {
     if [ -f "$map" ] && [ ! -L "$map" ]; then
       existing=$(sed -n 's/^note_id=//p' "$map" | head -1)
       [ -n "$existing" ] || die_locked "external inbox map is malformed: $map"
-      printf 'queued %s\n' "$existing"
-      printf '  duplicate external id; no new wake was appended.\n'
+      if [ "$(sed -n 's/^announced=//p' "$map" | head -1)" = "0" ]; then
+        # The original note exists but its announcement failed earlier.
+        # Retry announcing that same note; never create a duplicate.
+        existing_summary=$(sed -n 's/^summary=//p' "$map" | head -1)
+        if wake_for "$existing" "$existing_summary"; then
+          rewrite_external_map_announced "$map" 1 || die_locked "cannot update external inbox map: $map"
+          printf 'queued %s\n' "$existing"
+          printf '  announcement retried and delivered; no new note was created.\n'
+        else
+          printf 'queued %s\n' "$existing"
+          printf '  announcement retry FAILED; the original note stays saved at %s/%s.note.\n' "$INBOX" "$existing" >&2
+          fm_lock_release "$lock"
+          lock_held=0
+          trap - RETURN
+          return 1
+        fi
+      else
+        printf 'queued %s\n' "$existing"
+        printf '  duplicate external id; no new wake was appended.\n'
+      fi
       fm_lock_release "$lock"
       lock_held=0
       trap - RETURN
@@ -278,23 +307,28 @@ queue_note() {
 external_id=$external_id"
     id=$(queue_note_file "$source" "$body" "$extra")
     tmp_map=$(mktemp "$INBOX/external/.map-XXXXXX")
+    summary=$(printf '%s' "$body" | tr '\n\t' '  ' | cut -c1-100)
     {
-      printf 'schema=fm-inbox-external-map.v1\n'
+      printf 'schema=fm-inbox-external-map.v2\n'
       printf 'source=%s\n' "$source"
       printf 'external_id=%s\n' "$external_id"
       printf 'note_id=%s\n' "$id"
+      printf 'announced=0\n'
+      printf 'summary=%s\n' "$summary"
       [ -z "$metadata_dst" ] || printf 'metadata=%s\n' "$metadata_dst"
     } > "$tmp_map"
     chmod 600 "$tmp_map" || die_locked "cannot protect external inbox map"
     mv "$tmp_map" "$map" || die_locked "cannot publish external inbox map"
-    summary=$(printf '%s' "$body" | tr '\n\t' '  ' | cut -c1-100)
     printf 'queued %s\n' "$id"
     printf '  %s\n' "$summary"
     if wake_for "$id" "$summary"; then
+      rewrite_external_map_announced "$map" 1 || die_locked "cannot update external inbox map: $map"
       printf '  firstmate will pick this up at its next check.\n'
     else
-      rm -f -- "$map" 2>/dev/null || true
-      [ -z "$metadata_dst" ] || rm -f -- "$metadata_dst" 2>/dev/null || true
+      # Keep the note and its external mapping (announced=0) so a replay of
+      # the same source/external-id re-announces the original note instead of
+      # creating a duplicate.
+      printf '  announcement FAILED; replay the same source/external-id to retry. Note stays at %s/%s.note.\n' "$INBOX" "$id" >&2
       fm_lock_release "$lock"
       lock_held=0
       trap - RETURN

--- a/bin/fm-procevent-discord-workspace.sh
+++ b/bin/fm-procevent-discord-workspace.sh
@@ -11,13 +11,19 @@
 #   fm-procevent-discord-workspace.sh autohandle <source-id> <sequence> <result-file>
 #   fm-procevent-discord-workspace.sh answers <result-file>
 #
-# The adapter is deliberately inert for live services in this phase. `arm`
-# renders a dry-run registration plan and every non-dry-run arm refuses until a
-# later activation task supplies live approval. `source` reads only an offline
-# fixture named by FM_DISCORD_WORKSPACE_FIXTURE or poll.fixture_file; without one
-# it refuses before any network call. Accepted forum-post/thread messages are
+# `arm` renders a dry-run registration plan. With live polling enabled in the
+# workspace config, non-dry-run arm registers this adapter as the built-in
+# discord-workspace process-event source; while disabled it refuses.
+# `source` runs in one of two modes. Fixture mode (live polling disabled)
+# reads only an offline fixture named by FM_DISCORD_WORKSPACE_FIXTURE or
+# poll.fixture_file and refuses before any network call without one. Live mode
+# (live polling enabled) runs one bounded live-source pass per invocation
+# through the bounded live activation layer: a successful scan is silent and
+# exits nonzero with no output so the runner records no-result and keeps the
+# source armed, while a genuine failure prints one bounded redacted actionable
+# line as a captured result. Accepted forum-post/thread messages are
 # normalized into one durable fm-inbox note through fm-inbox.sh's external-id
-# idempotency seam. Ignored messages are marked handled without a wake, and the
+# idempotency seam, and cursors advance only after successful handoff. The
 # adapter declares self-announcing so an accepted message produces only the
 # ordinary captain-inbox notification.
 set -euo pipefail

--- a/bin/fm-procevent-discord-workspace.sh
+++ b/bin/fm-procevent-discord-workspace.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# fm-procevent-discord-workspace.sh - built-in process-event adapter for Discord workspace intake.
+#
+# Usage:
+#   fm-procevent-discord-workspace.sh arm [--dry-run] [--config <json>]
+#   fm-procevent-discord-workspace.sh source [--config <json>]
+#   fm-procevent-discord-workspace.sh classify <result-file>
+#   fm-procevent-discord-workspace.sh silent <result-file>
+#   fm-procevent-discord-workspace.sh terminal <result-file>
+#   fm-procevent-discord-workspace.sh self-announcing
+#   fm-procevent-discord-workspace.sh autohandle <source-id> <sequence> <result-file>
+#   fm-procevent-discord-workspace.sh answers <result-file>
+#
+# The adapter is deliberately inert for live services in this phase. `arm`
+# renders a dry-run registration plan and every non-dry-run arm refuses until a
+# later activation task supplies live approval. `source` reads only an offline
+# fixture named by FM_DISCORD_WORKSPACE_FIXTURE or poll.fixture_file; without one
+# it refuses before any network call. Accepted forum-post/thread messages are
+# normalized into one durable fm-inbox note through fm-inbox.sh's external-id
+# idempotency seam. Ignored messages are marked handled without a wake, and the
+# adapter declares self-announcing so an accepted message produces only the
+# ordinary captain-inbox notification.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+exec python3 "$SCRIPT_DIR/fm_discord_workspace_lib.py" procevent "$SCRIPT_DIR" "$@"

--- a/bin/fm-procevent.sh
+++ b/bin/fm-procevent.sh
@@ -182,6 +182,8 @@ state_root_bind() {  # [create]
   if [ ! -e "$STATE" ] && [ ! -L "$STATE" ]; then
     [ "${1-}" = create ] || return 1
     (umask 077; mkdir -p "$STATE") || return 1
+  elif [ -d "$STATE" ] && [ ! -L "$STATE" ]; then
+    chmod go-w "$STATE" 2>/dev/null || true
   fi
   STATE=$(fm_procevent_state_root_resolve "$STATE") || return 1
   REG=$(fm_procevent_registry_dir "$STATE")

--- a/bin/fm-remote-job-lib.sh
+++ b/bin/fm-remote-job-lib.sh
@@ -57,7 +57,8 @@
 #
 # The worker accepts only a tracked, non-symlink executable named fm-*.sh below
 # its configured FM_ROOT/bin. Every child receives env -i with the composed
-# PATH, HOME, FM_HOME, FM_ROOT_OVERRIDE, and FM_REMOTE_JOB_ACTIVE=1. The PATH
+# PATH, HOME, XDG_CONFIG_HOME, GH_CONFIG_DIR, FM_HOME, FM_ROOT_OVERRIDE, and
+# FM_REMOTE_JOB_ACTIVE=1. The PATH
 # is intentionally filesystem-discovered rather than login-shell-derived:
 # ~/.local/bin; nvm, asdf, and mise shims/install bins; Nix; Homebrew; and the
 # system tail. No shell startup files are evaluated. Each discovered set is
@@ -834,10 +835,13 @@ fm_remote_job_plist_safe_path() {
 }
 
 fm_remote_job_render_launchagent() { # <remote-root> <account-home>
-  local root=$1 account_home=$2 worker
+  local root=$1 account_home=$2 worker xdg_config_home gh_config_dir
   worker="$root/bin/fm-remote-job-worker.sh"
+  xdg_config_home=$account_home/.config
+  gh_config_dir=$xdg_config_home/gh
   fm_remote_job_launchagent_paths "$account_home"
   fm_remote_job_plist_safe_path "$worker" && fm_remote_job_plist_safe_path "$account_home" &&
+    fm_remote_job_plist_safe_path "$xdg_config_home" && fm_remote_job_plist_safe_path "$gh_config_dir" &&
     fm_remote_job_plist_safe_path "$FM_REMOTE_JOB_LAUNCH_AGENT_LOG" || return 1
   cat <<XML
 <?xml version="1.0" encoding="UTF-8"?>
@@ -854,6 +858,10 @@ fm_remote_job_render_launchagent() { # <remote-root> <account-home>
 	<dict>
 		<key>HOME</key>
 		<string>$account_home</string>
+		<key>XDG_CONFIG_HOME</key>
+		<string>$xdg_config_home</string>
+		<key>GH_CONFIG_DIR</key>
+		<string>$gh_config_dir</string>
 		<key>FM_ROOT_OVERRIDE</key>
 		<string>$root</string>
 	</dict>
@@ -1147,13 +1155,15 @@ fm_remote_job_reload_launchagent() { # <account-home> <uid>
 }
 
 fm_remote_job_start_linux_worker() { # <remote-root> <account-home>
-  local root=$1 account_home=$2 worker pid
+  local root=$1 account_home=$2 worker pid xdg_config_home gh_config_dir
   worker="$root/bin/fm-remote-job-worker.sh"
   [ -f "$worker" ] && [ ! -L "$worker" ] && [ -x "$worker" ] || {
     FM_REMOTE_JOB_ERROR="remote job worker is not a genuine executable in the configured code root"
     return 1
   }
   fm_remote_job_prepare_state "$account_home" || return 1
+  xdg_config_home=${XDG_CONFIG_HOME:-$account_home/.config}
+  gh_config_dir=${GH_CONFIG_DIR:-$xdg_config_home/gh}
   if fm_remote_job_worker_owned_alive "$root" "$account_home"; then
     if fm_remote_job_worker_identity_matches "$root" "$account_home"; then return 0; fi
     # The owner pid is the serving child; its restart supervisor sits above it
@@ -1173,6 +1183,8 @@ fm_remote_job_start_linux_worker() { # <remote-root> <account-home>
   set -m
   nohup env \
     HOME="$account_home" \
+    XDG_CONFIG_HOME="$xdg_config_home" \
+    GH_CONFIG_DIR="$gh_config_dir" \
     FM_ROOT_OVERRIDE="$root" \
     FM_REMOTE_JOB_STATE_ROOT="$FM_REMOTE_JOB_STATE" \
     FM_REMOTE_JOB_PLATFORM_OVERRIDE="${FM_REMOTE_JOB_PLATFORM_OVERRIDE:-}" \

--- a/bin/fm-remote-job-worker.sh
+++ b/bin/fm-remote-job-worker.sh
@@ -8,7 +8,8 @@
 # tracked non-symlink fm-*.sh under this worker's configured FM_ROOT/bin.
 #
 # Each child runs under env -i with the shared filesystem-composed PATH, HOME,
-# FM_HOME, FM_ROOT_OVERRIDE, and FM_REMOTE_JOB_ACTIVE=1. Commands receive their
+# XDG_CONFIG_HOME, GH_CONFIG_DIR, FM_HOME, FM_ROOT_OVERRIDE, and
+# FM_REMOTE_JOB_ACTIVE=1. Commands receive their
 # captured stdin and have a 360-second default timeout. Their stdout and stderr
 # are independently constrained to the job library's 1048576-byte bound. A
 # record is marked done only after its bounded outputs and numeric exit status
@@ -678,6 +679,7 @@ worker_capture_output() { # <fifo> <destination>
 
 worker_run_job() { # <account-home> <job-dir>
   local account_home=$1 job=$2 root home command command_path git_bin rc deadline remaining
+  local xdg_config_home gh_config_dir
   local stdout_pipe stderr_pipe stdout_reader stderr_reader preemptible=0
   local -a argv child_env
   root=$(worker_read_text "$job" root 8192) || { worker_publish_result "$job" 126; return; }
@@ -724,6 +726,8 @@ worker_run_job() { # <account-home> <job-dir>
     *) worker_publish_result "$job" 126; return ;;
   esac
   fm_remote_job_build_child_path "$root" >/dev/null
+  xdg_config_home=${XDG_CONFIG_HOME:-$account_home/.config}
+  gh_config_dir=${GH_CONFIG_DIR:-$xdg_config_home/gh}
   for command in stdin stdout stderr; do
     [ -f "$job/$command" ] && [ ! -L "$job/$command" ] || { worker_publish_result "$job" 126; return; }
   done
@@ -747,6 +751,8 @@ worker_run_job() { # <account-home> <job-dir>
     /usr/bin/env -i
     "PATH=$FM_REMOTE_JOB_CHILD_PATH"
     "HOME=$account_home"
+    "XDG_CONFIG_HOME=$xdg_config_home"
+    "GH_CONFIG_DIR=$gh_config_dir"
     "FM_HOME=$home"
     "FM_ROOT_OVERRIDE=$root"
     FM_REMOTE_JOB_ACTIVE=1

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -2771,6 +2771,18 @@ if [ "$KIND" = scout ] && [ "$FORCE" != "--force" ]; then
   fi
 fi
 
+if [ "$FORCE" != "--force" ] \
+  && { [ -e "$STATE/discord-workspace/pending-followups/$ID.json" ] \
+    || [ -L "$STATE/discord-workspace/pending-followups/$ID.json" ]; }; then
+  if ! DISCORD_WORKSPACE_BLOCKING=$(FM_HOME="$FM_HOME" FM_STATE_OVERRIDE="$STATE" \
+      "$SCRIPT_DIR/fm-discord-workspace.sh" guard-work "$ID" 2>&1); then
+    echo "REFUSED: task $ID still owes a private Discord workspace final reply." >&2
+    printf '%s\n' "$DISCORD_WORKSPACE_BLOCKING" >&2
+    echo "Deliver it with bin/fm-discord-workspace.sh followup $ID --final --text-file <file>, or use --force after explicit discard approval." >&2
+    exit 1
+  fi
+fi
+
 # A public commitment is not kept until its final reply lands in the ORIGINAL
 # thread, and this cleanup removes the task records that make the promise
 # reconcilable. Refuse while this home still owes a public reply for exactly this

--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -220,7 +220,7 @@ family_for_basename() {
     fm-classify-decision-key.test.sh|\
     fm-composer-ghost.test.sh|fm-composer-lib.test.sh|\
     fm-crew-state.test.sh|fm-captain-hold-lifecycle.test.sh|\
-    fm-documentation-audiences.test.sh|fm-ensure-agents-md.test.sh|fm-grok-harness.test.sh|\
+    fm-discord-workspace.test.sh|fm-documentation-audiences.test.sh|fm-ensure-agents-md.test.sh|fm-grok-harness.test.sh|\
     fm-kimi-harness.test.sh|fm-muse-harness.test.sh|fm-rovo-harness.test.sh|fm-herdr-lab.test.sh|fm-lint.test.sh|\
     fm-lint-workflows.test.sh|\
     fm-operational-input.test.sh|fm-pi-primary-types.test.sh|\
@@ -239,7 +239,8 @@ family_for_basename() {
     fm-wake-drain-unread-status.test.sh|\
     fm-tool-update-check.test.sh|\
     fm-wake-queue.test.sh|fm-watch-arm.test.sh|fm-watch-checkpoint.test.sh|fm-watch-recovery-loop.test.sh|\
-    fm-watch-triage.test.sh|fm-task-inbox.test.sh|\
+    fm-watch-triage.test.sh|fm-task-inbox.test.sh|fm-inbox-external.test.sh|\
+    fm-procevent-discord-workspace.test.sh|\
     fm-watcher-lock.test.sh|fm-inactive-reconcile.test.sh)
       printf '%s\n' watcher-wake-lock
       ;;
@@ -692,7 +693,7 @@ portable_serial_unhinted() {
   tmp=$(mktemp -d "${TMPDIR:-/tmp}/fm-test-unhinted.XXXXXX") || return 1
   portable_serial_weight_hints | awk 'NF { print $1 }' | LC_ALL=C sort -u >"$tmp/hinted"
   list_portable_serial | LC_ALL=C sort -u >"$tmp/serial"
-  comm -23 "$tmp/serial" "$tmp/hinted"
+  LC_ALL=C comm -23 "$tmp/serial" "$tmp/hinted"
   rm -rf "$tmp"
 }
 
@@ -840,8 +841,8 @@ run_coverage_guard() {
     return 1
   fi
   cat "$tmp/s1" "$tmp/s2" | LC_ALL=C sort -u >"$tmp/shards_union"
-  missing=$(comm -23 "$tmp/proven" "$tmp/shards_union" || true)
-  extra=$(comm -13 "$tmp/proven" "$tmp/shards_union" || true)
+  missing=$(LC_ALL=C comm -23 "$tmp/proven" "$tmp/shards_union" || true)
+  extra=$(LC_ALL=C comm -13 "$tmp/proven" "$tmp/shards_union" || true)
   if [ -n "$missing" ] || [ -n "$extra" ]; then
     log "coverage guard: portable shards must equal the proven-isolated set"
     [ -z "$missing" ] || { log "missing from shards:"; printf '%s\n' "$missing" >&2; }
@@ -885,8 +886,8 @@ run_coverage_guard() {
     return 1
   fi
   LC_ALL=C sort -u "$tmp/serial_shards_raw" >"$tmp/serial_shards"
-  missing=$(comm -23 "$tmp/serial" "$tmp/serial_shards" || true)
-  extra=$(comm -13 "$tmp/serial" "$tmp/serial_shards" || true)
+  missing=$(LC_ALL=C comm -23 "$tmp/serial" "$tmp/serial_shards" || true)
+  extra=$(LC_ALL=C comm -13 "$tmp/serial" "$tmp/serial_shards" || true)
   if [ -n "$missing" ] || [ -n "$extra" ]; then
     log "coverage guard: portable serial shards must equal the portable serial lane"
     [ -z "$missing" ] || { log "missing from serial shards:"; printf '%s\n' "$missing" >&2; }
@@ -898,7 +899,7 @@ run_coverage_guard() {
   for pair in "shards_union:serial" "shards_union:herdr" "serial:herdr"; do
     a=${pair%%:*}
     b=${pair#*:}
-    comm -12 "$tmp/$a" "$tmp/$b" >"$tmp/overlap"
+    LC_ALL=C comm -12 "$tmp/$a" "$tmp/$b" >"$tmp/overlap"
     if [ -s "$tmp/overlap" ]; then
       log "coverage guard: overlap between $a and $b:"
       cat "$tmp/overlap" >&2
@@ -916,8 +917,8 @@ run_coverage_guard() {
     return 1
   fi
   LC_ALL=C sort -u "$tmp/union_raw" >"$tmp/union"
-  missing=$(comm -23 "$tmp/all" "$tmp/union" || true)
-  extra=$(comm -13 "$tmp/all" "$tmp/union" || true)
+  missing=$(LC_ALL=C comm -23 "$tmp/all" "$tmp/union" || true)
+  extra=$(LC_ALL=C comm -13 "$tmp/all" "$tmp/union" || true)
   if [ -n "$missing" ] || [ -n "$extra" ]; then
     log "coverage guard: union of portable shards + portable serial + Herdr must equal tests/*.test.sh"
     [ -z "$missing" ] || { log "missing from union:"; printf '%s\n' "$missing" >&2; }
@@ -947,7 +948,7 @@ run_coverage_guard() {
     "$ROOT/bin/fm-test-isolation-proof.sh" --list | LC_ALL=C sort -u >"$tmp/proof_list"
     if ! cmp -s "$tmp/proven" "$tmp/proof_list"; then
       log "coverage guard: embedded proven-isolated set diverges from bin/fm-test-isolation-proof.sh --list"
-      comm -3 "$tmp/proven" "$tmp/proof_list" >&2 || true
+      LC_ALL=C comm -3 "$tmp/proven" "$tmp/proof_list" >&2 || true
       rm -rf "$tmp"
       return 1
     fi

--- a/bin/fm-watch.sh
+++ b/bin/fm-watch.sh
@@ -1115,6 +1115,17 @@ procevent_surfaced_marker() {  # <queue-key>
   printf '%s/.seen-procevent-%s' "$STATE" "$(printf '%s' "$1" | LC_ALL=C od -An -tx1 | tr -d ' \n')"
 }
 
+inbox_surfaced_marker() {  # <queue-key>
+  printf '%s/.seen-inbox-%s' "$STATE" "$(printf '%s' "$1" | LC_ALL=C od -An -tx1 | tr -d ' \n')"
+}
+
+# Row payload of one queued check key, read under the caller's queue lock.
+# fm_wake_clean_field keeps tabs out of every field, so the payload is $5.
+queued_check_payload() {  # <queue-key>
+  awk -F '\t' -v key="$1" 'NF >= 5 && $3 == "check" && $4 == key { print $5; exit }' \
+    "$FM_WAKE_QUEUE" 2>/dev/null || true
+}
+
 procevent_surface_after_output() {
   local output_status=$1 key marker tmp status=0
   if [ "$output_status" -eq 0 ]; then
@@ -1126,26 +1137,61 @@ procevent_surface_after_output() {
         status=1
       fi
     done
+    for key in $INBOX_SURFACED; do
+      marker=$(inbox_surfaced_marker "$key")
+      tmp=$(umask 077; mktemp "$STATE/.seen-inbox.XXXXXX") || { status=1; continue; }
+      if ! mv -f -- "$tmp" "$marker"; then
+        rm -f -- "$tmp"
+        status=1
+      fi
+    done
   fi
   fm_lock_release "$FM_WAKE_QUEUE_LOCK"
   return "$status"
 }
 
 procevent_surface_queued() {
-  local key reason
+  local key reason payload
   PROCEVENT_SURFACED=
+  INBOX_SURFACED=
   [ -s "$FM_WAKE_QUEUE" ] || return 0
   fm_lock_acquire_wait "$FM_WAKE_QUEUE_LOCK"
   while IFS= read -r key; do
-    case "$key" in procevent:*) ;; *) continue ;; esac
-    [ -e "$(procevent_surfaced_marker "$key")" ] && continue
-    PROCEVENT_SURFACED="$PROCEVENT_SURFACED $key"
+    case "$key" in
+      procevent:*)
+        [ -e "$(procevent_surfaced_marker "$key")" ] && continue
+        PROCEVENT_SURFACED="$PROCEVENT_SURFACED $key"
+        ;;
+      inbox:*)
+        # A captain-inbox note wake carries no owning sweep; without this
+        # surface the queued row never closes a watcher cycle and an idle
+        # main session is never woken for the note.
+        [ -e "$(inbox_surfaced_marker "$key")" ] && continue
+        INBOX_SURFACED="$INBOX_SURFACED $key"
+        ;;
+      *) continue ;;
+    esac
   done < <(fm_wake_queued_keys_locked check)
-  if [ -z "$PROCEVENT_SURFACED" ]; then
+  if [ -z "$PROCEVENT_SURFACED" ] && [ -z "$INBOX_SURFACED" ]; then
     fm_lock_release "$FM_WAKE_QUEUE_LOCK"
     return 0
   fi
-  reason="check: process-event result captured:$PROCEVENT_SURFACED"
+  reason=""
+  if [ -n "$PROCEVENT_SURFACED" ]; then
+    reason="check: process-event result captured:$PROCEVENT_SURFACED"
+  fi
+  if [ -n "$INBOX_SURFACED" ]; then
+    payload=""
+    for key in $INBOX_SURFACED; do
+      payload=$(queued_check_payload "$key")
+      [ -n "$payload" ] && break
+    done
+    if [ -n "$payload" ]; then
+      reason="$reason${reason:+ }$payload"
+    else
+      reason="$reason${reason:+ }check: captain inbox notes waiting:$INBOX_SURFACED"
+    fi
+  fi
   # shellcheck disable=SC2034 # Consumed by wake() in the separately linted transition owner.
   FM_WAKE_POST_OUTPUT_ACTION=procevent_surface_after_output
   wake "$reason"

--- a/bin/fm_discord_live.py
+++ b/bin/fm_discord_live.py
@@ -361,57 +361,59 @@ def handoff_event(env: "fwl.Env", event: Dict[str, Any]) -> int:
     return 0
 
 
+def live_source_pass(env: "fwl.Env", cfg: "fwl.WorkspaceConfig", client: "DiscordClient") -> int:
+    """One inbound pass: guild-scoped active threads, cursor-filtered handoff."""
+    forum_ids = {p["exchange_forum_id"] for p in cfg.profiles.values() if p["exchange_forum_id"]}
+    profile_by_forum = {p["exchange_forum_id"]: key for key, p in cfg.profiles.items() if p["exchange_forum_id"]}
+    listing = client.request("GET", f"/guilds/{cfg.guild_id}/threads/active")
+    threads = listing.get("threads") if isinstance(listing.get("threads"), list) else []
+    ingested = 0
+    for thread in threads:
+        if not isinstance(thread, dict):
+            continue
+        thread_id = str(thread.get("id") or "")
+        parent_id = str(thread.get("parent_id") or "")
+        if not thread_id.isdigit() or parent_id not in forum_ids:
+            continue
+        key = profile_by_forum[parent_id]
+        last = fwl.read_cursor(env, key, thread_id)
+        params = {"limit": "100"}
+        if last:
+            params["after"] = str(last)
+        messages = client.request("GET", f"/channels/{thread_id}/messages", params=params)
+        if not isinstance(messages, list):
+            raise FMError(f"message listing for thread {thread_id} was malformed")
+        for message in reversed(messages):
+            if not isinstance(message, dict):
+                continue
+            normalized = {
+                "id": message.get("id"),
+                "guild_id": cfg.guild_id,
+                "channel_id": thread_id,
+                "parent_id": parent_id,
+                "author": message.get("author"),
+                "author_id": message.get("author_id"),
+                "content": message.get("content"),
+                "timestamp": message.get("timestamp"),
+                "flags": message.get("flags"),
+                "attachments": message.get("attachments"),
+            }
+            event = fwl.message_to_event(cfg, normalized)
+            status = handoff_event(env, event)
+            if status != 0:
+                return status
+            if str(message.get("id") or "").isdigit():
+                fwl.write_cursor(env, key, thread_id, str(message["id"]))
+                ingested += 1
+    print(f"live source pass complete; {ingested} messages scanned")
+    return 0
+
+
 def cmd_live_source(args: Any, env: "fwl.Env") -> int:
     cfg = fwl.load_config(env, args.config)
     require_live_flag(cfg, cfg.live_polling_enabled, "live inbound source")
     client = DiscordClient(decrypt_token(env, cfg))
-    ingested = 0
-    for key in fwl.ACTIVE_PROFILE_KEYS:
-        p = cfg.profiles[key]
-        forum_id = p["exchange_forum_id"]
-        if not forum_id:
-            continue
-        listing = client.request("GET", f"/channels/{forum_id}/threads/active")
-        threads = listing.get("threads") if isinstance(listing.get("threads"), list) else []
-        for thread in threads:
-            if not isinstance(thread, dict):
-                continue
-            thread_id = str(thread.get("id") or "")
-            if not thread_id.isdigit() or thread_id == forum_id:
-                continue
-            if str(thread.get("parent_id") or "") != forum_id:
-                continue
-            last = fwl.read_cursor(env, key, thread_id)
-            params = {"limit": "100"}
-            if last:
-                params["after"] = str(last)
-            messages = client.request("GET", f"/channels/{thread_id}/messages", params=params)
-            if not isinstance(messages, list):
-                raise FMError(f"message listing for thread {thread_id} was malformed")
-            for message in reversed(messages):
-                if not isinstance(message, dict):
-                    continue
-                normalized = {
-                    "id": message.get("id"),
-                    "guild_id": cfg.guild_id,
-                    "channel_id": thread_id,
-                    "parent_id": forum_id,
-                    "author": message.get("author"),
-                    "author_id": message.get("author_id"),
-                    "content": message.get("content"),
-                    "timestamp": message.get("timestamp"),
-                    "flags": message.get("flags"),
-                    "attachments": message.get("attachments"),
-                }
-                event = fwl.message_to_event(cfg, normalized)
-                status = handoff_event(env, event)
-                if status != 0:
-                    return status
-                if str(message.get("id") or "").isdigit():
-                    fwl.write_cursor(env, key, thread_id, str(message["id"]))
-                    ingested += 1
-    print(f"live source pass complete; {ingested} messages scanned")
-    return 0
+    return live_source_pass(env, cfg, client)
 
 
 def main(argv: List[str]) -> int:

--- a/bin/fm_discord_live.py
+++ b/bin/fm_discord_live.py
@@ -275,7 +275,7 @@ def atomic_write_config(env: "fwl.Env", raw: Dict[str, Any]) -> None:
 def cmd_live_reply(args: Any, env: "fwl.Env", verify: bool = False) -> int:
     cfg = fwl.load_config(env, args.config)
     require_live_flag(cfg, cfg.live_posting_enabled, "live reply")
-    text = fwl.read_text_file(args.text_file)
+    text = fwl.read_text_file(args.text_file).strip()
     guild_id, channel_id, message_id, profile_key, forum_kind = cfg.profile_for_request_id(args.request_id)
     if forum_kind != "exchange":
         raise FMError("replies must target an exchange forum thread")
@@ -283,8 +283,13 @@ def cmd_live_reply(args: Any, env: "fwl.Env", verify: bool = False) -> int:
     nonce = args.nonce or f"reply:{args.request_id}:{text_digest}"
     target = {"guild_id": guild_id, "channel_id": channel_id, "message_id": message_id, "request_id": args.request_id}
     receipt = fwl.base_receipt("reply", profile_key, target, text_digest)
-    client = DiscordClient(decrypt_token(env, cfg))
     existing = fwl.load_existing_json(fwl.receipt_path(env, nonce))
+    if existing is None and _receipt_shares_text_and_channel(env, text_digest, channel_id):
+        # Single outbound owner: the identical text already reached this thread
+        # through the mirror delivery identity, so a reply would duplicate it.
+        print("mirror exists; no second delivery")
+        return 0
+    client = DiscordClient(decrypt_token(env, cfg))
     if existing is not None:
         comparable = dict(existing)
         comparable.pop("recorded_at", None)
@@ -423,6 +428,87 @@ def cmd_live_source(args: Any, env: "fwl.Env") -> int:
     return 0
 
 
+def _receipt_shares_text_and_channel(env: "fwl.Env", digest: str, channel_id: str) -> bool:
+    receipts_dir = fwl.discord_state_path(env, "receipts")
+    if not receipts_dir.is_dir():
+        return False
+    for path in receipts_dir.glob("*.json"):
+        try:
+            receipt = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            continue
+        if str(receipt.get("text_sha256") or "") != digest:
+            continue
+        target = receipt.get("target") if isinstance(receipt.get("target"), dict) else {}
+        if str(target.get("channel_id") or "") == channel_id:
+            return True
+    return False
+
+
+def cmd_live_post(args: Any, env: "fwl.Env") -> int:
+    """Post one mirrored conversational item with single-owner idempotency.
+
+    Same text to the same thread converges on one durable delivery identity:
+    both the mirror and any explicit reply share the text digest, so neither
+    path can issue a second post for content already delivered to the thread.
+    """
+    cfg = fwl.load_config(env, args.config)
+    require_live_flag(cfg, cfg.live_posting_enabled, "live mirror")
+    thread_id = fwl.validate_snowflake(args.thread, "--thread") or ""
+    allowed = any(
+        thread_id in p["exchange_thread_ids"] or thread_id in p["artifact_thread_ids"]
+        or thread_id in (p["exchange_forum_id"], p["artifact_forum_id"])
+        for p in cfg.profiles.values()
+    )
+    if not allowed:
+        raise FMError("mirror target thread is outside the configured allowlist")
+    text = fwl.read_text_file(args.text_file).strip()
+    if not text:
+        return 0
+    # Discord-origin and operational text never mirrors: the caller passes only
+    # terminal-origin conversation, and these markers are machinery evidence.
+    for marker in ("FIRSTMATE WATCHER WAKE", "FIRSTMATE_OP:", "\u2063", "\u26f5"):
+        if marker in text:
+            raise FMError("refusing to mirror operational text")
+    digest = fwl.sha256_text(text)
+    if _receipt_shares_text_and_channel(env, digest, thread_id):
+        print("mirror exists; no second post")
+        return 0
+    tag = "main" if args.tag == "main" else "captain"
+    nonce = f"mirror:{thread_id}:{digest}"
+    target = {"guild_id": cfg.guild_id, "channel_id": thread_id}
+    receipt = fwl.base_receipt("mirror", tag, target, digest)
+    client = DiscordClient(decrypt_token(env, cfg))
+    # The typing marker fires only around the actual post: real processing
+    # already happened in the main turn, so this is never a queued lie.
+    client.request("POST", f"/channels/{thread_id}/typing")
+    sent = client.request(
+        "POST",
+        f"/channels/{thread_id}/messages",
+        {"content": f"[{tag}] {text}", "allowed_mentions": {"parse": []}},
+    )
+    discord_message_id = str(sent.get("id") or "")
+    if not discord_message_id.isdigit():
+        raise FMError("Discord did not return a usable message id for the mirror post")
+    recorded = fwl.record_receipt(env, nonce, receipt, discord_message_id)
+    record_mirror_cursor(env, digest, thread_id, recorded)
+    print(recorded)
+    return 0
+
+
+def record_mirror_cursor(env: "fwl.Env", digest: str, thread_id: str, recorded: str) -> None:
+    cursor_path = fwl.discord_state_path(env, "mirror-cursor.json")
+    try:
+        cursor = json.loads(cursor_path.read_text(encoding="utf-8")) if cursor_path.exists() else []
+    except (OSError, json.JSONDecodeError):
+        cursor = []
+    if not isinstance(cursor, list):
+        cursor = []
+    cursor.append({"digest": digest, "thread": thread_id, "result": recorded})
+    with fwl.state_transaction(env):
+        fwl.atomic_json(cursor_path, cursor[-100:])
+
+
 def registered_source_pass(env: "fwl.Env", cfg: "fwl.WorkspaceConfig", client: "DiscordClient") -> int:
     """Wire contract for the registered process-event source.
 
@@ -461,6 +547,11 @@ def main(argv: List[str]) -> int:
     p.add_argument("--request-id", required=True)
     p.add_argument("--text-file", required=True)
     p.add_argument("--nonce")
+    p = sub.add_parser("live-post")
+    fwl.add_config_argument(p)
+    p.add_argument("--thread", required=True)
+    p.add_argument("--tag", choices=("captain", "main"), required=True)
+    p.add_argument("--text-file", required=True)
     args = parser.parse_args(argv[2:])
     env = fwl.Env(argv[1])
     handlers = {
@@ -469,6 +560,7 @@ def main(argv: List[str]) -> int:
         "live-reply": cmd_live_reply,
         "live-source": cmd_live_source,
         "live-roundtrip": lambda a, e: cmd_live_reply(a, e, verify=True),
+        "live-post": cmd_live_post,
     }
     return handlers[args.command](args, env)
 

--- a/bin/fm_discord_live.py
+++ b/bin/fm_discord_live.py
@@ -362,7 +362,12 @@ def handoff_event(env: "fwl.Env", event: Dict[str, Any]) -> int:
 
 
 def live_source_pass(env: "fwl.Env", cfg: "fwl.WorkspaceConfig", client: "DiscordClient") -> int:
-    """One inbound pass: guild-scoped active threads, cursor-filtered handoff."""
+    """One inbound pass: guild-scoped active threads, cursor-filtered handoff.
+
+    Returns the number of messages scanned. Raises FMError on failure; failed
+    messages never advance their cursors because each cursor is written only
+    after its message's handoff succeeded.
+    """
     forum_ids = {p["exchange_forum_id"] for p in cfg.profiles.values() if p["exchange_forum_id"]}
     profile_by_forum = {p["exchange_forum_id"]: key for key, p in cfg.profiles.items() if p["exchange_forum_id"]}
     listing = client.request("GET", f"/guilds/{cfg.guild_id}/threads/active")
@@ -405,15 +410,34 @@ def live_source_pass(env: "fwl.Env", cfg: "fwl.WorkspaceConfig", client: "Discor
             if str(message.get("id") or "").isdigit():
                 fwl.write_cursor(env, key, thread_id, str(message["id"]))
                 ingested += 1
-    print(f"live source pass complete; {ingested} messages scanned")
-    return 0
+    return ingested
 
 
 def cmd_live_source(args: Any, env: "fwl.Env") -> int:
+    """Human-facing one-shot pass; progress goes to stdout."""
     cfg = fwl.load_config(env, args.config)
     require_live_flag(cfg, cfg.live_polling_enabled, "live inbound source")
     client = DiscordClient(decrypt_token(env, cfg))
-    return live_source_pass(env, cfg, client)
+    scanned = live_source_pass(env, cfg, client)
+    print(f"live source pass complete; {scanned} messages scanned")
+    return 0
+
+
+def registered_source_pass(env: "fwl.Env", cfg: "fwl.WorkspaceConfig", client: "DiscordClient") -> int:
+    """Wire contract for the registered process-event source.
+
+    A successful scan is silent and exits nonzero with empty stdout so the
+    runner records no-result and keeps the source armed; durable effects
+    already went through fm-inbox. A genuine failure prints one bounded
+    redacted actionable line (captured as a result) and exits nonzero so the
+    failed pass stays visible and retryable without advancing cursors.
+    """
+    try:
+        live_source_pass(env, cfg, client)
+    except FMError as exc:
+        print(redact(f"discord live source failed: {exc}", client.token))
+        return 1
+    return fwl.EXIT_NO_RESULT
 
 
 def main(argv: List[str]) -> int:

--- a/bin/fm_discord_live.py
+++ b/bin/fm_discord_live.py
@@ -1,0 +1,455 @@
+#!/usr/bin/env python3
+"""Bounded live Discord activation layer for the offline workspace core.
+
+This module owns the minimum live path authorized by the captain: secret
+decryption into process memory, authenticated read-only health, idempotent
+category/forum setup apply, live outbound replies with existing receipt
+idempotency, a live inbound source that feeds the existing external-id inbox
+seam, and one round-trip verification command.
+
+Out of scope by contract: retirement/deletion of Discord resources, voice
+capture, hosted transcription, webhooks, arbitrary guilds, and generalized
+transports. The bot token is never printed, logged, or written to disk; every
+error message is redacted before display. Per captain correction: forum
+channels are created and reused directly; no Community-mode or related
+guild-setting prerequisite is inspected, enabled, or managed here.
+
+Usage (via bin/fm-discord-live.sh):
+    fm-discord-live.sh health --config <json>
+    fm-discord-live.sh setup-apply --config <json>
+    fm-discord-live.sh live-reply --config <json> --request-id <id> --text-file <f> [--nonce <n>]
+    fm-discord-live.sh live-source --config <json>
+    fm-discord-live.sh live-roundtrip --config <json> --request-id <id> --text-file <f>
+
+Test seams: FM_DISCORD_LIVE_API_BASE overrides the API base URL and
+FM_DISCORD_LIVE_SOPS overrides the sops binary; FM_DISCORD_LIVE_RETRY_SLEEP
+bounds retry backoff. These never change what is redacted.
+"""
+
+import importlib.util
+import json
+import os
+import re
+import subprocess
+import sys
+import tempfile
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+
+_spec = importlib.util.spec_from_file_location("fwl", SCRIPT_DIR / "fm_discord_workspace_lib.py")
+fwl = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(fwl)
+
+FMError = fwl.FMError
+API_BASE_DEFAULT = "https://discord.com/api/v10"
+CHANNEL_TYPE_CATEGORY = 4
+CHANNEL_TYPE_FORUM = 15
+TOKEN_KEY = "FIRSTMATE_DISCORD_BOT_TOKEN"
+MAX_RETRIES = 3
+USER_AGENT = "firstmate-discord-workspace (bounded activation layer, +https://localhost)"
+
+
+def redact(text: str, token: str) -> str:
+    if not token:
+        return text
+    return text.replace(token, "[REDACTED]")
+
+
+def decrypt_token(env: "fwl.Env", cfg: "fwl.WorkspaceConfig") -> str:
+    """Decrypt only the bot token into process memory. Never printed."""
+    secret_ref = str((cfg.transcription or {}).get("secret_file") or "config/discord-workspace.secrets.sops.yaml")
+    path = Path(secret_ref).expanduser()
+    if not path.is_absolute():
+        path = env.home / path
+    if not path.is_file():
+        raise FMError(f"secret file is missing: {path}")
+    sops = os.environ.get("FM_DISCORD_LIVE_SOPS", "sops")
+    proc = subprocess.run(
+        [sops, "-d", str(path)],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    if proc.returncode != 0:
+        raise FMError("secret decryption failed; the secret file was not modified")
+    token = ""
+    for line in proc.stdout.splitlines():
+        match = re.fullmatch(rf"{TOKEN_KEY}:\s*(\S+)\s*", line)
+        if match:
+            token = match.group(1)
+            break
+    if not token:
+        raise FMError(f"decrypted secret file does not contain {TOKEN_KEY}")
+    for bad in ("\n", "\r"):
+        if bad in token:
+            raise FMError("decrypted token contains a newline; refusing")
+    proc.stdout = ""
+    return token
+
+
+class DiscordError(FMError):
+    pass
+
+
+class DiscordClient:
+    def __init__(self, token: str, base: Optional[str] = None):
+        self.token = token
+        self.base = (base or os.environ.get("FM_DISCORD_LIVE_API_BASE") or API_BASE_DEFAULT).rstrip("/")
+
+    def request(self, method: str, path: str, body: Optional[Dict[str, Any]] = None, params: Optional[Dict[str, str]] = None) -> Dict[str, Any]:
+        url = f"{self.base}{path}"
+        if params:
+            query = "&".join(f"{k}={v}" for k, v in params.items())
+            url = f"{url}?{query}"
+        data = json.dumps(body).encode("utf-8") if body is not None else None
+        headers = {
+            "Authorization": f"Bot {self.token}",
+            "User-Agent": USER_AGENT,
+            "Accept": "application/json",
+        }
+        if data is not None:
+            headers["Content-Type"] = "application/json"
+        last_error = ""
+        for attempt in range(MAX_RETRIES + 1):
+            req = urllib.request.Request(url, data=data, headers=headers, method=method)
+            try:
+                with urllib.request.urlopen(req) as resp:
+                    payload = resp.read().decode("utf-8")
+                    return json.loads(payload) if payload else {}
+            except urllib.error.HTTPError as exc:
+                detail = exc.read().decode("utf-8", "replace")
+                if exc.code == 429 and attempt < MAX_RETRIES:
+                    time.sleep(self._retry_after(detail, exc.headers))
+                    continue
+                if 500 <= exc.code < 600 and attempt < MAX_RETRIES:
+                    time.sleep(float(os.environ.get("FM_DISCORD_LIVE_RETRY_SLEEP", "1")))
+                    continue
+                raise DiscordError(redact(f"Discord API {method} {path} failed with HTTP {exc.code}: {detail}", self.token))
+            except urllib.error.URLError as exc:
+                last_error = redact(f"Discord API {method} {path} transport failure: {exc.reason}", self.token)
+                if attempt < MAX_RETRIES:
+                    time.sleep(float(os.environ.get("FM_DISCORD_LIVE_RETRY_SLEEP", "1")))
+                    continue
+                raise DiscordError(last_error)
+        raise DiscordError(last_error or f"Discord API {method} {path} failed")
+
+    @staticmethod
+    def _retry_after(detail: str, headers: Any) -> float:
+        sleep_default = float(os.environ.get("FM_DISCORD_LIVE_RETRY_SLEEP", "1"))
+        try:
+            parsed = json.loads(detail)
+            retry = parsed.get("retry_after")
+            if isinstance(retry, (int, float)) and retry >= 0:
+                return min(float(retry), 30.0)
+        except (json.JSONDecodeError, ValueError):
+            pass
+        try:
+            header_value = headers.get("Retry-After")
+            if header_value:
+                return min(float(header_value) / 1000.0, 30.0)
+        except (TypeError, ValueError):
+            pass
+        return sleep_default
+
+
+def require_live_flag(cfg: "fwl.WorkspaceConfig", flag: bool, what: str) -> None:
+    if not flag:
+        raise FMError(f"{what} requires its live approval flag in the workspace config")
+
+
+def cmd_health(args: Any, env: "fwl.Env") -> int:
+    cfg = fwl.load_config(env, args.config)
+    client = DiscordClient(decrypt_token(env, cfg))
+    me = client.request("GET", "/users/@me")
+    if str(me.get("id") or "") != cfg.bot_user_id:
+        raise FMError(f"authenticated bot id {me.get('id')} does not match the configured bot user id")
+    guild = client.request("GET", f"/guilds/{cfg.guild_id}")
+    if str(guild.get("id") or "") != cfg.guild_id:
+        raise FMError(f"guild lookup returned id {guild.get('id')} instead of the configured operations guild")
+    print(f"bot identity ok: {me.get('username')}")
+    print(f"operations guild ok: {guild.get('name')}")
+    print("live health ok")
+    return 0
+
+
+def _match_channel(channels: List[Dict[str, Any]], name: str, ctype: int, parent_id: str) -> Optional[Dict[str, Any]]:
+    for channel in channels:
+        if channel.get("name") != name:
+            continue
+        if int(channel.get("type") or -1) != ctype:
+            return None
+        if str(channel.get("parent_id") or "") != parent_id:
+            return None
+        return channel
+    return None
+
+
+def _name_owner(channels: List[Dict[str, Any]], name: str) -> Optional[str]:
+    for channel in channels:
+        if channel.get("name") == name:
+            return f"type {channel.get('type')} parent {channel.get('parent_id')}"
+    return None
+
+
+def cmd_setup_apply(args: Any, env: "fwl.Env") -> int:
+    cfg = fwl.load_config(env, args.config)
+    client = DiscordClient(decrypt_token(env, cfg))
+    # Forum channels are created and reused directly; no Community-mode or
+    # other guild-setting prerequisite is inspected, enabled, or managed.
+    channels = client.request("GET", f"/guilds/{cfg.guild_id}/channels")
+    if not isinstance(channels, list):
+        raise FMError("guild channel listing was malformed")
+    created: List[str] = []
+    for key in fwl.ACTIVE_PROFILE_KEYS:
+        p = cfg.profiles[key]
+        plans = [
+            (CHANNEL_TYPE_CATEGORY, "", p["category_name"]),
+            (CHANNEL_TYPE_FORUM, p["category_name"], p["exchange_forum_name"]),
+            (CHANNEL_TYPE_FORUM, p["category_name"], p["artifact_forum_name"]),
+        ]
+        ids: Dict[str, str] = {}
+        for ctype, parent_name, name in plans:
+            parent_id = ""
+            if parent_name:
+                parent = _match_channel(channels, parent_name, CHANNEL_TYPE_CATEGORY, "")
+                if parent is None:
+                    raise FMError(f"category {parent_name!r} is not available for {name!r}")
+                parent_id = str(parent["id"])
+            existing = _match_channel(channels, name, ctype, parent_id)
+            if existing is not None:
+                ids[name] = str(existing["id"])
+                continue
+            owner = _name_owner(channels, name)
+            if owner is not None:
+                raise FMError(f"channel {name!r} already exists with mismatched shape ({owner}); refusing to substitute")
+            body: Dict[str, Any] = {"name": name, "type": ctype}
+            if parent_id:
+                body["parent_id"] = parent_id
+            if ctype == CHANNEL_TYPE_FORUM:
+                tags = cfg.exchange_tags if name == p["exchange_forum_name"] else cfg.artifact_tags
+                body["available_tags"] = [{"name": tag} for tag in tags]
+            channel = client.request("POST", f"/guilds/{cfg.guild_id}/channels", body)
+            ids[name] = str(channel["id"])
+            channels.append(channel)
+            created.append(f"{name} -> {channel['id']}")
+            _write_profile_ids(env, cfg.raw, key, ids, p, name)
+        _write_profile_ids(env, cfg.raw, key, ids, p, None)
+    for item in created:
+        print(f"created {item}")
+    print("setup apply complete; non-secret ids written to the workspace config")
+    return 0
+
+
+def _write_profile_ids(env: "fwl.Env", raw: Dict[str, Any], key: str, ids: Dict[str, str], p: Dict[str, Any], only: Optional[str]) -> None:
+    profile_raw = raw["profiles"][key]
+    changed = False
+    category_id = ids.get(p["category_name"])
+    exchange_id = ids.get(p["exchange_forum_name"])
+    artifact_id = ids.get(p["artifact_forum_name"])
+    if only is None:
+        for slot, value in (("category_id", category_id), ("exchange_forum_id", exchange_id), ("artifact_forum_id", artifact_id)):
+            if value and str(profile_raw.get(slot) or "") != value:
+                profile_raw[slot] = value
+                changed = True
+    else:
+        slot = {p["exchange_forum_name"]: "exchange_forum_id", p["artifact_forum_name"]: "artifact_forum_id", p["category_name"]: "category_id"}.get(only)
+        value = ids.get(only)
+        if slot and value and str(profile_raw.get(slot) or "") != value:
+            profile_raw[slot] = value
+            changed = True
+    if not changed:
+        return
+    atomic_write_config(env, raw)
+
+
+def atomic_write_config(env: "fwl.Env", raw: Dict[str, Any]) -> None:
+    path = Path(env.home) / "config" / "discord-workspace.json"
+    fwl.atomic_json(path, raw)
+
+
+def cmd_live_reply(args: Any, env: "fwl.Env", verify: bool = False) -> int:
+    cfg = fwl.load_config(env, args.config)
+    require_live_flag(cfg, cfg.live_posting_enabled, "live reply")
+    text = fwl.read_text_file(args.text_file)
+    guild_id, channel_id, message_id, profile_key, forum_kind = cfg.profile_for_request_id(args.request_id)
+    if forum_kind != "exchange":
+        raise FMError("replies must target an exchange forum thread")
+    text_digest = fwl.sha256_text(text)
+    nonce = args.nonce or f"reply:{args.request_id}:{text_digest}"
+    target = {"guild_id": guild_id, "channel_id": channel_id, "message_id": message_id, "request_id": args.request_id}
+    receipt = fwl.base_receipt("reply", profile_key, target, text_digest)
+    client = DiscordClient(decrypt_token(env, cfg))
+    existing = fwl.load_existing_json(fwl.receipt_path(env, nonce))
+    if existing is not None:
+        comparable = dict(existing)
+        comparable.pop("recorded_at", None)
+        recorded = str(existing.get("discord_message_id") or "")
+        if comparable != fwl.receipt_record(nonce, receipt, recorded):
+            raise FMError("refusing to overwrite a different Discord outbound receipt for the same nonce")
+        print(f"receipt exists for nonce {nonce}; no second delivery")
+        if not verify or not recorded:
+            return 0
+        posted = client.request("GET", f"/channels/{channel_id}/messages/{recorded}")
+        if str(posted.get("id") or "") != recorded:
+            raise FMError("round-trip verification could not read back the recorded message")
+        print("round-trip verified against the recorded message id")
+        return 0
+    sent = client.request(
+        "POST",
+        f"/channels/{channel_id}/messages",
+        {"content": text, "allowed_mentions": {"parse": []}},
+    )
+    discord_message_id = str(sent.get("id") or "")
+    if not discord_message_id.isdigit():
+        raise FMError("Discord did not return a usable message id for the reply")
+    print(fwl.record_receipt(env, nonce, receipt, discord_message_id))
+    if verify:
+        back = client.request("GET", f"/channels/{channel_id}/messages/{discord_message_id}")
+        if str(back.get("id") or "") != discord_message_id:
+            raise FMError("round-trip verification could not read back the posted message")
+        print("round-trip verified against the posted message id")
+    return 0
+
+
+def handoff_event(env: "fwl.Env", event: Dict[str, Any]) -> int:
+    """Feed one normalized event through the existing external-id inbox seam."""
+    cls = fwl.event_class(event)
+    if cls == "malformed":
+        raise FMError("event is malformed")
+    if cls == "ignored":
+        return 0
+    request = fwl.request_record_from_event(event)
+    with fwl.state_transaction(env):
+        fwl.write_same_or_refuse(fwl.request_record_path(env, str(event.get("external_id"))), request, "request record")
+    body = fwl.note_body_for_event(event)
+    metadata_dir = fwl.discord_state_path(env, "metadata-staging")
+    metadata_dir.mkdir(parents=True, exist_ok=True)
+    fd, meta_tmp = tempfile.mkstemp(prefix=".metadata.", suffix=".json", dir=str(metadata_dir))
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            json.dump(fwl.event_metadata(event), f, indent=2, sort_keys=True)
+            f.write("\n")
+        os.chmod(meta_tmp, 0o600)
+        inbox_cmd = [
+            str(env.script_dir / "fm-inbox.sh"),
+            "note",
+            "--source",
+            "discord-workspace",
+            "--external-id",
+            str(event.get("external_id")),
+            "--metadata-file",
+            meta_tmp,
+            "-",
+        ]
+        proc = subprocess.run(inbox_cmd, input=body, text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        if proc.returncode != 0:
+            if proc.stdout:
+                print(proc.stdout, end="")
+            if proc.stderr:
+                print(proc.stderr, end="", file=sys.stderr)
+            return proc.returncode
+    finally:
+        try:
+            os.unlink(meta_tmp)
+        except FileNotFoundError:
+            pass
+    return 0
+
+
+def cmd_live_source(args: Any, env: "fwl.Env") -> int:
+    cfg = fwl.load_config(env, args.config)
+    require_live_flag(cfg, cfg.live_polling_enabled, "live inbound source")
+    client = DiscordClient(decrypt_token(env, cfg))
+    ingested = 0
+    for key in fwl.ACTIVE_PROFILE_KEYS:
+        p = cfg.profiles[key]
+        forum_id = p["exchange_forum_id"]
+        if not forum_id:
+            continue
+        listing = client.request("GET", f"/channels/{forum_id}/threads/active")
+        threads = listing.get("threads") if isinstance(listing.get("threads"), list) else []
+        for thread in threads:
+            if not isinstance(thread, dict):
+                continue
+            thread_id = str(thread.get("id") or "")
+            if not thread_id.isdigit() or thread_id == forum_id:
+                continue
+            if str(thread.get("parent_id") or "") != forum_id:
+                continue
+            last = fwl.read_cursor(env, key, thread_id)
+            params = {"limit": "100"}
+            if last:
+                params["after"] = str(last)
+            messages = client.request("GET", f"/channels/{thread_id}/messages", params=params)
+            if not isinstance(messages, list):
+                raise FMError(f"message listing for thread {thread_id} was malformed")
+            for message in reversed(messages):
+                if not isinstance(message, dict):
+                    continue
+                normalized = {
+                    "id": message.get("id"),
+                    "guild_id": cfg.guild_id,
+                    "channel_id": thread_id,
+                    "parent_id": forum_id,
+                    "author": message.get("author"),
+                    "author_id": message.get("author_id"),
+                    "content": message.get("content"),
+                    "timestamp": message.get("timestamp"),
+                    "flags": message.get("flags"),
+                    "attachments": message.get("attachments"),
+                }
+                event = fwl.message_to_event(cfg, normalized)
+                status = handoff_event(env, event)
+                if status != 0:
+                    return status
+                if str(message.get("id") or "").isdigit():
+                    fwl.write_cursor(env, key, thread_id, str(message["id"]))
+                    ingested += 1
+    print(f"live source pass complete; {ingested} messages scanned")
+    return 0
+
+
+def main(argv: List[str]) -> int:
+    import argparse
+
+    parser = argparse.ArgumentParser(prog="fm-discord-live.sh")
+    sub = parser.add_subparsers(dest="command", required=True)
+    p = sub.add_parser("health")
+    fwl.add_config_argument(p)
+    p = sub.add_parser("setup-apply")
+    fwl.add_config_argument(p)
+    p = sub.add_parser("live-reply")
+    fwl.add_config_argument(p)
+    p.add_argument("--request-id", required=True)
+    p.add_argument("--text-file", required=True)
+    p.add_argument("--nonce")
+    p = sub.add_parser("live-source")
+    fwl.add_config_argument(p)
+    p = sub.add_parser("live-roundtrip")
+    fwl.add_config_argument(p)
+    p.add_argument("--request-id", required=True)
+    p.add_argument("--text-file", required=True)
+    p.add_argument("--nonce")
+    args = parser.parse_args(argv[2:])
+    env = fwl.Env(argv[1])
+    handlers = {
+        "health": cmd_health,
+        "setup-apply": cmd_setup_apply,
+        "live-reply": cmd_live_reply,
+        "live-source": cmd_live_source,
+        "live-roundtrip": lambda a, e: cmd_live_reply(a, e, verify=True),
+    }
+    return handlers[args.command](args, env)
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main(sys.argv))
+    except FMError as exc:
+        print(f"fm-discord-live: {exc}", file=sys.stderr)
+        sys.exit(1)

--- a/bin/fm_discord_workspace_lib.py
+++ b/bin/fm_discord_workspace_lib.py
@@ -30,13 +30,12 @@ PENDING_SCHEMA = "fm-discord-workspace-pending-followup.v1"
 ARTIFACT_SCHEMA = "fm-discord-workspace-artifact.v1"
 ARTIFACT_INDEX_SCHEMA = "fm-discord-workspace-artifact-source-index.v1"
 
-ACTIVE_PROFILE_KEYS = ["proapplis", "folium", "arfal"]
+ACTIVE_PROFILE_KEYS = ["firstmate", "proapplis", "folium"]
 ACTIVE_PROFILE_LABELS = {
+    "firstmate": "System / Firstmate",
     "proapplis": "ProApplis",
     "folium": "Folium",
-    "arfal": "ARFAL",
 }
-DISABLED_PROFILE_KEYS = ["lbdb", "maratone-labs"]
 DEFAULT_EXCHANGE_TAGS = ["request", "decision", "work", "status", "blocked", "done"]
 DEFAULT_ARTIFACT_TAGS = ["report", "board", "document", "image", "audio", "draft", "final", "expired"]
 DEFAULT_CDN_HOSTS = ["cdn.discordapp.com", "media.discordapp.net", "media.discordapp.com"]
@@ -227,9 +226,9 @@ def validate_tags(raw: Any, default: List[str], field: str) -> List[str]:
 def normalize_profile_key(key: str) -> str:
     lowered = key.strip().lower().replace("_", "-").replace(" ", "-")
     aliases = {
+        "system-firstmate": "firstmate",
+        "system-/-firstmate": "firstmate",
         "pro-applis": "proapplis",
-        "maratone": "maratone-labs",
-        "maratone-labs": "maratone-labs",
     }
     return aliases.get(lowered, lowered)
 
@@ -325,11 +324,8 @@ class WorkspaceConfig:
             self.captain_user_ids.append(sid)
         if not self.captain_user_ids:
             raise FMError("captain_user_ids must contain at least one captain Discord user id")
-        disabled = raw.get("disabled_profiles", DISABLED_PROFILE_KEYS)
-        self.disabled_profiles = [normalize_profile_key(str(x)) for x in as_list(disabled, "disabled_profiles")]
-        missing_disabled = [p for p in DISABLED_PROFILE_KEYS if p not in self.disabled_profiles]
-        if missing_disabled:
-            raise FMError(f"disabled_profiles must include dormant profile(s): {', '.join(missing_disabled)}")
+        if "disabled_profiles" in raw:
+            raise FMError("disabled_profiles is unsupported; configure only the three active profiles")
         tags_obj = raw.get("tags") if isinstance(raw.get("tags"), dict) else {}
         self.exchange_tags = validate_tags(tags_obj.get("exchange"), DEFAULT_EXCHANGE_TAGS, "tags.exchange")
         self.artifact_tags = validate_tags(tags_obj.get("artifacts", tags_obj.get("artifact")), DEFAULT_ARTIFACT_TAGS, "tags.artifacts")
@@ -337,6 +333,12 @@ class WorkspaceConfig:
         raw_profiles = raw.get("profiles")
         if not isinstance(raw_profiles, dict):
             raise FMError("profiles must be an object")
+        normalized_profile_keys = [normalize_profile_key(str(key)) for key in raw_profiles]
+        if len(normalized_profile_keys) != len(set(normalized_profile_keys)):
+            raise FMError("profiles contains duplicate normalized profile keys")
+        unsupported_profiles = sorted(set(normalized_profile_keys) - set(ACTIVE_PROFILE_KEYS))
+        if unsupported_profiles:
+            raise FMError(f"profiles contains unsupported profile(s): {', '.join(unsupported_profiles)}")
         seen_ids: Dict[str, str] = {}
         for key in ACTIVE_PROFILE_KEYS:
             p = extract_profile(raw_profiles, key)
@@ -388,14 +390,6 @@ class WorkspaceConfig:
                 "exchange_forum_name": p.get("exchange_forum_name") or f"{key}-exchanges",
                 "artifact_forum_name": p.get("artifact_forum_name") or f"{key}-artifacts",
             }
-        for disabled_key in DISABLED_PROFILE_KEYS:
-            p = extract_profile(raw_profiles, disabled_key)
-            if not p:
-                continue
-            enabled = validate_bool(p.get("enabled", False), f"profiles.{disabled_key}.enabled", default=False)
-            channelish = [name for name in ("category_id", "exchange_forum_id", "artifact_forum_id", "artifacts_forum_id") if p.get(name)]
-            if enabled or channelish:
-                raise FMError(f"disabled profile {disabled_key} must not be enabled or carry channel ids")
         approvals = raw.get("approvals") if isinstance(raw.get("approvals"), dict) else {}
         live = raw.get("live") if isinstance(raw.get("live"), dict) else {}
         self.message_content_enabled = bool_from_path(raw, ["message_content", "message_content_intent", "approvals.message_content", "live.message_content"], False)
@@ -482,8 +476,15 @@ def sample_config() -> Dict[str, Any]:
         "guild": {"id": "111111111111111111"},
         "bot": {"application_id": "222222222222222222", "user_id": "333333333333333333"},
         "captain_user_ids": ["444444444444444444"],
-        "disabled_profiles": DISABLED_PROFILE_KEYS,
         "profiles": {
+            "firstmate": {
+                "enabled": True,
+                "label": "System / Firstmate",
+                "category_id": "777777777777777771",
+                "exchange_forum_id": "777777777777777772",
+                "artifact_forum_id": "777777777777777773",
+                "thread_ids": {"exchange": [], "artifacts": []},
+            },
             "proapplis": {
                 "enabled": True,
                 "label": "ProApplis",
@@ -500,16 +501,6 @@ def sample_config() -> Dict[str, Any]:
                 "artifact_forum_id": "666666666666666663",
                 "thread_ids": {"exchange": [], "artifacts": []},
             },
-            "arfal": {
-                "enabled": True,
-                "label": "ARFAL",
-                "category_id": "777777777777777771",
-                "exchange_forum_id": "777777777777777772",
-                "artifact_forum_id": "777777777777777773",
-                "thread_ids": {"exchange": [], "artifacts": []},
-            },
-            "lbdb": {"enabled": False},
-            "maratone-labs": {"enabled": False},
         },
         "tags": {"exchange": DEFAULT_EXCHANGE_TAGS, "artifacts": DEFAULT_ARTIFACT_TAGS},
         "outbound": {"final_replies_required": True, "live_posting": False},
@@ -550,7 +541,6 @@ def print_config_ok(cfg: WorkspaceConfig) -> None:
     print(f"config ok: {cfg.path}")
     print(f"guild: {cfg.guild_id}")
     print("active profiles: " + ", ".join(ACTIVE_PROFILE_KEYS))
-    print("disabled profiles: " + ", ".join(DISABLED_PROFILE_KEYS))
     print("exchange forum tags: " + ", ".join(cfg.exchange_tags))
     print("artifact forum tags: " + ", ".join(cfg.artifact_tags))
     for row in cfg.thread_summary():

--- a/bin/fm_discord_workspace_lib.py
+++ b/bin/fm_discord_workspace_lib.py
@@ -1133,7 +1133,10 @@ def cmd_followup(args: argparse.Namespace, env: Env) -> int:
                 "status": "pending",
             }
             write_same_or_refuse(pending_path, pending, "pending final follow-up")
-        print("pending final follow-up: present")
+        if pending.get("status") == "delivered":
+            print("final follow-up already delivered")
+        else:
+            print("pending final follow-up: present")
     if args.record_discord_message_id:
         msg_id = validate_snowflake(args.record_discord_message_id, "--record-discord-message-id") or ""
         print(record_receipt(env, nonce, receipt, msg_id))
@@ -1149,6 +1152,8 @@ def cmd_followup(args: argparse.Namespace, env: Env) -> int:
             }
             atomic_json(pending_followup_path(env, args.task_id), delivered)
             print("pending final follow-up delivered")
+    elif args.final and pending.get("status") == "delivered":
+        print("dry-run only; final follow-up was already delivered.")
     else:
         print("dry-run only; pending final follow-up remains unresolved.")
     return 0

--- a/bin/fm_discord_workspace_lib.py
+++ b/bin/fm_discord_workspace_lib.py
@@ -12,6 +12,7 @@ from contextlib import contextmanager
 import datetime as _dt
 import fcntl
 import hashlib
+import importlib
 import json
 import math
 import mimetypes
@@ -1976,18 +1977,37 @@ def fixture_messages(cfg: WorkspaceConfig) -> List[Dict[str, Any]]:
 def procevent_cmd_arm(args: argparse.Namespace, env: Env) -> int:
     cfg = load_config(env, args.config)
     command = [str(env.script_dir / "fm-procevent-discord-workspace.sh"), "source", "--config", str(cfg.path)]
+    register_cmd = [str(env.script_dir / "fm-procevent.sh"), "register", "discord-workspace", DISCORD_SOURCE_ID, "--"] + command
     if args.dry_run:
         print("Discord workspace process-event arm dry-run (no network).")
         print(f"source id: {DISCORD_SOURCE_ID}")
         print("register command:")
-        print(" ".join([str(env.script_dir / "fm-procevent.sh"), "register", "discord-workspace", DISCORD_SOURCE_ID, "--"] + command))
-        print("live polling remains disabled until an activation task approves it.")
+        print(" ".join(register_cmd))
+        print("live polling remains disabled until the workspace config enables it.")
         return 0
-    raise FMError("process-event arm refused in this offline phase; no live source was registered")
+    if not cfg.live_polling_enabled:
+        raise FMError("process-event arm refused while live polling is disabled in the workspace config")
+    proc = subprocess.run(register_cmd, text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    if proc.returncode != 0:
+        if proc.stdout:
+            print(proc.stdout, end="")
+        if proc.stderr:
+            print(proc.stderr, end="", file=sys.stderr)
+        raise FMError("process-event registration failed")
+    if proc.stdout:
+        print(proc.stdout, end="")
+    print("Discord workspace live source registered; repeat and retire through fm-procevent.sh")
+    return 0
 
 
 def procevent_cmd_source(args: argparse.Namespace, env: Env) -> int:
     cfg = load_config(env, args.config)
+    if cfg.live_polling_enabled:
+        spec = importlib.util.spec_from_file_location("fm_discord_live", env.script_dir / "fm_discord_live.py")
+        live = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(live)
+        client = live.DiscordClient(live.decrypt_token(env, cfg))
+        return live.live_source_pass(env, cfg, client)
     messages = fixture_messages(cfg)
     for message in messages:
         event = message_to_event(cfg, message)

--- a/bin/fm_discord_workspace_lib.py
+++ b/bin/fm_discord_workspace_lib.py
@@ -1646,9 +1646,9 @@ def procevent_cmd_autohandle(args: argparse.Namespace, env: Env) -> int:
     cls = event_class(event)
     if cls == "malformed":
         raise FMError("result is malformed")
-    if event.get("profile") and event.get("channel_id") and event.get("message_id"):
-        write_cursor(env, str(event["profile"]), str(event["channel_id"]), str(event["message_id"]))
     if cls == "ignored":
+        if event.get("profile") and event.get("channel_id") and event.get("message_id"):
+            write_cursor(env, str(event["profile"]), str(event["channel_id"]), str(event["message_id"]))
         procevent_mark_handled(env, source_id, sequence)
         print("handled ignored Discord workspace event")
         return 0
@@ -1687,6 +1687,8 @@ def procevent_cmd_autohandle(args: argparse.Namespace, env: Env) -> int:
     if cls == "message":
         request = request_record_from_event(event)
         write_same_or_refuse(request_record_path(env, str(event.get("external_id"))), request, "request record")
+    if event.get("profile") and event.get("channel_id") and event.get("message_id"):
+        write_cursor(env, str(event["profile"]), str(event["channel_id"]), str(event["message_id"]))
     procevent_mark_handled(env, source_id, sequence)
     print("autohandled Discord workspace event through fm-inbox")
     return 0

--- a/bin/fm_discord_workspace_lib.py
+++ b/bin/fm_discord_workspace_lib.py
@@ -613,6 +613,20 @@ class WorkspaceConfig:
                 if parent_id and parent_id != p["artifact_forum_id"]:
                     return None
                 return key, "artifact", p["artifact_forum_id"]
+        # A Discord forum post arrives as a newly created child thread whose
+        # parent is the configured forum, so a verified parent link admits the
+        # thread under the same guild/profile/forum allowlists even when its
+        # id is not pre-allowlisted. Explicit allowlist entries above always
+        # win, and the thread must be a plain snowflake distinct from the
+        # forum itself.
+        if parent_id and ID_RE.fullmatch(channel_id):
+            for key, p in self.profiles.items():
+                if channel_id in (p["exchange_forum_id"], p["artifact_forum_id"]):
+                    return None
+                if parent_id == p["exchange_forum_id"]:
+                    return key, "exchange", p["exchange_forum_id"]
+                if parent_id == p["artifact_forum_id"]:
+                    return key, "artifact", p["artifact_forum_id"]
         return None
 
     def profile_for_request_id(self, request_id: str) -> Tuple[str, str, str, str, str]:

--- a/bin/fm_discord_workspace_lib.py
+++ b/bin/fm_discord_workspace_lib.py
@@ -7,14 +7,19 @@ This module contains the shared parsing and planning logic so the outbound owner
 from __future__ import annotations
 
 import argparse
+import codecs
+from contextlib import contextmanager
 import datetime as _dt
+import fcntl
 import hashlib
 import json
+import math
 import mimetypes
 import os
 from pathlib import Path
 import re
 import shutil
+import stat
 import subprocess
 import sys
 import tempfile
@@ -40,10 +45,10 @@ DEFAULT_EXCHANGE_TAGS = ["request", "decision", "work", "status", "blocked", "do
 DEFAULT_ARTIFACT_TAGS = ["report", "board", "document", "image", "audio", "draft", "final", "expired"]
 DEFAULT_CDN_HOSTS = ["cdn.discordapp.com", "media.discordapp.net", "media.discordapp.com"]
 VOICE_MESSAGE_FLAG = 1 << 13
-STEADY_PERMISSION = 101376
-STEADY_THREADS_PERMISSION = 274878008320
-SETUP_PERMISSION = 268536848
-SETUP_THREADS_PERMISSION = 275146443792
+STEADY_PERMISSION = 117760
+STEADY_THREADS_PERMISSION = 274878024704
+SETUP_PERMISSION = 268553232
+SETUP_THREADS_PERMISSION = 275146460176
 DIRECT_ATTACHMENT_MAX = 8 * 1024 * 1024
 AUDIO_MAX_BYTES = 25 * 1024 * 1024
 AUDIO_MAX_DURATION_SECS = 600
@@ -65,6 +70,7 @@ BLOCKED_EXTENSIONS = {
     ".p12", ".pfx", ".key", ".crt", ".cer",
 }
 ALLOWED_TEXT_EXTENSIONS = {".md", ".markdown", ".txt"}
+PROTECTED_TEXT_EXTENSIONS = {".html", ".htm"}
 ALLOWED_IMAGE_EXTENSIONS = {".png", ".jpg", ".jpeg", ".gif", ".webp"}
 ALLOWED_DOCUMENT_EXTENSIONS = {".pdf"}
 ALLOWED_DIRECT_EXTENSIONS = ALLOWED_TEXT_EXTENSIONS | ALLOWED_IMAGE_EXTENSIONS | ALLOWED_DOCUMENT_EXTENSIONS
@@ -92,11 +98,40 @@ class Env:
 
     @property
     def discord_state(self) -> Path:
-        return self.state / "discord-workspace"
+        path = self.state / "discord-workspace"
+        if path.is_symlink() or (path.exists() and not path.is_dir()):
+            raise FMError(f"Discord state root is unsafe: {path}")
+        try:
+            path.resolve().relative_to(self.state)
+        except ValueError as exc:
+            raise FMError(f"Discord state root is outside the configured state directory: {path}") from exc
+        return path
 
     @property
     def inbox(self) -> Path:
         return self.state / "inbox"
+
+
+def discord_state_path(env: Env, *parts: str) -> Path:
+    root = env.discord_state
+    for part in parts:
+        if any(component in (".", "..") for component in str(part).split(os.sep)):
+            raise FMError("Discord state path contains a dot component")
+    path = root.joinpath(*parts)
+    try:
+        relative_parts = path.relative_to(root).parts
+    except ValueError as exc:
+        raise FMError(f"Discord state path is outside the state root: {path}") from exc
+    current = root
+    for part in relative_parts:
+        current /= part
+        if current.is_symlink():
+            raise FMError(f"Discord state path has a symlink component: {current}")
+    try:
+        path.resolve().relative_to(root.resolve())
+    except ValueError as exc:
+        raise FMError(f"Discord state path resolves outside the state root: {path}") from exc
+    return path
 
 
 def die(message: str, code: int = 1) -> None:
@@ -245,6 +280,8 @@ def extract_profile(raw_profiles: Dict[str, Any], key: str) -> Dict[str, Any]:
 def thread_ids_for(profile: Dict[str, Any], kind: str, field_prefix: str) -> List[str]:
     raw = None
     threads = profile.get("thread_ids")
+    if "thread_ids" in profile and not isinstance(threads, dict):
+        raise FMError(f"{field_prefix}.thread_ids must be a JSON object")
     if isinstance(threads, dict) and kind in threads:
         raw = threads[kind]
     if raw is None:
@@ -261,6 +298,14 @@ def thread_ids_for(profile: Dict[str, Any], kind: str, field_prefix: str) -> Lis
     return out
 
 
+def validate_positive_json_integer(value: Any, path: str, maximum: Optional[int] = None) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+        raise FMError(f"{path} must be a positive JSON integer")
+    if maximum is not None and value > maximum:
+        raise FMError(f"{path} must be no more than {maximum}")
+    return value
+
+
 def maybe_id(profile: Dict[str, Any], *names: str) -> Any:
     for name in names:
         if name in profile:
@@ -268,20 +313,87 @@ def maybe_id(profile: Dict[str, Any], *names: str) -> Any:
     return None
 
 
-INLINE_SECRET_KEYS = {"token", "bot_token", "discord_bot_token", "groq_api_key", "api_key_value", "secret", "password", "client_secret"}
+SECRET_VALUE_KEY_RE = re.compile(
+    r"(?:^|_)(?:token|tokens|password|passwords|credential|credentials|secret|secrets|client_secret|api_key)(?:$|_)"
+)
+SECRET_REFERENCE_RE = re.compile(r"^[A-Z][A-Z0-9_]*$")
+SECRET_REFERENCE_PATHS = {
+    "config.discord_bot_token_key",
+    "config.transcription.discord_bot_token_key",
+    "config.transcription.api_key",
+    "config.transcription.api_key_name",
+    "config.secret_file",
+    "config.secrets_file",
+    "config.transcription.secret_file",
+    "config.transcription.secrets_file",
+}
 
 
 def reject_inline_secret_values(value: Any, path: str = "config") -> None:
     if isinstance(value, dict):
         for key, child in value.items():
             key_text = str(key)
-            lowered = key_text.lower().replace("-", "_")
-            if lowered in INLINE_SECRET_KEYS:
-                raise FMError(f"{path}.{key_text} appears to contain an inline secret; store only secret file paths and key names")
-            reject_inline_secret_values(child, f"{path}.{key_text}")
+            child_path = f"{path}.{key_text}"
+            normalized = re.sub(r"([a-z0-9])([A-Z])", r"\1_\2", key_text).lower().replace("-", "_")
+            if child_path not in SECRET_REFERENCE_PATHS and SECRET_VALUE_KEY_RE.search(normalized):
+                raise FMError(f"{child_path} appears to contain an inline secret; store only secret file paths and key names")
+            reject_inline_secret_values(child, child_path)
     elif isinstance(value, list):
         for index, child in enumerate(value):
             reject_inline_secret_values(child, f"{path}[{index}]")
+
+
+def validate_secret_file_reference(value: Any, path: str, home: Path) -> None:
+    if not isinstance(value, str):
+        raise FMError(f"{path} must be a normalized secret file reference under config/")
+    parts = value.split("/")
+    if (
+        Path(value).is_absolute()
+        or len(parts) < 2
+        or parts[0] != "config"
+        or any(part in ("", ".", "..") for part in parts)
+        or not value.endswith(".sops.yaml")
+    ):
+        raise FMError(f"{path} must be a normalized .sops.yaml secret file reference under config/")
+    home_root = home.resolve()
+    config_root = (home / "config").resolve()
+    candidate = (home / value).resolve()
+    try:
+        config_root.relative_to(home_root)
+        candidate.relative_to(config_root)
+    except ValueError as exc:
+        raise FMError(f"{path} secret file reference must not escape the config directory through symlinks") from exc
+
+
+def validate_secret_reference_fields(cfg: Dict[str, Any], home: Path) -> None:
+    tx = cfg.get("transcription") if isinstance(cfg.get("transcription"), dict) else {}
+    name_fields = [
+        (cfg, "discord_bot_token_key", "discord_bot_token_key"),
+        (tx, "discord_bot_token_key", "transcription.discord_bot_token_key"),
+        (tx, "api_key", "transcription.api_key"),
+        (tx, "api_key_name", "transcription.api_key_name"),
+    ]
+    for owner, key, path in name_fields:
+        if key in owner and (not isinstance(owner[key], str) or not SECRET_REFERENCE_RE.fullmatch(owner[key])):
+            raise FMError(f"{path} must be an uppercase secret reference name")
+    file_fields = [
+        (cfg, "secret_file", "secret_file"),
+        (cfg, "secrets_file", "secrets_file"),
+        (tx, "secret_file", "transcription.secret_file"),
+        (tx, "secrets_file", "transcription.secrets_file"),
+    ]
+    for owner, key, path in file_fields:
+        if key in owner:
+            validate_secret_file_reference(owner[key], path, home)
+
+
+def config_object_section(cfg: Dict[str, Any], name: str) -> Dict[str, Any]:
+    value = cfg.get(name)
+    if value is None and name not in cfg:
+        return {}
+    if not isinstance(value, dict):
+        raise FMError(f"{name} must be a JSON object")
+    return value
 
 
 def config_secret_references(cfg: Dict[str, Any]) -> List[str]:
@@ -289,26 +401,31 @@ def config_secret_references(cfg: Dict[str, Any]) -> List[str]:
     tx = cfg.get("transcription") if isinstance(cfg.get("transcription"), dict) else {}
     secret_file = cfg.get("secret_file") or cfg.get("secrets_file") or tx.get("secret_file") or tx.get("secrets_file")
     if isinstance(secret_file, str) and secret_file:
-        refs.append(f"secret file: {secret_file}")
+        refs.append("secret file reference: configured")
     token_key = cfg.get("discord_bot_token_key") or tx.get("discord_bot_token_key")
     if isinstance(token_key, str) and token_key:
-        refs.append(f"Discord bot token key: {token_key}")
+        refs.append("Discord bot token reference: configured")
     api_key = tx.get("api_key") or tx.get("api_key_name")
     if isinstance(api_key, str) and api_key:
-        refs.append(f"transcription key name: {api_key}")
+        refs.append("transcription key reference: configured")
     return refs
 
 
 class WorkspaceConfig:
-    def __init__(self, path: Path, raw: Dict[str, Any]):
+    def __init__(self, path: Path, raw: Dict[str, Any], home: Path):
         self.path = path
         self.raw = raw
         reject_inline_secret_values(raw)
+        sections = {
+            name: config_object_section(raw, name)
+            for name in ("guild", "bot", "tags", "approvals", "live", "outbound", "artifacts", "audio", "transcription", "poll")
+        }
+        validate_secret_reference_fields(raw, home)
         schema = raw.get("schema", SCHEMA)
         if schema != SCHEMA:
             raise FMError(f"unsupported config schema: {schema}")
-        guild_obj = raw.get("guild") if isinstance(raw.get("guild"), dict) else {}
-        bot_obj = raw.get("bot") if isinstance(raw.get("bot"), dict) else {}
+        guild_obj = sections["guild"]
+        bot_obj = sections["bot"]
         self.guild_id = validate_snowflake(raw.get("guild_id") or guild_obj.get("id"), "guild.id") or ""
         self.bot_application_id = validate_snowflake(
             raw.get("bot_application_id") or bot_obj.get("application_id"),
@@ -326,7 +443,7 @@ class WorkspaceConfig:
             raise FMError("captain_user_ids must contain at least one captain Discord user id")
         if "disabled_profiles" in raw:
             raise FMError("disabled_profiles is unsupported; configure only the three active profiles")
-        tags_obj = raw.get("tags") if isinstance(raw.get("tags"), dict) else {}
+        tags_obj = sections["tags"]
         self.exchange_tags = validate_tags(tags_obj.get("exchange"), DEFAULT_EXCHANGE_TAGS, "tags.exchange")
         self.artifact_tags = validate_tags(tags_obj.get("artifacts", tags_obj.get("artifact")), DEFAULT_ARTIFACT_TAGS, "tags.artifacts")
         self.profiles: Dict[str, Dict[str, Any]] = {}
@@ -390,40 +507,89 @@ class WorkspaceConfig:
                 "exchange_forum_name": p.get("exchange_forum_name") or f"{key}-exchanges",
                 "artifact_forum_name": p.get("artifact_forum_name") or f"{key}-artifacts",
             }
-        approvals = raw.get("approvals") if isinstance(raw.get("approvals"), dict) else {}
-        live = raw.get("live") if isinstance(raw.get("live"), dict) else {}
+        approvals = sections["approvals"]
+        live = sections["live"]
         self.message_content_enabled = bool_from_path(raw, ["message_content", "message_content_intent", "approvals.message_content", "live.message_content"], False)
         self.live_posting_enabled = bool_from_path(raw, ["live_posting", "approvals.live_posting", "outbound.live_posting", "live.posting"], False)
         self.live_polling_enabled = bool_from_path(raw, ["live_polling", "approvals.live_polling", "live.polling"], False)
         self.temporary_setup_permissions = bool_from_path(raw, ["temporary_setup_permissions", "approvals.temporary_setup_permissions", "live.temporary_setup_permissions"], False)
         self.community_mode_required = bool_from_path(raw, ["community_mode_required", "approvals.community_mode_required", "live.community_mode_required"], False)
-        self.host_choice = str(raw.get("host") or live.get("host") or approvals.get("host") or "disabled")
-        outbound = raw.get("outbound") if isinstance(raw.get("outbound"), dict) else {}
+        host_values = []
+        for label, container in (("host", raw), ("live.host", live), ("approvals.host", approvals)):
+            if label.rsplit(".", 1)[-1] in container:
+                value = container[label.rsplit(".", 1)[-1]]
+                if not isinstance(value, str) or value not in ("disabled", "none", "dry-run", "omarchy", "vps"):
+                    raise FMError(f"{label} must be disabled, none, dry-run, omarchy, or vps")
+                host_values.append(value)
+        self.host_choice = host_values[0] if host_values else "disabled"
+        outbound = sections["outbound"]
         self.final_replies_required = validate_bool(outbound.get("final_replies_required", True), "outbound.final_replies_required", default=True)
-        artifacts = raw.get("artifacts") if isinstance(raw.get("artifacts"), dict) else {}
-        self.artifact_access = str(artifacts.get("access") or artifacts.get("access_mode") or "disabled")
-        self.artifact_default_expiry = str(artifacts.get("default_expiry") or "7d")
+        artifacts = sections["artifacts"]
+        artifact_access_values = []
+        for key in ("access", "access_mode"):
+            if key in artifacts:
+                value = artifacts[key]
+                if not isinstance(value, str) or value not in ("disabled", "tailnet", "cloudflare-access", "local"):
+                    raise FMError(f"artifacts.{key} must be disabled, tailnet, cloudflare-access, or local")
+                artifact_access_values.append(value)
+        self.artifact_access = artifact_access_values[0] if artifact_access_values else "disabled"
+        self.artifact_default_expiry = str(artifacts.get("default_expiry", "7d"))
+        if not re.fullmatch(r"[1-9][0-9]*[dh]", self.artifact_default_expiry):
+            raise FMError("artifacts.default_expiry must be a positive duration like 7d or 24h")
         self.client_confidential_allowed = validate_bool(artifacts.get("client_confidential_allowed", False), "artifacts.client_confidential_allowed", default=False)
-        self.direct_attachment_max_bytes = int(artifacts.get("direct_attachment_max_bytes", DIRECT_ATTACHMENT_MAX))
-        if self.direct_attachment_max_bytes <= 0 or self.direct_attachment_max_bytes > 10 * 1024 * 1024:
-            raise FMError("artifacts.direct_attachment_max_bytes must be positive and no more than 10 MiB in this phase")
+        self.direct_attachment_max_bytes = validate_positive_json_integer(
+            artifacts.get("direct_attachment_max_bytes", DIRECT_ATTACHMENT_MAX),
+            "artifacts.direct_attachment_max_bytes",
+            10 * 1024 * 1024,
+        )
         allowed_roots_raw = artifacts.get("allowed_roots", ["data"])
-        self.allowed_roots = [str(x) for x in as_list(allowed_roots_raw, "artifacts.allowed_roots")]
-        audio = raw.get("audio") if isinstance(raw.get("audio"), dict) else {}
-        self.audio_max_bytes = int(audio.get("max_bytes", AUDIO_MAX_BYTES))
-        self.audio_max_duration_secs = float(audio.get("max_duration_secs", AUDIO_MAX_DURATION_SECS))
+        self.allowed_roots = []
+        for index, value in enumerate(as_list(allowed_roots_raw, "artifacts.allowed_roots")):
+            label = f"artifacts.allowed_roots[{index}]"
+            if not isinstance(value, str) or not value.strip():
+                raise FMError(f"{label} must be a non-empty JSON string")
+            if any(ord(character) < 32 for character in value):
+                raise FMError(f"{label} has an unsupported root form")
+            try:
+                root_path = Path(value).expanduser()
+            except (RuntimeError, ValueError) as exc:
+                raise FMError(f"{label} has an unsupported root form") from exc
+            if not root_path.parts or any(part in (".", "..") for part in root_path.parts):
+                raise FMError(f"{label} has an unsupported root form")
+            self.allowed_roots.append(value)
+        audio = sections["audio"]
+        self.audio_max_bytes = validate_positive_json_integer(
+            audio.get("max_bytes", AUDIO_MAX_BYTES), "audio.max_bytes"
+        )
+        max_duration = audio.get("max_duration_secs", AUDIO_MAX_DURATION_SECS)
+        if isinstance(max_duration, bool) or not isinstance(max_duration, (int, float)):
+            raise FMError("audio.max_duration_secs must be a positive finite number encoded as a JSON number")
+        self.audio_max_duration_secs = float(max_duration)
+        if not math.isfinite(self.audio_max_duration_secs) or self.audio_max_duration_secs <= 0:
+            raise FMError("audio.max_duration_secs must be a positive finite number encoded as a JSON number")
         self.audio_delete_raw = validate_bool(audio.get("delete_temporary_raw", audio.get("delete_raw", True)), "audio.delete_temporary_raw", default=True)
-        self.cdn_hosts = [str(x).lower() for x in as_list(audio.get("allowed_cdn_hosts", DEFAULT_CDN_HOSTS), "audio.allowed_cdn_hosts")]
+        self.cdn_hosts = []
+        seen_cdn_hosts = set()
+        for index, value in enumerate(as_list(audio.get("allowed_cdn_hosts", DEFAULT_CDN_HOSTS), "audio.allowed_cdn_hosts")):
+            label = f"audio.allowed_cdn_hosts[{index}]"
+            if not isinstance(value, str) or not value or value != value.lower() or len(value) > 253:
+                raise FMError(f"{label} must be a normalized lowercase hostname")
+            hostname_labels = value.split(".")
+            if any(not re.fullmatch(r"[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?", part) for part in hostname_labels):
+                raise FMError(f"{label} must be a normalized lowercase hostname")
+            if value in seen_cdn_hosts:
+                raise FMError(f"{label} duplicates an earlier hostname")
+            seen_cdn_hosts.add(value)
+            self.cdn_hosts.append(value)
         if not self.cdn_hosts:
             raise FMError("audio.allowed_cdn_hosts must not be empty")
-        transcription = raw.get("transcription") if isinstance(raw.get("transcription"), dict) else {}
+        transcription = sections["transcription"]
         self.transcription = transcription
-        self.transcription_provider = str(transcription.get("provider") or "disabled")
+        provider = transcription.get("provider", "disabled")
+        if not isinstance(provider, str) or provider not in ("disabled", "fake", "groq"):
+            raise FMError("transcription.provider must be disabled, fake, or groq")
+        self.transcription_provider = provider
         self.hosted_groq_enabled = self.transcription_provider == "groq" or bool_from_path(raw, ["hosted_groq", "approvals.hosted_groq", "transcription.hosted_groq"], False)
-        if self.host_choice not in ("disabled", "none", "dry-run", "omarchy", "vps"):
-            raise FMError("host must be disabled, omarchy, or vps")
-        if self.artifact_access not in ("disabled", "tailnet", "cloudflare-access", "local"):
-            raise FMError("artifacts.access must be disabled, tailnet, cloudflare-access, or local")
 
     @classmethod
     def load(cls, env: Env, path_text: Optional[str]) -> "WorkspaceConfig":
@@ -431,7 +597,7 @@ class WorkspaceConfig:
         if not path.is_absolute():
             path = (Path.cwd() / path).resolve()
         raw = read_json(path)
-        return cls(path.resolve(), raw)
+        return cls(path.resolve(), raw, env.home)
 
     def profile_for_channel(self, channel_id: str, parent_id: Optional[str] = None, *, allow_forums: bool = False) -> Optional[Tuple[str, str, str]]:
         for key, p in self.profiles.items():
@@ -630,15 +796,81 @@ def cmd_health(args: argparse.Namespace, env: Env) -> int:
     return 0
 
 
+@contextmanager
+def open_regular_readonly(path: Path, label: str) -> Iterable[Tuple[int, os.stat_result]]:
+    flags = os.O_RDONLY | os.O_NONBLOCK | os.O_NOFOLLOW
+    try:
+        fd = os.open(path, flags)
+    except OSError as exc:
+        raise FMError(f"refusing unsafe {label}: {path}") from exc
+    try:
+        before = os.fstat(fd)
+        if not stat.S_ISREG(before.st_mode):
+            raise FMError(f"refusing unsafe {label}: {path}")
+        yield fd, before
+    finally:
+        os.close(fd)
+
+
+@contextmanager
+def open_regular_under_root(root: Path, relative: Path, label: str) -> Iterable[Tuple[int, os.stat_result]]:
+    parts = relative.parts
+    if not parts or any(part in ("", ".", "..") for part in parts):
+        raise FMError(f"refusing unsafe {label}: {root / relative}")
+    directory_flags = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW
+    descriptors = []
+    try:
+        current = os.open(root, directory_flags)
+        descriptors.append(current)
+        for part in parts[:-1]:
+            current = os.open(part, directory_flags, dir_fd=current)
+            descriptors.append(current)
+        fd = os.open(parts[-1], os.O_RDONLY | os.O_NONBLOCK | os.O_NOFOLLOW, dir_fd=current)
+        descriptors.append(fd)
+        before = os.fstat(fd)
+        if not stat.S_ISREG(before.st_mode):
+            raise FMError(f"refusing unsafe {label}: {root / relative}")
+        yield fd, before
+    except OSError as exc:
+        raise FMError(f"refusing unsafe {label}: {root / relative}") from exc
+    finally:
+        for descriptor in reversed(descriptors):
+            os.close(descriptor)
+
+
+def descriptor_unchanged(before: os.stat_result, after: os.stat_result, bytes_read: int) -> bool:
+    return (
+        before.st_dev == after.st_dev
+        and before.st_ino == after.st_ino
+        and before.st_size == after.st_size == bytes_read
+        and before.st_mtime_ns == after.st_mtime_ns
+        and before.st_ctime_ns == after.st_ctime_ns
+    )
+
+
 def read_text_file(path_text: str, max_bytes: int = 4000) -> str:
-    path = Path(path_text).expanduser()
-    if not path.is_absolute():
-        path = (Path.cwd() / path).resolve()
-    if path.is_symlink() or not path.is_file():
-        raise FMError(f"refusing unsafe text file: {path}")
-    data = path.read_bytes()
+    supplied = Path(path_text).expanduser()
+    path = supplied if supplied.is_absolute() else Path.cwd() / supplied
+    for component in (path, *path.parents):
+        if component.is_symlink():
+            raise FMError(f"refusing unsafe text file: {path}")
+    with open_regular_readonly(path, "text file") as (fd, before):
+        if before.st_size > max_bytes:
+            raise FMError(f"text file is too large for a Discord phase-1 message: {path}")
+        chunks = []
+        remaining = max_bytes + 1
+        while remaining:
+            chunk = os.read(fd, remaining)
+            if not chunk:
+                break
+            chunks.append(chunk)
+            remaining -= len(chunk)
+        data = b"".join(chunks)
+        after = os.fstat(fd)
     if len(data) > max_bytes:
         raise FMError(f"text file is too large for a Discord phase-1 message: {path}")
+    if not descriptor_unchanged(before, after, len(data)):
+        raise FMError(f"text file changed while being read: {path}")
     try:
         text = data.decode("utf-8")
     except UnicodeDecodeError as exc:
@@ -653,7 +885,7 @@ def read_text_file(path_text: str, max_bytes: int = 4000) -> str:
 
 
 def receipt_path(env: Env, nonce: str) -> Path:
-    return safe_digest_path(env.discord_state / "receipts", nonce)
+    return discord_state_path(env, "receipts", f"{sha256_text(nonce)}.json")
 
 
 def load_existing_json(path: Path) -> Optional[Dict[str, Any]]:
@@ -661,28 +893,65 @@ def load_existing_json(path: Path) -> Optional[Dict[str, Any]]:
         return None
     if path.is_symlink() or not path.is_file():
         raise FMError(f"refusing unsafe state path: {path}")
-    with path.open("r", encoding="utf-8") as f:
-        data = json.load(f)
+    try:
+        with path.open("r", encoding="utf-8") as f:
+            data = json.load(f)
+    except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+        raise FMError(f"state file is malformed: {path}") from exc
     if not isinstance(data, dict):
         raise FMError(f"state file is malformed: {path}")
     return data
 
 
-def record_receipt(env: Env, nonce: str, payload: Dict[str, Any], discord_message_id: str) -> str:
-    path = receipt_path(env, nonce)
-    existing = load_existing_json(path)
-    payload = dict(payload)
-    payload.update({"schema": RECEIPT_SCHEMA, "nonce": nonce, "discord_message_id": discord_message_id})
-    if existing:
-        comparable = dict(existing)
-        comparable.pop("recorded_at", None)
-        candidate = dict(payload)
-        if comparable == candidate:
-            return "receipt exists"
+@contextmanager
+def state_transaction(env: Env) -> Iterable[None]:
+    env.discord_state.mkdir(parents=True, exist_ok=True)
+    path = env.discord_state / ".state.lock"
+    flags = os.O_CREAT | os.O_RDWR
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    try:
+        fd = os.open(path, flags, 0o600)
+    except OSError as exc:
+        raise FMError(f"cannot lock Discord workspace state: {path}") from exc
+    try:
+        os.fchmod(fd, 0o600)
+        fcntl.flock(fd, fcntl.LOCK_EX)
+        yield
+    finally:
+        fcntl.flock(fd, fcntl.LOCK_UN)
+        os.close(fd)
+
+
+def receipt_record(nonce: str, payload: Dict[str, Any], discord_message_id: str) -> Dict[str, Any]:
+    record = dict(payload)
+    record.update({"schema": RECEIPT_SCHEMA, "nonce": nonce, "discord_message_id": discord_message_id})
+    return record
+
+
+def preflight_receipt(env: Env, nonce: str, payload: Dict[str, Any], discord_message_id: str) -> bool:
+    existing = load_existing_json(receipt_path(env, nonce))
+    if existing is None:
+        return False
+    comparable = dict(existing)
+    comparable.pop("recorded_at", None)
+    if comparable != receipt_record(nonce, payload, discord_message_id):
         raise FMError("refusing to overwrite a different Discord outbound receipt for the same nonce")
-    payload["recorded_at"] = utc_now()
-    atomic_json(path, payload)
+    return True
+
+
+def record_receipt_unlocked(env: Env, nonce: str, payload: Dict[str, Any], discord_message_id: str) -> str:
+    if preflight_receipt(env, nonce, payload, discord_message_id):
+        return "receipt exists"
+    stored = receipt_record(nonce, payload, discord_message_id)
+    stored["recorded_at"] = utc_now()
+    atomic_json(receipt_path(env, nonce), stored)
     return "receipt recorded"
+
+
+def record_receipt(env: Env, nonce: str, payload: Dict[str, Any], discord_message_id: str) -> str:
+    with state_transaction(env):
+        return record_receipt_unlocked(env, nonce, payload, discord_message_id)
 
 
 def base_receipt(kind: str, profile: str, target: Dict[str, Any], text_digest: str) -> Dict[str, Any]:
@@ -764,48 +1033,92 @@ def path_under(child: Path, parent: Path) -> bool:
         return False
 
 
-def sniff_mime(path: Path) -> str:
+def inspect_artifact(fd: int, before: os.stat_result, path: Path, *, allow_protected_html: bool, direct_limit: Optional[int]) -> Tuple[int, str, str]:
     ext = path.suffix.lower()
-    head = path.read_bytes()[:32]
-    if ext in ALLOWED_TEXT_EXTENSIONS:
-        data = path.read_bytes()
-        if b"\x00" in data:
-            raise FMError("text artifact contains a NUL byte")
-        try:
-            data.decode("utf-8")
-        except UnicodeDecodeError as exc:
-            raise FMError("text artifact must be UTF-8") from exc
-        return "text/markdown" if ext in {".md", ".markdown"} else "text/plain"
-    if ext == ".png":
+    if not (ext in ALLOWED_DIRECT_EXTENSIONS or (allow_protected_html and ext in PROTECTED_TEXT_EXTENSIONS)):
+        guessed, _ = mimetypes.guess_type(str(path))
+        raise FMError(f"unsupported artifact type: {guessed or ext or 'unknown'}")
+    if direct_limit is not None and before.st_size > direct_limit:
+        raise FMError("artifact exceeds the direct attachment cap")
+    decoder = None
+    text_label = ""
+    if allow_protected_html and ext in PROTECTED_TEXT_EXTENSIONS:
+        decoder = codecs.getincrementaldecoder("utf-8")()
+        text_label = "HTML"
+    elif ext in ALLOWED_TEXT_EXTENSIONS:
+        decoder = codecs.getincrementaldecoder("utf-8")()
+        text_label = "text"
+    digest = hashlib.sha256()
+    head = b""
+    leading = ""
+    started = False
+    total = 0
+    remaining = before.st_size + 1
+    try:
+        while remaining:
+            chunk = os.read(fd, min(64 * 1024, remaining))
+            if not chunk:
+                break
+            total += len(chunk)
+            remaining -= len(chunk)
+            if direct_limit is not None and total > direct_limit:
+                raise FMError("artifact exceeds the direct attachment cap")
+            digest.update(chunk)
+            if len(head) < 32:
+                head += chunk[:32 - len(head)]
+            if decoder is not None:
+                if b"\x00" in chunk:
+                    raise FMError(f"{text_label} artifact contains a NUL byte")
+                text = decoder.decode(chunk)
+                if text_label == "HTML" and len(leading) < 15:
+                    if not started:
+                        text = text.lstrip()
+                        started = bool(text)
+                    if started:
+                        leading += text[:15 - len(leading)]
+        if decoder is not None:
+            decoder.decode(b"", final=True)
+    except UnicodeDecodeError as exc:
+        raise FMError(f"{text_label} artifact must be UTF-8") from exc
+    after = os.fstat(fd)
+    if not descriptor_unchanged(before, after, total):
+        raise FMError("artifact changed while being read")
+    if text_label == "HTML":
+        leading = leading.lower()
+        if not (leading.startswith("<!doctype html") or leading.startswith("<html")):
+            raise FMError("HTML extension does not match file bytes")
+        mime = "text/html"
+    elif text_label:
+        mime = "text/markdown" if ext in {".md", ".markdown"} else "text/plain"
+    elif ext == ".png":
         if not head.startswith(b"\x89PNG\r\n\x1a\n"):
             raise FMError("PNG extension does not match file bytes")
-        return "image/png"
-    if ext in {".jpg", ".jpeg"}:
+        mime = "image/png"
+    elif ext in {".jpg", ".jpeg"}:
         if not head.startswith(b"\xff\xd8"):
             raise FMError("JPEG extension does not match file bytes")
-        return "image/jpeg"
-    if ext == ".gif":
+        mime = "image/jpeg"
+    elif ext == ".gif":
         if not (head.startswith(b"GIF87a") or head.startswith(b"GIF89a")):
             raise FMError("GIF extension does not match file bytes")
-        return "image/gif"
-    if ext == ".webp":
+        mime = "image/gif"
+    elif ext == ".webp":
         if len(head) < 12 or head[:4] != b"RIFF" or head[8:12] != b"WEBP":
             raise FMError("WebP extension does not match file bytes")
-        return "image/webp"
-    if ext == ".pdf":
+        mime = "image/webp"
+    else:
         if not head.startswith(b"%PDF-"):
             raise FMError("PDF extension does not match file bytes")
-        return "application/pdf"
-    guessed, _ = mimetypes.guess_type(str(path))
-    raise FMError(f"unsupported artifact type: {guessed or ext or 'unknown'}")
+        mime = "application/pdf"
+    return total, mime, digest.hexdigest()
 
 
-def validate_artifact_file(env: Env, cfg: WorkspaceConfig, file_text: str, *, client_confidential: bool, approved_client_confidential: bool, require_direct: bool = False) -> Dict[str, Any]:
-    path = Path(file_text).expanduser()
-    if not path.is_absolute():
-        path = (Path.cwd() / path).resolve()
-    if path.is_symlink() or not path.is_file():
-        raise FMError(f"refusing unsafe artifact path: {path}")
+def validate_artifact_file(env: Env, cfg: WorkspaceConfig, file_text: str, *, client_confidential: bool, approved_client_confidential: bool, require_direct: bool = False, allow_protected_html: bool = False) -> Dict[str, Any]:
+    supplied = Path(file_text).expanduser()
+    path = supplied if supplied.is_absolute() else Path.cwd() / supplied
+    for component in (path, *path.parents):
+        if component.is_symlink():
+            raise FMError(f"refusing unsafe artifact path: {supplied}")
     resolved = path.resolve()
     if path_under(resolved, env.home / "projects"):
         raise FMError("artifact source under projects/ is blocked by default")
@@ -814,17 +1127,20 @@ def validate_artifact_file(env: Env, cfg: WorkspaceConfig, file_text: str, *, cl
     if SECRETISH_RE.search(name) or ext in BLOCKED_EXTENSIONS:
         raise FMError("artifact filename or extension is blocked by the default safety policy")
     roots = [root_for_name(env, item) for item in cfg.allowed_roots]
-    if not any(path_under(resolved, root) for root in roots):
+    allowed_root = next((root for root in roots if path_under(resolved, root)), None)
+    if allowed_root is None:
         raise FMError("artifact source is outside the configured allowed roots")
     if client_confidential and not (cfg.client_confidential_allowed and approved_client_confidential):
         raise FMError("client-confidential artifacts are blocked without explicit captain approval and config opt-in")
-    size = resolved.stat().st_size
-    mime = sniff_mime(resolved)
-    if ext not in ALLOWED_DIRECT_EXTENSIONS:
-        raise FMError("artifact extension is not allowed for phase-1 direct sharing")
-    if require_direct and size > cfg.direct_attachment_max_bytes:
-        raise FMError("artifact exceeds the direct attachment cap")
-    digest = sha256_file(resolved)
+    relative = resolved.relative_to(allowed_root)
+    with open_regular_under_root(allowed_root, relative, "artifact path") as (fd, before):
+        size, mime, digest = inspect_artifact(
+            fd,
+            before,
+            resolved,
+            allow_protected_html=allow_protected_html,
+            direct_limit=cfg.direct_attachment_max_bytes if require_direct else None,
+        )
     return {
         "path": str(resolved),
         "name": name,
@@ -843,7 +1159,7 @@ def artifact_id_for(info: Dict[str, Any], profile: str, purpose: str) -> str:
 def artifact_source_index_path(env: Env, source_sha256: str) -> Path:
     if not re.fullmatch(r"[0-9a-f]{64}", source_sha256):
         raise FMError("artifact source digest is invalid")
-    return env.discord_state / "artifact-source-index" / f"{source_sha256}.json"
+    return discord_state_path(env, "artifact-source-index", f"{source_sha256}.json")
 
 
 def write_artifact_source_index(env: Env, source_sha256: str, artifact_id: str, record: Dict[str, Any]) -> bool:
@@ -867,28 +1183,39 @@ def write_artifact_source_index(env: Env, source_sha256: str, artifact_id: str, 
     return True
 
 
-def write_artifact_record(env: Env, artifact_id: str, record: Dict[str, Any]) -> str:
-    path = env.discord_state / "artifacts" / f"{artifact_id}.json"
-    source = record.get("source") if isinstance(record.get("source"), dict) else {}
-    source_sha256 = str(source.get("sha256") or "")
+def preflight_artifact_record(env: Env, artifact_id: str, record: Dict[str, Any]) -> bool:
+    path = discord_state_path(env, "artifacts", f"{artifact_id}.json")
     existing = load_existing_json(path)
-    if existing:
+    if existing is not None:
         comparable = dict(existing)
         comparable.pop("recorded_at", None)
-        candidate = dict(record)
-        if comparable == candidate:
-            if source_sha256:
-                write_artifact_source_index(env, source_sha256, artifact_id, record)
-            return "artifact record exists"
-        raise FMError("refusing to overwrite a different artifact record")
+        if comparable != record:
+            raise FMError("refusing to overwrite a different artifact record")
+    source = record.get("source") if isinstance(record.get("source"), dict) else {}
+    source_sha256 = str(source.get("sha256") or "")
+    if source_sha256:
+        index = load_existing_json(artifact_source_index_path(env, source_sha256))
+        if index is not None and str(index.get("artifact_id") or "") != artifact_id:
+            raise FMError(f"artifact source already has a canonical artifact record: {index.get('artifact_id') or ''}")
+    return existing is not None
+
+
+def write_artifact_record_unlocked(env: Env, artifact_id: str, record: Dict[str, Any]) -> str:
+    exists = preflight_artifact_record(env, artifact_id, record)
+    source = record.get("source") if isinstance(record.get("source"), dict) else {}
+    source_sha256 = str(source.get("sha256") or "")
+    if exists:
+        if source_sha256:
+            write_artifact_source_index(env, source_sha256, artifact_id, record)
+        return "artifact record exists"
     created_index = False
     index_path = artifact_source_index_path(env, source_sha256) if source_sha256 else None
     if source_sha256:
         created_index = write_artifact_source_index(env, source_sha256, artifact_id, record)
-    record = dict(record)
-    record["recorded_at"] = utc_now()
+    stored = dict(record)
+    stored["recorded_at"] = utc_now()
     try:
-        atomic_json(path, record)
+        atomic_json(discord_state_path(env, "artifacts", f"{artifact_id}.json"), stored)
     except Exception:
         if created_index and index_path is not None:
             try:
@@ -897,6 +1224,11 @@ def write_artifact_record(env: Env, artifact_id: str, record: Dict[str, Any]) ->
                 pass
         raise
     return "artifact record written"
+
+
+def write_artifact_record(env: Env, artifact_id: str, record: Dict[str, Any]) -> str:
+    with state_transaction(env):
+        return write_artifact_record_unlocked(env, artifact_id, record)
 
 
 def cmd_artifact(args: argparse.Namespace, env: Env) -> int:
@@ -911,7 +1243,7 @@ def cmd_artifact(args: argparse.Namespace, env: Env) -> int:
         args.file,
         client_confidential=args.client_confidential,
         approved_client_confidential=args.captain_approved_client_confidential,
-        require_direct=not bool(args.private_url),
+        require_direct=True,
     )
     profile = cfg.profiles[args.profile]
     if args.request_id:
@@ -923,10 +1255,6 @@ def cmd_artifact(args: argparse.Namespace, env: Env) -> int:
         guild_id = cfg.guild_id
         exchange_channel_id = profile["exchange_forum_id"]
     artifact_id = artifact_id_for(info, args.profile, args.purpose)
-    if args.private_url:
-        args.private_url = validate_private_url(args.private_url)
-    if not info["direct_attachment"] and not args.private_url:
-        raise FMError("artifact exceeds the direct cap; use publish-artifact with a private expiring URL")
     target = {
         "guild_id": guild_id,
         "artifact_forum_id": profile["artifact_forum_id"],
@@ -941,7 +1269,6 @@ def cmd_artifact(args: argparse.Namespace, env: Env) -> int:
         "purpose": args.purpose,
         "source": info,
         "target": target,
-        "private_url": args.private_url,
         "canonical_location": "artifacts-forum-post",
         "exchange_behavior": "summary-card-and-link-only",
         "duplicate_binary_in_exchange": False,
@@ -951,20 +1278,22 @@ def cmd_artifact(args: argparse.Namespace, env: Env) -> int:
     print(f"canonical post forum: {profile['artifact_forum_id']}")
     print(f"canonical post tag: {args.purpose}")
     print(f"source file: {info['name']} {info['mime']} {info['size']} bytes sha256:{info['sha256']}")
-    if info["direct_attachment"]:
-        print("artifact transfer: direct attachment in the artifacts forum only")
-    else:
-        print("artifact transfer: private expiring link in the artifacts forum only")
+    print("artifact transfer: direct attachment in the artifacts forum only")
     print(f"exchange summary destination: {exchange_channel_id}")
     print("exchange summary includes a card and link only; it will not duplicate the binary.")
     print(f"allowed_mentions: {json.dumps({'parse': []}, sort_keys=True)}")
     print(f"nonce: {nonce}")
     if args.record_discord_message_id:
         msg_id = validate_snowflake(args.record_discord_message_id, "--record-discord-message-id") or ""
-        print(write_artifact_record(env, artifact_id, record))
         receipt = base_receipt("artifact", args.profile, target, info["sha256"])
         receipt["artifact_id"] = artifact_id
-        print(record_receipt(env, nonce, receipt, msg_id))
+        with state_transaction(env):
+            preflight_artifact_record(env, artifact_id, record)
+            preflight_receipt(env, nonce, receipt, msg_id)
+            artifact_result = write_artifact_record_unlocked(env, artifact_id, record)
+            receipt_result = record_receipt_unlocked(env, nonce, receipt, msg_id)
+        print(artifact_result)
+        print(receipt_result)
     else:
         print("dry-run only; no artifact record or Discord receipt was written.")
     return 0
@@ -987,7 +1316,8 @@ def cmd_publish_artifact(args: argparse.Namespace, env: Env) -> int:
         raise FMError("publish-artifact purpose must be in the configured artifact tag vocabulary")
     if args.access not in ("tailnet", "cloudflare-access", "local"):
         raise FMError("publish-artifact access must be tailnet, cloudflare-access, or local")
-    if not re.fullmatch(r"[1-9][0-9]*[dh]", args.expires):
+    expires = args.expires or cfg.artifact_default_expiry
+    if not re.fullmatch(r"[1-9][0-9]*[dh]", expires):
         raise FMError("publish-artifact --expires must be a duration like 7d or 24h")
     url = validate_private_url(args.url)
     info = validate_artifact_file(
@@ -997,6 +1327,7 @@ def cmd_publish_artifact(args: argparse.Namespace, env: Env) -> int:
         client_confidential=args.client_confidential,
         approved_client_confidential=args.captain_approved_client_confidential,
         require_direct=False,
+        allow_protected_html=True,
     )
     artifact_id = artifact_id_for(info, args.profile, args.purpose)
     record = {
@@ -1005,13 +1336,13 @@ def cmd_publish_artifact(args: argparse.Namespace, env: Env) -> int:
         "profile": args.profile,
         "purpose": args.purpose,
         "source": info,
-        "publication": {"url": url, "access": args.access, "expires": args.expires},
+        "publication": {"url": url, "access": args.access, "expires": expires},
         "canonical_location": "private-expiring-link",
     }
     print("Private artifact link plan (no network).")
     print(f"artifact id: {artifact_id}")
     print(f"access: {args.access}")
-    print(f"expires: {args.expires}")
+    print(f"expires: {expires}")
     print(f"url: {url}")
     print("revocation must be handled by the selected private publication host.")
     if args.record:
@@ -1022,30 +1353,48 @@ def cmd_publish_artifact(args: argparse.Namespace, env: Env) -> int:
 
 
 def request_record_path(env: Env, request_id: str) -> Path:
-    return safe_digest_path(env.discord_state / "requests", request_id)
+    return discord_state_path(env, "requests", f"{sha256_text(request_id)}.json")
 
 
 def task_link_path(env: Env, task_id: str) -> Path:
-    return env.discord_state / "task-links" / f"{task_id}.json"
+    return discord_state_path(env, "task-links", f"{task_id}.json")
 
 
 def pending_followup_path(env: Env, task_id: str) -> Path:
-    return env.discord_state / "pending-followups" / f"{task_id}.json"
+    return discord_state_path(env, "pending-followups", f"{task_id}.json")
+
+
+def preflight_same_or_absent(path: Path, data: Dict[str, Any], label: str) -> bool:
+    existing = load_existing_json(path)
+    if existing is None:
+        return False
+    comparable = dict(existing)
+    comparable.pop("recorded_at", None)
+    if comparable != data:
+        raise FMError(f"refusing to overwrite a different {label}")
+    return True
 
 
 def write_same_or_refuse(path: Path, data: Dict[str, Any], label: str) -> str:
-    existing = load_existing_json(path)
-    if existing:
-        comparable = dict(existing)
-        comparable.pop("recorded_at", None)
-        candidate = dict(data)
-        if comparable == candidate:
-            return f"{label} exists"
-        raise FMError(f"refusing to overwrite a different {label}")
-    data = dict(data)
-    data["recorded_at"] = utc_now()
-    atomic_json(path, data)
+    if preflight_same_or_absent(path, data, label):
+        return f"{label} exists"
+    stored = dict(data)
+    stored["recorded_at"] = utc_now()
+    atomic_json(path, stored)
     return f"{label} written"
+
+
+def canonical_request_record(request_id: str, guild_id: str, channel_id: str, message_id: str, profile: str) -> Dict[str, Any]:
+    return {
+        "schema": REQUEST_SCHEMA,
+        "request_id": request_id,
+        "guild_id": guild_id,
+        "channel_id": channel_id,
+        "message_id": message_id,
+        "profile": profile,
+        "origin": "discord-workspace",
+        "jump_url": discord_jump_url(guild_id, channel_id, message_id),
+    }
 
 
 def cmd_link_task(args: argparse.Namespace, env: Env) -> int:
@@ -1055,15 +1404,7 @@ def cmd_link_task(args: argparse.Namespace, env: Env) -> int:
     guild_id, channel_id, message_id, profile_key, forum_kind = cfg.profile_for_request_id(args.request_id)
     if forum_kind != "exchange":
         raise FMError("task links must originate from an exchange thread")
-    request = {
-        "schema": REQUEST_SCHEMA,
-        "request_id": args.request_id,
-        "guild_id": guild_id,
-        "channel_id": channel_id,
-        "message_id": message_id,
-        "profile": profile_key,
-        "origin": "discord-workspace",
-    }
+    request = canonical_request_record(args.request_id, guild_id, channel_id, message_id, profile_key)
     link = {
         "schema": TASK_LINK_SCHEMA,
         "task_id": args.task_id,
@@ -1071,20 +1412,82 @@ def cmd_link_task(args: argparse.Namespace, env: Env) -> int:
         "profile": profile_key,
         "final_followup_required": cfg.final_replies_required,
     }
-    print(write_same_or_refuse(request_record_path(env, args.request_id), request, "request record"))
-    print(write_same_or_refuse(task_link_path(env, args.task_id), link, "task link"))
-    if cfg.final_replies_required:
-        pending = {
-            "schema": PENDING_SCHEMA,
-            "task_id": args.task_id,
-            "request_id": args.request_id,
-            "profile": profile_key,
-            "status": "pending",
-        }
-        print(write_same_or_refuse(pending_followup_path(env, args.task_id), pending, "pending final follow-up"))
-    else:
-        print("final follow-up is not required by config")
+    pending = {
+        "schema": PENDING_SCHEMA,
+        "task_id": args.task_id,
+        "request_id": args.request_id,
+        "profile": profile_key,
+        "status": "pending",
+    }
+    request_path = request_record_path(env, args.request_id)
+    link_path = task_link_path(env, args.task_id)
+    pending_path = pending_followup_path(env, args.task_id)
+    with state_transaction(env):
+        preflight_same_or_absent(request_path, request, "request record")
+        preflight_same_or_absent(link_path, link, "task link")
+        delivered = False
+        if cfg.final_replies_required:
+            existing_pending = load_existing_json(pending_path)
+            if existing_pending is not None:
+                delivered = validate_followup_record(
+                    env, pending_path, existing_pending, args.task_id, args.request_id, profile_key
+                ) == "delivered"
+            if not delivered:
+                preflight_same_or_absent(pending_path, pending, "pending final follow-up")
+        request_result = write_same_or_refuse(request_path, request, "request record")
+        if cfg.final_replies_required and not delivered:
+            pending_result = write_same_or_refuse(pending_path, pending, "pending final follow-up")
+        elif delivered:
+            pending_result = "pending final follow-up already delivered"
+        else:
+            pending_result = "final follow-up is not required by config"
+        link_result = write_same_or_refuse(link_path, link, "task link")
+    print(request_result)
+    print(link_result)
+    print(pending_result)
     return 0
+
+
+def validate_followup_record(env: Env, path: Path, data: Dict[str, Any], task_id: str, request_id: Optional[str] = None, profile: Optional[str] = None) -> str:
+    if data.get("schema") != PENDING_SCHEMA or data.get("task_id") != task_id:
+        raise FMError(f"pending final follow-up record is malformed or names the wrong task: {path}")
+    if request_id is not None and data.get("request_id") != request_id:
+        raise FMError(f"pending final follow-up record names the wrong request: {path}")
+    if profile is not None and data.get("profile") != profile:
+        raise FMError(f"pending final follow-up record names the wrong profile: {path}")
+    status = data.get("status")
+    if status == "pending":
+        return status
+    if status != "delivered":
+        raise FMError(f"pending final follow-up record has an unknown status: {path}")
+    nonce = data.get("receipt_nonce")
+    message_id = data.get("discord_message_id")
+    if not isinstance(nonce, str) or not nonce or not isinstance(message_id, str) or not ID_RE.fullmatch(message_id):
+        raise FMError(f"delivered final follow-up record has invalid evidence: {path}")
+    receipt = load_existing_json(receipt_path(env, nonce))
+    if not receipt or any((
+        receipt.get("schema") != RECEIPT_SCHEMA,
+        receipt.get("nonce") != nonce,
+        receipt.get("discord_message_id") != message_id,
+        receipt.get("task_id") != task_id,
+        receipt.get("kind") != "final-followup",
+    )):
+        raise FMError(f"delivered final follow-up record has invalid evidence: {path}")
+    return status
+
+
+def validate_task_link(path: Path, data: Dict[str, Any], task_id: str) -> Tuple[str, str]:
+    if data.get("schema") != TASK_LINK_SCHEMA or data.get("task_id") != task_id:
+        raise FMError(f"Discord workspace task link is malformed or names the wrong task: {path}")
+    request_id = data.get("request_id")
+    profile = data.get("profile")
+    if not isinstance(request_id, str) or not REQUEST_RE.fullmatch(request_id):
+        raise FMError(f"Discord workspace task link names an invalid request: {path}")
+    if not isinstance(profile, str) or profile not in ACTIVE_PROFILE_KEYS:
+        raise FMError(f"Discord workspace task link names an invalid profile: {path}")
+    if not isinstance(data.get("final_followup_required"), bool):
+        raise FMError(f"Discord workspace task link has invalid final follow-up policy: {path}")
+    return request_id, profile
 
 
 def cmd_followup(args: argparse.Namespace, env: Env) -> int:
@@ -1092,13 +1495,16 @@ def cmd_followup(args: argparse.Namespace, env: Env) -> int:
     if not TASK_ID_RE.fullmatch(args.task_id):
         raise FMError("task id must be path-safe")
     text = read_text_file(args.text_file)
-    link = load_existing_json(task_link_path(env, args.task_id))
-    if not link:
+    link_path = task_link_path(env, args.task_id)
+    link = load_existing_json(link_path)
+    if link is None:
         raise FMError("task has no Discord workspace request link")
-    request_id = str(link["request_id"])
+    request_id, linked_profile = validate_task_link(link_path, link, args.task_id)
     guild_id, channel_id, message_id, profile_key, forum_kind = cfg.profile_for_request_id(request_id)
     if forum_kind != "exchange":
         raise FMError("follow-up request no longer resolves to an exchange thread")
+    if linked_profile != profile_key:
+        raise FMError("Discord workspace task link profile no longer matches the resolved request")
     text_digest = sha256_text(text)
     kind = "final-followup" if args.final else "followup"
     nonce = args.nonce or f"{kind}:{args.task_id}:{request_id}:{text_digest}"
@@ -1111,38 +1517,54 @@ def cmd_followup(args: argparse.Namespace, env: Env) -> int:
     print(f"destination thread/channel: {channel_id}")
     print(f"allowed_mentions: {json.dumps({'parse': []}, sort_keys=True)}")
     print(f"nonce: {nonce}")
+    pending = None
+    pending_path = pending_followup_path(env, args.task_id)
     if args.final:
-        pending_path = pending_followup_path(env, args.task_id)
-        pending = load_existing_json(pending_path)
-        if not pending:
-            pending = {
-                "schema": PENDING_SCHEMA,
-                "task_id": args.task_id,
-                "request_id": request_id,
-                "profile": profile_key,
-                "status": "pending",
-            }
-            write_same_or_refuse(pending_path, pending, "pending final follow-up")
-        if pending.get("status") == "delivered":
-            print("final follow-up already delivered")
-        else:
-            print("pending final follow-up: present")
+        with state_transaction(env):
+            pending = load_existing_json(pending_path)
+            if not pending:
+                pending = {
+                    "schema": PENDING_SCHEMA,
+                    "task_id": args.task_id,
+                    "request_id": request_id,
+                    "profile": profile_key,
+                    "status": "pending",
+                }
+                write_same_or_refuse(pending_path, pending, "pending final follow-up")
+        status = validate_followup_record(env, pending_path, pending, args.task_id, request_id, profile_key)
+        print("final follow-up already delivered" if status == "delivered" else "pending final follow-up: present")
     if args.record_discord_message_id:
         msg_id = validate_snowflake(args.record_discord_message_id, "--record-discord-message-id") or ""
-        print(record_receipt(env, nonce, receipt, msg_id))
         if args.final:
-            delivered = {
-                "schema": PENDING_SCHEMA,
-                "task_id": args.task_id,
-                "request_id": request_id,
-                "profile": profile_key,
-                "status": "delivered",
-                "receipt_nonce": nonce,
-                "discord_message_id": msg_id,
-            }
-            atomic_json(pending_followup_path(env, args.task_id), delivered)
-            print("pending final follow-up delivered")
-    elif args.final and pending.get("status") == "delivered":
+            with state_transaction(env):
+                current = load_existing_json(pending_path)
+                if not current:
+                    raise FMError("pending final follow-up record disappeared")
+                current_status = validate_followup_record(env, pending_path, current, args.task_id, request_id, profile_key)
+                if current_status == "delivered":
+                    if current.get("receipt_nonce") != nonce or current.get("discord_message_id") != msg_id:
+                        raise FMError("refusing to record a second final follow-up after delivery")
+                    receipt_result = record_receipt_unlocked(env, nonce, receipt, msg_id)
+                else:
+                    receipt_result = record_receipt_unlocked(env, nonce, receipt, msg_id)
+                    delivered = {
+                        "schema": PENDING_SCHEMA,
+                        "task_id": args.task_id,
+                        "request_id": request_id,
+                        "profile": profile_key,
+                        "status": "delivered",
+                        "receipt_nonce": nonce,
+                        "discord_message_id": msg_id,
+                    }
+                    atomic_json(pending_path, delivered)
+            print(receipt_result)
+            if current_status == "delivered":
+                print("pending final follow-up already delivered")
+            else:
+                print("pending final follow-up delivered")
+        else:
+            print(record_receipt(env, nonce, receipt, msg_id))
+    elif args.final and status == "delivered":
         print("dry-run only; final follow-up was already delivered.")
     else:
         print("dry-run only; pending final follow-up remains unresolved.")
@@ -1150,13 +1572,16 @@ def cmd_followup(args: argparse.Namespace, env: Env) -> int:
 
 
 def iter_pending_followups(env: Env) -> Iterable[Tuple[Path, Dict[str, Any]]]:
-    root = env.discord_state / "pending-followups"
+    root = discord_state_path(env, "pending-followups")
     if not root.exists():
         return []
     out: List[Tuple[Path, Dict[str, Any]]] = []
     for path in sorted(root.glob("*.json")):
         data = load_existing_json(path)
-        if data and data.get("status") == "pending":
+        task_id = path.stem
+        if not data:
+            raise FMError(f"pending final follow-up record is malformed: {path}")
+        if validate_followup_record(env, path, data, task_id) != "delivered":
             out.append((path, data))
     return out
 
@@ -1167,14 +1592,19 @@ def cmd_guard_work(args: argparse.Namespace, env: Env) -> int:
     path = pending_followup_path(env, args.task_id)
     if not path.exists() and not path.is_symlink():
         return 0
-    data = load_existing_json(path)
-    if not data:
-        return 0
-    if data.get("status") == "pending":
-        print(f"task {args.task_id} still owes a Discord workspace final reply for {data.get('request_id')}")
-        print(f"Deliver it with bin/fm-discord-workspace.sh followup {args.task_id} --final --text-file <file> after live posting is approved, or explicitly abandon the pending record after discard approval.")
+    try:
+        data = load_existing_json(path)
+        if not data:
+            raise FMError(f"pending final follow-up record is malformed: {path}")
+        status = validate_followup_record(env, path, data, args.task_id)
+    except FMError as exc:
+        print(f"task {args.task_id} has unsafe Discord workspace follow-up state: {exc}")
         return 1
-    return 0
+    if status == "delivered":
+        return 0
+    print(f"task {args.task_id} still owes a Discord workspace final reply for {data.get('request_id')}")
+    print(f"Deliver it with bin/fm-discord-workspace.sh followup {args.task_id} --final --text-file <file> after live posting is approved, or explicitly abandon the pending record after discard approval.")
+    return 1
 
 
 def cmd_retire(args: argparse.Namespace, env: Env) -> int:
@@ -1197,9 +1627,19 @@ def cmd_retire(args: argparse.Namespace, env: Env) -> int:
 # ------------------------ process-event adapter ----------------------------
 
 def parse_message_author(message: Dict[str, Any]) -> Tuple[str, bool]:
-    author = message.get("author") if isinstance(message.get("author"), dict) else {}
+    author_value = message.get("author")
+    if "author" in message and not isinstance(author_value, dict):
+        raise FMError("message author metadata must be a JSON object")
+    author = author_value if isinstance(author_value, dict) else {}
     author_id = str(author.get("id") or message.get("author_id") or "")
-    bot = bool(author.get("bot") or message.get("author_is_bot") or False)
+    if "bot" in author:
+        bot = author["bot"]
+    elif "author_is_bot" in message:
+        bot = message["author_is_bot"]
+    else:
+        bot = False
+    if not isinstance(bot, bool):
+        raise FMError("author bot metadata must be a JSON boolean")
     return author_id, bot
 
 
@@ -1231,10 +1671,10 @@ def attachment_content_type(attachment: Dict[str, Any]) -> str:
 
 
 def attachment_size(attachment: Dict[str, Any]) -> int:
-    try:
-        return int(attachment.get("size"))
-    except (TypeError, ValueError):
-        raise FMError("attachment size is missing or invalid")
+    value = attachment.get("size")
+    if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+        raise FMError("attachment size must be a positive JSON integer")
+    return value
 
 
 def attachment_duration(attachment: Dict[str, Any], message: Dict[str, Any]) -> float:
@@ -1243,16 +1683,23 @@ def attachment_duration(attachment: Dict[str, Any], message: Dict[str, Any]) -> 
         value = attachment.get("durationSecs")
     if value is None:
         value = message.get("duration_secs")
-    try:
-        duration = float(value)
-    except (TypeError, ValueError):
-        raise FMError("audio duration is missing or invalid")
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise FMError("audio duration must be a positive finite number encoded as a JSON number")
+    duration = float(value)
+    if not math.isfinite(duration) or duration <= 0:
+        raise FMError("audio duration must be a positive finite number encoded as a JSON number")
     return duration
 
 
-def validate_audio_attachment(cfg: WorkspaceConfig, message: Dict[str, Any]) -> Tuple[Dict[str, Any], str]:
+def message_flags(message: Dict[str, Any]) -> int:
+    value = message.get("flags", 0)
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        raise FMError("message flags must be a non-negative JSON integer")
+    return value
+
+
+def validate_audio_attachment(cfg: WorkspaceConfig, message: Dict[str, Any], flags: int) -> Tuple[Dict[str, Any], str]:
     attachments = as_list(message.get("attachments"), "message.attachments")
-    flags = int(message.get("flags") or 0)
     voice = bool(flags & VOICE_MESSAGE_FLAG)
     audio_candidates = []
     for attachment in attachments:
@@ -1277,7 +1724,7 @@ def validate_audio_attachment(cfg: WorkspaceConfig, message: Dict[str, Any]) -> 
     if size <= 0 or size > cfg.audio_max_bytes:
         raise FMError("audio attachment exceeds the configured size limit")
     duration = attachment_duration(attachment, message)
-    if duration <= 0 or duration > cfg.audio_max_duration_secs:
+    if duration > cfg.audio_max_duration_secs:
         raise FMError("audio attachment exceeds the configured duration limit")
     url = validate_discord_cdn_url(str(attachment.get("url") or ""), cfg)
     host = urlparse(url).hostname or ""
@@ -1322,28 +1769,10 @@ def message_to_event(cfg: WorkspaceConfig, message: Dict[str, Any]) -> Dict[str,
     if profile is None:
         return ignored_event("unknown-channel-or-thread", guild_id, channel_id, message_id)
     profile_key, forum_kind, forum_id = profile
-    author_id, author_is_bot = parse_message_author(message)
-    if author_is_bot or author_id == cfg.bot_user_id:
-        return ignored_event("bot-author", guild_id, channel_id, message_id, profile_key, forum_kind)
-    if author_id not in cfg.captain_user_ids:
-        return ignored_event("unknown-author", guild_id, channel_id, message_id, profile_key, forum_kind)
-    content = str(message.get("content") or "").strip()
-    attachments = as_list(message.get("attachments"), "message.attachments")
-    has_audio = False
-    try:
-        flags = int(message.get("flags") or 0)
-    except (TypeError, ValueError):
-        flags = 0
-    if flags & VOICE_MESSAGE_FLAG:
-        has_audio = True
-    else:
-        for attachment in attachments:
-            if isinstance(attachment, dict):
-                ctype = attachment_content_type(attachment)
-                ext = Path(str(attachment.get("filename") or "")).suffix.lower()
-                if ctype.startswith(ALLOWED_AUDIO_MIME_PREFIXES) or ext in ALLOWED_AUDIO_EXTENSIONS:
-                    has_audio = True
-                    break
+    author = message.get("author") if isinstance(message.get("author"), dict) else {}
+    author_id = str(author.get("id") or message.get("author_id") or "")
+    content_value = message.get("content", "")
+    content = content_value.strip() if isinstance(content_value, str) else ""
     base = {
         "schema": EVENT_SCHEMA,
         "source": DISCORD_SOURCE_ID,
@@ -1358,17 +1787,56 @@ def message_to_event(cfg: WorkspaceConfig, message: Dict[str, Any]) -> Dict[str,
         "jump_url": discord_jump_url(guild_id, channel_id, message_id),
         "timestamp": str(message.get("timestamp") or ""),
     }
+    if author_id == cfg.bot_user_id:
+        return ignored_event("bot-author", guild_id, channel_id, message_id, profile_key, forum_kind)
+    if author_id not in cfg.captain_user_ids:
+        return ignored_event("unknown-author", guild_id, channel_id, message_id, profile_key, forum_kind)
+    try:
+        _author_id, author_is_bot = parse_message_author(message)
+    except FMError as exc:
+        item = dict(base)
+        item.update({"kind": "message-rejected", "content": content, "reason": str(exc), "attachments": []})
+        return item
+    if author_is_bot:
+        return ignored_event("bot-author", guild_id, channel_id, message_id, profile_key, forum_kind)
+    if "content" in message and not isinstance(content_value, str):
+        item = dict(base)
+        item.update({"kind": "message-rejected", "content": content, "reason": "message content must be a JSON string", "attachments": []})
+        return item
+    try:
+        attachments = as_list(message.get("attachments"), "message.attachments")
+        if any(not isinstance(attachment, dict) for attachment in attachments):
+            raise FMError("message attachments must contain only JSON objects")
+    except FMError as exc:
+        item = dict(base)
+        item.update({"kind": "message-rejected", "content": content, "reason": str(exc), "attachments": []})
+        return item
     if forum_kind != "exchange":
         item = dict(base)
         item.update({"kind": "ignored", "reason": "artifact-thread-input-disabled"})
         return item
+    try:
+        flags = message_flags(message)
+    except FMError as exc:
+        item = dict(base)
+        item.update({"kind": "message-rejected", "content": content, "reason": str(exc), "attachments": safe_attachment_metadata(attachments)})
+        return item
+    has_audio = bool(flags & VOICE_MESSAGE_FLAG)
+    if not has_audio:
+        for attachment in attachments:
+            if isinstance(attachment, dict):
+                ctype = attachment_content_type(attachment)
+                ext = Path(str(attachment.get("filename") or "")).suffix.lower()
+                if ctype.startswith(ALLOWED_AUDIO_MIME_PREFIXES) or ext in ALLOWED_AUDIO_EXTENSIONS:
+                    has_audio = True
+                    break
     if has_audio:
         try:
-            audio, audio_kind = validate_audio_attachment(cfg, message)
+            audio, audio_kind = validate_audio_attachment(cfg, message, flags)
             transcript = fake_transcript_for(cfg, message, audio)
         except FMError as exc:
             item = dict(base)
-            item.update({"kind": "audio-rejected", "reason": str(exc), "attachments": safe_attachment_metadata(attachments)})
+            item.update({"kind": "audio-rejected", "content": content, "reason": str(exc), "attachments": safe_attachment_metadata(attachments)})
             return item
         item = dict(base)
         item.update({
@@ -1429,7 +1897,7 @@ def ignored_event(reason: str, guild_id: str, channel_id: str, message_id: str, 
 
 
 def cursor_path(env: Env, profile: str, channel_id: str) -> Path:
-    return env.discord_state / "cursors" / profile / f"{channel_id}.cursor"
+    return discord_state_path(env, "cursors", profile, f"{channel_id}.cursor")
 
 
 def read_cursor(env: Env, profile: str, channel_id: str) -> int:
@@ -1449,20 +1917,24 @@ def read_cursor(env: Env, profile: str, channel_id: str) -> int:
 def write_cursor(env: Env, profile: str, channel_id: str, message_id: str) -> None:
     if not message_id.isdigit():
         return
-    path = cursor_path(env, profile, channel_id)
-    path.parent.mkdir(parents=True, exist_ok=True)
-    fd, tmp = tempfile.mkstemp(prefix=".cursor.", dir=str(path.parent))
-    try:
-        with os.fdopen(fd, "w", encoding="utf-8") as f:
-            f.write(message_id + "\n")
-        os.chmod(tmp, 0o600)
-        os.replace(tmp, path)
-    except Exception:
+    candidate = int(message_id)
+    with state_transaction(env):
+        if candidate <= read_cursor(env, profile, channel_id):
+            return
+        path = cursor_path(env, profile, channel_id)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        fd, tmp = tempfile.mkstemp(prefix=".cursor.", dir=str(path.parent))
         try:
-            os.unlink(tmp)
-        except FileNotFoundError:
-            pass
-        raise
+            with os.fdopen(fd, "w", encoding="utf-8") as f:
+                f.write(message_id + "\n")
+            os.chmod(tmp, 0o600)
+            os.replace(tmp, path)
+        except Exception:
+            try:
+                os.unlink(tmp)
+            except FileNotFoundError:
+                pass
+            raise
 
 
 def fixture_messages(cfg: WorkspaceConfig) -> List[Dict[str, Any]]:
@@ -1539,8 +2011,8 @@ def event_class(event: Dict[str, Any]) -> str:
     kind = str(event.get("kind") or "")
     if kind in ("text", "voice-transcript", "audio-transcript"):
         return "message"
-    if kind == "audio-rejected":
-        return "audio-rejected"
+    if kind in ("audio-rejected", "message-rejected"):
+        return kind
     if kind == "ignored":
         return "ignored"
     return "malformed"
@@ -1601,6 +2073,8 @@ def note_body_for_event(event: Dict[str, Any]) -> str:
         lines.append("transcription: fake fixture, no secret")
         if event.get("jump_url"):
             lines.append(f"link: {event.get('jump_url')}")
+        if event.get("content"):
+            lines.append(f"caption: {event.get('content')}")
         lines.append("")
         lines.append(str(event.get("transcript") or ""))
     elif kind == "audio-rejected":
@@ -1608,22 +2082,30 @@ def note_body_for_event(event: Dict[str, Any]) -> str:
         lines.append(f"request: {event.get('external_id')}")
         lines.append(f"from: {event.get('author_id')}")
         lines.append(f"reason: {event.get('reason')}")
+        if event.get("content"):
+            lines.append(f"caption: {event.get('content')}")
+    elif kind == "message-rejected":
+        lines.append(header + "message rejected")
+        lines.append(f"request: {event.get('external_id')}")
+        lines.append(f"from: {event.get('author_id')}")
+        lines.append(f"reason: invalid message metadata: {event.get('reason')}")
+        if event.get("jump_url"):
+            lines.append(f"link: {event.get('jump_url')}")
+        if event.get("content"):
+            lines.append(f"context: {event.get('content')}")
     else:
         raise FMError("event is not inbox-addressable")
     return "\n".join(lines).rstrip() + "\n"
 
 
 def request_record_from_event(event: Dict[str, Any]) -> Dict[str, Any]:
-    return {
-        "schema": REQUEST_SCHEMA,
-        "request_id": event.get("external_id"),
-        "guild_id": event.get("guild_id"),
-        "channel_id": event.get("channel_id"),
-        "message_id": event.get("message_id"),
-        "profile": event.get("profile"),
-        "origin": "discord-workspace",
-        "jump_url": event.get("jump_url"),
-    }
+    return canonical_request_record(
+        str(event.get("external_id")),
+        str(event.get("guild_id")),
+        str(event.get("channel_id")),
+        str(event.get("message_id")),
+        str(event.get("profile")),
+    )
 
 
 def procevent_mark_handled(env: Env, source_id: str, sequence: str) -> None:
@@ -1647,8 +2129,12 @@ def procevent_cmd_autohandle(args: argparse.Namespace, env: Env) -> int:
         procevent_mark_handled(env, source_id, sequence)
         print("handled ignored Discord workspace event")
         return 0
+    if cls == "message":
+        request = request_record_from_event(event)
+        with state_transaction(env):
+            write_same_or_refuse(request_record_path(env, str(event.get("external_id"))), request, "request record")
     body = note_body_for_event(event)
-    metadata_dir = env.discord_state / "metadata-staging"
+    metadata_dir = discord_state_path(env, "metadata-staging")
     metadata_dir.mkdir(parents=True, exist_ok=True)
     fd, meta_tmp = tempfile.mkstemp(prefix=".metadata.", suffix=".json", dir=str(metadata_dir))
     try:
@@ -1679,9 +2165,6 @@ def procevent_cmd_autohandle(args: argparse.Namespace, env: Env) -> int:
             os.unlink(meta_tmp)
         except FileNotFoundError:
             pass
-    if cls == "message":
-        request = request_record_from_event(event)
-        write_same_or_refuse(request_record_path(env, str(event.get("external_id"))), request, "request record")
     if event.get("profile") and event.get("channel_id") and event.get("message_id"):
         write_cursor(env, str(event["profile"]), str(event["channel_id"]), str(event["message_id"]))
     procevent_mark_handled(env, source_id, sequence)
@@ -1740,7 +2223,6 @@ def build_tool_parser() -> argparse.ArgumentParser:
     p.add_argument("--file", required=True)
     p.add_argument("--purpose", required=True)
     p.add_argument("--request-id")
-    p.add_argument("--private-url")
     p.add_argument("--client-confidential", action="store_true")
     p.add_argument("--captain-approved-client-confidential", action="store_true")
     p.add_argument("--nonce")
@@ -1753,7 +2235,7 @@ def build_tool_parser() -> argparse.ArgumentParser:
     p.add_argument("--purpose", required=True)
     p.add_argument("--url", required=True)
     p.add_argument("--access", required=True)
-    p.add_argument("--expires", default="7d")
+    p.add_argument("--expires")
     p.add_argument("--client-confidential", action="store_true")
     p.add_argument("--captain-approved-client-confidential", action="store_true")
     p.add_argument("--record", action="store_true")

--- a/bin/fm_discord_workspace_lib.py
+++ b/bin/fm_discord_workspace_lib.py
@@ -1,0 +1,1840 @@
+#!/usr/bin/env python3
+"""Offline support code for Firstmate's private Discord operations workspace.
+
+The shell entrypoints are the public interface.
+This module contains the shared parsing and planning logic so the outbound owner and process-event adapter enforce the same non-secret config contract.
+"""
+from __future__ import annotations
+
+import argparse
+import datetime as _dt
+import hashlib
+import json
+import mimetypes
+import os
+from pathlib import Path
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+from typing import Any, Dict, Iterable, List, Optional, Tuple
+from urllib.parse import urlparse
+
+SCHEMA = "fm-discord-workspace.config.v1"
+EVENT_SCHEMA = "fm-discord-workspace-event.v1"
+RECEIPT_SCHEMA = "fm-discord-workspace-receipt.v1"
+REQUEST_SCHEMA = "fm-discord-workspace-request.v1"
+TASK_LINK_SCHEMA = "fm-discord-workspace-task-link.v1"
+PENDING_SCHEMA = "fm-discord-workspace-pending-followup.v1"
+ARTIFACT_SCHEMA = "fm-discord-workspace-artifact.v1"
+ARTIFACT_INDEX_SCHEMA = "fm-discord-workspace-artifact-source-index.v1"
+
+ACTIVE_PROFILE_KEYS = ["proapplis", "folium", "arfal"]
+ACTIVE_PROFILE_LABELS = {
+    "proapplis": "ProApplis",
+    "folium": "Folium",
+    "arfal": "ARFAL",
+}
+DISABLED_PROFILE_KEYS = ["lbdb", "maratone-labs"]
+DEFAULT_EXCHANGE_TAGS = ["request", "decision", "work", "status", "blocked", "done"]
+DEFAULT_ARTIFACT_TAGS = ["report", "board", "document", "image", "audio", "draft", "final", "expired"]
+DEFAULT_CDN_HOSTS = ["cdn.discordapp.com", "media.discordapp.net", "media.discordapp.com"]
+VOICE_MESSAGE_FLAG = 1 << 13
+STEADY_PERMISSION = 101376
+STEADY_THREADS_PERMISSION = 274878008320
+SETUP_PERMISSION = 268536848
+SETUP_THREADS_PERMISSION = 275146443792
+DIRECT_ATTACHMENT_MAX = 8 * 1024 * 1024
+AUDIO_MAX_BYTES = 25 * 1024 * 1024
+AUDIO_MAX_DURATION_SECS = 600
+DISCORD_SOURCE_ID = "discord-workspace"
+
+ID_RE = re.compile(r"^[0-9]{5,32}$")
+PROFILE_KEY_RE = re.compile(r"^[a-z0-9][a-z0-9-]{0,39}$")
+TASK_ID_RE = re.compile(r"^[A-Za-z0-9._-]{1,120}$")
+TAG_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._ -]{0,49}$")
+SOURCE_RE = re.compile(r"^[A-Za-z0-9._-]{1,80}$")
+REQUEST_RE = re.compile(r"^discord:([0-9]{5,32}):([0-9]{5,32}):([0-9]{5,32})$")
+SECRETISH_RE = re.compile(
+    r"(^|[._-])(env|secret|secrets|token|tokens|key|keys|credential|credentials|cookie|cookies|cert|certificate|private)([._-]|$)",
+    re.IGNORECASE,
+)
+BLOCKED_EXTENSIONS = {
+    ".zip", ".tar", ".tgz", ".gz", ".bz2", ".xz", ".7z", ".rar", ".zst",
+    ".sqlite", ".sqlite3", ".db", ".dump", ".sql", ".log", ".har", ".pem",
+    ".p12", ".pfx", ".key", ".crt", ".cer",
+}
+ALLOWED_TEXT_EXTENSIONS = {".md", ".markdown", ".txt"}
+ALLOWED_IMAGE_EXTENSIONS = {".png", ".jpg", ".jpeg", ".gif", ".webp"}
+ALLOWED_DOCUMENT_EXTENSIONS = {".pdf"}
+ALLOWED_DIRECT_EXTENSIONS = ALLOWED_TEXT_EXTENSIONS | ALLOWED_IMAGE_EXTENSIONS | ALLOWED_DOCUMENT_EXTENSIONS
+ALLOWED_AUDIO_MIME_PREFIXES = ("audio/",)
+ALLOWED_AUDIO_EXTENSIONS = {".wav", ".ogg", ".opus", ".mp3", ".m4a", ".flac", ".webm"}
+EXIT_NO_RESULT = 75
+
+
+class FMError(Exception):
+    """A user-facing refusal that should not show a traceback."""
+
+
+class Env:
+    def __init__(self, script_dir: str):
+        self.script_dir = Path(script_dir).resolve()
+        self.root = self.script_dir.parent
+        self.home = Path(os.environ.get("FM_HOME") or os.environ.get("FM_ROOT_OVERRIDE") or self.root).resolve()
+        self.state = Path(os.environ.get("FM_STATE_OVERRIDE") or self.home / "state").resolve()
+        self.data = Path(os.environ.get("FM_DATA_OVERRIDE") or self.home / "data").resolve()
+        self.config = Path(os.environ.get("FM_CONFIG_OVERRIDE") or self.home / "config").resolve()
+
+    @property
+    def default_config(self) -> Path:
+        return self.config / "discord-workspace.json"
+
+    @property
+    def discord_state(self) -> Path:
+        return self.state / "discord-workspace"
+
+    @property
+    def inbox(self) -> Path:
+        return self.state / "inbox"
+
+
+def die(message: str, code: int = 1) -> None:
+    print(f"fm-discord-workspace: {message}", file=sys.stderr)
+    raise SystemExit(code)
+
+
+def utc_now() -> str:
+    return _dt.datetime.now(_dt.timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def sha256_text(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def sha256_file(path: Path) -> str:
+    h = hashlib.sha256()
+    with path.open("rb") as f:
+        for chunk in iter(lambda: f.read(1024 * 1024), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def safe_digest_path(root: Path, digest_input: str, suffix: str = ".json") -> Path:
+    return root / f"{sha256_text(digest_input)}{suffix}"
+
+
+def atomic_json(path: Path, data: Dict[str, Any], mode: int = 0o600) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_name = tempfile.mkstemp(prefix=f".{path.name}.", dir=str(path.parent))
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            json.dump(data, f, indent=2, sort_keys=True)
+            f.write("\n")
+        os.chmod(tmp_name, mode)
+        os.replace(tmp_name, path)
+    except Exception:
+        try:
+            os.unlink(tmp_name)
+        except FileNotFoundError:
+            pass
+        raise
+
+
+def read_json(path: Path) -> Dict[str, Any]:
+    if not path.exists():
+        raise FMError(f"config file is missing: {path}")
+    if path.is_symlink() or not path.is_file():
+        raise FMError(f"refusing unsafe config path: {path}")
+    try:
+        with path.open("r", encoding="utf-8") as f:
+            data = json.load(f)
+    except json.JSONDecodeError as exc:
+        raise FMError(f"config is not valid JSON: {path}: {exc}") from exc
+    if not isinstance(data, dict):
+        raise FMError("config root must be a JSON object")
+    return data
+
+
+def json_load_file(path: Path) -> Any:
+    if path.is_symlink() or not path.is_file():
+        raise FMError(f"refusing unsafe JSON path: {path}")
+    with path.open("r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def as_list(value: Any, field: str) -> List[Any]:
+    if value is None:
+        return []
+    if not isinstance(value, list):
+        raise FMError(f"{field} must be a list")
+    return value
+
+
+def validate_snowflake(value: Any, field: str, *, required: bool = True) -> Optional[str]:
+    if value is None or value == "":
+        if required:
+            raise FMError(f"{field} is required")
+        return None
+    if not isinstance(value, str):
+        raise FMError(f"{field} must be a string Discord id")
+    if not ID_RE.fullmatch(value):
+        raise FMError(f"{field} must be a decimal Discord id")
+    return value
+
+
+def validate_bool(value: Any, field: str, *, default: bool = False) -> bool:
+    if value is None:
+        return default
+    if not isinstance(value, bool):
+        raise FMError(f"{field} must be true or false")
+    return value
+
+
+def bool_from_path(obj: Dict[str, Any], names: Iterable[str], default: bool = False) -> bool:
+    for name in names:
+        cur: Any = obj
+        ok = True
+        for part in name.split("."):
+            if isinstance(cur, dict) and part in cur:
+                cur = cur[part]
+            else:
+                ok = False
+                break
+        if ok:
+            return validate_bool(cur, name, default=default)
+    return default
+
+
+def validate_tags(raw: Any, default: List[str], field: str) -> List[str]:
+    values = default if raw is None else as_list(raw, field)
+    out: List[str] = []
+    seen: set[str] = set()
+    for item in values:
+        if not isinstance(item, str) or not TAG_RE.fullmatch(item):
+            raise FMError(f"{field} contains an invalid forum tag")
+        key = item.lower()
+        if key in seen:
+            raise FMError(f"{field} contains duplicate forum tag: {item}")
+        seen.add(key)
+        out.append(item)
+    if not out:
+        raise FMError(f"{field} must contain at least one forum tag")
+    return out
+
+
+def normalize_profile_key(key: str) -> str:
+    lowered = key.strip().lower().replace("_", "-").replace(" ", "-")
+    aliases = {
+        "pro-applis": "proapplis",
+        "maratone": "maratone-labs",
+        "maratone-labs": "maratone-labs",
+    }
+    return aliases.get(lowered, lowered)
+
+
+def extract_profile(raw_profiles: Dict[str, Any], key: str) -> Dict[str, Any]:
+    for raw_key, value in raw_profiles.items():
+        if normalize_profile_key(raw_key) == key:
+            if not isinstance(value, dict):
+                raise FMError(f"profiles.{raw_key} must be an object")
+            return value
+    return {}
+
+
+def thread_ids_for(profile: Dict[str, Any], kind: str, field_prefix: str) -> List[str]:
+    raw = None
+    threads = profile.get("thread_ids")
+    if isinstance(threads, dict) and kind in threads:
+        raw = threads[kind]
+    if raw is None:
+        raw = profile.get(f"{kind}_thread_ids")
+    out: List[str] = []
+    seen: set[str] = set()
+    for item in as_list(raw, f"{field_prefix}.thread_ids.{kind}"):
+        sid = validate_snowflake(item, f"{field_prefix}.thread_ids.{kind}[]")
+        assert sid is not None
+        if sid in seen:
+            raise FMError(f"{field_prefix}.thread_ids.{kind} has duplicate thread id: {sid}")
+        seen.add(sid)
+        out.append(sid)
+    return out
+
+
+def maybe_id(profile: Dict[str, Any], *names: str) -> Any:
+    for name in names:
+        if name in profile:
+            return profile[name]
+    return None
+
+
+INLINE_SECRET_KEYS = {"token", "bot_token", "discord_bot_token", "groq_api_key", "api_key_value", "secret", "password", "client_secret"}
+
+
+def reject_inline_secret_values(value: Any, path: str = "config") -> None:
+    if isinstance(value, dict):
+        for key, child in value.items():
+            key_text = str(key)
+            lowered = key_text.lower().replace("-", "_")
+            if lowered in INLINE_SECRET_KEYS:
+                raise FMError(f"{path}.{key_text} appears to contain an inline secret; store only secret file paths and key names")
+            reject_inline_secret_values(child, f"{path}.{key_text}")
+    elif isinstance(value, list):
+        for index, child in enumerate(value):
+            reject_inline_secret_values(child, f"{path}[{index}]")
+
+
+def config_secret_references(cfg: Dict[str, Any]) -> List[str]:
+    refs: List[str] = []
+    tx = cfg.get("transcription") if isinstance(cfg.get("transcription"), dict) else {}
+    secret_file = cfg.get("secret_file") or cfg.get("secrets_file") or tx.get("secret_file") or tx.get("secrets_file")
+    if isinstance(secret_file, str) and secret_file:
+        refs.append(f"secret file: {secret_file}")
+    token_key = cfg.get("discord_bot_token_key") or tx.get("discord_bot_token_key")
+    if isinstance(token_key, str) and token_key:
+        refs.append(f"Discord bot token key: {token_key}")
+    api_key = tx.get("api_key") or tx.get("api_key_name")
+    if isinstance(api_key, str) and api_key:
+        refs.append(f"transcription key name: {api_key}")
+    return refs
+
+
+class WorkspaceConfig:
+    def __init__(self, path: Path, raw: Dict[str, Any]):
+        self.path = path
+        self.raw = raw
+        reject_inline_secret_values(raw)
+        schema = raw.get("schema", SCHEMA)
+        if schema != SCHEMA:
+            raise FMError(f"unsupported config schema: {schema}")
+        guild_obj = raw.get("guild") if isinstance(raw.get("guild"), dict) else {}
+        bot_obj = raw.get("bot") if isinstance(raw.get("bot"), dict) else {}
+        self.guild_id = validate_snowflake(raw.get("guild_id") or guild_obj.get("id"), "guild.id") or ""
+        self.bot_application_id = validate_snowflake(
+            raw.get("bot_application_id") or bot_obj.get("application_id"),
+            "bot.application_id",
+        ) or ""
+        self.bot_user_id = validate_snowflake(raw.get("bot_user_id") or bot_obj.get("user_id"), "bot.user_id") or ""
+        self.captain_user_ids = []
+        for user_id in as_list(raw.get("captain_user_ids"), "captain_user_ids"):
+            sid = validate_snowflake(user_id, "captain_user_ids[]")
+            assert sid is not None
+            if sid == self.bot_user_id:
+                raise FMError("captain_user_ids must not include the bot user id")
+            self.captain_user_ids.append(sid)
+        if not self.captain_user_ids:
+            raise FMError("captain_user_ids must contain at least one captain Discord user id")
+        disabled = raw.get("disabled_profiles", DISABLED_PROFILE_KEYS)
+        self.disabled_profiles = [normalize_profile_key(str(x)) for x in as_list(disabled, "disabled_profiles")]
+        missing_disabled = [p for p in DISABLED_PROFILE_KEYS if p not in self.disabled_profiles]
+        if missing_disabled:
+            raise FMError(f"disabled_profiles must include dormant profile(s): {', '.join(missing_disabled)}")
+        tags_obj = raw.get("tags") if isinstance(raw.get("tags"), dict) else {}
+        self.exchange_tags = validate_tags(tags_obj.get("exchange"), DEFAULT_EXCHANGE_TAGS, "tags.exchange")
+        self.artifact_tags = validate_tags(tags_obj.get("artifacts", tags_obj.get("artifact")), DEFAULT_ARTIFACT_TAGS, "tags.artifacts")
+        self.profiles: Dict[str, Dict[str, Any]] = {}
+        raw_profiles = raw.get("profiles")
+        if not isinstance(raw_profiles, dict):
+            raise FMError("profiles must be an object")
+        seen_ids: Dict[str, str] = {}
+        for key in ACTIVE_PROFILE_KEYS:
+            p = extract_profile(raw_profiles, key)
+            if not p:
+                raise FMError(f"profiles.{key} is required")
+            if not validate_bool(p.get("enabled", True), f"profiles.{key}.enabled", default=True):
+                raise FMError(f"profiles.{key} must be enabled for this phase")
+            category_id = validate_snowflake(p.get("category_id"), f"profiles.{key}.category_id") or ""
+            exchange_forum_id = validate_snowflake(
+                maybe_id(p, "exchange_forum_id", "exchanges_forum_id"),
+                f"profiles.{key}.exchange_forum_id",
+            ) or ""
+            artifact_forum_id = validate_snowflake(
+                maybe_id(p, "artifact_forum_id", "artifacts_forum_id"),
+                f"profiles.{key}.artifact_forum_id",
+            ) or ""
+            for field_name, sid in [
+                ("category_id", category_id),
+                ("exchange_forum_id", exchange_forum_id),
+                ("artifact_forum_id", artifact_forum_id),
+            ]:
+                owner = seen_ids.get(sid)
+                if owner:
+                    raise FMError(f"duplicate Discord id {sid} appears in {owner} and profiles.{key}.{field_name}")
+                seen_ids[sid] = f"profiles.{key}.{field_name}"
+            label = p.get("label") if isinstance(p.get("label"), str) else ACTIVE_PROFILE_LABELS[key]
+            exchange_threads = thread_ids_for(p, "exchange", f"profiles.{key}")
+            artifact_threads = thread_ids_for(p, "artifacts", f"profiles.{key}")
+            artifact_threads += [x for x in thread_ids_for(p, "artifact", f"profiles.{key}") if x not in artifact_threads]
+            for tid in exchange_threads:
+                owner = seen_ids.get(tid)
+                if owner:
+                    raise FMError(f"duplicate Discord id {tid} appears in {owner} and profiles.{key}.thread_ids.exchange")
+                seen_ids[tid] = f"profiles.{key}.thread_ids.exchange"
+            for tid in artifact_threads:
+                owner = seen_ids.get(tid)
+                if owner:
+                    raise FMError(f"duplicate Discord id {tid} appears in {owner} and profiles.{key}.thread_ids.artifacts")
+                seen_ids[tid] = f"profiles.{key}.thread_ids.artifacts"
+            self.profiles[key] = {
+                "key": key,
+                "label": label,
+                "category_id": category_id,
+                "exchange_forum_id": exchange_forum_id,
+                "artifact_forum_id": artifact_forum_id,
+                "exchange_thread_ids": exchange_threads,
+                "artifact_thread_ids": artifact_threads,
+                "category_name": p.get("category_name") or label,
+                "exchange_forum_name": p.get("exchange_forum_name") or f"{key}-exchanges",
+                "artifact_forum_name": p.get("artifact_forum_name") or f"{key}-artifacts",
+            }
+        for disabled_key in DISABLED_PROFILE_KEYS:
+            p = extract_profile(raw_profiles, disabled_key)
+            if not p:
+                continue
+            enabled = validate_bool(p.get("enabled", False), f"profiles.{disabled_key}.enabled", default=False)
+            channelish = [name for name in ("category_id", "exchange_forum_id", "artifact_forum_id", "artifacts_forum_id") if p.get(name)]
+            if enabled or channelish:
+                raise FMError(f"disabled profile {disabled_key} must not be enabled or carry channel ids")
+        approvals = raw.get("approvals") if isinstance(raw.get("approvals"), dict) else {}
+        live = raw.get("live") if isinstance(raw.get("live"), dict) else {}
+        self.message_content_enabled = bool_from_path(raw, ["message_content", "message_content_intent", "approvals.message_content", "live.message_content"], False)
+        self.live_posting_enabled = bool_from_path(raw, ["live_posting", "approvals.live_posting", "outbound.live_posting", "live.posting"], False)
+        self.live_polling_enabled = bool_from_path(raw, ["live_polling", "approvals.live_polling", "live.polling"], False)
+        self.temporary_setup_permissions = bool_from_path(raw, ["temporary_setup_permissions", "approvals.temporary_setup_permissions", "live.temporary_setup_permissions"], False)
+        self.community_mode_required = bool_from_path(raw, ["community_mode_required", "approvals.community_mode_required", "live.community_mode_required"], False)
+        self.host_choice = str(raw.get("host") or live.get("host") or approvals.get("host") or "disabled")
+        outbound = raw.get("outbound") if isinstance(raw.get("outbound"), dict) else {}
+        self.final_replies_required = validate_bool(outbound.get("final_replies_required", True), "outbound.final_replies_required", default=True)
+        artifacts = raw.get("artifacts") if isinstance(raw.get("artifacts"), dict) else {}
+        self.artifact_access = str(artifacts.get("access") or artifacts.get("access_mode") or "disabled")
+        self.artifact_default_expiry = str(artifacts.get("default_expiry") or "7d")
+        self.client_confidential_allowed = validate_bool(artifacts.get("client_confidential_allowed", False), "artifacts.client_confidential_allowed", default=False)
+        self.direct_attachment_max_bytes = int(artifacts.get("direct_attachment_max_bytes", DIRECT_ATTACHMENT_MAX))
+        if self.direct_attachment_max_bytes <= 0 or self.direct_attachment_max_bytes > 10 * 1024 * 1024:
+            raise FMError("artifacts.direct_attachment_max_bytes must be positive and no more than 10 MiB in this phase")
+        allowed_roots_raw = artifacts.get("allowed_roots", ["data"])
+        self.allowed_roots = [str(x) for x in as_list(allowed_roots_raw, "artifacts.allowed_roots")]
+        audio = raw.get("audio") if isinstance(raw.get("audio"), dict) else {}
+        self.audio_max_bytes = int(audio.get("max_bytes", AUDIO_MAX_BYTES))
+        self.audio_max_duration_secs = float(audio.get("max_duration_secs", AUDIO_MAX_DURATION_SECS))
+        self.audio_delete_raw = validate_bool(audio.get("delete_temporary_raw", audio.get("delete_raw", True)), "audio.delete_temporary_raw", default=True)
+        self.cdn_hosts = [str(x).lower() for x in as_list(audio.get("allowed_cdn_hosts", DEFAULT_CDN_HOSTS), "audio.allowed_cdn_hosts")]
+        if not self.cdn_hosts:
+            raise FMError("audio.allowed_cdn_hosts must not be empty")
+        transcription = raw.get("transcription") if isinstance(raw.get("transcription"), dict) else {}
+        self.transcription = transcription
+        self.transcription_provider = str(transcription.get("provider") or "disabled")
+        self.hosted_groq_enabled = self.transcription_provider == "groq" or bool_from_path(raw, ["hosted_groq", "approvals.hosted_groq", "transcription.hosted_groq"], False)
+        if self.host_choice not in ("disabled", "none", "dry-run", "omarchy", "vps"):
+            raise FMError("host must be disabled, omarchy, or vps")
+        if self.artifact_access not in ("disabled", "tailnet", "cloudflare-access", "local"):
+            raise FMError("artifacts.access must be disabled, tailnet, cloudflare-access, or local")
+
+    @classmethod
+    def load(cls, env: Env, path_text: Optional[str]) -> "WorkspaceConfig":
+        path = Path(path_text).expanduser() if path_text else env.default_config
+        if not path.is_absolute():
+            path = (Path.cwd() / path).resolve()
+        raw = read_json(path)
+        return cls(path.resolve(), raw)
+
+    def profile_for_channel(self, channel_id: str, parent_id: Optional[str] = None, *, allow_forums: bool = False) -> Optional[Tuple[str, str, str]]:
+        for key, p in self.profiles.items():
+            if allow_forums and channel_id == p["exchange_forum_id"]:
+                return key, "exchange", p["exchange_forum_id"]
+            if allow_forums and channel_id == p["artifact_forum_id"]:
+                return key, "artifact", p["artifact_forum_id"]
+            if channel_id in p["exchange_thread_ids"]:
+                if parent_id and parent_id != p["exchange_forum_id"]:
+                    return None
+                return key, "exchange", p["exchange_forum_id"]
+            if channel_id in p["artifact_thread_ids"]:
+                if parent_id and parent_id != p["artifact_forum_id"]:
+                    return None
+                return key, "artifact", p["artifact_forum_id"]
+        return None
+
+    def profile_for_request_id(self, request_id: str) -> Tuple[str, str, str, str, str]:
+        match = REQUEST_RE.fullmatch(request_id)
+        if not match:
+            raise FMError("request id must be discord:<guild_id>:<channel_or_thread_id>:<message_id>")
+        guild_id, channel_id, message_id = match.groups()
+        if guild_id != self.guild_id:
+            raise FMError("request id names a guild outside the configured operations guild")
+        profile = self.profile_for_channel(channel_id)
+        if profile is None:
+            raise FMError("request id names a channel/thread outside the configured allowlist")
+        profile_key, forum_kind, forum_id = profile
+        return guild_id, channel_id, message_id, profile_key, forum_kind
+
+    def thread_summary(self) -> List[str]:
+        rows: List[str] = []
+        for key in ACTIVE_PROFILE_KEYS:
+            p = self.profiles[key]
+            rows.append(f"{p['label']}: exchange threads {len(p['exchange_thread_ids'])}, artifact threads {len(p['artifact_thread_ids'])}")
+        return rows
+
+
+def sample_config() -> Dict[str, Any]:
+    return {
+        "schema": SCHEMA,
+        "guild": {"id": "111111111111111111"},
+        "bot": {"application_id": "222222222222222222", "user_id": "333333333333333333"},
+        "captain_user_ids": ["444444444444444444"],
+        "disabled_profiles": DISABLED_PROFILE_KEYS,
+        "profiles": {
+            "proapplis": {
+                "enabled": True,
+                "label": "ProApplis",
+                "category_id": "555555555555555551",
+                "exchange_forum_id": "555555555555555552",
+                "artifact_forum_id": "555555555555555553",
+                "thread_ids": {"exchange": [], "artifacts": []},
+            },
+            "folium": {
+                "enabled": True,
+                "label": "Folium",
+                "category_id": "666666666666666661",
+                "exchange_forum_id": "666666666666666662",
+                "artifact_forum_id": "666666666666666663",
+                "thread_ids": {"exchange": [], "artifacts": []},
+            },
+            "arfal": {
+                "enabled": True,
+                "label": "ARFAL",
+                "category_id": "777777777777777771",
+                "exchange_forum_id": "777777777777777772",
+                "artifact_forum_id": "777777777777777773",
+                "thread_ids": {"exchange": [], "artifacts": []},
+            },
+            "lbdb": {"enabled": False},
+            "maratone-labs": {"enabled": False},
+        },
+        "tags": {"exchange": DEFAULT_EXCHANGE_TAGS, "artifacts": DEFAULT_ARTIFACT_TAGS},
+        "outbound": {"final_replies_required": True, "live_posting": False},
+        "artifacts": {
+            "direct_attachment_max_bytes": DIRECT_ATTACHMENT_MAX,
+            "allowed_roots": ["data"],
+            "access": "disabled",
+            "default_expiry": "7d",
+            "client_confidential_allowed": False,
+        },
+        "audio": {
+            "max_bytes": AUDIO_MAX_BYTES,
+            "max_duration_secs": AUDIO_MAX_DURATION_SECS,
+            "delete_temporary_raw": True,
+            "allowed_cdn_hosts": DEFAULT_CDN_HOSTS,
+        },
+        "transcription": {
+            "provider": "disabled",
+            "secret_file": "config/discord-workspace.secrets.sops.yaml",
+            "discord_bot_token_key": "FIRSTMATE_DISCORD_BOT_TOKEN",
+            "api_key": "FIRSTMATE_DISCORD_GROQ_API_KEY",
+        },
+        "approvals": {
+            "message_content": False,
+            "temporary_setup_permissions": False,
+            "hosted_groq": False,
+            "community_mode_required": False,
+        },
+        "live": {"polling": False, "posting": False, "host": "disabled"},
+    }
+
+
+def load_config(env: Env, path_text: Optional[str]) -> WorkspaceConfig:
+    return WorkspaceConfig.load(env, path_text)
+
+
+def print_config_ok(cfg: WorkspaceConfig) -> None:
+    print(f"config ok: {cfg.path}")
+    print(f"guild: {cfg.guild_id}")
+    print("active profiles: " + ", ".join(ACTIVE_PROFILE_KEYS))
+    print("disabled profiles: " + ", ".join(DISABLED_PROFILE_KEYS))
+    print("exchange forum tags: " + ", ".join(cfg.exchange_tags))
+    print("artifact forum tags: " + ", ".join(cfg.artifact_tags))
+    for row in cfg.thread_summary():
+        print("thread allowlist: " + row)
+
+
+def cmd_sample_config(args: argparse.Namespace, env: Env) -> int:
+    print(json.dumps(sample_config(), indent=2, sort_keys=True))
+    return 0
+
+
+def cmd_config_check(args: argparse.Namespace, env: Env) -> int:
+    cfg = load_config(env, args.config)
+    print_config_ok(cfg)
+    return 0
+
+
+def setup_remaining_unapproved(cfg: WorkspaceConfig) -> List[str]:
+    remaining = [
+        "live Discord setup/apply is intentionally disabled in this repository phase",
+        "no category, forum channel, thread, or tag will be created",
+        "Discord MESSAGE_CONTENT is configured but inactive" if cfg.message_content_enabled else "Discord MESSAGE_CONTENT approval is not active",
+        "host choice is unset for live service execution" if cfg.host_choice in ("disabled", "none", "dry-run") else f"host {cfg.host_choice} is configured but not activated",
+        "hosted Groq transcription is configured but inactive" if cfg.hosted_groq_enabled else "hosted Groq transcription consent and limits are not active",
+        "artifact access is dry-run only" if cfg.artifact_access == "disabled" else f"artifact access {cfg.artifact_access} with expiry {cfg.artifact_default_expiry} is configured but inactive",
+        "temporary setup permissions are configured but unusable in this phase" if cfg.temporary_setup_permissions else "temporary setup permissions are not approved",
+        "Community-mode requirement remains an operator check" if cfg.community_mode_required else "Community-mode requirement is not active",
+        "live posting is configured but refused in this phase" if cfg.live_posting_enabled else "live posting is disabled",
+        "live process-event polling is configured but refused in this phase" if cfg.live_polling_enabled else "live process-event polling is disabled",
+    ]
+    return remaining
+
+
+def cmd_setup(args: argparse.Namespace, env: Env) -> int:
+    cfg = load_config(env, args.config)
+    if args.apply:
+        raise FMError("setup --apply is not available in this offline phase; run setup --dry-run for a non-network plan")
+    if not args.dry_run:
+        raise FMError("setup requires --dry-run; apply mode intentionally refuses in this phase")
+    print("Discord workspace setup dry-run (no network).")
+    print(f"operations guild: {cfg.guild_id}")
+    thread_support = any(cfg.profiles[p]["exchange_thread_ids"] or cfg.profiles[p]["artifact_thread_ids"] for p in ACTIVE_PROFILE_KEYS)
+    print(f"temporary setup permission integer: {SETUP_THREADS_PERMISSION if thread_support else SETUP_PERMISSION}")
+    print(f"steady-state permission integer: {STEADY_THREADS_PERMISSION if thread_support else STEADY_PERMISSION}")
+    print("steady-state permissions exclude administrator, message management, webhooks, and live voice permissions.")
+    for key in ACTIVE_PROFILE_KEYS:
+        p = cfg.profiles[key]
+        print(f"profile {p['label']} category id {p['category_id']} name {p['category_name']}")
+        print(f"  exchanges forum id {p['exchange_forum_id']} name {p['exchange_forum_name']}")
+        print(f"  artifacts forum id {p['artifact_forum_id']} name {p['artifact_forum_name']}")
+        print(f"  exchange allowed thread ids: {', '.join(p['exchange_thread_ids']) or '(none yet)'}")
+        print(f"  artifact allowed thread ids: {', '.join(p['artifact_thread_ids']) or '(none yet)'}")
+    print("exchange draft tag vocabulary: " + ", ".join(cfg.exchange_tags))
+    print("artifact draft tag vocabulary: " + ", ".join(cfg.artifact_tags))
+    print("remaining unapproved live choices:")
+    for item in setup_remaining_unapproved(cfg):
+        print(f"- {item}")
+    return 0
+
+
+def cmd_health(args: argparse.Namespace, env: Env) -> int:
+    cfg = load_config(env, args.config)
+    if args.secrets:
+        refs = config_secret_references(cfg.raw)
+        print("secrets health dry-run only; no secret was decrypted or printed.")
+        if refs:
+            for ref in refs:
+                print(ref)
+        else:
+            print("secret references are not configured.")
+        raise FMError("live secret validation is disabled until activation supplies approval")
+    if args.discord:
+        raise FMError("live Discord health is disabled in this phase; no network call was made")
+    if args.transcription:
+        print("transcription health is dry-run only; fake transcription fixtures are supported for tests.")
+        print("ffmpeg, sops, and age are reported but not installed or invoked for live work.")
+        for tool in ("ffmpeg", "sops", "age"):
+            print(f"{tool}: {'found' if shutil.which(tool) else 'not found'}")
+        raise FMError("live transcription health is disabled until hosted/local transcription is approved")
+    if args.process_event:
+        source = env.state / "procevent" / f"{DISCORD_SOURCE_ID}.source"
+        print(f"process-event source {DISCORD_SOURCE_ID}: {'registered' if source.exists() else 'not registered'}")
+    print("local health ok; no network call was made.")
+    print_config_ok(cfg)
+    print(f"state root: {env.discord_state}")
+    print("required live tools are not installed by this command.")
+    return 0
+
+
+def read_text_file(path_text: str, max_bytes: int = 4000) -> str:
+    path = Path(path_text).expanduser()
+    if not path.is_absolute():
+        path = (Path.cwd() / path).resolve()
+    if path.is_symlink() or not path.is_file():
+        raise FMError(f"refusing unsafe text file: {path}")
+    data = path.read_bytes()
+    if len(data) > max_bytes:
+        raise FMError(f"text file is too large for a Discord phase-1 message: {path}")
+    try:
+        text = data.decode("utf-8")
+    except UnicodeDecodeError as exc:
+        raise FMError(f"text file must be UTF-8: {path}") from exc
+    if "\x00" in text:
+        raise FMError("text file contains a NUL byte")
+    if not text.strip():
+        raise FMError("text file is empty")
+    if len(text) > 2000:
+        raise FMError("Discord message text exceeds the 2000 character phase-1 limit")
+    return text
+
+
+def receipt_path(env: Env, nonce: str) -> Path:
+    return safe_digest_path(env.discord_state / "receipts", nonce)
+
+
+def load_existing_json(path: Path) -> Optional[Dict[str, Any]]:
+    if not path.exists():
+        return None
+    if path.is_symlink() or not path.is_file():
+        raise FMError(f"refusing unsafe state path: {path}")
+    with path.open("r", encoding="utf-8") as f:
+        data = json.load(f)
+    if not isinstance(data, dict):
+        raise FMError(f"state file is malformed: {path}")
+    return data
+
+
+def record_receipt(env: Env, nonce: str, payload: Dict[str, Any], discord_message_id: str) -> str:
+    path = receipt_path(env, nonce)
+    existing = load_existing_json(path)
+    payload = dict(payload)
+    payload.update({"schema": RECEIPT_SCHEMA, "nonce": nonce, "discord_message_id": discord_message_id})
+    if existing:
+        comparable = dict(existing)
+        comparable.pop("recorded_at", None)
+        candidate = dict(payload)
+        if comparable == candidate:
+            return "receipt exists"
+        raise FMError("refusing to overwrite a different Discord outbound receipt for the same nonce")
+    payload["recorded_at"] = utc_now()
+    atomic_json(path, payload)
+    return "receipt recorded"
+
+
+def base_receipt(kind: str, profile: str, target: Dict[str, Any], text_digest: str) -> Dict[str, Any]:
+    return {
+        "kind": kind,
+        "profile": profile,
+        "target": target,
+        "text_sha256": text_digest,
+        "allowed_mentions": {"parse": []},
+    }
+
+
+def cmd_reply(args: argparse.Namespace, env: Env) -> int:
+    cfg = load_config(env, args.config)
+    text = read_text_file(args.text_file)
+    guild_id, channel_id, message_id, profile_key, forum_kind = cfg.profile_for_request_id(args.request_id)
+    if forum_kind != "exchange":
+        raise FMError("replies must target an allowlisted exchange forum thread")
+    text_digest = sha256_text(text)
+    nonce = args.nonce or f"reply:{args.request_id}:{text_digest}"
+    target = {"guild_id": guild_id, "channel_id": channel_id, "message_id": message_id, "request_id": args.request_id}
+    receipt = base_receipt("reply", profile_key, target, text_digest)
+    print("Discord reply plan (no network).")
+    print(f"profile: {profile_key}")
+    print(f"destination thread/channel: {channel_id}")
+    print(f"reply-to request: {args.request_id}")
+    print(f"allowed_mentions: {json.dumps({'parse': []}, sort_keys=True)}")
+    print(f"nonce: {nonce}")
+    if args.record_discord_message_id:
+        msg_id = validate_snowflake(args.record_discord_message_id, "--record-discord-message-id") or ""
+        print(record_receipt(env, nonce, receipt, msg_id))
+    else:
+        print("dry-run only; no receipt was written and no Discord post was made.")
+    return 0
+
+
+def cmd_status(args: argparse.Namespace, env: Env) -> int:
+    cfg = load_config(env, args.config)
+    text = read_text_file(args.text_file)
+    if args.profile not in cfg.profiles:
+        raise FMError("status profile must be one of the active configured profiles")
+    profile = cfg.profiles[args.profile]
+    channel_id = args.thread or profile["exchange_forum_id"]
+    if args.thread and args.thread not in profile["exchange_thread_ids"]:
+        raise FMError("status thread is not allowlisted for the selected profile")
+    text_digest = sha256_text(text)
+    nonce = args.nonce or f"status:{args.profile}:{channel_id}:{text_digest}"
+    target = {"guild_id": cfg.guild_id, "channel_id": channel_id}
+    receipt = base_receipt("status", args.profile, target, text_digest)
+    print("Discord status plan (no network).")
+    print(f"profile: {args.profile}")
+    print(f"destination thread/channel: {channel_id}")
+    print(f"allowed_mentions: {json.dumps({'parse': []}, sort_keys=True)}")
+    print(f"nonce: {nonce}")
+    if args.record_discord_message_id:
+        msg_id = validate_snowflake(args.record_discord_message_id, "--record-discord-message-id") or ""
+        print(record_receipt(env, nonce, receipt, msg_id))
+    else:
+        print("dry-run only; no receipt was written and no Discord post was made.")
+    return 0
+
+
+def root_for_name(env: Env, name: str) -> Path:
+    if name == "data":
+        return env.data
+    if name == "state-discord-workspace":
+        return env.discord_state
+    raw = Path(name)
+    if raw.is_absolute():
+        return raw.resolve()
+    return (env.home / raw).resolve()
+
+
+def path_under(child: Path, parent: Path) -> bool:
+    try:
+        child.relative_to(parent)
+        return True
+    except ValueError:
+        return False
+
+
+def sniff_mime(path: Path) -> str:
+    ext = path.suffix.lower()
+    head = path.read_bytes()[:32]
+    if ext in ALLOWED_TEXT_EXTENSIONS:
+        data = path.read_bytes()
+        if b"\x00" in data:
+            raise FMError("text artifact contains a NUL byte")
+        try:
+            data.decode("utf-8")
+        except UnicodeDecodeError as exc:
+            raise FMError("text artifact must be UTF-8") from exc
+        return "text/markdown" if ext in {".md", ".markdown"} else "text/plain"
+    if ext == ".png":
+        if not head.startswith(b"\x89PNG\r\n\x1a\n"):
+            raise FMError("PNG extension does not match file bytes")
+        return "image/png"
+    if ext in {".jpg", ".jpeg"}:
+        if not head.startswith(b"\xff\xd8"):
+            raise FMError("JPEG extension does not match file bytes")
+        return "image/jpeg"
+    if ext == ".gif":
+        if not (head.startswith(b"GIF87a") or head.startswith(b"GIF89a")):
+            raise FMError("GIF extension does not match file bytes")
+        return "image/gif"
+    if ext == ".webp":
+        if len(head) < 12 or head[:4] != b"RIFF" or head[8:12] != b"WEBP":
+            raise FMError("WebP extension does not match file bytes")
+        return "image/webp"
+    if ext == ".pdf":
+        if not head.startswith(b"%PDF-"):
+            raise FMError("PDF extension does not match file bytes")
+        return "application/pdf"
+    guessed, _ = mimetypes.guess_type(str(path))
+    raise FMError(f"unsupported artifact type: {guessed or ext or 'unknown'}")
+
+
+def validate_artifact_file(env: Env, cfg: WorkspaceConfig, file_text: str, *, client_confidential: bool, approved_client_confidential: bool, require_direct: bool = False) -> Dict[str, Any]:
+    path = Path(file_text).expanduser()
+    if not path.is_absolute():
+        path = (Path.cwd() / path).resolve()
+    if path.is_symlink() or not path.is_file():
+        raise FMError(f"refusing unsafe artifact path: {path}")
+    resolved = path.resolve()
+    if path_under(resolved, env.home / "projects"):
+        raise FMError("artifact source under projects/ is blocked by default")
+    name = resolved.name
+    ext = resolved.suffix.lower()
+    if SECRETISH_RE.search(name) or ext in BLOCKED_EXTENSIONS:
+        raise FMError("artifact filename or extension is blocked by the default safety policy")
+    roots = [root_for_name(env, item) for item in cfg.allowed_roots]
+    if not any(path_under(resolved, root) for root in roots):
+        raise FMError("artifact source is outside the configured allowed roots")
+    if client_confidential and not (cfg.client_confidential_allowed and approved_client_confidential):
+        raise FMError("client-confidential artifacts are blocked without explicit captain approval and config opt-in")
+    size = resolved.stat().st_size
+    mime = sniff_mime(resolved)
+    if ext not in ALLOWED_DIRECT_EXTENSIONS:
+        raise FMError("artifact extension is not allowed for phase-1 direct sharing")
+    if require_direct and size > cfg.direct_attachment_max_bytes:
+        raise FMError("artifact exceeds the direct attachment cap")
+    digest = sha256_file(resolved)
+    return {
+        "path": str(resolved),
+        "name": name,
+        "extension": ext,
+        "size": size,
+        "mime": mime,
+        "sha256": digest,
+        "direct_attachment": size <= cfg.direct_attachment_max_bytes,
+    }
+
+
+def artifact_id_for(info: Dict[str, Any], profile: str, purpose: str) -> str:
+    return sha256_text(f"artifact:{profile}:{purpose}:{info['sha256']}:{info['name']}")[:24]
+
+
+def artifact_source_index_path(env: Env, source_sha256: str) -> Path:
+    if not re.fullmatch(r"[0-9a-f]{64}", source_sha256):
+        raise FMError("artifact source digest is invalid")
+    return env.discord_state / "artifact-source-index" / f"{source_sha256}.json"
+
+
+def write_artifact_source_index(env: Env, source_sha256: str, artifact_id: str, record: Dict[str, Any]) -> bool:
+    path = artifact_source_index_path(env, source_sha256)
+    existing = load_existing_json(path)
+    if existing:
+        existing_artifact = str(existing.get("artifact_id") or "")
+        if existing_artifact == artifact_id:
+            return False
+        raise FMError(f"artifact source already has a canonical artifact record: {existing_artifact}")
+    index = {
+        "schema": ARTIFACT_INDEX_SCHEMA,
+        "source_sha256": source_sha256,
+        "artifact_id": artifact_id,
+        "profile": record.get("profile"),
+        "purpose": record.get("purpose"),
+        "canonical_location": record.get("canonical_location"),
+        "recorded_at": utc_now(),
+    }
+    atomic_json(path, index)
+    return True
+
+
+def write_artifact_record(env: Env, artifact_id: str, record: Dict[str, Any]) -> str:
+    path = env.discord_state / "artifacts" / f"{artifact_id}.json"
+    source = record.get("source") if isinstance(record.get("source"), dict) else {}
+    source_sha256 = str(source.get("sha256") or "")
+    existing = load_existing_json(path)
+    if existing:
+        comparable = dict(existing)
+        comparable.pop("recorded_at", None)
+        candidate = dict(record)
+        if comparable == candidate:
+            if source_sha256:
+                write_artifact_source_index(env, source_sha256, artifact_id, record)
+            return "artifact record exists"
+        raise FMError("refusing to overwrite a different artifact record")
+    created_index = False
+    index_path = artifact_source_index_path(env, source_sha256) if source_sha256 else None
+    if source_sha256:
+        created_index = write_artifact_source_index(env, source_sha256, artifact_id, record)
+    record = dict(record)
+    record["recorded_at"] = utc_now()
+    try:
+        atomic_json(path, record)
+    except Exception:
+        if created_index and index_path is not None:
+            try:
+                index_path.unlink()
+            except FileNotFoundError:
+                pass
+        raise
+    return "artifact record written"
+
+
+def cmd_artifact(args: argparse.Namespace, env: Env) -> int:
+    cfg = load_config(env, args.config)
+    if args.profile not in cfg.profiles:
+        raise FMError("artifact profile must be one of the active configured profiles")
+    if args.purpose not in cfg.artifact_tags:
+        raise FMError("artifact purpose must be in the configured artifact tag vocabulary")
+    info = validate_artifact_file(
+        env,
+        cfg,
+        args.file,
+        client_confidential=args.client_confidential,
+        approved_client_confidential=args.captain_approved_client_confidential,
+        require_direct=not bool(args.private_url),
+    )
+    profile = cfg.profiles[args.profile]
+    if args.request_id:
+        guild_id, channel_id, _message_id, profile_key, forum_kind = cfg.profile_for_request_id(args.request_id)
+        if profile_key != args.profile or forum_kind != "exchange":
+            raise FMError("artifact request link must name an exchange thread for the selected profile")
+        exchange_channel_id = channel_id
+    else:
+        guild_id = cfg.guild_id
+        exchange_channel_id = profile["exchange_forum_id"]
+    artifact_id = artifact_id_for(info, args.profile, args.purpose)
+    if args.private_url:
+        args.private_url = validate_private_url(args.private_url)
+    if not info["direct_attachment"] and not args.private_url:
+        raise FMError("artifact exceeds the direct cap; use publish-artifact with a private expiring URL")
+    target = {
+        "guild_id": guild_id,
+        "artifact_forum_id": profile["artifact_forum_id"],
+        "exchange_channel_id": exchange_channel_id,
+        "request_id": args.request_id,
+    }
+    nonce = args.nonce or f"artifact:{artifact_id}:{args.request_id or exchange_channel_id}"
+    record = {
+        "schema": ARTIFACT_SCHEMA,
+        "artifact_id": artifact_id,
+        "profile": args.profile,
+        "purpose": args.purpose,
+        "source": info,
+        "target": target,
+        "private_url": args.private_url,
+        "canonical_location": "artifacts-forum-post",
+        "exchange_behavior": "summary-card-and-link-only",
+        "duplicate_binary_in_exchange": False,
+    }
+    print("Discord artifact publication plan (no network).")
+    print(f"artifact id: {artifact_id}")
+    print(f"canonical post forum: {profile['artifact_forum_id']}")
+    print(f"canonical post tag: {args.purpose}")
+    print(f"source file: {info['name']} {info['mime']} {info['size']} bytes sha256:{info['sha256']}")
+    if info["direct_attachment"]:
+        print("artifact transfer: direct attachment in the artifacts forum only")
+    else:
+        print("artifact transfer: private expiring link in the artifacts forum only")
+    print(f"exchange summary destination: {exchange_channel_id}")
+    print("exchange summary includes a card and link only; it will not duplicate the binary.")
+    print(f"allowed_mentions: {json.dumps({'parse': []}, sort_keys=True)}")
+    print(f"nonce: {nonce}")
+    if args.record_discord_message_id:
+        msg_id = validate_snowflake(args.record_discord_message_id, "--record-discord-message-id") or ""
+        print(write_artifact_record(env, artifact_id, record))
+        receipt = base_receipt("artifact", args.profile, target, info["sha256"])
+        receipt["artifact_id"] = artifact_id
+        print(record_receipt(env, nonce, receipt, msg_id))
+    else:
+        print("dry-run only; no artifact record or Discord receipt was written.")
+    return 0
+
+
+def validate_private_url(url: str) -> str:
+    parsed = urlparse(url)
+    if parsed.scheme != "https" or not parsed.netloc:
+        raise FMError("private artifact URL must be an https URL")
+    if len(url) < 40:
+        raise FMError("private artifact URL is too short to be a safe capability-style URL")
+    return url
+
+
+def cmd_publish_artifact(args: argparse.Namespace, env: Env) -> int:
+    cfg = load_config(env, args.config)
+    if args.profile not in cfg.profiles:
+        raise FMError("publish-artifact profile must be active")
+    if args.purpose not in cfg.artifact_tags:
+        raise FMError("publish-artifact purpose must be in the configured artifact tag vocabulary")
+    if args.access not in ("tailnet", "cloudflare-access", "local"):
+        raise FMError("publish-artifact access must be tailnet, cloudflare-access, or local")
+    if not re.fullmatch(r"[1-9][0-9]*[dh]", args.expires):
+        raise FMError("publish-artifact --expires must be a duration like 7d or 24h")
+    url = validate_private_url(args.url)
+    info = validate_artifact_file(
+        env,
+        cfg,
+        args.file,
+        client_confidential=args.client_confidential,
+        approved_client_confidential=args.captain_approved_client_confidential,
+        require_direct=False,
+    )
+    artifact_id = artifact_id_for(info, args.profile, args.purpose)
+    record = {
+        "schema": ARTIFACT_SCHEMA,
+        "artifact_id": artifact_id,
+        "profile": args.profile,
+        "purpose": args.purpose,
+        "source": info,
+        "publication": {"url": url, "access": args.access, "expires": args.expires},
+        "canonical_location": "private-expiring-link",
+    }
+    print("Private artifact link plan (no network).")
+    print(f"artifact id: {artifact_id}")
+    print(f"access: {args.access}")
+    print(f"expires: {args.expires}")
+    print(f"url: {url}")
+    print("revocation must be handled by the selected private publication host.")
+    if args.record:
+        print(write_artifact_record(env, artifact_id, record))
+    else:
+        print("dry-run only; no artifact record was written.")
+    return 0
+
+
+def request_record_path(env: Env, request_id: str) -> Path:
+    return safe_digest_path(env.discord_state / "requests", request_id)
+
+
+def task_link_path(env: Env, task_id: str) -> Path:
+    return env.discord_state / "task-links" / f"{task_id}.json"
+
+
+def pending_followup_path(env: Env, task_id: str) -> Path:
+    return env.discord_state / "pending-followups" / f"{task_id}.json"
+
+
+def write_same_or_refuse(path: Path, data: Dict[str, Any], label: str) -> str:
+    existing = load_existing_json(path)
+    if existing:
+        comparable = dict(existing)
+        comparable.pop("recorded_at", None)
+        candidate = dict(data)
+        if comparable == candidate:
+            return f"{label} exists"
+        raise FMError(f"refusing to overwrite a different {label}")
+    data = dict(data)
+    data["recorded_at"] = utc_now()
+    atomic_json(path, data)
+    return f"{label} written"
+
+
+def cmd_link_task(args: argparse.Namespace, env: Env) -> int:
+    cfg = load_config(env, args.config)
+    if not TASK_ID_RE.fullmatch(args.task_id):
+        raise FMError("task id must be path-safe")
+    guild_id, channel_id, message_id, profile_key, forum_kind = cfg.profile_for_request_id(args.request_id)
+    if forum_kind != "exchange":
+        raise FMError("task links must originate from an exchange thread")
+    request = {
+        "schema": REQUEST_SCHEMA,
+        "request_id": args.request_id,
+        "guild_id": guild_id,
+        "channel_id": channel_id,
+        "message_id": message_id,
+        "profile": profile_key,
+        "origin": "discord-workspace",
+    }
+    link = {
+        "schema": TASK_LINK_SCHEMA,
+        "task_id": args.task_id,
+        "request_id": args.request_id,
+        "profile": profile_key,
+        "final_followup_required": cfg.final_replies_required,
+    }
+    print(write_same_or_refuse(request_record_path(env, args.request_id), request, "request record"))
+    print(write_same_or_refuse(task_link_path(env, args.task_id), link, "task link"))
+    if cfg.final_replies_required:
+        pending = {
+            "schema": PENDING_SCHEMA,
+            "task_id": args.task_id,
+            "request_id": args.request_id,
+            "profile": profile_key,
+            "status": "pending",
+        }
+        print(write_same_or_refuse(pending_followup_path(env, args.task_id), pending, "pending final follow-up"))
+    else:
+        print("final follow-up is not required by config")
+    return 0
+
+
+def cmd_followup(args: argparse.Namespace, env: Env) -> int:
+    cfg = load_config(env, args.config)
+    if not TASK_ID_RE.fullmatch(args.task_id):
+        raise FMError("task id must be path-safe")
+    text = read_text_file(args.text_file)
+    link = load_existing_json(task_link_path(env, args.task_id))
+    if not link:
+        raise FMError("task has no Discord workspace request link")
+    request_id = str(link["request_id"])
+    guild_id, channel_id, message_id, profile_key, forum_kind = cfg.profile_for_request_id(request_id)
+    if forum_kind != "exchange":
+        raise FMError("follow-up request no longer resolves to an exchange thread")
+    text_digest = sha256_text(text)
+    kind = "final-followup" if args.final else "followup"
+    nonce = args.nonce or f"{kind}:{args.task_id}:{request_id}:{text_digest}"
+    target = {"guild_id": guild_id, "channel_id": channel_id, "message_id": message_id, "request_id": request_id}
+    receipt = base_receipt(kind, profile_key, target, text_digest)
+    receipt["task_id"] = args.task_id
+    print("Discord follow-up plan (no network).")
+    print(f"task: {args.task_id}")
+    print(f"request: {request_id}")
+    print(f"destination thread/channel: {channel_id}")
+    print(f"allowed_mentions: {json.dumps({'parse': []}, sort_keys=True)}")
+    print(f"nonce: {nonce}")
+    if args.final:
+        pending_path = pending_followup_path(env, args.task_id)
+        pending = load_existing_json(pending_path)
+        if not pending:
+            pending = {
+                "schema": PENDING_SCHEMA,
+                "task_id": args.task_id,
+                "request_id": request_id,
+                "profile": profile_key,
+                "status": "pending",
+            }
+            write_same_or_refuse(pending_path, pending, "pending final follow-up")
+        print("pending final follow-up: present")
+    if args.record_discord_message_id:
+        msg_id = validate_snowflake(args.record_discord_message_id, "--record-discord-message-id") or ""
+        print(record_receipt(env, nonce, receipt, msg_id))
+        if args.final:
+            delivered = {
+                "schema": PENDING_SCHEMA,
+                "task_id": args.task_id,
+                "request_id": request_id,
+                "profile": profile_key,
+                "status": "delivered",
+                "receipt_nonce": nonce,
+                "discord_message_id": msg_id,
+            }
+            atomic_json(pending_followup_path(env, args.task_id), delivered)
+            print("pending final follow-up delivered")
+    else:
+        print("dry-run only; pending final follow-up remains unresolved.")
+    return 0
+
+
+def iter_pending_followups(env: Env) -> Iterable[Tuple[Path, Dict[str, Any]]]:
+    root = env.discord_state / "pending-followups"
+    if not root.exists():
+        return []
+    out: List[Tuple[Path, Dict[str, Any]]] = []
+    for path in sorted(root.glob("*.json")):
+        data = load_existing_json(path)
+        if data and data.get("status") == "pending":
+            out.append((path, data))
+    return out
+
+
+def cmd_guard_work(args: argparse.Namespace, env: Env) -> int:
+    if not TASK_ID_RE.fullmatch(args.task_id):
+        raise FMError("task id must be path-safe")
+    path = pending_followup_path(env, args.task_id)
+    if not path.exists() and not path.is_symlink():
+        return 0
+    data = load_existing_json(path)
+    if not data:
+        return 0
+    if data.get("status") == "pending":
+        print(f"task {args.task_id} still owes a Discord workspace final reply for {data.get('request_id')}")
+        print(f"Deliver it with bin/fm-discord-workspace.sh followup {args.task_id} --final --text-file <file> after live posting is approved, or explicitly abandon the pending record after discard approval.")
+        return 1
+    return 0
+
+
+def cmd_retire(args: argparse.Namespace, env: Env) -> int:
+    cfg = load_config(env, args.config)
+    pending = list(iter_pending_followups(env))
+    if pending:
+        print("Discord workspace retirement refused; pending final replies remain:")
+        for path, item in pending:
+            print(f"- task {item.get('task_id')} request {item.get('request_id')} ({path})")
+        raise FMError("deliver or explicitly abandon pending final replies before retirement")
+    if args.apply:
+        raise FMError("retire --apply is disabled in this offline phase; use the process-event owner after live activation")
+    print("Discord workspace retirement dry-run (no network).")
+    print("No pending final replies are open.")
+    print(f"If a local process-event source is registered later, retire it with: bin/fm-procevent.sh retire {DISCORD_SOURCE_ID}")
+    print("Local Discord workspace state is preserved for audit and retry safety.")
+    return 0
+
+
+# ------------------------ process-event adapter ----------------------------
+
+def parse_message_author(message: Dict[str, Any]) -> Tuple[str, bool]:
+    author = message.get("author") if isinstance(message.get("author"), dict) else {}
+    author_id = str(author.get("id") or message.get("author_id") or "")
+    bot = bool(author.get("bot") or message.get("author_is_bot") or False)
+    return author_id, bot
+
+
+def external_id(guild_id: str, channel_id: str, message_id: str) -> str:
+    return f"discord:{guild_id}:{channel_id}:{message_id}"
+
+
+def discord_jump_url(guild_id: str, channel_id: str, message_id: str) -> str:
+    return f"https://discord.com/channels/{guild_id}/{channel_id}/{message_id}"
+
+
+def validate_discord_cdn_url(url: str, cfg: WorkspaceConfig) -> str:
+    parsed = urlparse(url)
+    if parsed.scheme != "https" or not parsed.netloc:
+        raise FMError("attachment URL is not https")
+    host = parsed.hostname.lower() if parsed.hostname else ""
+    if host not in cfg.cdn_hosts:
+        raise FMError("attachment URL host is not in the Discord CDN allowlist")
+    return url
+
+
+def attachment_id(attachment: Dict[str, Any]) -> str:
+    aid = attachment.get("id")
+    return str(aid) if aid is not None else ""
+
+
+def attachment_content_type(attachment: Dict[str, Any]) -> str:
+    return str(attachment.get("content_type") or attachment.get("contentType") or "").lower()
+
+
+def attachment_size(attachment: Dict[str, Any]) -> int:
+    try:
+        return int(attachment.get("size"))
+    except (TypeError, ValueError):
+        raise FMError("attachment size is missing or invalid")
+
+
+def attachment_duration(attachment: Dict[str, Any], message: Dict[str, Any]) -> float:
+    value = attachment.get("duration_secs")
+    if value is None:
+        value = attachment.get("durationSecs")
+    if value is None:
+        value = message.get("duration_secs")
+    try:
+        duration = float(value)
+    except (TypeError, ValueError):
+        raise FMError("audio duration is missing or invalid")
+    return duration
+
+
+def validate_audio_attachment(cfg: WorkspaceConfig, message: Dict[str, Any]) -> Tuple[Dict[str, Any], str]:
+    attachments = as_list(message.get("attachments"), "message.attachments")
+    flags = int(message.get("flags") or 0)
+    voice = bool(flags & VOICE_MESSAGE_FLAG)
+    audio_candidates = []
+    for attachment in attachments:
+        if not isinstance(attachment, dict):
+            raise FMError("attachment must be an object")
+        ctype = attachment_content_type(attachment)
+        filename = str(attachment.get("filename") or "")
+        ext = Path(filename).suffix.lower()
+        if ctype.startswith(ALLOWED_AUDIO_MIME_PREFIXES) or ext in ALLOWED_AUDIO_EXTENSIONS:
+            audio_candidates.append(attachment)
+    if voice and len(audio_candidates) != 1:
+        raise FMError("Discord voice messages must carry exactly one audio attachment")
+    if not voice and len(audio_candidates) != 1:
+        raise FMError("uploaded audio messages must carry exactly one supported audio attachment")
+    attachment = audio_candidates[0]
+    ctype = attachment_content_type(attachment)
+    filename = str(attachment.get("filename") or "")
+    ext = Path(filename).suffix.lower()
+    if not (ctype.startswith(ALLOWED_AUDIO_MIME_PREFIXES) or ext in ALLOWED_AUDIO_EXTENSIONS):
+        raise FMError("attachment is not an allowed audio type")
+    size = attachment_size(attachment)
+    if size <= 0 or size > cfg.audio_max_bytes:
+        raise FMError("audio attachment exceeds the configured size limit")
+    duration = attachment_duration(attachment, message)
+    if duration <= 0 or duration > cfg.audio_max_duration_secs:
+        raise FMError("audio attachment exceeds the configured duration limit")
+    url = validate_discord_cdn_url(str(attachment.get("url") or ""), cfg)
+    host = urlparse(url).hostname or ""
+    meta = {
+        "id": attachment_id(attachment),
+        "filename": filename,
+        "content_type": ctype,
+        "size": size,
+        "duration_secs": duration,
+        "cdn_host": host.lower(),
+        "voice_message": voice,
+    }
+    return meta, "voice" if voice else "audio-upload"
+
+
+def fake_transcript_for(cfg: WorkspaceConfig, message: Dict[str, Any], attachment: Dict[str, Any]) -> str:
+    tx = cfg.transcription
+    if cfg.transcription_provider != "fake":
+        raise FMError("live transcription is disabled; configure transcription.provider=fake for offline fixtures")
+    fake = tx.get("fake_transcripts")
+    if not isinstance(fake, dict):
+        raise FMError("fake transcription requires transcription.fake_transcripts")
+    keys = [str(message.get("id") or ""), attachment.get("id") or "", attachment.get("filename") or ""]
+    for key in keys:
+        if key and key in fake and isinstance(fake[key], str) and fake[key].strip():
+            return fake[key]
+    raise FMError("fake transcript fixture is missing for audio message")
+
+
+def message_to_event(cfg: WorkspaceConfig, message: Dict[str, Any]) -> Dict[str, Any]:
+    guild_id = str(message.get("guild_id") or "")
+    channel_id = str(message.get("channel_id") or "")
+    parent_id = str(message.get("parent_id") or "") if message.get("parent_id") else None
+    message_id = str(message.get("id") or "")
+    if not guild_id:
+        return ignored_event("dm", guild_id, channel_id, message_id)
+    if not ID_RE.fullmatch(message_id):
+        return ignored_event("invalid-message-id", guild_id, channel_id, message_id)
+    if guild_id != cfg.guild_id:
+        return ignored_event("unknown-guild", guild_id, channel_id, message_id)
+    profile = cfg.profile_for_channel(channel_id, parent_id)
+    if profile is None:
+        return ignored_event("unknown-channel-or-thread", guild_id, channel_id, message_id)
+    profile_key, forum_kind, forum_id = profile
+    author_id, author_is_bot = parse_message_author(message)
+    if author_is_bot or author_id == cfg.bot_user_id:
+        return ignored_event("bot-author", guild_id, channel_id, message_id, profile_key, forum_kind)
+    if author_id not in cfg.captain_user_ids:
+        return ignored_event("unknown-author", guild_id, channel_id, message_id, profile_key, forum_kind)
+    content = str(message.get("content") or "").strip()
+    attachments = as_list(message.get("attachments"), "message.attachments")
+    has_audio = False
+    try:
+        flags = int(message.get("flags") or 0)
+    except (TypeError, ValueError):
+        flags = 0
+    if flags & VOICE_MESSAGE_FLAG:
+        has_audio = True
+    else:
+        for attachment in attachments:
+            if isinstance(attachment, dict):
+                ctype = attachment_content_type(attachment)
+                ext = Path(str(attachment.get("filename") or "")).suffix.lower()
+                if ctype.startswith(ALLOWED_AUDIO_MIME_PREFIXES) or ext in ALLOWED_AUDIO_EXTENSIONS:
+                    has_audio = True
+                    break
+    base = {
+        "schema": EVENT_SCHEMA,
+        "source": DISCORD_SOURCE_ID,
+        "guild_id": guild_id,
+        "channel_id": channel_id,
+        "message_id": message_id,
+        "profile": profile_key,
+        "forum_kind": forum_kind,
+        "forum_channel_id": forum_id,
+        "author_id": author_id,
+        "external_id": external_id(guild_id, channel_id, message_id),
+        "jump_url": discord_jump_url(guild_id, channel_id, message_id),
+        "timestamp": str(message.get("timestamp") or ""),
+    }
+    if forum_kind != "exchange":
+        item = dict(base)
+        item.update({"kind": "ignored", "reason": "artifact-thread-input-disabled"})
+        return item
+    if has_audio:
+        try:
+            audio, audio_kind = validate_audio_attachment(cfg, message)
+            transcript = fake_transcript_for(cfg, message, audio)
+        except FMError as exc:
+            item = dict(base)
+            item.update({"kind": "audio-rejected", "reason": str(exc), "attachments": safe_attachment_metadata(attachments)})
+            return item
+        item = dict(base)
+        item.update({
+            "kind": "voice-transcript" if audio_kind == "voice" else "audio-transcript",
+            "content": content,
+            "audio": audio,
+            "transcript": transcript,
+            "transcription": {"provider": "fake", "secret_printed": False},
+            "conversion_plan": {
+                "tool": "ffmpeg",
+                "input": "validated-discord-cdn-url",
+                "output": "provider-preferred-audio",
+                "delete_temporary_raw": cfg.audio_delete_raw,
+            },
+        })
+        return item
+    if not content:
+        item = dict(base)
+        item.update({"kind": "ignored", "reason": "empty-message"})
+        return item
+    item = dict(base)
+    item.update({"kind": "text", "content": content, "attachments": safe_attachment_metadata(attachments)})
+    return item
+
+
+def safe_attachment_metadata(attachments: List[Any]) -> List[Dict[str, Any]]:
+    out: List[Dict[str, Any]] = []
+    for attachment in attachments:
+        if not isinstance(attachment, dict):
+            continue
+        out.append({
+            "id": str(attachment.get("id") or ""),
+            "filename": str(attachment.get("filename") or ""),
+            "content_type": str(attachment.get("content_type") or ""),
+            "size": attachment.get("size"),
+            "duration_secs": attachment.get("duration_secs"),
+        })
+    return out
+
+
+def ignored_event(reason: str, guild_id: str, channel_id: str, message_id: str, profile: Optional[str] = None, forum_kind: Optional[str] = None) -> Dict[str, Any]:
+    item = {
+        "schema": EVENT_SCHEMA,
+        "source": DISCORD_SOURCE_ID,
+        "kind": "ignored",
+        "reason": reason,
+        "guild_id": guild_id,
+        "channel_id": channel_id,
+        "message_id": message_id,
+    }
+    if profile:
+        item["profile"] = profile
+    if forum_kind:
+        item["forum_kind"] = forum_kind
+    if guild_id and channel_id and message_id:
+        item["external_id"] = external_id(guild_id, channel_id, message_id)
+    return item
+
+
+def cursor_path(env: Env, profile: str, channel_id: str) -> Path:
+    return env.discord_state / "cursors" / profile / f"{channel_id}.cursor"
+
+
+def read_cursor(env: Env, profile: str, channel_id: str) -> int:
+    path = cursor_path(env, profile, channel_id)
+    if not path.exists():
+        return 0
+    if path.is_symlink() or not path.is_file():
+        raise FMError(f"refusing unsafe cursor path: {path}")
+    text = path.read_text(encoding="utf-8").strip()
+    if not text:
+        return 0
+    if not text.isdigit():
+        raise FMError(f"cursor is not a numeric Discord message id: {path}")
+    return int(text)
+
+
+def write_cursor(env: Env, profile: str, channel_id: str, message_id: str) -> None:
+    if not message_id.isdigit():
+        return
+    path = cursor_path(env, profile, channel_id)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp = tempfile.mkstemp(prefix=".cursor.", dir=str(path.parent))
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            f.write(message_id + "\n")
+        os.chmod(tmp, 0o600)
+        os.replace(tmp, path)
+    except Exception:
+        try:
+            os.unlink(tmp)
+        except FileNotFoundError:
+            pass
+        raise
+
+
+def fixture_messages(cfg: WorkspaceConfig) -> List[Dict[str, Any]]:
+    poll = cfg.raw.get("poll") if isinstance(cfg.raw.get("poll"), dict) else {}
+    path_text = os.environ.get("FM_DISCORD_WORKSPACE_FIXTURE") or poll.get("fixture_file")
+    if not path_text:
+        raise FMError("live Discord polling is disabled in this phase; no network call was made")
+    path = Path(str(path_text)).expanduser()
+    if not path.is_absolute():
+        path = (cfg.path.parent / path).resolve()
+    data = json_load_file(path)
+    if isinstance(data, dict):
+        data = data.get("messages")
+    if not isinstance(data, list):
+        raise FMError("Discord fixture must be a list or an object with messages[]")
+    out = []
+    for item in data:
+        if not isinstance(item, dict):
+            raise FMError("Discord fixture message must be an object")
+        out.append(item)
+    out.sort(key=lambda m: int(str(m.get("id") or "0")) if str(m.get("id") or "0").isdigit() else 0)
+    return out
+
+
+def procevent_cmd_arm(args: argparse.Namespace, env: Env) -> int:
+    cfg = load_config(env, args.config)
+    command = [str(env.script_dir / "fm-procevent-discord-workspace.sh"), "source", "--config", str(cfg.path)]
+    if args.dry_run:
+        print("Discord workspace process-event arm dry-run (no network).")
+        print(f"source id: {DISCORD_SOURCE_ID}")
+        print("register command:")
+        print(" ".join([str(env.script_dir / "fm-procevent.sh"), "register", "discord-workspace", DISCORD_SOURCE_ID, "--"] + command))
+        print("live polling remains disabled until an activation task approves it.")
+        return 0
+    raise FMError("process-event arm refused in this offline phase; no live source was registered")
+
+
+def procevent_cmd_source(args: argparse.Namespace, env: Env) -> int:
+    cfg = load_config(env, args.config)
+    messages = fixture_messages(cfg)
+    for message in messages:
+        event = message_to_event(cfg, message)
+        profile = event.get("profile")
+        channel_id = str(event.get("channel_id") or "")
+        message_id = str(event.get("message_id") or "")
+        if profile and channel_id and message_id.isdigit():
+            cursor = read_cursor(env, str(profile), channel_id)
+            if int(message_id) <= cursor:
+                continue
+        if event_class(event) == "ignored":
+            if profile and channel_id and message_id.isdigit():
+                write_cursor(env, str(profile), channel_id, message_id)
+            continue
+        print(json.dumps(event, sort_keys=True))
+        return 0
+    return EXIT_NO_RESULT
+
+
+def load_event_result(result_file: str) -> Dict[str, Any]:
+    path = Path(result_file)
+    if path.is_symlink() or not path.is_file():
+        raise FMError("result file is unavailable or unsafe")
+    text = path.read_text(encoding="utf-8")
+    try:
+        data = json.loads(text)
+    except json.JSONDecodeError as exc:
+        raise FMError(f"result is not valid JSON: {exc}") from exc
+    if not isinstance(data, dict) or data.get("schema") != EVENT_SCHEMA:
+        raise FMError("result schema is not fm-discord-workspace-event.v1")
+    return data
+
+
+def event_class(event: Dict[str, Any]) -> str:
+    kind = str(event.get("kind") or "")
+    if kind in ("text", "voice-transcript", "audio-transcript"):
+        return "message"
+    if kind == "audio-rejected":
+        return "audio-rejected"
+    if kind == "ignored":
+        return "ignored"
+    return "malformed"
+
+
+def procevent_cmd_classify(args: argparse.Namespace, env: Env) -> int:
+    try:
+        event = load_event_result(args.result_file)
+        print(event_class(event))
+    except FMError:
+        print("malformed")
+    return 0
+
+
+def procevent_cmd_silent(args: argparse.Namespace, env: Env) -> int:
+    try:
+        event = load_event_result(args.result_file)
+    except FMError:
+        return 1
+    return 0 if event_class(event) == "ignored" else 1
+
+
+def procevent_cmd_terminal(args: argparse.Namespace, env: Env) -> int:
+    return 1
+
+
+def procevent_cmd_self_announcing(args: argparse.Namespace, env: Env) -> int:
+    return 0
+
+
+def event_metadata(event: Dict[str, Any]) -> Dict[str, Any]:
+    allowed = [
+        "source", "kind", "profile", "forum_kind", "guild_id", "channel_id", "forum_channel_id",
+        "message_id", "author_id", "external_id", "jump_url", "timestamp", "audio", "attachments",
+        "transcription", "conversion_plan", "reason",
+    ]
+    return {key: event[key] for key in allowed if key in event}
+
+
+def note_body_for_event(event: Dict[str, Any]) -> str:
+    kind = str(event.get("kind"))
+    header = f"Discord workspace / {event.get('profile')} / "
+    lines = []
+    if kind == "text":
+        lines.append(header + "text")
+        lines.append(f"request: {event.get('external_id')}")
+        lines.append(f"from: {event.get('author_id')}")
+        if event.get("jump_url"):
+            lines.append(f"link: {event.get('jump_url')}")
+        lines.append("")
+        lines.append(str(event.get("content") or ""))
+    elif kind in ("voice-transcript", "audio-transcript"):
+        audio = event.get("audio") if isinstance(event.get("audio"), dict) else {}
+        lines.append(header + ("voice transcript" if kind == "voice-transcript" else "audio transcript"))
+        lines.append(f"request: {event.get('external_id')}")
+        lines.append(f"from: {event.get('author_id')}")
+        lines.append(f"attachment: {audio.get('id')} {audio.get('filename')} {audio.get('content_type')} {audio.get('size')} {audio.get('duration_secs')}")
+        lines.append("transcription: fake fixture, no secret")
+        if event.get("jump_url"):
+            lines.append(f"link: {event.get('jump_url')}")
+        lines.append("")
+        lines.append(str(event.get("transcript") or ""))
+    elif kind == "audio-rejected":
+        lines.append(header + "audio rejected")
+        lines.append(f"request: {event.get('external_id')}")
+        lines.append(f"from: {event.get('author_id')}")
+        lines.append(f"reason: {event.get('reason')}")
+    else:
+        raise FMError("event is not inbox-addressable")
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def request_record_from_event(event: Dict[str, Any]) -> Dict[str, Any]:
+    return {
+        "schema": REQUEST_SCHEMA,
+        "request_id": event.get("external_id"),
+        "guild_id": event.get("guild_id"),
+        "channel_id": event.get("channel_id"),
+        "message_id": event.get("message_id"),
+        "profile": event.get("profile"),
+        "origin": "discord-workspace",
+        "jump_url": event.get("jump_url"),
+    }
+
+
+def procevent_mark_handled(env: Env, source_id: str, sequence: str) -> None:
+    subprocess.run([str(env.script_dir / "fm-procevent.sh"), "handled", source_id, sequence], check=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+
+
+def procevent_cmd_autohandle(args: argparse.Namespace, env: Env) -> int:
+    source_id = args.source_id
+    sequence = args.sequence
+    if source_id != DISCORD_SOURCE_ID:
+        raise FMError(f"not a Discord workspace source: {source_id}")
+    if not str(sequence).isdigit():
+        raise FMError("sequence must be numeric")
+    event = load_event_result(args.result_file)
+    cls = event_class(event)
+    if cls == "malformed":
+        raise FMError("result is malformed")
+    if event.get("profile") and event.get("channel_id") and event.get("message_id"):
+        write_cursor(env, str(event["profile"]), str(event["channel_id"]), str(event["message_id"]))
+    if cls == "ignored":
+        procevent_mark_handled(env, source_id, sequence)
+        print("handled ignored Discord workspace event")
+        return 0
+    body = note_body_for_event(event)
+    metadata_dir = env.discord_state / "metadata-staging"
+    metadata_dir.mkdir(parents=True, exist_ok=True)
+    fd, meta_tmp = tempfile.mkstemp(prefix=".metadata.", suffix=".json", dir=str(metadata_dir))
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            json.dump(event_metadata(event), f, indent=2, sort_keys=True)
+            f.write("\n")
+        os.chmod(meta_tmp, 0o600)
+        inbox_cmd = [
+            str(env.script_dir / "fm-inbox.sh"),
+            "note",
+            "--source",
+            "discord-workspace",
+            "--external-id",
+            str(event.get("external_id")),
+            "--metadata-file",
+            meta_tmp,
+            "-",
+        ]
+        proc = subprocess.run(inbox_cmd, input=body, text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        if proc.returncode != 0:
+            if proc.stdout:
+                print(proc.stdout, end="")
+            if proc.stderr:
+                print(proc.stderr, end="", file=sys.stderr)
+            return proc.returncode
+    finally:
+        try:
+            os.unlink(meta_tmp)
+        except FileNotFoundError:
+            pass
+    if cls == "message":
+        request = request_record_from_event(event)
+        write_same_or_refuse(request_record_path(env, str(event.get("external_id"))), request, "request record")
+    procevent_mark_handled(env, source_id, sequence)
+    print("autohandled Discord workspace event through fm-inbox")
+    return 0
+
+
+def procevent_cmd_answers(args: argparse.Namespace, env: Env) -> int:
+    return 0
+
+
+def add_config_argument(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument("--config", help="non-secret Discord workspace config JSON")
+
+
+def build_tool_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="fm-discord-workspace.sh")
+    sub = parser.add_subparsers(dest="command", required=True)
+    p = sub.add_parser("sample-config")
+    p.set_defaults(func=cmd_sample_config)
+    p = sub.add_parser("config-check")
+    add_config_argument(p)
+    p.set_defaults(func=cmd_config_check)
+    p = sub.add_parser("setup")
+    add_config_argument(p)
+    p.add_argument("--dry-run", action="store_true")
+    p.add_argument("--apply", action="store_true")
+    p.set_defaults(func=cmd_setup)
+    p = sub.add_parser("health")
+    add_config_argument(p)
+    p.add_argument("--local", action="store_true")
+    p.add_argument("--secrets", action="store_true")
+    p.add_argument("--discord", action="store_true")
+    p.add_argument("--transcription", action="store_true")
+    p.add_argument("--process-event", action="store_true")
+    p.add_argument("--outbound-dry-run", action="store_true")
+    p.set_defaults(func=cmd_health)
+    p = sub.add_parser("reply")
+    add_config_argument(p)
+    p.add_argument("--request-id", required=True)
+    p.add_argument("--text-file", required=True)
+    p.add_argument("--nonce")
+    p.add_argument("--record-discord-message-id")
+    p.set_defaults(func=cmd_reply)
+    p = sub.add_parser("status")
+    add_config_argument(p)
+    p.add_argument("--profile", required=True, choices=ACTIVE_PROFILE_KEYS)
+    p.add_argument("--thread")
+    p.add_argument("--text-file", required=True)
+    p.add_argument("--nonce")
+    p.add_argument("--record-discord-message-id")
+    p.set_defaults(func=cmd_status)
+    p = sub.add_parser("artifact")
+    add_config_argument(p)
+    p.add_argument("--profile", required=True, choices=ACTIVE_PROFILE_KEYS)
+    p.add_argument("--file", required=True)
+    p.add_argument("--purpose", required=True)
+    p.add_argument("--request-id")
+    p.add_argument("--private-url")
+    p.add_argument("--client-confidential", action="store_true")
+    p.add_argument("--captain-approved-client-confidential", action="store_true")
+    p.add_argument("--nonce")
+    p.add_argument("--record-discord-message-id")
+    p.set_defaults(func=cmd_artifact)
+    p = sub.add_parser("publish-artifact")
+    add_config_argument(p)
+    p.add_argument("--profile", required=True, choices=ACTIVE_PROFILE_KEYS)
+    p.add_argument("--file", required=True)
+    p.add_argument("--purpose", required=True)
+    p.add_argument("--url", required=True)
+    p.add_argument("--access", required=True)
+    p.add_argument("--expires", default="7d")
+    p.add_argument("--client-confidential", action="store_true")
+    p.add_argument("--captain-approved-client-confidential", action="store_true")
+    p.add_argument("--record", action="store_true")
+    p.set_defaults(func=cmd_publish_artifact)
+    p = sub.add_parser("link-task")
+    add_config_argument(p)
+    p.add_argument("task_id")
+    p.add_argument("--request-id", required=True)
+    p.set_defaults(func=cmd_link_task)
+    p = sub.add_parser("followup")
+    add_config_argument(p)
+    p.add_argument("task_id")
+    p.add_argument("--final", action="store_true")
+    p.add_argument("--text-file", required=True)
+    p.add_argument("--nonce")
+    p.add_argument("--record-discord-message-id")
+    p.set_defaults(func=cmd_followup)
+    p = sub.add_parser("guard-work")
+    p.add_argument("task_id")
+    p.set_defaults(func=cmd_guard_work)
+    p = sub.add_parser("retire")
+    add_config_argument(p)
+    p.add_argument("--apply", action="store_true")
+    p.set_defaults(func=cmd_retire)
+    return parser
+
+
+def build_procevent_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="fm-procevent-discord-workspace.sh")
+    sub = parser.add_subparsers(dest="command", required=True)
+    p = sub.add_parser("arm")
+    add_config_argument(p)
+    p.add_argument("--dry-run", action="store_true")
+    p.set_defaults(func=procevent_cmd_arm)
+    p = sub.add_parser("source")
+    add_config_argument(p)
+    p.set_defaults(func=procevent_cmd_source)
+    p = sub.add_parser("classify")
+    p.add_argument("result_file")
+    p.set_defaults(func=procevent_cmd_classify)
+    p = sub.add_parser("silent")
+    p.add_argument("result_file")
+    p.set_defaults(func=procevent_cmd_silent)
+    p = sub.add_parser("terminal")
+    p.add_argument("result_file")
+    p.set_defaults(func=procevent_cmd_terminal)
+    p = sub.add_parser("self-announcing")
+    p.set_defaults(func=procevent_cmd_self_announcing)
+    p = sub.add_parser("autohandle")
+    p.add_argument("source_id")
+    p.add_argument("sequence")
+    p.add_argument("result_file")
+    p.set_defaults(func=procevent_cmd_autohandle)
+    p = sub.add_parser("answers")
+    p.add_argument("result_file")
+    p.set_defaults(func=procevent_cmd_answers)
+    return parser
+
+
+def main(argv: List[str]) -> int:
+    if len(argv) < 3:
+        print("usage: fm_discord_workspace_lib.py <tool|procevent> <script-dir> ...", file=sys.stderr)
+        return 2
+    mode = argv[1]
+    env = Env(argv[2])
+    rest = argv[3:]
+    parser = build_tool_parser() if mode == "tool" else build_procevent_parser() if mode == "procevent" else None
+    if parser is None:
+        print(f"unknown mode: {mode}", file=sys.stderr)
+        return 2
+    args = parser.parse_args(rest)
+    try:
+        return int(args.func(args, env))
+    except FMError as exc:
+        die(str(exc))
+    except BrokenPipeError:
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/bin/fm_discord_workspace_lib.py
+++ b/bin/fm_discord_workspace_lib.py
@@ -2007,7 +2007,7 @@ def procevent_cmd_source(args: argparse.Namespace, env: Env) -> int:
         live = importlib.util.module_from_spec(spec)
         spec.loader.exec_module(live)
         client = live.DiscordClient(live.decrypt_token(env, cfg))
-        return live.live_source_pass(env, cfg, client)
+        return live.registered_source_pass(env, cfg, client)
     messages = fixture_messages(cfg)
     for message in messages:
         event = message_to_event(cfg, message)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -664,8 +664,8 @@ It is separate from Relay, Hermes, and any client or audience Discord bot.
 The repository-supported phase is offline only: it validates config, renders setup and health dry-runs, plans replies and artifacts, links requests to tasks, preserves pending final replies, and exercises intake through fixtures.
 `bin/fm-discord-workspace.sh` owns the exact schema, fields, state files, receipt formats, artifact checks, final-reply guard, and command mechanics.
 `docs/discord-workspace.md` is the operator guide for the presentation contract, security boundary, dry-run setup, artifact policy, audio policy, and rollback.
-The supported presentation is one private operations guild with ProApplis, Folium, and ARFAL categories, each with exchanges and artifacts forum channels.
-LBDB and Maratone Labs stay configured only as disabled inventory entries until a later captain approval activates them.
+The supported presentation is one private operations guild with System / Firstmate, ProApplis, and Folium categories, each with exchanges and artifacts forum channels.
+Only those three active profiles belong in this phase's configuration.
 The config carries non-secret ids, profile metadata, allowlists, forum tag vocabularies, and disabled live choices only.
 Secret values never belong in this file, argv, logs, process-event records, receipts, artifact records, or inbox metadata.
 Secret references may name `config/discord-workspace.secrets.sops.yaml` and key names for a later sops+age live task, but this phase never decrypts or reads that file.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -366,6 +366,7 @@ Other ambient names must be listed explicitly, including custom credential-store
 The command shell and worker may still create their own variables.
 Allowed values come from the destination pane at execution time; they are neither copied from the invoking Firstmate process nor written into the launch command.
 Listing a name does not provision it in a daemon's environment or transfer credentials to another machine.
+The remote job worker also exposes the account's `XDG_CONFIG_HOME` and `GH_CONFIG_DIR` roots to each child, defaulting to `$HOME/.config` and `$HOME/.config/gh`, so stored provider and GitHub CLI configuration remains visible after the worker's environment reset.
 
 Choose the minimum additions for the authentication method actually in use:
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -657,6 +657,26 @@ The session-start digest separately prints a "Public commitments" subsection fro
 `FM_PF_RETRY_BACKOFF_SECS` (default 900) sets the next-attempt time recorded with a retryable delivery error.
 See [verification/public-followup.md](verification/public-followup.md) for the current maintainer evidence behind restart recovery, retained-loop disposition, and the relay-disabled zero-overhead guarantee.
 
+## Discord workspace (config/discord-workspace.json)
+
+The private Discord operations workspace is configured by the local, gitignored `config/discord-workspace.json` file under the effective `FM_HOME`.
+It is separate from Relay, Hermes, and any client or audience Discord bot.
+The repository-supported phase is offline only: it validates config, renders setup and health dry-runs, plans replies and artifacts, links requests to tasks, preserves pending final replies, and exercises intake through fixtures.
+`bin/fm-discord-workspace.sh` owns the exact schema, fields, state files, receipt formats, artifact checks, final-reply guard, and command mechanics.
+`docs/discord-workspace.md` is the operator guide for the presentation contract, security boundary, dry-run setup, artifact policy, audio policy, and rollback.
+The supported presentation is one private operations guild with ProApplis, Folium, and ARFAL categories, each with exchanges and artifacts forum channels.
+LBDB and Maratone Labs stay configured only as disabled inventory entries until a later captain approval activates them.
+The config carries non-secret ids, profile metadata, allowlists, forum tag vocabularies, and disabled live choices only.
+Secret values never belong in this file, argv, logs, process-event records, receipts, artifact records, or inbox metadata.
+Secret references may name `config/discord-workspace.secrets.sops.yaml` and key names for a later sops+age live task, but this phase never decrypts or reads that file.
+Live choices are represented but inert for Discord `MESSAGE_CONTENT`, Omarchy versus VPS host, hosted Groq transcription, artifact access and expiry, temporary setup permissions, Community-mode requirement, live polling, and live posting.
+Apply mode for setup, live Discord health, live transcription, and non-dry-run process-event arming refuses until a later activation task supplies every approval.
+The built-in `discord-workspace` process-event adapter lives at `bin/fm-procevent-discord-workspace.sh` and uses the existing `bin/fm-procevent.sh` owner for source registration, capture, durable result acknowledgement, and retirement.
+Its offline source reads only `FM_DISCORD_WORKSPACE_FIXTURE` or `poll.fixture_file`, accepts only allowlisted operations-guild exchange forum posts or threads from allowlisted captain users, and turns accepted results into idempotent `bin/fm-inbox.sh note` records.
+The idempotency seam is `bin/fm-inbox.sh note --source <name> --external-id <id> [--metadata-file <json>]`, which records a private map under `state/inbox/external/` so replay returns the original note id and appends no second wake.
+Outbound dry-run state lives under `state/discord-workspace/`, including request records, task links, nonce-keyed receipts, pending final replies, and artifact records.
+`bin/fm-teardown.sh` refuses to clean up a task while `state/discord-workspace/pending-followups/<task-id>.json` still records an unresolved private Discord final reply, unless explicit discard authority is carried by `--force`.
+
 ## Trusted external process-event adapters (config/extensions.d)
 
 A home can explicitly enable a trusted external `process-event-adapter/1` package without adding package code to Firstmate.

--- a/docs/discord-workspace.md
+++ b/docs/discord-workspace.md
@@ -1,0 +1,119 @@
+# Discord workspace
+
+Firstmate's private Discord operations workspace is an offline-supported integration for one captain-owned operations guild.
+It is separate from the public Relay integration and separate from any future Hermes audience bots.
+The repository support in this phase validates configuration, plans setup, plans outbound messages and artifacts, links requests to work, preserves pending final replies, and exercises intake through offline fixtures only.
+It does not contact Discord or Groq, create live resources, decrypt secrets, install tools, arm a live source, or post live messages.
+
+## Presentation contract
+
+The supported workspace is one private operations guild.
+The active profile categories are ProApplis, Folium, and ARFAL.
+Each active profile has exactly two configured Discord forum channels for this phase.
+One forum is the profile's exchanges forum.
+One forum is the profile's artifacts forum.
+Each forum post or thread is the Discord analogue of an operator tab.
+Voice messages, uploaded audio, and transcripts stay in the relevant exchange post.
+Every artifact is canonical in exactly one tagged artifact-forum post.
+The related exchange receives only a concise card and a link to that artifact post or private artifact URL.
+LBDB and Maratone Labs remain disabled inventory entries until a later captain approval activates them.
+There is no live voice-channel capture in this phase.
+
+## Bot identity boundary
+
+One Firstmate operations bot handles text intake, artifact cards and index links, audio transcription replies, and status replies.
+Do not create feature-specific bots, webhook personas, or separate bot identities for visual activities.
+Make profile context visible through categories, forum tags, artifact cards, and profile metadata.
+Separate Hermes audience bots may exist later when an activated security or audience boundary needs them.
+Those Hermes bots are outside this integration and must never share Firstmate Discord workspace credentials or private Firstmate authority.
+
+## Non-secret config
+
+The default non-secret config path is `config/discord-workspace.json` under the effective `FM_HOME`.
+Use `bin/fm-discord-workspace.sh sample-config` to print a copyable draft.
+Use `bin/fm-discord-workspace.sh config-check --config <json>` to validate the local file.
+The config schema is owned by `bin/fm_discord_workspace_lib.py` and surfaced through `bin/fm-discord-workspace.sh --help`.
+The schema names one operations guild id, one bot application id, one bot user id, captain Discord user ids, disabled profiles, three active profiles, category ids, exchange forum ids, artifact forum ids, optional thread allowlists, exchange tags, artifact tags, artifact policy, audio policy, transcription references, and disabled live choices.
+Exchange tag defaults are request, decision, work, status, blocked, and done.
+Artifact tag defaults are report, board, document, image, audio, draft, final, and expired.
+The script validates ids and duplicate channel assignments but never creates any category, channel, thread, or tag.
+The config stores secret file paths and key names only.
+It must never store Discord tokens, Groq keys, plaintext `.env` values, or decrypted secret material.
+
+## Setup and health dry-runs
+
+Run `bin/fm-discord-workspace.sh setup --dry-run --config <json>` to render the planned guild tree, forum ids, thread allowlists, tag vocabulary, and permission integers.
+The dry-run prints temporary setup and steady-state permission integers without contacting Discord.
+The dry-run also prints every live choice that remains unapproved or inactive.
+`setup --apply` refuses in this phase.
+Run `bin/fm-discord-workspace.sh health --local --config <json>` for local config and state checks without network access.
+`health --secrets`, `health --discord`, and `health --transcription` report the planned checks and refuse before live secret or network use.
+Live choices remain configurable but disabled for Discord `MESSAGE_CONTENT`, Omarchy versus VPS host, hosted Groq consent and limits, artifact access and expiry, temporary setup permissions, Community-mode requirement, live polling, and live posting.
+
+## Inbound process-event adapter
+
+`bin/fm-procevent-discord-workspace.sh` is the built-in process-event adapter for this integration.
+Its canonical source id is `discord-workspace`.
+`arm --dry-run` prints the registration command and does not register a live source.
+A non-dry-run arm refuses in this phase even when config contains a future live-polling choice.
+The source command reads only offline fixtures named by `FM_DISCORD_WORKSPACE_FIXTURE` or by `poll.fixture_file` in config.
+Without a fixture it refuses before any network call.
+The adapter accepts only messages from the configured operations guild, configured exchange forum posts or allowlisted exchange threads, configured captain user ids, and non-bot authors.
+It ignores DMs, bots, unknown guilds, unknown channels, unknown authors, artifact-forum input, disabled profiles, and invalid message ids.
+Accepted text, voice transcript, audio transcript, and audio rejection events are passed to `bin/fm-inbox.sh note` with `--source discord-workspace` and a validated `--external-id`.
+The existing captain inbox remains the durable authority and wake owner.
+The process-event adapter declares self-announcing so a successfully handled Discord event produces only the ordinary captain-inbox notification.
+
+## Inbox replay idempotency
+
+`bin/fm-inbox.sh note` accepts `--source <name> --external-id <id> [--metadata-file <json>]` for trusted external intake.
+The external source and id are non-secret identifiers.
+The inbox writes a private map under `state/inbox/external/`.
+A replay with the same source and external id returns the original note id and appends no second notification.
+The metadata file must be bounded JSON and is copied into private inbox state.
+The note body remains the durable human-readable captain note.
+
+## Outbound replies and final follow-ups
+
+Workers must not post to Discord directly.
+Use `bin/fm-discord-workspace.sh reply`, `status`, `artifact`, `publish-artifact`, `link-task`, and `followup` to plan private outbound work.
+Every outbound plan uses `allowed_mentions: { "parse": [] }`.
+A live post receipt is represented by a nonce-keyed private record under `state/discord-workspace/receipts/`.
+A retry with the same nonce and identical planned payload returns the existing receipt instead of authorizing a duplicate post.
+`link-task` records a Discord-originated request under `state/discord-workspace/requests/` and links the task under `state/discord-workspace/task-links/`.
+When final replies are required, it also creates a pending final-reply record under `state/discord-workspace/pending-followups/`.
+`followup --final` keeps the pending record unresolved in dry-run mode and marks it delivered only when a validated live receipt id is recorded.
+`bin/fm-teardown.sh` refuses to clean up a task while its private Discord workspace final reply is still pending unless explicit discard authority is carried through `--force`.
+
+## Artifact protection
+
+Direct Discord attachments are for small, deliberately selected files only.
+The default direct attachment cap is 8 MiB and cannot exceed Discord's documented 10 MiB default in this phase.
+Allowed direct types are UTF-8 Markdown or text, PNG, JPEG, GIF, WebP, and generated PDF files.
+The artifact helper blocks secret-looking names, archives, databases, dumps, raw logs, credential files, unknown MIME types, MIME mismatches, files under `projects/`, directories, symlinks, and files outside configured allowed roots.
+Client-confidential artifacts are blocked unless config opts in and the command carries explicit captain approval for that file.
+The canonical artifact plan posts the binary or private URL only in the artifacts forum.
+The exchange plan receives only a summary card and link.
+For larger or interactive artifacts, use `publish-artifact` with a private HTTPS URL, an access mode, and an expiry.
+The helper records source digest, policy, destination, and revocation metadata but does not operate the private publication host in this phase.
+
+## Audio and transcription
+
+Phase 1 handles Discord voice messages and uploaded audio files only.
+Live voice-channel capture is excluded.
+Audio intake validates the Discord CDN host, MIME or extension, size, and duration before transcription planning.
+Discord voice messages must carry the voice-message flag and exactly one audio attachment.
+The conversion plan names `ffmpeg`, records that temporary raw audio should be deleted by default, and does not invoke live conversion in this phase.
+Tests may use `transcription.provider` set to `fake` with fixture transcripts.
+Hosted Groq support is only a design and configuration boundary in this phase.
+A later live task must use a dedicated Firstmate Discord/transcription secret file decrypted with sops and age into process memory.
+No plaintext `.env`, Hermes recipient, client recipient, shared client key, Groq network call, or committed secret is part of this phase.
+
+## Rollback and retirement
+
+`bin/fm-discord-workspace.sh retire --config <json>` is a dry-run retirement check.
+It refuses while pending final replies remain.
+It preserves `state/discord-workspace/` so receipts, request links, artifact records, and pending replies remain auditable.
+If a live process-event source is activated later, retire that source through `bin/fm-procevent.sh retire discord-workspace` or a stricter owner-matching command printed by the activation task.
+Do not delete live Discord channels, categories, posts, bot permissions, or secrets without a separate explicit captain-approved live operation.
+Rotate the Discord bot token or dedicated transcription key if compromise is suspected.

--- a/docs/discord-workspace.md
+++ b/docs/discord-workspace.md
@@ -57,7 +57,7 @@ Its canonical source id is `discord-workspace`.
 A non-dry-run arm refuses in this phase even when config contains a future live-polling choice.
 The source command reads only offline fixtures named by `FM_DISCORD_WORKSPACE_FIXTURE` or by `poll.fixture_file` in config.
 Without a fixture it refuses before any network call.
-The adapter accepts only messages from the configured operations guild, configured exchange forum posts or allowlisted exchange threads, configured captain user ids, and non-bot authors.
+The adapter accepts only messages from the configured operations guild, configured exchange forum posts (a newly created child thread of a configured exchange forum, verified by its parent id) or allowlisted exchange threads, configured captain user ids, and non-bot authors.
 It ignores DMs, bots, unknown guilds, unknown channels, unknown authors, artifact-forum input, and invalid message ids.
 Accepted text, voice transcript, audio transcript, and audio rejection events are passed to `bin/fm-inbox.sh note` with `--source discord-workspace` and a validated `--external-id`.
 The existing captain inbox remains the durable authority and wake owner.

--- a/docs/discord-workspace.md
+++ b/docs/discord-workspace.md
@@ -8,7 +8,7 @@ It does not contact Discord or Groq, create live resources, decrypt secrets, ins
 ## Presentation contract
 
 The supported workspace is one private operations guild.
-The active profile categories are ProApplis, Folium, and ARFAL.
+The active profile categories are System / Firstmate, ProApplis, and Folium.
 Each active profile has exactly two configured Discord forum channels for this phase.
 One forum is the profile's exchanges forum.
 One forum is the profile's artifacts forum.
@@ -16,7 +16,6 @@ Each forum post or thread is the Discord analogue of an operator tab.
 Voice messages, uploaded audio, and transcripts stay in the relevant exchange post.
 Every artifact is canonical in exactly one tagged artifact-forum post.
 The related exchange receives only a concise card and a link to that artifact post or private artifact URL.
-LBDB and Maratone Labs remain disabled inventory entries until a later captain approval activates them.
 There is no live voice-channel capture in this phase.
 
 ## Bot identity boundary
@@ -33,7 +32,7 @@ The default non-secret config path is `config/discord-workspace.json` under the 
 Use `bin/fm-discord-workspace.sh sample-config` to print a copyable draft.
 Use `bin/fm-discord-workspace.sh config-check --config <json>` to validate the local file.
 The config schema is owned by `bin/fm_discord_workspace_lib.py` and surfaced through `bin/fm-discord-workspace.sh --help`.
-The schema names one operations guild id, one bot application id, one bot user id, captain Discord user ids, disabled profiles, three active profiles, category ids, exchange forum ids, artifact forum ids, optional thread allowlists, exchange tags, artifact tags, artifact policy, audio policy, transcription references, and disabled live choices.
+The schema names one operations guild id, one bot application id, one bot user id, captain Discord user ids, exactly three active profiles, category ids, exchange forum ids, artifact forum ids, optional thread allowlists, exchange tags, artifact tags, artifact policy, audio policy, transcription references, and disabled live choices.
 Exchange tag defaults are request, decision, work, status, blocked, and done.
 Artifact tag defaults are report, board, document, image, audio, draft, final, and expired.
 The script validates ids and duplicate channel assignments but never creates any category, channel, thread, or tag.
@@ -59,7 +58,7 @@ A non-dry-run arm refuses in this phase even when config contains a future live-
 The source command reads only offline fixtures named by `FM_DISCORD_WORKSPACE_FIXTURE` or by `poll.fixture_file` in config.
 Without a fixture it refuses before any network call.
 The adapter accepts only messages from the configured operations guild, configured exchange forum posts or allowlisted exchange threads, configured captain user ids, and non-bot authors.
-It ignores DMs, bots, unknown guilds, unknown channels, unknown authors, artifact-forum input, disabled profiles, and invalid message ids.
+It ignores DMs, bots, unknown guilds, unknown channels, unknown authors, artifact-forum input, and invalid message ids.
 Accepted text, voice transcript, audio transcript, and audio rejection events are passed to `bin/fm-inbox.sh note` with `--source discord-workspace` and a validated `--external-id`.
 The existing captain inbox remains the durable authority and wake owner.
 The process-event adapter declares self-announcing so a successfully handled Discord event produces only the ordinary captain-inbox notification.

--- a/docs/discord-workspace.md
+++ b/docs/discord-workspace.md
@@ -91,9 +91,10 @@ The default direct attachment cap is 8 MiB and cannot exceed Discord's documente
 Allowed direct types are UTF-8 Markdown or text, PNG, JPEG, GIF, WebP, and generated PDF files.
 The artifact helper blocks secret-looking names, archives, databases, dumps, raw logs, credential files, unknown MIME types, MIME mismatches, files under `projects/`, directories, symlinks, and files outside configured allowed roots.
 Client-confidential artifacts are blocked unless config opts in and the command carries explicit captain approval for that file.
-The canonical artifact plan posts the binary or private URL only in the artifacts forum.
+The `artifact` command accepts only direct attachments and posts the binary only in the artifacts forum.
 The exchange plan receives only a summary card and link.
-For larger or interactive artifacts, use `publish-artifact` with a private HTTPS URL, an access mode, and an expiry.
+For larger artifacts or validated HTML boards, use the single protected `publish-artifact` path with a private HTTPS URL, an access mode, and an expiry.
+HTML is never accepted as a direct Discord attachment.
 The helper records source digest, policy, destination, and revocation metadata but does not operate the private publication host in this phase.
 
 ## Audio and transcription

--- a/docs/discord-workspace.md
+++ b/docs/discord-workspace.md
@@ -117,3 +117,15 @@ It preserves `state/discord-workspace/` so receipts, request links, artifact rec
 If a live process-event source is activated later, retire that source through `bin/fm-procevent.sh retire discord-workspace` or a stricter owner-matching command printed by the activation task.
 Do not delete live Discord channels, categories, posts, bot permissions, or secrets without a separate explicit captain-approved live operation.
 Rotate the Discord bot token or dedicated transcription key if compromise is suspected.
+
+## Bounded live activation layer
+
+`bin/fm-discord-live.sh` is the only live surface, and only while the workspace config enables the matching live approval flag.
+`health` verifies the exact configured operations guild and bot identity.
+`setup-apply` reuses an existing category or forum only when its name, type, and parent match exactly, creates the three profile categories with their exchanges and artifacts forums plus configured tags, writes only non-secret IDs back to the config atomically, and never enables or inspects Community mode: forum channels are created and reused directly.
+`live-reply` posts with empty `allowed_mentions` and reuses the outbound receipt so a replay never posts twice.
+`live-source` lists a guild's active threads once per pass, filters strictly by the configured exchange forum parents, reads only captain-authored non-bot messages after durable monotonic cursors, and feeds the existing external-id inbox seam.
+`live-roundtrip` posts one reply and reads it back to verify delivery.
+The bot token is decrypted from the sops secret file into process memory only and is redacted from every failure path.
+Deletion or retirement of live resources, voice capture, hosted transcription, webhooks, and non-configured guilds stay out of scope.
+For continuous inbound listening, arm the built-in process-event source with `bin/fm-procevent-discord-workspace.sh arm --config <json>` once live polling is enabled; it registers `bin/fm-procevent.sh register discord-workspace discord-workspace -- bin/fm-procevent-discord-workspace.sh source --config <json>`, and retirement stays `bin/fm-procevent.sh retire discord-workspace`.

--- a/docs/documentation-audiences.json
+++ b/docs/documentation-audiences.json
@@ -313,6 +313,10 @@
       "audience": "maintainer-architecture"
     },
     {
+      "path": "docs/discord-workspace.md",
+      "audience": "operator-current"
+    },
+    {
       "path": "docs/documentation-audiences.md",
       "audience": "maintainer-architecture"
     },

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -78,6 +78,7 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-extension.sh`        | Expose extension binding commands through the tracked shell and remote-home command boundary |
 | `fm-procevent.sh`        | Register, supervise, capture, classify, acknowledge, and safely retire built-in or explicitly bound process-event sources |
 | `fm-procevent-remote-reply.sh` | Relay the remote-secondmate status stream through non-destructive process-event deltas |
+| `fm-procevent-discord-workspace.sh` | Built-in offline process-event adapter for private Discord workspace intake |
 | `fm-procevent-quota.sh`  | Wake Firstmate when tracked quota drops below a threshold, is exhausted, or cannot be polled |
 | `fm-procevent-when.sh`   | Fire a trust-bound deterministic action at most once when its registered condition holds, then wake with the outcome |
 | `fm-gate-refuse-lib.sh`  | Shared no-mistakes gate-context refusal for fleet lifecycle entrypoints               |
@@ -144,6 +145,7 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-public-followup-emit.sh` | Report one typed terminal work result into the home that owes the public reply, or stage it when that home is on another machine |
 | `fm-public-followup-collect.sh` | Read and retire the typed terminal results a remote work home staged for the home that owes the public reply |
 | `fm-inbox.sh`            | The captain's out-of-band capture surface: queue a note, dictate one, read status, ask a side question |
+| `fm-discord-workspace.sh` | Validate and dry-run private Discord workspace setup, replies, artifacts, links, final follow-ups, and retirement |
 | `fm-voice-relay.py`      | Hold the spoken conversation on this host, answer from the records, and hand real work to `fm-inbox.sh` ([voice-relay.md](voice-relay.md)) |
 | `fm-voice-client.py`     | The laptop end of the spoken interface: capture, playback, and turn timing over SSH; audio devices unverified |
 | `fm_voice_frame.py`      | The wire format both machines share, copied to the laptop beside the client          |

--- a/tests/fm-discord-live.test.sh
+++ b/tests/fm-discord-live.test.sh
@@ -453,6 +453,85 @@ NOTES15B=$(find "$H/state/inbox" -maxdepth 1 -name '*.note' 2>/dev/null | wc -l 
 pe "$H" retire discord-workspace >/dev/null 2>&1 || fail "retire failed"
 if pe "$H" list | grep -q discord-workspace; then fail "retire left the registration in place"; fi
 pass "process-event arm registers, repeated starts stay idempotent, and retire clears the source"
+# --- 16. registered source: empty scans are silent no-results ----------------
+new_home h16
+CFG16="$H/config/discord-workspace.json"
+python3 - "$WORLD" <<'PY'
+import json, sys
+world = json.load(open(sys.argv[1]))
+world["threads"] = {}
+world["messages"] = {}
+json.dump(world, open(sys.argv[1], "w"))
+PY
+ped() { FM_HOME="$1" "$ROOT/bin/fm-procevent-discord-workspace.sh" "${@:2}"; }
+ped "$H" arm --config "$CFG16" >/dev/null || fail "arm failed for the empty-scan case"
+out=$(pe "$H" start discord-workspace 2>&1) || fail "empty-scan start failed: $out"
+assert_contains "$out" "no-result" "an empty scan records no-result: files: $(find "$H/state/procevent-inbox" -type f 2>/dev/null | head -2 | xargs -r head -c 500)"
+CAPTURES=$(find "$H/state/procevent-inbox" -type f 2>/dev/null | wc -l | tr -d ' ')
+[ "$CAPTURES" = 0 ] || fail "an empty scan captured $CAPTURES result files: $(head -c 400 "$H/state/procevent-inbox"/* 2>/dev/null)"
+out=$(pe "$H" start discord-workspace 2>&1) || fail "repeated empty scan failed: $out"
+CAPTURES=$(find "$H/state/procevent-inbox" -type f 2>/dev/null | wc -l | tr -d ' ')
+[ "$CAPTURES" = 0 ] || fail "repeated empty scans captured results"
+pass "registered source: repeated empty scans create zero unhandled captures"
+
+# --- 17. one captain message makes exactly one note; a repeat makes none -----
+python3 - "$WORLD" <<'PY'
+import json, sys
+world = json.load(open(sys.argv[1]))
+world["counter"] = int(world["counter"]) + 1
+thread = str(world["counter"])
+world["threads"] = {"777777777777777772": [{"id": thread, "parent_id": "777777777777777772", "name": "control"}]}
+world["messages"] = {thread: [
+    {"id": str(world["counter"] + 1), "guild_id": "111111111111111111", "channel_id": thread,
+     "author": {"id": "444444444444444444"}, "content": "one real captain message"},
+]}
+json.dump(world, open(sys.argv[1], "w"))
+PY
+out=$(pe "$H" start discord-workspace 2>&1) || fail "captain-message start failed: $out"
+NOTES=$(find "$H/state/inbox" -maxdepth 1 -name '*.note' 2>/dev/null | wc -l | tr -d ' ')
+[ "$NOTES" = 1 ] || fail "one captain message produced $NOTES notes instead of 1"
+out=$(pe "$H" start discord-workspace 2>&1) || fail "repeat after captain message failed: $out"
+NOTES2=$(find "$H/state/inbox" -maxdepth 1 -name '*.note' 2>/dev/null | wc -l | tr -d ' ')
+[ "$NOTES2" = 1 ] || fail "a repeat produced $((NOTES2 - NOTES)) extra notes"
+pass "one captain message makes exactly one inbox note and a repeat makes none"
+
+# --- 18. a genuine failure is captured as bounded redacted evidence ----------
+world_set '{"inject":{"path":"/threads/active","method":"GET","remaining":9,"status":500,"body":{"message":"threads listing down faketoken-abc123"}}}'
+BEFORE_NOTES=$(find "$H/state/inbox" -maxdepth 1 -name '*.note' 2>/dev/null | wc -l | tr -d ' ')
+BEFORE_CURSORS=$(find "$H/state/discord-workspace/cursors" -type f 2>/dev/null | wc -l | tr -d ' ')
+out=$(pe "$H" start discord-workspace 2>&1) || fail "failing start crashed the runner: $out"
+assert_contains "$out" "captured" "a genuine failure is captured as a result"
+grep -rl "discord live source failed" "$H/state/procevent-inbox" >/dev/null 2>&1 \
+  || fail "the captured result lacks actionable failure evidence"
+grep -rl "faketoken-abc123" "$H/state/procevent-inbox" >/dev/null 2>&1 && fail "a captured result leaked the token"
+NOTES3=$(find "$H/state/inbox" -maxdepth 1 -name '*.note' 2>/dev/null | wc -l | tr -d ' ')
+[ "$NOTES3" = "$BEFORE_NOTES" ] || fail "a failed pass changed durable notes"
+CURSORS=$(find "$H/state/discord-workspace/cursors" -type f 2>/dev/null | wc -l | tr -d ' ')
+[ "$CURSORS" = "$BEFORE_CURSORS" ] || fail "a failed pass advanced cursors ($BEFORE_CURSORS -> $CURSORS)"
+world_set '{"inject":null}'
+pass "genuine failures stay visible, redacted, and retryable without advancing cursors"
+
+# --- 19. deployment shape: installed main runner without the task adapter ----
+new_home h19
+MAINBIN="$TMP_ROOT/mainbin"
+mkdir -p "$MAINBIN"
+for f in fm-procevent.sh fm-pr-lib.sh fm-wake-lib.sh fm-procevent-lib.sh fm-classify-lib.sh fm-timeout-lib.sh fm-lock-lib.sh fm-harness.sh; do
+  cp "$ROOT/bin/$f" "$MAINBIN/$f"
+done
+# The emulated installed runner runs from MAINBIN while FM_ROOT points at
+# the checkout whose bin owns the Discord adapter - the real deployment shape.
+pe19() { FM_HOME="$1" FM_ROOT_OVERRIDE="$ROOT" "$MAINBIN/fm-procevent.sh" "${@:2}"; }
+pe19 "$H" register discord-workspace discord-workspace -- \
+  "$ROOT/bin/fm-procevent-discord-workspace.sh" source --config "$H/config/discord-workspace.json" >/dev/null \
+  || fail "registration through the emulated installed runner failed"
+out=$(pe19 "$H" start discord-workspace 2>&1) || fail "installed-runner start failed: $out"
+NOTES19=$(find "$H/state/inbox" -maxdepth 1 -name '*.note' 2>/dev/null | wc -l | tr -d ' ')
+[ "$NOTES19" = 1 ] || fail "installed-runner start produced $NOTES19 notes instead of 1"
+out=$(pe19 "$H" start discord-workspace 2>&1) || fail "installed-runner repeat failed: $out"
+NOTES19B=$(find "$H/state/inbox" -maxdepth 1 -name '*.note' 2>/dev/null | wc -l | tr -d ' ')
+[ "$NOTES19B" = 1 ] || fail "installed-runner repeat duplicated notes"
+pe19 "$H" retire discord-workspace >/dev/null 2>&1 || fail "installed-runner retire failed"
+pass "registered argv to the task copy works under a main runner from a different code root"
 
 # --- cleanup -----------------------------------------------------------------
 kill %1 2>/dev/null || true

--- a/tests/fm-discord-live.test.sh
+++ b/tests/fm-discord-live.test.sh
@@ -86,8 +86,11 @@ class Handler(BaseHTTPRequestHandler):
             self._send(200, world.get("channels", []))
         elif parts == ["users", "@me"]:
             self._send(200, {"id": world.get("bot_id", BOT), "username": "fake-bot"})
+        elif len(parts) == 4 and parts[0] == "guilds" and parts[2] == "threads" and parts[3] == "active":
+            all_threads = [t for ts in world.get("threads", {}).values() for t in ts]
+            self._send(200, {"threads": all_threads})
         elif len(parts) == 4 and parts[2] == "threads" and parts[3] == "active":
-            self._send(200, {"threads": world.get("threads", {}).get(parts[1], [])})
+            self._send(404, {"code": 0, "message": "channel-scoped active-thread listing is unsupported"})
         elif len(parts) == 3 and parts[2] == "messages":
             after = int(query.get("after", ["0"])[0])
             limit = int(query.get("limit", ["100"])[0])
@@ -370,6 +373,10 @@ world["messages"] = {thread: [
     {"id": str(int(stale) + 3), "guild_id": "$GUILD", "channel_id": thread, "author": {"id": "$CAPTAIN"}, "content": "newest captain request"},
 ]}
 world["threads"]["$FORUM_F"] = world["threads"]["$FORUM_F"] + [{"id": "888888888888888999", "parent_id": "wrong-parent", "name": "foreign"}]
+world["threads"]["555555555555555553"] = [{"id": "888888888888888998", "parent_id": "555555555555555553", "name": "artifacts tab"}]
+world["messages"]["888888888888888998"] = [
+    {"id": "888888888888888997", "guild_id": "$GUILD", "channel_id": "888888888888888998", "author": {"id": "$CAPTAIN"}, "content": "artifacts forum child must not ingest"},
+]
 json.dump(world, open("$WORLD", "w"))
 PY
 out=$(dl live-source --config "$CFG12" 2>&1) || fail "live source failed: $out"
@@ -410,6 +417,42 @@ out2=$(dl live-roundtrip --config "$H/config/discord-workspace.json" --request-i
   || fail "roundtrip replay failed: $out2"
 assert_contains "$out2" "round-trip verified against the recorded message id" "roundtrip replay verifies from the receipt"
 pass "live roundtrip posts once and verifies in both fresh and replay paths"
+
+
+# --- 14. process-event arm gates on the live polling flag --------------------
+pe() { FM_HOME="$1" "$ROOT/bin/fm-procevent.sh" "${@:2}"; }
+ped() { FM_HOME="$1" "$ROOT/bin/fm-procevent-discord-workspace.sh" "${@:2}"; }
+new_home h14
+CFG14="$H/config/discord-workspace.json"
+python3 - "$CFG14" <<'PY'
+import json, sys
+data = json.load(open(sys.argv[1]))
+data["live"]["polling"] = False
+json.dump(data, open(sys.argv[1], "w"), indent=2, sort_keys=True)
+PY
+arm_status=0
+arm_out=$(ped "$H" arm --config "$CFG14" 2>&1) || arm_status=$?
+[ "$arm_status" -ne 0 ] || fail "arm registered while live polling was disabled"
+assert_contains "$arm_out" "live polling is disabled" "arm refusal names the disabled flag"
+out=$(ped "$H" arm --dry-run --config "$CFG14")
+assert_contains "$out" "register command:" "arm dry-run prints the registration command"
+pass "process-event arm refuses while live polling is disabled and prints the registration command"
+
+# --- 15. arm registers, start repeats through the inbox seam, retire clears --
+new_home h15
+CFG15="$H/config/discord-workspace.json"
+out=$(ped "$H" arm --config "$CFG15" 2>&1) || fail "arm failed with live polling enabled: $out"
+assert_contains "$out" "live source registered" "arm registers the live source"
+assert_grep "discord-workspace" <(pe "$H" list) || fail "the registered source is missing from the list"
+out=$(pe "$H" start discord-workspace 2>&1) || fail "first procevent start failed: $out"
+NOTES15=$(find "$H/state/inbox" -maxdepth 1 -name '*.note' 2>/dev/null | wc -l | tr -d ' ')
+[ "$NOTES15" -ge 1 ] || fail "the registered live source ingested nothing on start: start output: $out; claims: $(ls "$H/state/procevent-inbox" 2>/dev/null); result: $(cat "$H/state/procevent-inbox"/*.result 2>/dev/null | head -5)"
+out=$(pe "$H" start discord-workspace 2>&1) || fail "second procevent start failed: $out"
+NOTES15B=$(find "$H/state/inbox" -maxdepth 1 -name '*.note' 2>/dev/null | wc -l | tr -d ' ')
+[ "$NOTES15B" = "$NOTES15" ] || fail "a repeated start duplicated notes ($NOTES15 -> $NOTES15B)"
+pe "$H" retire discord-workspace >/dev/null 2>&1 || fail "retire failed"
+if pe "$H" list | grep -q discord-workspace; then fail "retire left the registration in place"; fi
+pass "process-event arm registers, repeated starts stay idempotent, and retire clears the source"
 
 # --- cleanup -----------------------------------------------------------------
 kill %1 2>/dev/null || true

--- a/tests/fm-discord-live.test.sh
+++ b/tests/fm-discord-live.test.sh
@@ -1,0 +1,415 @@
+#!/usr/bin/env bash
+# Tests for the bounded live Discord activation layer, driven entirely by a
+# fake local HTTP server: no real token is read and no network call leaves
+# loopback. Covers health, community preflight, idempotent setup apply with
+# partial recovery, live reply receipt idempotency and retries, the live
+# inbound source with durable monotonic cursors, and token redaction.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+TMP_ROOT=$(fm_test_tmproot fm-discord-live-tests)
+GUILD=111111111111111111
+BOT=333333333333333333
+CAPTAIN=444444444444444444
+FORUM_F=777777777777777772
+FAKE_TOKEN=faketoken-abc123
+THREAD=888888888888888881
+
+dl() { FM_HOME="$H" "$ROOT/bin/fm-discord-live.sh" "$@"; }
+
+start_server() { # start_server <world-file> <port-file> <guild-id>
+  python3 - "$1" "$2" "$FAKE_TOKEN" "$3" > "$TMP_ROOT/fake-server.log" 2>&1 <<'PY' &
+import json, sys
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from urllib.parse import urlparse, parse_qs
+
+WORLD, PORT_FILE, TOKEN, GUILD = sys.argv[1], sys.argv[2], sys.argv[3], sys.argv[4]
+BOT = "333333333333333333"
+
+def load():
+    with open(WORLD, encoding="utf-8") as f:
+        return json.load(f)
+
+def save(world):
+    with open(WORLD, "w", encoding="utf-8") as f:
+        json.dump(world, f)
+
+class Handler(BaseHTTPRequestHandler):
+    def log_message(self, *a):
+        pass
+
+    def _send(self, status, payload):
+        body = json.dumps(payload).encode()
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def _authorized(self, world):
+        return self.headers.get("Authorization") == f"Bot {world.get('token') or TOKEN}"
+
+    def _injected(self, path, method):
+        world = load()
+        inject = world.get("inject") or {}
+        if inject and inject.get("remaining", 0) > 0 and inject.get("path") in path and inject.get("method", method) == method:
+            inject["remaining"] -= 1
+            world["inject"] = inject
+            save(world)
+            return inject.get("status", 500), inject.get("body", {"message": "injected"})
+        return None
+
+    def handle_one_request(self):
+        try:
+            super().handle_one_request()
+        except (BrokenPipeError, ConnectionResetError):
+            pass
+
+    def do_GET(self):
+        url = urlparse(self.path)
+        parts = [p for p in url.path.split("/") if p]
+        query = parse_qs(url.query)
+        world = load()
+        if not self._authorized(world):
+            self._send(401, {"message": "Unauthorized", "note": "leak-attempt " + TOKEN})
+            return
+        hit = self._injected(url.path, "GET")
+        if hit:
+            self._send(hit[0], hit[1])
+            return
+        if parts[:2] == ["guilds", GUILD] and len(parts) == 2:
+            self._send(200, {"id": GUILD, "name": "Fake Guild", "features": world.get("features", [])})
+        elif parts[:2] == ["guilds", GUILD] and parts[2] == "channels":
+            self._send(200, world.get("channels", []))
+        elif parts == ["users", "@me"]:
+            self._send(200, {"id": world.get("bot_id", BOT), "username": "fake-bot"})
+        elif len(parts) == 4 and parts[2] == "threads" and parts[3] == "active":
+            self._send(200, {"threads": world.get("threads", {}).get(parts[1], [])})
+        elif len(parts) == 3 and parts[2] == "messages":
+            after = int(query.get("after", ["0"])[0])
+            limit = int(query.get("limit", ["100"])[0])
+            msgs = [m for m in world.get("messages", {}).get(parts[1], []) if int(m["id"]) > after]
+            msgs.sort(key=lambda m: int(m["id"]), reverse=True)
+            self._send(200, msgs[:limit])
+        elif len(parts) == 4 and parts[2] == "messages":
+            for m in world.get("messages", {}).get(parts[1], []):
+                if m["id"] == parts[3]:
+                    self._send(200, m)
+                    return
+            self._send(404, {"message": "Unknown Message"})
+        else:
+            self._send(404, {"message": "not found"})
+
+    def do_POST(self):
+        url = urlparse(self.path)
+        parts = [p for p in url.path.split("/") if p]
+        length = int(self.headers.get("Content-Length") or 0)
+        raw = self.rfile.read(length).decode("utf-8") if length else ""
+        try:
+            body = json.loads(raw) if raw else {}
+        except json.JSONDecodeError:
+            body = {}
+        world = load()
+        if not self._authorized(world):
+            self._send(401, {"message": "Unauthorized"})
+            return
+        hit = self._injected(url.path, "POST")
+        if hit:
+            self._send(hit[0], hit[1])
+            return
+        if len(parts) == 3 and parts[2] == "channels":
+            for c in world.get("channels", []):
+                if c.get("name") == body.get("name"):
+                    self._send(500, {"code": 50035, "message": "name already exists"})
+                    return
+            world["counter"] = int(world.get("counter", 900000000000000000)) + 1
+            channel = {"id": str(world["counter"]), "name": body.get("name"), "type": body.get("type"),
+                       "parent_id": body.get("parent_id"), "available_tags": body.get("available_tags", [])}
+            world.setdefault("channels", []).append(channel)
+            world["creates"] = int(world.get("creates", 0)) + 1
+            save(world)
+            self._send(201, channel)
+        elif len(parts) == 3 and parts[2] == "messages":
+            if body.get("allowed_mentions") != {"parse": []}:
+                self._send(400, {"message": "allowed_mentions must be empty parse"})
+                return
+            world["counter"] = int(world.get("counter", 900000000000000000)) + 1
+            message = {"id": str(world["counter"]), "content": body.get("content"),
+                       "author": {"id": BOT, "bot": True}, "channel_id": parts[1]}
+            world.setdefault("messages", {}).setdefault(parts[1], []).append(message)
+            world["posts"] = int(world.get("posts", 0)) + 1
+            save(world)
+            self._send(200, message)
+        else:
+            self._send(404, {"message": "not found"})
+
+server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+with open(PORT_FILE, "w", encoding="utf-8") as f:
+    f.write(str(server.server_port))
+server.serve_forever()
+PY
+  for _ in $(seq 1 50); do
+    [ -s "$2" ] && break
+    sleep 0.1
+  done
+  [ -s "$2" ] || fail "fake Discord server did not start"
+}
+
+world_set() { python3 - "$WORLD" "$1" <<'PY'
+import json, sys
+world, update = json.load(open(sys.argv[1])), json.loads(sys.argv[2])
+world.update(update)
+json.dump(world, open(sys.argv[1], "w"))
+PY
+}
+
+new_home() {
+  H="$TMP_ROOT/$1"
+  mkdir -p "$H/state" "$H/data" "$H/config"
+  FM_HOME="$H" "$ROOT/bin/fm-discord-workspace.sh" sample-config > "$H/config/discord-workspace.json"
+  python3 - "$H/config/discord-workspace.json" <<'PY'
+import json, sys
+data = json.load(open(sys.argv[1]))
+data["live"]["posting"] = True
+data["live"]["polling"] = True
+data["outbound"]["live_posting"] = True
+data["profiles"]["proapplis"]["thread_ids"]["exchange"] = ["888888888888888881"]
+json.dump(data, open(sys.argv[1], "w"), indent=2, sort_keys=True)
+PY
+  printf 'FIRSTMATE_DISCORD_BOT_TOKEN: %s\n' "$FAKE_TOKEN" > "$H/config/discord-workspace.secrets.sops.yaml"
+}
+
+# --- fake sops + fake server -------------------------------------------------
+cat > "$TMP_ROOT/fake-sops" <<FAKE
+#!/usr/bin/env bash
+[ "\$1" = "-d" ] || exit 64
+printf 'FIRSTMATE_DISCORD_BOT_TOKEN: $FAKE_TOKEN\n'
+FAKE
+chmod +x "$TMP_ROOT/fake-sops"
+
+WORLD="$TMP_ROOT/world.json"
+PORT_FILE="$TMP_ROOT/port"
+printf '{"features":["COMMUNITY"],"channels":[],"threads":{},"messages":{},"creates":0,"posts":0,"counter":900000000000000000}\n' > "$WORLD"
+start_server "$WORLD" "$PORT_FILE" "$GUILD"
+PORT=$(cat "$PORT_FILE")
+export FM_DISCORD_LIVE_API_BASE="http://127.0.0.1:$PORT"
+export FM_DISCORD_LIVE_SOPS="$TMP_ROOT/fake-sops"
+export FM_DISCORD_LIVE_RETRY_SLEEP=0
+
+# --- 1. live health verifies exact guild and bot identity --------------------
+new_home h1
+out=$(dl health --config "$H/config/discord-workspace.json" 2>&1) \
+  || fail "health failed against the fake server: $out"
+assert_contains "$out" "bot identity ok: fake-bot" "health verifies the configured bot identity"
+assert_contains "$out" "operations guild ok: Fake Guild" "health verifies the configured operations guild"
+assert_not_contains "$out" "community" "health does not inspect or report Community mode"
+pass "live health verifies exact guild and bot identity"
+
+# --- 2. health refuses a bot identity mismatch -------------------------------
+new_home h2
+world_set '{"bot_id":"999999999999999999"}'
+out=$(dl health --config "$H/config/discord-workspace.json" 2>&1) && fail "health accepted a foreign bot identity" || true
+assert_contains "$out" "does not match the configured bot user id" "health refuses a bot identity mismatch"
+world_set '{"bot_id":"'"$BOT"'"}'
+pass "live health refuses a bot identity mismatch"
+
+# --- 3. the token is redacted from every failure path ------------------------
+new_home h3
+# A sops stub that emits a token the server rejects.
+world_set '{"token":"wrong"}'
+cat > "$TMP_ROOT/fake-sops-wrong" <<FAKE
+#!/usr/bin/env bash
+[ "\$1" = "-d" ] || exit 64
+printf 'FIRSTMATE_DISCORD_BOT_TOKEN: leakedtoken-xyz\n'
+FAKE
+out=$(dl health --config "$H/config/discord-workspace.json" 2>&1) && fail "health accepted a wrong token" || true
+assert_contains "$out" "401" "a rejected token surfaces the HTTP failure"
+printf '%s' "$out" | grep -q "leakedtoken-xyz" && fail "the token leaked into failure output: $out"
+pass "the bot token is redacted from failure output"
+world_set '{"token":null}'
+
+# --- 4. setup apply creates forums directly without any COMMUNITY dependency -
+new_home h4
+world_set '{"features":[]}'
+out=$(dl setup-apply --config "$H/config/discord-workspace.json" 2>&1) \
+  || fail "setup apply failed on a guild without COMMUNITY: $out"
+CREATES=$(python3 -c "import json;print(json.load(open('$WORLD'))['creates'])")
+[ "$CREATES" = 9 ] || fail "setup apply created $CREATES channels instead of 9"
+FORUMS=$(python3 -c "import json;print(sum(1 for c in json.load(open('$WORLD'))['channels'] if c['type']==15))")
+[ "$FORUMS" = 6 ] || fail "setup apply created $FORUMS forums instead of 6"
+pass "setup apply creates forum channels directly without any COMMUNITY prerequisite"
+
+# --- 5. setup apply is idempotent and tags forums ----------------------------
+new_home h5
+out=$(dl setup-apply --config "$H/config/discord-workspace.json" 2>&1) \
+  || fail "setup apply failed: $out"
+CREATES=$(python3 -c "import json;print(json.load(open('$WORLD'))['creates'])")
+CFG_IDS=$(python3 - "$H/config/discord-workspace.json" <<'CFGIDS'
+import json, sys
+data = json.load(open(sys.argv[1]))
+p = data["profiles"]["firstmate"]
+print(all(str(p[k]).isdigit() for k in ("category_id", "exchange_forum_id", "artifact_forum_id")))
+CFGIDS
+)
+[ "$CFG_IDS" = "True" ] || fail "setup apply did not write non-secret ids into the config"
+TAGS_OK=$(python3 - "$WORLD" <<'TAGSOK'
+import json, sys
+world = json.load(open(sys.argv[1]))
+forums = [c for c in world["channels"] if c["type"] == 15]
+print(bool(forums) and all(c["available_tags"] for c in forums))
+TAGSOK
+)
+[ "$TAGS_OK" = "True" ] || fail "created forums lack the configured tag vocabulary"
+pass "setup apply creates the three categories with exchanges and artifacts forums plus tags"
+
+# --- 6. setup apply rerun reuses everything ---------------------------------
+out=$(dl setup-apply --config "$H/config/discord-workspace.json" 2>&1) \
+  || fail "second setup apply failed: $out"
+CREATES2=$(python3 -c "import json;print(json.load(open('$WORLD'))['creates'])")
+[ "$CREATES2" = "$CREATES" ] || fail "second setup apply created $((CREATES2 - CREATES)) duplicate channels"
+pass "setup apply reuses exact existing categories and forums on rerun"
+
+# --- 7. setup apply recovers from a partial run ------------------------------
+new_home h7
+python3 - "$WORLD" <<'RESETW'
+import json, sys
+world = json.load(open(sys.argv[1]))
+world["counter"] = int(world["counter"]) + 1
+world["channels"] = [{"id": str(world["counter"]), "name": "System / Firstmate", "type": 4, "parent_id": "", "available_tags": []}]
+world["creates"] = 1
+json.dump(world, open(sys.argv[1], "w"))
+RESETW
+out=$(dl setup-apply --config "$H/config/discord-workspace.json" 2>&1) \
+  || fail "setup apply failed on a partially provisioned guild: $out"
+REUSED=$(python3 - "$H/config/discord-workspace.json" "$WORLD" <<'REUSEOK'
+import json, sys
+data = json.load(open(sys.argv[1]))
+world = json.load(open(sys.argv[2]))
+pre = [c for c in world["channels"] if c["name"] == "System / Firstmate" and c["type"] == 4]
+print(len(pre) == 1 and data["profiles"]["firstmate"]["category_id"] == pre[0]["id"])
+REUSEOK
+)
+[ "$REUSED" = "True" ] || fail "setup apply did not reuse the pre-created category"
+CHANNELS7=$(python3 -c "import json;print(len(json.load(open('$WORLD'))['channels']))")
+[ "$CHANNELS7" = 9 ] || fail "partial recovery produced $CHANNELS7 channels instead of 9"
+pass "setup apply reuses exact existing channels and recovers from partial runs"
+
+# --- 8. setup apply refuses a wrong-shape name collision ---------------------
+new_home h8
+python3 - "$WORLD" <<'PY'
+import json, sys
+world = json.load(open(sys.argv[1]))
+world["counter"] = int(world["counter"]) + 1
+# A text channel squatting on a planned forum name must stop the apply.
+world["channels"] = [{"id": str(world["counter"]), "name": "firstmate-exchanges", "type": 0, "parent_id": "", "available_tags": []}]
+world["creates"] = 0
+json.dump(world, open(sys.argv[1], "w"))
+PY
+out=$(dl setup-apply --config "$H/config/discord-workspace.json" 2>&1) && fail "setup apply accepted a wrong-shape collision" || true
+assert_contains "$out" "mismatched shape" "a wrong-shape collision is named as such"
+assert_not_contains "$out" "text channel substitute" "no silent substitution is claimed"
+pass "setup apply refuses name collisions with a different channel type or parent"
+
+# --- 9. live reply posts once, records a receipt, and replays idempotently ---
+new_home h9
+printf 'Round-trip reply body.\n' > "$TMP_ROOT/reply.txt"
+REQUEST_ID="discord:$GUILD:$THREAD:777777777777777701"
+out=$(dl live-reply --config "$H/config/discord-workspace.json" --request-id "$REQUEST_ID" --text-file "$TMP_ROOT/reply.txt" 2>&1) \
+  || fail "live reply failed: $out"
+POSTS=$(python3 -c "import json;print(json.load(open('$WORLD'))['posts'])")
+[ "$POSTS" = 1 ] || fail "live reply posted $POSTS times"
+assert_grep "receipt recorded" <(printf '%s\n' "$out") || true
+out2=$(dl live-reply --config "$H/config/discord-workspace.json" --request-id "$REQUEST_ID" --text-file "$TMP_ROOT/reply.txt" 2>&1) \
+  || fail "live reply replay failed: $out2"
+assert_contains "$out2" "no second delivery" "replay reports no second delivery"
+POSTS2=$(python3 -c "import json;print(json.load(open('$WORLD'))['posts'])")
+[ "$POSTS2" = 1 ] || fail "replay posted again ($POSTS2 posts)"
+pass "live reply posts once with empty allowed_mentions and replays through the receipt"
+
+# --- 10. live reply retries transient server errors then records once --------
+new_home h10
+world_set '{"inject":{"path":"/messages","method":"POST","remaining":2,"status":500}}'
+out=$(dl live-reply --config "$H/config/discord-workspace.json" --request-id "$REQUEST_ID" --text-file "$TMP_ROOT/reply.txt" --nonce retry-nonce 2>&1) \
+  || fail "live reply did not survive two transient 500s: $out"
+POSTS3=$(python3 -c "import json;print(json.load(open('$WORLD'))['posts'])")
+[ "$POSTS3" = 2 ] || fail "retried reply produced $POSTS3 posts instead of 1 new post"
+assert_contains "$out" "receipt recorded" "the retried reply records its receipt"
+pass "live reply retries transient 5xx responses and records the receipt once"
+
+# --- 11. live reply fails without a receipt after sustained errors -----------
+new_home h11
+world_set '{"inject":{"path":"/messages","method":"POST","remaining":9,"status":500,"body":{"message":"injected faketoken-abc123"}}}'
+out=$(dl live-reply --config "$H/config/discord-workspace.json" --request-id "$REQUEST_ID" --text-file "$TMP_ROOT/reply.txt" --nonce fail-nonce 2>&1) \
+  && fail "live reply accepted sustained server errors" || true
+printf '%s' "$out" | grep -q "faketoken-abc123" && fail "the token leaked through an injected error body: $out"
+RECEIPTS=$(find "$H/state/discord-workspace/receipts" -name '*.json' 2>/dev/null | wc -l | tr -d ' ')
+[ "$RECEIPTS" = 0 ] || fail "a failed reply left a durable receipt"
+world_set '{"inject":null}'
+pass "sustained API failures record no receipt and never leak the token"
+
+# --- 12. live source ingests only captain messages and advances cursors ------
+new_home h12
+CFG12="$H/config/discord-workspace.json"
+python3 - "$WORLD" <<PY
+import json
+world = json.load(open("$WORLD"))
+world["counter"] = int(world["counter"]) + 1
+forum = str(world["counter"])
+world["counter"] += 1
+thread = str(world["counter"])
+world["counter"] += 1
+stale = str(world["counter"])
+world["threads"] = {"$FORUM_F": [{"id": thread, "parent_id": "$FORUM_F", "name": "tab"}]}
+world["messages"] = {thread: [
+    {"id": stale, "guild_id": "$GUILD", "channel_id": thread, "author": {"id": "$CAPTAIN"}, "content": "older captain message"},
+    {"id": str(int(stale) + 1), "guild_id": "$GUILD", "channel_id": thread, "author": {"id": "333333333333333333", "bot": True}, "content": "bot message"},
+    {"id": str(int(stale) + 2), "guild_id": "$GUILD", "channel_id": thread, "author": {"id": "121212121212121212"}, "content": "unknown author"},
+    {"id": str(int(stale) + 3), "guild_id": "$GUILD", "channel_id": thread, "author": {"id": "$CAPTAIN"}, "content": "newest captain request"},
+]}
+world["threads"]["$FORUM_F"] = world["threads"]["$FORUM_F"] + [{"id": "888888888888888999", "parent_id": "wrong-parent", "name": "foreign"}]
+json.dump(world, open("$WORLD", "w"))
+PY
+out=$(dl live-source --config "$CFG12" 2>&1) || fail "live source failed: $out"
+NOTES=$(find "$H/state/inbox" -maxdepth 1 -name '*.note' 2>/dev/null | wc -l | tr -d ' ')
+[ "$NOTES" = 2 ] || fail "live source created $NOTES notes instead of 2 (captain messages only)"
+grep -rl "newest captain request" "$H/state/inbox" >/dev/null 2>&1 || fail "the newest captain message was not ingested"
+grep -rl "older captain message" "$H/state/inbox" >/dev/null 2>&1 || fail "the older captain message was not ingested"
+if grep -rl "bot message" "$H/state/inbox"/*.note >/dev/null 2>&1; then fail "a bot message was ingested"; fi
+CURSOR=$(find "$H/state/discord-workspace/cursors" -name '*.cursor' -exec cat {} + | sort -n | tail -1)
+EXPECTED=$(python3 -c "import json;w=json.load(open('$WORLD'));print(max(int(m['id']) for ms in w['messages'].values() for m in ms))")
+[ "$CURSOR" = "$EXPECTED" ] || fail "the cursor is $CURSOR instead of the newest id $EXPECTED"
+# Replay is a no-op: same messages, monotonic cursor, no duplicate notes.
+BEFORE_NOTES=$NOTES
+out=$(dl live-source --config "$CFG12" 2>&1) || fail "second live source pass failed: $out"
+AFTER_NOTES=$(find "$H/state/inbox" -maxdepth 1 -name '*.note' 2>/dev/null | wc -l | tr -d ' ')
+[ "$AFTER_NOTES" = "$BEFORE_NOTES" ] || fail "a second source pass duplicated notes"
+# A late lower-id message must not move the cursor backwards or re-ingest.
+python3 - "$WORLD" <<PY
+import json
+world = json.load(open("$WORLD"))
+thread = next(iter(world["messages"]))
+world["messages"][thread].insert(0, {"id": "1", "guild_id": "$GUILD", "channel_id": thread, "author": {"id": "$CAPTAIN"}, "content": "late stale message"})
+json.dump(world, open("$WORLD", "w"))
+PY
+dl live-source --config "$CFG12" >/dev/null 2>&1 || true
+CURSOR2=$(find "$H/state/discord-workspace/cursors" -name '*.cursor' -exec cat {} + | sort -n | tail -1)
+[ "$CURSOR2" = "$EXPECTED" ] || fail "a stale lower-id message moved the cursor backwards to $CURSOR2"
+FINAL_NOTES=$(find "$H/state/inbox" -maxdepth 1 -name '*.note' 2>/dev/null | wc -l | tr -d ' ')
+[ "$FINAL_NOTES" = "$BEFORE_NOTES" ] || fail "the stale message was ingested after the cursor advanced"
+pass "live source ingests only captain messages after durable monotonic cursors"
+
+# --- 13. live roundtrip posts and verifies against Discord ------------------
+new_home h13
+out=$(dl live-roundtrip --config "$H/config/discord-workspace.json" --request-id "$REQUEST_ID" --text-file "$TMP_ROOT/reply.txt" --nonce rt-nonce 2>&1) \
+  || fail "live roundtrip failed: $out"
+assert_contains "$out" "round-trip verified" "the roundtrip verifies the posted message"
+out2=$(dl live-roundtrip --config "$H/config/discord-workspace.json" --request-id "$REQUEST_ID" --text-file "$TMP_ROOT/reply.txt" --nonce rt-nonce 2>&1) \
+  || fail "roundtrip replay failed: $out2"
+assert_contains "$out2" "round-trip verified against the recorded message id" "roundtrip replay verifies from the receipt"
+pass "live roundtrip posts once and verifies in both fresh and replay paths"
+
+# --- cleanup -----------------------------------------------------------------
+kill %1 2>/dev/null || true

--- a/tests/fm-discord-live.test.sh
+++ b/tests/fm-discord-live.test.sh
@@ -21,7 +21,7 @@ THREAD=888888888888888881
 dl() { FM_HOME="$H" "$ROOT/bin/fm-discord-live.sh" "$@"; }
 
 start_server() { # start_server <world-file> <port-file> <guild-id>
-  python3 - "$1" "$2" "$FAKE_TOKEN" "$3" > "$TMP_ROOT/fake-server.log" 2>&1 <<'PY' &
+  setsid python3 - "$1" "$2" "$FAKE_TOKEN" "$3" > "/tmp/livekeep/fake-server.log" 2>&1 <<'PY' &
 import json, sys
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from urllib.parse import urlparse, parse_qs
@@ -135,6 +135,10 @@ class Handler(BaseHTTPRequestHandler):
             world["creates"] = int(world.get("creates", 0)) + 1
             save(world)
             self._send(201, channel)
+        elif len(parts) == 3 and parts[2] == "typing":
+            world["typing"] = int(world.get("typing", 0)) + 1
+            save(world)
+            self._send(204, {})
         elif len(parts) == 3 and parts[2] == "messages":
             if body.get("allowed_mentions") != {"parse": []}:
                 self._send(400, {"message": "allowed_mentions must be empty parse"})
@@ -197,6 +201,7 @@ WORLD="$TMP_ROOT/world.json"
 PORT_FILE="$TMP_ROOT/port"
 printf '{"features":["COMMUNITY"],"channels":[],"threads":{},"messages":{},"creates":0,"posts":0,"counter":900000000000000000}\n' > "$WORLD"
 start_server "$WORLD" "$PORT_FILE" "$GUILD"
+echo "$$" > /tmp/livekeep/test-pid
 PORT=$(cat "$PORT_FILE")
 export FM_DISCORD_LIVE_API_BASE="http://127.0.0.1:$PORT"
 export FM_DISCORD_LIVE_SOPS="$TMP_ROOT/fake-sops"
@@ -419,6 +424,7 @@ assert_contains "$out2" "round-trip verified against the recorded message id" "r
 pass "live roundtrip posts once and verifies in both fresh and replay paths"
 
 
+
 # --- 14. process-event arm gates on the live polling flag --------------------
 pe() { FM_HOME="$1" "$ROOT/bin/fm-procevent.sh" "${@:2}"; }
 ped() { FM_HOME="$1" "$ROOT/bin/fm-procevent-discord-workspace.sh" "${@:2}"; }
@@ -530,8 +536,51 @@ NOTES19=$(find "$H/state/inbox" -maxdepth 1 -name '*.note' 2>/dev/null | wc -l |
 out=$(pe19 "$H" start discord-workspace 2>&1) || fail "installed-runner repeat failed: $out"
 NOTES19B=$(find "$H/state/inbox" -maxdepth 1 -name '*.note' 2>/dev/null | wc -l | tr -d ' ')
 [ "$NOTES19B" = 1 ] || fail "installed-runner repeat duplicated notes"
+probeR1=$(python3 -c "import socket;s=socket.socket();s.settimeout(1);print(s.connect_ex(('127.0.0.1',$PORT)))")
+echo "PROBE_pre_retire=$probeR1"
 pe19 "$H" retire discord-workspace >/dev/null 2>&1 || fail "installed-runner retire failed"
+probeR2=$(python3 -c "import socket;s=socket.socket();s.settimeout(1);print(s.connect_ex(('127.0.0.1',$PORT)))")
+echo "PROBE_post_retire=$probeR2"
 pass "registered argv to the task copy works under a main runner from a different code root"
+probeS1=$(python3 -c "import socket;s=socket.socket();s.settimeout(1);print(s.connect_ex(('127.0.0.1',$PORT)))")
+echo "PROBE_S1=$probeS1"
+sleep 2
+probeS2=$(python3 -c "import socket;s=socket.socket();s.settimeout(1);print(s.connect_ex(('127.0.0.1',$PORT)))")
+echo "PROBE_S2=$probeS2"
+
+
+# --- 20. live mirror posts once, converges with replies, fires typing --------
+new_home h20
+CFG20="$H/config/discord-workspace.json"
+printf 'Mirrored conversational text.\n' > "$TMP_ROOT/mirror.txt"
+out=$(FM_DISCORD_LIVE_API_BASE="$FM_DISCORD_LIVE_API_BASE" dl live-post --config "$CFG20" --thread "$THREAD" --tag main --text-file "$TMP_ROOT/mirror.txt" 2>&1) \
+  || fail "mirror post failed: base=$FM_DISCORD_LIVE_API_BASE out=$out probe=$(python3 -c "import socket;s=socket.socket();s.settimeout(1);print(s.connect_ex(('127.0.0.1',$PORT)))")"
+assert_contains "$out" "receipt recorded" "the mirror records its receipt"
+POSTS=$(python3 -c "import json;print(json.load(open('$WORLD'))['posts'])")
+TYPING=$(python3 -c "import json;print(json.load(open('$WORLD')).get('typing',0))")
+[ "$TYPING" -ge 1 ] || fail "no typing marker fired around the mirror post"
+out=$(dl live-post --config "$CFG20" --thread "$THREAD" --tag main --text-file "$TMP_ROOT/mirror.txt" 2>&1) \
+  || fail "mirror replay failed: $out"
+assert_contains "$out" "no second post" "mirror replay reports convergence"
+POSTS2=$(python3 -c "import json;print(json.load(open('$WORLD'))['posts'])")
+[ "$POSTS2" = "$POSTS" ] || fail "mirror replay posted again"
+# An explicit reply with the same text converges on the mirror's delivery.
+out=$(dl live-reply --config "$CFG20" --request-id "discord:$GUILD:$THREAD:777777777777777701" --text-file "$TMP_ROOT/mirror.txt" --nonce converge-nonce 2>&1) \
+  || fail "converging reply failed: $out"
+assert_contains "$out" "no second delivery" "an explicit reply with identical text converges on the mirror"
+# Operational text never mirrors.
+printf 'FIRSTMATE WATCHER WAKE: stale\n' > "$TMP_ROOT/op.txt"
+op_status=0
+op_out=$(dl live-post --config "$CFG20" --thread "$THREAD" --tag main --text-file "$TMP_ROOT/op.txt" 2>&1) || op_status=$?
+[ "$op_status" -ne 0 ] || fail "operational text was mirrored"
+assert_contains "$op_out" "refusing to mirror operational text" "operational markers are refused before any post"
+CURSOR_ENTRIES=$(python3 -c "import json;print(len(json.load(open('$H/state/discord-workspace/mirror-cursor.json'))))")
+[ "$CURSOR_ENTRIES" = 1 ] || fail "the mirror cursor logged $CURSOR_ENTRIES deliveries instead of 1"
+# Mirror refuses a thread outside the configured allowlist.
+out=$(dl live-post --config "$CFG20" --thread 123456789012345678 --tag main --text-file "$TMP_ROOT/mirror.txt" 2>&1) \
+  && fail "mirror accepted a non-allowlisted thread" || true
+assert_contains "$out" "outside the configured allowlist" "the mirror stays bounded to allowlisted threads"
+pass "live mirror posts once, fires typing, converges with replies, and stays allowlist-bounded"
 
 # --- cleanup -----------------------------------------------------------------
 kill %1 2>/dev/null || true

--- a/tests/fm-discord-workspace-concurrency.test.sh
+++ b/tests/fm-discord-workspace-concurrency.test.sh
@@ -35,9 +35,9 @@ PY
 }
 
 run_parallel() { # run_parallel <mode> <key> <payload-json> [<count>]
-  local mode=$1 key=$2 payload=$3 count=${4:-8} i out_file
+  local mode=$1 key=$2 payload=$3 count=${4:-8} out_file
   out_file=$(mktemp)
-  for i in $(seq 1 "$count"); do
+  for _ in $(seq 1 "$count"); do
     worker "$mode" "$key" "$payload" >> "$out_file" 2>&1 &
   done
   wait

--- a/tests/fm-discord-workspace-concurrency.test.sh
+++ b/tests/fm-discord-workspace-concurrency.test.sh
@@ -1,0 +1,154 @@
+#!/usr/bin/env bash
+# Focused concurrency and descriptor-safety tests for the Discord workspace core:
+# serialized receipt/artifact/task-link writes and descriptor-bound file reads.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+TMP_ROOT=$(fm_test_tmproot fm-discord-concurrency-tests)
+HOME1="$TMP_ROOT/home"
+mkdir -p "$HOME1/state" "$HOME1/data" "$HOME1/config"
+FM_HOME="$HOME1"
+export FM_HOME
+LIB="$ROOT/bin/fm_discord_workspace_lib.py"
+
+worker() { # worker <mode> <key> <payload-json>
+  python3 - "$LIB" "$1" "$2" "$3" <<'PY'
+import importlib.util, json, sys
+spec = importlib.util.spec_from_file_location("fwl", sys.argv[1])
+fwl = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(fwl)
+mode, key, payload = sys.argv[2], sys.argv[3], json.loads(sys.argv[4])
+env = fwl.Env(sys.argv[1])
+try:
+    if mode == "receipt":
+        print(fwl.record_receipt(env, key, payload, "mid-" + key))
+    elif mode == "artifact":
+        print(fwl.write_artifact_record(env, key, payload))
+    elif mode == "tasklink":
+        print(fwl.write_same_or_refuse(fwl.task_link_path(env, key), payload, "task link"))
+except fwl.FMError as exc:
+    print("FMError:", exc)
+PY
+}
+
+run_parallel() { # run_parallel <mode> <key> <payload-json> [<count>]
+  local mode=$1 key=$2 payload=$3 count=${4:-8} i out_file
+  out_file=$(mktemp)
+  for i in $(seq 1 "$count"); do
+    worker "$mode" "$key" "$payload" >> "$out_file" 2>&1 &
+  done
+  wait
+  sort "$out_file"
+  rm -f "$out_file"
+}
+
+# --- concurrent identical receipt writes: exactly one durable record ----
+receipt_payload='{"kind":"reply","profile":"proapplis","text_digest":"deadbeef"}'
+results=$(run_parallel receipt n1 "$receipt_payload")
+[ "$(printf '%s\n' "$results" | grep -c 'receipt recorded')" -eq 1 ] \
+  || fail "expected exactly one receipt recorded, got: $results"
+[ "$(printf '%s\n' "$results" | grep -c 'receipt exists')" -eq 7 ] \
+  || fail "expected seven idempotent receipt exists results, got: $results"
+[ -f "$HOME1/state/discord-workspace/receipts/$(python3 -c "import hashlib,sys;print(hashlib.sha256(b'n1').hexdigest())").json" ] \
+  || fail "receipt file missing after concurrent writes"
+pass "concurrent identical receipt writes serialize to one durable receipt"
+
+# --- conflicting receipt for the same nonce is refused ------------------
+results=$(run_parallel receipt n1 '{"kind":"reply","profile":"proapplis","text_digest":"cafebabe"}' 4)
+printf '%s\n' "$results" | grep -q 'FMError: refusing to overwrite a different Discord outbound receipt' \
+  || fail "conflicting receipt payload was not refused: $results"
+pass "conflicting receipt payload for the same nonce is refused"
+
+# --- concurrent identical artifact writes: one canonical record ---------
+artifact_payload='{"schema":"fw-artifact.v1","artifact_id":"art1","profile":"proapplis","purpose":"exchange"}'
+results=$(run_parallel artifact art1 "$artifact_payload")
+[ "$(printf '%s\n' "$results" | grep -c 'artifact record written')" -eq 1 ] \
+  || fail "expected exactly one artifact record written, got: $results"
+[ "$(printf '%s\n' "$results" | grep -c 'artifact record exists')" -eq 7 ] \
+  || fail "expected seven idempotent artifact exists results, got: $results"
+pass "concurrent identical artifact writes produce one canonical artifact record"
+
+# --- conflicting artifact record for the same id is refused -------------
+results=$(run_parallel artifact art1 '{"schema":"fw-artifact.v1","artifact_id":"art1","profile":"proapplis","purpose":"other"}' 4)
+printf '%s\n' "$results" | grep -q 'FMError: refusing to overwrite a different artifact record' \
+  || fail "conflicting artifact record was not refused: $results"
+pass "conflicting artifact record for the same id is refused"
+
+# --- concurrent identical task-link writes ------------------------------
+tasklink_payload='{"schema":"fw-task-link.v1","task_id":"tl1","request_id":"discord:1:2:3"}'
+results=$(run_parallel tasklink tl1 "$tasklink_payload")
+[ "$(printf '%s\n' "$results" | grep -c 'task link written')" -eq 1 ] \
+  || fail "expected exactly one task link written, got: $results"
+[ "$(printf '%s\n' "$results" | grep -c 'task link exists')" -eq 7 ] \
+  || fail "expected seven idempotent task link exists results, got: $results"
+pass "concurrent identical task-link writes are idempotent"
+
+# --- conflicting task-link content is refused ---------------------------
+results=$(run_parallel tasklink tl1 '{"schema":"fw-task-link.v1","task_id":"tl1","request_id":"discord:1:2:9"}' 4)
+printf '%s\n' "$results" | grep -q 'FMError: refusing to overwrite a different task link' \
+  || fail "conflicting task link was not refused: $results"
+pass "conflicting task-link content is refused"
+
+# --- descriptor-bound reads: symlinks and traversal are refused ----------
+target="$TMP_ROOT/plain.txt"
+printf 'hello' > "$target"
+link="$TMP_ROOT/link.txt"
+ln -s "$target" "$link"
+descriptor_out=$(python3 - "$LIB" "$target" "$link" "$TMP_ROOT" <<'PY'
+import importlib.util, os, sys
+from pathlib import Path
+spec = importlib.util.spec_from_file_location("fwl", sys.argv[1])
+fwl = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(fwl)
+target, link, root = Path(sys.argv[2]), Path(sys.argv[3]), Path(sys.argv[4])
+
+def expect_refuse(fn, label):
+    try:
+        fn()
+        print("NO-REFUSE", label)
+    except fwl.FMError as exc:
+        print("refused", label, "-", exc)
+
+print("read:", fwl.read_text_file(str(target)))
+expect_refuse(lambda: fwl.read_text_file(str(link)), "symlinked text file")
+
+def traversal():
+    with fwl.open_regular_under_root(root, Path("../escape.txt"), "artifact"):
+        pass
+expect_refuse(traversal, "root traversal via ..")
+
+def empty_relative():
+    with fwl.open_regular_under_root(root, Path(""), "artifact"):
+        pass
+expect_refuse(empty_relative, "empty relative path")
+
+nested_dir = root / "sub"
+nested_dir.mkdir(exist_ok=True)
+nested = nested_dir / "artifact.txt"
+nested.write_text("artifact body")
+with fwl.open_regular_under_root(root, Path("sub/artifact.txt"), "artifact") as (fd, before):
+    data = os.read(fd, 1024)
+    after = os.fstat(fd)
+print("under-root read:", data.decode(), "unchanged:", fwl.descriptor_unchanged(before, after, len(data)))
+
+with fwl.open_regular_readonly(target, "text file") as (fd, before):
+    data = os.read(fd, 1024)
+    after = os.fstat(fd)
+print("readonly unchanged:", fwl.descriptor_unchanged(before, after, len(data)))
+print("tampered unchanged:", fwl.descriptor_unchanged(before, after, len(data) + 1))
+PY
+) || descriptor_out="$descriptor_out (python failed)"
+printf '%s\n' "$descriptor_out" | grep -q 'NO-REFUSE' \
+  && fail "an unsafe descriptor read was not refused: $descriptor_out"
+printf '%s\n' "$descriptor_out" | grep -q 'read: hello' || fail "plain text read failed: $descriptor_out"
+printf '%s\n' "$descriptor_out" | grep -q 'refused symlinked text file' || fail "symlinked text read not refused: $descriptor_out"
+printf '%s\n' "$descriptor_out" | grep -q 'refused root traversal' || fail "traversal read not refused: $descriptor_out"
+printf '%s\n' "$descriptor_out" | grep -q 'refused empty relative path' || fail "empty relative path not refused: $descriptor_out"
+printf '%s\n' "$descriptor_out" | grep -q 'under-root read: artifact body unchanged: True' \
+  || fail "under-root descriptor read failed: $descriptor_out"
+printf '%s\n' "$descriptor_out" | grep -q 'readonly unchanged: True' || fail "readonly descriptor check failed: $descriptor_out"
+printf '%s\n' "$descriptor_out" | grep -q 'tampered unchanged: False' || fail "tampered descriptor not detected: $descriptor_out"
+pass "descriptor-bound reads refuse symlinks and traversal and verify descriptor stability"

--- a/tests/fm-discord-workspace.test.sh
+++ b/tests/fm-discord-workspace.test.sh
@@ -949,8 +949,8 @@ mkdir -p "$HOME2/state/discord-workspace" "$HOME2/data" "$HOME2/config"
 cp "$CFG" "$HOME2/config/discord-workspace.json"
 printf 'blocks task-link directory creation\n' > "$HOME2/state/discord-workspace/task-links"
 link_failure_status=0
-link_failure_out=$(FM_HOME="$HOME2" "$ROOT/bin/fm-discord-workspace.sh" link-task guarded-partial \
-  --config "$HOME2/config/discord-workspace.json" --request-id "$request_id" 2>&1) || link_failure_status=$?
+FM_HOME="$HOME2" "$ROOT/bin/fm-discord-workspace.sh" link-task guarded-partial \
+  --config "$HOME2/config/discord-workspace.json" --request-id "$request_id" >/dev/null 2>&1 || link_failure_status=$?
 [ "$link_failure_status" -ne 0 ] || fail "task-link publication failure unexpectedly succeeded"
 assert_present "$HOME2/state/discord-workspace/pending-followups/guarded-partial.json" "task-link failure preserves its pending-final guard"
 partial_guard_status=0

--- a/tests/fm-discord-workspace.test.sh
+++ b/tests/fm-discord-workspace.test.sh
@@ -1,0 +1,222 @@
+#!/usr/bin/env bash
+# Behavior tests for private Discord workspace planning, receipts, and artifacts.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+TMP_ROOT=$(fm_test_tmproot fm-discord-workspace-tests)
+HOME1="$TMP_ROOT/home"
+mkdir -p "$HOME1/state" "$HOME1/data" "$HOME1/config" "$HOME1/projects"
+CFG="$HOME1/config/discord-workspace.json"
+FM_HOME="$HOME1" "$ROOT/bin/fm-discord-workspace.sh" sample-config > "$CFG"
+python3 - "$CFG" <<'PY'
+import json, sys
+p=sys.argv[1]
+data=json.load(open(p))
+data["profiles"]["proapplis"]["thread_ids"]["exchange"]=["888888888888888881"]
+data["profiles"]["proapplis"]["thread_ids"]["artifacts"]=["888888888888888882"]
+data["transcription"]["provider"]="fake"
+data["transcription"]["fake_transcripts"]={"999999999999999998":"transcribed voice fixture"}
+json.dump(data, open(p,"w"), indent=2, sort_keys=True)
+PY
+
+fw() { FM_HOME="$HOME1" "$ROOT/bin/fm-discord-workspace.sh" "$@"; }
+request_id='discord:111111111111111111:888888888888888881:999999999999999999'
+thread_request_id='discord:111111111111111111:888888888888888881:999999999999999997'
+
+out=$(fw config-check --config "$CFG")
+assert_contains "$out" "config ok" "valid config passes"
+assert_contains "$out" "ProApplis: exchange threads 1" "thread allowlist is reported"
+pass "valid non-secret config is accepted"
+
+DUP="$TMP_ROOT/duplicate.json"
+cp "$CFG" "$DUP"
+python3 - "$DUP" <<'PY'
+import json, sys
+p=sys.argv[1]
+data=json.load(open(p))
+data["profiles"]["folium"]["exchange_forum_id"]=data["profiles"]["proapplis"]["exchange_forum_id"]
+json.dump(data, open(p,"w"), indent=2, sort_keys=True)
+PY
+dup_status=0
+dup_out=$(fw config-check --config "$DUP" 2>&1) || dup_status=$?
+[ "$dup_status" -ne 0 ] || fail "duplicate forum id was accepted"
+assert_contains "$dup_out" "duplicate Discord id" "duplicate forum id refusal is explicit"
+
+DISABLED="$TMP_ROOT/disabled.json"
+cp "$CFG" "$DISABLED"
+python3 - "$DISABLED" <<'PY'
+import json, sys
+p=sys.argv[1]
+data=json.load(open(p))
+data["profiles"]["lbdb"]={"enabled": True, "category_id":"121212121212121212"}
+json.dump(data, open(p,"w"), indent=2, sort_keys=True)
+PY
+disabled_status=0
+disabled_out=$(fw config-check --config "$DISABLED" 2>&1) || disabled_status=$?
+[ "$disabled_status" -ne 0 ] || fail "enabled dormant profile was accepted"
+assert_contains "$disabled_out" "disabled profile lbdb" "disabled profile refusal is explicit"
+
+SECRET="$TMP_ROOT/secret.json"
+cp "$CFG" "$SECRET"
+python3 - "$SECRET" <<'PY'
+import json, sys
+p=sys.argv[1]
+data=json.load(open(p))
+data["bot_token"]="do-not-print-this-value"
+json.dump(data, open(p,"w"), indent=2, sort_keys=True)
+PY
+secret_status=0
+secret_out=$(fw config-check --config "$SECRET" 2>&1) || secret_status=$?
+[ "$secret_status" -ne 0 ] || fail "inline secret-looking config was accepted"
+assert_contains "$secret_out" "inline secret" "inline secret refusal is explicit"
+assert_not_contains "$secret_out" "do-not-print-this-value" "secret-looking value is not printed"
+pass "config rejects duplicate channels, enabled dormant profiles, and inline secrets"
+
+out=$(fw setup --dry-run --config "$CFG")
+assert_contains "$out" "no network" "setup dry-run says it is offline"
+assert_contains "$out" "temporary setup permission integer" "setup dry-run prints setup permissions"
+assert_contains "$out" "steady-state permission integer" "setup dry-run prints steady permissions"
+assert_contains "$out" "exchanges forum" "setup dry-run names exchange forums"
+assert_contains "$out" "artifacts forum" "setup dry-run names artifact forums"
+assert_contains "$out" "request, decision, work, status, blocked, done" "setup dry-run prints exchange tags"
+assert_contains "$out" "report, board, document, image, audio, draft, final, expired" "setup dry-run prints artifact tags"
+assert_contains "$out" "remaining unapproved live choices" "setup dry-run reports inactive live choices"
+apply_status=0
+apply_out=$(fw setup --apply --config "$CFG" 2>&1) || apply_status=$?
+[ "$apply_status" -ne 0 ] || fail "setup --apply was accepted"
+assert_contains "$apply_out" "not available" "setup --apply refuses in phase one"
+
+LIVECHOICES="$TMP_ROOT/live-choices.json"
+cp "$CFG" "$LIVECHOICES"
+python3 - "$LIVECHOICES" <<'PY'
+import json, sys
+p=sys.argv[1]
+data=json.load(open(p))
+data["approvals"]["message_content"]=True
+data["approvals"]["temporary_setup_permissions"]=True
+data["approvals"]["hosted_groq"]=True
+data["approvals"]["community_mode_required"]=True
+data["live"]={"polling": True, "posting": True, "host": "omarchy"}
+data["outbound"]["live_posting"]=True
+data["artifacts"]["access"]="tailnet"
+data["artifacts"]["default_expiry"]="3d"
+data["transcription"]["provider"]="groq"
+json.dump(data, open(p,"w"), indent=2, sort_keys=True)
+PY
+out=$(fw setup --dry-run --config "$LIVECHOICES")
+assert_contains "$out" "Discord MESSAGE_CONTENT is configured but inactive" "message content remains inert when configured"
+assert_contains "$out" "host omarchy is configured but not activated" "host choice remains inert when configured"
+assert_contains "$out" "hosted Groq transcription is configured but inactive" "hosted Groq remains inert when configured"
+assert_contains "$out" "artifact access tailnet with expiry 3d is configured but inactive" "artifact access remains inert when configured"
+assert_contains "$out" "temporary setup permissions are configured but unusable" "temporary setup permissions remain inert when configured"
+assert_contains "$out" "live posting is configured but refused" "live posting remains inert when configured"
+assert_contains "$out" "live process-event polling is configured but refused" "live polling remains inert when configured"
+pass "setup planning is explicit, live choices stay inert, and apply mode refuses"
+
+health_status=0
+health_out=$(FMX_PAIRING_TOKEN='do-not-print-this-value' fw health --secrets --config "$CFG" 2>&1) || health_status=$?
+[ "$health_status" -ne 0 ] || fail "live secret health unexpectedly succeeded"
+assert_contains "$health_out" "no secret was decrypted or printed" "secret health reports the privacy boundary"
+assert_not_contains "$health_out" "do-not-print-this-value" "secret health never prints ambient secrets"
+discord_status=0
+discord_out=$(fw health --discord --config "$CFG" 2>&1) || discord_status=$?
+[ "$discord_status" -ne 0 ] || fail "live Discord health unexpectedly succeeded"
+assert_contains "$discord_out" "no network call" "Discord health refuses without network"
+pass "health checks stay dry-run only"
+
+TEXT="$TMP_ROOT/reply.txt"
+printf 'Reply text for Discord.\n' > "$TEXT"
+out=$(fw reply --config "$CFG" --request-id "$request_id" --text-file "$TEXT")
+assert_contains "$out" "Discord reply plan" "reply renders a dry-run plan"
+assert_contains "$out" '"parse": []' "reply disables mentions"
+assert_contains "$out" "no Discord post was made" "reply dry-run avoids posting"
+out=$(fw reply --config "$CFG" --request-id "$request_id" --text-file "$TEXT" --record-discord-message-id 123456789012345678)
+assert_contains "$out" "receipt recorded" "reply receipt is recorded"
+out=$(fw reply --config "$CFG" --request-id "$request_id" --text-file "$TEXT" --record-discord-message-id 123456789012345678)
+assert_contains "$out" "receipt exists" "reply receipt deduplicates retries"
+receipt_count=$(find "$HOME1/state/discord-workspace/receipts" -type f -name '*.json' | wc -l | tr -d ' ')
+[ "$receipt_count" = 1 ] || fail "receipt retry created duplicate receipts"
+pass "outbound reply receipts are idempotent"
+
+out=$(fw link-task discord-task --config "$CFG" --request-id "$thread_request_id")
+assert_contains "$out" "request record written" "link-task writes the request record"
+assert_contains "$out" "task link written" "link-task writes the task link"
+assert_contains "$out" "pending final follow-up written" "link-task writes a pending final follow-up"
+guard_status=0
+guard_out=$(fw guard-work discord-task 2>&1) || guard_status=$?
+[ "$guard_status" -ne 0 ] || fail "guard-work allowed a pending final reply"
+assert_contains "$guard_out" "still owes" "guard-work names the pending final reply"
+out=$(fw followup discord-task --config "$CFG" --final --text-file "$TEXT")
+assert_contains "$out" "pending final follow-up: present" "dry-run final follow-up sees the pending record"
+assert_contains "$out" "remains unresolved" "dry-run final follow-up does not clear the promise"
+out=$(fw followup discord-task --config "$CFG" --final --text-file "$TEXT" --record-discord-message-id 123456789012345679)
+assert_contains "$out" "pending final follow-up delivered" "recorded final follow-up clears the pending state"
+fw guard-work discord-task >/dev/null || fail "guard-work refused after final delivery"
+pass "request links preserve and clear pending final replies"
+
+REPORT="$HOME1/data/report.md"
+printf '# Report\n\nSafe report.\n' > "$REPORT"
+out=$(fw artifact --config "$CFG" --profile proapplis --file "$REPORT" --purpose report --request-id "$request_id")
+assert_contains "$out" "canonical post forum" "artifact plan names the canonical artifact forum"
+assert_contains "$out" "exchange summary includes a card and link only" "artifact plan avoids duplicate binaries"
+assert_contains "$out" "direct attachment in the artifacts forum only" "small artifact plan uses one direct attachment"
+out=$(fw artifact --config "$CFG" --profile proapplis --file "$REPORT" --purpose report --request-id "$request_id" --record-discord-message-id 123456789012345680)
+assert_contains "$out" "artifact record written" "recorded artifact writes its artifact record"
+assert_contains "$out" "receipt recorded" "recorded artifact writes a receipt"
+duplicate_artifact_status=0
+duplicate_artifact_out=$(fw artifact --config "$CFG" --profile proapplis --file "$REPORT" --purpose final --request-id "$request_id" --record-discord-message-id 123456789012345681 2>&1) || duplicate_artifact_status=$?
+[ "$duplicate_artifact_status" -ne 0 ] || fail "duplicate canonical artifact source was accepted"
+assert_contains "$duplicate_artifact_out" "already has a canonical artifact" "canonical artifact source cannot be posted twice"
+
+mkdir -p "$HOME1/projects/client"
+printf '# Project report\n' > "$HOME1/projects/client/report.md"
+project_status=0
+project_out=$(fw artifact --config "$CFG" --profile proapplis --file "$HOME1/projects/client/report.md" --purpose report 2>&1) || project_status=$?
+[ "$project_status" -ne 0 ] || fail "project path artifact was accepted"
+assert_contains "$project_out" "under projects" "project artifact refusal names the path class"
+
+printf 'not really an image\n' > "$HOME1/data/bad.png"
+mime_status=0
+mime_out=$(fw artifact --config "$CFG" --profile proapplis --file "$HOME1/data/bad.png" --purpose image 2>&1) || mime_status=$?
+[ "$mime_status" -ne 0 ] || fail "MIME mismatch was accepted"
+assert_contains "$mime_out" "PNG extension" "MIME mismatch refusal names the mismatch"
+
+printf 'archive bytes\n' > "$HOME1/data/archive.zip"
+archive_status=0
+archive_out=$(fw artifact --config "$CFG" --profile proapplis --file "$HOME1/data/archive.zip" --purpose document 2>&1) || archive_status=$?
+[ "$archive_status" -ne 0 ] || fail "archive artifact was accepted"
+assert_contains "$archive_out" "blocked" "archive refusal reports the default block"
+
+printf 'secret bytes\n' > "$HOME1/data/api-token.txt"
+secret_artifact_status=0
+secret_artifact_out=$(fw artifact --config "$CFG" --profile proapplis --file "$HOME1/data/api-token.txt" --purpose document 2>&1) || secret_artifact_status=$?
+[ "$secret_artifact_status" -ne 0 ] || fail "secret-looking artifact was accepted"
+assert_contains "$secret_artifact_out" "blocked" "secret-looking artifact refusal reports the default block"
+
+BIG="$HOME1/data/big.txt"
+python3 - "$BIG" <<'PY'
+import sys
+with open(sys.argv[1], "wb") as f:
+    f.write(b"a" * (8 * 1024 * 1024 + 1))
+PY
+big_status=0
+big_out=$(fw artifact --config "$CFG" --profile proapplis --file "$BIG" --purpose document 2>&1) || big_status=$?
+[ "$big_status" -ne 0 ] || fail "oversized direct artifact was accepted"
+assert_contains "$big_out" "exceeds the direct attachment cap" "oversized artifact points to private publishing"
+pass "artifact planning blocks unsafe paths, MIME mismatches, archives, secrets, and oversized direct uploads"
+
+DOCUMENT="$HOME1/data/document.md"
+printf '# Document\n\nSafe document.\n' > "$DOCUMENT"
+out=$(fw publish-artifact --config "$CFG" --profile proapplis --file "$DOCUMENT" --purpose document --url 'https://private.example.invalid/capability/abcdefghijklmnopqrstuvwxyz' --access tailnet --expires 7d --record)
+assert_contains "$out" "Private artifact link plan" "private artifact publishing renders a plan"
+assert_contains "$out" "artifact record" "private artifact publishing records metadata when asked"
+pass "larger private artifact interface records expiring link metadata"
+
+retire_status=0
+retire_out=$(fw retire --config "$CFG" 2>&1) || retire_status=$?
+[ "$retire_status" -eq 0 ] || fail "retire refused after pending final was delivered: $retire_out"
+assert_contains "$retire_out" "retirement dry-run" "retirement stays dry-run"
+pass "safe retirement preserves state and refuses no live action"

--- a/tests/fm-discord-workspace.test.sh
+++ b/tests/fm-discord-workspace.test.sh
@@ -31,6 +31,301 @@ assert_contains "$out" "config ok" "valid config passes"
 assert_contains "$out" "ProApplis: exchange threads 1" "thread allowlist is reported"
 pass "valid non-secret config is accepted"
 
+for invalid_expiry in '' 0d forever; do
+  INVALID_EXPIRY="$TMP_ROOT/invalid-expiry-${invalid_expiry:-empty}.json"
+  python3 - "$CFG" "$INVALID_EXPIRY" "$invalid_expiry" <<'PY'
+import json, sys
+with open(sys.argv[1], encoding="utf-8") as stream:
+    data = json.load(stream)
+data["artifacts"]["default_expiry"] = sys.argv[3]
+with open(sys.argv[2], "w", encoding="utf-8") as stream:
+    json.dump(data, stream)
+PY
+  invalid_expiry_status=0
+  invalid_expiry_out=$(fw config-check --config "$INVALID_EXPIRY" 2>&1) || invalid_expiry_status=$?
+  [ "$invalid_expiry_status" -ne 0 ] || fail "invalid default artifact expiry was accepted: $invalid_expiry"
+  assert_contains "$invalid_expiry_out" "positive duration" "invalid default artifact expiry is refused"
+done
+for invalid_audio_bytes in 0 -1; do
+  INVALID_AUDIO_BYTES="$TMP_ROOT/invalid-audio-bytes-$invalid_audio_bytes.json"
+  python3 - "$CFG" "$INVALID_AUDIO_BYTES" "$invalid_audio_bytes" <<'PY'
+import json, sys
+with open(sys.argv[1], encoding="utf-8") as stream:
+    data = json.load(stream)
+data["audio"]["max_bytes"] = int(sys.argv[3])
+with open(sys.argv[2], "w", encoding="utf-8") as stream:
+    json.dump(data, stream)
+PY
+  invalid_audio_bytes_status=0
+  invalid_audio_bytes_out=$(fw config-check --config "$INVALID_AUDIO_BYTES" 2>&1) || invalid_audio_bytes_status=$?
+  [ "$invalid_audio_bytes_status" -ne 0 ] || fail "non-positive audio byte limit was accepted: $invalid_audio_bytes"
+  assert_contains "$invalid_audio_bytes_out" "positive JSON integer" "non-positive audio byte limit is refused"
+done
+for byte_field in direct audio; do
+  for invalid_type in boolean string fraction; do
+    INVALID_BYTE_TYPE="$TMP_ROOT/invalid-$byte_field-$invalid_type.json"
+    python3 - "$CFG" "$INVALID_BYTE_TYPE" "$byte_field" "$invalid_type" <<'PY'
+import json, sys
+with open(sys.argv[1], encoding="utf-8") as stream:
+    data = json.load(stream)
+value = {"boolean": True, "string": "1024", "fraction": 1024.5}[sys.argv[4]]
+if sys.argv[3] == "direct":
+    data["artifacts"]["direct_attachment_max_bytes"] = value
+else:
+    data["audio"]["max_bytes"] = value
+with open(sys.argv[2], "w", encoding="utf-8") as stream:
+    json.dump(data, stream)
+PY
+    invalid_byte_status=0
+    invalid_byte_out=$(fw config-check --config "$INVALID_BYTE_TYPE" 2>&1) || invalid_byte_status=$?
+    [ "$invalid_byte_status" -ne 0 ] || fail "$byte_field byte limit accepted $invalid_type JSON"
+    assert_contains "$invalid_byte_out" "positive JSON integer" "$byte_field byte limit rejects invalid JSON type"
+  done
+done
+pass "config validates artifact expiry and byte limit types"
+
+for invalid_root_case in empty whitespace boolean numeric list object dot traversal; do
+  INVALID_ROOT_CFG="$TMP_ROOT/invalid-root-$invalid_root_case.json"
+  python3 - "$CFG" "$INVALID_ROOT_CFG" "$invalid_root_case" <<'PY'
+import json, sys
+with open(sys.argv[1], encoding="utf-8") as stream:
+    data = json.load(stream)
+value = {
+    "empty": "",
+    "whitespace": "   ",
+    "boolean": True,
+    "numeric": 7,
+    "list": ["data"],
+    "object": {"root": "data"},
+    "dot": ".",
+    "traversal": "../outside",
+}[sys.argv[3]]
+data["artifacts"]["allowed_roots"] = [value]
+with open(sys.argv[2], "w", encoding="utf-8") as stream:
+    json.dump(data, stream)
+PY
+  invalid_root_status=0
+  invalid_root_out=$(fw config-check --config "$INVALID_ROOT_CFG" 2>&1) || invalid_root_status=$?
+  [ "$invalid_root_status" -ne 0 ] || fail "invalid artifact root was accepted: $invalid_root_case"
+  assert_contains "$invalid_root_out" "artifacts.allowed_roots[0]" "invalid artifact root identifies its config item"
+done
+for valid_root_case in relative absolute; do
+  VALID_ROOT_CFG="$TMP_ROOT/valid-root-$valid_root_case.json"
+  python3 - "$CFG" "$VALID_ROOT_CFG" "$valid_root_case" "$HOME1" <<'PY'
+import json, sys
+with open(sys.argv[1], encoding="utf-8") as stream:
+    data = json.load(stream)
+data["artifacts"]["allowed_roots"] = [
+    "data/custom-artifacts" if sys.argv[3] == "relative" else f"{sys.argv[4]}/data/custom-artifacts"
+]
+with open(sys.argv[2], "w", encoding="utf-8") as stream:
+    json.dump(data, stream)
+PY
+  valid_root_out=$(fw config-check --config "$VALID_ROOT_CFG")
+  assert_contains "$valid_root_out" "config ok" "valid $valid_root_case custom artifact root remains supported"
+done
+pass "artifact roots require explicit non-empty string forms"
+
+for invalid_provider_case in unknown boolean numeric list object null; do
+  INVALID_PROVIDER_CFG="$TMP_ROOT/invalid-provider-$invalid_provider_case.json"
+  python3 - "$CFG" "$INVALID_PROVIDER_CFG" "$invalid_provider_case" <<'PY'
+import json, sys
+with open(sys.argv[1], encoding="utf-8") as stream:
+    data = json.load(stream)
+data["transcription"]["provider"] = {
+    "unknown": "fakse",
+    "boolean": True,
+    "numeric": 1,
+    "list": ["fake"],
+    "object": {"name": "fake"},
+    "null": None,
+}[sys.argv[3]]
+with open(sys.argv[2], "w", encoding="utf-8") as stream:
+    json.dump(data, stream)
+PY
+  invalid_provider_status=0
+  invalid_provider_out=$(fw config-check --config "$INVALID_PROVIDER_CFG" 2>&1) || invalid_provider_status=$?
+  [ "$invalid_provider_status" -ne 0 ] || fail "invalid transcription provider was accepted: $invalid_provider_case"
+  assert_contains "$invalid_provider_out" "transcription.provider must be disabled, fake, or groq" "invalid transcription provider is rejected at config load"
+done
+for valid_provider in disabled fake groq; do
+  VALID_PROVIDER_CFG="$TMP_ROOT/valid-provider-$valid_provider.json"
+  python3 - "$CFG" "$VALID_PROVIDER_CFG" "$valid_provider" <<'PY'
+import json, sys
+with open(sys.argv[1], encoding="utf-8") as stream:
+    data = json.load(stream)
+data["transcription"]["provider"] = sys.argv[3]
+with open(sys.argv[2], "w", encoding="utf-8") as stream:
+    json.dump(data, stream)
+PY
+  valid_provider_out=$(fw config-check --config "$VALID_PROVIDER_CFG")
+  assert_contains "$valid_provider_out" "config ok" "supported $valid_provider transcription provider remains valid"
+done
+pass "transcription providers enforce supported JSON strings"
+
+for invalid_cdn_case in empty whitespace boolean numeric list object scheme port path wildcard trailing-dot uppercase duplicate; do
+  INVALID_CDN_CFG="$TMP_ROOT/invalid-cdn-$invalid_cdn_case.json"
+  python3 - "$CFG" "$INVALID_CDN_CFG" "$invalid_cdn_case" <<'PY'
+import json, sys
+with open(sys.argv[1], encoding="utf-8") as stream:
+    data = json.load(stream)
+value = {
+    "empty": "",
+    "whitespace": "   ",
+    "boolean": True,
+    "numeric": 7,
+    "list": ["cdn.discordapp.com"],
+    "object": {"host": "cdn.discordapp.com"},
+    "scheme": "https://cdn.discordapp.com",
+    "port": "cdn.discordapp.com:443",
+    "path": "cdn.discordapp.com/audio",
+    "wildcard": "*.discordapp.com",
+    "trailing-dot": "cdn.discordapp.com.",
+    "uppercase": "CDN.DISCORDAPP.COM",
+    "duplicate": "cdn.discordapp.com",
+}[sys.argv[3]]
+data["audio"]["allowed_cdn_hosts"] = (
+    ["cdn.discordapp.com", value] if sys.argv[3] == "duplicate" else [value]
+)
+with open(sys.argv[2], "w", encoding="utf-8") as stream:
+    json.dump(data, stream)
+PY
+  invalid_cdn_status=0
+  invalid_cdn_out=$(fw config-check --config "$INVALID_CDN_CFG" 2>&1) || invalid_cdn_status=$?
+  [ "$invalid_cdn_status" -ne 0 ] || fail "invalid CDN hostname was accepted: $invalid_cdn_case"
+  assert_contains "$invalid_cdn_out" "audio.allowed_cdn_hosts" "invalid CDN hostname identifies its config item"
+done
+VALID_CDN_CFG="$TMP_ROOT/valid-cdn-hosts.json"
+python3 - "$CFG" "$VALID_CDN_CFG" <<'PY'
+import json, sys
+with open(sys.argv[1], encoding="utf-8") as stream:
+    data = json.load(stream)
+data["audio"]["allowed_cdn_hosts"] = ["cdn.discordapp.com", "media.discordapp.net"]
+with open(sys.argv[2], "w", encoding="utf-8") as stream:
+    json.dump(data, stream)
+PY
+valid_cdn_out=$(fw config-check --config "$VALID_CDN_CFG")
+assert_contains "$valid_cdn_out" "config ok" "safe Discord CDN hostname defaults remain valid"
+pass "audio CDN policy requires unique normalized hostnames"
+
+for policy_alias in host live-host approvals-host artifact-access artifact-access-mode; do
+  for invalid_policy_type in boolean numeric list object null; do
+    INVALID_POLICY_ALIAS_CFG="$TMP_ROOT/invalid-$policy_alias-$invalid_policy_type.json"
+    python3 - "$CFG" "$INVALID_POLICY_ALIAS_CFG" "$policy_alias" "$invalid_policy_type" <<'PY'
+import json, sys
+with open(sys.argv[1], encoding="utf-8") as stream:
+    data = json.load(stream)
+value = {
+    "boolean": False,
+    "numeric": 0,
+    "list": ["disabled"],
+    "object": {"value": "disabled"},
+    "null": None,
+}[sys.argv[4]]
+alias = sys.argv[3]
+if alias == "host":
+    data["host"] = value
+elif alias == "live-host":
+    data["live"]["host"] = value
+elif alias == "approvals-host":
+    data["approvals"]["host"] = value
+elif alias == "artifact-access":
+    data["artifacts"]["access"] = value
+else:
+    data["artifacts"]["access_mode"] = value
+with open(sys.argv[2], "w", encoding="utf-8") as stream:
+    json.dump(data, stream)
+PY
+    invalid_policy_alias_status=0
+    invalid_policy_alias_out=$(fw config-check --config "$INVALID_POLICY_ALIAS_CFG" 2>&1) || invalid_policy_alias_status=$?
+    [ "$invalid_policy_alias_status" -ne 0 ] \
+      || fail "$policy_alias accepted $invalid_policy_type JSON"
+    case "$policy_alias" in
+      artifact-*) assert_contains "$invalid_policy_alias_out" "artifacts." "invalid artifact access alias identifies its config path" ;;
+      *) assert_contains "$invalid_policy_alias_out" "host must be" "invalid host alias identifies its config path" ;;
+    esac
+  done
+done
+for valid_policy_alias in root-host approvals-host access-mode; do
+  VALID_POLICY_ALIAS_CFG="$TMP_ROOT/valid-policy-$valid_policy_alias.json"
+  python3 - "$CFG" "$VALID_POLICY_ALIAS_CFG" "$valid_policy_alias" <<'PY'
+import json, sys
+with open(sys.argv[1], encoding="utf-8") as stream:
+    data = json.load(stream)
+case = sys.argv[3]
+if case == "root-host":
+    data["host"] = "omarchy"
+elif case == "approvals-host":
+    data["approvals"]["host"] = "vps"
+else:
+    data["artifacts"].pop("access", None)
+    data["artifacts"]["access_mode"] = "tailnet"
+with open(sys.argv[2], "w", encoding="utf-8") as stream:
+    json.dump(data, stream)
+PY
+  valid_policy_alias_out=$(fw config-check --config "$VALID_POLICY_ALIAS_CFG")
+  assert_contains "$valid_policy_alias_out" "config ok" "supported $valid_policy_alias remains valid"
+done
+pass "host and artifact access aliases enforce enum strings"
+
+for policy_section in guild bot tags approvals live outbound artifacts audio transcription poll; do
+  INVALID_SECTION="$TMP_ROOT/invalid-section-$policy_section.json"
+  python3 - "$CFG" "$INVALID_SECTION" "$policy_section" <<'PY'
+import json, sys
+with open(sys.argv[1], encoding="utf-8") as stream:
+    data = json.load(stream)
+data[sys.argv[3]] = []
+with open(sys.argv[2], "w", encoding="utf-8") as stream:
+    json.dump(data, stream)
+PY
+  invalid_section_status=0
+  invalid_section_out=$(fw config-check --config "$INVALID_SECTION" 2>&1) || invalid_section_status=$?
+  [ "$invalid_section_status" -ne 0 ] || fail "$policy_section policy section accepted a non-object"
+  assert_contains "$invalid_section_out" "$policy_section must be a JSON object" "$policy_section policy section enforces its type"
+done
+for invalid_duration_type in boolean string; do
+  INVALID_DURATION_TYPE="$TMP_ROOT/invalid-duration-type-$invalid_duration_type.json"
+  python3 - "$CFG" "$INVALID_DURATION_TYPE" "$invalid_duration_type" <<'PY'
+import json, sys
+with open(sys.argv[1], encoding="utf-8") as stream:
+    data = json.load(stream)
+data["audio"]["max_duration_secs"] = {"boolean": True, "string": "12"}[sys.argv[3]]
+with open(sys.argv[2], "w", encoding="utf-8") as stream:
+    json.dump(data, stream)
+PY
+  invalid_duration_type_status=0
+  invalid_duration_type_out=$(fw config-check --config "$INVALID_DURATION_TYPE" 2>&1) || invalid_duration_type_status=$?
+  [ "$invalid_duration_type_status" -ne 0 ] || fail "audio duration accepted $invalid_duration_type JSON"
+  assert_contains "$invalid_duration_type_out" "encoded as a JSON number" "audio duration rejects $invalid_duration_type JSON"
+done
+VALID_FRACTIONAL_DURATION="$TMP_ROOT/valid-fractional-duration.json"
+python3 - "$CFG" "$VALID_FRACTIONAL_DURATION" <<'PY'
+import json, sys
+with open(sys.argv[1], encoding="utf-8") as stream:
+    data = json.load(stream)
+data["audio"]["max_duration_secs"] = 12.5
+with open(sys.argv[2], "w", encoding="utf-8") as stream:
+    json.dump(data, stream)
+PY
+fractional_duration_out=$(fw config-check --config "$VALID_FRACTIONAL_DURATION")
+assert_contains "$fractional_duration_out" "config ok" "positive fractional JSON duration remains valid"
+pass "config enforces policy object and duration types"
+
+INVALID_THREAD_IDS="$TMP_ROOT/invalid-thread-ids.json"
+python3 - "$CFG" "$INVALID_THREAD_IDS" <<'PY'
+import json, sys
+with open(sys.argv[1], encoding="utf-8") as stream:
+    data = json.load(stream)
+data["profiles"]["proapplis"]["thread_ids"] = []
+with open(sys.argv[2], "w", encoding="utf-8") as stream:
+    json.dump(data, stream)
+PY
+invalid_thread_ids_status=0
+invalid_thread_ids_out=$(fw config-check --config "$INVALID_THREAD_IDS" 2>&1) || invalid_thread_ids_status=$?
+[ "$invalid_thread_ids_status" -ne 0 ] || fail "thread_ids accepted a non-object container"
+assert_contains "$invalid_thread_ids_out" "thread_ids must be a JSON object" "thread_ids container enforces its type"
+pass "profile thread allowlists reject malformed containers"
+
 DUP="$TMP_ROOT/duplicate.json"
 cp "$CFG" "$DUP"
 python3 - "$DUP" <<'PY'
@@ -73,7 +368,63 @@ secret_out=$(fw config-check --config "$SECRET" 2>&1) || secret_status=$?
 [ "$secret_status" -ne 0 ] || fail "inline secret-looking config was accepted"
 assert_contains "$secret_out" "inline secret" "inline secret refusal is explicit"
 assert_not_contains "$secret_out" "do-not-print-this-value" "secret-looking value is not printed"
-pass "config rejects duplicate channels, profile placeholders, and inline secrets"
+for secret_key in access_token discord_token groq_password service_credential client-secret vendor_api_key; do
+  SECRET_VARIANT="$TMP_ROOT/secret-variant-${secret_key//_/-}.json"
+  python3 - "$CFG" "$SECRET_VARIANT" "$secret_key" <<'PY'
+import json, sys
+with open(sys.argv[1], encoding="utf-8") as stream:
+    data = json.load(stream)
+data["nested"] = {sys.argv[3]: "fixture-value"}
+with open(sys.argv[2], "w", encoding="utf-8") as stream:
+    json.dump(data, stream)
+PY
+  secret_variant_status=0
+  secret_variant_out=$(fw config-check --config "$SECRET_VARIANT" 2>&1) || secret_variant_status=$?
+  [ "$secret_variant_status" -ne 0 ] || fail "secret-shaped key was accepted: $secret_key"
+  assert_contains "$secret_variant_out" "inline secret" "secret-shaped key is rejected recursively"
+  assert_not_contains "$secret_variant_out" "fixture-value" "secret-shaped field value is not echoed"
+done
+for secret_field in discord_bot_token_key transcription.api_key; do
+  SECRET_REF="$TMP_ROOT/secret-ref-${secret_field//./-}.json"
+  python3 - "$CFG" "$SECRET_REF" "$secret_field" <<'PY'
+import json, sys
+with open(sys.argv[1], encoding="utf-8") as stream:
+    data = json.load(stream)
+if sys.argv[3] == "discord_bot_token_key":
+    data["discord_bot_token_key"] = "actual.token-looking-value"
+else:
+    data["transcription"]["api_key"] = "gsk_actual_token_value"
+with open(sys.argv[2], "w", encoding="utf-8") as stream:
+    json.dump(data, stream)
+PY
+  secret_ref_status=0
+  secret_ref_out=$(fw health --secrets --config "$SECRET_REF" 2>&1) || secret_ref_status=$?
+  [ "$secret_ref_status" -ne 0 ] || fail "inline-looking secret reference was accepted: $secret_field"
+  assert_contains "$secret_ref_out" "uppercase secret reference name" "invalid secret reference is refused"
+  assert_not_contains "$secret_ref_out" "actual.token-looking-value" "Discord token value is not echoed"
+  assert_not_contains "$secret_ref_out" "gsk_actual_token_value" "transcription token value is not echoed"
+done
+pass "config rejects profile placeholders, inline secrets, and invalid references"
+
+mkdir -p "$HOME1/data/reference-store"
+ln -s "$HOME1/data/reference-store" "$HOME1/config/reference-link"
+for invalid_reference in '/config/reference.sops.yaml' 'config/../reference.sops.yaml' 'config//reference.sops.yaml' 'config/reference.yaml' 'config/reference-link/reference.sops.yaml'; do
+  SECRET_PATH_CFG="$TMP_ROOT/invalid-secret-path-$(printf '%s' "$invalid_reference" | tr '/.' '--').json"
+  python3 - "$CFG" "$SECRET_PATH_CFG" "$invalid_reference" <<'PY'
+import json, sys
+with open(sys.argv[1], encoding="utf-8") as stream:
+    data = json.load(stream)
+data["transcription"]["secret_file"] = sys.argv[3]
+with open(sys.argv[2], "w", encoding="utf-8") as stream:
+    json.dump(data, stream)
+PY
+  secret_path_status=0
+  secret_path_out=$(fw config-check --config "$SECRET_PATH_CFG" 2>&1) || secret_path_status=$?
+  [ "$secret_path_status" -ne 0 ] || fail "invalid secret file reference was accepted: $invalid_reference"
+  assert_contains "$secret_path_out" "secret file reference" "invalid secret file path is refused without disclosure"
+  assert_not_contains "$secret_path_out" "$invalid_reference" "invalid secret file value is not echoed"
+done
+pass "secret file references stay normalized beneath config"
 
 out=$(fw setup --dry-run --config "$CFG")
 assert_contains "$out" "no network" "setup dry-run says it is offline"
@@ -119,10 +470,47 @@ assert_contains "$out" "live posting is configured but refused" "live posting re
 assert_contains "$out" "live process-event polling is configured but refused" "live polling remains inert when configured"
 pass "setup planning is explicit, live choices stay inert, and apply mode refuses"
 
+THREAD_PERMISSION_PLAN="$TMP_ROOT/thread-permissions.txt"
+NO_THREAD_PERMISSION_PLAN="$TMP_ROOT/no-thread-permissions.txt"
+fw setup --dry-run --config "$CFG" > "$THREAD_PERMISSION_PLAN"
+NO_THREADS_CFG="$TMP_ROOT/no-threads.json"
+python3 - "$CFG" "$NO_THREADS_CFG" <<'PY'
+import json, sys
+with open(sys.argv[1], encoding="utf-8") as stream:
+    data = json.load(stream)
+for profile in data["profiles"].values():
+    profile["thread_ids"] = {"exchange": [], "artifacts": []}
+with open(sys.argv[2], "w", encoding="utf-8") as stream:
+    json.dump(data, stream)
+PY
+fw setup --dry-run --config "$NO_THREADS_CFG" > "$NO_THREAD_PERMISSION_PLAN"
+python3 - "$THREAD_PERMISSION_PLAN" "$NO_THREAD_PERMISSION_PLAN" <<'PY'
+import re, sys
+required = 1 << 14
+excluded = (1 << 3) | (1 << 13) | (1 << 20) | (1 << 21) | (1 << 29)
+for path in sys.argv[1:]:
+    text = open(path, encoding="utf-8").read()
+    values = [int(value) for value in re.findall(r"permission integer: ([0-9]+)", text)]
+    if len(values) != 2:
+        raise SystemExit("permission plan did not expose setup and steady integers")
+    for value in values:
+        if not value & required:
+            raise SystemExit("permission plan omitted EMBED_LINKS")
+        if value & excluded:
+            raise SystemExit("permission plan included an excluded permission")
+PY
+pass "setup permission plans include embeds without privileged permissions"
+
 health_status=0
 health_out=$(FMX_PAIRING_TOKEN='do-not-print-this-value' fw health --secrets --config "$CFG" 2>&1) || health_status=$?
 [ "$health_status" -ne 0 ] || fail "live secret health unexpectedly succeeded"
 assert_contains "$health_out" "no secret was decrypted or printed" "secret health reports the privacy boundary"
+assert_contains "$health_out" "Discord bot token reference: configured" "secret health reports the bot reference generically"
+assert_contains "$health_out" "transcription key reference: configured" "secret health reports the transcription reference generically"
+assert_contains "$health_out" "secret file reference: configured" "secret health reports a configured file reference"
+assert_not_contains "$health_out" "FIRSTMATE_DISCORD_BOT_TOKEN" "secret health does not print the bot reference name"
+assert_not_contains "$health_out" "FIRSTMATE_DISCORD_GROQ_API_KEY" "secret health does not print the transcription reference name"
+assert_not_contains "$health_out" "discord-workspace.secrets.sops.yaml" "secret health does not print the file reference value"
 assert_not_contains "$health_out" "do-not-print-this-value" "secret health never prints ambient secrets"
 discord_status=0
 discord_out=$(fw health --discord --config "$CFG" 2>&1) || discord_status=$?
@@ -130,8 +518,91 @@ discord_out=$(fw health --discord --config "$CFG" 2>&1) || discord_status=$?
 assert_contains "$discord_out" "no network call" "Discord health refuses without network"
 pass "health checks stay dry-run only"
 
+SYMLINK_HOME="$TMP_ROOT/symlink-state-home"
+mkdir -p "$SYMLINK_HOME/state" "$SYMLINK_HOME/data/redirected-state" "$SYMLINK_HOME/config"
+cp "$CFG" "$SYMLINK_HOME/config/discord-workspace.json"
+ln -s "$SYMLINK_HOME/data/redirected-state" "$SYMLINK_HOME/state/discord-workspace"
+SYMLINK_TEXT="$TMP_ROOT/symlink-state-reply.txt"
+printf 'State root safety check.\n' > "$SYMLINK_TEXT"
+symlink_state_status=0
+symlink_state_out=$(FM_HOME="$SYMLINK_HOME" "$ROOT/bin/fm-discord-workspace.sh" reply \
+  --config "$SYMLINK_HOME/config/discord-workspace.json" --request-id "$request_id" \
+  --text-file "$SYMLINK_TEXT" --record-discord-message-id 123456789012345677 2>&1) || symlink_state_status=$?
+[ "$symlink_state_status" -ne 0 ] || fail "receipt write followed a symlinked Discord state root"
+assert_contains "$symlink_state_out" "Discord state root is unsafe" "symlinked Discord state root is refused"
+[ -z "$(find "$SYMLINK_HOME/data/redirected-state" -mindepth 1 -print -quit)" ] \
+  || fail "symlinked Discord state root received state files"
+pass "Discord state access rejects symlinked roots"
+
+CHILD_SYMLINK_HOME="$TMP_ROOT/child-symlink-state-home"
+mkdir -p "$CHILD_SYMLINK_HOME/state/discord-workspace" "$CHILD_SYMLINK_HOME/data/redirected-requests" "$CHILD_SYMLINK_HOME/config"
+cp "$CFG" "$CHILD_SYMLINK_HOME/config/discord-workspace.json"
+ln -s "$CHILD_SYMLINK_HOME/data/redirected-requests" "$CHILD_SYMLINK_HOME/state/discord-workspace/requests"
+child_symlink_status=0
+child_symlink_out=$(FM_HOME="$CHILD_SYMLINK_HOME" "$ROOT/bin/fm-discord-workspace.sh" link-task child-symlink-task \
+  --config "$CHILD_SYMLINK_HOME/config/discord-workspace.json" --request-id "$request_id" 2>&1) || child_symlink_status=$?
+[ "$child_symlink_status" -ne 0 ] || fail "task linking followed a symlinked Discord state child"
+assert_contains "$child_symlink_out" "symlink component" "symlinked Discord state child is refused"
+[ -z "$(find "$CHILD_SYMLINK_HOME/data/redirected-requests" -mindepth 1 -print -quit)" ] \
+  || fail "symlinked Discord state child received request records"
+pass "Discord state access rejects symlinked child directories"
+
+PATH_ESCAPE_HOME="$TMP_ROOT/path-escape-state-home"
+mkdir -p "$PATH_ESCAPE_HOME/state" "$PATH_ESCAPE_HOME/config"
+for unsafe_profile in . ../../../config; do
+  PATH_ESCAPE_RESULT="$TMP_ROOT/path-escape-$(printf '%s' "$unsafe_profile" | tr '/.' '--').json"
+  python3 - "$PATH_ESCAPE_RESULT" "$unsafe_profile" <<'PY'
+import json, sys
+with open(sys.argv[1], "w", encoding="utf-8") as stream:
+    json.dump({
+        "schema": "fm-discord-workspace-event.v1",
+        "kind": "ignored",
+        "profile": sys.argv[2],
+        "channel_id": "888888888888888881",
+        "message_id": "999999999999999999",
+    }, stream)
+PY
+  path_escape_status=0
+  path_escape_out=$(FM_HOME="$PATH_ESCAPE_HOME" "$ROOT/bin/fm-procevent-discord-workspace.sh" \
+    autohandle discord-workspace 1 "$PATH_ESCAPE_RESULT" 2>&1) || path_escape_status=$?
+  [ "$path_escape_status" -ne 0 ] || fail "Discord state accepted dot path profile: $unsafe_profile"
+  assert_contains "$path_escape_out" "dot component" "Discord state rejects dot path components"
+done
+[ -z "$(find "$PATH_ESCAPE_HOME/config" -mindepth 1 -print -quit)" ] \
+  || fail "Discord state traversal wrote outside its state root"
+pass "Discord state paths reject dot components and traversal"
+
 TEXT="$TMP_ROOT/reply.txt"
 printf 'Reply text for Discord.\n' > "$TEXT"
+TEXT_FIFO="$TMP_ROOT/reply-fifo.txt"
+mkfifo "$TEXT_FIFO"
+text_fifo_status=0
+fw reply --config "$CFG" --request-id "$request_id" --text-file "$TEXT_FIFO" \
+  > "$TMP_ROOT/text-fifo.out" 2>&1 &
+text_fifo_pid=$!
+for _ in $(seq 1 100); do
+  kill -0 "$text_fifo_pid" 2>/dev/null || break
+  sleep 0.01
+done
+if kill -0 "$text_fifo_pid" 2>/dev/null; then
+  kill "$text_fifo_pid" 2>/dev/null || true
+  wait "$text_fifo_pid" 2>/dev/null || true
+  fail "Discord text intake blocked on a FIFO"
+fi
+wait "$text_fifo_pid" || text_fifo_status=$?
+[ "$text_fifo_status" -ne 0 ] || fail "Discord text intake accepted a FIFO"
+assert_contains "$(cat "$TMP_ROOT/text-fifo.out")" "refusing unsafe text file" "Discord text intake rejects non-regular descriptors"
+TEXT_OVERSIZED="$TMP_ROOT/reply-oversized.txt"
+python3 - "$TEXT_OVERSIZED" <<'PY'
+import sys
+with open(sys.argv[1], "wb") as stream:
+    stream.write(b"x" * 4001)
+PY
+text_oversized_status=0
+text_oversized_out=$(fw reply --config "$CFG" --request-id "$request_id" --text-file "$TEXT_OVERSIZED" 2>&1) || text_oversized_status=$?
+[ "$text_oversized_status" -ne 0 ] || fail "Discord text intake accepted an oversized file"
+assert_contains "$text_oversized_out" "text file is too large" "Discord text intake enforces its descriptor byte bound"
+pass "Discord text intake bounds one regular-file descriptor"
 out=$(fw reply --config "$CFG" --request-id "$request_id" --text-file "$TEXT")
 assert_contains "$out" "Discord reply plan" "reply renders a dry-run plan"
 assert_contains "$out" '"parse": []' "reply disables mentions"
@@ -144,10 +615,73 @@ receipt_count=$(find "$HOME1/state/discord-workspace/receipts" -type f -name '*.
 [ "$receipt_count" = 1 ] || fail "receipt retry created duplicate receipts"
 pass "outbound reply receipts are idempotent"
 
+concurrent_request_a='discord:111111111111111111:888888888888888881:999999999999999995'
+concurrent_request_b='discord:111111111111111111:888888888888888881:999999999999999996'
+fw link-task concurrent-task --config "$CFG" --request-id "$concurrent_request_a" >"$TMP_ROOT/link-a.out" 2>&1 &
+link_a_pid=$!
+fw link-task concurrent-task --config "$CFG" --request-id "$concurrent_request_b" >"$TMP_ROOT/link-b.out" 2>&1 &
+link_b_pid=$!
+link_a_status=0
+link_b_status=0
+wait "$link_a_pid" || link_a_status=$?
+wait "$link_b_pid" || link_b_status=$?
+[ $((link_a_status == 0 ? 1 : 0)) -ne $((link_b_status == 0 ? 1 : 0)) ] || fail "concurrent task links did not produce exactly one winner"
+python3 - "$HOME1/state/discord-workspace/task-links/concurrent-task.json" "$HOME1/state/discord-workspace/pending-followups/concurrent-task.json" <<'PY'
+import json, sys
+link = json.load(open(sys.argv[1]))
+pending = json.load(open(sys.argv[2]))
+if link["request_id"] != pending["request_id"] or link["profile"] != pending["profile"]:
+    raise SystemExit("task link and pending follow-up disagree")
+PY
+request_count=$(find "$HOME1/state/discord-workspace/requests" -type f -name '*.json' | wc -l | tr -d ' ')
+[ "$request_count" = 1 ] || fail "losing task-link conflict published an unlinked request record"
+rm -f "$HOME1/state/discord-workspace/task-links/concurrent-task.json" "$HOME1/state/discord-workspace/pending-followups/concurrent-task.json"
+pass "task linking serializes its complete persistent transition"
+
 out=$(fw link-task discord-task --config "$CFG" --request-id "$thread_request_id")
 assert_contains "$out" "request record written" "link-task writes the request record"
 assert_contains "$out" "task link written" "link-task writes the task link"
 assert_contains "$out" "pending final follow-up written" "link-task writes a pending final follow-up"
+TASK_LINK="$HOME1/state/discord-workspace/task-links/discord-task.json"
+TASK_LINK_BACKUP="$TMP_ROOT/discord-task-link.json"
+cp "$TASK_LINK" "$TASK_LINK_BACKUP"
+for link_fault in schema task request policy; do
+  python3 - "$TASK_LINK_BACKUP" "$TASK_LINK" "$link_fault" <<'PY'
+import json, sys
+with open(sys.argv[1], encoding="utf-8") as stream:
+    data = json.load(stream)
+if sys.argv[3] == "schema":
+    data["schema"] = "unknown"
+elif sys.argv[3] == "task":
+    data["task_id"] = "another-task"
+elif sys.argv[3] == "request":
+    data["request_id"] = "not-a-request"
+else:
+    data["final_followup_required"] = "yes"
+with open(sys.argv[2], "w", encoding="utf-8") as stream:
+    json.dump(data, stream)
+PY
+  bad_link_status=0
+  bad_link_out=$(fw followup discord-task --config "$CFG" --text-file "$TEXT" 2>&1) || bad_link_status=$?
+  [ "$bad_link_status" -ne 0 ] || fail "follow-up accepted a task link with invalid $link_fault"
+  assert_contains "$bad_link_out" "task link" "follow-up rejects invalid task-link $link_fault"
+done
+cp "$TASK_LINK_BACKUP" "$TASK_LINK"
+REASSIGNED_CFG="$TMP_ROOT/reassigned-thread.json"
+python3 - "$CFG" "$REASSIGNED_CFG" <<'PY'
+import json, sys
+with open(sys.argv[1], encoding="utf-8") as stream:
+    data = json.load(stream)
+data["profiles"]["proapplis"]["thread_ids"]["exchange"] = []
+data["profiles"]["folium"]["thread_ids"]["exchange"] = ["888888888888888881"]
+with open(sys.argv[2], "w", encoding="utf-8") as stream:
+    json.dump(data, stream)
+PY
+reassigned_status=0
+reassigned_out=$(fw followup discord-task --config "$REASSIGNED_CFG" --text-file "$TEXT" 2>&1) || reassigned_status=$?
+[ "$reassigned_status" -ne 0 ] || fail "follow-up accepted a reassigned task-link profile"
+assert_contains "$reassigned_out" "profile no longer matches" "follow-up preserves the stored profile binding"
+pass "follow-up validates the complete persistent task link"
 guard_status=0
 guard_out=$(fw guard-work discord-task 2>&1) || guard_status=$?
 [ "$guard_status" -ne 0 ] || fail "guard-work allowed a pending final reply"
@@ -157,13 +691,81 @@ assert_contains "$out" "pending final follow-up: present" "dry-run final follow-
 assert_contains "$out" "remains unresolved" "dry-run final follow-up does not clear the promise"
 out=$(fw followup discord-task --config "$CFG" --final --text-file "$TEXT" --record-discord-message-id 123456789012345679)
 assert_contains "$out" "pending final follow-up delivered" "recorded final follow-up clears the pending state"
+exact_final_replay=$(fw followup discord-task --config "$CFG" --final --text-file "$TEXT" --record-discord-message-id 123456789012345679)
+assert_contains "$exact_final_replay" "receipt exists" "exact final follow-up replay reuses its receipt"
+assert_contains "$exact_final_replay" "already delivered" "exact final follow-up replay preserves delivered state"
 fw guard-work discord-task >/dev/null || fail "guard-work refused after final delivery"
 out=$(fw followup discord-task --config "$CFG" --final --text-file "$TEXT")
 assert_contains "$out" "final follow-up already delivered" "dry-run final follow-up after delivery reports delivered status"
 assert_contains "$out" "was already delivered" "dry-run final follow-up after delivery does not claim it is unresolved"
 assert_not_contains "$out" "pending final follow-up: present" "dry-run final follow-up after delivery does not claim it is pending"
 assert_not_contains "$out" "remains unresolved" "dry-run final follow-up after delivery does not claim it remains unresolved"
-pass "request links preserve and clear pending final replies"
+link_replay_out=$(fw link-task discord-task --config "$CFG" --request-id "$thread_request_id")
+assert_contains "$link_replay_out" "task link exists" "link-task replay keeps the existing task link"
+assert_contains "$link_replay_out" "already delivered" "link-task replay recognizes completed final delivery"
+fw guard-work discord-task >/dev/null || fail "link-task replay replaced delivered final evidence"
+second_final_status=0
+second_final_out=$(fw followup discord-task --config "$CFG" --final --text-file "$TEXT" --record-discord-message-id 123456789012345688 2>&1) || second_final_status=$?
+[ "$second_final_status" -ne 0 ] || fail "a second recorded final follow-up was accepted"
+assert_contains "$second_final_out" "refusing to record a second final" "second final recording is refused explicitly"
+DIFFERENT_FINAL="$TMP_ROOT/different-final.txt"
+printf 'Different final payload.\n' > "$DIFFERENT_FINAL"
+different_final_status=0
+different_final_out=$(fw followup discord-task --config "$CFG" --final --text-file "$DIFFERENT_FINAL" --record-discord-message-id 123456789012345679 2>&1) || different_final_status=$?
+[ "$different_final_status" -ne 0 ] || fail "different final payload replay was accepted"
+assert_contains "$different_final_out" "refusing to record a second final" "different final payload evidence is refused"
+pass "request links preserve idempotent final delivery evidence"
+
+mkdir -p "$HOME1/state/discord-workspace/pending-followups"
+for bad_task in malformed-followup wrong-task-followup unknown-followup; do
+  case "$bad_task" in
+    malformed-followup) printf '{}\n' > "$HOME1/state/discord-workspace/pending-followups/$bad_task.json" ;;
+    wrong-task-followup) printf '{"schema":"fm-discord-workspace-pending-followup.v1","task_id":"another-task","status":"pending"}\n' > "$HOME1/state/discord-workspace/pending-followups/$bad_task.json" ;;
+    unknown-followup) printf '{"schema":"fm-discord-workspace-pending-followup.v1","task_id":"unknown-followup","status":"mystery"}\n' > "$HOME1/state/discord-workspace/pending-followups/$bad_task.json" ;;
+  esac
+  bad_guard_status=0
+  fw guard-work "$bad_task" >/dev/null 2>&1 || bad_guard_status=$?
+  [ "$bad_guard_status" -ne 0 ] || fail "guard-work accepted unsafe follow-up state for $bad_task"
+done
+bad_retire_status=0
+fw retire --config "$CFG" >/dev/null 2>&1 || bad_retire_status=$?
+[ "$bad_retire_status" -ne 0 ] || fail "retirement accepted unsafe follow-up records"
+rm -f "$HOME1/state/discord-workspace/pending-followups/"{malformed-followup,wrong-task-followup,unknown-followup}.json
+pass "follow-up guards fail closed for malformed persistent state"
+
+RECEIPT_A="$TMP_ROOT/receipt-a.txt"
+RECEIPT_B="$TMP_ROOT/receipt-b.txt"
+printf 'Concurrent receipt A.\n' > "$RECEIPT_A"
+printf 'Concurrent receipt B.\n' > "$RECEIPT_B"
+fw reply --config "$CFG" --request-id "$request_id" --text-file "$RECEIPT_A" --nonce shared-concurrent-nonce --record-discord-message-id 123456789012345690 >"$TMP_ROOT/receipt-a.out" 2>&1 &
+receipt_a_pid=$!
+fw reply --config "$CFG" --request-id "$request_id" --text-file "$RECEIPT_B" --nonce shared-concurrent-nonce --record-discord-message-id 123456789012345691 >"$TMP_ROOT/receipt-b.out" 2>&1 &
+receipt_b_pid=$!
+receipt_a_status=0
+receipt_b_status=0
+wait "$receipt_a_pid" || receipt_a_status=$?
+wait "$receipt_b_pid" || receipt_b_status=$?
+[ $((receipt_a_status == 0 ? 1 : 0)) -ne $((receipt_b_status == 0 ? 1 : 0)) ] || fail "concurrent conflicting receipts did not produce exactly one winner"
+pass "receipt compare-and-write is serialized"
+
+CONFLICT_REPORT="$HOME1/data/conflict-report.md"
+printf '# Conflicting artifact receipt\n' > "$CONFLICT_REPORT"
+conflict_plan=$(fw artifact --config "$CFG" --profile proapplis --file "$CONFLICT_REPORT" --purpose report --request-id "$request_id")
+conflict_artifact_id=$(printf '%s\n' "$conflict_plan" | awk '/^artifact id: / { print $3 }')
+conflict_digest=$(python3 - "$CONFLICT_REPORT" <<'PY'
+import hashlib, sys
+with open(sys.argv[1], "rb") as stream:
+    print(hashlib.sha256(stream.read()).hexdigest())
+PY
+)
+fw reply --config "$CFG" --request-id "$request_id" --text-file "$TEXT" --nonce artifact-conflict-nonce --record-discord-message-id 123456789012345694 >/dev/null
+artifact_conflict_status=0
+artifact_conflict_out=$(fw artifact --config "$CFG" --profile proapplis --file "$CONFLICT_REPORT" --purpose report --request-id "$request_id" --nonce artifact-conflict-nonce --record-discord-message-id 123456789012345695 2>&1) || artifact_conflict_status=$?
+[ "$artifact_conflict_status" -ne 0 ] || fail "artifact delivery accepted a conflicting receipt nonce"
+assert_contains "$artifact_conflict_out" "different Discord outbound receipt" "artifact receipt conflict is explicit"
+assert_absent "$HOME1/state/discord-workspace/artifacts/$conflict_artifact_id.json" "receipt conflict does not publish an artifact record"
+assert_absent "$HOME1/state/discord-workspace/artifact-source-index/$conflict_digest.json" "receipt conflict does not publish a source index"
+pass "artifact delivery preflights all persistent records"
 
 REPORT="$HOME1/data/report.md"
 printf '# Report\n\nSafe report.\n' > "$REPORT"
@@ -171,6 +773,18 @@ out=$(fw artifact --config "$CFG" --profile proapplis --file "$REPORT" --purpose
 assert_contains "$out" "canonical post forum" "artifact plan names the canonical artifact forum"
 assert_contains "$out" "exchange summary includes a card and link only" "artifact plan avoids duplicate binaries"
 assert_contains "$out" "direct attachment in the artifacts forum only" "small artifact plan uses one direct attachment"
+ln -s report.md "$HOME1/data/relative-report.md"
+relative_symlink_status=0
+relative_symlink_out=$(cd "$HOME1/data" && fw artifact --config "$CFG" --profile proapplis --file relative-report.md --purpose report 2>&1) || relative_symlink_status=$?
+[ "$relative_symlink_status" -ne 0 ] || fail "relative artifact symlink was accepted"
+assert_contains "$relative_symlink_out" "unsafe artifact path" "relative artifact symlink refusal names the safety boundary"
+mkdir -p "$HOME1/data/real-artifacts"
+printf '# Nested report\n' > "$HOME1/data/real-artifacts/report.md"
+ln -s real-artifacts "$HOME1/data/alias-artifacts"
+parent_symlink_status=0
+parent_symlink_out=$(fw artifact --config "$CFG" --profile proapplis --file "$HOME1/data/alias-artifacts/report.md" --purpose report 2>&1) || parent_symlink_status=$?
+[ "$parent_symlink_status" -ne 0 ] || fail "artifact beneath a symlinked parent was accepted"
+assert_contains "$parent_symlink_out" "unsafe artifact path" "symlinked artifact parent refusal names the safety boundary"
 out=$(fw artifact --config "$CFG" --profile proapplis --file "$REPORT" --purpose report --request-id "$request_id" --record-discord-message-id 123456789012345680)
 assert_contains "$out" "artifact record written" "recorded artifact writes its artifact record"
 assert_contains "$out" "receipt recorded" "recorded artifact writes a receipt"
@@ -179,12 +793,56 @@ duplicate_artifact_out=$(fw artifact --config "$CFG" --profile proapplis --file 
 [ "$duplicate_artifact_status" -ne 0 ] || fail "duplicate canonical artifact source was accepted"
 assert_contains "$duplicate_artifact_out" "already has a canonical artifact" "canonical artifact source cannot be posted twice"
 
+CONCURRENT_REPORT="$HOME1/data/concurrent-report.md"
+printf '# Concurrent report\n\nOne canonical source.\n' > "$CONCURRENT_REPORT"
+fw artifact --config "$CFG" --profile proapplis --file "$CONCURRENT_REPORT" --purpose report --record-discord-message-id 123456789012345692 >"$TMP_ROOT/artifact-a.out" 2>&1 &
+artifact_a_pid=$!
+fw artifact --config "$CFG" --profile proapplis --file "$CONCURRENT_REPORT" --purpose final --record-discord-message-id 123456789012345693 >"$TMP_ROOT/artifact-b.out" 2>&1 &
+artifact_b_pid=$!
+artifact_a_status=0
+artifact_b_status=0
+wait "$artifact_a_pid" || artifact_a_status=$?
+wait "$artifact_b_pid" || artifact_b_status=$?
+[ $((artifact_a_status == 0 ? 1 : 0)) -ne $((artifact_b_status == 0 ? 1 : 0)) ] || fail "concurrent canonical artifact writes did not produce exactly one winner"
+concurrent_digest=$(python3 - "$CONCURRENT_REPORT" <<'PY'
+import hashlib, sys
+print(hashlib.sha256(open(sys.argv[1], "rb").read()).hexdigest())
+PY
+)
+concurrent_artifact=$(python3 - "$HOME1/state/discord-workspace/artifact-source-index/$concurrent_digest.json" <<'PY'
+import json, sys
+print(json.load(open(sys.argv[1]))["artifact_id"])
+PY
+)
+assert_present "$HOME1/state/discord-workspace/artifacts/$concurrent_artifact.json" "canonical index names a published artifact record"
+pass "canonical artifact index and record publication are serialized"
+
 mkdir -p "$HOME1/projects/client"
 printf '# Project report\n' > "$HOME1/projects/client/report.md"
 project_status=0
 project_out=$(fw artifact --config "$CFG" --profile proapplis --file "$HOME1/projects/client/report.md" --purpose report 2>&1) || project_status=$?
 [ "$project_status" -ne 0 ] || fail "project path artifact was accepted"
 assert_contains "$project_out" "under projects" "project artifact refusal names the path class"
+
+ARTIFACT_FIFO="$HOME1/data/artifact.pdf"
+mkfifo "$ARTIFACT_FIFO"
+artifact_fifo_status=0
+fw artifact --config "$CFG" --profile proapplis --file "$ARTIFACT_FIFO" --purpose document \
+  > "$TMP_ROOT/artifact-fifo.out" 2>&1 &
+artifact_fifo_pid=$!
+for _ in $(seq 1 100); do
+  kill -0 "$artifact_fifo_pid" 2>/dev/null || break
+  sleep 0.01
+done
+if kill -0 "$artifact_fifo_pid" 2>/dev/null; then
+  kill "$artifact_fifo_pid" 2>/dev/null || true
+  wait "$artifact_fifo_pid" 2>/dev/null || true
+  fail "artifact validation blocked on a FIFO"
+fi
+wait "$artifact_fifo_pid" || artifact_fifo_status=$?
+[ "$artifact_fifo_status" -ne 0 ] || fail "artifact validation accepted a FIFO"
+assert_contains "$(cat "$TMP_ROOT/artifact-fifo.out")" "refusing unsafe artifact path" "artifact validation rejects non-regular descriptors"
+pass "artifact validation opens only regular descriptors"
 
 printf 'not really an image\n' > "$HOME1/data/bad.png"
 mime_status=0
@@ -214,11 +872,68 @@ big_status=0
 big_out=$(fw artifact --config "$CFG" --profile proapplis --file "$BIG" --purpose document 2>&1) || big_status=$?
 [ "$big_status" -ne 0 ] || fail "oversized direct artifact was accepted"
 assert_contains "$big_out" "exceeds the direct attachment cap" "oversized artifact points to private publishing"
-pass "artifact planning blocks unsafe paths, MIME mismatches, archives, secrets, and oversized direct uploads"
+EARLY_BIG="$HOME1/data/early-big.txt"
+python3 - "$EARLY_BIG" <<'PY'
+import os, sys
+with open(sys.argv[1], "wb") as stream:
+    stream.write(b"\x00")
+    stream.truncate(8 * 1024 * 1024 + 1)
+PY
+early_big_status=0
+early_big_out=$(fw artifact --config "$CFG" --profile proapplis --file "$EARLY_BIG" --purpose document 2>&1) || early_big_status=$?
+[ "$early_big_status" -ne 0 ] || fail "oversized invalid text artifact was accepted"
+assert_contains "$early_big_out" "exceeds the direct attachment cap" "oversized direct input is rejected before content scanning"
+assert_not_contains "$early_big_out" "NUL byte" "oversized direct input was scanned before cap rejection"
+BOARD="$HOME1/data/board.html"
+printf '<!doctype html><html><body>Safe board.</body></html>\n' > "$BOARD"
+direct_html_status=0
+direct_html_out=$(fw artifact --config "$CFG" --profile proapplis --file "$BOARD" --purpose board 2>&1) || direct_html_status=$?
+[ "$direct_html_status" -ne 0 ] || fail "HTML was accepted as a direct Discord attachment"
+assert_contains "$direct_html_out" "unsupported artifact type" "direct HTML refusal names the unsupported type"
+protected_html_out=$(fw publish-artifact --config "$CFG" --profile proapplis --file "$BOARD" --purpose board --url 'https://private.example.invalid/capability/board-abcdefghijklmnopqrstuvwxyz' --access tailnet --expires 7d --record)
+assert_contains "$protected_html_out" "Private artifact link plan" "protected publication accepts validated HTML"
+BAD_HTML="$HOME1/data/bad-board.html"
+printf 'not an HTML document\n' > "$BAD_HTML"
+bad_html_status=0
+bad_html_out=$(fw publish-artifact --config "$CFG" --profile proapplis --file "$BAD_HTML" --purpose board --url 'https://private.example.invalid/capability/bad-board-abcdefghijklmnopqrstuvwxyz' --access tailnet --expires 7d 2>&1) || bad_html_status=$?
+[ "$bad_html_status" -ne 0 ] || fail "mismatched HTML artifact was accepted"
+assert_contains "$bad_html_out" "HTML extension does not match" "protected HTML enforces MIME matching"
+bypass_status=0
+bypass_out=$(fw artifact --config "$CFG" --profile proapplis --file "$BIG" --purpose document --private-url 'https://public.example.invalid/capability/abcdefghijklmnopqrstuvwxyz' 2>&1) || bypass_status=$?
+[ "$bypass_status" -ne 0 ] || fail "removed private URL artifact bypass was accepted"
+assert_contains "$bypass_out" "unrecognized arguments: --private-url" "artifact CLI rejects the removed private URL bypass"
+protected_big_out=$(fw publish-artifact --config "$CFG" --profile proapplis --file "$BIG" --purpose document --url 'https://private.example.invalid/capability/large-abcdefghijklmnopqrstuvwxyz' --access cloudflare-access --expires 24h --record)
+big_digest=$(python3 - "$BIG" <<'PY'
+import hashlib, sys
+with open(sys.argv[1], "rb") as stream:
+    print(hashlib.sha256(stream.read()).hexdigest())
+PY
+)
+protected_big_id=$(printf '%s\n' "$protected_big_out" | awk '/^artifact id: / { print $3 }')
+protected_big_digest=$(python3 - "$HOME1/state/discord-workspace/artifacts/$protected_big_id.json" <<'PY'
+import json, sys
+with open(sys.argv[1], encoding="utf-8") as stream:
+    print(json.load(stream)["source"]["sha256"])
+PY
+)
+[ "$protected_big_digest" = "$big_digest" ] || fail "protected artifact record did not hash the accepted descriptor bytes"
+assert_contains "$protected_big_out" "access: cloudflare-access" "protected oversized publication records access mode"
+assert_contains "$protected_big_out" "expires: 24h" "protected oversized publication records expiry"
+pass "artifact planning blocks unsafe inputs and routes oversized publication through controls"
 
 DOCUMENT="$HOME1/data/document.md"
 printf '# Document\n\nSafe document.\n' > "$DOCUMENT"
-out=$(fw publish-artifact --config "$CFG" --profile proapplis --file "$DOCUMENT" --purpose document --url 'https://private.example.invalid/capability/abcdefghijklmnopqrstuvwxyz' --access tailnet --expires 7d --record)
+DEFAULT_EXPIRY_CFG="$TMP_ROOT/default-expiry.json"
+python3 - "$CFG" "$DEFAULT_EXPIRY_CFG" <<'PY'
+import json, sys
+with open(sys.argv[1], encoding="utf-8") as stream:
+    data = json.load(stream)
+data["artifacts"]["default_expiry"] = "1d"
+with open(sys.argv[2], "w", encoding="utf-8") as stream:
+    json.dump(data, stream)
+PY
+out=$(fw publish-artifact --config "$DEFAULT_EXPIRY_CFG" --profile proapplis --file "$DOCUMENT" --purpose document --url 'https://private.example.invalid/capability/abcdefghijklmnopqrstuvwxyz' --access tailnet --record)
+assert_contains "$out" "expires: 1d" "protected publication uses the configured default expiry"
 assert_contains "$out" "Private artifact link plan" "private artifact publishing renders a plan"
 assert_contains "$out" "artifact record" "private artifact publishing records metadata when asked"
 pass "larger private artifact interface records expiring link metadata"
@@ -228,3 +943,17 @@ retire_out=$(fw retire --config "$CFG" 2>&1) || retire_status=$?
 [ "$retire_status" -eq 0 ] || fail "retire refused after pending final was delivered: $retire_out"
 assert_contains "$retire_out" "retirement dry-run" "retirement stays dry-run"
 pass "safe retirement preserves state and refuses no live action"
+
+HOME2="$TMP_ROOT/home-link-failure"
+mkdir -p "$HOME2/state/discord-workspace" "$HOME2/data" "$HOME2/config"
+cp "$CFG" "$HOME2/config/discord-workspace.json"
+printf 'blocks task-link directory creation\n' > "$HOME2/state/discord-workspace/task-links"
+link_failure_status=0
+link_failure_out=$(FM_HOME="$HOME2" "$ROOT/bin/fm-discord-workspace.sh" link-task guarded-partial \
+  --config "$HOME2/config/discord-workspace.json" --request-id "$request_id" 2>&1) || link_failure_status=$?
+[ "$link_failure_status" -ne 0 ] || fail "task-link publication failure unexpectedly succeeded"
+assert_present "$HOME2/state/discord-workspace/pending-followups/guarded-partial.json" "task-link failure preserves its pending-final guard"
+partial_guard_status=0
+FM_HOME="$HOME2" "$ROOT/bin/fm-discord-workspace.sh" guard-work guarded-partial >/dev/null 2>&1 || partial_guard_status=$?
+[ "$partial_guard_status" -ne 0 ] || fail "task-link partial state bypassed the final-follow-up guard"
+pass "task-link publication failures remain guarded"

--- a/tests/fm-discord-workspace.test.sh
+++ b/tests/fm-discord-workspace.test.sh
@@ -155,6 +155,11 @@ assert_contains "$out" "remains unresolved" "dry-run final follow-up does not cl
 out=$(fw followup discord-task --config "$CFG" --final --text-file "$TEXT" --record-discord-message-id 123456789012345679)
 assert_contains "$out" "pending final follow-up delivered" "recorded final follow-up clears the pending state"
 fw guard-work discord-task >/dev/null || fail "guard-work refused after final delivery"
+out=$(fw followup discord-task --config "$CFG" --final --text-file "$TEXT")
+assert_contains "$out" "final follow-up already delivered" "dry-run final follow-up after delivery reports delivered status"
+assert_contains "$out" "was already delivered" "dry-run final follow-up after delivery does not claim it is unresolved"
+assert_not_contains "$out" "pending final follow-up: present" "dry-run final follow-up after delivery does not claim it is pending"
+assert_not_contains "$out" "remains unresolved" "dry-run final follow-up after delivery does not claim it remains unresolved"
 pass "request links preserve and clear pending final replies"
 
 REPORT="$HOME1/data/report.md"

--- a/tests/fm-discord-workspace.test.sh
+++ b/tests/fm-discord-workspace.test.sh
@@ -45,19 +45,19 @@ dup_out=$(fw config-check --config "$DUP" 2>&1) || dup_status=$?
 [ "$dup_status" -ne 0 ] || fail "duplicate forum id was accepted"
 assert_contains "$dup_out" "duplicate Discord id" "duplicate forum id refusal is explicit"
 
-DISABLED="$TMP_ROOT/disabled.json"
-cp "$CFG" "$DISABLED"
-python3 - "$DISABLED" <<'PY'
+PLACEHOLDER="$TMP_ROOT/placeholder.json"
+cp "$CFG" "$PLACEHOLDER"
+python3 - "$PLACEHOLDER" <<'PY'
 import json, sys
 p=sys.argv[1]
 data=json.load(open(p))
-data["profiles"]["lbdb"]={"enabled": True, "category_id":"121212121212121212"}
+data["profiles"]["example-client"]={"enabled": False}
 json.dump(data, open(p,"w"), indent=2, sort_keys=True)
 PY
-disabled_status=0
-disabled_out=$(fw config-check --config "$DISABLED" 2>&1) || disabled_status=$?
-[ "$disabled_status" -ne 0 ] || fail "enabled dormant profile was accepted"
-assert_contains "$disabled_out" "disabled profile lbdb" "disabled profile refusal is explicit"
+placeholder_status=0
+placeholder_out=$(fw config-check --config "$PLACEHOLDER" 2>&1) || placeholder_status=$?
+[ "$placeholder_status" -ne 0 ] || fail "dormant profile placeholder was accepted"
+assert_contains "$placeholder_out" "unsupported profile(s): example-client" "profile placeholder refusal is explicit"
 
 SECRET="$TMP_ROOT/secret.json"
 cp "$CFG" "$SECRET"
@@ -73,12 +73,15 @@ secret_out=$(fw config-check --config "$SECRET" 2>&1) || secret_status=$?
 [ "$secret_status" -ne 0 ] || fail "inline secret-looking config was accepted"
 assert_contains "$secret_out" "inline secret" "inline secret refusal is explicit"
 assert_not_contains "$secret_out" "do-not-print-this-value" "secret-looking value is not printed"
-pass "config rejects duplicate channels, enabled dormant profiles, and inline secrets"
+pass "config rejects duplicate channels, profile placeholders, and inline secrets"
 
 out=$(fw setup --dry-run --config "$CFG")
 assert_contains "$out" "no network" "setup dry-run says it is offline"
 assert_contains "$out" "temporary setup permission integer" "setup dry-run prints setup permissions"
 assert_contains "$out" "steady-state permission integer" "setup dry-run prints steady permissions"
+assert_contains "$out" "profile System / Firstmate" "setup dry-run names the system category"
+assert_contains "$out" "profile ProApplis" "setup dry-run names the ProApplis category"
+assert_contains "$out" "profile Folium" "setup dry-run names the Folium category"
 assert_contains "$out" "exchanges forum" "setup dry-run names exchange forums"
 assert_contains "$out" "artifacts forum" "setup dry-run names artifact forums"
 assert_contains "$out" "request, decision, work, status, blocked, done" "setup dry-run prints exchange tags"

--- a/tests/fm-extension-binding.test.sh
+++ b/tests/fm-extension-binding.test.sh
@@ -133,6 +133,7 @@ new_home() {
 make_package() {  # <dir> <id> <adapter> [fixed-scenario] [required-consent]
   local dir=$1 id=$2 adapter=$3 fixed=${4:-good} consent=${5:-} required
   mkdir -p "$dir"
+  chmod 0755 "$dir"
   if [ -n "$consent" ]; then
     required=$(printf '["%s"]' "$consent")
   else

--- a/tests/fm-inbox-external.test.sh
+++ b/tests/fm-inbox-external.test.sh
@@ -61,3 +61,45 @@ bad_out=$(FM_HOME="$HOME1" "$ROOT/bin/fm-inbox.sh" note \
 [ "$bad_status" -ne 0 ] || fail "invalid external id was accepted"
 assert_contains "$bad_out" "external id" "invalid external id refusal names the problem"
 pass "external source ids are validated before queuing"
+
+note_count_for() {
+  find "$1/state/inbox" -maxdepth 1 -name '*.note' 2>/dev/null | wc -l | tr -d ' '
+}
+HOME2="$TMP_ROOT/home2"
+mkdir -p "$HOME2/state" "$HOME2/data"
+EXT_ID2=discord:111111111111111111:222222222222222222:888888888888888777
+mkdir "$HOME2/state/.wake-queue.seq"
+fail_status=0
+fail_out=$(FM_HOME="$HOME2" "$ROOT/bin/fm-inbox.sh" note \
+  --source discord-workspace \
+  --external-id "$EXT_ID2" - 2>&1 <<'WAKENOTE'
+Note whose announcement will fail.
+WAKENOTE
+) || fail_status=$?
+[ "$fail_status" -ne 0 ] || fail "announcement failure did not report failure"
+[ "$(note_count_for "$HOME2")" = 1 ] || fail "failed announcement lost or duplicated the note"
+fail_id=$(printf '%s\n' "$fail_out" | awk '/^queued / { print $2; exit }')
+[ -n "$fail_id" ] || fail "could not parse the note id from the failed announcement"
+map_file=$(python3 - "$HOME2" "$EXT_ID2" <<'PY2'
+import hashlib, sys
+home, ext = sys.argv[1], sys.argv[2]
+digest = hashlib.sha256(f"discord-workspace:{ext}".encode()).hexdigest()
+print(f"{home}/state/inbox/external/{digest}.map")
+PY2
+)
+assert_present "$map_file" "failed announcement keeps its external map"
+assert_grep "announced=0" "$map_file" "failed announcement records announced=0 in the map"
+assert_grep "note_id=$fail_id" "$map_file" "failed announcement map keeps the original note id"
+rmdir "$HOME2/state/.wake-queue.seq"
+replay_out=$(FM_HOME="$HOME2" "$ROOT/bin/fm-inbox.sh" note \
+  --source discord-workspace \
+  --external-id "$EXT_ID2" - <<'WAKENOTE'
+Replay body that must only re-announce.
+WAKENOTE
+)
+assert_contains "$replay_out" "queued $fail_id" "replay after failed announcement returns the original note id"
+assert_contains "$replay_out" "announcement retried and delivered" "replay re-announces the original note"
+[ "$(note_count_for "$HOME2")" = 1 ] || fail "replay after failed announcement created a duplicate note"
+[ "$(awk 'END { print NR + 0 }' "$HOME2/state/.wake-queue" 2>/dev/null)" = 1 ] || fail "replay produced the wrong wake count"
+assert_grep "announced=1" "$map_file" "delivered retry marks the map announced=1"
+pass "replay after a failed announcement re-announces the original note instead of duplicating"

--- a/tests/fm-inbox-external.test.sh
+++ b/tests/fm-inbox-external.test.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# Behavior tests for fm-inbox.sh external-source idempotency.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+TMP_ROOT=$(fm_test_tmproot fm-inbox-external-tests)
+HOME1="$TMP_ROOT/home"
+mkdir -p "$HOME1/state" "$HOME1/data"
+
+note_count() {
+  find "$HOME1/state/inbox" -maxdepth 1 -name '*.note' 2>/dev/null | wc -l | tr -d ' '
+}
+
+wake_count() {
+  awk 'END { print NR + 0 }' "$HOME1/state/.wake-queue" 2>/dev/null
+}
+
+META="$TMP_ROOT/meta.json"
+printf '{"profile":"proapplis","message_id":"999999999999999999"}\n' > "$META"
+
+out=$(FM_HOME="$HOME1" "$ROOT/bin/fm-inbox.sh" note \
+  --source discord-workspace \
+  --external-id discord:111111111111111111:222222222222222222:999999999999999999 \
+  --metadata-file "$META" - <<'EOF'
+Discord note body.
+EOF
+)
+assert_contains "$out" "queued" "external note queues a note"
+first_id=$(printf '%s\n' "$out" | awk '/^queued / { print $2; exit }')
+[ -n "$first_id" ] || fail "could not parse the queued note id"
+[ "$(note_count)" = 1 ] || fail "external note created the wrong note count"
+[ "$(wake_count)" = 1 ] || fail "external note created the wrong wake count"
+assert_grep "external_source=discord-workspace" "$HOME1/state/inbox/$first_id.note" "external source is recorded in the note"
+assert_grep "external_id=discord:111111111111111111:222222222222222222:999999999999999999" "$HOME1/state/inbox/$first_id.note" "external id is recorded in the note"
+assert_present "$HOME1/state/inbox/external" "external source map directory exists"
+metadata_copy=$(sed -n 's/^external_metadata=//p' "$HOME1/state/inbox/$first_id.note")
+assert_present "$metadata_copy" "metadata file is copied into private inbox state"
+assert_grep '"profile"' "$metadata_copy" "metadata copy keeps the bounded JSON"
+pass "external-source note records one note, one wake, and private metadata"
+
+out2=$(FM_HOME="$HOME1" "$ROOT/bin/fm-inbox.sh" note \
+  --source discord-workspace \
+  --external-id discord:111111111111111111:222222222222222222:999999999999999999 \
+  --metadata-file "$META" - <<'EOF'
+Replay body that must not create a new note.
+EOF
+)
+assert_contains "$out2" "queued $first_id" "replay returns the first note id"
+assert_contains "$out2" "no new wake" "replay reports that no wake was appended"
+[ "$(note_count)" = 1 ] || fail "replay created a duplicate note"
+[ "$(wake_count)" = 1 ] || fail "replay created a duplicate wake"
+pass "external-source replay is idempotent"
+
+bad_status=0
+bad_out=$(FM_HOME="$HOME1" "$ROOT/bin/fm-inbox.sh" note \
+  --source discord-workspace \
+  --external-id 'discord:bad/slash' - <<< 'bad' 2>&1) || bad_status=$?
+[ "$bad_status" -ne 0 ] || fail "invalid external id was accepted"
+assert_contains "$bad_out" "external id" "invalid external id refusal names the problem"
+pass "external source ids are validated before queuing"

--- a/tests/fm-procevent-discord-workspace.test.sh
+++ b/tests/fm-procevent-discord-workspace.test.sh
@@ -1,0 +1,194 @@
+#!/usr/bin/env bash
+# Behavior tests for the Discord workspace process-event adapter.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+TMP_ROOT=$(fm_test_tmproot fm-procevent-discord-workspace-tests)
+export FM_PROCEVENT_CLAIM_ROOT="$TMP_ROOT/claims"
+HOME1="$TMP_ROOT/home1"
+HOME2="$TMP_ROOT/home2"
+HOME3="$TMP_ROOT/home3"
+
+pe() { FM_HOME="$1" "$ROOT/bin/fm-procevent.sh" "${@:2}"; }
+ped() { FM_HOME="$1" "$ROOT/bin/fm-procevent-discord-workspace.sh" "${@:2}"; }
+
+cleanup_procevent_discord() {
+  pe "$HOME1" sweep-home >/dev/null 2>&1 || true
+  pe "$HOME2" sweep-home >/dev/null 2>&1 || true
+  pe "$HOME3" sweep-home >/dev/null 2>&1 || true
+  fm_test_cleanup
+}
+trap cleanup_procevent_discord EXIT
+
+make_config() {
+  local home=$1 cfg=$2
+  mkdir -p "$home/state" "$home/data" "$home/config"
+  chmod 700 "$home/state"
+  FM_HOME="$home" "$ROOT/bin/fm-discord-workspace.sh" sample-config > "$cfg"
+  python3 - "$cfg" <<'PY'
+import json, sys
+p=sys.argv[1]
+data=json.load(open(p))
+data["profiles"]["proapplis"]["thread_ids"]["exchange"]=["888888888888888881"]
+data["transcription"]["provider"]="fake"
+data["transcription"]["fake_transcripts"]={
+  "999999999999999998":"transcribed voice fixture",
+  "999999999999999996":"transcribed upload fixture"
+}
+json.dump(data, open(p,"w"), indent=2, sort_keys=True)
+PY
+}
+
+note_count() {
+  find "$1/state/inbox" -maxdepth 1 -name '*.note' 2>/dev/null | wc -l | tr -d ' '
+}
+
+wake_count() {
+  awk 'END { print NR + 0 }' "$1/state/.wake-queue" 2>/dev/null
+}
+
+wake_payloads() {
+  awk -F '\t' '{print $5}' "$1/state/.wake-queue" 2>/dev/null
+}
+
+first_note() {
+  local home=$1
+  for f in "$home/state/inbox"/*.note; do
+    [ -e "$f" ] || continue
+    printf '%s\n' "$f"
+    return 0
+  done
+  return 1
+}
+
+result_path() {
+  local home=$1 seq=$2
+  printf '%s/state/procevent-inbox/discord-workspace.%s.result\n' "$home" "$seq"
+}
+
+CFG1="$HOME1/config/discord-workspace.json"
+make_config "$HOME1" "$CFG1"
+FIXTURE1="$TMP_ROOT/messages.json"
+cat > "$FIXTURE1" <<'JSON'
+{
+  "messages": [
+    {"id":"999999999999999991","channel_id":"555555555555555552","author":{"id":"444444444444444444"},"content":"direct message without a guild"},
+    {"id":"999999999999999992","guild_id":"121212121212121212","channel_id":"555555555555555552","author":{"id":"444444444444444444"},"content":"wrong guild"},
+    {"id":"999999999999999993","guild_id":"111111111111111111","channel_id":"888888888888888881","parent_id":"555555555555555552","author":{"id":"333333333333333333","bot":true},"content":"bot message"},
+    {"id":"999999999999999994","guild_id":"111111111111111111","channel_id":"888888888888888881","parent_id":"555555555555555552","author":{"id":"454545454545454545"},"content":"wrong author"},
+    {"id":"999999999999999995","guild_id":"111111111111111111","channel_id":"555555555555555553","author":{"id":"444444444444444444"},"content":"artifact forum input"},
+    {"id":"999999999999999996","guild_id":"111111111111111111","channel_id":"555555555555555552","author":{"id":"444444444444444444"},"content":"forum root input without an allowlisted thread"},
+    {"id":"999999999999999997","guild_id":"111111111111111111","channel_id":"888888888888888881","parent_id":"555555555555555552","author":{"id":"444444444444444444"},"content":"Thread text request."}
+  ]
+}
+JSON
+
+out=$(FM_DISCORD_WORKSPACE_FIXTURE="$FIXTURE1" ped "$HOME1" source --config "$CFG1")
+assert_contains "$out" "Thread text request" "source returns the first allowlisted exchange-thread message"
+assert_not_contains "$out" "wrong guild" "source skips unknown guilds"
+printf '%s\n' "$out" > "$TMP_ROOT/result.json"
+class=$(ped "$HOME1" classify "$TMP_ROOT/result.json")
+assert_contains "$class" "message" "classify identifies accepted text messages"
+if ped "$HOME1" silent "$TMP_ROOT/result.json" >/dev/null 2>&1; then
+  fail "accepted text message was classified silent"
+fi
+pass "source enforces guild, channel, author, bot, and forum allowlists"
+
+nofixture_status=0
+nofixture_out=$(ped "$HOME1" source --config "$CFG1" 2>&1) || nofixture_status=$?
+[ "$nofixture_status" -ne 0 ] || fail "source without fixture succeeded"
+assert_contains "$nofixture_out" "no network call" "source without fixture refuses before network"
+out=$(ped "$HOME1" arm --dry-run --config "$CFG1")
+assert_contains "$out" "arm dry-run" "arm dry-run is explicit"
+assert_contains "$out" "register command" "arm dry-run prints the registration command"
+arm_status=0
+arm_out=$(ped "$HOME1" arm --config "$CFG1" 2>&1) || arm_status=$?
+[ "$arm_status" -ne 0 ] || fail "non-dry-run arm was accepted"
+assert_contains "$arm_out" "offline phase" "non-dry-run arm refuses while inactive"
+pass "process-event arming remains offline unless a later live task activates it"
+
+pe "$HOME1" register discord-workspace discord-workspace -- \
+  "$ROOT/bin/fm-procevent-discord-workspace.sh" source --config "$CFG1" >/dev/null
+out=$(FM_DISCORD_WORKSPACE_FIXTURE="$FIXTURE1" pe "$HOME1" start discord-workspace)
+assert_contains "$out" "autohandled" "process-event start autohandles accepted Discord messages"
+assert_present "$(result_path "$HOME1" 1)" "first captured Discord result exists"
+assert_present "$HOME1/state/procevent-inbox/discord-workspace.1.handled" "autohandle records the process-event acknowledgement"
+[ "$(note_count "$HOME1")" = 1 ] || fail "autohandle created the wrong inbox note count"
+[ "$(wake_count "$HOME1")" = 1 ] || fail "autohandle created the wrong wake count"
+assert_contains "$(wake_payloads "$HOME1")" "captain inbox note" "accepted Discord event announces through the inbox"
+assert_not_contains "$(wake_payloads "$HOME1")" "procevent discord-workspace" "self-announcing adapter suppresses duplicate process-event wake"
+NOTE=$(first_note "$HOME1") || fail "autohandle did not create an inbox note"
+assert_grep "Discord workspace / proapplis / text" "$NOTE" "note body identifies Discord text intake"
+assert_grep "Thread text request." "$NOTE" "note body preserves the captain text"
+ack_out=$(pe "$HOME1" handled discord-workspace 1)
+assert_contains "$ack_out" "already-handled" "process-event acknowledgement is idempotent"
+pass "accepted Discord process-event creates one inbox notification and one handled marker"
+
+rm -f "$HOME1/state/discord-workspace/cursors/proapplis/888888888888888881.cursor"
+out=$(FM_DISCORD_WORKSPACE_FIXTURE="$FIXTURE1" pe "$HOME1" start discord-workspace)
+assert_contains "$out" "autohandled" "replayed fixture is still handled"
+assert_present "$HOME1/state/procevent-inbox/discord-workspace.2.handled" "replayed fixture is acknowledged"
+[ "$(note_count "$HOME1")" = 1 ] || fail "replayed Discord message created a duplicate inbox note"
+[ "$(wake_count "$HOME1")" = 1 ] || fail "replayed Discord message created a duplicate inbox wake"
+pass "Discord process-event replay deduplicates through fm-inbox external ids"
+
+CFG2="$HOME2/config/discord-workspace.json"
+make_config "$HOME2" "$CFG2"
+FIXTURE2="$TMP_ROOT/voice.json"
+cat > "$FIXTURE2" <<'JSON'
+{
+  "messages": [
+    {
+      "id":"999999999999999998",
+      "guild_id":"111111111111111111",
+      "channel_id":"888888888888888881",
+      "parent_id":"555555555555555552",
+      "author":{"id":"444444444444444444"},
+      "content":"Voice context.",
+      "flags":8192,
+      "attachments":[{"id":"101010101010101010","filename":"voice.ogg","content_type":"audio/ogg","size":1024,"duration_secs":12,"url":"https://cdn.discordapp.com/attachments/1/voice.ogg"}]
+    }
+  ]
+}
+JSON
+pe "$HOME2" register discord-workspace discord-workspace -- \
+  "$ROOT/bin/fm-procevent-discord-workspace.sh" source --config "$CFG2" >/dev/null
+out=$(FM_DISCORD_WORKSPACE_FIXTURE="$FIXTURE2" pe "$HOME2" start discord-workspace)
+assert_contains "$out" "autohandled" "voice fixture is autohandled"
+NOTE2=$(first_note "$HOME2") || fail "voice fixture did not create a note"
+assert_grep "voice transcript" "$NOTE2" "voice note is identified as a transcript"
+assert_grep "transcribed voice fixture" "$NOTE2" "fake transcription is used for voice fixtures"
+assert_grep "transcription: fake fixture, no secret" "$NOTE2" "voice note does not print provider secrets"
+assert_not_contains "$(cat "$NOTE2")" "FIRSTMATE_DISCORD_GROQ_API_KEY" "voice note does not leak secret key names"
+pass "voice-message fixtures validate audio and produce safe transcript notes"
+
+CFG3="$HOME3/config/discord-workspace.json"
+make_config "$HOME3" "$CFG3"
+FIXTURE3="$TMP_ROOT/bad-audio.json"
+cat > "$FIXTURE3" <<'JSON'
+{
+  "messages": [
+    {
+      "id":"999999999999999996",
+      "guild_id":"111111111111111111",
+      "channel_id":"888888888888888881",
+      "parent_id":"555555555555555552",
+      "author":{"id":"444444444444444444"},
+      "flags":8192,
+      "attachments":[{"id":"202020202020202020","filename":"voice.ogg","content_type":"audio/ogg","size":1024,"duration_secs":12,"url":"https://evil.example.invalid/voice.ogg"}]
+    }
+  ]
+}
+JSON
+pe "$HOME3" register discord-workspace discord-workspace -- \
+  "$ROOT/bin/fm-procevent-discord-workspace.sh" source --config "$CFG3" >/dev/null
+out=$(FM_DISCORD_WORKSPACE_FIXTURE="$FIXTURE3" pe "$HOME3" start discord-workspace)
+assert_contains "$out" "autohandled" "bad audio rejection is autohandled"
+NOTE3=$(first_note "$HOME3") || fail "bad audio fixture did not create an error note"
+assert_grep "audio rejected" "$NOTE3" "bad audio creates a durable rejection note"
+assert_grep "Discord CDN allowlist" "$NOTE3" "bad audio refusal names the failed check"
+assert_not_contains "$(cat "$NOTE3")" "do-not-print" "bad audio note does not leak secret material"
+pass "audio intake rejects non-Discord CDN URLs with a durable non-secret note"

--- a/tests/fm-procevent-discord-workspace.test.sh
+++ b/tests/fm-procevent-discord-workspace.test.sh
@@ -12,6 +12,7 @@ HOME1="$TMP_ROOT/home1"
 HOME2="$TMP_ROOT/home2"
 HOME3="$TMP_ROOT/home3"
 HOME4="$TMP_ROOT/home4"
+HOME5="$TMP_ROOT/home5"
 
 pe() { FM_HOME="$1" "$ROOT/bin/fm-procevent.sh" "${@:2}"; }
 ped() { FM_HOME="$1" "$ROOT/bin/fm-procevent-discord-workspace.sh" "${@:2}"; }
@@ -21,6 +22,7 @@ cleanup_procevent_discord() {
   pe "$HOME2" sweep-home >/dev/null 2>&1 || true
   pe "$HOME3" sweep-home >/dev/null 2>&1 || true
   pe "$HOME4" sweep-home >/dev/null 2>&1 || true
+  pe "$HOME5" sweep-home >/dev/null 2>&1 || true
   fm_test_cleanup
 }
 trap cleanup_procevent_discord EXIT
@@ -482,3 +484,35 @@ assert_grep "Discord CDN allowlist" "$NOTE3" "bad audio refusal names the failed
 assert_grep "caption: Keep this rejected audio caption." "$NOTE3" "rejected audio note preserves its text caption"
 assert_not_contains "$(cat "$NOTE3")" "do-not-print" "bad audio note does not leak secret material"
 pass "audio intake rejects non-Discord CDN URLs with a durable non-secret note"
+
+# --- forum child threads route through their verified configured parent ----
+CFG5="$HOME5/config/discord-workspace.json"
+make_config "$HOME5" "$CFG5"
+python3 - "$CFG5" <<'PY'
+import json, sys
+p = sys.argv[1]
+data = json.load(open(p))
+# Empty thread allowlists: forum posts must still enter via their parent forum.
+data["profiles"]["proapplis"]["thread_ids"]["exchange"] = []
+data["profiles"]["proapplis"]["thread_ids"]["artifacts"] = []
+json.dump(data, open(p, "w"), indent=2, sort_keys=True)
+PY
+
+FIXTURE5="$TMP_ROOT/forum-childs.json"
+cat > "$FIXTURE5" <<'JSON'
+{
+  "messages": [
+    {"id":"888888888888888771","guild_id":"111111111111111111","channel_id":"777777777777777771","parent_id":"777777777777777772","author":{"id":"444444444444444444"},"content":"Forum child exchange request."},
+    {"id":"888888888888888772","guild_id":"111111111111111111","channel_id":"777777777777777772","author":{"id":"444444444444444444"},"content":"forum root input"},
+    {"id":"888888888888888773","guild_id":"111111111111111111","channel_id":"777777777777777775","parent_id":"777777777777777772","author":{"id":"444444444444444444"},"content":"wrong-forum parent"},
+    {"id":"888888888888888774","guild_id":"111111111111111111","channel_id":"777777777777777776","parent_id":"777777777777777773","author":{"id":"444444444444444444"},"content":"artifact forum child"}
+  ]
+}
+JSON
+out=$(FM_DISCORD_WORKSPACE_FIXTURE="$FIXTURE5" ped "$HOME5" source --config "$CFG5")
+assert_contains "$out" "Forum child exchange request." \
+  "a verified forum child thread enters its exchange lane without a pre-allowlisted id"
+assert_not_contains "$out" "forum root input" "the forum channel itself is not accepted as a lane"
+assert_not_contains "$out" "wrong-forum parent" "a child of another profile's forum stays out"
+assert_not_contains "$out" "artifact forum child" "artifact forum children stay out of exchange intake"
+pass "forum child threads route by their verified configured parent forum"

--- a/tests/fm-procevent-discord-workspace.test.sh
+++ b/tests/fm-procevent-discord-workspace.test.sh
@@ -128,7 +128,7 @@ assert_contains "$out" "register command" "arm dry-run prints the registration c
 arm_status=0
 arm_out=$(ped "$HOME1" arm --config "$CFG1" 2>&1) || arm_status=$?
 [ "$arm_status" -ne 0 ] || fail "non-dry-run arm was accepted"
-assert_contains "$arm_out" "offline phase" "non-dry-run arm refuses while inactive"
+assert_contains "$arm_out" "live polling is disabled" "non-dry-run arm refuses while live polling is disabled"
 pass "process-event arming remains offline unless a later live task activates it"
 
 pe "$HOME1" register discord-workspace discord-workspace -- \

--- a/tests/fm-procevent-discord-workspace.test.sh
+++ b/tests/fm-procevent-discord-workspace.test.sh
@@ -11,6 +11,7 @@ export FM_PROCEVENT_CLAIM_ROOT="$TMP_ROOT/claims"
 HOME1="$TMP_ROOT/home1"
 HOME2="$TMP_ROOT/home2"
 HOME3="$TMP_ROOT/home3"
+HOME4="$TMP_ROOT/home4"
 
 pe() { FM_HOME="$1" "$ROOT/bin/fm-procevent.sh" "${@:2}"; }
 ped() { FM_HOME="$1" "$ROOT/bin/fm-procevent-discord-workspace.sh" "${@:2}"; }
@@ -19,6 +20,7 @@ cleanup_procevent_discord() {
   pe "$HOME1" sweep-home >/dev/null 2>&1 || true
   pe "$HOME2" sweep-home >/dev/null 2>&1 || true
   pe "$HOME3" sweep-home >/dev/null 2>&1 || true
+  pe "$HOME4" sweep-home >/dev/null 2>&1 || true
   fm_test_cleanup
 }
 trap cleanup_procevent_discord EXIT
@@ -71,6 +73,23 @@ result_path() {
 
 CFG1="$HOME1/config/discord-workspace.json"
 make_config "$HOME1" "$CFG1"
+for invalid_limit in NaN Infinity 0; do
+  INVALID_CFG="$TMP_ROOT/invalid-limit-$invalid_limit.json"
+  python3 - "$CFG1" "$INVALID_CFG" "$invalid_limit" <<'PY'
+import json, sys
+with open(sys.argv[1], encoding="utf-8") as stream:
+    data = json.load(stream)
+data["audio"]["max_duration_secs"] = sys.argv[3]
+with open(sys.argv[2], "w", encoding="utf-8") as stream:
+    json.dump(data, stream)
+PY
+  invalid_status=0
+  invalid_out=$(FM_HOME="$HOME1" "$ROOT/bin/fm-discord-workspace.sh" config-check --config "$INVALID_CFG" 2>&1) || invalid_status=$?
+  [ "$invalid_status" -ne 0 ] || fail "audio duration limit $invalid_limit was accepted"
+  assert_contains "$invalid_out" "positive finite number" "invalid audio duration limit is refused"
+done
+pass "audio configuration rejects non-finite and non-positive durations"
+
 FIXTURE1="$TMP_ROOT/messages.json"
 cat > "$FIXTURE1" <<'JSON'
 {
@@ -125,7 +144,12 @@ assert_grep "Discord workspace / proapplis / text" "$NOTE" "note body identifies
 assert_grep "Thread text request." "$NOTE" "note body preserves the captain text"
 ack_out=$(pe "$HOME1" handled discord-workspace 1)
 assert_contains "$ack_out" "already-handled" "process-event acknowledgement is idempotent"
-pass "accepted Discord process-event creates one inbox notification and one handled marker"
+link_out=$(FM_HOME="$HOME1" "$ROOT/bin/fm-discord-workspace.sh" link-task inbound-task \
+  --config "$CFG1" \
+  --request-id discord:111111111111111111:888888888888888881:999999999999999997)
+assert_contains "$link_out" "request record exists" "task linking reuses the canonical inbound request record"
+assert_contains "$link_out" "task link written" "processed inbound request links to a task"
+pass "processed inbound requests use the task-link request shape"
 
 rm -f "$HOME1/state/discord-workspace/cursors/proapplis/888888888888888881.cursor"
 out=$(FM_DISCORD_WORKSPACE_FIXTURE="$FIXTURE1" pe "$HOME1" start discord-workspace)
@@ -137,6 +161,269 @@ pass "Discord process-event replay deduplicates through fm-inbox external ids"
 
 CFG2="$HOME2/config/discord-workspace.json"
 make_config "$HOME2" "$CFG2"
+for invalid_duration in NaN Infinity 0; do
+  INVALID_AUDIO="$TMP_ROOT/invalid-audio-$invalid_duration.json"
+  cat > "$INVALID_AUDIO" <<JSON
+{"messages":[{"id":"999999999999999990","guild_id":"111111111111111111","channel_id":"888888888888888881","parent_id":"555555555555555552","author":{"id":"444444444444444444"},"flags":8192,"attachments":[{"id":"101010101010101011","filename":"voice.ogg","content_type":"audio/ogg","size":1024,"duration_secs":"$invalid_duration","url":"https://cdn.discordapp.com/attachments/1/voice.ogg"}]}]}
+JSON
+  invalid_audio_out=$(FM_DISCORD_WORKSPACE_FIXTURE="$INVALID_AUDIO" ped "$HOME2" source --config "$CFG2")
+  assert_contains "$invalid_audio_out" '"kind": "audio-rejected"' "invalid attachment duration is rejected"
+  assert_contains "$invalid_audio_out" "positive finite number" "invalid attachment duration refusal names the boundary"
+done
+pass "audio attachments reject non-finite and non-positive durations"
+
+for metadata_case in size-boolean size-string size-fraction duration-boolean duration-string; do
+  INVALID_METADATA="$TMP_ROOT/invalid-metadata-$metadata_case.json"
+  python3 - "$INVALID_METADATA" "$metadata_case" <<'PY'
+import json, sys
+case = sys.argv[2]
+size = {"size-boolean": True, "size-string": "1024", "size-fraction": 1024.5}.get(case, 1024)
+duration = {"duration-boolean": True, "duration-string": "12"}.get(case, 12)
+data = {"messages": [{
+    "id": "999999999999999990",
+    "guild_id": "111111111111111111",
+    "channel_id": "888888888888888881",
+    "parent_id": "555555555555555552",
+    "author": {"id": "444444444444444444"},
+    "flags": 8192,
+    "attachments": [{
+        "id": "101010101010101011",
+        "filename": "voice.ogg",
+        "content_type": "audio/ogg",
+        "size": size,
+        "duration_secs": duration,
+        "url": "https://cdn.discordapp.com/attachments/1/voice.ogg",
+    }],
+}]}
+with open(sys.argv[1], "w", encoding="utf-8") as stream:
+    json.dump(data, stream)
+PY
+  invalid_metadata_out=$(FM_DISCORD_WORKSPACE_FIXTURE="$INVALID_METADATA" ped "$HOME2" source --config "$CFG2")
+  assert_contains "$invalid_metadata_out" '"kind": "audio-rejected"' "invalid $metadata_case metadata is rejected"
+  case "$metadata_case" in
+    size-*) assert_contains "$invalid_metadata_out" "positive JSON integer" "invalid $metadata_case refusal names the JSON type boundary" ;;
+    *) assert_contains "$invalid_metadata_out" "encoded as a JSON number" "invalid $metadata_case refusal names the JSON type boundary" ;;
+  esac
+done
+pass "audio metadata preserves strict JSON numeric types"
+
+for flags_case in boolean numeric-string invalid-string negative; do
+  INVALID_FLAGS="$TMP_ROOT/invalid-flags-$flags_case.json"
+  python3 - "$INVALID_FLAGS" "$flags_case" <<'PY'
+import json, sys
+flags = {"boolean": True, "numeric-string": "8192", "invalid-string": "voice", "negative": -1}[sys.argv[2]]
+data = {"messages": [{
+    "id": "999999999999999990",
+    "guild_id": "111111111111111111",
+    "channel_id": "888888888888888881",
+    "parent_id": "555555555555555552",
+    "author": {"id": "444444444444444444"},
+    "content": "Retain rejected text context.",
+    "flags": flags,
+    "attachments": [{
+        "id": "101010101010101011",
+        "filename": "voice.ogg",
+        "content_type": "audio/ogg",
+        "size": 1024,
+        "duration_secs": 12,
+        "url": "https://cdn.discordapp.com/attachments/1/voice.ogg",
+    }],
+}]}
+with open(sys.argv[1], "w", encoding="utf-8") as stream:
+    json.dump(data, stream)
+PY
+  invalid_flags_status=0
+  invalid_flags_out=$(FM_DISCORD_WORKSPACE_FIXTURE="$INVALID_FLAGS" ped "$HOME2" source --config "$CFG2") || invalid_flags_status=$?
+  [ "$invalid_flags_status" -eq 0 ] || fail "malformed $flags_case flags aborted Discord source"
+  assert_contains "$invalid_flags_out" '"kind": "message-rejected"' "malformed $flags_case flags produce a controlled rejection"
+  assert_not_contains "$invalid_flags_out" '"kind": "audio-rejected"' "malformed general metadata is not mislabeled as audio"
+  assert_contains "$invalid_flags_out" "Retain rejected text context." "malformed $flags_case flags retain safe text context"
+  assert_contains "$invalid_flags_out" "non-negative JSON integer" "malformed $flags_case flags name the type boundary"
+done
+for bot_case in string-false numeric-zero; do
+  INVALID_BOT="$TMP_ROOT/invalid-bot-$bot_case.json"
+  python3 - "$INVALID_BOT" "$bot_case" <<'PY'
+import json, sys
+bot = {"string-false": "false", "numeric-zero": 0}[sys.argv[2]]
+data = {"messages": [{
+    "id": "999999999999999990",
+    "guild_id": "111111111111111111",
+    "channel_id": "888888888888888881",
+    "parent_id": "555555555555555552",
+    "author": {"id": "444444444444444444", "bot": bot},
+    "content": "Retain malformed author context.",
+}]}
+with open(sys.argv[1], "w", encoding="utf-8") as stream:
+    json.dump(data, stream)
+PY
+  invalid_bot_status=0
+  invalid_bot_out=$(FM_DISCORD_WORKSPACE_FIXTURE="$INVALID_BOT" ped "$HOME2" source --config "$CFG2") || invalid_bot_status=$?
+  [ "$invalid_bot_status" -eq 0 ] || fail "malformed $bot_case bot metadata aborted Discord source"
+  assert_contains "$invalid_bot_out" '"kind": "message-rejected"' "malformed $bot_case bot metadata produces a generic rejection"
+  assert_contains "$invalid_bot_out" "author bot metadata must be a JSON boolean" "malformed $bot_case bot metadata names the type boundary"
+  assert_contains "$invalid_bot_out" "Retain malformed author context." "malformed $bot_case bot metadata retains text context"
+done
+for container_case in attachments author content attachment-member; do
+  INVALID_CONTAINER="$TMP_ROOT/invalid-container-$container_case.json"
+  python3 - "$INVALID_CONTAINER" "$container_case" <<'PY'
+import json, sys
+message = {
+    "id": "999999999999999990",
+    "guild_id": "111111111111111111",
+    "channel_id": "888888888888888881",
+    "parent_id": "555555555555555552",
+    "author": {"id": "444444444444444444"},
+    "content": "Retain malformed container context.",
+}
+if sys.argv[2] == "attachments":
+    message["attachments"] = {}
+elif sys.argv[2] == "author":
+    message["author"] = []
+    message["author_id"] = "444444444444444444"
+elif sys.argv[2] == "content":
+    message["content"] = {"request": "not text"}
+else:
+    message["attachments"] = ["not an object"]
+with open(sys.argv[1], "w", encoding="utf-8") as stream:
+    json.dump({"messages": [message]}, stream)
+PY
+  invalid_container_status=0
+  invalid_container_out=$(FM_DISCORD_WORKSPACE_FIXTURE="$INVALID_CONTAINER" ped "$HOME2" source --config "$CFG2") || invalid_container_status=$?
+  [ "$invalid_container_status" -eq 0 ] || fail "malformed $container_case container aborted Discord source"
+  assert_contains "$invalid_container_out" '"kind": "message-rejected"' "malformed $container_case container produces a generic rejection"
+  case "$container_case" in
+    attachments) assert_contains "$invalid_container_out" "message.attachments must be a list" "malformed attachments container names the type boundary" ;;
+    author) assert_contains "$invalid_container_out" "message author metadata must be a JSON object" "malformed author container names the type boundary" ;;
+    content)
+      assert_contains "$invalid_container_out" "message content must be a JSON string" "malformed content names the type boundary"
+      assert_not_contains "$invalid_container_out" "not text" "malformed content is not coerced into request text"
+      ;;
+    attachment-member) assert_contains "$invalid_container_out" "attachments must contain only JSON objects" "malformed attachment member names the type boundary" ;;
+  esac
+  if [ "$container_case" != content ]; then
+    assert_contains "$invalid_container_out" "Retain malformed container context." "malformed $container_case container retains text context"
+  fi
+done
+CFG4="$HOME4/config/discord-workspace.json"
+make_config "$HOME4" "$CFG4"
+pe "$HOME4" register discord-workspace discord-workspace -- \
+  "$ROOT/bin/fm-procevent-discord-workspace.sh" source --config "$CFG4" >/dev/null
+MALFORMED_SEQUENCE="$TMP_ROOT/malformed-sequence.json"
+cat > "$MALFORMED_SEQUENCE" <<'JSON'
+{"messages":[
+  {"id":"999999999999999991","guild_id":"111111111111111111","channel_id":"888888888888888881","parent_id":"555555555555555552","author":{"id":"444444444444444444"},"attachments":{},"content":"Retain malformed attachment context."},
+  {"id":"999999999999999992","guild_id":"111111111111111111","channel_id":"888888888888888881","parent_id":"555555555555555552","author":{"id":"444444444444444444"},"content":"Message after malformed metadata."}
+]}
+JSON
+out=$(FM_DISCORD_WORKSPACE_FIXTURE="$MALFORMED_SEQUENCE" pe "$HOME4" start discord-workspace)
+assert_contains "$out" "autohandled" "generic metadata rejection is autohandled"
+NOTE4=$(first_note "$HOME4") || fail "generic metadata rejection did not create an inbox note"
+assert_grep "message rejected" "$NOTE4" "invalid general metadata creates a generic rejection note"
+assert_grep "context: Retain malformed attachment context." "$NOTE4" "generic rejection note retains safe text context"
+assert_not_contains "$(cat "$NOTE4")" "audio rejected" "generic rejection note does not claim an audio failure"
+out=$(FM_DISCORD_WORKSPACE_FIXTURE="$MALFORMED_SEQUENCE" pe "$HOME4" start discord-workspace)
+assert_contains "$out" "autohandled" "intake advances beyond malformed message metadata"
+[ "$(note_count "$HOME4")" = 2 ] || fail "malformed metadata prevented the following message from being captured"
+grep -q "Message after malformed metadata." "$HOME4/state/inbox/"*.note \
+  || fail "message following malformed metadata was not preserved"
+pass "malformed message containers reject durably without wedging intake"
+
+HIGH_CURSOR_FIXTURE="$TMP_ROOT/high-cursor.json"
+LOW_CURSOR_FIXTURE="$TMP_ROOT/low-cursor.json"
+python3 - "$HIGH_CURSOR_FIXTURE" "$LOW_CURSOR_FIXTURE" <<'PY'
+import json, sys
+def fixture(message_id):
+    return {"messages": [{
+        "id": message_id,
+        "guild_id": "111111111111111111",
+        "channel_id": "888888888888888881",
+        "parent_id": "555555555555555552",
+        "author": {"id": "333333333333333333", "bot": True},
+        "content": "ignored bot fixture",
+    }]}
+for path, message_id in zip(sys.argv[1:], ("999999999999999995", "999999999999999994")):
+    with open(path, "w", encoding="utf-8") as stream:
+        json.dump(fixture(message_id), stream)
+PY
+state_lock="$HOME4/state/discord-workspace/.state.lock"
+mkdir -p "$(dirname "$state_lock")"
+exec 9>"$state_lock"
+flock -x 9
+FM_DISCORD_WORKSPACE_FIXTURE="$HIGH_CURSOR_FIXTURE" ped "$HOME4" source --config "$CFG4" >"$TMP_ROOT/high-cursor.out" 2>&1 9>&- &
+high_cursor_pid=$!
+sleep 0.1
+kill -0 "$high_cursor_pid" 2>/dev/null || fail "high cursor update did not wait for the state transaction"
+FM_DISCORD_WORKSPACE_FIXTURE="$LOW_CURSOR_FIXTURE" ped "$HOME4" source --config "$CFG4" >"$TMP_ROOT/low-cursor.out" 2>&1 9>&- &
+low_cursor_pid=$!
+sleep 0.1
+flock -u 9
+exec 9>&-
+high_cursor_status=0
+low_cursor_status=0
+wait "$high_cursor_pid" || high_cursor_status=$?
+wait "$low_cursor_pid" || low_cursor_status=$?
+[ "$high_cursor_status" -eq 75 ] && [ "$low_cursor_status" -eq 75 ] \
+  || fail "ignored cursor fixtures returned unexpected statuses: $high_cursor_status $low_cursor_status"
+cursor_value=$(cat "$HOME4/state/discord-workspace/cursors/proapplis/888888888888888881.cursor")
+[ "$cursor_value" = 999999999999999995 ] || fail "concurrent cursor updates regressed to $cursor_value"
+pass "concurrent cursor updates advance monotonically"
+
+REQUEST_FIXTURE="$TMP_ROOT/concurrent-request.json"
+cat > "$REQUEST_FIXTURE" <<'JSON'
+{"messages":[{"id":"999999999999999999","guild_id":"111111111111111111","channel_id":"888888888888888881","parent_id":"555555555555555552","author":{"id":"444444444444444444"},"content":"Concurrent request binding."}]}
+JSON
+REASSIGNED_CFG="$TMP_ROOT/reassigned-request.json"
+python3 - "$CFG4" "$REASSIGNED_CFG" <<'PY'
+import json, sys
+with open(sys.argv[1], encoding="utf-8") as stream:
+    data = json.load(stream)
+data["profiles"]["proapplis"]["thread_ids"]["exchange"] = []
+data["profiles"]["folium"]["thread_ids"]["exchange"] = ["888888888888888881"]
+with open(sys.argv[2], "w", encoding="utf-8") as stream:
+    json.dump(data, stream)
+PY
+concurrent_request_id='discord:111111111111111111:888888888888888881:999999999999999999'
+request_digest=$(python3 - "$concurrent_request_id" <<'PY'
+import hashlib, sys
+print(hashlib.sha256(sys.argv[1].encode()).hexdigest())
+PY
+)
+request_record="$HOME4/state/discord-workspace/requests/$request_digest.json"
+baseline_note_count=$(note_count "$HOME4")
+exec 9>"$state_lock"
+flock -x 9
+FM_HOME="$HOME4" "$ROOT/bin/fm-discord-workspace.sh" link-task concurrent-binding \
+  --config "$REASSIGNED_CFG" --request-id "$concurrent_request_id" >"$TMP_ROOT/concurrent-link.out" 2>&1 9>&- &
+concurrent_link_pid=$!
+sleep 0.1
+kill -0 "$concurrent_link_pid" 2>/dev/null || fail "concurrent task link did not wait for the state transaction"
+FM_DISCORD_WORKSPACE_FIXTURE="$REQUEST_FIXTURE" pe "$HOME4" start discord-workspace >"$TMP_ROOT/concurrent-autohandle.out" 2>&1 9>&- &
+autohandle_pid=$!
+sleep 0.2
+[ "$(note_count "$HOME4")" = "$baseline_note_count" ] \
+  || fail "blocked autohandle exposed an inbox note before canonical request publication"
+assert_absent "$request_record" "concurrent request publication waits for the state transaction"
+flock -u 9
+exec 9>&-
+autohandle_status=0
+concurrent_link_status=0
+wait "$concurrent_link_pid" || concurrent_link_status=$?
+wait "$autohandle_pid" || autohandle_status=$?
+[ "$concurrent_link_status" -eq 0 ] \
+  || fail "first concurrent request publisher did not win: link=$concurrent_link_status autohandle=$autohandle_status"
+python3 - "$request_record" "$HOME4/state/discord-workspace/task-links/concurrent-binding.json" <<'PY'
+import json, sys
+with open(sys.argv[1], encoding="utf-8") as stream:
+    request = json.load(stream)
+with open(sys.argv[2], encoding="utf-8") as stream:
+    link = json.load(stream)
+if request["profile"] != "folium" or request["profile"] != link["profile"] or request["request_id"] != link["request_id"]:
+    raise SystemExit("canonical request and task link bindings disagree")
+PY
+[ "$(note_count "$HOME4")" = "$baseline_note_count" ] \
+  || fail "losing autohandle exposed a misprofiled inbox note"
+pass "concurrent request conflicts leave no misprofiled inbox note"
+
 FIXTURE2="$TMP_ROOT/voice.json"
 cat > "$FIXTURE2" <<'JSON'
 {
@@ -160,6 +447,7 @@ out=$(FM_DISCORD_WORKSPACE_FIXTURE="$FIXTURE2" pe "$HOME2" start discord-workspa
 assert_contains "$out" "autohandled" "voice fixture is autohandled"
 NOTE2=$(first_note "$HOME2") || fail "voice fixture did not create a note"
 assert_grep "voice transcript" "$NOTE2" "voice note is identified as a transcript"
+assert_grep "caption: Voice context." "$NOTE2" "voice note preserves its text caption"
 assert_grep "transcribed voice fixture" "$NOTE2" "fake transcription is used for voice fixtures"
 assert_grep "transcription: fake fixture, no secret" "$NOTE2" "voice note does not print provider secrets"
 assert_not_contains "$(cat "$NOTE2")" "FIRSTMATE_DISCORD_GROQ_API_KEY" "voice note does not leak secret key names"
@@ -177,6 +465,7 @@ cat > "$FIXTURE3" <<'JSON'
       "channel_id":"888888888888888881",
       "parent_id":"555555555555555552",
       "author":{"id":"444444444444444444"},
+      "content":"Keep this rejected audio caption.",
       "flags":8192,
       "attachments":[{"id":"202020202020202020","filename":"voice.ogg","content_type":"audio/ogg","size":1024,"duration_secs":12,"url":"https://evil.example.invalid/voice.ogg"}]
     }
@@ -190,5 +479,6 @@ assert_contains "$out" "autohandled" "bad audio rejection is autohandled"
 NOTE3=$(first_note "$HOME3") || fail "bad audio fixture did not create an error note"
 assert_grep "audio rejected" "$NOTE3" "bad audio creates a durable rejection note"
 assert_grep "Discord CDN allowlist" "$NOTE3" "bad audio refusal names the failed check"
+assert_grep "caption: Keep this rejected audio caption." "$NOTE3" "rejected audio note preserves its text caption"
 assert_not_contains "$(cat "$NOTE3")" "do-not-print" "bad audio note does not leak secret material"
 pass "audio intake rejects non-Discord CDN URLs with a durable non-secret note"

--- a/tests/fm-procevent.test.sh
+++ b/tests/fm-procevent.test.sh
@@ -146,6 +146,18 @@ assert_contains "$out" "published=0 started=0" "reconcile is a no-op with nothin
 [ -z "$(ls -A "$IDLE/state" 2>/dev/null)" ] || fail "an unconfigured home generated state: $(ls -A "$IDLE/state")"
 pass "no configured source means no generated state and no process"
 
+HMODE="$TMP_ROOT/hmode"
+mkdir -p "$HMODE/state"
+chmod 775 "$HMODE/state"
+out=$(pe "$HMODE" list)
+assert_contains "$out" "no sources registered" "process-event tolerates a same-user state dir created under a group-writable umask"
+mode=$(PATH="${FM_TEST_BASE_PATH:-/usr/bin:/bin:/usr/sbin:/sbin}" bash -c \
+  '. "$1/bin/fm-pr-lib.sh"; fm_pr_file_mode "$2"' _ "$ROOT" "$HMODE/state")
+case "$mode" in ''|*[!0-7]*) fail "process-event produced an unreadable state-root mode: $mode" ;; esac
+[ $((8#$mode & 8#022)) -eq 0 ] \
+  || fail "process-event left the state root group/other writable: $mode"
+pass "process-event normalizes an ambient-umask state directory before validating it"
+
 sup=$(PATH="${FM_TEST_BASE_PATH:-/usr/bin:/bin:/usr/sbin:/sbin}" bash -c \
   '. "$1/bin/fm-supervision-lib.sh"; fm_supervision_needed "$2" && echo yes || echo no' _ "$ROOT" "$IDLE/state")
 assert_contains "$sup" no "an unconfigured home does not need supervision"
@@ -336,6 +348,7 @@ assert_absent "$HRACE/state/.wake-queue" "an acknowledged result was appended af
 pass "publication cannot race a handled acknowledgement"
 
 HPRIVATE="$TMP_ROOT/hprivate"; new_home "$HPRIVATE"
+chmod 700 "$HPRIVATE/state"
 mkdir -p "$HPRIVATE/state/procevent-inbox"
 printf 'private result\n' > "$HPRIVATE/state/procevent-inbox/private-src.1.result"
 printf 'lavish\n' > "$HPRIVATE/state/procevent-inbox/private-src.1.adapter"

--- a/tests/fm-remote-job.test.sh
+++ b/tests/fm-remote-job.test.sh
@@ -188,16 +188,13 @@ MISE_EXPECTED=$(printf '%s\n' "$MISE_INSTALLS"/*/*/bin)
 rm -rf -- "$ACCOUNT_HOME/.local/share/mise"
 pass "operator PATH orders discovered tool installs deterministically"
 
+# Exercise the public Linux gateway start path, not only the worker executable.
 HOME="$ACCOUNT_HOME" XDG_CONFIG_HOME="$TMP_ROOT/custom-config" GH_CONFIG_DIR="$TMP_ROOT/custom-gh" \
   PATH="$RUNTIME_BIN:/usr/bin:/bin:/usr/sbin:/sbin" FM_FAKE_PERL_LOG="$FAKE_PERL_LOG" \
   FM_ROOT_OVERRIDE="$REMOTE_ROOT" FM_REMOTE_JOB_STATE_ROOT="$STATE_ROOT" \
   FM_REMOTE_JOB_PLATFORM_OVERRIDE=Linux FM_REMOTE_JOB_TIMEOUT=5 \
-  "$REMOTE_ROOT/bin/fm-remote-job-worker.sh" > "$TMP_ROOT/worker.out" 2> "$TMP_ROOT/worker.err" &
-for _ in $(seq 1 100); do
-  [ -f "$STATE_ROOT/worker.ready" ] && break
-  sleep 0.05
-done
-assert_present "$STATE_ROOT/worker.ready" "the worker did not publish its readiness heartbeat"
+  fm_remote_job_ensure_worker "$REMOTE_ROOT" "$ACCOUNT_HOME" \
+  || fail "the Linux gateway did not start the custom-root worker"
 
 file_mode() {
   if [ "$(uname)" = Darwin ]; then

--- a/tests/fm-remote-job.test.sh
+++ b/tests/fm-remote-job.test.sh
@@ -42,7 +42,9 @@ printf 'fixture\n' > "$REMOTE_ROOT/AGENTS.md"
 cat > "$REMOTE_ROOT/bin/fm-probe-job.sh" <<'SH'
 #!/bin/bash
 set -u
-printf 'home=%s\nroot=%s\nactive=%s\npath=%s\n' "$FM_HOME" "$FM_ROOT_OVERRIDE" "${FM_REMOTE_JOB_ACTIVE:-}" "$PATH"
+credential_vars=absent
+[ -n "${GH_TOKEN+x}${GITHUB_TOKEN+x}${FMX_PAIRING_TOKEN+x}" ] && credential_vars=present
+printf 'uid=%s\nhome=%s\nroot=%s\nactive=%s\npath=%s\nxdg=%s\ngh_config=%s\ncredential_vars=%s\n' "$(id -u)" "$FM_HOME" "$FM_ROOT_OVERRIDE" "${FM_REMOTE_JOB_ACTIVE:-}" "$PATH" "${XDG_CONFIG_HOME-unset}" "${GH_CONFIG_DIR-unset}" "$credential_vars"
 printf 'args:'
 printf ' <%s>' "$@"
 printf '\n'
@@ -186,7 +188,8 @@ MISE_EXPECTED=$(printf '%s\n' "$MISE_INSTALLS"/*/*/bin)
 rm -rf -- "$ACCOUNT_HOME/.local/share/mise"
 pass "operator PATH orders discovered tool installs deterministically"
 
-HOME="$ACCOUNT_HOME" PATH="$RUNTIME_BIN:/usr/bin:/bin:/usr/sbin:/sbin" FM_FAKE_PERL_LOG="$FAKE_PERL_LOG" \
+HOME="$ACCOUNT_HOME" XDG_CONFIG_HOME="$TMP_ROOT/custom-config" GH_CONFIG_DIR="$TMP_ROOT/custom-gh" \
+  PATH="$RUNTIME_BIN:/usr/bin:/bin:/usr/sbin:/sbin" FM_FAKE_PERL_LOG="$FAKE_PERL_LOG" \
   FM_ROOT_OVERRIDE="$REMOTE_ROOT" FM_REMOTE_JOB_STATE_ROOT="$STATE_ROOT" \
   FM_REMOTE_JOB_PLATFORM_OVERRIDE=Linux FM_REMOTE_JOB_TIMEOUT=5 \
   "$REMOTE_ROOT/bin/fm-remote-job-worker.sh" > "$TMP_ROOT/worker.out" 2> "$TMP_ROOT/worker.err" &
@@ -217,6 +220,17 @@ fm_remote_job_wait "$ACCOUNT_HOME" "$JOB_ID" || fail "$FM_REMOTE_JOB_ERROR"
 OUT=$(<"$FM_REMOTE_JOB_STDOUT")
 assert_contains "$OUT" "home=$REMOTE_HOME" "the worker did not pass the staged FM_HOME"
 assert_contains "$OUT" "root=$REMOTE_ROOT" "the worker did not pass the configured root"
+case "$OUT" in uid=[0-9]*$'\n'*) : ;; *) fail "the worker context did not report a numeric uid" ;; esac
+assert_contains "$OUT" "xdg=$TMP_ROOT/custom-config" "the worker did not preserve the worker XDG config root"
+assert_contains "$OUT" "gh_config=$TMP_ROOT/custom-gh" "the worker did not preserve the worker gh config root"
+assert_contains "$OUT" 'credential_vars=absent' "credential variables crossed into the worker child"
+printf 'observed worker context: %s %s %s %s %s %s\n' \
+  "$(printf '%s\n' "$OUT" | grep '^uid=')" \
+  "$(printf '%s\n' "$OUT" | grep '^home=')" \
+  "$(printf '%s\n' "$OUT" | grep '^xdg=')" \
+  "$(printf '%s\n' "$OUT" | grep '^gh_config=')" \
+  "$(printf '%s\n' "$OUT" | grep '^path=')" \
+  "$(printf '%s\n' "$OUT" | grep '^credential_vars=')"
 assert_contains "$OUT" 'active=1' "the target did not execute inside the worker environment"
 # shellcheck disable=SC2016 # Literal shell-looking expected output is an injection probe.
 assert_contains "$OUT" 'args: <two words> <$(not executed)>' "the worker changed argv boundaries"
@@ -228,6 +242,42 @@ fm_remote_job_reap "$ACCOUNT_HOME" "$JOB_ID" || fail "the completed job could no
 assert_absent "$JOB_DIR" "reap retained a completed job record"
 assert_absent "$FAKE_PERL_LOG" "the worker invoked an unavailable Perl runtime"
 pass "the worker preserves bounded argv and stdin in an empty environment"
+
+# An unset worker configuration uses the account-home roots, including when the
+# worker is started through the Linux gateway path rather than LaunchAgent.
+fm_remote_job_stop_worker_tree "$(cat "$STATE_ROOT/worker.pid")" \
+  || fail "the custom-root worker could not be stopped before the default-root probe"
+env -u XDG_CONFIG_HOME -u GH_CONFIG_DIR \
+  HOME="$ACCOUNT_HOME" PATH="$RUNTIME_BIN:/usr/bin:/bin:/usr/sbin:/sbin" \
+  FM_ROOT_OVERRIDE="$REMOTE_ROOT" FM_REMOTE_JOB_STATE_ROOT="$STATE_ROOT" \
+  FM_REMOTE_JOB_PLATFORM_OVERRIDE=Linux FM_REMOTE_JOB_TIMEOUT=5 \
+  "$REMOTE_ROOT/bin/fm-remote-job-worker.sh" > "$TMP_ROOT/default-worker.out" 2> "$TMP_ROOT/default-worker.err" &
+for _ in $(seq 1 100); do
+  [ -f "$STATE_ROOT/worker.ready" ] && break
+  sleep 0.05
+done
+assert_present "$STATE_ROOT/worker.ready" "the default-root worker did not publish readiness"
+unset XDG_CONFIG_HOME GH_CONFIG_DIR
+fm_remote_job_stage "$ACCOUNT_HOME" "$REMOTE_ROOT" "$REMOTE_HOME" fm-probe-job.sh < /dev/null > /dev/null
+JOB_ID=$FM_REMOTE_JOB_ID
+fm_remote_job_wait "$ACCOUNT_HOME" "$JOB_ID" || fail "$FM_REMOTE_JOB_ERROR"
+OUT=$(<"$FM_REMOTE_JOB_STDOUT")
+assert_contains "$OUT" "xdg=$ACCOUNT_HOME/.config" "the worker did not apply the default XDG config root"
+assert_contains "$OUT" "gh_config=$ACCOUNT_HOME/.config/gh" "the worker did not apply the default gh config root"
+fm_remote_job_reap "$ACCOUNT_HOME" "$JOB_ID" || fail "the default-root probe could not be reaped"
+pass "the Linux worker applies account-home configuration defaults"
+
+# The rendered and installed Aqua contract must carry the same defaults.
+PLIST=$(fm_remote_job_render_launchagent "$REMOTE_ROOT" "$ACCOUNT_HOME")
+assert_contains "$PLIST" '<key>XDG_CONFIG_HOME</key>' "the LaunchAgent omitted XDG_CONFIG_HOME"
+assert_contains "$PLIST" "<string>$ACCOUNT_HOME/.config</string>" "the LaunchAgent omitted the XDG default"
+assert_contains "$PLIST" '<key>GH_CONFIG_DIR</key>' "the LaunchAgent omitted GH_CONFIG_DIR"
+assert_contains "$PLIST" "<string>$ACCOUNT_HOME/.config/gh</string>" "the LaunchAgent omitted the gh default"
+fm_remote_job_write_launchagent "$REMOTE_ROOT" "$ACCOUNT_HOME" \
+  || fail "$FM_REMOTE_JOB_ERROR"
+fm_remote_job_launchagent_contract_matches "$REMOTE_ROOT" "$ACCOUNT_HOME" \
+  || fail "the installed LaunchAgent diverged from its rendered contract"
+pass "the macOS LaunchAgent carries the account-home configuration defaults"
 
 ACTIVE_SIDE_EFFECT="$TMP_ROOT/active-side-effect"
 FM_REMOTE_JOB_TIMEOUT=10

--- a/tests/fm-teardown.test.sh
+++ b/tests/fm-teardown.test.sh
@@ -635,6 +635,28 @@ test_teardown_closes_the_backlog_item_itself() {
   pass "teardown closes its own backlog item before reporting success"
 }
 
+test_discord_workspace_pending_final_refuses_cleanup() {
+  local case_dir rc
+  case_dir=$(make_case discord-workspace-pending-final)
+  write_meta "$case_dir" no-mistakes ship
+  mkdir -p "$case_dir/state/discord-workspace/pending-followups"
+  cat > "$case_dir/state/discord-workspace/pending-followups/task-x1.json" <<'JSON'
+{"schema":"fm-discord-workspace-pending-followup.v1","task_id":"task-x1","request_id":"discord:111111111111111111:222222222222222222:333333333333333333","profile":"proapplis","status":"pending"}
+JSON
+
+  set +e
+  run_teardown "$case_dir" > "$case_dir/stdout" 2> "$case_dir/stderr"
+  rc=$?
+  set -e
+
+  expect_code 1 "$rc" "discord-workspace-pending-final: teardown should refuse"
+  grep -q 'private Discord workspace final reply' "$case_dir/stderr" \
+    || fail "discord-workspace-pending-final: refusal did not name the pending final reply"
+  assert_present "$case_dir/state/task-x1.meta" \
+    "discord-workspace-pending-final: teardown removed task state despite a pending final reply"
+  pass "teardown refuses while a private Discord workspace final reply is pending"
+}
+
 test_teardown_manual_backend_leaves_the_backlog_to_the_operator() {
   local case_dir out backlog_path
   case_dir=$(make_case tasks-axi-manual-optout)
@@ -3466,6 +3488,7 @@ EOF
 
 test_local_only_fork_remote_allows
 test_teardown_closes_the_backlog_item_itself
+test_discord_workspace_pending_final_refuses_cleanup
 test_teardown_manual_backend_leaves_the_backlog_to_the_operator
 test_local_only_truly_unpushed_refuses
 test_local_only_merged_to_local_main_allows

--- a/tests/fm-test-run.test.sh
+++ b/tests/fm-test-run.test.sh
@@ -1296,59 +1296,25 @@ SH
 
 test_herdr_ci_family_run_has_a_step_timeout() {
   # The required Herdr lane's hang tripwire is the family-run *step* bound, not
-  # the 75-minute job cap. Parse the workflow's indentation structure with the
-  # standard Python runtime so nested `with.name` artifact keys cannot
-  # masquerade as the step contract and local tests need no Ruby dependency.
+  # the 75-minute job cap. Parse the workflow as real YAML so nested `with.name`
+  # artifact keys cannot masquerade as the step contract.
   local json job_timeout step_timeout
   json=$(python3 - "$ROOT/.github/workflows/ci.yml" <<'PY'
-import json, re, sys
-path = sys.argv[1]
-lines = open(path, encoding="utf-8").read().splitlines()
-
-def indent(line):
-    return len(line) - len(line.lstrip(" "))
-
-def active(line):
-    stripped = line.strip()
-    return bool(stripped and not stripped.startswith("#"))
-
-job_start = None
-for i, line in enumerate(lines):
-    if active(line) and re.match(r"^  tests-herdr:\s*$", line):
-        job_start = i
-        break
-if job_start is None:
-    raise SystemExit("missing tests-herdr job")
-job_end = len(lines)
-for i in range(job_start + 1, len(lines)):
-    line = lines[i]
-    if active(line) and indent(line) <= 2:
-        job_end = i
-        break
-job = lines[job_start:job_end]
-job_timeout = None
-steps_start = None
-for offset, line in enumerate(job):
-    if active(line) and re.match(r"^    timeout-minutes:\s*([0-9]+)\s*$", line):
-        job_timeout = int(line.split(":", 1)[1].strip())
-    if active(line) and re.match(r"^    steps:\s*$", line):
-        steps_start = offset
-if job_timeout is None:
-    raise SystemExit("tests-herdr job has no timeout-minutes")
-if steps_start is None:
-    raise SystemExit("tests-herdr job has no steps")
-step_timeout = None
-in_target = False
-for line in job[steps_start + 1:]:
-    if active(line) and re.match(r"^      -\s+name:\s*", line):
-        in_target = line.split(":", 1)[1].strip() == "Run real-Herdr family (serial, required)"
-        continue
-    if in_target and active(line) and re.match(r"^        timeout-minutes:\s*([0-9]+)\s*$", line):
-        step_timeout = int(line.split(":", 1)[1].strip())
-        break
-if step_timeout is None:
-    raise SystemExit("family-run step has no timeout-minutes")
-print(json.dumps({"job_timeout": job_timeout, "step_timeout": step_timeout}))
+import json, sys
+try:
+    import yaml
+except ImportError:
+    raise SystemExit("PyYAML is required to parse .github/workflows/ci.yml as YAML")
+doc = yaml.safe_load(open(sys.argv[1], encoding="utf-8"))
+job = doc["jobs"]["tests-herdr"]
+step = next(
+    s for s in job["steps"]
+    if isinstance(s, dict) and s.get("name") == "Run real-Herdr family (serial, required)"
+)
+print(json.dumps({
+    "job_timeout": job["timeout-minutes"],
+    "step_timeout": step["timeout-minutes"],
+}))
 PY
 ) || fail "could not parse tests-herdr timeouts from ci.yml"
   job_timeout=$(python3 -c 'import json,sys; print(json.load(sys.stdin)["job_timeout"])' <<<"$json") \

--- a/tests/fm-test-run.test.sh
+++ b/tests/fm-test-run.test.sh
@@ -25,8 +25,8 @@ test_list_all_exact_suite_coverage() {
     done | LC_ALL=C sort
   )
   [ -n "$listed" ] || fail "--list --all printed nothing"
-  missing=$(comm -23 <(printf '%s\n' "$expected") <(printf '%s\n' "$listed") || true)
-  extra=$(comm -13 <(printf '%s\n' "$expected") <(printf '%s\n' "$listed") || true)
+  missing=$(LC_ALL=C comm -23 <(printf '%s\n' "$expected") <(printf '%s\n' "$listed") || true)
+  extra=$(LC_ALL=C comm -13 <(printf '%s\n' "$expected") <(printf '%s\n' "$listed") || true)
   [ -z "$missing" ] || fail "--list --all missing scripts: $missing"
   [ -z "$extra" ] || fail "--list --all unexpected scripts: $extra"
   # No duplicates.
@@ -761,7 +761,7 @@ test_portable_shard_union_and_coverage_guard() {
   herdr=$("$RUNNER" --list --family real-herdr-gated)
   [ -n "$s1" ] && [ -n "$s2" ] || fail "portable parallel shards must be non-empty"
   # Shards disjoint.
-  overlap=$(comm -12 <(printf '%s\n' "$s1" | LC_ALL=C sort) <(printf '%s\n' "$s2" | LC_ALL=C sort) || true)
+  overlap=$(LC_ALL=C comm -12 <(printf '%s\n' "$s1" | LC_ALL=C sort) <(printf '%s\n' "$s2" | LC_ALL=C sort) || true)
   [ -z "$overlap" ] || fail "portable parallel shards overlap: $overlap"
   # Union of shards equals proven-isolated.
   [ "$(printf '%s\n' "$s1" "$s2" | LC_ALL=C sort -u)" = \
@@ -1296,25 +1296,61 @@ SH
 
 test_herdr_ci_family_run_has_a_step_timeout() {
   # The required Herdr lane's hang tripwire is the family-run *step* bound, not
-  # the 75-minute job cap. Parse the workflow as YAML so nested `with.name`
-  # artifact keys cannot masquerade as the step contract.
-  command -v ruby >/dev/null 2>&1 \
-    || fail "ruby is required to parse .github/workflows/ci.yml as YAML"
+  # the 75-minute job cap. Parse the workflow's indentation structure with the
+  # standard Python runtime so nested `with.name` artifact keys cannot
+  # masquerade as the step contract and local tests need no Ruby dependency.
   local json job_timeout step_timeout
-  json=$(ruby -ryaml -rjson -e '
-doc = YAML.load_file(ARGV[0])
-job = doc.fetch("jobs").fetch("tests-herdr")
-step = job.fetch("steps").find { |s|
-  s.is_a?(Hash) && s["name"] == "Run real-Herdr family (serial, required)"
-}
-raise "missing family-run step" if step.nil?
-raise "family-run step has no timeout-minutes" unless step.key?("timeout-minutes")
-puts JSON.generate(
-  "job_timeout" => job.fetch("timeout-minutes"),
-  "step_timeout" => step.fetch("timeout-minutes")
-)
-' "$ROOT/.github/workflows/ci.yml") \
-    || fail "could not parse tests-herdr timeouts from ci.yml"
+  json=$(python3 - "$ROOT/.github/workflows/ci.yml" <<'PY'
+import json, re, sys
+path = sys.argv[1]
+lines = open(path, encoding="utf-8").read().splitlines()
+
+def indent(line):
+    return len(line) - len(line.lstrip(" "))
+
+def active(line):
+    stripped = line.strip()
+    return bool(stripped and not stripped.startswith("#"))
+
+job_start = None
+for i, line in enumerate(lines):
+    if active(line) and re.match(r"^  tests-herdr:\s*$", line):
+        job_start = i
+        break
+if job_start is None:
+    raise SystemExit("missing tests-herdr job")
+job_end = len(lines)
+for i in range(job_start + 1, len(lines)):
+    line = lines[i]
+    if active(line) and indent(line) <= 2:
+        job_end = i
+        break
+job = lines[job_start:job_end]
+job_timeout = None
+steps_start = None
+for offset, line in enumerate(job):
+    if active(line) and re.match(r"^    timeout-minutes:\s*([0-9]+)\s*$", line):
+        job_timeout = int(line.split(":", 1)[1].strip())
+    if active(line) and re.match(r"^    steps:\s*$", line):
+        steps_start = offset
+if job_timeout is None:
+    raise SystemExit("tests-herdr job has no timeout-minutes")
+if steps_start is None:
+    raise SystemExit("tests-herdr job has no steps")
+step_timeout = None
+in_target = False
+for line in job[steps_start + 1:]:
+    if active(line) and re.match(r"^      -\s+name:\s*", line):
+        in_target = line.split(":", 1)[1].strip() == "Run real-Herdr family (serial, required)"
+        continue
+    if in_target and active(line) and re.match(r"^        timeout-minutes:\s*([0-9]+)\s*$", line):
+        step_timeout = int(line.split(":", 1)[1].strip())
+        break
+if step_timeout is None:
+    raise SystemExit("family-run step has no timeout-minutes")
+print(json.dumps({"job_timeout": job_timeout, "step_timeout": step_timeout}))
+PY
+) || fail "could not parse tests-herdr timeouts from ci.yml"
   job_timeout=$(python3 -c 'import json,sys; print(json.load(sys.stdin)["job_timeout"])' <<<"$json") \
     || fail "could not read job timeout from parsed workflow"
   step_timeout=$(python3 -c 'import json,sys; print(json.load(sys.stdin)["step_timeout"])' <<<"$json") \

--- a/tests/fm-watch-inbox-surface.test.sh
+++ b/tests/fm-watch-inbox-surface.test.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# Focused regression: a queued captain-inbox note wake (check key inbox:<id>)
+# closes one watcher cycle for an idle main with the note's own reason, leaves
+# exactly one surfaced marker, and never re-closes a later cycle while the row
+# stays unhandled. Uses the documented wake-helpers owners and one bounded
+# watcher subprocess in an isolated test home; never touches a real home.
+set -u
+
+# shellcheck source=tests/wake-helpers.sh
+. "$(dirname "${BASH_SOURCE[0]}")/wake-helpers.sh"
+
+WATCH="$ROOT/bin/fm-watch.sh"
+TMP_ROOT=$(fm_test_tmproot fm-watch-inbox-surface-tests)
+
+dir=$(make_case inbox-note-surface)
+state="$dir/state"
+append_wake "$state" check "inbox:test-note-1" \
+  "check: captain inbox note test-note-1 - Discord workspace / text request: discord:1:2:3"
+
+out="$dir/watch.out"
+PATH="$dir/fakebin:$PATH" FM_STATE_OVERRIDE="$state" FM_HOME="$dir" \
+  FM_CREW_STATE_BIN="$dir/fakebin/fm-crew-state.sh" \
+  FM_POLL=1 FM_SIGNAL_GRACE=1 FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 \
+  "$WATCH" > "$out" 2>&1 &
+pid=$!
+
+# Bounded exit wait: the first cycle must end with the inbox reason.
+i=0
+while [ "$i" -lt 100 ]; do
+  kill -0 "$pid" 2>/dev/null || break
+  sleep 0.1
+  i=$((i + 1))
+done
+if kill -0 "$pid" 2>/dev/null; then
+  kill "$pid" 2>/dev/null
+  wait "$pid" 2>/dev/null
+  fail "the watcher did not surface the queued inbox note within the bound: $(cat "$out")"
+fi
+wait "$pid" 2>/dev/null
+grep -q "captain inbox note test-note-1" "$out" \
+  || fail "the surfaced reason lost the note summary: $(cat "$out")"
+ls "$state"/.seen-inbox-* >/dev/null 2>&1 \
+  || fail "the surfaced inbox wake left no surfaced marker"
+pass "a queued inbox-note wake closes the watcher cycle with the note reason and one marker"
+
+# Second cycle: the surfaced row must not re-close a later cycle.
+out2="$dir/watch2.out"
+PATH="$dir/fakebin:$PATH" FM_STATE_OVERRIDE="$state" FM_HOME="$dir" \
+  FM_CREW_STATE_BIN="$dir/fakebin/fm-crew-state.sh" \
+  FM_POLL=1 FM_SIGNAL_GRACE=1 FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 \
+  "$WATCH" > "$out2" 2>&1 &
+pid2=$!
+i=0
+alive=1
+while [ "$i" -lt 40 ]; do
+  kill -0 "$pid2" 2>/dev/null || { alive=0; break; }
+  sleep 0.1
+  i=$((i + 1))
+done
+if [ "$alive" = 0 ]; then
+  wait "$pid2" 2>/dev/null
+  grep -q "captain inbox note test-note-1" "$out2" \
+    && fail "a surfaced inbox wake re-closed a later cycle: $(cat "$out2")"
+  pass "a surfaced inbox row does not re-close later watcher cycles"
+else
+  kill "$pid2" 2>/dev/null
+  wait "$pid2" 2>/dev/null
+  grep -q "captain inbox note test-note-1" "$out2" \
+    && fail "a surfaced inbox wake re-closed a later cycle"
+  pass "a surfaced inbox row does not re-close later watcher cycles"
+fi


### PR DESCRIPTION
Summary:
- carry XDG_CONFIG_HOME and GH_CONFIG_DIR through the Linux remote-worker start boundary and sanitized child environment
- install equivalent account-home defaults in the macOS LaunchAgent contract
- document the supported configuration visibility and add executable regression coverage

Verification:
- bash tests/fm-remote-job.test.sh
- bash tests/fm-remote-doctor.test.sh
- bash tests/fm-remote-entrypoint.test.sh
- ./bin/fm-lint.sh
- ./bin/fm-doc-audience-check.sh
- bash syntax checks and git diff --check

Security:
- the worker observation is limited to uid, HOME, XDG_CONFIG_HOME, GH_CONFIG_DIR, PATH, and boolean credential-variable presence
- no credentials are copied or exposed; ambient credential variables remain absent from the env -i child