### PR TITLE
fix(backends): launch headless Zellij sessions via PowerShell on native Windows

### DIFF
--- a/bin/backends/zellij.sh
+++ b/bin/backends/zellij.sh
@@ -227,16 +227,49 @@ fm_backend_zellij_session_exists() {  # <session>
 # fm_backend_zellij_server_ensure: create the named session in the background,
 # headless (no attached client), if it does not already exist - mirrors
 # tmux's `tmux has-session || tmux new-session -d` and herdr's server_ensure.
-# Verified: `zellij attach -b <name>` with stdin redirected from /dev/null and
-# no controlling TTY creates the session and returns promptly (it cannot
-# actually attach without a TTY, so it exits after creating); running it again
-# against an EXISTING session prints "Session already exists" and exits 1 -
-# harmless here because existence is checked first and the launch is
-# backgrounded, its exit status never inspected.
+# On the default branch - everything but Git Bash/MSYS, Cygwin included,
+# whose real fork/setsid makes `&` detach properly - verified: `zellij attach
+# -b <name>` with stdin redirected from /dev/null and no controlling TTY
+# creates the session and returns promptly (it cannot actually attach without
+# a TTY, so it exits after creating); running it again against an EXISTING
+# session prints "Session already exists" and exits 1 - harmless here because
+# existence is checked first and the launch is backgrounded, its exit status
+# never inspected.
+#
+# On native Windows (Git Bash/MSYS, not Cygwin), that same command never
+# comes up: Git Bash's `&` backgrounding does not achieve real OS-level
+# process detachment the way a Unix double-fork/setsid does, so the
+# backgrounded zellij server is tied to the invoking bash process's lifetime
+# and dies the instant this one-shot function's subshell exits, before the
+# poll loop below ever finds it. Verified live by elimination on Windows 11
+# (Developer Mode on, Zellij 0.45.1): the identical `zellij attach -b <name>`
+# launched instead as a genuinely separate Windows process via PowerShell's
+# Start-Process persists independently and is found by `zellij list-sessions`
+# afterward, proving Zellij's own background-session support works fine there
+# - only this script's Unix-style backgrounding idiom does not survive. The
+# session name is interpolated into a single-quoted PowerShell string, so
+# that branch charset-guards it first even though it is normally only the
+# fixed default "firstmate" or an operator-supplied FM_ZELLIJ_SESSION
+# (fm_backend_zellij_session above), never arbitrary task-controlled content.
 fm_backend_zellij_server_ensure() {  # <session>
   local session=$1 i
   fm_backend_zellij_session_exists "$session" && return 0
-  ( nohup zellij attach -b "$session" </dev/null >/dev/null 2>&1 & ) || return 1
+  case "${OSTYPE:-}" in
+    msys*|mingw*)
+      case "$session" in
+        ''|*[!A-Za-z0-9._-]*)
+          echo "error: refusing zellij session name '$session' (must match [A-Za-z0-9._-]+)" >&2
+          return 1
+          ;;
+      esac
+      powershell.exe -NoProfile -NonInteractive -Command \
+        "Start-Process -FilePath 'zellij.exe' -ArgumentList 'attach','-b','$session' -WindowStyle Hidden" \
+        >/dev/null 2>&1 || return 1
+      ;;
+    *)
+      ( nohup zellij attach -b "$session" </dev/null >/dev/null 2>&1 & ) || return 1
+      ;;
+  esac
   for i in $(seq 1 20); do
     fm_backend_zellij_session_exists "$session" && return 0
     sleep 0.5

--- a/docs/verification/runtime-backends.md
+++ b/docs/verification/runtime-backends.md
@@ -1123,6 +1123,11 @@ tests/fm-backend-zellij-smoke.test.sh
 
 The real lifecycle smoke proved spawn, metadata, nested-subshell worktree discovery, send, capture, unlanded-work refusal, approved local landing, exact tab cleanup, and session cleanup without retaining task-specific ids or branch names here.
 
+### Windows (native, no WSL)
+
+On 2026-09-10, Windows 11 with Git Bash/MSYS and Zellij 0.45.1 verified that a PowerShell-launched headless Zellij session persists after its Git Bash launcher exits, unlike the prior `nohup ... &` background attempt.
+`tests/fm-backend-zellij.test.sh` pins that guarantee portably through forced `OSTYPE` fixtures because CI has no native Windows host.
+
 ## Orca
 
 Real readiness was verified against `/usr/local/bin/orca` with `/Applications/Orca.app` bundle version 1.4.116.

--- a/docs/zellij-backend.md
+++ b/docs/zellij-backend.md
@@ -20,6 +20,7 @@ A spawn stops before creating a session or acquiring a worktree when Zellij or `
 
 Firstmate uses one shared session named `firstmate` by default.
 `FM_ZELLIJ_SESSION` can select another name for isolated verification.
+On native Windows under Git Bash/MSYS or MinGW, the session name must match `[A-Za-z0-9._-]+`, because the headless session is launched through PowerShell there; every other platform accepts any name Zellij itself accepts.
 Attach with:
 
 ```sh

--- a/tests/fm-backend-zellij.test.sh
+++ b/tests/fm-backend-zellij.test.sh
@@ -429,6 +429,134 @@ test_server_ensure_skips_attach_when_already_exists() {
   pass "fm_backend_zellij_server_ensure: reuses an existing session without calling attach"
 }
 
+# make_windows_zellij_fakebin: a `zellij` + `powershell.exe` fake pair for the
+# native-Windows branch of fm_backend_zellij_server_ensure. Unlike
+# make_zellij_fakebin's static FM_ZELLIJ_SESSION_LIST, `zellij list-sessions`
+# here reads a session-membership file so the fake `powershell.exe` can
+# simulate the real Start-Process behavior of making the session actually come
+# up - the poll loop in fm_backend_zellij_server_ensure then observes it and
+# returns promptly instead of spinning out the full 10s timeout.
+make_windows_zellij_fakebin() {  # <dir> -> echoes fakebin dir
+  local dir=$1 fb="$1/fakebin"
+  mkdir -p "$fb"
+  cat > "$fb/zellij" <<'SH'
+#!/usr/bin/env bash
+set -u
+LOG="${FM_ZELLIJ_LOG:?}"
+{
+  printf 'zellij'
+  for a in "$@"; do printf '\x1f%s' "$a"; done
+  printf '\n'
+} >> "$LOG"
+if [ "${1:-}" = list-sessions ]; then
+  cat "${FM_ZELLIJ_SESSION_FILE:?}" 2>/dev/null
+  exit 0
+fi
+if [ "${1:-}" = attach ] && [ -n "${FM_ZELLIJ_ATTACH_STARTS_SESSION:-}" ]; then
+  printf '%s\n' "$3" >> "${FM_ZELLIJ_SESSION_FILE:?}"
+fi
+exit 0
+SH
+  chmod +x "$fb/zellij"
+  cat > "$fb/powershell.exe" <<'SH'
+#!/usr/bin/env bash
+set -u
+LOG="${FM_POWERSHELL_LOG:?}"
+{
+  for a in "$@"; do printf '\x1f%s' "$a"; done
+  printf '\n'
+} >> "$LOG"
+if [ -n "${FM_POWERSHELL_STARTS_SESSION:-}" ]; then
+  printf '%s\n' "$FM_POWERSHELL_STARTS_SESSION" >> "${FM_ZELLIJ_SESSION_FILE:?}"
+fi
+exit 0
+SH
+  chmod +x "$fb/powershell.exe"
+  printf '%s\n' "$fb"
+}
+
+test_server_ensure_uses_powershell_start_process_on_windows() {
+  # Git Bash's `&` backgrounding does not detach a process from the invoking
+  # bash's lifetime the way a Unix double-fork does, so the old `nohup ... &`
+  # session died with its one-shot invocation and never survived to be found -
+  # confirmed live on Windows 11. The fix launches via a genuinely separate
+  # Windows process (PowerShell's Start-Process) instead.
+  local dir fb session_file
+  dir="$TMP_ROOT/server-windows"; mkdir -p "$dir"
+  fb=$(make_windows_zellij_fakebin "$dir")
+  session_file="$dir/sessions"
+  : > "$session_file"
+  OSTYPE=msys PATH="$fb:$PATH" FM_ZELLIJ_LOG="$dir/zellij.log" FM_ZELLIJ_SESSION_FILE="$session_file" \
+    FM_POWERSHELL_LOG="$dir/powershell.log" FM_POWERSHELL_STARTS_SESSION=firstmate \
+    bash -c '. "$0/bin/backends/zellij.sh"; fm_backend_zellij_server_ensure firstmate' "$ROOT"
+  expect_code 0 $? "server_ensure should succeed on Windows once the PowerShell-launched session appears"
+  assert_contains "$(cat "$dir/powershell.log")" $'\x1f''-NoProfile' \
+    "server_ensure did not launch powershell.exe with -NoProfile on Windows"
+  assert_contains "$(cat "$dir/powershell.log")" "attach','-b','firstmate'" \
+    "server_ensure did not embed the session name in the PowerShell Start-Process argument list"
+  assert_not_contains "$(cat "$dir/zellij.log")" $'\x1f''attach' \
+    "server_ensure should not call zellij attach directly on Windows - only powershell.exe should"
+  pass "fm_backend_zellij_server_ensure: launches the headless session via PowerShell Start-Process on native Windows"
+}
+
+test_server_ensure_refuses_unsafe_session_name_on_windows() {
+  local dir fb out status
+  dir="$TMP_ROOT/server-windows-unsafe"; mkdir -p "$dir"
+  fb=$(make_windows_zellij_fakebin "$dir")
+  : > "$dir/powershell.log"
+  out=$( OSTYPE=msys PATH="$fb:$PATH" FM_ZELLIJ_LOG="$dir/zellij.log" FM_ZELLIJ_SESSION_FILE="$dir/sessions" \
+    FM_POWERSHELL_LOG="$dir/powershell.log" \
+    bash -c '. "$0/bin/backends/zellij.sh"; fm_backend_zellij_server_ensure "$1"' "$ROOT" "firstmate'; Remove-Item C:\\" 2>&1 )
+  status=$?
+  [ "$status" -ne 0 ] || fail "server_ensure should refuse a session name containing a single quote"
+  assert_contains "$out" "refusing zellij session name" "server_ensure did not report the charset refusal"
+  [ ! -s "$dir/powershell.log" ] || fail "server_ensure invoked powershell.exe despite an unsafe session name"
+  pass "fm_backend_zellij_server_ensure: refuses an unsafe session name before ever building the PowerShell command"
+}
+
+test_server_ensure_uses_nohup_on_cygwin() {
+  # Cygwin implements real fork/setsid, so `&` detaches properly there and it
+  # never had the Git Bash backgrounding problem - it also frequently has no
+  # powershell.exe on PATH, so routing it through Start-Process would break a
+  # working platform. Same platform boundary as the lock fix's own
+  # fm_lock_legacy_dir_platform.
+  local dir fb session_file
+  dir="$TMP_ROOT/server-cygwin"; mkdir -p "$dir"
+  fb=$(make_windows_zellij_fakebin "$dir")
+  session_file="$dir/sessions"
+  : > "$session_file"
+  : > "$dir/powershell.log"
+  OSTYPE=cygwin PATH="$fb:$PATH" FM_ZELLIJ_LOG="$dir/zellij.log" FM_ZELLIJ_SESSION_FILE="$session_file" \
+    FM_POWERSHELL_LOG="$dir/powershell.log" FM_ZELLIJ_ATTACH_STARTS_SESSION=1 \
+    bash -c '. "$0/bin/backends/zellij.sh"; fm_backend_zellij_server_ensure firstmate' "$ROOT"
+  expect_code 0 $? "server_ensure should succeed on Cygwin via the unchanged nohup-based launch"
+  assert_contains "$(cat "$dir/zellij.log")" $'\x1f''attach' \
+    "server_ensure did not launch zellij attach directly on Cygwin"
+  [ ! -s "$dir/powershell.log" ] || fail "server_ensure routed Cygwin through powershell.exe instead of nohup"
+  pass "fm_backend_zellij_server_ensure: keeps the nohup-based launch on Cygwin, unlike MSYS/MinGW"
+}
+
+test_server_ensure_accepts_unusual_session_name_off_windows() {
+  # The charset guard exists only because the Windows branch interpolates the
+  # name into a single-quoted PowerShell string. The nohup branch passes it
+  # through ordinary shell quoting, so names zellij itself accepts (spaces,
+  # `+`, `@`, ...) must keep working there.
+  local dir fb session_file
+  dir="$TMP_ROOT/server-posix-odd-name"; mkdir -p "$dir"
+  fb=$(make_windows_zellij_fakebin "$dir")
+  session_file="$dir/sessions"
+  : > "$session_file"
+  : > "$dir/powershell.log"
+  OSTYPE=linux-gnu PATH="$fb:$PATH" FM_ZELLIJ_LOG="$dir/zellij.log" FM_ZELLIJ_SESSION_FILE="$session_file" \
+    FM_POWERSHELL_LOG="$dir/powershell.log" FM_ZELLIJ_ATTACH_STARTS_SESSION=1 \
+    bash -c '. "$0/bin/backends/zellij.sh"; fm_backend_zellij_server_ensure "$1"' "$ROOT" 'fm smoke+1'
+  expect_code 0 $? "server_ensure should accept a space-bearing session name on the nohup-based branch"
+  assert_contains "$(cat "$dir/zellij.log")" $'\x1f''fm smoke+1' \
+    "server_ensure did not pass the session name through verbatim on the nohup-based branch"
+  [ ! -s "$dir/powershell.log" ] || fail "server_ensure invoked powershell.exe on a non-Windows OSTYPE"
+  pass "fm_backend_zellij_server_ensure: accepts session names outside the PowerShell charset off Windows"
+}
+
 # --- dispatch wiring (fm-backend.sh) ------------------------------------------
 
 test_dispatch_routes_zellij_backend() {
@@ -1315,6 +1443,10 @@ test_resolve_bare_selector_refuses_cross_session_ambiguous_untagged
 test_session_exists_true_when_listed
 test_session_exists_false_when_absent
 test_server_ensure_skips_attach_when_already_exists
+test_server_ensure_uses_powershell_start_process_on_windows
+test_server_ensure_refuses_unsafe_session_name_on_windows
+test_server_ensure_uses_nohup_on_cygwin
+test_server_ensure_accepts_unusual_session_name_off_windows
 test_dispatch_routes_zellij_backend
 test_dispatch_busy_state_unknown_for_zellij
 test_create_task_refuses_duplicate_label


### PR DESCRIPTION
## Intent

`fm_backend_zellij_server_ensure` in `bin/backends/zellij.sh` launches a headless Zellij session with `( nohup zellij attach -b "$session" </dev/null >/dev/null 2>&1 & )`. On native Windows (Git Bash/MSYS, not Cygwin), this session never comes up, even though Zellij itself is fully functional there.

## Root cause

Git Bash's `&` backgrounding does not achieve real OS-level process detachment the way a Unix double-fork/`setsid` does. The backgrounded `zellij attach -b` process is tied to the invoking one-shot bash subshell's lifetime and dies the instant that subshell exits — before the poll loop that waits for the session to appear ever gets a chance to find it.

Verified live by elimination on Windows 11 (Git Bash, Zellij 0.45.1):
- The identical `zellij attach -b <name>` command, run interactively with an attached client, works fine (creates the session, renders correctly, exits cleanly).
- The same command launched instead as a genuinely separate Windows process via PowerShell's `Start-Process` persists independently, and `zellij list-sessions` finds it afterward.

This proves Zellij's own background-session support is fine on Windows — only this script's Unix-style backgrounding idiom fails to survive there.

## Fix

On `msys*`/`mingw*` only (Cygwin has a real fork/setsid and keeps the existing `nohup ... &` path, since it never had this bug to begin with), launch the headless session via `powershell.exe -NoProfile -NonInteractive -Command "Start-Process -FilePath 'zellij.exe' -ArgumentList 'attach','-b','$session' -WindowStyle Hidden"` instead. Since the session name is interpolated into a single-quoted PowerShell string, it is charset-guarded (`[A-Za-z0-9._-]+`) first — the session name is normally only the fixed default `"firstmate"` or an operator-supplied `FM_ZELLIJ_SESSION`, never arbitrary task-controlled content, but the guard is there regardless.

## Testing

Added to `tests/fm-backend-zellij.test.sh`:
- `fm_backend_zellij_server_ensure` launches via PowerShell `Start-Process` on a forced `OSTYPE=msys` fixture (fake `zellij`/`powershell.exe` binaries), and the session appearing in the simulated `list-sessions` output lets the existing poll loop return promptly.
- The same forced-Windows fixture refuses a session name containing a single quote before ever building the PowerShell command line, and never invokes `powershell.exe` in that case.
- A forced `OSTYPE=cygwin` fixture keeps the original `nohup`-based path, proving Cygwin is unaffected.
- A default (non-Windows) `OSTYPE` fixture still accepts a session name with a space, proving the charset guard is scoped to the Windows branch only.

Full suite: `tests/fm-backend-zellij.test.sh` — 68/68 passing.

Since this environment has no native Windows host, the Windows branch itself is exercised only through the forced-`OSTYPE` fixtures above; the actual PowerShell `Start-Process` behavior and the root-cause diagnosis were verified live on a real Windows 11 machine (Git Bash, Zellij 0.45.1) before writing this fix.

## Risk

Low: the change is fully scoped to native-Windows `fm_backend_zellij_server_ensure`, guarded by a narrow `OSTYPE` case that Cygwin and every non-Windows platform fall through unchanged, with an added defensive charset check that has no effect off Windows.
