### PR TITLE
docs(agents): route duplicated reference detail to its owners

### DIFF
--- a/.agents/skills/quota-array-dispatch/SKILL.md
+++ b/.agents/skills/quota-array-dispatch/SKILL.md
@@ -29,7 +29,7 @@ An `exhausted_now` runway vetoes the candidate.
 The helper selects a candidate only when its applicable quota has a known `effectivePercentRemaining` greater than zero.
 This is an optional narrow helper with a known limitation: it maps each harness to one primary provider family only, so a candidate whose established provider differs from that primary family is checked against the wrong quota row.
 omp has no primary family, so the helper keys an `omp:` candidate on its model prefix, mapping only `openai-codex/` and `claude-bridge/` and refusing every other prefix; the helper's header owns that mapping.
-Authoritative multi-provider routing - including provider discovery from the harness catalog and quota matching by that explicit provider - stays owned by this skill's intake procedure above and AGENTS.md section 4, not by the helper.
+Authoritative multi-provider routing - including provider discovery from the harness catalog and quota matching by that explicit provider - stays owned by this skill's intake procedure above, not by the helper.
 Use it only when the brief already fixed the candidate order and every candidate's provider is the harness's primary family.
 It does not replace the reasoning-class, runway-feasibility, or authentication gates above.
 Firstmate can optionally arm `bin/fm-procevent-quota.sh` for a recurring mid-task check that wakes when the tracked provider drops below its configured threshold or its runway becomes `exhausted_now`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,7 +62,7 @@ Tracked files hold shared instructions and tooling.
 `config/` holds this home's local operating choices, and `.env` holds its optional Relay and mail credentials.
 `projects/` contains clones that are read-only to firstmate except under hard rule 1's concrete captain-approved project operation exception.
 
-Records under `state/` belong to the scripts that write them; never hand-edit or hand-delete them, apart from the custom check section 7 has you author yourself.
+Records under `state/` belong to the scripts that write them; never hand-delete them, and never hand-edit them apart from the custom check section 7 has you author yourself.
 A `state/<id>.status` line is a wake event, not current-state truth; `bin/fm-crew-state.sh` owns current-state reconciliation.
 Treat `data/captain.md` as the domain-local record of captain preferences, optional `data/captain-shared.md` as the main-authoritative shared captain-preference file for secondmate inheritance, and `data/learnings.md` as curated home-local knowledge, regardless of harness memory.
 
@@ -209,7 +209,7 @@ When the configured tasks-axi backlog gate applies, the spawn itself moves the w
 After spawning, confirm the worker is processing the brief and handle any trust dialog through `harness-adapters`.
 A persistent secondmate is recorded in the secondmate registry and runtime state, never as a backlog work item.
 
-Steer a worker with ordinary text through fail-closed `fm-send`, which turns the message into a durable record in the task's steering inbox and leaves the watcher to re-ring an unacknowledged message and escalate a stuck one (`bin/fm-send.sh` and `bin/fm-task-inbox-lib.sh` own the mechanics, carve-outs, and remote transport).
+Steer a worker with ordinary text through fail-closed `fm-send`, which turns the message into a durable record in the task's steering inbox and leaves the watcher to re-ring an unacknowledged local message and escalate a stuck one (`bin/fm-send.sh` and `bin/fm-task-inbox-lib.sh` own the mechanics, carve-outs, and remote transport).
 After an unconfirmed remote delivery, resend only with the exact command `fm-send` printed, because it preserves the request body the remote enqueue deduplicates on.
 When a steer answers an open keyed decision or blocker, pass `fm-send`'s `--resolve-key` so the answer itself closes that decision record at answer time, identically for local and remote workers.
 `fm-send` is the data plane for text the worker should read; never use its key or text paths for interrupt, exit, or other lifecycle control, because routing-marked lifecycle text becomes chat the worker reasons about instead of executing.
@@ -296,7 +296,7 @@ Promotion itself writes that worker's ship instructions, including the scratch-s
 
 Fleet supervision is an always-loaded operational contract; `docs/architecture.md`, `docs/turnend-guard.md`, the emitted session-start block, and script help own mechanisms and harness-specific recipes.
 
-Keep exactly one live supervision cycle using the emitted protocol for this primary harness whenever work is under way, or whenever this home has an armed Relay poll, a registered process-event source, or a registered custom check, each of which requires that same live cycle with no fleet work.
+Keep exactly one live supervision cycle using the emitted protocol for this primary harness whenever work is under way, or whenever this home has an armed Relay poll, a registered process-event source, or a registered check, each of which requires that same live cycle with no fleet work.
 Do not substitute another harness's wait shape, use shell `&`, or create a second cycle when a healthy one already exists.
 For every actionable wake, follow the ordinary-wake continuation in the emitted protocol; use its repair action only when the live cycle is missing or failed.
 No turn ends blind while work is under way, including turns described as holding or waiting.
@@ -351,7 +351,7 @@ The skill owns the daemon procedure; these safety facts remain inline:
 **Talk in outcomes, not mechanics.**
 Every captain-facing message must translate internal state into the project outcome, consequence, and next decision.
 Use the captain's nouns: the investigation, the scout, the fix, the PR, the review, the decision, the blocker, the credential, the local copy, the worker, or the project.
-Never expose firstmate's internal vocabulary, including every term the rewrite table below names plus startup machinery, locks, polling, task ids, promotion, context budgets, delivery-mode names, autonomy flags, and status prefixes.
+Never expose firstmate's internal vocabulary, including every internal term the rewrite table below rewrites plus startup machinery, locks, polling, task ids, promotion, context budgets, delivery-mode names, autonomy flags, and status prefixes.
 Scout and second mate are accepted Firstmate nautical house vocabulary and do not need translation when they naturally name that work or role.
 When evidence uses an internal label, rewrite it before sending:
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,7 +62,7 @@ Tracked files hold shared instructions and tooling.
 `config/` holds this home's local operating choices, and `.env` holds its optional Relay and mail credentials.
 `projects/` contains clones that are read-only to firstmate except under hard rule 1's concrete captain-approved project operation exception.
 
-Records under `state/` belong to the scripts that write them; never hand-edit or hand-delete them.
+Records under `state/` belong to the scripts that write them; never hand-edit or hand-delete them, apart from the custom check section 7 has you author yourself.
 A `state/<id>.status` line is a wake event, not current-state truth; `bin/fm-crew-state.sh` owns current-state reconciliation.
 Treat `data/captain.md` as the domain-local record of captain preferences, optional `data/captain-shared.md` as the main-authoritative shared captain-preference file for secondmate inheritance, and `data/learnings.md` as curated home-local knowledge, regardless of harness memory.
 
@@ -77,7 +77,7 @@ Run-tier harness surfaces run this command for you at session open while the res
 Read the complete digest once and trust it as this turn's startup and recovery input.
 If the harness shows only a preview and persists the full output to a file, read that file before acting.
 Do not separately re-read the context, backlog, metadata, or bulk status inputs it just printed unless a source was reported absent or corrupt, older history is specifically needed, or a targeted workflow must inspect before writing.
-An `ABSENT` marker means the source does not exist, never an empty-but-present file, and that absence is meaningful: absent captain preferences mean the firstmate repo's built-in defaults, absent registries mean no shared captain preferences and no registered secondmates, and an absent or stale project registry must be rebuilt from the clones under `projects/` before dispatch.
+An `ABSENT` marker means the source does not exist, never an empty-but-present file, and that absence is meaningful: absent captain preferences mean the firstmate repo's built-in defaults, an absent shared-captain, secondmate, or learnings file means none exist, and an absent or stale project registry must be rebuilt from the clones under `projects/` before dispatch.
 
 If the session lock cannot be acquired and verified, report its exact diagnostic and remain read-only; another active session is only one possible cause.
 A lock-refused session must not spawn, steer, merge, drain the wake queue, repair supervision, repair a checkout, or perform any other fleet mutation.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,7 +49,7 @@ Never add an agent name as a commit co-author.
 
 ## 2. Layout and state
 
-`docs/configuration.md` is the single owner of the operational-home layout and every configuration schema; each producing script's header and help own exact child fields and mutation mechanics.
+`docs/configuration.md` owns the top-level operational-home layout and the configuration schemas it documents, while each producing script's header and help own exact child fields and mutation mechanics, and each per-feature doc owns its own schema.
 Read those owners when a concrete path, field, or configuration knob matters rather than working from a remembered file list.
 
 `FM_HOME` selects an instance's private `data/`, `state/`, `config/`, and `projects/`, while scripts continue to come from their tracked code root.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,7 +62,7 @@ Tracked files hold shared instructions and tooling.
 `config/` holds this home's local operating choices, and `.env` holds its optional Relay and mail credentials.
 `projects/` contains clones that are read-only to firstmate except under hard rule 1's concrete captain-approved project operation exception.
 
-Watcher, wake-queue, lease, away-mode, sub-supervisor, and turn-end auto-arm or stop-hook records under `state/` belong to the scripts that write them; never hand-edit or hand-delete them, and retire a registered check only through its unregister or teardown script.
+Records under `state/` belong to the scripts that write them; never hand-edit or hand-delete them.
 A `state/<id>.status` line is a wake event, not current-state truth; `bin/fm-crew-state.sh` owns current-state reconciliation.
 Treat `data/captain.md` as the domain-local record of captain preferences, optional `data/captain-shared.md` as the main-authoritative shared captain-preference file for secondmate inheritance, and `data/learnings.md` as curated home-local knowledge, regardless of harness memory.
 
@@ -105,7 +105,7 @@ If static `config/crew-harness` or `config/secondmate-harness` names an unverifi
 When dispatch profiles exist, consult them at every crewmate or scout intake and pass the resolved concrete profile required by `fm-spawn`.
 Routing precedence is an explicit per-task captain override, then the best-fit configured rule, then the configured default, then the static crewmate harness.
 Firstmate alone resolves a matched profile array, and `quota-array-dispatch` is the single owner of that selection procedure: load it before choosing among a matched array.
-These boundaries bind the outcome however that procedure resolves.
+The boundaries stated below bind the outcome however that procedure resolves.
 Account for every candidate visibly rather than omitting one, guessing, falling back silently, or calling the result quota-informed without that accounting.
 Preserve malformed profile configuration as an actionable error rather than selecting around it.
 Missing quota, authentication, or headroom evidence is disclosed uncertainty that keeps a candidate eligible, never a credential or login escalation, and only concrete contradictory evidence blocks a candidate.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,159 +49,51 @@ Never add an agent name as a commit co-author.
 
 ## 2. Layout and state
 
-`docs/configuration.md` is the single owner of the top-level operational-home layout and configuration schemas; each producing script's header and help own exact child fields and mutation mechanics.
+`docs/configuration.md` is the single owner of the operational-home layout and every configuration schema; each producing script's header and help own exact child fields and mutation mechanics.
+Read those owners when a concrete path, field, or configuration knob matters rather than working from a remembered file list.
+
 `FM_HOME` selects an instance's private `data/`, `state/`, `config/`, and `projects/`, while scripts continue to come from their tracked code root.
 Each secondmate has a persistent isolated `FM_HOME`, including its own state, backlog, projects, and session lock.
 `bin/fm-send.sh` fails closed unless `FM_HOME` is explicit, so a steer cannot silently resolve against another home.
 
-Tracked files hold shared instructions and tooling; `data/` holds durable private fleet records; `state/` holds runtime records and append-only status events; `config/` holds local operating choices; and `projects/` contains clones that are read-only to firstmate except under hard rule 1's concrete captain-approved project operation exception.
+Tracked files hold shared instructions and tooling.
+`data/` holds durable private fleet records: the backlog, the project and secondmate registries, captain preferences, shared captain preferences, learnings, per-task briefs, and scout reports that survive cleanup.
+`state/` holds runtime records: task metadata, append-only status events, the durable wake queue, steering inboxes, decision and poll records, the away posture, and watcher coordination.
+`config/` holds this home's local operating choices, and `.env` holds its optional Relay and mail credentials.
+`projects/` contains clones that are read-only to firstmate except under hard rule 1's concrete captain-approved project operation exception.
+`.env`, `data/`, `state/`, `config/`, `projects/`, and `.no-mistakes/` are captain-private and gitignored.
 
-```
-AGENTS.md            this file (CLAUDE.md is a real @AGENTS.md pointer to it)
-CONTRIBUTING.md      contributor workflow and repo conventions
-README.md            public overview and development notes
-.github/workflows/   shared CI and PR enforcement, committed
-.tasks.toml          tracked tasks-axi markdown backend config for the default backlog backend (section 10)
-.agents/skills/      firstmate-loaded internal skills, committed; each carries metadata.internal=true for installers
-.claude/skills       symlink to .agents/skills for claude compatibility
-skills/              standalone public installer-facing skills, committed; not loaded by firstmate
-bin/                 helper scripts, committed; read each script's header before first use
-.env                 optional Relay pairing token (presence-gates section 14) and mail-plane credentials (schema: docs/configuration.md "Mail plane"); LOCAL, gitignored
-config/crew-harness  crewmate harness override; LOCAL, gitignored; absent or "default" = same as firstmate. Inherited as the literal file: a concrete primary adapter value also controls a secondmate home's own crewmates (section 4)
-config/crew-dispatch.json  optional crewmate dispatch profiles; LOCAL, gitignored; firstmate-maintained but human-editable natural-language rules that choose a per-task harness/model/effort profile (section 4). Inherited by secondmate homes
-config/secondmate-harness  harness the PRIMARY uses to launch SECONDMATE agents, optionally followed by a model and effort token on the same line ("<harness> [<model>] [<effort>]"; section 4); LOCAL, gitignored; absent or "default" harness falls back to config/crew-harness then firstmate's own. The primary's own setting; NOT inherited into secondmate homes (secondmates do not spawn secondmates)
-config/backlog-backend  backlog backend override; LOCAL, gitignored; absent or "tasks-axi" = the configured tasks-axi backend, "manual" = force routine backlog updates to hand-editing; inherited by secondmate homes (section 10)
-config/backend  runtime session-provider backend override for new tasks; LOCAL, gitignored; absent = falls through to runtime auto-detection (the runtime firstmate itself is executing inside), then tmux; tmux is the verified reference backend (docs/tmux-backend.md), herdr has its own required CI lane (docs/herdr-backend.md), while zellij, orca, and cmux remain experimental with no dedicated real-backend CI lane (docs/zellij-backend.md, docs/orca-backend.md, docs/cmux-backend.md) - herdr and cmux can also be selected by runtime auto-detection, zellij and orca never are (always explicit), and codex-app is not accepted; see docs/codex-app-backend.md; inherited by secondmate homes under the primary-authoritative contract in secondmate-provisioning
-config/calm     Pi Calm presentation preference; LOCAL, gitignored, and not inherited; see docs/configuration.md "Pi Calm preference"
-config/supervision-branch-model config/supervision-branch-effort  Pi supervision-branch model and reasoning-effort pins written by /supervision-model; LOCAL, gitignored, independently settable, and not inherited; see docs/configuration.md "Pi supervision branch model and effort"
-config/startup-memory-budget     primary-authoritative per-home startup-memory budget; LOCAL, gitignored, materialized as 7,500 estimated tokens by locked primary bootstrap and inherited into secondmate homes; see docs/configuration.md "Startup memory budget"
-config/stow-pass-horizon  optional presence flag opting this home in to /stow's default-off pass-count decay horizon; LOCAL, gitignored, and not inherited; see docs/configuration.md "Stow pass horizon"
-config/herdr-presentation-spaces  optional "off" opt-out from, or "on" opt-in to, Herdr's default-on disposable single-task visual projection, which is unconfigured-default-on only at or above a Herdr version floor; LOCAL, gitignored; inherited by secondmate homes; see docs/herdr-backend.md "Presentation spaces"
-config/trace-context  optional presence flag enabling default-off native W3C trace-context propagation to spawned agents; LOCAL, gitignored; inherited by secondmate homes; see docs/configuration.md "Trace context propagation" and docs/trace-context.md
-config/turnend-churn-absorb  optional presence flag opting this home into the default-off absorb of bare turn-end wakes on pane churn; LOCAL, gitignored, and not inherited; see docs/configuration.md "Turn-end pane-churn absorb"
-config/cmux-socket-password  optional cmux control-socket password; LOCAL, gitignored; read fresh on every cmux CLI call and passed through without ever overriding an operator's own ambient CMUX_SOCKET_PASSWORD when absent (docs/cmux-backend.md "Setup")
-config/wedge-alarm  optional away-mode wedge-alarm active-alert directives; LOCAL, gitignored; absent means auto (macOS Notification Center when available); see docs/wedge-alarm.md
-config/watched-tools.json  optional list of the tools this home depends on, read by the update check armed with bin/fm-tool-update-check.sh; LOCAL, gitignored, firstmate-maintained but human-editable, and NOT inherited by secondmate homes; see docs/configuration.md "Watched tool updates"
-config/x-mode.env    generated Relay watcher cadence; LOCAL, gitignored; source before arming watcher when present
-data/                personal fleet records; LOCAL, gitignored as a whole
-  backlog.md         task queue, dependencies, history
-  captain.md         this home's domain-local captain preferences and working style; LOCAL, gitignored, canonical even if harness memory mirrors it, and updated with inspect-then-update
-  captain-shared.md  main-authoritative shared captain preferences propagated read-only to secondmate homes; LOCAL, gitignored, owned by secondmate-provisioning
-  learnings.md       fleet-local operational facts and gotchas; LOCAL, gitignored; dated, evidence-backed, curated, and updated with inspect-then-update - rewrite and prune rather than append forever, the same contract as captain.md; created lazily, absent until this home has a learning to store
-  projects.md        thin fleet navigation registry recording each project's standing delivery posture; firstmate-private, parsed for mechanical sync and seeding by fm-project-mode.sh (section 6)
-  secondmates.md      local and remote secondmate routing table; firstmate-private, maintained by the secondmate seed helpers (section 6)
-  <id>/brief.md      per-task crewmate brief, or per-secondmate charter brief when kind=secondmate
-  <id>/report.md     scout task deliverable, written by the crewmate; survives teardown
-projects/            cloned repos; gitignored; read-only except under hard rule 1's concrete captain-approved project operation exception
-state/               runtime records and signals; gitignored
-  <id>.status        appended by crewmates: "<state>: <note>" wake-event lines, not current-state truth
-  <id>.turn-ended    touched by turn-end hooks
-  <id>.progress      touched for observed native-harness activity inside one Pi turn; bin/fm-busy-event.sh owns its generation binding and bin/fm-watch.sh reads it beside turn-ended for the busy-age bound only, never as a completed turn
-  <id>.grok-turnend-token   firstmate-owned grok hook registry token for the task; removed by teardown
-  <id>.kimi-turnend-token   firstmate-owned Kimi hook registry token for the task; removed by teardown
-  <id>.gemini-settings.json  firstmate-owned per-task Gemini settings carrying the busy-state and turn-end hooks, reached through GEMINI_CLI_SYSTEM_SETTINGS_PATH so nothing is written into the project's own .gemini/; removed by teardown
-  <id>.muse-session  muse busy-source binding (sessions root plus task worktree) written by fm-spawn; removed by teardown
-  <id>.cursor-session  cursor busy-source binding (projects root, task worktree, prior conversations) written by fm-spawn; removed by teardown
-  <id>.reconcile-nudged  epoch second of the last inventory-reconcile nudge sent to this secondmate; bin/fm-secondmate-reconcile.sh owns its per-home cooldown window
-  <id>.backlog-close  the exact backlog transition a teardown recorded before removing the task's record, so an interrupted cleanup can still be finished at the next session start; bin/fm-backlog-transition-lib.sh owns its format and replay, and a landed transition removes it
-  <id>.inbox/          durable steering inbox: sequenced firstmate instruction records the worker acknowledges by moving them into its handled/ subdirectory; written by fm-send, with ordinary records re-rung and escalated by the watcher while explicit fire-and-forget records are excluded from that ladder, and removed by teardown (bin/fm-task-inbox-lib.sh)
-  <id>.meta          task metadata; each producer script's header owns its exact fields and mutation contract, with docs/configuration.md routing operator-facing backend and trace-context details
-  <id>.herdr-presentation  quarantinable attempt and restart-binding journal for Herdr's optional visual projection; never task or endpoint authority; see docs/herdr-backend.md "Presentation spaces"
-  <id>.check.sh      authenticated slow poll; the watcher dispatches validated PR data and the byte-identified Relay shim through trusted repository scripts, runs registered custom checks from hash-validated private snapshots, and rejects every other state check without execution
-  <id>.check-trust   private content binding created by fm-check-register.sh for an intentional custom check
-  <id>.pr-poll       private validated data sidecar for the byte-static PR merge poll
-  <id>.pr-poll-registration  private transactional provenance record binding the task, canonical metadata identity, sidecar, and static poll publication
-  <id>.pr-poll-retirement  private identity-bound crash-recovery receipt for one exact validated merged result; removed after its poll artifacts retire
-  <id>.pr-poll-merge-notified  canonical PR identity of the last merge outcome delivered for this task; bin/fm-pr-lib.sh owns the marker format and identity mechanics, while bin/fm-merge-outcome-lib.sh owns locked publication, duplicate suppression, and replacement
-  branch-outcomes.jsonl .branch-outcomes-cursor .branch-outcomes-processed .<task>.branch-outcome-index .branch-outcome-index-ready  Pi supervision-branch durable outcome store, its read cursor, main's processed marker, bounded latest per-task status-coverage caches, and their recovery marker; bin/fm-branch-outcome.sh owns the formats
-  branch-session/ .branch-session .branch-mirror-cursor  the branch's per-main-session conversations, the pointer to the current one, and the dialog-mirror cursor; extension-owned (docs/pi-supervision-branch.md)
-  .branch-eligible-rows .branch-eligible-owner .main-eligible-rows  per-actor wake-row claims and branch-owner evidence; docs/watcher-continuity.md owns the acknowledgement contract
-  .lease-<task>        per-task supervision lease naming which actor (main or branch) may change that task; bin/fm-lease-lib.sh owns the contract the guarded scripts enforce
-  x-watch.check.sh   generated Relay poll shim; present only when opted in (section 14)
-  tool-updates.check.sh  generated watched-tool update poll shim and its .check-trust binding; present only after bin/fm-tool-update-check.sh arm; its report record .tool-updates is what keeps one pending update from being reported on every poll
-  mail.check.sh      generated received-mail poll shim and its .check-trust binding; present only after bin/fm-mail-check.sh arm; report record .mail-check (mail schema: docs/configuration.md "Mail plane")
-  .mail-seen .mail-woken .mail-retry .mail-retry-pos .mail-turn .mail-seen.lock  mail-plane poll cursor, emission journal, transient-fetch retry set, retry-scan position, contended-slot turn flag, and overlapping-poll lock; written only by bin/fm-mail.sh (mail schema: docs/configuration.md "Mail plane")
-  pending-replies/   parent-owned secondmate pending-reply records (correlation id, delivery vs reply, recovery, escalation); fm-pending-reply-lib.sh
-  procevent/         registered process-to-event sources, one private record per canonical source id; written only by bin/fm-procevent.sh, and their presence alone keeps supervision required (section 13)
-  procevent-inbox/   private captured results and their durable handled-acknowledgement markers; source output lives here and never in an event line
-  decision-bindings/ private records marking a captured-answer source as feeding the keyed-answer intake, with a legacy origin on pre-collapse records; written only by bin/fm-captain-hold.sh bind, dropped by unbind and by source retirement (section 13; docs/captain-hold-lifecycle.md)
-  reconcile-requests/ private open obligations to re-check a captain call whose board selection was `reconcile`; written only by bin/fm-captain-hold.sh, retired by its verify-then-decide outcomes or a normal answer that settles the call (section 13; docs/captain-hold-lifecycle.md)
-  when/              private condition->action watch specs, their trust bindings, and single-fire markers; written only by bin/fm-procevent-when.sh (section 13's process-event-sources trigger)
-  inbox/             captain notes captured out of band by bin/fm-inbox.sh, including the voice handover's queued requests; each note appends one `check` wake and stays pending until acknowledged with `bin/fm-inbox.sh drain --ack <id>`, which moves it to inbox/handled/ (docs/voice-relay.md)
-  x-inbox/           generated Relay pending mention payloads; fmx-respond drains it (section 14)
-  x-context/         generated Relay durable per-request reply context and one-wake offer markers, keyed by request_id; survives inbox cleanup and expires within seven days (section 14; bin/fm-x-lib.sh)
-  x-outbox/          generated Relay dry-run reply and dismiss previews; inspect it when FMX_DRY_RUN is set (section 14)
-  public-followup/   generated private transport for promised public replies: retained open-loop registrations, typed terminal-result inbox, results staged for an owning home on another machine, accepted/rejected ledgers, and retirement receipts (section 14; bin/fm-public-followup.sh)
-  x-poll.error x-poll.claim-error  generated Relay and offer-claim diagnostic dedupe markers
-  .startup-network.*  status, report, per-step elapsed timings, inline-print claim, and lock for the deferred startup stage that runs network checks and the inactive-outcome scan off the digest's blocking path; bin/fm-startup-network.sh
-  .wake-queue        durable queued wakes retained until post-handling acknowledgement: epoch<TAB>seq<TAB>kind<TAB>key<TAB>payload
-  .watcher-down      private generation-bound recovery state coupling watcher downtime, durable wake presentation, and post-handling acknowledgement; never touch
-  .<id>.open-decisions-cursor  per-task byte cursor and folded open-decision set bounding the OPEN DECISIONS scan's cost to new status-log appends; written only by fm-classify-lib.sh's status_open_decisions_incremental, removed by teardown, safe to delete (forces one full re-fold)
-  .status-presentation-cursor .status-presentation-lock  fleet-wide per-task status identity plus independent annotation and outcome-backstop byte offsets, with a serialization lock preventing already-presented lines from replaying while preserving delayed signal annotations; owned by fm-classify-lib.sh, with each task's row retired by teardown
-  .afk-contract      the away-posture record: the captain's verbatim away words, expected return, reach profile, spend cap, and structured mandate clauses; written only by bin/fm-afk-contract.sh after the captain confirms the read-back, archived under afk-contracts/ at return; its presence IS the away posture in every harness
-  afk-contracts/     archived away-posture records: one final record per away window keyed by entry time, plus any superseded mandates from that window
-  .afk               durable away-mode daemon flag on the harnesses that still launch the daemon (never on Pi); present = sub-supervisor may inject escalations (set by the daemon entry, cleared on user return)
-  .watch.lock .wake-queue.lock watcher singleton and queue serialization locks
-  .claude-autoarm.lock .claude-autoarm-epoch .claude-autoarm-failure-notified .claude-autoarm-failure-alarmed .turnend-claude-blocks .turnend-claude-blocks.lock   Claude Stop auto-arm single-flight, epoch, failure-episode, attended-alarm, guard-budget, and budget-lock records; never touch
-  .cursor-park-owner .cursor-park-owner.lock .turnend-cursor-blocks   Cursor stop-hook owner record, publication and commit lock, and bounded repair-nag budget; never touch
-  .hash-* .count-* .stale-* .stale-since-* .churn-since-* .paused-* .wedge-escalations-* .writing-* .seen-* .hb-surfaced-* .last-* .heartbeat-streak   watcher internals; never touch
-  .watch-triage.log  watcher's absorbed-wake debug log (size-capped); never relied on, safe to delete
-  .last-watcher-beat watcher liveness beacon, touched every poll (including while absorbing benign wakes); guard scripts read it
-  .subsuper-* .supervise-daemon.*   sub-supervisor internals; never touch
-.no-mistakes/        local validation state and evidence; gitignored
-```
-
+Watcher, wake-queue, lease, away-mode, sub-supervisor, and turn-end auto-arm or stop-hook records under `state/` belong to the scripts that write them; never hand-edit or hand-delete them, and retire a registered check only through its unregister or teardown script.
 A `state/<id>.status` line is a wake event, not current-state truth; `bin/fm-crew-state.sh` owns current-state reconciliation.
 Treat `data/captain.md` as the domain-local record of captain preferences, optional `data/captain-shared.md` as the main-authoritative shared captain-preference file for secondmate inheritance, and `data/learnings.md` as curated home-local knowledge, regardless of harness memory.
 
 ## 3. Session start (run once at every session start)
 
 Run `bin/fm-session-start.sh` exactly once at session start.
-Its header is the single owner of composed commands, ordering, and digest contents.
-`bin/fm-supervision-instructions.sh` renders the emitted supervision block from `docs/supervision-protocols/`.
+Its header is the single owner of composed commands, ordering, and digest contents, and `bin/fm-supervision-instructions.sh` renders the emitted supervision block from `docs/supervision-protocols/`.
 Do not reimplement it by separately running its lock, bootstrap, initial wake-drain, or deferred-network components.
+It emits one supervision operating block for the detected primary harness but never starts supervision itself; that emitted protocol owns the exact wait or wake mechanism.
 Run-tier harness surfaces run this command for you at session open while the rest only nudge it, so confirm the digest is present in this session and run it yourself when it is not; `docs/sessionstart-nudge.md` owns adapter tiers, source routing, and compatibility.
 
 Read the complete digest once and trust it as this turn's startup and recovery input.
 If the harness shows only a preview and persists the full output to a file, read that file before acting.
 Do not separately re-read the context, backlog, metadata, or bulk status inputs it just printed unless a source was reported absent or corrupt, older history is specifically needed, or a targeted workflow must inspect before writing.
-An `ABSENT` captain, shared-captain, secondmate, or learnings file means the firstmate repo's built-in defaults, no shared captain preferences, no registered secondmates, or no captured learnings; rebuild an absent or stale project registry from the clones before dispatch.
+An `ABSENT` marker means the source does not exist, never an empty-but-present file, and that absence is meaningful: absent captain preferences mean the firstmate repo's built-in defaults, absent registries mean no shared captain preferences and no registered secondmates, and an absent or stale project registry must be rebuilt from the clones under `projects/` before dispatch.
 
 If the session lock cannot be acquired and verified, report its exact diagnostic and remain read-only; another active session is only one possible cause.
 A lock-refused session must not spawn, steer, merge, drain the wake queue, repair supervision, repair a checkout, or perform any other fleet mutation.
+Every mutating startup sweep runs only when this session actually holds the lock, so a lock-refused digest leaves the wake queue untouched and prints its tangle and watcher-liveness alarms as read-only advice with no repair command.
+A locked digest presents the durable wake queue as this turn's first work queue; section 8 owns how to handle and acknowledge everything that drain prints.
 
 The digest itself makes no external-network call and never waits for one.
-Every network check a session start owes - GitHub auth, dead-secondmate relaunch, secondmate convergence, pending handoff delivery, and project clone refresh - runs off the digest's blocking path in a bounded worker owned by `bin/fm-startup-network.sh` and is reported in the digest's own `NETWORK CHECKS` section.
-The locked startup inactive-outcome scan joins that worker so a slow local current-state read cannot block the digest; its findings use the ordinary durable wake queue.
+Every network check a session start owes - GitHub auth, dead-secondmate relaunch, secondmate convergence, pending handoff delivery, and project clone refresh - runs off that blocking path in the bounded worker owned by `bin/fm-startup-network.sh` and is reported in the digest's own `NETWORK CHECKS` section.
 When that section reports its checks still in progress it names exactly what is unconfirmed; treat none of those as passed until `bin/fm-startup-network.sh report` returns the finished result, while a failed or otherwise actionable result also arrives as a `check: startup-network` wake.
-
-1. **Lock** - acquires the per-home session lock first, before anything mutates shared state, then starts the deferred startup stage above.
-2. **Bootstrap** - detect-only checks (tool/version problems, the worktree-tangle check, harness override, dispatch-profile validation, backlog-backend status) always run, but routine confirmations stay silent by default.
-   When the lock could not be acquired, the worktree-tangle check uses read-only advisory wording without a checkout repair command.
-   Home-local stale Herdr projection cleanup and the six bootstrap MUTATING sweeps - same-home backlog reconciliation, fleet sync, secondmate convergence, secondmate liveness, pending remote handoff retry, and Relay artifact writes - run only when this session actually holds the lock from step 1; the four network ones among them run in the deferred stage rather than in this section.
-   The secondmate liveness sweep deterministically accounts for every registered secondmate: it relaunches only from the recovery-grade `dead` or `missing` states, preserves ambiguous, unreadable, or unreachable remote targets, and reports skipped or failed guarantees as `SECONDMATE_LIVENESS:` lines (`bin/fm-bootstrap.sh`; `bin/fm-backend.sh`'s `fm_backend_agent_state`; `docs/remote-secondmates.md`).
-3. **Wake queue** - when locked, drains and presents the durable wake queue without running the inactive-outcome scan inline, and prints the raw records prominently as this turn's first work queue; a clearly labeled status-event annotation may follow a valid `signal` record and includes every status line still unread at the presentation cursor, but never replaces the raw record or current-state reconciliation, and a lapsed watcher chain still surfaces here via the same guard alarm.
-   Presented records remain durable until the handling turn runs the generation-bound acknowledgement printed by the drain.
-   Every locked drain also prints a bounded fleet-wide `OPEN DECISIONS` section when durable decision records remain open, including when the queue itself is empty; reconcile those entries before continuing.
-   A main drain may also print a bounded, one-shot `STATUS OUTCOME BACKSTOP` when a task's newest captain-facing status event has no covering supervision-branch outcome; handle it as a recovered wake even when no queue row remains.
-   The same drain prints every still-unread `note:` line and pending-reply resolution since the last presentation in an unbounded `UNREAD STATUS` section, so an answer buried under a later routine line is not dropped; those lines are not re-printed after that presentation.
-   It also prints a bounded `RECORD DIVERGENCE` section naming every captain call the status log reads as resolved while its backlog task is still held; nothing is closed for you, and `captain-hold-lifecycle` owns the reconciliation.
-   When the lock could not be acquired and verified, the queue is left untouched because no session mutation is authorized, and the guard's tangle/watcher-liveness alarms still print in read-only advisory mode without drain, supervision repair, or checkout repair commands.
-4. **Supervision operating instructions** - after the wake queue and before both digests, the digest emits exactly one operating block for the detected primary harness, followed by the read-once contract that governs them.
-   The script itself never starts supervision; the emitted harness protocol owns the exact wait or wake mechanism.
-5. **Fleet-state digest** - after that read-once contract and ahead of the context digest, the compact backlog listing owned by `bin/fm-session-start.sh`; every `state/<id>.meta`; a bounded tail of each task's `state/<id>.status` (labeled as wake-EVENT history, not current state, with the full log path printed for a deeper read); the away posture (`state/.afk-contract`, plus the `state/.afk` daemon flag where a daemon runs); and one cheap alive/dead read of each task's recorded backend endpoint.
-   That liveness line is a fast presence check only, not a full state read - when you need a crew's actual current state (a run-step, not just "is the pane there"), read it with `bin/fm-crew-state.sh <id>` as before; the digest deliberately skips that deeper, slower read for every task so it stays fast and bounded.
-6. **Network checks** - after the fleet-state digest, the deferred stage's result, or an explicit statement of what it has not confirmed yet.
-   A read-only session runs no network checks at all and says so.
-7. **Context digest and next step** - last of the bulk sections, the full contents of `data/projects.md`, `data/secondmates.md`, `data/captain.md`, `data/captain-shared.md`, and `data/learnings.md`, each clearly delimited, followed by the closing reminder.
-   A file that does not exist prints an explicit `ABSENT` marker, never confused with an empty-but-present file: absence is meaningful (`captain.md` absent means use the firstmate repo's built-in defaults, `projects.md` absent means rebuild it from the clones under `projects/`, etc.).
-   The closing reminder points back to the emitted supervision block and preserves only the lock, afk, Relay, and read-once reminders.
+A read-only session runs no network checks at all and says so.
 
 Bootstrap detects first, asks for consent, and installs only after the captain approves in the current session.
 Do not dispatch until the required tools are present and GitHub authentication is good.
 Use `gh-axi` for GitHub, `chrome-devtools-axi` for browser work, and `lavish-axi` for structured decisions or reports; consult current help rather than memorizing flags.
-A silent bootstrap section needs no action; for any printed actionable diagnostic line, load `bootstrap-diagnostics` and follow its owner procedure.
-`BOOTSTRAP_INFO:` lines are completed no-action facts and do not require loading a skill.
+A silent bootstrap section needs no action, and `BOOTSTRAP_INFO:` lines are completed no-action facts; for any printed actionable diagnostic line, load `bootstrap-diagnostics` and follow its owner procedure.
 `secondmate-provisioning` owns startup secondmate sync, liveness, and inherited local-material convergence.
 
 ## 4. Harness and runtime dispatch
@@ -213,16 +105,14 @@ If static `config/crew-harness` or `config/secondmate-harness` names an unverifi
 `docs/configuration.md` owns dispatch-profile and runtime-backend schemas, `bin/fm-harness.sh` owns static resolution, and `bin/fm-spawn.sh` owns launch flags and fail-closed validation.
 When dispatch profiles exist, consult them at every crewmate or scout intake and pass the resolved concrete profile required by `fm-spawn`.
 Routing precedence is an explicit per-task captain override, then the best-fit configured rule, then the configured default, then the static crewmate harness.
-Firstmate alone resolves a matched profile array: begin with `quota-axi`'s default TOON at that intake, using the skill's narrow TOON-then-`--json` fallback only for genuine ambiguity, evaluate every configured candidate against that current output, and choose with inspectable `spendPriority` as the one quota-perspective ranker after the skill's eligibility, reasoning-class, and runway-feasibility gates.
-Account for every candidate with the catalog evidence, provider relationship, applicable quota and authentication facts, remaining uncertainty, fit and reasoning class, and the spendPriority and runway evidence used in selection; never omit a candidate, guess, fall back silently, or call the result quota-informed without them.
-Establish model support and provider family from that harness's own authoritative catalog, then read `quota-axi` at the granularity the vendor actually supplies: provider-level or all-model evidence applies to every model established in that family, and a named-model window bounds only that model.
-Missing model-level quota, a missing authentication source, unmeasurable headroom, or unmodeled authentication is disclosed uncertainty that keeps a candidate eligible, never a credential or login escalation.
-Only concrete contradictory evidence blocks a candidate, such as an authoritative catalog proving the model unsupported or proof that the credential selected for that surface is unusable; never infer a credential store, provider family, or quota mapping from a harness, model, or source name, and never launch another harness's CLI to judge a candidate.
+Firstmate alone resolves a matched profile array, and `quota-array-dispatch` is the single owner of that selection procedure: load it before choosing among a matched array.
+These boundaries bind the outcome however that procedure resolves.
+Account for every candidate visibly rather than omitting one, guessing, falling back silently, or calling the result quota-informed without that accounting.
 Preserve malformed profile configuration as an actionable error rather than selecting around it.
+Missing quota, authentication, or headroom evidence is disclosed uncertainty that keeps a candidate eligible, never a credential or login escalation, and only concrete contradictory evidence blocks a candidate.
+Never infer a credential store, provider family, or quota mapping from a harness, model, or source name, and never launch another harness's CLI to judge a candidate.
 When every candidate is tight, preserve the captain's strongest-reasoning class rather than silently downgrading it solely to conserve quota; stop and report the tight choice if that class cannot proceed.
 Break genuine evidence ties without array-order or harness bias.
-`quota-axi` owns how model or product windows relate to bounding account windows and remains data-only.
-Load `quota-array-dispatch` before choosing among a matched profile array; that skill is the single owner of the TOON-first spendPriority selection procedure.
 The generic effort fallback and its precedence are owned by `harness-adapters`: explicit captain and standing configured effort win; otherwise use low for well-understood explicit work, xhigh for ambiguous investigation or design, intermediate levels proportionally, and never max without explicit captain preference.
 Do not add model-specific versions of that policy.
 
@@ -234,7 +124,7 @@ A missing dependency, authentication failure, unsupported backend, or version re
 
 After the one session-start digest, reconcile reality with durable records before taking new work.
 Honor lock-refused read-only mode exactly as section 3 requires.
-Treat digest status tails as wake-event history and use targeted current-state reconciliation when the live state matters.
+Treat the digest's status tails as wake-event history and its endpoint line as a presence check only, never a run step; use `bin/fm-crew-state.sh <id>` for targeted current-state reconciliation when the live state matters.
 
 Reconcile only this home's recorded direct reports and their recorded backend inventory; never sweep a shared endpoint namespace for matching names or claim another home's work.
 For an ordinary direct report whose endpoint is dead or metadata has no window, load `stuck-crewmate-recovery` and preserve the recorded worktree and unlanded work while reconciling ownership.
@@ -253,8 +143,6 @@ That skill owns registry syntax, delivery-mode selection, outward-facing consent
 Project creation never authorizes an unmentioned remote, and project removal never bypasses that preflight or unlanded-work checks; hard rule 1's concrete captain-approved project operation exception remains available when its exact conditions are met.
 
 Load `secondmate-provisioning` before creating, seeding, validating, launching, handing backlog to, recovering, pushing inherited local material into, or retiring a secondmate home, and before editing `data/secondmates.md`.
-Its scope field drives routing and its project list is non-exclusive provisioning data, not ownership.
-Keep `local-only` work in the main home.
 
 A secondmate is idle by default and acts only on work routed by the main firstmate.
 It reconciles its own work under way after restart, then waits silently; an empty queue never authorizes a survey, audit, or self-directed improvement sweep.
@@ -322,9 +210,9 @@ When the configured tasks-axi backlog gate applies, the spawn itself moves the w
 After spawning, confirm the worker is processing the brief and handle any trust dialog through `harness-adapters`.
 A persistent secondmate is recorded in the secondmate registry and runtime state, never as a backlog work item.
 
-Steer a worker with ordinary text through fail-closed `fm-send`: the message becomes a durable record in the task's steering inbox (multi-line text is legal, local and remote alike) and the worker's terminal receives only a constant doorbell line, with the watcher re-ringing an unacknowledged local message and escalating a stuck one (`bin/fm-task-inbox-lib.sh`; `bin/fm-send.sh` owns the typed-plane carve-outs).
-A remote secondmate steer rides the same durable-inbox model through the remote transport; after an unconfirmed delivery, only the exact `FM_PENDING_REPLY_EXISTING_CORR=<id>` resend command printed by `fm-send` is safe because it preserves the request body for remote enqueue deduplication (`bin/fm-send.sh` header).
-When a steer answers an open keyed decision or blocker, pass `fm-send`'s `--resolve-key` so the answer itself closes that decision record at answer time, identically for local and remote workers (contract: `bin/fm-send.sh` header).
+Steer a worker with ordinary text through fail-closed `fm-send`, which turns the message into a durable record in the task's steering inbox and leaves the watcher to re-ring an unacknowledged message and escalate a stuck one (`bin/fm-send.sh` and `bin/fm-task-inbox-lib.sh` own the mechanics, carve-outs, and remote transport).
+After an unconfirmed remote delivery, resend only with the exact command `fm-send` printed, because it preserves the request body the remote enqueue deduplicates on.
+When a steer answers an open keyed decision or blocker, pass `fm-send`'s `--resolve-key` so the answer itself closes that decision record at answer time, identically for local and remote workers.
 `fm-send` is the data plane for text the worker should read; never use its key or text paths for interrupt, exit, or other lifecycle control, because routing-marked lifecycle text becomes chat the worker reasons about instead of executing.
 Drive a worker's lifecycle through `bin/fm-control.sh <task-id> interrupt|exit|relaunch`, which owns the per-runtime mechanics, verifies each action, and never tears down or discards anything ([`docs/agent-control.md`](docs/agent-control.md)).
 A secondmate's routed reply returns through status or a document pointer, not by firstmate peeking into its chat.
@@ -374,7 +262,8 @@ Require the matching `resolved` event, forbid `--yes`, and require the worker to
 Resume fleet supervision immediately after the decision lands.
 
 Judge validation by the currently attributed run step through `bin/fm-crew-state.sh`, not by shell liveness or the last status event.
-Running, fixing, or CI states remain working; parked approval or fix-review states require the worker to follow the active gate help; passed or checks-passed is done; failed or cancelled is failed exactly as `bin/fm-crew-state.sh` prints it - only that state line reclassifies an orphaned ci monitor after green checks as held-for-merge done, or a terminal failed record with the daemon unreachable as unknown, never the raw run record.
+Trust exactly the state that helper prints, including its own reclassifications, and never the raw run record behind it; its header owns the run-step vocabulary and the mapping.
+A parked state means the worker must follow the active gate help, and a failed state is a failure to act on.
 A worker hand-editing, committing, aborting, or restarting during an active validation run duplicates pipeline ownership outside the supersession sequence above; steer it back to the gate response flow.
 The worker reports the PR when CI first becomes green rather than waiting for merge monitoring to finish.
 
@@ -402,7 +291,7 @@ A report may recommend implementation but does not authorize it.
 Before treating the investigation or any visual review as complete, load `captain-hold-lifecycle`; teardown enforces that shared completion gate.
 When a scout's deliverable is a visual artifact the captain will iterate on, prefer keeping that scout alive to host its own Lavish loop rather than tearing it down and mediating from firstmate, so the scout keeps its investigation context and the captain iterates in one continuous session.
 When implementation is separately authorized, promote the existing scout through `bin/fm-promote.sh` rather than creating a duplicate task.
-The promoted worker must inventory scratch state, return to a clean default-branch base, carry over only intended fix changes, create the ship branch, and follow the project's selected delivery path while leaving scratch commits and debug edits behind and turning a reproduced bug into the regression test.
+Promotion itself writes that worker's ship instructions, including the scratch-state inventory, the clean default-branch base, the ship branch, and the mode's definition of done; deliver them with the command it prints rather than restating the contract yourself.
 
 ## 8. Supervision protocol
 
@@ -419,6 +308,7 @@ Session start is the only exception because its one-shot digest already presente
 Treat any `OPEN DECISIONS` section from the drain as actionable reconciliation input even when no wake record was queued.
 Treat any `UNREAD STATUS` section as newly surfaced status that must be read this turn; those lines are not re-printed after this presentation.
 Treat any `RECORD DIVERGENCE` section as a contradiction between two records of one captain call, never as proof the captain ruled; load `captain-hold-lifecycle` and reconcile it in whichever direction the evidence supports.
+Treat any bounded one-shot `STATUS OUTCOME BACKSTOP` section as a recovered wake for a task whose newest captain-facing status event has no covering supervision-branch outcome, even when no queue row remains.
 After handling all emitted wakes and reconciling the OPEN DECISIONS and UNREAD STATUS sections, run the exact generation-bound `--ack-through` command printed as `WAKE_ACK_REQUIRED`; interruption before that acknowledgement deliberately leaves the work durable for idempotent re-handling.
 A status line is a wake event, not current state; use `bin/fm-crew-state.sh` when current state matters, especially before re-escalating an old decision, blocker, or pause.
 A declared `paused:` event means a bounded external wait expected to clear on its own, while `blocked:` means firstmate action is needed.
@@ -458,16 +348,12 @@ The skill owns the daemon procedure; these safety facts remain inline:
 - Away mode never expands approval authority for merges, ask-user findings, destructive actions, irreversible actions, or security-sensitive choices.
 - Bias ambiguous input toward exit because a present captain takes precedence.
 
-### Stuck-worker trigger
-
-For the full `stuck-crewmate-recovery` trigger, including a live worker claiming its no-mistakes pipeline is dead, unreachable, or timed out, follow section 13.
-
 ## 9. Escalation and captain etiquette
 
 **Talk in outcomes, not mechanics.**
 Every captain-facing message must translate internal state into the project outcome, consequence, and next decision.
 Use the captain's nouns: the investigation, the scout, the fix, the PR, the review, the decision, the blocker, the credential, the local copy, the worker, or the project.
-Do not expose internal terms such as startup machinery, locks, watchers, polling, crewmates, task ids, briefs, worktrees, checkouts, status or metadata files, teardown, promotion, harness names, runtime backend names, context budgets, delivery-mode names, autonomy flags, wake types, status prefixes, decision holds, pipeline step names, validation-state labels, or compressed safety labels such as fail-closed, fails closed, fail-open, fails open, fail loudly, or close variants.
+Never expose firstmate's internal vocabulary, including every term the rewrite table below names plus startup machinery, locks, polling, task ids, promotion, context budgets, delivery-mode names, autonomy flags, and status prefixes.
 Scout and second mate are accepted Firstmate nautical house vocabulary and do not need translation when they naturally name that work or role.
 When evidence uses an internal label, rewrite it before sending:
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -297,8 +297,7 @@ Promotion itself writes that worker's ship instructions, including the scratch-s
 
 Fleet supervision is an always-loaded operational contract; `docs/architecture.md`, `docs/turnend-guard.md`, the emitted session-start block, and script help own mechanisms and harness-specific recipes.
 
-Whenever work is under way, keep exactly one live supervision cycle using the emitted protocol for this primary harness.
-Relay may require that same live cycle with no fleet work.
+Keep exactly one live supervision cycle using the emitted protocol for this primary harness whenever work is under way, or whenever this home has an armed Relay poll, a registered process-event source, or a registered custom check, each of which requires that same live cycle with no fleet work.
 Do not substitute another harness's wait shape, use shell `&`, or create a second cycle when a healthy one already exists.
 For every actionable wake, follow the ordinary-wake continuation in the emitted protocol; use its repair action only when the live cycle is missing or failed.
 No turn ends blind while work is under way, including turns described as holding or waiting.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,7 +50,7 @@ Never add an agent name as a commit co-author.
 ## 2. Layout and state
 
 `docs/configuration.md` owns the top-level operational-home layout and the configuration schemas it documents, while each producing script's header and help own exact child fields and mutation mechanics, and each per-feature doc owns its own schema.
-Read those owners when a concrete path, field, or configuration knob matters rather than working from a remembered file list.
+Read those owners when a concrete path, field, or configuration knob matters rather than working from a remembered file list, and read a `bin/` script's own header before first use because that header is the authoritative account of its behavior, flags, and contracts.
 
 `FM_HOME` selects an instance's private `data/`, `state/`, `config/`, and `projects/`, while scripts continue to come from their tracked code root.
 Each secondmate has a persistent isolated `FM_HOME`, including its own state, backlog, projects, and session lock.
@@ -61,7 +61,6 @@ Tracked files hold shared instructions and tooling.
 `state/` holds runtime records: task metadata, append-only status events, the durable wake queue, steering inboxes, decision and poll records, the away posture, and watcher coordination.
 `config/` holds this home's local operating choices, and `.env` holds its optional Relay and mail credentials.
 `projects/` contains clones that are read-only to firstmate except under hard rule 1's concrete captain-approved project operation exception.
-`.env`, `data/`, `state/`, `config/`, `projects/`, and `.no-mistakes/` are captain-private and gitignored.
 
 Watcher, wake-queue, lease, away-mode, sub-supervisor, and turn-end auto-arm or stop-hook records under `state/` belong to the scripts that write them; never hand-edit or hand-delete them, and retire a registered check only through its unregister or teardown script.
 A `state/<id>.status` line is a wake event, not current-state truth; `bin/fm-crew-state.sh` owns current-state reconciliation.

--- a/bin/fm-quota-choose.sh
+++ b/bin/fm-quota-choose.sh
@@ -31,9 +31,9 @@
 # is checked against the wrong quota row. This is an accepted limitation of the
 # optional helper. Authoritative multi-provider routing - including provider
 # discovery from the harness catalog and quota matching by that explicit
-# provider - is owned by AGENTS.md section 4 and the quota-array-dispatch skill,
-# not by this helper. Use this helper only when the brief already fixed the
-# candidate order and every candidate's provider is the harness's primary family.
+# provider - is owned by the quota-array-dispatch skill, not by this helper.
+# Use this helper only when the brief already fixed the candidate order and
+# every candidate's provider is the harness's primary family.
 #
 # omp (Oh My Pi) has no single primary family, so its candidate model prefix
 # selects the family: openai-codex/<id> checks the codex row and
@@ -313,8 +313,8 @@ printf '%s\n' "$QUOTA_JSON" | fm_quota_json_valid || die "invalid quota-axi prov
 # Multi-provider harnesses (Pi, OpenCode) map to their primary family only; see
 # the header limitation note. omp is keyed on the candidate model prefix instead
 # and has no family for any other prefix (see the header). Authoritative
-# multi-provider routing is owned by AGENTS.md section 4 and the
-# quota-array-dispatch skill, not this helper.
+# multi-provider routing is owned by the quota-array-dispatch skill, not this
+# helper.
 provider_for_harness() {
   case "$1" in
     omp)

--- a/bin/fm-session-start.sh
+++ b/bin/fm-session-start.sh
@@ -708,7 +708,7 @@ fi
 # separate 900-second cadence remains unchanged.
 # Presented records are this turn's first work queue and remain durable until
 # post-handling acknowledgement. The drain's separate OPEN DECISIONS section
-# remains actionable even when that queue is empty (AGENTS.md sections 3 and 8).
+# remains actionable even when that queue is empty (AGENTS.md section 8).
 # The drain also runs fm-guard.sh internally on the locked path, so the
 # tangle/watcher-liveness alarms land right here too, ahead of the bulk digest
 # below. The read-only path never touches the queue because it lacks mutation

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -42,7 +42,8 @@ A genuinely no-op heartbeat is absorbed in bash and never reaches Pi, and every 
 A legacy `state/.afk` daemon flag still declines every wake offer, the away-posture record alone does not, and a broken branch still falls back to today's wake-to-main path.
 The branch's role stays bounded exactly as the captain-approved architecture set it: it cannot merge a PR, land local work, or freshly spawn, and every existing captain gate remains unchanged.
 Homes on any other primary harness never load this feature and are entirely unaffected.
-`AGENTS.md`'s `state/` inventory routes the branch's runtime files to their format and lifecycle owners.
+[docs/pi-supervision-branch.md](pi-supervision-branch.md) routes the branch's runtime files to their format and lifecycle owners: `bin/fm-branch-outcome.sh` owns the durable outcome store, its read cursor, and its bounded per-task status-coverage indexes, while `bin/fm-lease-lib.sh` owns the per-task supervision lease contract.
+[docs/watcher-continuity.md](watcher-continuity.md) owns the per-actor acknowledgement and the supervision-actor identity those leases name.
 A captain-facing (verdict `captain`) branch outcome persists as one exact, sequence-keyed visible transcript entry and then opens one sequence-keyed processing turn on main, which stays open until main acknowledges that sequence through its `fm_branch_processed` tool.
 The branch prompt's "Verdict: routine or captain" section owns the distinction between captain-facing, unsolicited routine, and unchanged-review outcomes.
 The generated [Pi supervision protocol](supervision-protocols/pi.md) owns main's event ownership, acknowledgement duty, and conversational treatment for merged outcomes, while the persisted entry itself owns captain visibility.


### PR DESCRIPTION
## Summary

`AGENTS.md` loads in full at every session of every home before any work runs, so
its size is a fixed tax on every session's context window.

**This change saves ~7,550 estimated tokens on every session, in every home.**

| | bytes | estimated tokens |
|---|---|---|
| `origin/main` | 78,144 | 26,048 |
| this branch | 55,495 | 18,498 |
| **saved per session** | **22,649** | **~7,550 (29.0%)** |

Measured by driving the real `bin/fm-session-start.sh` path that re-emits the
complete on-disk contract, using the repo's own `ceil(bytes / 3)` estimator -
not by reading the file.

## Approach

Apply the inline-stub pattern from `firstmate-coding-guidelines`: keep the
trigger and the safety boundary on the always-loaded page, and move the
procedure and the mechanics to the owner that already states them.

- **Section 2's 92-line file tree becomes a compact prose map.** That tree was a
  third copy: `docs/configuration.md` declares itself the single owner of the
  home layout *and* explicitly says state mechanics stay with their named
  scripts "rather than being duplicated into one exhaustive state tree here".
  Every config knob it listed was verified present in `docs/configuration.md` or
  its backend doc.
- **Section 3's seven-step digest anatomy moves to `bin/fm-session-start.sh`'s
  header**, which `AGENTS.md` already named as the single owner of digest
  contents one sentence above. The operator rules `docs/configuration.md`
  assigns to `AGENTS.md` - run-once, read-once, lock-refusal safety,
  installation consent, direct-report recovery - all stay inline.
- **Section 4** keeps the five boundaries `quota-array-dispatch`'s own text
  assigns to `AGENTS.md` and drops the procedure that skill owns.
- **Section 7's run-state enumeration** points at `bin/fm-crew-state.sh`'s
  header; **the promoted-worker instruction list** points at `bin/fm-promote.sh`,
  which writes those instructions itself.

Sections 1, 10, 11, 12, 13, 14, the precedence rule, and the preamble are
byte-identical. Section 13 in particular is unchanged, so every agent-only skill
trigger keeps its exact wording.

## Verification

Structural preservation is proven, and **the checker was proven able to fail** -
a renamed owner script, a retitled section 13, and an invented `section 99`
reference each produce a distinct failure:

- 16/16 sections preserved with identical titles; section 1's hard rules byte-identical.
- All `AGENTS.md section N` back-references across the tracked tree resolve.
- 31/31 named repo paths exist; 15/15 skill owners still routed.
- The 9 owner pointers the cut dropped remain reachable from `docs/configuration.md`, `docs/architecture.md`, and `docs/scripts.md`.
- One relocated boundary shown executing end to end: a real `bin/fm-promote.sh` run emitting the ship instructions `AGENTS.md` stopped restating.
- `bin/fm-doc-audience-check.sh` ok; `bin/fm-lint.sh` clean.

Two runs in this branch's history failed on a **pipeline-agent session limit**,
not on any code change, and one on an upstream push permission. No code issue
was involved in either.

---

## Boundary inventory

Every safety boundary in the pre-change file, and where it lives now.
"Verbatim" means the line is byte-identical; "kept" means the boundary is on the page with tightened wording.

### Untouched, byte-identical sections
`## 1`, `## 10`, `## 11`, `## 12`, `## 13`, `## 14`, `## Captain instruction precedence`, `## Maintaining this file`, and the preamble are unchanged. That covers:

| # | Boundary | Where now |
|---|---|---|
| 1 | Hard rule 1 - never write to a project, with its exact exception list, no forcing/stashing/discarding, and the no-standing-authority clause | §1, verbatim |
| 2 | Hard rule 2 - never merge a PR without the captain's explicit word; yolo is the only standing relaxation | §1, verbatim |
| 3 | Hard rule 3 - never tear down unlanded work; no `--force` without explicit discard authority; scout scratch gate | §1, verbatim |
| 4 | Hard rule 4 - crewmates never address the captain | §1, verbatim |
| 5 | Hard rule 5 - report outcomes faithfully | §1, verbatim |
| 6 | Shared tracked material list; delegate while crew is live; ship through no-mistakes + PR; never add an agent co-author | §1, verbatim |
| 7 | Mandatory "captain" address; secondmate parent-channel is the only real reach | preamble, verbatim |
| 8 | Backlog tracks work items only, never agents | §10, verbatim |
| 9 | Every ship brief retains the worktree-isolation assertion; scaffold is a safety contract, not a suggestion | §11, verbatim |
| 10 | `firstmate-coding-guidelines` required for firstmate-repo tasks; Herdr lab guard | §11, verbatim |
| 11 | All 14 agent-only skill load triggers, at full trigger precision | §13, byte-identical |
| 12 | Relay token is consent for reversible action only, never destructive/irreversible/security-sensitive | §14, verbatim |
| 13 | Only the home holding relay consent and thread binding posts the final public reply | §14, verbatim |
| 14 | Captain-instruction precedence: never infer, broaden, or carry an override; destructive/irreversible/security-sensitive/discard/merge still require the captain to name the concrete action | precedence section, verbatim |

### Boundaries in the rewritten sections

| # | Boundary | Where now |
|---|---|---|
| 15 | `FM_HOME` isolation per secondmate | §2, verbatim |
| 16 | `fm-send` fails closed unless `FM_HOME` is explicit, so a steer cannot resolve against another home | §2, verbatim |
| 17 | `projects/` read-only except hard rule 1's exception | §2, verbatim |
| 18 | Captain-private/gitignored set | §2, kept (one line) |
| 19 | Never hand-edit or hand-delete watcher/wake-queue/lease/away-mode/sub-supervisor/turn-end records | §2, kept - **broadened**: one line now covers more record classes than the five scattered "never touch" entries did, including lease records that previously carried no such rule |
| 20 | Retire a registered check only through its unregister or teardown script, never a hand-composed `rm` | §2 (new reinforcement) and §7, verbatim |
| 21 | A status line is a wake event, not current-state truth | §2, verbatim |
| 22 | captain.md / captain-shared.md / learnings.md are canonical regardless of harness memory | §2, verbatim |
| 23 | Run session start exactly once; never reimplement its components | §3, verbatim |
| 24 | Read the digest once; do not re-read its sources | §3, verbatim |
| 25 | `ABSENT` is never an empty-but-present file; absence is meaningful; rebuild a stale registry before dispatch | §3, kept |
| 26 | Lock refused -> read-only, with the explicit list of forbidden mutations | §3, verbatim |
| 27 | Lock-refused digest leaves the queue untouched; alarms are advisory with no repair command | §3, kept (one line) |
| 28 | Session start never starts supervision; the emitted protocol owns the wait/wake mechanism | §3, kept |
| 29 | Treat no network check as passed until its report returns | §3, verbatim |
| 30 | A read-only session runs no network checks and says so | §3, verbatim |
| 31 | Bootstrap detects, then asks consent, then installs only after captain approval this session | §3, verbatim |
| 32 | Do not dispatch until tools are present and GitHub auth is good | §3, verbatim |
| 33 | Load `bootstrap-diagnostics` on any actionable diagnostic line | §3 and §13, kept |
| 34 | Never dispatch on an unverified adapter; fall back only to a verified one | §4, verbatim |
| 35 | Account for every candidate; never omit, guess, or fall back silently | §4, kept |
| 36 | Malformed profile configuration is an actionable error, not something to select around | §4, kept |
| 37 | Missing evidence is disclosed uncertainty, never a credential or login escalation; only contradictory evidence blocks | §4, kept |
| 38 | Never infer a credential store, provider family, or quota mapping from a name; never launch another harness's CLI to judge a candidate | §4, verbatim |
| 39 | Preserve the captain's strongest-reasoning class; stop and report if it cannot proceed | §4, verbatim |
| 40 | Break ties without array-order or harness bias | §4, verbatim |
| 41 | Never select max effort without explicit captain preference | §4, verbatim |
| 42 | Backend must validate as spawn-capable; a refusal is a blocker, never a silent retry elsewhere | §4, verbatim |
| 43 | Reconcile only this home's reports; never sweep a shared namespace or claim another home's work | §5, verbatim |
| 44 | Preserve the recorded worktree and unlanded work during recovery | §5, verbatim |
| 45 | Never reconstruct or supervise a secondmate's child tree from the main home | §5 and §6, verbatim |
| 46 | Recovery never authorizes a secondmate to invent work; an empty queue is healthy | §5 and §6, verbatim |
| 47 | Endpoint liveness is a presence check only, never a run step | §5, kept (**moved** from §3 to the section that owns reconciliation) |
| 48 | Firstmate never writes a project's `AGENTS.md` directly | §6, verbatim |
| 49 | Project creation never authorizes an unmentioned remote; removal never bypasses preflight | §6, verbatim |
| 50 | Route by secondmate scope, not by the non-exclusive clone list; keep `local-only` in the main home | §7 intake, verbatim (the duplicate copy in §6 was dropped) |
| 51 | A diagnostic report is evidence, not authorization to change code | §7, verbatim |
| 52 | Delivery mode and yolo resolved at intake and passed explicitly; commands refuse to guess | §7, verbatim |
| 53 | Unregistered project resolves to no-mistakes with yolo off; never infer internal-only from path or name | §7, verbatim |
| 54 | Spawn must resolve an isolated worktree; a failed isolation assertion stops the task | §7, verbatim |
| 55 | The backlog gate refuses rather than dispatching work this home has no item for | §7, verbatim |
| 56 | `fm-send` is the data plane only; never use it for lifecycle control | §7, verbatim |
| 57 | `fm-control.sh` owns lifecycle and never tears down or discards anything | §7, verbatim |
| 58 | After an unconfirmed remote delivery, resend only with the exact command `fm-send` printed | §7, kept (the env-var spelling moved to `fm-send.sh`'s header) |
| 59 | `--resolve-key` closes the decision record at answer time | §7, verbatim |
| 60 | no-mistakes owns its own rigor; never stack manual reviews or infer review authority from risk | §7, verbatim |
| 61 | Each delivery mode waits for the configured merge authority | §7, verbatim |
| 62 | Never merge a red PR under either yolo setting; destructive/irreversible/security-sensitive merges still escalate | §7, verbatim |
| 63 | Standing yolo cannot authorize a red merge | §7, verbatim |
| 64 | The implementation worker never answers its own ask-user finding | §7, verbatim |
| 65 | Use the guarded merge scripts; never a lower-level merge command around their guards | §7, verbatim |
| 66 | Firstmate never invokes `axi respond` for a crew-owned run | §7, verbatim |
| 67 | Full validation-supersession sequence: single supported abort, confirm stopped before changing code, custody is not content, replace from the pre-invalidation base, no second run while the obsolete run owns the branch, validate exactly once against the final head | §7, verbatim - **not cut**, see below |
| 68 | Forbid `--yes`; require the matching `resolved` event | §7, verbatim |
| 69 | Judge validation by the attributed run step, not shell liveness or the last status event | §7, kept |
| 70 | Hand-editing during an active run duplicates pipeline ownership | §7, verbatim |
| 71 | Custom check contract plus never hand-compose an `rm` with `$STATE`/`$ID` | §7, verbatim |
| 72 | Teardown only after landing; a refusal is stop-and-investigate; never force without explicit discard authority | §7, verbatim |
| 73 | Secondmate retirement needs an explicit decision, no work under way, and explicit discard authority | §7, verbatim |
| 74 | A scout report must exist before scratch is discarded, and it never authorizes implementation | §7, verbatim |
| 75 | Exactly one live supervision cycle; no shell `&`; no second cycle | §8, verbatim |
| 75a | The supervision cycle is required by work in flight, an armed Relay poll, **a registered process-event source**, and **a registered custom check** (`bin/fm-supervision-lib.sh:76-81`) | §8, one sentence naming all four - see "Supervision trigger" note below |
| 76 | No turn ends blind while work is under way | §8, verbatim |
| 77 | Drain the wake queue before any other action; acknowledge only after handling | §8, verbatim |
| 78 | OPEN DECISIONS / UNREAD STATUS / RECORD DIVERGENCE handling | §8, verbatim |
| 79 | STATUS OUTCOME BACKSTOP handling | §8, kept (**moved** from §3 to sit with the other drain sections) |
| 80 | Never broadly kill watchers, especially never `pkill -f bin/fm-watch.sh` | §8, verbatim |
| 81 | Guard warnings do not replace the contract; worktree tangle resolved without touching unlanded work | §8, verbatim |
| 82 | Worktree isolation enforced by both the spawn assertion and the generated ship brief | §8, verbatim |
| 83 | All seven away-mode safety facts, including that away mode never expands approval authority | §8, verbatim |
| 84 | Never expose internal vocabulary to the captain; never relay reports verbatim | §9, kept |
| 85 | The six immediate-escalation triggers, including destructive/irreversible/security-sensitive and credential needs | §9, verbatim |
| 86 | In a secondmate home the parent channel is the only real reach | §9, verbatim |
| 87 | PR URLs copied verbatim, never assembled from memory | §9, verbatim |

### What moved to an existing owner, and why that is safe

| Moved | New owner | Why safe |
|---|---|---|
| The 92-line `state/`, `config/`, and `data/` file tree | `docs/configuration.md` "Operational home layout and state" plus each producing script's header | That doc already declares itself "the single owner of the top-level operational-home layout" **and** states that state mechanics "remain with their named scripts and reference sections rather than being duplicated into one exhaustive state tree here". The tree was a third copy of content the guidelines' decision tree routes to tier 7 (script header + `--help`). Every config knob in it was confirmed present in `docs/configuration.md` or its backend doc. Its only imperative content - the five "never touch" entries - is now one broader inline line. |
| The seven-step digest anatomy | `bin/fm-session-start.sh` header | AGENTS.md named that header "the single owner of composed commands, ordering, and digest contents" in the sentence directly above the steps it then restated. The header carries the same nine stages in more detail. `docs/configuration.md` also states which session-start facts AGENTS.md should retain - run-once, read-once, lock-refusal safety, installation consent, direct-report recovery - and all five are on the page. |
| The quota selection procedure (TOON read, catalog granularity, gate mechanics) | `quota-array-dispatch` | That skill's own line 16 declares the split: AGENTS.md owns "the always-loaded intake boundary, load trigger, malformed-config refusal, every-candidate accounting, and strongest-reasoning/tie safety rules", the skill owns the procedure. All five AGENTS.md-owned items are kept inline; only the procedure left. Its load trigger remains in both §4 and §13. |
| The validation run-state enumeration | `bin/fm-crew-state.sh` header | The removed sentence already ended "exactly as `bin/fm-crew-state.sh` prints it". That header owns the full run-step mapping including the ci/held-for-merge and daemon-unreachable reclassifications. |
| The promoted-worker instruction list | `bin/fm-promote.sh` | Promotion writes those instructions itself - its header states it carries "the scratch-state inventory, the clean default-branch base, the fm/<task-id> branch" and the mode's definition of done. AGENTS.md was restating output the script already produces. |
| `fm-send` transport mechanics (doorbell line, multi-line legality, env-var spelling) | `bin/fm-send.sh` and `bin/fm-task-inbox-lib.sh` headers | Named as owners in the original text. Every rule that binds firstmate's behavior stayed. |
| The `### Stuck-worker trigger` subsection | §13 | It carried no trigger of its own - it said "follow section 13". §13's entry is byte-identical and states that trigger in full; §5 and §8 item 2 also load the skill. |

### What I could not cut, and why

- **The validation supersession and custody sequence (§7).** No owner exists for it outside `AGENTS.md`. `bin/fm-nm-run-lib.sh` owns firstmate's *state attribution*, not the worker's abort-and-replace sequence, and no-mistakes' own skill is a third-party surface this repo does not track. Creating a skill for it would fail trigger hygiene: it fires mid-validation, where a skill load competes with an active pipeline.
- **The custom `state/<id>.check.sh` contract (§7).** Firstmate hand-writes these files. `bin/fm-check-register.sh`'s header is four lines and does not state the single-link, mode-0700, one-line-output, or timeout requirements, and no doc consolidates them. Cutting it would have moved a hand-written-file contract to nowhere.
- **The §9 rewrite table.** It has no other owner and applies to every captain-facing message. Only the redundant term enumeration above it - which listed the same terms the table already maps - was folded in.
- **§1, §10-§14, and the precedence section.** Pure boundary text with no duplicated mechanics to route away. Left byte-identical.

### Base verification, rebase, and recent-boundary delta check

This branch is rebased onto `origin/main` at `34bd4189` and carries nine commits.

**Final measurement, against the current upstream base**, taken by driving the
real `bin/fm-session-start.sh` path rather than by reading the file, using the
repo's own `ceil(bytes / 3)` estimator:

| | bytes | estimated tokens |
|---|---|---|
| `origin/main` | 78,144 | 26,048 |
| this branch | 55,495 | 18,498 |
| **saved every session** | **22,649** | **7,550** |

That is **29.0%**, and the percentage held across the rebase.

**A boundary was added upstream while this work was in flight**, which is exactly
the case a stale inventory loses silently. Commit `34bd418` ("restrict captain
address rule to user chat") rewrote the preamble and introduced a new rule:

> The obligation is limited to chat and binds every agent reading this file,
> first mate or not: never put "captain" or any other direct address into a
> non-chat artifact such as a commit message, PR or issue description, brief,
> code, or comment.

This change never touches the preamble, so that boundary survives **verbatim**
and the preamble is byte-identical to upstream. This PR body and every commit
message on the branch were checked against the new rule and carry no direct
address.

**Structural checks, re-run against the new base:**

| Check | Result |
|---|---|
| Section count and titles | 16/16 identical to upstream |
| Section 1 hard rules | byte-identical |
| `section N` back-references | all resolve |
| Named repo paths | 36 referenced; 9 absent, all gitignored runtime files (`data/`, `state/`, `config/`), **identical in base**, zero new |
| Skill owners routed | 20 skills; 3 unrouted (`ahoy`, `bearings` are captain-invocable, `decision-hold-lifecycle` is a deprecated stub), **identical in base**, zero new |

The rebase produced no conflicts, and none of the upstream commits had already
moved detail this change moves, so there was no duplicate to drop.

### Supervision trigger: one restored regression and one pre-existing gap

Review caught that section 8's trigger for keeping a live supervision cycle had
narrowed to two of the four conditions `bin/fm-supervision-lib.sh:76-81`
actually tests. Both are now named in one always-loaded sentence. The two halves
have different histories, and the distinction matters for reading this PR:

- **Registered process-event source - a regression introduced by this PR.** That
  clause lived only in the section 2 `procevent/` tree line ("their presence
  alone keeps supervision required"), which this change deleted. Restoring it
  undoes that loss. It is the one boundary this cut lost, and the audit missed it
  because the wording carried no imperative keyword.
- **Registered custom check - a pre-existing gap, NOT removed by this PR.** The
  pre-change `AGENTS.md` contains no supervision-required claim for registered
  custom checks anywhere; `grep` over the base file returns nothing. It was
  already absent. It is fixed here because it is the same sentence in the same
  file, and leaving the always-loaded contract disagreeing with the code that
  enforces it would be the exact defect class this change exists to reduce.

Both cases stay inline rather than moving to a skill: a trigger that decides
whether supervision runs at all has to be on the always-loaded page.


### Script-header discipline: restored, and more load-bearing than before

The deleted tracked-file tree carried one general operating rule -
`bin/  helper scripts, committed; read each script's header before first use` -
and the first draft of this change dropped it. It is restored as a clause on
section 2's owner-routing sentence.

State this plainly for anyone reading later: **this change made that rule more
load-bearing, not less.** Roughly 23k bytes of reference detail moved out of
`AGENTS.md` and into script headers and their `--help` output, which is exactly
where the knowledge-placement decision tree's tier 7 sends it. "Read the
script's header before first use" is the rule that makes that routing usable.
Removing it while increasing reliance on headers would have left the change
internally incoherent - a worse outcome than not making the change at all.

### Two self-inflicted corrections caught in review

Both were introduced by this change and are fixed in it:

- **Duplicated captain-private list.** The section 2 rewrite restated section 1's
  `.env`, `data/`, `state/`, `config/`, `projects/`, `.no-mistakes/` sentence
  word for word. Section 1 owns the shared-tracked versus captain-private split,
  so the section 2 copy is removed and line 47 stands. This was the one-owner
  violation this change exists to reduce, committed by the change itself.
- **Stale `sections 3 and 8` pointer.** `bin/fm-session-start.sh` referenced the
  OPEN DECISIONS rule as living in both sections; this change moved it to
  section 8 alone, so the pointer now names section 8 only. The rule was not
  restored to section 3 - section 3 keeps only its routing line.

### Deliberate tightening, recorded

Section 2's blanket rule ("Watcher, wake-queue, lease, away-mode, sub-supervisor,
and turn-end auto-arm or stop-hook records under `state/` belong to the scripts
that write them; never hand-edit or hand-delete them") covers all five
never-touch families the old tree listed, and additionally covers two records the
old text marked safe to delete (`.watch-triage.log` and the open-decisions
cursor). That is a deliberate tightening toward the safe side, not a lost
boundary: both remain safe for their owning scripts to remove.


### The pattern worth more than the byte count

Three boundaries had to be restored during review, and they failed the same way.
Naming it is the most useful thing this change can teach whoever edits
`AGENTS.md` next:

> **Enumerations narrowed silently. General rules did not.**

Every restored boundary was lost the moment a list stood in for a rule:

| Restored boundary | How it was lost | Whose narrowing |
|---|---|---|
| Supervision required by a registered process-event source | The rule lived only as one entry in a 92-line file tree; deleting the tree deleted the rule | **This change's.** The custom-check half of the same rule was already missing before it |
| Read a `bin/` script's header before first use | Same - carried only as a tree entry, and this change moved ~23k bytes *into* script headers, so it got more load-bearing as it disappeared | **This change's** |
| Never hand-edit records under `state/` | The first rewrite replaced per-record notes with a list of six families, which silently dropped `procevent/`, `when/`, `decision-bindings/`, `reconcile-requests/`, the `.mail-*` cursors, and `pending-replies/` | **This change's**, but the original per-record notes were themselves an enumeration with the same defect |

The first attempt at the third fix then failed in the *opposite* direction, and
that is the part worth keeping:

> The enumeration was too **narrow** and lost boundaries; the general rule was
> too **broad** and forbade a legitimate action. Both failures are real, they
> point in opposite directions, and the lesson is not "prefer general rules" -
> it is that a rule about what may be touched needs its exceptions stated where
> the rule lives, or it is wrong in one direction or the other.

Concretely: the generalized sentence forbade hand-editing any record under
`state/`, while section 7 instructs firstmate to hand-author a custom
`state/<id>.check.sh`. The always-loaded contract contradicted itself. The
final wording keeps the general rule and names the single exception as a pointer
to the owner:

> Records under `state/` belong to the scripts that write them; never hand-edit
> or hand-delete them, apart from the custom check section 7 has you author
> yourself.

**Provenance, stated plainly:** that contradiction was introduced by the review
round's own generalization, approved without checking it against section 7, and
was caught by the next review round - not by the original cut. A fix round
introducing a new defect is exactly the kind of thing this change is meant to
make visible, so hiding where it came from would be the same dishonesty as a
comment claiming a guarantee the code does not have.

The general form of the fix for all three cases:

> Records under `state/` belong to the scripts that write them; never hand-edit or hand-delete them.

That sentence is **shorter** than the six-family list it replaces, strictly
broader than both that list and the original per-record notes, and it protects
records nobody has written yet. A list of six families would have rotted the
moment a seventh appeared - which is precisely the defect it was introduced to
patch. Generalizing removed the category instead of the instance.

The practical rule for future edits: when a fact must survive in `AGENTS.md`,
write it as a rule over a class, not as an annotation on a list of members.
A list is reference detail and belongs with its owner; the rule belongs on the
always-loaded page.

### Two further self-inflicted corrections

Both were introduced by this change's own first draft and are fixed in it:

- **Check-retirement clause was factually wrong.** The clause "retire a
  registered check only through its unregister or teardown script" is untrue for
  generated shims: `bin/fm-mail-check.sh` and `bin/fm-tool-update-check.sh`
  retire through their own `disarm` action and neither has an unregister script.
  It also restated a rule section 7 already owns in full. Dropped from section 2;
  section 7's line stands unchanged. It was added during the change's own
  boundary audit, which is how an audit step introduced both an inaccuracy and a
  one-owner violation in a single clause.
- **Dangling forward reference.** "These boundaries bind the outcome however
  that procedure resolves" pointed forward to five constraints while its nearest
  antecedent was an ownership fact, so read backward it asserted nothing.


### Two further rewrite errors caught in the same round

Both introduced by this change's rewrite of section 3's ABSENT handling:

- `data/captain-shared.md` was called a *registry*. It is the main-authoritative
  shared captain-preference **file**; the only registries under `data/` are
  `projects.md` and `secondmates.md`.
- The learnings case was dropped, although `bin/fm-session-start.sh` still emits
  an ABSENT marker for `data/learnings.md`.

### Review record

Four ask-user findings were raised across this change and **every one was a real
boundary or a real contradiction**: the supervision trigger, the script-header
discipline, the `state/` record narrowing, and the contradiction the fix for that
narrowing introduced. Three were defects in the original cut; the fourth came
from a fix round. None was waved through, and none was decided by the
implementation worker.


---

## The scope-error pattern (the real deliverable)

Five review rounds. **Every finding was a scope error in one direction or the
other** - and the same two sentences were wrong in *opposite* directions on
different rounds. That is worth more than the byte count, so it is written up
here rather than buried in the fix log.

| Round | Rule | Direction | Origin |
|---|---|---|---|
| 1 | Supervision required by a registered process-event source | too **narrow** - carried only as a tree entry | the cut |
| 2 | Read a `bin/` script's header before first use | too **narrow** - same | the cut |
| 3 | Never hand-edit `state/` records | too **narrow** - a list of six families dropped six more record types | the cut |
| 4 | Same rule, generalized | too **broad** - forbade the custom check section 7 tells you to author | **a fix round** |
| 5 | Same rule, with carve-out | too **broad** - the exception attached to *both* verbs, authorizing the hand-`rm` section 7 forbids | **a fix round** |
| 5 | Supervision trigger, after being widened | too **narrow** again - the word "custom" excluded two registered checks the code counts | a fix round |
| 5 | "Never expose... every term the rewrite table names" | too **broad** - forbids the approved replacements the table exists to recommend | the cut |

### What the pattern is not

It is **not** "prefer general rules." It is **not** "prefer enumerations."
Rounds 3 and 4 are the same rule failing in both forms.

### What it is

> A rule about what may be touched has to be checked against the code that
> enforces it, and against every other rule that grants or forbids the same
> action. Neither form - list or generalization - is safe without that check.

Both checks were load-bearing here, and each caught things the other missed:

- **Against the enforcing code.** `bin/fm-supervision-lib.sh:76-81` computes
  `FM_SUP_NEEDED` from four conditions; the prose named two, then three, then
  the right four. `bin/fm-supervision-lib.sh:72` counts *any* `.check-trust`,
  which is how the word "custom" was found to be excluding two real checks.
  Nobody finds these by reading the prose carefully - only by reading the code
  the prose claims to describe.
- **Against every other rule on the same action.** Section 2 said never
  hand-edit or hand-delete; section 7 said author this file yourself and retire
  it only through its script. Reading either section alone, both look correct.
  The contradiction exists only *between* them.

The sharpest instance is round 5's vocabulary sentence, and it deserves stating
on its own: **a sentence that forbids every term in a rewrite table also forbids
the approved replacements the table exists to recommend.** The rule ate its own
remedy, one line after the line that prescribes it. No amount of careful reading
finds that - only checking the rule against what it actually ranges over.

### Provenance, stated honestly

Of the scope errors above, **two were introduced by fix rounds, not by the
original cut** - the round-4 generalization and the round-5 carve-out that
attached to both verbs. Both were approved decisions that were not checked
against section 7 before being applied, and both were caught by the next review
round. A fix round introducing a new defect is precisely what this change is
meant to make visible; recording the cut's errors while quietly omitting the
fixes' errors would be the same dishonesty as a comment claiming a guarantee the
code does not have.


---

## On what this change does not prove, and why that is the right call

The test step proved boundary preservation structurally and refused to overclaim
beyond it. Both halves matter.

**Proven, by driving the real `bin/fm-session-start.sh`** on the path that
re-emits the full on-disk contract, using the repo's own `ceil(bytes / 3)`
estimator - not by reading the file:

- 77,990 -> 55,341 bytes; 25,997 -> 18,447 estimated tokens; **7,550 saved per
  session**; 29%.
- 14/14 numbered sections preserved with identical titles.
- Section 1's hard rules byte-identical.
- All 50 `AGENTS.md section N` back-references across the tracked tree resolve.
- 31/31 named repo paths exist; 15/15 skill owners still routed.
- The 9 owner pointers the cut dropped remain reachable from
  `docs/configuration.md`, `docs/architecture.md`, and `docs/scripts.md`.
- One relocated boundary shown executing end to end: a real `bin/fm-promote.sh`
  run emitting the ship instructions `AGENTS.md` stopped restating.
- **The checker was proven able to fail.** A renamed owner script, a retitled
  section 13, and an invented `section 99` reference each produce a distinct
  failure. A gate that cannot fail is worse than no gate.

**Not proven:** semantic equivalence, sentence by sentence, for the roughly 60
dropped imperative sentences - whether each rewritten or delegated rule still
*means* to a reading agent exactly what the base sentence meant.

That gap is deliberate, and reading it as laziness would be the wrong lesson:

1. **The test that would close it is a test this repo forbids.** Asserting that a
   prose contract still means the same thing by matching its source bytes, or by
   parsing or snapshotting it, is exactly the anti-pattern
   `firstmate-coding-guidelines` rules out, and model interpretation belongs in
   development-time evaluation rather than live CI. Writing it would be a defect
   dressed as diligence.
2. **The semantic check was performed, by the mechanism that suits it.** Five
   review rounds surfaced seven real scope errors: narrow enumerations,
   over-broad generalizations, a rule that forbade its own remedy, and two
   defects introduced by fix rounds rather than by the cut. **Not one would have
   been caught by any structural test.** That is why the residual risk is
   acceptable rather than merely unavoidable.
3. **This inventory is the durable record of that judgment**, and it ships in the
   PR body so the decision can be audited rather than taken on trust.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
