### PR TITLE
fix(bin): escalate decision-owned wakes once as the decision

### DIFF
--- a/bin/fm-supervise-daemon.sh
+++ b/bin/fm-supervise-daemon.sh
@@ -1329,6 +1329,10 @@ is_wake_reason() {  # <reason>
 
 # --- dispatch one wake reason to self-handle or escalate --------------------
 # Side effects: logging, marker records, escalation buffer appends.
+# A decision-owned queued row arrives as needs-decision:<files> rather than
+# signal:<files> (bin/fm-watch.sh). Classify it as a signal so the capture file
+# is populated, suppression markers commit, and the digest names the decision
+# instead of "unknown wake:".
 handle_wake() {  # <reason> <state>
   local reason=$1 state=$2 decision action distilled task last stale_detail
   local capture="$state/.subsuper-classified-end.$$" span_record='' span_rc='' endpoint ident rest sig marker
@@ -1340,7 +1344,12 @@ handle_wake() {  # <reason> <state>
     return
   fi
   case "$reason" in
-    signal:*) kind=signal; arg="${reason#signal: }"
+    signal:*|needs-decision:*)
+              kind=signal
+              case "$reason" in
+                needs-decision:*) arg="${reason#needs-decision: }" ;;
+                *) arg="${reason#signal: }" ;;
+              esac
               decision=$(FM_STATUS_SPAN_ENDPOINT_FILE="$capture" classify_signal "$arg" "$state") ;;
     stale:*)  kind=stale; arg="${reason#stale: }"; stale_detail="${arg#"$arg"}"
               case "$arg" in *" ("*) stale_detail="${arg#*" ("}"; arg="${arg%% \(*}" ;; esac

--- a/bin/fm-supervise-daemon.sh
+++ b/bin/fm-supervise-daemon.sh
@@ -350,15 +350,14 @@ _collapse_newlines() {  # <text>
 # field for "self" is informational (logged); for "escalate" it is the pre-read
 # summary firstmate would otherwise have to re-read.
 
-classify_signal() {  # <reason-after-colon> <state> [decision-owned]
-  local reason=$1 state=$2 owned=${3-} f last event record needs rest endpoint ident rc distilled="" rel="" seen_rel="" held="" task sig marker
+classify_signal() {  # <reason-after-colon> <state>
+  local reason=$1 state=$2 f last event record rest endpoint ident rc distilled="" rel="" seen_rel="" task sig marker
   for f in $reason; do
     case "$f" in *.status) ;; *) continue ;; esac
     [ -e "$f" ] || [ -L "$f" ] || continue
     task=$(basename "$f"); task="${task%.status}"
-    record=''; needs=0
-    status_span_first_actionable_record "$f" \
-      "$(status_seen_offset "$state" "$task")" record needs
+    record=$(status_span_first_actionable_record "$f" \
+      "$(status_seen_offset "$state" "$task")")
     rc=$?
     [ "$rc" -eq 1 ] && [ -z "$record" ] && continue
     if [ "$rc" -eq 2 ]; then
@@ -384,7 +383,6 @@ classify_signal() {  # <reason-after-colon> <state> [decision-owned]
     last=$(last_status_line "$f")
     [ -n "$last" ] || continue
     distilled="${distilled}$(basename "$f"): ${last} | "
-    [ "$needs" = 1 ] && held=1
     # Nothing captain-relevant is left ahead of the recorded offset. When the log
     # nonetheless ends on a captain-relevant line, this signal is a re-notification
     # of something already escalated, not a routine one; position is the whole
@@ -395,8 +393,6 @@ classify_signal() {  # <reason-after-colon> <state> [decision-owned]
   distilled="${distilled% | }"
   if [ -n "$rel" ]; then
     printf 'escalate|%s' "$distilled"
-  elif [ -n "$owned" ] && [ -n "$held" ]; then
-    printf 'escalate|captain-held decision: %s' "$distilled"
   elif [ -n "$seen_rel" ]; then
     # Already escalated by the per-wake path or the catch-all scan; self-handle
     # to avoid a duplicate entry in the digest.
@@ -1340,7 +1336,7 @@ is_wake_reason() {  # <reason>
 handle_wake() {  # <reason> <state>
   local reason=$1 state=$2 decision action distilled task last stale_detail
   local capture="$state/.subsuper-classified-end.$$" span_record='' span_rc='' endpoint ident rest sig marker
-  local kind="" arg="" owned="" classification_failed=0 span_failure_repeat=0
+  local kind="" arg="" classification_failed=0 span_failure_repeat=0
   : > "$capture" || return 1
   if should_force_self "$reason"; then
     log "wake force-self (FM_INJECT_SKIP): $reason"
@@ -1351,10 +1347,10 @@ handle_wake() {  # <reason> <state>
     signal:*|needs-decision:*)
               kind=signal
               case "$reason" in
-                needs-decision:*) arg="${reason#needs-decision: }"; owned=1 ;;
+                needs-decision:*) arg="${reason#needs-decision: }" ;;
                 *) arg="${reason#signal: }" ;;
               esac
-              decision=$(FM_STATUS_SPAN_ENDPOINT_FILE="$capture" classify_signal "$arg" "$state" "$owned") ;;
+              decision=$(FM_STATUS_SPAN_ENDPOINT_FILE="$capture" classify_signal "$arg" "$state") ;;
     stale:*)  kind=stale; arg="${reason#stale: }"; stale_detail="${arg#"$arg"}"
               case "$arg" in *" ("*) stale_detail="${arg#*" ("}"; arg="${arg%% \(*}" ;; esac
               task=$(window_to_task "$arg" "$state")

--- a/bin/fm-supervise-daemon.sh
+++ b/bin/fm-supervise-daemon.sh
@@ -350,14 +350,15 @@ _collapse_newlines() {  # <text>
 # field for "self" is informational (logged); for "escalate" it is the pre-read
 # summary firstmate would otherwise have to re-read.
 
-classify_signal() {  # <reason-after-colon> <state>
-  local reason=$1 state=$2 f last event record rest endpoint ident rc distilled="" rel="" seen_rel="" task sig marker
+classify_signal() {  # <reason-after-colon> <state> [decision-owned]
+  local reason=$1 state=$2 owned=${3-} f last event record needs rest endpoint ident rc distilled="" rel="" seen_rel="" held="" task sig marker
   for f in $reason; do
     case "$f" in *.status) ;; *) continue ;; esac
     [ -e "$f" ] || [ -L "$f" ] || continue
     task=$(basename "$f"); task="${task%.status}"
-    record=$(status_span_first_actionable_record "$f" \
-      "$(status_seen_offset "$state" "$task")")
+    record=''; needs=0
+    status_span_first_actionable_record "$f" \
+      "$(status_seen_offset "$state" "$task")" record needs
     rc=$?
     [ "$rc" -eq 1 ] && [ -z "$record" ] && continue
     if [ "$rc" -eq 2 ]; then
@@ -383,6 +384,7 @@ classify_signal() {  # <reason-after-colon> <state>
     last=$(last_status_line "$f")
     [ -n "$last" ] || continue
     distilled="${distilled}$(basename "$f"): ${last} | "
+    [ "$needs" = 1 ] && held=1
     # Nothing captain-relevant is left ahead of the recorded offset. When the log
     # nonetheless ends on a captain-relevant line, this signal is a re-notification
     # of something already escalated, not a routine one; position is the whole
@@ -393,6 +395,8 @@ classify_signal() {  # <reason-after-colon> <state>
   distilled="${distilled% | }"
   if [ -n "$rel" ]; then
     printf 'escalate|%s' "$distilled"
+  elif [ -n "$owned" ] && [ -n "$held" ]; then
+    printf 'escalate|captain-held decision: %s' "$distilled"
   elif [ -n "$seen_rel" ]; then
     # Already escalated by the per-wake path or the catch-all scan; self-handle
     # to avoid a duplicate entry in the digest.
@@ -1336,7 +1340,7 @@ is_wake_reason() {  # <reason>
 handle_wake() {  # <reason> <state>
   local reason=$1 state=$2 decision action distilled task last stale_detail
   local capture="$state/.subsuper-classified-end.$$" span_record='' span_rc='' endpoint ident rest sig marker
-  local kind="" arg="" classification_failed=0 span_failure_repeat=0
+  local kind="" arg="" owned="" classification_failed=0 span_failure_repeat=0
   : > "$capture" || return 1
   if should_force_self "$reason"; then
     log "wake force-self (FM_INJECT_SKIP): $reason"
@@ -1347,10 +1351,10 @@ handle_wake() {  # <reason> <state>
     signal:*|needs-decision:*)
               kind=signal
               case "$reason" in
-                needs-decision:*) arg="${reason#needs-decision: }" ;;
+                needs-decision:*) arg="${reason#needs-decision: }"; owned=1 ;;
                 *) arg="${reason#signal: }" ;;
               esac
-              decision=$(FM_STATUS_SPAN_ENDPOINT_FILE="$capture" classify_signal "$arg" "$state") ;;
+              decision=$(FM_STATUS_SPAN_ENDPOINT_FILE="$capture" classify_signal "$arg" "$state" "$owned") ;;
     stale:*)  kind=stale; arg="${reason#stale: }"; stale_detail="${arg#"$arg"}"
               case "$arg" in *" ("*) stale_detail="${arg#*" ("}"; arg="${arg%% \(*}" ;; esac
               task=$(window_to_task "$arg" "$state")

--- a/bin/fm-watch.sh
+++ b/bin/fm-watch.sh
@@ -2057,11 +2057,12 @@ EOF
     # instead of the ordinary "signal:" below (other files in the same batch
     # keep the ordinary payload). The wake reason line itself, and every
     # harness-arm consumer that pattern-matches it, stays byte-identical -
-    # only the per-row payload changes, which is what
-    # docs/pi-supervision-branch.md's Pi-only branch dispatcher reads to keep a
+    # only the per-row payload changes. Two readers branch on that payload:
+    # docs/pi-supervision-branch.md's Pi-only branch dispatcher, to keep a
     # decision-owned row off the supervision branch (fm-branch-dispatch.ts,
-    # fm-primary-pi-watch.ts). Every other harness and script keeps seeing the
-    # exact same "signal:$files" wake it always has.
+    # fm-primary-pi-watch.ts), and the away daemon, whose handle_durable_wakes
+    # passes it to handle_wake (see the comment above handle_wake in
+    # bin/fm-supervise-daemon.sh).
     # shellcheck disable=SC2086  # same space-separated status-path list
     if afk_present || [ "$signal_actionable" -eq 0 ] \
       || { ! signal_crew_provably_working $files && ! signal_turnend_panes_churned $files; }; then

--- a/tests/fm-daemon.test.sh
+++ b/tests/fm-daemon.test.sh
@@ -1,10 +1,11 @@
 #!/usr/bin/env bash
 # tests/fm-daemon.test.sh - supervise-daemon classifiers, the captain-relevant
-# status-phrase matrix (a product contract), escalation batching/dedupe, afk
-# presence-gating, and the injection-hardening units that an e2e cannot
-# deterministically reach (persistent-Enter-swallow, max-defer wedge alarms,
-# fm-send typed-plane swallow reporting, composer-pending ANSI parsing). The operator-visible
-# inject flow lives in fm-afk-inject-e2e and fm-wake-daemon-lifecycle-e2e.
+# status-phrase matrix (a product contract), escalation batching/dedupe,
+# decision-owned queued-row suppression, afk presence-gating, and the
+# injection-hardening units that an e2e cannot deterministically reach
+# (persistent-Enter-swallow, max-defer wedge alarms, fm-send typed-plane swallow
+# reporting, composer-pending ANSI parsing). The operator-visible inject flow
+# lives in fm-afk-inject-e2e and fm-wake-daemon-lifecycle-e2e.
 set -u
 
 # shellcheck source=tests/wake-helpers.sh
@@ -1480,6 +1481,87 @@ test_handle_wake_routes_self_and_escalate() {
   pass "handle_wake routes routine->self and captain->escalate"
 }
 
+# Decision-owned queued rows are marked needs-decision:<files> by the watcher.
+# The away-mode daemon must classify that payload the same way it classifies an
+# ordinary signal: escalate once as the decision, suppress an unchanged repeat
+# (queued-row and catch-all alike), and re-escalate when the status log grows.
+# https://github.com/kunchenguid/firstmate/issues/4096
+test_needs_decision_queued_row_escalates_once_as_the_decision() {
+  local dir state fakebin status_file payload out
+  dir=$(make_supercase needs-decision-queued-row)
+  state="$dir/state"
+  fakebin="$dir/daemon-bin"
+  mkdir -p "$fakebin"
+  status_file="$state/decision-task.status"
+  printf 'working: setup\nneeds-decision [key=release]: pick A or B\n' > "$status_file"
+  payload="needs-decision: $status_file"
+  cat > "$fakebin/fm-wake-drain.sh" <<EOF
+#!/usr/bin/env bash
+if [ "\${1:-}" = --ack-through ]; then printf '%s\n' ack >> "$dir/acked"; exit 0; fi
+printf '1\t1\tsignal\tdecision-task.status\t%s\n' "$payload"
+printf 'WAKE_ACK_REQUIRED: retry --ack-through 1 --recovery-generation gen\n' >&2
+EOF
+  chmod +x "$fakebin/fm-wake-drain.sh"
+
+  FM_DAEMON_DIR="$fakebin" FM_STATE_OVERRIDE="$state" FM_ESCALATE_BATCH_SECS=999 \
+    handle_durable_wakes fallback "$state" \
+    || fail "the first decision-owned queued row was not handled"
+  out=$(cat "$state/.subsuper-escalations" 2>/dev/null || true)
+  case "$out" in
+    *"unknown wake:"*) fail "a decision-owned wake was labelled unknown: $out" ;;
+  esac
+  case "$out" in
+    *"needs-decision [key=release]: pick A or B"*) ;;
+    *) fail "the first decision-owned wake was not presented as the decision: $out" ;;
+  esac
+  [ "$(wc -l < "$state/.subsuper-escalations" | tr -d ' ')" = 1 ] \
+    || fail "the first decision-owned wake did not escalate exactly once: $out"
+
+  : > "$state/.subsuper-escalations"
+  FM_DAEMON_DIR="$fakebin" FM_STATE_OVERRIDE="$state" FM_ESCALATE_BATCH_SECS=999 \
+    handle_durable_wakes fallback "$state" \
+    || fail "an unchanged decision-owned repeat was not handled"
+  [ ! -s "$state/.subsuper-escalations" ] \
+    || fail "an unchanged open decision re-escalated: $(cat "$state/.subsuper-escalations")"
+
+  rm -f "$state/.subsuper-last-scan"
+  FM_STATE_OVERRIDE="$state" housekeeping "$state"
+  [ ! -s "$state/.subsuper-escalations" ] \
+    || fail "the catch-all scan re-escalated an already-surfaced open decision: $(cat "$state/.subsuper-escalations")"
+
+  printf 'needs-decision [key=release]: pick A, C, or D\n' >> "$status_file"
+  : > "$state/.subsuper-escalations"
+  FM_DAEMON_DIR="$fakebin" FM_STATE_OVERRIDE="$state" FM_ESCALATE_BATCH_SECS=999 \
+    handle_durable_wakes fallback "$state" \
+    || fail "a changed decision-owned wake was not handled"
+  out=$(cat "$state/.subsuper-escalations" 2>/dev/null || true)
+  case "$out" in
+    *"unknown wake:"*) fail "a changed decision-owned wake was labelled unknown: $out" ;;
+  esac
+  case "$out" in
+    *"needs-decision [key=release]: pick A, C, or D"*) ;;
+    *) fail "a later status change did not re-escalate the decision: $out" ;;
+  esac
+
+  : > "$state/.subsuper-escalations"
+  printf 'working: still going\n' > "$state/ordinary-routine.status"
+  FM_STATE_OVERRIDE="$state" handle_wake "signal: $state/ordinary-routine.status" "$state"
+  [ -s "$state/.subsuper-escalations" ] \
+    && fail "an ordinary routine signal was escalated: $(cat "$state/.subsuper-escalations")"
+  printf 'done: PR https://example.test/pull/1\n' > "$state/ordinary-done.status"
+  FM_STATE_OVERRIDE="$state" handle_wake "signal: $state/ordinary-done.status" "$state"
+  out=$(cat "$state/.subsuper-escalations" 2>/dev/null || true)
+  case "$out" in
+    *"done: PR https://example.test/pull/1"*) ;;
+    *) fail "an ordinary captain-relevant signal lost its escalate behaviour: $out" ;;
+  esac
+  case "$out" in
+    *"unknown wake:"*) fail "an ordinary signal was labelled unknown: $out" ;;
+  esac
+
+  pass "a decision-owned queued row escalates once as the decision, then suppresses until the status changes"
+}
+
 test_inject_skip_forces_self() {
   local dir state
   dir=$(make_supercase skip)
@@ -2704,6 +2786,7 @@ test_escalate_batches_into_one_digest
 test_escalate_batch_age_uses_first_append
 test_heartbeat_scan_dedup
 test_handle_wake_routes_self_and_escalate
+test_needs_decision_queued_row_escalates_once_as_the_decision
 test_inject_skip_forces_self
 test_is_wake_reason_distinguishes_status_stdout
 test_terminal_stale_escalate_leaves_no_marker

--- a/tests/fm-daemon.test.sh
+++ b/tests/fm-daemon.test.sh
@@ -1562,6 +1562,50 @@ EOF
   pass "a decision-owned queued row escalates once as the decision, then suppresses until the status changes"
 }
 
+# The watcher also marks a row decision-owned when its only new line is a
+# captain-held transfer, which ordinary signal classification self-handles as
+# routine. The daemon must still surface that row once as the held decision,
+# stay quiet while the status is unchanged, and leave ordinary signal: rows alone.
+test_captain_held_decision_owned_row_escalates_once_as_the_decision() {
+  local dir state fakebin status_file held out
+  dir=$(make_supercase captain-held-decision-owned-row)
+  state="$dir/state"
+  fakebin="$dir/daemon-bin"
+  mkdir -p "$fakebin"
+  held='captain-held [key=route]: tracked by task-decision-route'
+  status_file="$state/held-task.status"
+  printf '%s\n' "$held" > "$status_file"
+  cat > "$fakebin/fm-wake-drain.sh" <<EOF
+#!/usr/bin/env bash
+if [ "\${1:-}" = --ack-through ]; then exit 0; fi
+printf '1\t1\tsignal\theld-task.status\t%s\n' "needs-decision: $status_file"
+printf 'WAKE_ACK_REQUIRED: retry --ack-through 1 --recovery-generation gen\n' >&2
+EOF
+  chmod +x "$fakebin/fm-wake-drain.sh"
+
+  FM_DAEMON_DIR="$fakebin" FM_STATE_OVERRIDE="$state" FM_ESCALATE_BATCH_SECS=999 \
+    handle_durable_wakes fallback "$state" \
+    || fail "the captain-held decision-owned row was not handled"
+  out=$(cat "$state/.subsuper-escalations" 2>/dev/null || true)
+  [ "$out" = "captain-held decision: held-task.status: $held" ] \
+    || fail "a captain-held decision-owned row did not escalate once as the decision: $out"
+
+  : > "$state/.subsuper-escalations"
+  FM_DAEMON_DIR="$fakebin" FM_STATE_OVERRIDE="$state" FM_ESCALATE_BATCH_SECS=999 \
+    handle_durable_wakes fallback "$state" \
+    || fail "an unchanged captain-held decision-owned repeat was not handled"
+  [ ! -s "$state/.subsuper-escalations" ] \
+    || fail "an unchanged captain-held decision re-escalated: $(cat "$state/.subsuper-escalations")"
+
+  printf '%s\n' "$held" > "$state/held-ordinary.status"
+  FM_STATE_OVERRIDE="$state" handle_wake "signal: $state/held-ordinary.status" "$state" \
+    || fail "an ordinary captain-held signal was not handled"
+  [ ! -s "$state/.subsuper-escalations" ] \
+    || fail "an ordinary signal: row escalated a captain-held transfer: $(cat "$state/.subsuper-escalations")"
+
+  pass "a captain-held decision-owned row escalates once as the decision; ordinary signal rows stay self-handled"
+}
+
 test_inject_skip_forces_self() {
   local dir state
   dir=$(make_supercase skip)
@@ -2787,6 +2831,7 @@ test_escalate_batch_age_uses_first_append
 test_heartbeat_scan_dedup
 test_handle_wake_routes_self_and_escalate
 test_needs_decision_queued_row_escalates_once_as_the_decision
+test_captain_held_decision_owned_row_escalates_once_as_the_decision
 test_inject_skip_forces_self
 test_is_wake_reason_distinguishes_status_stdout
 test_terminal_stale_escalate_leaves_no_marker

--- a/tests/fm-daemon.test.sh
+++ b/tests/fm-daemon.test.sh
@@ -1563,18 +1563,17 @@ EOF
 }
 
 # The watcher also marks a row decision-owned when its only new line is a
-# captain-held transfer, which ordinary signal classification self-handles as
-# routine. The daemon must still surface that row once as the held decision,
-# stay quiet while the status is unchanged, and leave ordinary signal: rows alone.
-test_captain_held_decision_owned_row_escalates_once_as_the_decision() {
-  local dir state fakebin status_file held out
+# captain-held transfer. fm-captain-hold.sh complete writes that line through the
+# self-announced append and the hold stays durable in the backlog, so the daemon
+# self-handles the row like any other captain-held line, now and on repeat.
+test_captain_held_decision_owned_row_is_self_handled() {
+  local dir state fakebin status_file
   dir=$(make_supercase captain-held-decision-owned-row)
   state="$dir/state"
   fakebin="$dir/daemon-bin"
   mkdir -p "$fakebin"
-  held='captain-held [key=route]: tracked by task-decision-route'
   status_file="$state/held-task.status"
-  printf '%s\n' "$held" > "$status_file"
+  printf 'captain-held [key=route]: tracked by task-decision-route\n' > "$status_file"
   cat > "$fakebin/fm-wake-drain.sh" <<EOF
 #!/usr/bin/env bash
 if [ "\${1:-}" = --ack-through ]; then exit 0; fi
@@ -1586,24 +1585,16 @@ EOF
   FM_DAEMON_DIR="$fakebin" FM_STATE_OVERRIDE="$state" FM_ESCALATE_BATCH_SECS=999 \
     handle_durable_wakes fallback "$state" \
     || fail "the captain-held decision-owned row was not handled"
-  out=$(cat "$state/.subsuper-escalations" 2>/dev/null || true)
-  [ "$out" = "captain-held decision: held-task.status: $held" ] \
-    || fail "a captain-held decision-owned row did not escalate once as the decision: $out"
+  [ ! -s "$state/.subsuper-escalations" ] \
+    || fail "a captain-held decision-owned row escalated: $(cat "$state/.subsuper-escalations")"
 
-  : > "$state/.subsuper-escalations"
   FM_DAEMON_DIR="$fakebin" FM_STATE_OVERRIDE="$state" FM_ESCALATE_BATCH_SECS=999 \
     handle_durable_wakes fallback "$state" \
     || fail "an unchanged captain-held decision-owned repeat was not handled"
   [ ! -s "$state/.subsuper-escalations" ] \
-    || fail "an unchanged captain-held decision re-escalated: $(cat "$state/.subsuper-escalations")"
+    || fail "an unchanged captain-held decision-owned repeat escalated: $(cat "$state/.subsuper-escalations")"
 
-  printf '%s\n' "$held" > "$state/held-ordinary.status"
-  FM_STATE_OVERRIDE="$state" handle_wake "signal: $state/held-ordinary.status" "$state" \
-    || fail "an ordinary captain-held signal was not handled"
-  [ ! -s "$state/.subsuper-escalations" ] \
-    || fail "an ordinary signal: row escalated a captain-held transfer: $(cat "$state/.subsuper-escalations")"
-
-  pass "a captain-held decision-owned row escalates once as the decision; ordinary signal rows stay self-handled"
+  pass "a captain-held decision-owned row is self-handled without escalation, now and on repeat"
 }
 
 test_inject_skip_forces_self() {
@@ -2831,7 +2822,7 @@ test_escalate_batch_age_uses_first_append
 test_heartbeat_scan_dedup
 test_handle_wake_routes_self_and_escalate
 test_needs_decision_queued_row_escalates_once_as_the_decision
-test_captain_held_decision_owned_row_escalates_once_as_the_decision
+test_captain_held_decision_owned_row_is_self_handled
 test_inject_skip_forces_self
 test_is_wake_reason_distinguishes_status_stdout
 test_terminal_stale_escalate_leaves_no_marker


### PR DESCRIPTION
Fixes #4096

## Intent

Captain's words (2026-09-10), about upstream issue https://github.com/kunchenguid/firstmate/issues/4096: "maintainer labeled as ready-for-pr. that's a signal to start a PR for it."

What that issue reports: a decision-owned wake re-escalates into the supervisor conversation on every poll, unbounded, for as long as the decision stays open, and reaches the captain labelled `unknown wake:` instead of as the decision it is.
`bin/fm-watch.sh` marks a decision-owned queued row payload `needs-decision:<files>` instead of the ordinary `signal:<files>`.
`bin/fm-supervise-daemon.sh` `handle_wake` consumes the row payload and has arms only for `signal:*`, `stale:*`, `check:*` and `heartbeat*`, so `needs-decision:*` falls through to the catch-all `classify_unknown`, which returns `escalate|unknown wake: ...`.
The catch-all never runs `classify_signal` with `FM_STATUS_SPAN_ENDPOINT_FILE="$capture"`, so the capture file stays empty and `mark_escalated_seen` commits no per-task status byte offset; the next poll sees the same unchanged status and escalates again.
Expected behaviour: a decision-owned wake whose underlying status content has not changed escalates once and is then suppressed on the same terms as any other wake, and is presented as the decision rather than as an unknown wake.
Suppression must not lose the decision: it stays in the durable wake queue, in the OPEN DECISIONS section of every locked drain, and in the backlog hold.
Measured consequence on one fleet: 34 of 104 escalations over four days were repeats of this one class.

The maintainer's triage (kunchenguid, 2026-09-10, against main `b1ad702fafdd`) confirmed the defect is still real on main, classified it as a restore, and labeled the issue ready-for-pr.
Accepted scope in the maintainer's words: "decision-owned wakes should escalate once then suppress like ordinary signals, labelled as the decision".
Proposed direction in the maintainer's words: "add a `needs-decision:*` arm (or route through `classify_signal` with capture) so suppression markers commit, and present as the decision rather than `unknown wake:`."
The maintainer found no covering open PR.

## What Changed
- `bin/fm-supervise-daemon.sh`: `handle_wake` now has a `needs-decision:*` arm alongside `signal:*`. It strips the prefix and calls `classify_signal` with `FM_STATUS_SPAN_ENDPOINT_FILE` set to the capture file. Before this, a decision-owned queued row fell through to `classify_unknown` and reached the captain as `unknown wake:`. Now it escalates once, labelled with its `needs-decision [...]` status line. Because the capture file gets filled, the suppression marker is committed, so an unchanged repeat stays quiet (both from the queue and from the catch-all scan) until the status log grows. A row whose only new line is `captain-held` is handled by the daemon itself, like any other captain-held line.
- `bin/fm-watch.sh`: comment-only change. It now names the away daemon (`handle_durable_wakes` → `handle_wake`) as the second reader of the `needs-decision:<files>` row payload, next to the Pi branch dispatcher.
- `tests/fm-daemon.test.sh`: adds two tests.
  - `test_needs_decision_queued_row_escalates_once_as_the_decision` checks four things: the wake escalates once as the decision, not as `unknown wake:`; an unchanged repeat and the `housekeeping` catch-all scan are both suppressed; the wake escalates again when a new status line is appended; and ordinary `signal:` routing still works.
  - `test_captain_held_decision_owned_row_is_self_handled` checks that a captain-held decision-owned row never escalates, on first delivery or on repeat.

Addresses kunchenguid/firstmate#4096.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Risk Assessment

✅ Low: The production change is a small routing fix. It sends `needs-decision:*` queued rows through the existing `classify_signal` with the capture file, so the daemon offset commits and the digest shows the decision text instead of `unknown wake:`. Fix round 2 cleanly reverted fix round 1: `git diff d48b20a HEAD` touches only tests, so the only source change left is the original fix. A static trace shows needs-decision and pending-reply blocked decisions escalate exactly once, whether the per-row path, a sibling ordinary row or the catch-all scan commits the offset first. Captain-held rows are self-handled, as the user decided. OPEN DECISIONS uses its own cursor, and drain ack behaviour is the same as base.

## Testing

<code>I ran the targeted `tests/fm-daemon.test.sh` (pass, including both new tests). I then drove the real daemon, watcher, and drain end to end in away mode on a private tmux socket, on this commit and on base 527aa7c. Each was run twice: with a 3s catch-all, and with a 20s catch-all in a throwaway home holding a real tasks-axi captain hold.&#10;&#10;**On this commit:**&#10;- A keyed needs-decision reached the supervisor exactly once, labelled as the decision and never as `unknown wake:`.&#10;- With the slow catch-all, the queued `needs-decision:` row escalated by itself, and the next catch-all scan did not repeat it.&#10;- A changed decision re-escalated exactly once with the new text.&#10;- A captain-held-only decision-owned row was self-handled with zero submissions.&#10;- Ordinary routine and done signals behaved as before.&#10;- After the run, a locked drain still listed the decision under OPEN DECISIONS, and the backlog captain hold was still open.&#10;&#10;**On base:** both runs submitted every decision twice. One copy was labelled `unknown wake: needs-decision: &lt;path&gt;`, and the catch-all scan repeated it, which reproduces #4096.&#10;&#10;I did not inspect the wake-queue files themselves. The evidence is terminal transcripts (pane capture plus verbatim submission log), because this daemon has no GUI surface. The temporary base export was removed and the worktree is clean.</code>

- Live validation: ✅ go - 7 of 7 scenarios driven live against the product

| Scenario | Result | Live | Evidence |
| --- | --- | --- | --- |
| A crewmate&#39;s keyed needs-decision stays unchanged under afk: the supervisor gets exactly one digest carrying the decision text, none labelled `unknown wake:`, and no repeat across later catch-all scan… | ✅ pass | live | live-target/summary.txt phase A (3s catch-all) and live-target-slowscan.run.log phase A (20s catch-all): 1 submission naming the task, 0 &#39;unknown wake:&#39;, carrying &#39;needs-decision [key=release]: pick A… |
| The queued `needs-decision:` row reads the span first and escalates by itself, labelled as the decision, and the later catch-all scan does not repeat it | ✅ pass | live | live-target-slowscan.run.log phase A: escalated by the queued row itself 1, supervisor submissions 1, tagged catch-all 0, no repeat over 35s that included a catch-all scan. |
| Adversarial baseline: the same live flow on base 527aa7c reproduces #4096. The queued row escalates as `unknown wake: needs-decision: &lt;path&gt;` and the next catch-all scan escalates the same unchanged d… | ✅ pass | live | live-base-slowscan.run.log phase A: 2 submissions, 1 labelled &#39;unknown wake:&#39;, 1 tagged catch-all. Phase B: 2 new submissions. live-base/summary.txt shows the same duplication with a 3s catch-all. |
| The crewmate appends a changed decision: the supervisor gets exactly one new digest with the new text and no repeat while it stays unchanged | ✅ pass | live | live-target/summary.txt and live-target-slowscan.run.log phase B: 1 new submission carrying &#39;needs-decision [key=release]: pick A, C, or D&#39;, 0 &#39;unknown wake:&#39;. Base produced 2. |
| A task whose only new line is `captain-held [key=route]: ...` produces a decision-owned row that the daemon self-handles with no escalation, now and across later scans (review round 2 decision) | ✅ pass | live | live-target and live-target-slowscan phase C: 1 queued row handled as needs-decision, 1 self-handled, 0 supervisor submissions naming held-task. Base escalated it as &#39;unknown wake: needs-decision: ...… |
| Ordinary signal wakes are unchanged: a routine `working:` note is self-handled silently and a `done:` line reaches the supervisor once, labelled with the done line | ✅ pass | live | live-target and live-target-slowscan phase D: 0 routine submissions. 1 done submission carrying &#39;done: PR https://example.test/pull/1&#39;, 0 &#39;unknown wake:&#39;. Identical on base. |
| Suppression does not lose the decision: a locked `fm-wake-drain.sh` still lists it under OPEN DECISIONS, and a real tasks-axi backlog captain hold on the task is still open after escalation and suppre… | ✅ pass | live | live-target-slowscan.run.log phase E: drain exit 0; OPEN DECISIONS lists &#39;decision-task [key=release] needs-decision: pick A, C, or D&#39;; &#39;backlog captain hold on decision-task still open after the run:… |

<details>
<summary>Evidence: Live driver script (real daemon + watcher + drain on a private tmux socket, throwaway home with a real captain hold)</summary>

Source: [Live driver script (real daemon + watcher + drain on a private tmux socket, throwaway home with a real captain hold)](https://github.com/tiago-peixoto/firstmate/blob/a20d98eddd65dcd31a1dac9a9295f03f1e629171/.no-mistakes/evidence/fm/firstmate-upstream-decision-wake-dedupe/live-decision-wake.sh)

```text
#!/usr/bin/env bash
# Live driver for kunchenguid/firstmate#4096. Runs the REAL bin/fm-supervise-daemon.sh
# as a background process (with its real bin/fm-watch.sh child and real
# bin/fm-wake-drain.sh) in away mode, against a throwaway firstmate home and a
# private tmux socket whose supervisor pane logs every submitted line verbatim.
# It then writes status logs the way crewmates do and records exactly what
# reached the supervisor pane. The decision's backlog row is placed under a real
# captain hold (bin/fm-captain-hold.sh + tasks-axi) before the daemon starts.
#
# Usage: [FM_LIVE_SCAN_SECS=N] live-decision-wake.sh <repo-root> <label> <out-dir>
set -u
REPO=$1 LABEL=$2 OUT=$3
SCAN=${FM_LIVE_SCAN_SECS:-3}
BIN="$REPO/bin"
DAEMON="$BIN/fm-supervise-daemon.sh"
DRAIN="$BIN/fm-wake-drain.sh"
REAL_TMUX=$(command -v tmux)
SOCKET="nd-live-$LABEL-$$"
mkdir -p "$OUT"
WORK=$(mktemp -d "${TMPDIR:-/tmp}/fm-nd-live.XXXXXX")
HOME_DIR="$WORK/home"
STATE_DIR="$HOME_DIR/state"
SHIM="$WORK/shim"
HOLDBIN="$WORK/holdbin"
mkdir -p "$HOME_DIR/data" "$STATE_DIR" "$HOME_DIR/config" "$HOME_DIR/projects" "$SHIM" "$HOLDBIN"
LOG_FILE="$STATE_DIR/submitted.log"; : > "$LOG_FILE"
SUMMARY="$OUT/summary.txt"; : > "$SUMMARY"
DAEMON_PID=

stop_daemon() {
  [ -n "$DAEMON_PID" ] || return 0
  kill "$DAEMON_PID" 2>/dev/null; wait "$DAEMON_PID" 2>/dev/null
  DAEMON_PID=
}
cleanup() {
  stop_daemon
  "$REAL_TMUX" -L "$SOCKET" kill-server 2>/dev/null
  rm -rf "$WORK"
}
trap cleanup EXIT

note() { printf '%s\n' "$*" | tee -a "$SUMMARY"; }
count_sub() { grep -c -- "$1" "$LOG_FILE" 2>/dev/null; }
count_log() { grep -c -- "$1" "$STATE_DIR/.supervise-daemon.log" 2>/dev/null; }
wait_for_sub() {  # <pattern> <timeout-secs>
  local i=0
  while [ "$i" -lt "$2" ]; do
    grep -q -- "$1" "$LOG_FILE" && return 0
    sleep 1; i=$((i + 1))
  done
  return 1
}
hold_cmd() {
  PATH="$HOLDBIN:$PATH" FM_HOME="$HOME_DIR" FM_STATE_OVERRIDE="$STATE_DIR" \
    FM_DATA_OVERRIDE="$HOME_DIR/data" FM_CONFIG_OVERRIDE="$HOME_DIR/config" \
    "$BIN/fm-captain-hold.sh" "$@"
}

# --- throwaway home with the decision's backlog row under a captain hold -------
cp "$REPO/.tasks.toml" "$HOME_DIR/.tasks.toml"
printf '## In flight\n\n## Queued\n- [ ] decision-task - Ship the release (repo: sample) (kind: ship) (since 2026-01-01)\n\n## Done\n' \
  > "$HOME_DIR/data/backlog.md"
for t in tmux treehouse no-mistakes gh gh-axi; do
  printf '#!/usr/bin/env bash\nexit 0\n' > "$HOLDBIN/$t"; chmod +x "$HOLDBIN/$t"
done

# --- supervisor pane: a deterministic composer that logs each submitted line ---
# (same fixture shape as tests/fm-afk-inject-e2e.test.sh: "❯ " prompt glyph, logs
# hex, text and whether the line carried the operational-input marker.)
LOOP="$SHIM/supervisor-loop.sh"
cat > "$LOOP" <<'LOOP'
#!/usr/bin/env bash
MARK=$'\xE2\x81\xA3'
LOG="$1"
OLD_STTY=$(stty -g 2>/dev/null || true)
[ -z "$OLD_STTY" ] || stty -echo -icanon min 1 time 0 2>/dev/null || true
trap '[ -z "$OLD_STTY" ] || stty "$OLD_STTY" 2>/dev/null || true' EXIT INT TERM
_buf=
redraw() { printf '\r\033[K\xe2\x9d\xaf %s' "$_buf"; }
submit_line() {
  local _line=$_buf _c _hex
  if [ "${_line:0:1}" = "$MARK" ]; then _c=injection; else _c=user; fi
  _hex=$(printf '%s' "$_line" | od -An -tx1 | tr -d ' \n')
  printf '%s\t%s\t%s\n' "$_hex" "$_line" "$_c" >> "$LOG"
  _buf=
  printf '\r\033[K%s\n' "$_line"
  redraw
}
redraw
while IFS= read -r -n 1 _ch; do
  if [ -z "$_ch" ]; then submit_line; continue; fi
  case "$_ch" in
    $'\r'|$'\n') submit_line ;;
    $'\177'|$'\b') _buf=${_buf%?}; redraw ;;
    *) _buf="${_buf}${_ch}"; redraw ;;
  esac
done
LOOP
chmod +x "$LOOP"

"$REAL_TMUX" -L "$SOCKET" new-session -d -s supervisor -x 250 -y 60
PANE=$("$REAL_TMUX" -L "$SOCKET" display-message -p -t supervisor '#{pane_id}')
"$REAL_TMUX" -L "$SOCKET" send-keys -t "$PANE" "bash '$LOOP' '$LOG_FILE'" Enter
sleep 1

cat > "$SHIM/tmux" <<SH
#!/usr/bin/env bash
exec "$REAL_TMUX" -L "$SOCKET" "\$@"
SH
chmod +x "$SHIM/tmux"

hold_cmd hold decision-task --reason "needs-decision [key=release]: pick A or B" >/dev/null 2>"$OUT/hold.err"
note "== [$LABEL] captain hold placed on backlog row decision-task: exit $?"
hold_cmd open decision-task >/dev/null 2>&1
note "   hold open before the daemon starts: exit $? (0 = open)"

# --- away mode on, start the real daemon --------------------------------------
date '+%s' > "$STATE_DIR/.afk"
env -u TMUX -u TMUX_PANE -u HERDR_ENV -u HERDR_PANE_ID \
  PATH="$SHIM:$PATH" \
  FM_HOME="$HOME_DIR" \
  FM_STATE_OVERRIDE="$STATE_DIR" \
  FM_DATA_OVERRIDE="$HOME_DIR/data" \
  FM_CONFIG_OVERRIDE="$HOME_DIR/config" \
  FM_SUPERVISOR_TARGET="$PANE" \
  FM_SUPERVISOR_BACKEND=tmux \
  FM_ESCALATE_BATCH_SECS=0 \
  FM_HOUSEKEEPING_TICK=1 \
  FM_HEARTBEAT_SCAN_SECS="$SCAN" \
  FM_POLL=1 \
  FM_SIGNAL_GRACE=1 \
  FM_HEARTBEAT=999999 \
  FM_CHECK_INTERVAL=999999 \
  FM_INJECT_CONFIRM_SLEEP=0.3 \
  FM_INJECT_CONFIRM_RETRIES=5 \
  FM_STALE_ESCALATE_SECS=999999 \
  nohup "$DAEMON" > "$OUT/daemon.out" 2> "$OUT/daemon.err" &
DAEMON_PID=$!
i=0; while [ "$i" -lt 30 ] && [ ! -f "$STATE_DIR/.supervise-daemon.pid" ]; do sleep 0.2; i=$((i + 1)); done
[ -f "$STATE_DIR/.supervise-daemon.pid" ] || { note "daemon did not start"; cat "$OUT/daemon.err"; exit 1; }
note "== [$LABEL] real daemon pid $DAEMON_PID up; afk on; catch-all scan every ${SCAN}s, watcher poll 1s"
sleep 2   # let the startup catch-all scan pass, so the next one is ${SCAN}s away

# --- A: a decision-owned needs-decision wake, then the status stays unchanged ---
note ""
note "== A. crewmate writes a keyed needs-decision; status then stays unchanged for 35s"
printf 'working: setup\nneeds-decision [key=release]: pick A or B\n' > "$STATE_DIR/decision-task.status"
wait_for_sub 'decision-task' 30 || note "  (no submission naming decision-task within 30s)"
sleep 35
note "  queued rows handled as needs-decision:    $(count_log 'needs-decision: .*decision-task.status')"
note "  escalated by the queued row itself:       $(count_log 'escalate: needs-decision: .*decision-task.status')"
note "  supervisor submissions naming the task:   $(count_sub 'decision-task')"
note "  ...tagged (catch-all scan):               $(grep 'decision-task' "$LOG_FILE" | grep -c 'catch-all scan')"
note "  ...labelled 'unknown wake:':              $(grep 'decision-task' "$LOG_FILE" | grep -c 'unknown wake:')"
note "  ...carrying the decision text:            $(count_sub 'needs-decision \[key=release\]: pick A or B')"
A_TOTAL=$(count_sub 'decision-task')

# --- B: the decision changes (status grows) -------------------------------------
note ""
note "== B. crewmate appends a changed decision; then unchanged for 30s"
printf 'needs-decision [key=release]: pick A, C, or D\n' >> "$STATE_DIR/decision-task.status"
wait_for_sub 'pick A, C, or D' 30 || note "  (changed decision not submitted within 30s)"
sleep 30
note "  new submissions naming the task:          $(( $(count_sub 'decision-task') - A_TOTAL ))"
note "  ...carrying the changed decision text:    $(count_sub 'needs-decision \[key=release\]: pick A, C, or D')"
note "  ...labelled 'unknown wake:' (all time):   $(grep 'decision-task' "$LOG_FILE" | grep -c 'unknown wake:')"
note "  escalated by the queued row (all time):   $(count_log 'escalate: needs-decision: .*decision-task.status')"

# --- C: a captain-held transfer is the only new line ----------------------------
note ""
note "== C. a task's only new line is a captain-held [key=...] transfer; watch 30s"
printf 'captain-held [key=route]: tracked by task-decision-route\n' > "$STATE_DIR/held-task.status"
sleep 30
note "  queued rows handled as needs-decision:    $(count_log 'needs-decision: .*held-task.status')"
note "  daemon self-handled those rows:           $(count_log 'self-handle: needs-decision: .*held-task.status')"
note "  supervisor submissions naming held-task:  $(count_sub 'held-task')"

# --- D: ordinary signal wakes ---------------------------------------------------
note ""
note "== D. ordinary signals: a routine working: note, then a done: line"
printf 'working: still going\n' > "$STATE_DIR/routine-task.status"
sleep 12
note "  routine rows handled as signal:           $(count_log 'signal: .*routine-task.status')"
note "  supervisor submissions naming routine:    $(count_sub 'routine-task')"
printf 'done: PR https://example.test/pull/1\n' > "$STATE_DIR/done-task.status"
wait_for_sub 'done-task' 30 || note "  (done not submitted within 30s)"
sleep 25
note "  escalated by the queued signal row:       $(count_log 'escalate: signal: .*done-task.status')"
note "  supervisor submissions naming done-task:  $(count_sub 'done-task')"
note "  ...carrying the done line:                $(count_sub 'done: PR https://example.test/pull/1')"
note "  ...labelled 'unknown wake:':              $(grep 'done-task' "$LOG_FILE" | grep -c 'unknown wake:')"

# --- evidence: pane, submissions, daemon log -------------------------------------
"$REAL_TMUX" -L "$SOCKET" capture-pane -p -J -S -300 -t "$PANE" > "$OUT/supervisor-pane.txt" 2>/dev/null
stop_daemon
cut -f2,3 "$LOG_FILE" > "$OUT/supervisor-submissions.txt"
sed "s#$STATE_DIR/##g" "$STATE_DIR/.supervise-daemon.log" > "$OUT/supervise-daemon.log" 2>/dev/null

# --- E: the decision is not lost: a locked drain and the backlog hold -----------
note ""
note "== E. daemon stopped; a locked fm-wake-drain.sh run over the same state, and the backlog hold"
env -u TMUX -u TMUX_PANE -u HERDR_ENV -u HERDR_PANE_ID PATH="$SHIM:$PATH" \
  FM_HOME="$HOME_DIR" FM_STATE_OVERRIDE="$STATE_DIR" \
  FM_DATA_OVERRIDE="$HOME_DIR/data" FM_CONFIG_OVERRIDE="$HOME_DIR/config" \
  "$DRAIN" > "$OUT/drain.out" 2> "$OUT/drain.err"
note "  drain exit: $?"
note "  OPEN DECISIONS lines naming decision-task: $(grep -A20 '^OPEN DECISIONS' "$OUT/drain.out" | grep -c 'decision-task')"
grep -A20 '^OPEN DECISIONS' "$OUT/drain.out" | grep 'decision-task\|^OPEN DECISIONS' | sed 's/^/    /' | tee -a "$SUMMARY"
hold_cmd open decision-task >/dev/null 2>&1
note "  backlog captain hold on decision-task still open after the run: exit $? (0 = open)"
note ""
note "== supervisor submissions (verbatim text, classification):"
sed "s#$STATE_DIR/##g" "$OUT/supervisor-submissions.txt" | sed 's/^/    /' | tee -a "$SUMMARY"
```
</details>
<details>
<summary>Evidence: Target commit, 20s catch-all: live run summary (queued row escalates by itself; backlog hold survives)</summary>

Source: [Target commit, 20s catch-all: live run summary (queued row escalates by itself; backlog hold survives)](https://github.com/tiago-peixoto/firstmate/blob/a20d98eddd65dcd31a1dac9a9295f03f1e629171/.no-mistakes/evidence/fm/firstmate-upstream-decision-wake-dedupe/live-target-slowscan.run.log)

```text
== [target] captain hold placed on backlog row decision-task: exit 0
   hold open before the daemon starts: exit 0 (0 = open)
== [target] real daemon pid 13067 up; afk on; catch-all scan every 20s, watcher poll 1s

== A. crewmate writes a keyed needs-decision; status then stays unchanged for 35s
  queued rows handled as needs-decision:    1
  escalated by the queued row itself:       1
  supervisor submissions naming the task:   1
  ...tagged (catch-all scan):               0
  ...labelled 'unknown wake:':              0
  ...carrying the decision text:            1

== B. crewmate appends a changed decision; then unchanged for 30s
  new submissions naming the task:          1
  ...carrying the changed decision text:    1
  ...labelled 'unknown wake:' (all time):   0
  escalated by the queued row (all time):   2

== C. a task's only new line is a captain-held [key=...] transfer; watch 30s
  queued rows handled as needs-decision:    1
  daemon self-handled those rows:           1
  supervisor submissions naming held-task:  0

== D. ordinary signals: a routine working: note, then a done: line
  routine rows handled as signal:           2
  supervisor submissions naming routine:    0
  escalated by the queued signal row:       1
  supervisor submissions naming done-task:  1
  ...carrying the done line:                1
  ...labelled 'unknown wake:':              0

== E. daemon stopped; a locked fm-wake-drain.sh run over the same state, and the backlog hold
  drain exit: 0
  OPEN DECISIONS lines naming decision-task: 1
    OPEN DECISIONS (still open, folded from the durable status logs - not just the latest line):
    decision-task [key=release] needs-decision: pick A, C, or D
    OPEN DECISIONS: close one by answering it: bin/fm-send.sh <task> --resolve-key <key> '<answer>'
  backlog captain hold on decision-task still open after the run: exit 0 (0 = open)

== supervisor submissions (verbatim text, classification):
    ⁣FIRSTMATE_OP: v1 away-supervisor: Supervisor escalate (       1 event(s)): decision-task.status: needs-decision [key=release]: pick A or B (pre-read; re-arm not needed — watcher daemon-managed)	injection
    ⁣FIRSTMATE_OP: v1 away-supervisor: Supervisor escalate (       1 event(s)): decision-task.status: needs-decision [key=release]: pick A, C, or D (pre-read; re-arm not needed — watcher daemon-managed)	injection
    ⁣FIRSTMATE_OP: v1 away-supervisor: Supervisor escalate (       1 event(s)): done-task.status: done: PR https://example.test/pull/1 (pre-read; re-arm not needed — watcher daemon-managed)	injection
exit=0
```
</details>
<details>
<summary>Evidence: Base 527aa7c, 20s catch-all: live run summary (unknown wake followed by a catch-all repeat)</summary>

Source: [Base 527aa7c, 20s catch-all: live run summary (unknown wake followed by a catch-all repeat)](https://github.com/tiago-peixoto/firstmate/blob/a20d98eddd65dcd31a1dac9a9295f03f1e629171/.no-mistakes/evidence/fm/firstmate-upstream-decision-wake-dedupe/live-base-slowscan.run.log)

```text
== [base] captain hold placed on backlog row decision-task: exit 0
   hold open before the daemon starts: exit 0 (0 = open)
== [base] real daemon pid 18734 up; afk on; catch-all scan every 20s, watcher poll 1s

== A. crewmate writes a keyed needs-decision; status then stays unchanged for 35s
  queued rows handled as needs-decision:    1
  escalated by the queued row itself:       1
  supervisor submissions naming the task:   2
  ...tagged (catch-all scan):               1
  ...labelled 'unknown wake:':              1
  ...carrying the decision text:            1

== B. crewmate appends a changed decision; then unchanged for 30s
  new submissions naming the task:          2
  ...carrying the changed decision text:    1
  ...labelled 'unknown wake:' (all time):   2
  escalated by the queued row (all time):   2

== C. a task's only new line is a captain-held [key=...] transfer; watch 30s
  queued rows handled as needs-decision:    1
  daemon self-handled those rows:           0
  supervisor submissions naming held-task:  1

== D. ordinary signals: a routine working: note, then a done: line
  routine rows handled as signal:           2
  supervisor submissions naming routine:    0
  escalated by the queued signal row:       1
  supervisor submissions naming done-task:  1
  ...carrying the done line:                1
  ...labelled 'unknown wake:':              0

== E. daemon stopped; a locked fm-wake-drain.sh run over the same state, and the backlog hold
  drain exit: 0
  OPEN DECISIONS lines naming decision-task: 1
    OPEN DECISIONS (still open, folded from the durable status logs - not just the latest line):
    decision-task [key=release] needs-decision: pick A, C, or D
    OPEN DECISIONS: close one by answering it: bin/fm-send.sh <task> --resolve-key <key> '<answer>'
  backlog captain hold on decision-task still open after the run: exit 0 (0 = open)

== supervisor submissions (verbatim text, classification):
    ⁣FIRSTMATE_OP: v1 away-supervisor: Supervisor escalate (       1 event(s)): unknown wake: needs-decision: decision-task.status (pre-read; re-arm not needed — watcher daemon-managed)	injection
    ⁣FIRSTMATE_OP: v1 away-supervisor: Supervisor escalate (       1 event(s)): decision-task.status: needs-decision [key=release]: pick A or B (catch-all scan) (pre-read; re-arm not needed — watcher daemon-managed)	injection
    ⁣FIRSTMATE_OP: v1 away-supervisor: Supervisor escalate (       1 event(s)): unknown wake: needs-decision: decision-task.status (pre-read; re-arm not needed — watcher daemon-managed)	injection
    ⁣FIRSTMATE_OP: v1 away-supervisor: Supervisor escalate (       1 event(s)): decision-task.status: needs-decision [key=release]: pick A, C, or D (catch-all scan) (pre-read; re-arm not needed — watcher daemon-managed)	injection
    ⁣FIRSTMATE_OP: v1 away-supervisor: Supervisor escalate (       1 event(s)): unknown wake: needs-decision: held-task.status (pre-read; re-arm not needed — watcher daemon-managed)	injection
    ⁣FIRSTMATE_OP: v1 away-supervisor: Supervisor escalate (       1 event(s)): done-task.status: done: PR https://example.test/pull/1 (pre-read; re-arm not needed — watcher daemon-managed)	injection
exit=0
```
</details>
<details>
<summary>Evidence: Target commit, 20s catch-all: verbatim supervisor-pane submissions</summary>

Source: [Target commit, 20s catch-all: verbatim supervisor-pane submissions](https://github.com/tiago-peixoto/firstmate/blob/a20d98eddd65dcd31a1dac9a9295f03f1e629171/.no-mistakes/evidence/fm/firstmate-upstream-decision-wake-dedupe/live-target-slowscan/supervisor-submissions.txt)

```text
⁣FIRSTMATE_OP: v1 away-supervisor: Supervisor escalate (       1 event(s)): decision-task.status: needs-decision [key=release]: pick A or B (pre-read; re-arm not needed — watcher daemon-managed)	injection
⁣FIRSTMATE_OP: v1 away-supervisor: Supervisor escalate (       1 event(s)): decision-task.status: needs-decision [key=release]: pick A, C, or D (pre-read; re-arm not needed — watcher daemon-managed)	injection
⁣FIRSTMATE_OP: v1 away-supervisor: Supervisor escalate (       1 event(s)): done-task.status: done: PR https://example.test/pull/1 (pre-read; re-arm not needed — watcher daemon-managed)	injection
```
</details>
<details>
<summary>Evidence: Base 527aa7c, 20s catch-all: verbatim supervisor-pane submissions</summary>

Source: [Base 527aa7c, 20s catch-all: verbatim supervisor-pane submissions](https://github.com/tiago-peixoto/firstmate/blob/a20d98eddd65dcd31a1dac9a9295f03f1e629171/.no-mistakes/evidence/fm/firstmate-upstream-decision-wake-dedupe/live-base-slowscan/supervisor-submissions.txt)

```text
⁣FIRSTMATE_OP: v1 away-supervisor: Supervisor escalate (       1 event(s)): unknown wake: needs-decision: /var/folders/r8/cylyt7xd7t50y9x5wc05my380000gn/T//fm-nd-live.P1r7Lw/home/state/decision-task.status (pre-read; re-arm not needed — watcher daemon-managed)	injection
⁣FIRSTMATE_OP: v1 away-supervisor: Supervisor escalate (       1 event(s)): decision-task.status: needs-decision [key=release]: pick A or B (catch-all scan) (pre-read; re-arm not needed — watcher daemon-managed)	injection
⁣FIRSTMATE_OP: v1 away-supervisor: Supervisor escalate (       1 event(s)): unknown wake: needs-decision: /var/folders/r8/cylyt7xd7t50y9x5wc05my380000gn/T//fm-nd-live.P1r7Lw/home/state/decision-task.status (pre-read; re-arm not needed — watcher daemon-managed)	injection
⁣FIRSTMATE_OP: v1 away-supervisor: Supervisor escalate (       1 event(s)): decision-task.status: needs-decision [key=release]: pick A, C, or D (catch-all scan) (pre-read; re-arm not needed — watcher daemon-managed)	injection
⁣FIRSTMATE_OP: v1 away-supervisor: Supervisor escalate (       1 event(s)): unknown wake: needs-decision: /var/folders/r8/cylyt7xd7t50y9x5wc05my380000gn/T//fm-nd-live.P1r7Lw/home/state/held-task.status (pre-read; re-arm not needed — watcher daemon-managed)	injection
⁣FIRSTMATE_OP: v1 away-supervisor: Supervisor escalate (       1 event(s)): done-task.status: done: PR https://example.test/pull/1 (pre-read; re-arm not needed — watcher daemon-managed)	injection
```
</details>
<details>
<summary>Evidence: Target commit, 20s catch-all: daemon log</summary>

Source: [Target commit, 20s catch-all: daemon log](https://github.com/tiago-peixoto/firstmate/blob/a20d98eddd65dcd31a1dac9a9295f03f1e629171/.no-mistakes/evidence/fm/firstmate-upstream-decision-wake-dedupe/live-target-slowscan/supervise-daemon.log)

```text
[2026-09-10T14:33:15-0300] daemon starting (pid 13067); target=%0; target_source=FM_SUPERVISOR_TARGET; backend=tmux; backend_source=FM_SUPERVISOR_BACKEND; afk=on; inject_skip='heartbeat'; stale_escalate=999999s; batch=0s
[2026-09-10T14:33:22-0300] wake: signal: decision-task.status
[2026-09-10T14:33:24-0300] escalate: needs-decision: decision-task.status -> decision-task.status: needs-decision [key=release]: pick A or B
[2026-09-10T14:34:03-0300] wake: signal: decision-task.status
[2026-09-10T14:34:04-0300] escalate: needs-decision: decision-task.status -> decision-task.status: needs-decision [key=release]: pick A, C, or D
[2026-09-10T14:34:39-0300] wake: signal: held-task.status
[2026-09-10T14:34:40-0300] self-handle: needs-decision: held-task.status -> routine signal: held-task.status: captain-held [key=route]: tracked by task-decision-route
[2026-09-10T14:35:10-0300] wake: signal: routine-task.status
[2026-09-10T14:35:11-0300] self-handle: signal: routine-task.status -> routine signal: routine-task.status: working: still going
[2026-09-10T14:35:24-0300] wake: signal: done-task.status
[2026-09-10T14:35:26-0300] escalate: signal: done-task.status -> done-task.status: done: PR https://example.test/pull/1
[2026-09-10T14:35:54-0300] daemon shutting down
```
</details>
<details>
<summary>Evidence: Target commit, 3s catch-all: live run summary</summary>

Source: [Target commit, 3s catch-all: live run summary](https://github.com/tiago-peixoto/firstmate/blob/a20d98eddd65dcd31a1dac9a9295f03f1e629171/.no-mistakes/evidence/fm/firstmate-upstream-decision-wake-dedupe/live-target/summary.txt)

```text
== [target] real daemon pid 25724 up; afk on; catch-all scan every 3s, watcher poll 1s

== A. crewmate writes a keyed needs-decision; status then stays unchanged for 30s
  queued rows handled as needs-decision:    1
  supervisor submissions naming the task:   1
  ...labelled 'unknown wake:':              0
  ...carrying the decision text:            1

== B. crewmate appends a changed decision; then unchanged for 20s
  new submissions naming the task:          1
  ...carrying the changed decision text:    1
  ...labelled 'unknown wake:' (all time):   0

== C. a task's only new line is a captain-held [key=...] transfer; watch 25s
  queued rows handled as needs-decision:    1
  daemon self-handled those rows:           1
  supervisor submissions naming held-task:  0

== D. ordinary signals: a routine working: note, then a done: line
  routine rows handled as signal:           2
  supervisor submissions naming routine:    0
  supervisor submissions naming done-task:  1
  ...carrying the done line:                1
  ...labelled 'unknown wake:':              0

== E. daemon stopped; a locked fm-wake-drain.sh run over the same state
  drain exit: 0
  OPEN DECISIONS lines naming decision-task: 1
    OPEN DECISIONS (still open, folded from the durable status logs - not just the latest line):
    decision-task [key=release] needs-decision: pick A, C, or D
    OPEN DECISIONS: close one by answering it: bin/fm-send.sh <task> --resolve-key <key> '<answer>'

== supervisor submissions (verbatim text, classification):
    ⁣FIRSTMATE_OP: v1 away-supervisor: Supervisor escalate (       1 event(s)): decision-task.status: needs-decision [key=release]: pick A or B (catch-all scan) (pre-read; re-arm not needed — watcher daemon-managed)	injection
    ⁣FIRSTMATE_OP: v1 away-supervisor: Supervisor escalate (       1 event(s)): decision-task.status: needs-decision [key=release]: pick A, C, or D (catch-all scan) (pre-read; re-arm not needed — watcher daemon-managed)	injection
    ⁣FIRSTMATE_OP: v1 away-supervisor: Supervisor escalate (       1 event(s)): done-task.status: done: PR https://example.test/pull/1 (catch-all scan) (pre-read; re-arm not needed — watcher daemon-managed)	injection
```
</details>
<details>
<summary>Evidence: Target commit, 3s catch-all: supervisor pane capture</summary>

Source: [Target commit, 3s catch-all: supervisor pane capture](https://github.com/tiago-peixoto/firstmate/blob/a20d98eddd65dcd31a1dac9a9295f03f1e629171/.no-mistakes/evidence/fm/firstmate-upstream-decision-wake-dedupe/live-target/supervisor-pane.txt)

```text
bash '/var/folders/r8/cylyt7xd7t50y9x5wc05my380000gn/T//fm-nd-shim.3QJFVb/supervisor-loop.sh' '/var/folders/r8/cylyt7xd7t50y9x5wc05my380000gn/T//fm-nd-live.Hv4MT7/submitted.log'
tiago@Tiagos-MBP 01M263CKW1B1H9FH3A4RFJQJ79 % bash '/var/folders/r8/cylyt7xd7t50y9x5wc05my380000gn/T//fm-nd-shim.3QJFVb/supervisor-loop.sh' '/var/folders/r8/cylyt7xd7t50y9x5wc05my380000gn/T//fm-nd-live.Hv4MT7/submitted.log'
FIRSTMATE_OP: v1 away-supervisor: Supervisor escalate (       1 event(s)): decision-task.status: needs-decision [key=release]: pick A or B (catch-all scan) (pre-read; re-arm not needed — watcher daemon-managed)
FIRSTMATE_OP: v1 away-supervisor: Supervisor escalate (       1 event(s)): decision-task.status: needs-decision [key=release]: pick A, C, or D (catch-all scan) (pre-read; re-arm not needed — watcher daemon-managed)
FIRSTMATE_OP: v1 away-supervisor: Supervisor escalate (       1 event(s)): done-task.status: done: PR https://example.test/pull/1 (catch-all scan) (pre-read; re-arm not needed — watcher daemon-managed)
❯ 
```
</details>
<details>
<summary>Evidence: Base 527aa7c, 3s catch-all: live run summary</summary>

Source: [Base 527aa7c, 3s catch-all: live run summary](https://github.com/tiago-peixoto/firstmate/blob/a20d98eddd65dcd31a1dac9a9295f03f1e629171/.no-mistakes/evidence/fm/firstmate-upstream-decision-wake-dedupe/live-base/summary.txt)

```text
== [base] real daemon pid 29795 up; afk on; catch-all scan every 3s, watcher poll 1s

== A. crewmate writes a keyed needs-decision; status then stays unchanged for 30s
  queued rows handled as needs-decision:    1
  supervisor submissions naming the task:   2
  ...labelled 'unknown wake:':              1
  ...carrying the decision text:            1

== B. crewmate appends a changed decision; then unchanged for 20s
  new submissions naming the task:          2
  ...carrying the changed decision text:    1
  ...labelled 'unknown wake:' (all time):   2

== C. a task's only new line is a captain-held [key=...] transfer; watch 25s
  queued rows handled as needs-decision:    1
  daemon self-handled those rows:           0
  supervisor submissions naming held-task:  1

== D. ordinary signals: a routine working: note, then a done: line
  routine rows handled as signal:           2
  supervisor submissions naming routine:    0
  supervisor submissions naming done-task:  1
  ...carrying the done line:                1
  ...labelled 'unknown wake:':              0

== E. daemon stopped; a locked fm-wake-drain.sh run over the same state
  drain exit: 0
  OPEN DECISIONS lines naming decision-task: 1
    OPEN DECISIONS (still open, folded from the durable status logs - not just the latest line):
    decision-task [key=release] needs-decision: pick A, C, or D
    OPEN DECISIONS: close one by answering it: bin/fm-send.sh <task> --resolve-key <key> '<answer>'

== supervisor submissions (verbatim text, classification):
    ⁣FIRSTMATE_OP: v1 away-supervisor: Supervisor escalate (       1 event(s)): decision-task.status: needs-decision [key=release]: pick A or B (catch-all scan) (pre-read; re-arm not needed — watcher daemon-managed)	injection
    ⁣FIRSTMATE_OP: v1 away-supervisor: Supervisor escalate (       1 event(s)): unknown wake: needs-decision: /var/folders/r8/cylyt7xd7t50y9x5wc05my380000gn/T//fm-nd-live.f9040K/decision-task.status (pre-read; re-arm not needed — watcher daemon-managed)	injection
    ⁣FIRSTMATE_OP: v1 away-supervisor: Supervisor escalate (       1 event(s)): decision-task.status: needs-decision [key=release]: pick A, C, or D (catch-all scan) (pre-read; re-arm not needed — watcher daemon-managed)	injection
    ⁣FIRSTMATE_OP: v1 away-supervisor: Supervisor escalate (       1 event(s)): unknown wake: needs-decision: /var/folders/r8/cylyt7xd7t50y9x5wc05my380000gn/T//fm-nd-live.f9040K/decision-task.status (pre-read; re-arm not needed — watcher daemon-managed)	injection
    ⁣FIRSTMATE_OP: v1 away-supervisor: Supervisor escalate (       1 event(s)): unknown wake: needs-decision: /var/folders/r8/cylyt7xd7t50y9x5wc05my380000gn/T//fm-nd-live.f9040K/held-task.status (pre-read; re-arm not needed — watcher daemon-managed)	injection
    ⁣FIRSTMATE_OP: v1 away-supervisor: Supervisor escalate (       1 event(s)): done-task.status: done: PR https://example.test/pull/1 (catch-all scan) (pre-read; re-arm not needed — watcher daemon-managed)	injection
```
</details>
<details>
<summary>Evidence: Same flow with a 20s catch-all: this commit vs base</summary>

```text
Phase A (keyed needs-decision, then unchanged 35s)
target: submissions=1 escalated-by-queued-row=1 tagged-catch-all=0 unknown-wake=0
base: submissions=2 escalated-by-queued-row=1 tagged-catch-all=1 unknown-wake=1
Phase B (decision changes, then unchanged 30s)
target: new submissions=1 unknown-wake(all)=0
base: new submissions=2 unknown-wake(all)=2
Phase E
target: OPEN DECISIONS lists 'decision-task [key=release] needs-decision: pick A, C, or D'; backlog captain hold still open (exit 0)
```
</details>

- Evidence: [Targeted daemon test file output](https://github.com/tiago-peixoto/firstmate/blob/a20d98eddd65dcd31a1dac9a9295f03f1e629171/.no-mistakes/evidence/fm/firstmate-upstream-decision-wake-dedupe/fm-daemon.test.log)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"f94f29314ef3d8a4f3358ecb4bd92e6f0a893076","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed (2) ✅</summary>

- ⚠️ `bin/fm-supervise-daemon.sh:1347` - The intent requires that &#34;a decision-owned wake whose underlying status content has not changed escalates once ... and is presented as the decision&#34;. The change sends every `needs-decision:*` row through `classify_signal`. That function only escalates on span rc=0 or on a captain-relevant last line, so one of the three decision-owned classes now never escalates at all.

Concrete sequence:
1. During afk, a task&#39;s status log gains only `captain-held [key=route]: tracked by task-decision-route`. This is the fixture used by tests/fm-pi-watch-extension.test.sh:826.
2. `status_span_first_actionable_record` (fm-classify-lib.sh:1701-1706) sets the decision-owned side-band flag but returns rc=1.
3. The watcher (fm-watch.sh:1545-1550, 2071) treats that as actionable and enqueues the row with payload `needs-decision: /state/task.status`.
4. The new arm calls `classify_signal`. The last line is `captain-held`, which `status_is_captain_relevant` explicitly rejects (fm-classify-lib.sh:161-164, pinned by tests/fm-daemon.test.sh:832). So the result is `self|routine signal: task.status: captain-held ...`.
5. `mark_escalated_seen` then commits the daemon offset, so the per-wake path and the catch-all scan never escalate it.
6. Housekeeping&#39;s pause re-surface also skips captain-held while an afk contract is present (fm-supervise-daemon.sh:1120).

Net effect: under afk this decision-owned class goes from &#34;escalated every poll as `unknown wake:`&#34; (base) to &#34;never escalated&#34;. The criterion requires exactly one escalation, labelled as the decision. The hold itself is not lost, because it stays in the backlog.

This may be the intended &#34;restore&#34;: before d6660d7, captain-held rows were ordinary `signal:` rows that the daemon self-handled as routine, and the supervisor usually created the hold itself. The new test only covers the `needs-decision` verb and does not pin either outcome. Please decide whether captain-held decision-owned rows should escalate once.

The remedy needs your approval, not the defect. Making them escalate once would add new classification behavior, for example a captain-held branch in `classify_signal` keyed on the needs-decision payload. Keeping the current behavior should come with a test that pins captain-held rows as intentionally self-handled.

🔧 Fix applied.
2 issues (1 warning, 1 info) still open:

- ⚠️ `bin/fm-supervise-daemon.sh:398` - The fix round&#39;s captain-held escalation (`elif [ -n &#34;$owned&#34; ] &amp;&amp; [ -n &#34;$held&#34; ]`) only fires if the `needs-decision:` row is the first path to commit the daemon&#39;s per-task offset. Two reachable paths commit a captain-held-only span silently first. In both, the instruction &#34;Every decision-owned queued row must escalate exactly once&#34; still fails, and the result is zero escalations. At base these rows escalated as `unknown wake:`.

(a) An ordinary row from the same batch. The watcher builds one `files` list per batch (fm-watch.sh:2020-2027), and every row&#39;s payload carries that whole list. Only the decision-owned file&#39;s row is marked `needs-decision:`. Rows are appended in scan_signals glob order (fm-watch.sh:1357), and the drain keeps queue order. Take a batch where A.status gained a routine `working:` line and B.status gained only `captain-held [key=route]: tracked by ...`:
1. Row A (`signal: A B`) runs `classify_signal` with owned=&#34;&#34;. For B, rc=1 and needs=1, so held=1, but owned is empty. The result is `self|routine signal`.
2. handle_wake&#39;s self path (fm-supervise-daemon.sh:1476-1477) calls `mark_escalated_seen`, which commits B&#39;s endpoint.
3. Row B (`needs-decision: A B`) now reads B from start&gt;=size. The span function sets needs=0, held stays empty, and the row is self-handled.

(b) A catch-all race. Housekeeping&#39;s heartbeat scan commits every rc=1 span (fm-supervise-daemon.sh:1204). A captain-held line becomes a queued row only after up to POLL (15s) plus SIGNAL_GRACE (30s). Housekeeping keeps running while the watcher child is alive. If the 300s catch-all lands inside that window, which is roughly 15% of events at the default settings, it commits B&#39;s offset. The later `needs-decision:` row then self-handles.

The new test uses a single-file batch with no scan in between, so it passes despite both gaps. For the invariant to hold, every path that advances the daemon&#39;s status offset must treat a captain-held-only span (side-band needs=1 with rc=1) the same way. Two options:
- Non-owned paths (ordinary `signal:` rows and the catch-all) leave such a span uncommitted.
- All paths classify it per file instead of per row payload.

Either option changes ordinary `signal:` or catch-all behavior, which your fix instructions asked to keep. The remedy, not the defect, needs your decision.
- ℹ️ `bin/fm-supervise-daemon.sh:399` - The held path labels the digest `captain-held decision: &lt;file&gt;: &lt;last status line&gt;` for every file in the payload, instead of listing the captain-held transfer lines in the new span.

`complete` appends one captain-held line per still-open key (fm-captain-hold.sh:1622-1631). For an origin with open keys a and b, the digest reads `captain-held decision: origin.status: captain-held [key=b]: tracked by ...` and never names key=a. If a routine line lands after the transfer in the same span, the label shows that routine line instead. Other files in the payload also appear under the same prefix.

The hold task ids still appear in `tracked by`, and the decision stays in the backlog and in OPEN DECISIONS. This is a presentation gap only, noted for awareness.

🔧 Fix applied.
✅ Re-checked - no issues remain.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- Live validation: ✅ go - 7 of 7 scenarios driven live against the product

| Scenario | Result | Live | Evidence |
| --- | --- | --- | --- |
| A crewmate&#39;s keyed needs-decision stays unchanged under afk: the supervisor gets exactly one digest carrying the decision text, none labelled `unknown wake:`, and no repeat across later catch-all scan… | ✅ pass | live | live-target/summary.txt phase A (3s catch-all) and live-target-slowscan.run.log phase A (20s catch-all): 1 submission naming the task, 0 &#39;unknown wake:&#39;, carrying &#39;needs-decision [key=release]: pick A… |
| The queued `needs-decision:` row reads the span first and escalates by itself, labelled as the decision, and the later catch-all scan does not repeat it | ✅ pass | live | live-target-slowscan.run.log phase A: escalated by the queued row itself 1, supervisor submissions 1, tagged catch-all 0, no repeat over 35s that included a catch-all scan. |
| Adversarial baseline: the same live flow on base 527aa7c reproduces #4096. The queued row escalates as `unknown wake: needs-decision: &lt;path&gt;` and the next catch-all scan escalates the same unchanged d… | ✅ pass | live | live-base-slowscan.run.log phase A: 2 submissions, 1 labelled &#39;unknown wake:&#39;, 1 tagged catch-all. Phase B: 2 new submissions. live-base/summary.txt shows the same duplication with a 3s catch-all. |
| The crewmate appends a changed decision: the supervisor gets exactly one new digest with the new text and no repeat while it stays unchanged | ✅ pass | live | live-target/summary.txt and live-target-slowscan.run.log phase B: 1 new submission carrying &#39;needs-decision [key=release]: pick A, C, or D&#39;, 0 &#39;unknown wake:&#39;. Base produced 2. |
| A task whose only new line is `captain-held [key=route]: ...` produces a decision-owned row that the daemon self-handles with no escalation, now and across later scans (review round 2 decision) | ✅ pass | live | live-target and live-target-slowscan phase C: 1 queued row handled as needs-decision, 1 self-handled, 0 supervisor submissions naming held-task. Base escalated it as &#39;unknown wake: needs-decision: ...… |
| Ordinary signal wakes are unchanged: a routine `working:` note is self-handled silently and a `done:` line reaches the supervisor once, labelled with the done line | ✅ pass | live | live-target and live-target-slowscan phase D: 0 routine submissions. 1 done submission carrying &#39;done: PR https://example.test/pull/1&#39;, 0 &#39;unknown wake:&#39;. Identical on base. |
| Suppression does not lose the decision: a locked `fm-wake-drain.sh` still lists it under OPEN DECISIONS, and a real tasks-axi backlog captain hold on the task is still open after escalation and suppre… | ✅ pass | live | live-target-slowscan.run.log phase E: drain exit 0; OPEN DECISIONS lists &#39;decision-task [key=release] needs-decision: pick A, C, or D&#39;; &#39;backlog captain hold on decision-task still open after the run:… |

- <code>`bash tests/fm-daemon.test.sh`: targeted daemon test file, exit 0. Includes the new tests `test_needs_decision_queued_row_escalates_once_as_the_decision` and `test_captain_held_decision_owned_row_is_self_handled`.</code>
- <code>`bash live-decision-wake.sh &lt;worktree&gt; target live-target`: runs the real `bin/fm-supervise-daemon.sh` as a background process, with its real `fm-watch.sh` child and the real `fm-wake-drain.sh`, in afk mode. It uses a private tmux socket whose supervisor pane logs every submitted line verbatim. The catch-all scans every 3s. Phases: A needs-decision then unchanged, B changed decision, C captain-held-only row, D routine and done signals, E locked drain.</code>
- <code>`bash live-decision-wake.sh $TMPDIR/fm-base-527aa7c base live-base`: the identical live flow against a `git archive` export of base 527aa7c.</code>
- <code>`FM_LIVE_SCAN_SECS=20 bash live-decision-wake.sh &lt;worktree&gt; target live-target-slowscan`: the same flow with a 20s catch-all, so the queued row reads the span first. It runs in a throwaway firstmate home where a real `fm-captain-hold.sh hold decision-task` (tasks-axi) is placed before the daemon starts, and `fm-captain-hold.sh open decision-task` is re-checked after the run.</code>
- <code>`FM_LIVE_SCAN_SECS=20 bash live-decision-wake.sh $TMPDIR/fm-base-527aa7c base live-base-slowscan`: the same slow-scan flow on base 527aa7c.</code>
- <code>Captain-hold probe in a throwaway home: `fm-captain-hold.sh hold decision-task --reason ...` then `open decision-task`, both exit 0.</code>
</details>

<details>
<summary>🔧 **Document** - 1 issue found → auto-fixed ✅</summary>

- ℹ️ `bin/fm-watch.sh:2063` - The comment at bin/fm-watch.sh:2056-2064 names the Pi branch dispatcher as the only reader of the `needs-decision:` row payload and says &#34;Every other harness and script keeps seeing the exact same \&#34;signal:$files\&#34; wake it always has.&#34; That is wrong. `handle_durable_wakes` in bin/fm-supervise-daemon.sh:1491-1495 also reads the row payload and passes it to `handle_wake`, and after this change `handle_wake` has an explicit `needs-decision:*` arm. The same false assumption produced issue #4096. The fix would be one comment line naming the away daemon as a second consumer, pointing to the comment above `handle_wake`. I left it unedited because your review-round decisions say not to change the watcher script. Please decide whether a comment-only edit there is acceptable.

🔧 Fix applied.
✅ Re-checked - no issues remain.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>

