### PR TITLE
fix(bearings): stop automated Lavish browser opens

### DIFF
--- a/.agents/skills/bearings/SKILL.md
+++ b/.agents/skills/bearings/SKILL.md
@@ -104,7 +104,7 @@ Compose the payload from the same snapshot with the same ranking judgment as the
 - Every Captain's Call item and every Underway, Recently Landed, and Charted Next row carries an explicit `repo` field. Fill it from the snapshot and task records wherever known; use null or an empty string only as the deliberate genuinely-no-repo marker, in which case the template may show the internal id. Ids otherwise stay in the payload only as the routing channel, and composed reasons name blockers in plain words.
 
 Run `build` once after composing the payload.
-Its serve-first sequence publishes the board, establishes and verifies its Lavish session with `lavish-axi`, reopens an ended session when necessary, and only then binds the answer source and proves a live polling listener; use the session URL it prints in the chat digest.
+Its serve-first sequence publishes the board, establishes and verifies its Lavish session with `lavish-axi` without opening a browser, reopens an ended session when necessary without opening a browser, and only then binds the answer source and proves a live polling listener; use the session URL it prints in the chat digest and open it explicitly when you want to review it.
 Never bind or arm the board before its session is listed open.
 Never run `lavish-axi poll` for the board yourself: the armed source's supervised runner owns the blocking poll, and both the build and the watcher's ordinary reconcile repair a missing listener, so no conversational turn ever blocks on the board.
 

--- a/bin/fm-bearings-board.sh
+++ b/bin/fm-bearings-board.sh
@@ -15,9 +15,10 @@
 #            already landed, give every surviving decision card the standard
 #            reconcile choice, and inject the result into a fresh copy of the
 #            shipped template at the stable board path. Establish the Lavish
-#            session on that board and PROVE it is live BEFORE binding and
-#            arming its answer source, so a registered poll can never race a
-#            session that does not exist or attach to one that has ended.
+#            session on that board without opening a browser, then PROVE it is
+#            live BEFORE binding and arming its answer source, so a registered
+#            poll can never race a session that does not exist or attach to one
+#            that has ended.
 #            Bind to the keyed-answer intake (bin/fm-captain-hold.sh) ALWAYS
 #            precedes arm, so the board can never produce an answer that has
 #            nowhere to go (captain-hold-lifecycle's ordering rule, enforced
@@ -221,22 +222,22 @@ lavish_board_live() {  # <establish output> <canonical-board-path>
   lavish_session_listed_open "$2"
 }
 
-# Establish the board session and PROVE it is live before anything arms a poll
-# on it. A session the captain ended is reopened once - the captain asked for
-# this board, which is exactly the attention `--reopen` exists for - and a
-# session that is still not live after that refuses the build rather than
-# arming a poll that can never attach.
+# Establish the board session without opening a browser and PROVE it is live
+# before anything arms a poll on it. A session the captain ended is reopened
+# once without opening a browser; the returned URL remains available for the
+# captain to open explicitly. A session that is still not live after that
+# refuses the build rather than arming a poll that can never attach.
 establish_board_session() {  # <board>
   local board=$1 real out status version
   BOARD_SESSION_REOPENED=0
   real=$(board_realpath "$board") || fail "cannot resolve the board path: $board"
-  out=$(lavish-axi "$board") || fail "cannot establish the board Lavish session"
+  out=$(lavish-axi "$board" --no-open) || fail "cannot establish the board Lavish session"
   printf '%s\n' "$out"
   if lavish_board_live "$out" "$real"; then
     printf 'session: live\n'
     return 0
   fi
-  out=$(lavish-axi "$board" --reopen) || fail "cannot reopen the ended board Lavish session"
+  out=$(lavish-axi "$board" --no-open --reopen) || fail "cannot reopen the ended board Lavish session"
   printf '%s\n' "$out"
   if lavish_board_live "$out" "$real"; then
     BOARD_SESSION_REOPENED=1

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -371,6 +371,7 @@ The report is the only thing that survives, so anything worth keeping must be in
 1. Never push to any remote and never open a PR.
 2. Stay inside this worktree; the only files you may write outside it are the report and the status file below.
 3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.
+When preparing or serving a Lavish artifact without a current explicit captain request to open it, pass \`--no-open\` and return the review URL without opening a browser. Use plain \`lavish-axi <html-file>\` or \`--reopen\` only when the captain explicitly asks to open or reopen that review.
 4. Report status by appending one line:
    \`echo "{state}: {one short line}" >> $STATUS_FILE\`
    States: working, needs-decision, blocked, $PAUSED_VERB, done, failed.
@@ -460,6 +461,7 @@ If the top-level path is the primary checkout or not the worktree you were launc
 $RULE1
 2. Stay inside this worktree; modify nothing outside it.
 3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.
+When preparing or serving a Lavish artifact without a current explicit captain request to open it, pass \`--no-open\` and return the review URL without opening a browser. Use plain \`lavish-axi <html-file>\` or \`--reopen\` only when the captain explicitly asks to open or reopen that review.
 4. Report status by appending one line:
    \`echo "{state}: {one short line}" >> $STATUS_FILE\`
    States: working, needs-decision, blocked, $PAUSED_VERB, done, failed.

--- a/tests/fm-bearings-board-lavish-live-e2e.test.sh
+++ b/tests/fm-bearings-board-lavish-live-e2e.test.sh
@@ -14,8 +14,10 @@
 #
 # The captain-ended state is reached through the same server route the browser's
 # End session button calls, so no browser is needed and nothing here depends on
-# a human. The artifact is a scratch page in a temporary directory, and the
-# session it opens is ended again before the guard returns.
+# a human. Every artifact-serving call uses --no-open because this guard needs
+# session state and URLs, not browser focus. The artifact is a scratch page in
+# a temporary directory, and the session it opens is ended again before the
+# guard returns.
 #
 # Standard CI has no lavish-axi, so this reports a capability skip there. The
 # portable counterpart in tests/fm-bearings-board.test.sh pins the build's logic
@@ -74,7 +76,7 @@ JSON
 
 run_board() {
   FM_HOME="$LAB" FM_STATE_OVERRIDE="$LAB/state" FM_DATA_OVERRIDE="$LAB/data" \
-    FM_PROCEVENT_CLAIM_ROOT="$LAB/procevent-claims" \
+    FM_PROCEVENT_CLAIM_ROOT="$LAB/procevent-claims" LAVISH_AXI_NO_OPEN=1 \
     "$ROOT/bin/fm-bearings-board.sh" "$@"
 }
 
@@ -82,7 +84,7 @@ BOARD="$LAB/.lavish/bearings-board.html"
 run_board build "$LAB/payload.json" >/dev/null 2>&1 || fail "the guard board did not build"
 [ -f "$BOARD" ] || fail "the guard board was not published"
 
-url=$(lavish-axi "$BOARD" | sed -n 's/^[[:space:]]*url:[[:space:]]*//p' | head -1 | tr -d '"')
+url=$(lavish-axi "$BOARD" --no-open | sed -n 's/^[[:space:]]*url:[[:space:]]*//p' | head -1 | tr -d '"')
 case "$url" in
   http://*/session/*) ;;
   *) fail "could not read the guard board session url: $url" ;;
@@ -96,7 +98,7 @@ curl -fsS -X POST "$base/api/$key/end" >/dev/null 2>&1 \
 
 # ASSUMPTION UNDER GUARD: this exits 0 while reporting the session is not live.
 set +e
-ended_out=$(lavish-axi "$BOARD" 2>&1)
+ended_out=$(lavish-axi "$BOARD" --no-open 2>&1)
 ended_rc=$?
 set -e
 [ "$ended_rc" -eq 0 ] \

--- a/tests/fm-bearings-board.test.sh
+++ b/tests/fm-bearings-board.test.sh
@@ -79,7 +79,12 @@ esac
 file=$1
 shift
 reopen=0
-for arg in "$@"; do [ "$arg" != --reopen ] || reopen=1; done
+no_open=0
+for arg in "$@"; do
+  [ "$arg" != --reopen ] || reopen=1
+  [ "$arg" != --no-open ] || no_open=1
+done
+[ "$no_open" = 1 ] || { printf 'automated artifact establishment must pass --no-open\n' >&2; exit 97; }
 real=$(cd "$(dirname "$file")" && pwd -P)/$(basename "$file")
 if [ -e "$state/user-ended" ] && [ "$reopen" = 0 ]; then
   emit "$real" user-ended

--- a/tests/fm-bearings-board.test.sh
+++ b/tests/fm-bearings-board.test.sh
@@ -84,8 +84,14 @@ for arg in "$@"; do
   [ "$arg" != --reopen ] || reopen=1
   [ "$arg" != --no-open ] || no_open=1
 done
-[ "$no_open" = 1 ] || { printf 'automated artifact establishment must pass --no-open\n' >&2; exit 97; }
+if [ "${LAVISH_FAKE_REQUIRE_NO_OPEN:-0}" = 1 ] && [ "$no_open" != 1 ]; then
+  printf 'automated artifact establishment must pass --no-open\n' >&2
+  exit 97
+fi
 real=$(cd "$(dirname "$file")" && pwd -P)/$(basename "$file")
+if [ "$no_open" = 0 ]; then
+  : > "$state/browser-open"
+fi
 if [ -e "$state/user-ended" ] && [ "$reopen" = 0 ]; then
   emit "$real" user-ended
   exit 0
@@ -112,6 +118,7 @@ run_board() {  # <home> <args...>
     FM_STATE_OVERRIDE="$home/state" FM_DATA_OVERRIDE="$home/data" \
     FM_PROCEVENT_CLAIM_ROOT="$home/procevent-claims" \
     LAVISH_FAKE_STATE="$home/lavish-state" \
+    LAVISH_FAKE_REQUIRE_NO_OPEN=1 \
     "$BOARD" "$@"
 }
 
@@ -336,6 +343,36 @@ test_build_injects_binds_then_arms() {
   run_procevent "$home" list | awk 'NR > 1 { print $1 }' | grep -Fxq "$sid" \
     || fail "the board source is not registered after build"
   pass "build injects the payload, binds any-origin, then arms the source"
+}
+
+test_automated_build_suppresses_browser_open_but_explicit_open_does() {
+  local home data board
+  home=$(make_home open-policy)
+  data="$home/payload.json"
+  board="$home/.lavish/bearings-board.html"
+  write_valid_payload "$data"
+
+  run_board "$home" build "$data" >/dev/null \
+    || fail "automated board preparation failed"
+  [ ! -e "$home/lavish-state/browser-open" ] \
+    || fail "automated board preparation opened a browser"
+
+  PATH="$home/fakebin:$PATH" FM_HOME="$home" LAVISH_FAKE_STATE="$home/lavish-state" \
+    lavish-axi "$board" >/dev/null \
+    || fail "an explicit human open failed"
+  [ -e "$home/lavish-state/browser-open" ] \
+    || fail "an explicit human open did not open a browser"
+
+  rm -f "$home/lavish-state/browser-open"
+  end_session_as_captain "$home"
+  PATH="$home/fakebin:$PATH" FM_HOME="$home" LAVISH_FAKE_STATE="$home/lavish-state" \
+    lavish-axi "$board" --reopen >/dev/null \
+    || fail "an explicit human reopen failed"
+  [ -e "$home/lavish-state/browser-open" ] \
+    || fail "an explicit human reopen did not open a browser"
+  [ ! -e "$home/lavish-state/user-ended" ] \
+    || fail "an explicit human reopen did not resume the ended session"
+  pass "automated board preparation stays headless while explicit open and reopen open"
 }
 
 test_registration_cannot_consume_before_any_origin_binding() {
@@ -772,6 +809,7 @@ test_path_is_stable_and_home_scoped
 test_build_refuses_malformed_payloads_before_touching_the_board
 test_charted_kind_is_optional_and_accepts_both_values
 test_build_injects_binds_then_arms
+test_automated_build_suppresses_browser_open_but_explicit_open_does
 test_registration_cannot_consume_before_any_origin_binding
 test_build_does_not_bind_or_arm_when_session_start_fails
 test_rebuild_is_idempotent_and_does_not_double_arm

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -214,8 +214,6 @@ test_ship_modes_generate_clean_briefs() {
     assert_grep "## Captain's intent" "$brief" "$id: brief missing Captain's intent subsection"
     assert_grep "## Firstmate spec" "$brief" "$id: brief missing Firstmate spec subsection"
     assert_grep 'never a bare number such as "PR 108"' "$brief" "$id: brief missing the full-PR-URL rule"
-    assert_grep "pass \`--no-open\`" "$brief" "$id: brief missing the automated Lavish no-open rule"
-    assert_grep 'captain explicitly asks to open or reopen' "$brief" "$id: brief missing the explicit Lavish open exception"
     assert_grep "mid-task \`working:\` line (including setup complete) is nonterminal" "$brief" \
       "$id: brief missing nonterminal working:/setup-complete gate protection"
     assert_no_grep "EOF" "$brief" "$id: brief leaked a heredoc EOF marker (unterminated heredoc)"
@@ -830,10 +828,6 @@ test_scout_and_secondmate_scaffold() {
   assert_grep "report.md" "$brief" "scout brief must point at the report deliverable"
   assert_grep "you may host the Lavish review loop yourself" "$brief" \
     "scout brief must mention the option to host a Lavish review loop"
-  assert_grep "pass \`--no-open\`" "$brief" \
-    "scout brief must require automated Lavish serving without browser open"
-  assert_grep 'captain explicitly asks to open or reopen' "$brief" \
-    "scout brief must preserve explicit Lavish open behavior"
   assert_grep "## Captain's intent" "$brief" "scout brief missing Captain's intent subsection"
   assert_grep "## Firstmate spec" "$brief" "scout brief missing Firstmate spec subsection"
   assert_grep "{FIRSTMATE_SPEC}" "$brief" "scout brief missing the spec placeholder"

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -214,6 +214,8 @@ test_ship_modes_generate_clean_briefs() {
     assert_grep "## Captain's intent" "$brief" "$id: brief missing Captain's intent subsection"
     assert_grep "## Firstmate spec" "$brief" "$id: brief missing Firstmate spec subsection"
     assert_grep 'never a bare number such as "PR 108"' "$brief" "$id: brief missing the full-PR-URL rule"
+    assert_grep 'pass `--no-open`' "$brief" "$id: brief missing the automated Lavish no-open rule"
+    assert_grep 'captain explicitly asks to open or reopen' "$brief" "$id: brief missing the explicit Lavish open exception"
     assert_grep "mid-task \`working:\` line (including setup complete) is nonterminal" "$brief" \
       "$id: brief missing nonterminal working:/setup-complete gate protection"
     assert_no_grep "EOF" "$brief" "$id: brief leaked a heredoc EOF marker (unterminated heredoc)"
@@ -828,6 +830,10 @@ test_scout_and_secondmate_scaffold() {
   assert_grep "report.md" "$brief" "scout brief must point at the report deliverable"
   assert_grep "you may host the Lavish review loop yourself" "$brief" \
     "scout brief must mention the option to host a Lavish review loop"
+  assert_grep 'pass `--no-open`' "$brief" \
+    "scout brief must require automated Lavish serving without browser open"
+  assert_grep 'captain explicitly asks to open or reopen' "$brief" \
+    "scout brief must preserve explicit Lavish open behavior"
   assert_grep "## Captain's intent" "$brief" "scout brief missing Captain's intent subsection"
   assert_grep "## Firstmate spec" "$brief" "scout brief missing Firstmate spec subsection"
   assert_grep "{FIRSTMATE_SPEC}" "$brief" "scout brief missing the spec placeholder"

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -214,7 +214,7 @@ test_ship_modes_generate_clean_briefs() {
     assert_grep "## Captain's intent" "$brief" "$id: brief missing Captain's intent subsection"
     assert_grep "## Firstmate spec" "$brief" "$id: brief missing Firstmate spec subsection"
     assert_grep 'never a bare number such as "PR 108"' "$brief" "$id: brief missing the full-PR-URL rule"
-    assert_grep 'pass `--no-open`' "$brief" "$id: brief missing the automated Lavish no-open rule"
+    assert_grep "pass \`--no-open\`" "$brief" "$id: brief missing the automated Lavish no-open rule"
     assert_grep 'captain explicitly asks to open or reopen' "$brief" "$id: brief missing the explicit Lavish open exception"
     assert_grep "mid-task \`working:\` line (including setup complete) is nonterminal" "$brief" \
       "$id: brief missing nonterminal working:/setup-complete gate protection"
@@ -830,7 +830,7 @@ test_scout_and_secondmate_scaffold() {
   assert_grep "report.md" "$brief" "scout brief must point at the report deliverable"
   assert_grep "you may host the Lavish review loop yourself" "$brief" \
     "scout brief must mention the option to host a Lavish review loop"
-  assert_grep 'pass `--no-open`' "$brief" \
+  assert_grep "pass \`--no-open\`" "$brief" \
     "scout brief must require automated Lavish serving without browser open"
   assert_grep 'captain explicitly asks to open or reopen' "$brief" \
     "scout brief must preserve explicit Lavish open behavior"


### PR DESCRIPTION
## Intent

Captain: "i dont like that lavish autoopens a tab without me opening it."
Desired behavior: preparing or serving a Lavish artifact should not launch a browser tab automatically. Firstmate should return the review URL, and the captain chooses when to open it. Explicit human requests to open or reopen a review may still open it.
Determine which current component owns the auto-open behavior and establish the smallest robust fix path.

The completed diagnosis established that automated Firstmate Bearings board serving omits Lavish's supported `--no-open` flag in initial establishment and ended-session recovery.
The captain's preference is sufficient implementation authority: update those automated call sites and tests so reviews return a URL without opening a browser, while explicit captain open/reopen behavior remains available.

Captain follow-up: "lavish no auto open is not a serious PR. The idea of this PR is that when i'm doing other stuff i get interrupted by the crewmates and a lavish thing opens without me ordering it to. when making PRs you have to follow a certain patter and be serious about it. the current description is not serious and i dont think the fix is serious about it or address the issue correctly."

Captain follow-up: "create a new pr with the fix follow the guidelines in firstmate for PRs and be serious dont be like \"captain said this\" read my voice.md"

Captain follow-up: "just make a fresh PR to fix the CI issue"

Write the replacement PR title and body in Rene's voice after reading `~/VOICE.md` completely.
Lead with the user-facing interruption problem and the concrete behavioral guarantee.
Do not frame the PR around the captain, quote private conversation, or use phrases such as "the captain said".
Follow the repository's current PR conventions and provide precise reproduction, root cause, implementation, compatibility, risk, and verification evidence without filler.

## What Changed
- Automated Bearings builds could launch a Lavish browser tab while someone was working elsewhere. Initial establishment and ended-session recovery now pass `--no-open` and return the review URL without opening it.
- The Bearings skill and brief instructions document the same headless behavior. Explicit `lavish-axi` open and `--reopen` behavior remains available, limiting the change to automated serving.
- Regression coverage requires `--no-open` for automated calls, asserts builds do not open a browser, and confirms explicit open/reopen still do.

## Risk Assessment

✅ Low: The change is narrowly scoped to suppressing automated Lavish browser opens while preserving explicit open and reopen behavior.

## Testing

Targeted board, brief-generation, and live Lavish tests passed. A real artifact was served with its URL returned and no browser opened; no screenshot was captured because opening a browser would recreate the interruption this change prevents.

<details>
<summary>Evidence: Real Lavish no-auto-open end-to-end transcript</summary>

Source: [Real Lavish no-auto-open end-to-end transcript](https://github.com/reneleogp/firstmate/blob/9a55d83aba114f42ee2a2c03b7056192e23855b9/.no-mistakes/evidence/fm/lavish-no-autoopen-l2/lavish-no-auto-open-transcript.txt)

```text
End-to-end artifact-serving transcript (irrelevant Lavish help text omitted):
$ bin/fm-bearings-board.sh build <payload.json>
board: <temp>/.lavish/bearings-board.html
session:
  url: "http://127.0.0.1:4387/session/2bb5b001222734a2"
  status: opened
session: live
served: <temp>/.lavish/bearings-board.html
bound: lavish-2bb5b001222734a2
armed: lavish-2bb5b001222734a2
listening: live
$ lavish-axi <board.html> --no-open
session:
  url: "http://127.0.0.1:4387/session/2bb5b001222734a2"
  status: opened
$ lavish-axi (session listing, filtered to the board)
  <temp>/.lavish/bearings-board.html,open,"http://127.0.0.1:4387/session/2bb5b001222734a2",0
Result: the automated build served and armed the review, returned its URL, and used --no-open; the captain can open that URL explicitly.
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"3207f19cb0875650dff50e89a245a3ce8c6f13ed","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed ✅</summary>

- ⚠️ `tests/fm-brief.test.sh:217` - The newly added assertions at lines 217-218 and 833-836 only grep generated natural-language brief text. Per the test-quality rule, this cannot prove that the instruction is effective; remove these source-content-only assertions or replace them with a semantic executable-behavior check.

🔧 Fix: Replace prose greps with behavioral Lavish open tests
✅ Re-checked - no issues remain.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `bash tests/fm-bearings-board.test.sh`
- `bash tests/fm-brief.test.sh`
- `bash tests/fm-bearings-board-lavish-live-e2e.test.sh`
- <code>Real `fm-bearings-board.sh build` followed by `lavish-axi &lt;board&gt; --no-open` and session-list verification</code>
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
