### PR TITLE
chore(fm-brief): add standing test-discipline section to ship brief scaffold

### DIFF
--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -64,6 +64,10 @@
 # it carries the AGENTS.md authoring bar (widely useful knowledge only, pointers
 # over copied detail) and defers self-governance recognition and insertion to
 # fm-ensure-agents-md.sh's contract.
+# Ship tasks also carry a standing test-discipline section: test only the named
+# acceptance criteria and load-bearing invariants, skip smoke/redundant/trivial
+# tests, and stay especially sparing early in a package's life. Scout scaffolds
+# omit it; a scout's deliverable is a report, not tests.
 # Scaffolds carry no role scope: fm-spawn.sh supplies fm_brief_worker_role from
 # fm-dod-lib.sh to every ship/scout launch brief, so this file never becomes a
 # second owner of a contract that must stay current across relaunches.

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -495,6 +495,13 @@ $ASK_USER_BLOCK
    the daemon accepts \`respond\` immediately and runs the round in the background, so a killed or
    timed-out call was only waiting for a read while the run kept working.
 
+# Test discipline
+Test the acceptance criteria and load-bearing invariants the task actually names, not every code path you happen to touch along the way.
+Skip smoke tests, redundant regression tests, and a test for a trivial getter/accessor that carries no real logic.
+When the task or a linked plan already names its own specific test list, treat that list as a ceiling, not a floor - do not pad past it.
+Favor a few sharp tests that would actually fail if the behavior broke over many tests that mostly restate the implementation.
+Be especially sparing early in a package's life, when the design is still likely to move and every extra test is one more thing to rewrite later.
+
 $INBOX_SECTION
 
 # Project memory

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -441,6 +441,47 @@ test_ship_project_memory_wording() {
   pass "fm-brief.sh: ship project-memory wording carries the AGENTS.md authoring bar"
 }
 
+# The standing test-discipline section must reach every ship delivery mode
+# exactly once, sit between the numbered Rules list and the inbox section, and
+# never reach the scout scaffold (a scout's deliverable is a report, not tests).
+test_ship_test_discipline_section() {
+  local home id brief mode rules_line discipline_line inbox_line count
+  home="$TMP_ROOT/test-discipline-home"
+  mkdir -p "$home/data"
+  for mode in no-mistakes direct-PR local-only; do
+    id="brief-discipline-$(printf '%s' "$mode" | tr '[:upper:]' '[:lower:]')"
+    FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" some-proj --mode "$mode" >/dev/null 2>&1
+    brief="$home/data/$id/brief.md"
+    assert_present "$brief" "$mode brief was not scaffolded"
+    assert_grep "# Test discipline" "$brief" "$mode brief is missing the test-discipline section header"
+    assert_grep "not every code path you happen to touch along the way" "$brief" \
+      "$mode brief lost the acceptance-criteria-first framing"
+    assert_grep "treat that list as a ceiling, not a floor" "$brief" \
+      "$mode brief lost the ceiling-not-a-floor guidance for a task's own named test list"
+    assert_grep "Be especially sparing early in a package's life" "$brief" \
+      "$mode brief lost the early-in-a-package's-life guidance"
+
+    count=$(grep -c "^# Test discipline$" "$brief")
+    assert_equals "1" "$count" "$mode brief must render the test-discipline section exactly once"
+
+    rules_line=$(grep -n "^# Rules$" "$brief" | cut -d: -f1)
+    discipline_line=$(grep -n "^# Test discipline$" "$brief" | cut -d: -f1)
+    inbox_line=$(grep -n "^# Firstmate instruction inbox$" "$brief" | cut -d: -f1)
+    [ "$rules_line" -lt "$discipline_line" ] \
+      || fail "$mode brief's test-discipline section must come after the Rules section"
+    [ "$discipline_line" -lt "$inbox_line" ] \
+      || fail "$mode brief's test-discipline section must come before the inbox section"
+  done
+
+  id="brief-discipline-scout"
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" some-proj --scout >/dev/null 2>&1
+  brief="$home/data/$id/brief.md"
+  assert_present "$brief" "scout brief was not scaffolded"
+  assert_no_grep "# Test discipline" "$brief" \
+    "scout brief must not carry the ship-only test-discipline section"
+  pass "fm-brief.sh: every ship delivery mode renders the test-discipline section once, in place, and scouts never receive it"
+}
+
 test_herdr_lab_contract_is_explicit_and_complete() {
   local home id brief
   home="$TMP_ROOT/herdr-lab-home"
@@ -880,6 +921,7 @@ test_faster_paths_use_configured_authority_without_stacked_review
 test_no_mistakes_dod_wording
 test_ask_user_escalation_format
 test_ship_project_memory_wording
+test_ship_test_discipline_section
 test_herdr_lab_contract_is_explicit_and_complete
 test_herdr_lab_contract_quotes_foreign_firstmate_path
 test_herdr_lab_omission_is_loud_for_ship_and_scout


### PR DESCRIPTION
## Intent

Add a standing test-discipline instruction to the ship-task brief scaffold in bin/fm-brief.sh so every future ship crewmate gets it automatically. Crewmates tend to write too many tests (smoke tests, redundant regression tests, a test per trivial getter/accessor), especially early in a package's life when the design is still likely to move; no standing instruction currently discourages this, only no-mistakes's own review step catches it after the fact. Insert a new '# Test discipline' section immediately after the numbered '# Rules' list and before $INBOX_SECTION in the shared ship-task heredoc used for all three delivery modes (no-mistakes, direct-PR, local-only), matching the terse style of the existing '# Project memory' section: test the acceptance criteria and load-bearing invariants named in the task, not every code path touched; do not add smoke tests, redundant regression tests, or a test for a trivial getter/accessor with no logic; when a task or plan document already names its own specific test list, that list is the ceiling not a floor; favor fewer, sharper tests that would actually fail if the behavior broke over many tests that mostly restate the implementation; be especially sparing early in a package's life. Written in original wording, not copied verbatim, a few sentences, no bulleted policy document. This is generated scaffold text, not a new skill or AGENTS.md change, since it is paid only by ship-task crewmates. Do NOT add this section to the separate scout scaffold, since a scout's deliverable is a report, not tests. Verify with bin/fm-lint.sh (shellcheck-clean) and by regenerating sample briefs for all three delivery modes to confirm the section renders once, correctly, in each, and that no other generated section changed unintentionally.

## What Changed
- Added a "# Test discipline" section to the shared ship-task brief heredoc in `bin/fm-brief.sh`, inserted between the numbered "# Rules" list and `$INBOX_SECTION`, instructing crewmates to test only the named acceptance criteria and load-bearing invariants, skip smoke/redundant/trivial-getter tests, treat a task's own named test list as a ceiling not a floor, and stay especially sparing early in a package's life.
- Added a header comment in `bin/fm-brief.sh` documenting that ship scaffolds carry this test-discipline section while scout scaffolds intentionally omit it.
- Added `test_ship_test_discipline_section` to `tests/fm-brief.test.sh`, verifying the section renders exactly once and in the correct position (after Rules, before the inbox section) for all three ship delivery modes (no-mistakes, direct-PR, local-only), and confirming it is absent from scout briefs.

## Risk Assessment

✅ Low: The change is a pure static-text scaffold addition (a new "# Test discipline" section) inserted exactly once in the ship-task heredoc of bin/fm-brief.sh, correctly placed immediately after the numbered Rules list and before $INBOX_SECTION, deliberately excluded from the scout heredoc, and mirrored by a matching header-comment update that usage()/--help already surfaces verbatim; no control flow, variable expansion, or other generated section was touched, and a repo-wide grep confirms no duplicate insertion point (e.g. fm-promote.sh only renders the separate DOD block).

## Testing

Manual regeneration of sample briefs across all three ship delivery modes plus scout confirmed the '# Test discipline' section renders exactly once, in the correct position, with intended wording, and that no other generated content changed unintentionally; I additionally wrote a focused automated test (test_ship_test_discipline_section) since none previously existed, verified it fails against the pre-feature base commit and passes at the target commit, and confirmed bin/fm-lint.sh remains shellcheck-clean with the full targeted test file (24/24) passing and the worktree left clean aside from the new test.

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"b0853011d72abc99d6743b2e3335e3c77fc6a526","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `bash bin/fm-lint.sh (shellcheck-clean)`
- `bash tests/fm-brief.test.sh (all 24 tests pass, including new test_ship_test_discipline_section)`
- `Regenerated sample briefs for --mode no-mistakes, --mode direct-PR, --mode local-only, and --scout from both the base commit (527aa7c) and target commit (d1c23b9) versions of bin/fm-brief.sh, then diffed each pair to confirm only the intended '# Test discipline' section was added (plus expected path substitutions), it appears exactly once per ship mode, and scout briefs never receive it`
- `grep -c '^# Test discipline$' on each generated ship-mode brief.md to confirm single occurrence; confirmed 0 occurrences in the scout brief`
- `Temporarily swapped bin/fm-brief.sh for the base-commit version and re-ran the new test to confirm it fails (regression-catching) before the feature, then restored the file and confirmed git status/diff show no unintended changes`
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
