### PR TITLE
fix(orca): accept compound Orca worktree ids in endpoint validation

### DIFF
--- a/bin/backends/orca.sh
+++ b/bin/backends/orca.sh
@@ -193,11 +193,9 @@ fm_backend_orca_send_literal() {  # <terminal-id> <text>
 # Refused: empty, leading or trailing whitespace, any control character (so a
 # line break, carriage return, or tab can never smuggle a second value onto one
 # record line), a second "::" (which would make the split ambiguous), a
-# non-atom repo half, a relative or bare path half, and any path character
-# outside the allowlist below. That allowlist is deliberately narrower than the
-# filesystem allows: it excludes every shell metacharacter and glob character,
-# so even an unquoted expansion of a recorded id cannot become an evaluated or
-# word-split command argument.
+# non-atom repo half, and a relative or bare path half. The path half is
+# otherwise whatever the filesystem allows on one line: it is Orca's workspace
+# path, and teardown binds it to the path Orca reports before acting on it.
 # The atom halves reuse fm_backend_endpoint_atom_valid, the shared endpoint
 # character contract owned by bin/fm-backend.sh, which is the dispatcher that
 # sources this adapter; the compound SHAPE stays here because it is Orca's,
@@ -217,9 +215,6 @@ fm_backend_orca_worktree_id_valid() {  # <value>
         *::*) return 1 ;;
         /?*) ;;
         *) return 1 ;;
-      esac
-      case "$path" in
-        *[!A-Za-z0-9._+@%,:#~=/\ -]*) return 1 ;;
       esac
       fm_backend_endpoint_atom_valid "$repo"
       ;;

--- a/bin/backends/orca.sh
+++ b/bin/backends/orca.sh
@@ -177,6 +177,58 @@ fm_backend_orca_send_literal() {  # <terminal-id> <text>
   fm_backend_orca_run_json orca terminal send --terminal "$terminal" --text "$text" --json
 }
 
+# fm_backend_orca_worktree_id_valid: the Orca-owned record-integrity check for
+# a recorded `orca_worktree_id=` value. Orca issues the id and firstmate stores
+# it verbatim and hands it straight back as `--worktree "id:<value>"`, so the
+# id is an OPAQUE selector: this predicate proves one metadata line still holds
+# exactly one intact, inert value, it never reconstructs an id or infers one
+# from ambient Orca state.
+#
+# Two shapes are accepted, and firstmate must keep accepting both because
+# records outlive Orca releases:
+#   - the atom form ("wt-7", a bare uuid), which older records carry;
+#   - the current compound form "<repo-atom>::<absolute-worktree-path>", whose
+#     path half routinely contains spaces (an Orca workspace path).
+#
+# Refused: empty, leading or trailing whitespace, any control character (so a
+# line break, carriage return, or tab can never smuggle a second value onto one
+# record line), a second "::" (which would make the split ambiguous), a
+# non-atom repo half, a relative or bare path half, and any path character
+# outside the allowlist below. That allowlist is deliberately narrower than the
+# filesystem allows: it excludes every shell metacharacter and glob character,
+# so even an unquoted expansion of a recorded id cannot become an evaluated or
+# word-split command argument.
+# The atom halves reuse fm_backend_endpoint_atom_valid, the shared endpoint
+# character contract owned by bin/fm-backend.sh, which is the dispatcher that
+# sources this adapter; the compound SHAPE stays here because it is Orca's,
+# not the fleet-wide endpoint contract's.
+fm_backend_orca_worktree_id_valid() {  # <value>
+  local value=${1-} repo path
+  case "$value" in
+    '') return 1 ;;
+    *[[:cntrl:]]*) return 1 ;;
+    ' '*|*' ') return 1 ;;
+  esac
+  case "$value" in
+    *::*)
+      repo=${value%%::*}
+      path=${value#*::}
+      case "$path" in
+        *::*) return 1 ;;
+        /?*) ;;
+        *) return 1 ;;
+      esac
+      case "$path" in
+        *[!A-Za-z0-9._+@%,:#~=/\ -]*) return 1 ;;
+      esac
+      fm_backend_endpoint_atom_valid "$repo"
+      ;;
+    *)
+      fm_backend_endpoint_atom_valid "$value"
+      ;;
+  esac
+}
+
 fm_backend_orca_remove_worktree() {  # <worktree-id>
   local worktree_id=${1:-}
   [ -n "$worktree_id" ] || { echo "error: missing Orca worktree id; cannot remove worktree" >&2; return 1; }

--- a/bin/fm-backend.sh
+++ b/bin/fm-backend.sh
@@ -382,6 +382,11 @@ fm_backend_meta_exact_value() {  # <meta-file> <key>
   printf '%s' "$value"
 }
 
+# fm_backend_endpoint_atom_valid: the shared, deliberately narrow character
+# class for one endpoint atom (a session, workspace, tab, pane, surface, or
+# terminal handle). Do NOT widen it for a backend whose runtime issues a
+# richer id: that backend's adapter owns its own id shape and validates it
+# there, as bin/backends/orca.sh does with fm_backend_orca_worktree_id_valid.
 fm_backend_endpoint_atom_valid() {  # <value>
   case "$1" in
     ''|*[!A-Za-z0-9._@%+-]*) return 1 ;;
@@ -506,9 +511,13 @@ fm_backend_validate_task_endpoint() {  # <meta-file> <task-id>
         echo "REFUSED: missing orca_worktree_id in $meta; cannot remove Orca worktree; preserving task state." >&2
         return 1
       }
+      fm_backend_source orca || {
+        echo "REFUSED: cannot load the Orca backend adapter to validate task $id; preserving task state." >&2
+        return 1
+      }
       if [ "$window" != "fm-$id" ] \
         || ! fm_backend_endpoint_atom_valid "$terminal" \
-        || ! fm_backend_endpoint_atom_valid "$worktree_id"; then
+        || ! fm_backend_orca_worktree_id_valid "$worktree_id"; then
         echo "REFUSED: Orca endpoint metadata for task $id is malformed or inconsistent; preserving task state." >&2
         return 1
       fi

--- a/docs/orca-backend.md
+++ b/docs/orca-backend.md
@@ -43,6 +43,9 @@ worktree=<absolute Orca worktree path>
 `window=` remains the caller-facing Firstmate alias.
 `terminal=` and `orca_worktree_id=` are the backend authority used by operation and cleanup paths.
 
+`orca_worktree_id=` is issued by Orca and recorded verbatim, so firstmate treats it as an opaque selector and accepts both the legacy bare-id form and the current `<repo-id>::<absolute-worktree-path>` compound form, whose path half may contain spaces and ordinary filesystem punctuation.
+A recorded id that is empty, whitespace-fringed, control-character-bearing, ambiguously double-separated, or non-absolute in its path half is refused as malformed and the task state is preserved.
+
 ## Current lifecycle and safety
 
 Spawn registers the repository, creates an independent worktree, reuses only the verified `result.terminal.handle` returned by Orca or creates a terminal explicitly, installs harness hooks, records metadata, and launches the selected harness.

--- a/tests/fm-backend-orca.test.sh
+++ b/tests/fm-backend-orca.test.sh
@@ -1337,6 +1337,9 @@ test_orca_worktree_id_accepts_opaque_forms_and_refuses_corruption() {
     '74c6a297-f6ab-433d-b0ca-6136c9b1dbea'
     '74c6a297-f6ab-433d-b0ca-6136c9b1dbea::/Users/cap/orca/workspaces/node/fm-audit-k9'
     'repo-1::/Users/cap/orca/work spaces/my project/fm-audit-k9'
+    'repo-1::/Users/cap/orca/My Repo (fork)/fm-audit-k9'
+    "repo-1::/Users/cap/orca/Cap's & Co [1]/fm-audit-k9"
+    'repo-1::/Users/cap/orca/$notes {draft}/fm-audit-k9'
     ''
     'wt 7'
     ' wt-7'
@@ -1350,21 +1353,10 @@ test_orca_worktree_id_accepts_opaque_forms_and_refuses_corruption() {
     '::/Users/cap/wt'
     'repo-1::/Users/cap/a::/Users/cap/b'
     're po::/Users/cap/wt'
-    'repo-1::/Users/cap/$(id)'
-    'repo-1::/Users/cap/`id`'
-    'repo-1::/Users/cap/a;rm -rf b'
-    'repo-1::/Users/cap/a|b'
-    'repo-1::/Users/cap/a&b'
-    'repo-1::/Users/cap/a*'
-    'repo-1::/Users/cap/a?b'
-    'repo-1::/Users/cap/a$b'
-    'repo-1::/Users/cap/a\b'
-    'repo-1::/Users/cap/"a"'
   )
-  expected=$'accept\naccept\naccept\naccept'
-  expected="$expected"$'\nrefuse\nrefuse\nrefuse\nrefuse\nrefuse\nrefuse\nrefuse\nrefuse'
-  expected="$expected"$'\nrefuse\nrefuse\nrefuse\nrefuse\nrefuse\nrefuse\nrefuse\nrefuse'
+  expected=$'accept\naccept\naccept\naccept\naccept\naccept\naccept'
   expected="$expected"$'\nrefuse\nrefuse\nrefuse\nrefuse\nrefuse\nrefuse\nrefuse'
+  expected="$expected"$'\nrefuse\nrefuse\nrefuse\nrefuse\nrefuse\nrefuse'
   verdicts=$( bash -c '
     . "$1/bin/fm-backend.sh"
     fm_backend_source orca || exit 9
@@ -1379,7 +1371,7 @@ test_orca_worktree_id_accepts_opaque_forms_and_refuses_corruption() {
   ' _ "$ROOT" "${values[@]}" )
   [ "$verdicts" = "$expected" ] || fail \
     "Orca worktree id verdicts changed"$'\n'"--- got ---"$'\n'"$verdicts"$'\n'"--- want ---"$'\n'"$expected"
-  pass "fm_backend_orca_worktree_id_valid: legacy atom and compound ids resolve; corrupt, ambiguous, and shell-unsafe ids refuse"
+  pass "fm_backend_orca_worktree_id_valid: legacy atom and compound ids resolve, including punctuated workspace paths; corrupt and ambiguous ids refuse"
 }
 
 test_orca_endpoint_records_validate_both_worktree_id_forms() {

--- a/tests/fm-backend-orca.test.sh
+++ b/tests/fm-backend-orca.test.sh
@@ -1323,6 +1323,174 @@ test_dispatcher_sources_orca_and_routes_primitives() {
   pass "fm-backend dispatcher: accepts orca and routes capture through bin/backends/orca.sh"
 }
 
+# Orca issues the worktree id and firstmate records it verbatim, so the id's
+# shape belongs to Orca and has already changed once: the atom form older
+# records carry became today's "<repo-id>::<absolute-path>" compound, whose
+# path half routinely holds spaces. Both must resolve, and every corrupt or
+# ambiguous record must still refuse.
+test_orca_worktree_id_accepts_opaque_forms_and_refuses_corruption() {
+  # Single quotes are the point: these cases must reach the validator as the
+  # literal bytes a corrupt record would hold, never as an expansion.
+  # shellcheck disable=SC2016
+  local verdicts expected values=(
+    'wt-teardown'
+    '74c6a297-f6ab-433d-b0ca-6136c9b1dbea'
+    '74c6a297-f6ab-433d-b0ca-6136c9b1dbea::/Users/cap/orca/workspaces/node/fm-audit-k9'
+    'repo-1::/Users/cap/orca/work spaces/my project/fm-audit-k9'
+    ''
+    'wt 7'
+    ' wt-7'
+    'wt-7 '
+    $'wt-\t7'
+    $'wt-7\nwt-8'
+    $'wt-7\r'
+    $'repo-1::/Users/cap/wt\t9'
+    'repo-1::relative/path'
+    'repo-1::'
+    '::/Users/cap/wt'
+    'repo-1::/Users/cap/a::/Users/cap/b'
+    're po::/Users/cap/wt'
+    'repo-1::/Users/cap/$(id)'
+    'repo-1::/Users/cap/`id`'
+    'repo-1::/Users/cap/a;rm -rf b'
+    'repo-1::/Users/cap/a|b'
+    'repo-1::/Users/cap/a&b'
+    'repo-1::/Users/cap/a*'
+    'repo-1::/Users/cap/a?b'
+    'repo-1::/Users/cap/a$b'
+    'repo-1::/Users/cap/a\b'
+    'repo-1::/Users/cap/"a"'
+  )
+  expected=$'accept\naccept\naccept\naccept'
+  expected="$expected"$'\nrefuse\nrefuse\nrefuse\nrefuse\nrefuse\nrefuse\nrefuse\nrefuse'
+  expected="$expected"$'\nrefuse\nrefuse\nrefuse\nrefuse\nrefuse\nrefuse\nrefuse\nrefuse'
+  expected="$expected"$'\nrefuse\nrefuse\nrefuse\nrefuse\nrefuse\nrefuse\nrefuse'
+  verdicts=$( bash -c '
+    . "$1/bin/fm-backend.sh"
+    fm_backend_source orca || exit 9
+    shift 1
+    for value in "$@"; do
+      if fm_backend_orca_worktree_id_valid "$value"; then
+        printf "accept\n"
+      else
+        printf "refuse\n"
+      fi
+    done
+  ' _ "$ROOT" "${values[@]}" )
+  [ "$verdicts" = "$expected" ] || fail \
+    "Orca worktree id verdicts changed"$'\n'"--- got ---"$'\n'"$verdicts"$'\n'"--- want ---"$'\n'"$expected"
+  pass "fm_backend_orca_worktree_id_valid: legacy atom and compound ids resolve; corrupt, ambiguous, and shell-unsafe ids refuse"
+}
+
+test_orca_endpoint_records_validate_both_worktree_id_forms() {
+  local dir state id target
+  dir="$TMP_ROOT/endpoint-id-forms"
+  mkdir -p "$dir/state" "$dir/worktree" "$dir/project"
+  state="$dir/state"
+  # shellcheck source=/dev/null
+  . "$ROOT/bin/fm-backend.sh"
+
+  for id in orcalegacyid orcacompoundid orcaspacedid; do
+    case "$id" in
+      orcalegacyid) target='worktree-9' ;;
+      orcacompoundid) target="74c6a297-f6ab-433d-b0ca-6136c9b1dbea::$dir/worktree" ;;
+      orcaspacedid) target="repo-1::$dir/work tree with spaces" ;;
+    esac
+    fm_write_meta "$state/$id.meta" \
+      "window=fm-$id" "endpoint_task_id=$id" "terminal=term-7" \
+      "worktree=$dir/worktree" "project=$dir/project" \
+      "backend=orca" "orca_worktree_id=$target"
+    fm_backend_validate_task_endpoint "$state/$id.meta" "$id" \
+      || fail "Orca endpoint with worktree id '$target' refused"
+    [ "$FM_BACKEND_VALIDATED_TARGET" = term-7 ] \
+      || fail "Orca validation stopped selecting the recorded terminal for '$target'"
+  done
+
+  id=orcabadcompoundid
+  fm_write_meta "$state/$id.meta" \
+    "window=fm-$id" "endpoint_task_id=$id" "terminal=term-7" \
+    "worktree=$dir/worktree" "project=$dir/project" \
+    "backend=orca" "orca_worktree_id=repo-1::relative/worktree"
+  set +e
+  fm_backend_validate_task_endpoint "$state/$id.meta" "$id" >/dev/null 2>&1
+  target=$?
+  set -e
+  [ "$target" -ne 0 ] || fail "Orca endpoint accepted a compound worktree id with a relative path"
+  pass "fm_backend_validate_task_endpoint: Orca records validate on either worktree id form and still refuse a malformed one"
+}
+
+test_ship_teardown_removes_orca_worktree_for_compound_id_with_spaces() {
+  local proj wt data state config id worktree_id out rc neutral
+  id="orcacompoundshipz7"
+  proj="$TMP_ROOT/compound-ship-project"
+  wt="$TMP_ROOT/compound ship wt"
+  data="$TMP_ROOT/compound-ship-data"
+  state="$TMP_ROOT/compound-ship-state"
+  config="$TMP_ROOT/compound-ship-config"
+  worktree_id="74c6a297-f6ab-433d-b0ca-6136c9b1dbea::$wt"
+  fm_git_worktree "$proj" "$wt" "fm/$id"
+  mkdir -p "$data/$id" "$state" "$config"
+  touch "$state/.last-watcher-beat"
+  fm_write_meta "$state/$id.meta" \
+    "window=fm-$id" "endpoint_task_id=$id" "terminal=term-compound" "worktree=$wt" "project=$proj" \
+    "harness=claude" "kind=ship" "mode=local-only" "yolo=off" \
+    "backend=orca" "orca_worktree_id=$worktree_id"
+  orca_case compound-ship
+  printf '{"ok":true,"result":{"worktree":{"id":"%s","path":"%s"}}}\n' "$worktree_id" "$wt" > "$RESP/1.out"
+  neutral=$(neutral_fm_root "$CASE_DIR/neutral")
+  set +e
+  out=$( PATH="$FB:$PATH" FM_ORCA_LOG="$LOG" FM_ORCA_RESPONSES="$RESP" \
+    FM_ROOT_OVERRIDE="$neutral" FM_STATE_OVERRIDE="$state" FM_DATA_OVERRIDE="$data" FM_CONFIG_OVERRIDE="$config" \
+    "$ROOT/bin/fm-teardown.sh" "$id" 2>&1 )
+  rc=$?
+  set -e
+  expect_code 0 "$rc" "Orca ship teardown should succeed for a compound worktree id whose path matches"$'\n'"$out"
+  # The fake CLI logs one \x1f-separated field per argv entry, so matching the
+  # whole spaced selector as ONE field is the proof it reached Orca unsplit.
+  assert_contains "$(cat "$LOG")" $'orca\x1f''worktree'$'\x1f''show'$'\x1f''--worktree'$'\x1f'"id:$worktree_id"$'\x1f''--json' \
+    "teardown did not resolve the compound Orca worktree id as a single argument"
+  assert_contains "$(cat "$LOG")" $'orca\x1f''worktree'$'\x1f''rm'$'\x1f''--worktree'$'\x1f'"id:$worktree_id"$'\x1f''--force'$'\x1f''--json' \
+    "teardown did not remove the compound Orca worktree as a single argument"
+  assert_absent "$state/$id.meta" "successful compound-id teardown should remove task metadata"
+  pass "fm-teardown.sh backend=orca: a compound worktree id with spaces resolves and removes unsplit"
+}
+
+test_ship_teardown_refuses_compound_orca_id_path_mismatch() {
+  local proj wt other_wt data state config id worktree_id out rc neutral
+  id="orcacompoundmismatchz8"
+  proj="$TMP_ROOT/compound-mismatch-project"
+  wt="$TMP_ROOT/compound mismatch wt"
+  other_wt="$TMP_ROOT/compound mismatch other wt"
+  data="$TMP_ROOT/compound-mismatch-data"
+  state="$TMP_ROOT/compound-mismatch-state"
+  config="$TMP_ROOT/compound-mismatch-config"
+  worktree_id="74c6a297-f6ab-433d-b0ca-6136c9b1dbea::$wt"
+  fm_git_worktree "$proj" "$wt" "fm/$id"
+  git -C "$proj" worktree add --quiet -b "fm/$id-other" "$other_wt"
+  mkdir -p "$data/$id" "$state" "$config"
+  touch "$state/.last-watcher-beat"
+  fm_write_meta "$state/$id.meta" \
+    "window=fm-$id" "endpoint_task_id=$id" "terminal=term-compound-mismatch" "worktree=$wt" "project=$proj" \
+    "harness=claude" "kind=ship" "mode=local-only" "yolo=off" \
+    "backend=orca" "orca_worktree_id=$worktree_id"
+  orca_case compound-mismatch
+  printf '{"ok":true,"result":{"worktree":{"id":"%s","path":"%s"}}}\n' "$worktree_id" "$other_wt" > "$RESP/1.out"
+  neutral=$(neutral_fm_root "$CASE_DIR/neutral")
+  set +e
+  out=$( PATH="$FB:$PATH" FM_ORCA_LOG="$LOG" FM_ORCA_RESPONSES="$RESP" \
+    FM_ROOT_OVERRIDE="$neutral" FM_STATE_OVERRIDE="$state" FM_DATA_OVERRIDE="$data" FM_CONFIG_OVERRIDE="$config" \
+    "$ROOT/bin/fm-teardown.sh" "$id" 2>&1 )
+  rc=$?
+  set -e
+  [ "$rc" -ne 0 ] || fail "compound Orca id resolving to another worktree should refuse teardown"
+  assert_contains "$out" "not inspected worktree" \
+    "compound-id mismatch refusal should name the mismatch"
+  assert_present "$state/$id.meta" "refused compound-id teardown removed task metadata"
+  assert_not_contains "$(cat "$LOG")" $'orca\x1f''worktree'$'\x1f''rm' \
+    "refused compound-id teardown still removed the Orca worktree"
+  pass "fm-teardown.sh backend=orca: a compound id whose resolved path differs still refuses before removal"
+}
+
 test_capture_reads_terminal_tail_json
 test_capture_falls_back_to_text_fields
 test_capture_fails_on_orca_error_json
@@ -1369,6 +1537,10 @@ test_ship_teardown_refuses_orca_missing_worktree_path
 test_ship_teardown_removes_orca_worktree_when_id_path_matches
 test_ship_teardown_refuses_orca_unresolvable_worktree_id
 test_ship_teardown_refuses_orca_id_path_mismatch
+test_orca_worktree_id_accepts_opaque_forms_and_refuses_corruption
+test_orca_endpoint_records_validate_both_worktree_id_forms
+test_ship_teardown_removes_orca_worktree_for_compound_id_with_spaces
+test_ship_teardown_refuses_compound_orca_id_path_mismatch
 test_teardown_refuses_orca_missing_worktree_id
 test_teardown_refuses_orca_worktree_without_terminal_handle
 test_secondmate_force_teardown_removes_orca_child_via_orca


### PR DESCRIPTION
## Intent

Help me verify the sealed prompt and API key behavior in econ-v1/node-app-api-store PR #68 (https://github.com/econ-v1/node-app-api-store/pull/68) and econ-v1/node PR #2900 (https://github.com/econ-v1/node/pull/2900).

PR #68, "Seal the prompt on every route that reaches a chip", claims to close three legs on which the prompt reached an ESP32 chip in clear text: (1) cross-node private, where the buyer POSTed the prompt to the seller's api-store, which read it and handed it to its own chip, so the seller's Pi saw every prompt it relayed; (2) local private, where Esp32Transport POSTed the prompt to the chip's unauthenticated /api/v1/llm/infer door over plain LAN HTTP; and (3) a peer's chip dialled directly, where a resolved peer door on a private/chip port made buildChatTransport construct an Esp32Transport pointed at peerBaseUrl and send a clear-text prompt to another node's chip.

PR #2900, "feat(network): local sealed ESP32 chip route with an own-chip key pin", claims to close the six action items a GitHub Advisory Review raised at head 8cdfd45e so the advisory verdict can move off CONDITIONAL: (1) the chip reqwest::Client is built without redirect(Policy::none()), so a compromised or misconfigured LAN chip answering 3xx would forward X-Node-Id and the sealed ciphertext to an unintended target, and the relay builder needs the same audit; (2) seal_attempt() hardcodes the error label core.network.execute_sealed_llm_on_peer even when the local route calls it; (3) an ephemeral reqwest::Client per call breaks the wired-dependency pattern every other external client in CoreCapabilityHandler follows; (4) no test exercises the local path's success branch through a real sealed SSE response asserting served_path chip_sealed_local; (5) no test covers run_with_reseal integration, that a chip 500 triggers exactly one reseal with a fresh nonce and that a 4xx does not retry; and (6) no test reaches the never-downgrade guard in resolve_own_chip_sealed_url with a public-port-type IP pool entry.

Verification is the deliverable: confirm whether the sealed-prompt and API-key behavior these two PRs describe actually holds.

## What Changed

- Added `fm_backend_orca_worktree_id_valid` in `bin/backends/orca.sh`, an Orca-owned predicate that accepts both the legacy bare-atom worktree id and the current `<repo-atom>::<absolute-path>` compound form (path half may contain spaces and ordinary punctuation), while refusing empty, whitespace-fringed, control-character-bearing, doubly-separated, non-atom-repo, and non-absolute-path values.
- `fm_backend_validate_task_endpoint` in `bin/fm-backend.sh` now sources the Orca adapter (refusing and preserving task state if it cannot load) and validates `orca_worktree_id` with that predicate instead of the narrow shared `fm_backend_endpoint_atom_valid`, which had rejected compound ids; the shared atom check keeps its character class and gains a comment stating backends validate richer ids in their own adapter.
- Documented the opaque-selector contract and the accepted/refused id shapes in `docs/orca-backend.md`, and added coverage in `tests/fm-backend-orca.test.sh` for the accepted and refused id forms and the endpoint-validation path.

## Risk Assessment

✅ Low: Well-bounded fix: one new pure-string predicate placed at the single shared validation boundary that all Orca teardown/relaunch/control paths route through, with the canonical resolve-then-path-match cleanup gate and the fleet-wide atom class left untouched, covered by behavioral tests.

## Testing

Ran the targeted Orca backend suite (all pass) and, because unit passes alone do not show the user-visible failure, reproduced the real teardown flow end-to-end against a fake Orca CLI at three commits: base 34bd418 and intermediate 19ba3f4 both print "REFUSED: Orca endpoint metadata ... malformed or inconsistent; preserving task state" (exit 1, no orca calls) for a compound id whose path contains spaces and parentheses, while HEAD completes teardown, removes the task metadata, and passes the id to `orca worktree show` and `orca worktree rm` as one unsplit argument. This is a CLI-level change with no rendered UI surface, so the evidence is a command transcript rather than a screenshot. The change is firstmate Orca id validation only; the supplied intent text describes sealed-prompt verification in the external econ-v1 PRs, a mismatch already raised and declined in review round 1, so no evidence for those PRs was produced.

<details>
<summary>Evidence: Before/after fm-teardown transcript for an Orca compound worktree id</summary>

Source: [Before/after fm-teardown transcript for an Orca compound worktree id](https://github.com/Huy-Hieuu/firstmate/blob/f7bbb2d9a22bc9be473c423c2e4675dd1948cecf/.no-mistakes/evidence/fm/orca-composite-id-cleanup-fix-j3/orca-compound-id-teardown.md)

```text
# Orca compound worktree-id teardown - before/after CLI transcript

Same scenario at three commits: a task recorded with the Orca-issued compound id
`<repo-uuid>::/.../My Repo (fork)/ship wt` (spaces + parentheses), torn down via bin/fm-teardown.sh against a fake orca CLI.

`` `
=== 34bd418 : recorded metadata line ===
orca_worktree_id=74c6a297-f6ab-433d-b0ca-6136c9b1dbea::/tmp/orca-evi/run/34bd418/My Repo (fork)/ship wt
=== fm-teardown.sh orcacompoundz7 ===
REFUSED: Orca endpoint metadata for task orcacompoundz7 is malformed or inconsistent; preserving task state.
exit=1
=== orca CLI calls ===
=== worktree dir still present? ===
YES - /tmp/orca-evi/run/34bd418/My Repo (fork)/ship wt
=== task metadata still present? ===
YES (task state preserved)

=== 19ba3f4 : recorded metadata line ===
orca_worktree_id=74c6a297-f6ab-433d-b0ca-6136c9b1dbea::/tmp/orca-evi/run/19ba3f4/My Repo (fork)/ship wt
=== fm-teardown.sh orcacompoundz7 ===
REFUSED: Orca endpoint metadata for task orcacompoundz7 is malformed or inconsistent; preserving task state.
exit=1
=== orca CLI calls ===
=== worktree dir still present? ===
YES - /tmp/orca-evi/run/19ba3f4/My Repo (fork)/ship wt
=== task metadata still present? ===
YES (task state preserved)

=== HEAD : recorded metadata line ===
orca_worktree_id=74c6a297-f6ab-433d-b0ca-6136c9b1dbea::/tmp/orca-evi/run/HEAD/My Repo (fork)/ship wt
=== fm-teardown.sh orcacompoundz7 ===
teardown orcacompoundz7 complete (window term-compound, worktree /tmp/orca-evi/run/HEAD/My Repo (fork)/ship wt)
Backlog: orcacompoundz7 just finished (this home keeps no markdown backlog at /private/tmp/orca-evi/run/HEAD/data/backlog.md). Update /private/tmp/orca-evi/run/HEAD/data/backlog.md - move orcacompoundz7 to Done, keep Done to the 10 most recent, then re-scan Queued and dispatch only work whose blockers are gone and date is due.
exit=0
=== orca CLI calls ===
orca [worktree] [show] [--worktree] [id:74c6a297-f6ab-433d-b0ca-6136c9b1dbea::/tmp/orca-evi/run/HEAD/My Repo (fork)/ship wt] [--json]
orca [terminal] [close] [--terminal] [term-compound] [--json]
orca [worktree] [rm] [--worktree] [id:74c6a297-f6ab-433d-b0ca-6136c9b1dbea::/tmp/orca-evi/run/HEAD/My Repo (fork)/ship wt] [--force] [--json]
=== worktree dir still present? ===
YES - /tmp/orca-evi/run/HEAD/My Repo (fork)/ship wt
=== task metadata still present? ===
no (torn down)

`` `
```
</details>
<details>
<summary>Evidence: Repro driver used to produce the transcript</summary>

Source: [Repro driver used to produce the transcript](https://github.com/Huy-Hieuu/firstmate/blob/f7bbb2d9a22bc9be473c423c2e4675dd1948cecf/.no-mistakes/evidence/fm/orca-composite-id-cleanup-fix-j3/repro-drive.sh)

```text
#!/usr/bin/env bash
# Manual E2E: an Orca-issued compound worktree id (repo atom :: absolute path
# with spaces and parentheses) recorded verbatim in task metadata, then torn
# down through bin/fm-teardown.sh against a fake `orca` CLI.
set -u
export FM_GATE_REFUSE_BYPASS=1
SRC=$1 CASE=$2
BASE=/tmp/orca-evi/run/$CASE
rm -rf "$BASE"; mkdir -p "$BASE"
id=orcacompoundz7
proj="$BASE/project"
wt="$BASE/My Repo (fork)/ship wt"
state="$BASE/state"; data="$BASE/data"; config="$BASE/config"
mkdir -p "$data/$id" "$state" "$config" "$BASE/My Repo (fork)"
worktree_id="74c6a297-f6ab-433d-b0ca-6136c9b1dbea::$wt"

git init -q "$proj"; git -C "$proj" -c user.email=t@t -c user.name=t commit -q --allow-empty -m init
git -C "$proj" remote add origin "$proj.origin.git"
git -C "$proj" worktree add --quiet -b "fm/$id" "$wt"
touch "$state/.last-watcher-beat"
cat > "$state/$id.meta" <<EOF
window=fm-$id
endpoint_task_id=$id
terminal=term-compound
worktree=$wt
project=$proj
harness=claude
kind=ship
mode=local-only
yolo=off
backend=orca
orca_worktree_id=$worktree_id
EOF

fb="$BASE/fakebin"; mkdir -p "$fb"
export FM_ORCA_LOG="$BASE/orca.log"; : > "$FM_ORCA_LOG"
cat > "$fb/orca" <<'SH'
#!/usr/bin/env bash
set -u
export FM_GATE_REFUSE_BYPASS=1
{ printf 'orca'; for a in "$@"; do printf ' [%s]' "$a"; done; printf '\n'; } >> "$FM_ORCA_LOG"
if [ "${1:-}" = status ]; then echo '{"ok":true,"result":{"runtime":{"reachable":true,"state":"ready"}}}'; exit 0; fi
if [ "${2:-}" = show ]; then printf '{"ok":true,"result":{"worktree":{"id":"%s","path":"%s"}}}\n' "$FM_WT_ID" "$FM_WT_PATH"; exit 0; fi
echo '{"ok":true}'
SH
chmod +x "$fb/orca"
export FM_WT_ID="$worktree_id" FM_WT_PATH="$wt"
mkdir -p "$BASE/neutral/bin"; printf '#!/usr/bin/env bash\nexit 0\n' > "$BASE/neutral/bin/fm-guard.sh"; chmod +x "$BASE/neutral/bin/fm-guard.sh"

echo "=== $CASE : recorded metadata line ==="
grep orca_worktree_id "$state/$id.meta"
echo "=== fm-teardown.sh $id ==="
PATH="$fb:$PATH" FM_ROOT_OVERRIDE="$BASE/neutral" FM_STATE_OVERRIDE="$state" \
  FM_DATA_OVERRIDE="$data" FM_CONFIG_OVERRIDE="$config" \
  "$SRC/bin/fm-teardown.sh" "$id" 2>&1
echo "exit=$?"
echo "=== orca CLI calls ==="; cat "$FM_ORCA_LOG"
echo "=== worktree dir still present? ==="; [ -d "$wt" ] && echo "YES - $wt" || echo "no (removed)"
echo "=== task metadata still present? ==="; [ -f "$state/$id.meta" ] && echo "YES (task state preserved)" || echo "no (torn down)"
```
</details>
<details>
<summary>Evidence: HEAD teardown result (key excerpt)</summary>

```text
=== HEAD ===
teardown orcacompoundz7 complete (window term-compound, worktree /tmp/orca-evi/run/HEAD/My Repo (fork)/ship wt)
exit=0
orca [worktree] [show] [--worktree] [id:74c6a297-...::/tmp/orca-evi/run/HEAD/My Repo (fork)/ship wt] [--json]
orca [worktree] [rm] [--worktree] [id:74c6a297-...::/tmp/orca-evi/run/HEAD/My Repo (fork)/ship wt] [--force] [--json]

=== 34bd418 (base) ===
REFUSED: Orca endpoint metadata for task orcacompoundz7 is malformed or inconsistent; preserving task state.
exit=1 (no orca calls)
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"6c9101a9981b0dfc0d05fcd9bddcee0323cae9f1","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`bash tests/fm-backend-orca.test.sh` (55 cases, all ok)</code>
- `test_orca_worktree_id_accepts_opaque_forms_and_refuses_corruption`
- `test_orca_endpoint_records_validate_both_worktree_id_forms`
- `test_ship_teardown_removes_orca_worktree_for_compound_id_with_spaces`
- `test_ship_teardown_refuses_compound_orca_id_path_mismatch`
- <code>Manual before/after E2E: `bin/fm-teardown.sh &lt;task&gt;` against a fake `orca` CLI with `orca_worktree_id=&lt;uuid&gt;::/.../My Repo (fork)/ship wt`, run at 34bd418, 19ba3f4 and HEAD (script: evidence/repro-drive.sh)</code>
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
