### PR TITLE
test(herdr): cover agent exit-to-shell liveness

### DIFF
--- a/bin/fm-test-isolation-proof.sh
+++ b/bin/fm-test-isolation-proof.sh
@@ -138,6 +138,7 @@ exclusion_reason() {
     fm-backend-autodetect-smoke.test.sh|fm-backend-herdr-eventwait-smoke.test.sh|\
     fm-backend-herdr-presentation-e2e.test.sh|fm-backend-herdr-prune-safety-e2e.test.sh|\
     fm-backend-herdr-respawn-idem-e2e.test.sh|fm-backend-herdr-smoke.test.sh|\
+    fm-backend-herdr-agent-exit-shell-e2e.test.sh|\
     fm-backend-herdr-workspace-per-home-e2e.test.sh|fm-herdr-session-cleanup-e2e.test.sh)
       printf '%s\n' 'real Herdr-gated; Herdr lane is a later phase'
       ;;

--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -292,6 +292,7 @@ family_for_basename() {
     fm-backend-herdr-prune-safety-e2e.test.sh|fm-backend-herdr-respawn-idem-e2e.test.sh|\
     fm-backend-herdr-focus-flash-e2e.test.sh|\
     fm-backend-herdr-stale-active-tab-e2e.test.sh|\
+    fm-backend-herdr-agent-exit-shell-e2e.test.sh|\
     fm-herdr-session-cleanup-e2e.test.sh|\
     fm-backend-herdr-smoke.test.sh|fm-backend-herdr-workspace-per-home-e2e.test.sh|\
     fm-control-herdr-smoke.test.sh)

--- a/docs/herdr-backend.md
+++ b/docs/herdr-backend.md
@@ -185,7 +185,6 @@ Operational compromises:
 `tests/fm-herdr-session-cleanup-e2e.test.sh` covers the restored-shell cleanup in a guarded non-default named lab.
 `tests/fm-backend-herdr-focus-flash-e2e.test.sh` reproduces the raw explicit-close focus steal on the installed release and proves the focus-safe emptying-close plan removes a doomed workspace with no wrong-focus interval; [`verification/runtime-backends.md`](verification/runtime-backends.md#workspace-removal-focus-safety) owns the active versioned evidence.
 `tests/fm-backend-herdr-stale-active-tab-e2e.test.sh` proves a persisted-focused tab still closes when no foreground client is attached.
-`tests/fm-backend-herdr-agent-exit-shell-e2e.test.sh` proves `herdr agent get` distinguishes a Pi that exited to a leftover shell from a sibling live idle Pi, and that the recovery classifier follows `agent get` rather than a lagged `pane get` `.agent_status`.
 
 ## Default-tab prune safety
 
@@ -287,6 +286,7 @@ The generic Herdr agent-liveness probe reuses the same pane classifier, then app
 A structurally gone pane or a pane read from a session positively reported as having no running server becomes `missing`, a restored agent-less shell becomes `dead`, a registered agent becomes `alive`, and every other unexpected read becomes `unreadable`.
 The stopped-server exception does not widen husk detection or any close authority; those paths still refuse an unreadable pane.
 Unlike tmux process-name inspection, native registration can classify Pi without guessing from a generic interpreter name.
+`tests/fm-backend-herdr-agent-exit-shell-e2e.test.sh` pins the live-Pi versus leftover-shell distinction; [`verification/runtime-backends.md`](verification/runtime-backends.md#agent-lifecycle-control) owns the versioned evidence.
 
 The session-start sweep uses this probe.
 Mid-session secondmate agent-process liveness is not implemented because idle secondmates are deliberately exempt from stale-pane escalation and need a separate periodic identity signal.

--- a/docs/herdr-backend.md
+++ b/docs/herdr-backend.md
@@ -185,6 +185,7 @@ Operational compromises:
 `tests/fm-herdr-session-cleanup-e2e.test.sh` covers the restored-shell cleanup in a guarded non-default named lab.
 `tests/fm-backend-herdr-focus-flash-e2e.test.sh` reproduces the raw explicit-close focus steal on the installed release and proves the focus-safe emptying-close plan removes a doomed workspace with no wrong-focus interval; [`verification/runtime-backends.md`](verification/runtime-backends.md#workspace-removal-focus-safety) owns the active versioned evidence.
 `tests/fm-backend-herdr-stale-active-tab-e2e.test.sh` proves a persisted-focused tab still closes when no foreground client is attached.
+`tests/fm-backend-herdr-agent-exit-shell-e2e.test.sh` proves `herdr agent get` distinguishes a Pi that exited to a leftover shell from a sibling live idle Pi, and that the recovery classifier follows `agent get` rather than a lagged `pane get` `.agent_status`.
 
 ## Default-tab prune safety
 
@@ -353,6 +354,7 @@ tests/fm-backend-herdr-respawn-idem-e2e.test.sh
 tests/fm-backend-herdr-workspace-per-home-e2e.test.sh
 tests/fm-backend-herdr-launcher-workspace-e2e.test.sh
 tests/fm-backend-herdr-presentation-e2e.test.sh
+tests/fm-backend-herdr-agent-exit-shell-e2e.test.sh
 tests/fm-backend-herdr-eventwait-smoke.test.sh
 tests/fm-control-herdr-smoke.test.sh
 tests/fm-herdr-session-cleanup.test.sh

--- a/docs/verification/runtime-backends.md
+++ b/docs/verification/runtime-backends.md
@@ -1025,6 +1025,23 @@ ok - real herdr: an agent that does not stop fails closed instead of being repor
 The registry read through `herdr pane report-agent` is the same source `fm_backend_herdr_agent_state` classifies, so registering and not registering an agent on a plain shell pane exercises exactly the gate every lifecycle verb depends on, with no real agent launched.
 That command is the guard that refreshes this record; run it after every Herdr upgrade rather than trusting the version above.
 
+On Herdr 0.9.0, `herdr agent get` is live detection of the pane occupant, not a spawn-time registration that can outlive the process.
+A Pi launched as a child of the pane shell (not via `exec`) that then `/quit`s or is SIGKILL'd leaves the pane and shell in place, and `agent get` returns `agent_not_found`.
+A sibling live idle Pi stays `agent=pi` with `agent_status=idle`.
+`fm_backend_herdr_pane_agent_state` maps that `agent_not_found` leftover shell to `no-agent` and `fm_backend_herdr_agent_state` maps it to `dead` (relaunch-allowed), while the live idle pane stays `alive`.
+`herdr pane get` `.agent_status` can still read `idle` after the occupant is gone; liveness is `agent get`, never that pane field.
+
+```sh
+tests/fm-backend-herdr-agent-exit-shell-e2e.test.sh
+```
+
+Refresh that live pair after every Herdr upgrade. Observed 2026-09-10 on Herdr 0.9.0 / protocol 22 with Pi 0.82.0 in an isolated `fm-lab-` session:
+
+```text
+ok - agent get distinguishes leftover-shell (dead/no-agent) from live idle Pi
+ok - pane get agent_status lag cannot keep an exited occupant classified alive
+```
+
 ### Endpoint recovery classification
 
 Measured 2026-09-10 on macOS aarch64 against Herdr 0.9.0 (protocol 22) in an isolated `fm-lab-` session.

--- a/docs/verification/runtime-backends.md
+++ b/docs/verification/runtime-backends.md
@@ -1025,7 +1025,7 @@ ok - real herdr: an agent that does not stop fails closed instead of being repor
 The registry read through `herdr pane report-agent` is the same source `fm_backend_herdr_agent_state` classifies, so registering and not registering an agent on a plain shell pane exercises exactly the gate every lifecycle verb depends on, with no real agent launched.
 That command is the guard that refreshes this record; run it after every Herdr upgrade rather than trusting the version above.
 
-On Herdr 0.9.0, `herdr agent get` is live detection of the pane occupant, not a spawn-time registration that can outlive the process.
+For Pi on Herdr 0.9.0, `herdr agent get` reflects whether the agent process remains live; its registration does not persist merely because the pane and parent shell do.
 A Pi launched as a child of the pane shell (not via `exec`) that then `/quit`s or is SIGKILL'd leaves the pane and shell in place, and `agent get` returns `agent_not_found`.
 A sibling live idle Pi stays `agent=pi` with `agent_status=idle`.
 `fm_backend_herdr_pane_agent_state` maps that `agent_not_found` leftover shell to `no-agent` and `fm_backend_herdr_agent_state` maps it to `dead` (relaunch-allowed), while the live idle pane stays `alive`.

--- a/tests/fm-backend-herdr-agent-exit-shell-e2e.test.sh
+++ b/tests/fm-backend-herdr-agent-exit-shell-e2e.test.sh
@@ -1,0 +1,213 @@
+#!/usr/bin/env bash
+# Real-Herdr regression: `herdr agent get` (not `pane get` `.agent_status`)
+# distinguishes a Pi that exited to a leftover shell from a live idle Pi, so
+# the recovery classifier maps the leftover shell to no-agent/dead
+# (relaunch-allowed) and keeps the live idle pane alive.
+#
+# Do not launch Pi with `exec`: the pane shell must survive when the agent
+# exits. That is the #4115 shape.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+# shellcheck source=tests/herdr-test-safety.sh
+. "$ROOT/tests/herdr-test-safety.sh"
+
+herdr_forget_inherited_pane
+fm_live_gate default-on FM_HERDR_AGENT_EXIT_SHELL_E2E herdr jq pi
+
+HERDR_LAB_HELPER=${HERDR_LAB_HELPER:-$ROOT/bin/fm-herdr-lab.sh}
+[ -x "$HERDR_LAB_HELPER" ] || { echo "skip: live: Herdr lab helper not executable at $HERDR_LAB_HELPER"; exit 0; }
+
+HERDR_ORIGINAL_PATH=$PATH
+TMP_ROOT=$(fm_test_tmproot fm-herdr-agent-exit-shell-e2e)
+FAKEBIN="$TMP_ROOT/fakebin"
+PROJECT="$TMP_ROOT/project"
+PI_DIR="$TMP_ROOT/pi-agent"
+mkdir -p "$FAKEBIN" "$PROJECT" "$PI_DIR"
+printf '# Isolated herdr agent-exit lab\n' > "$PROJECT/AGENTS.md"
+
+HERDR_LAB_SESSION=$("$HERDR_LAB_HELPER" name fm-herdr-agent-exit-shell)
+export HERDR_LAB_HELPER HERDR_LAB_SESSION HERDR_ORIGINAL_PATH
+
+cleanup() {
+  local status=$?
+  env PATH="$HERDR_ORIGINAL_PATH" "$HERDR_LAB_HELPER" teardown "$HERDR_LAB_SESSION" || status=1
+  fm_test_cleanup
+  exit "$status"
+}
+trap cleanup EXIT
+"$HERDR_LAB_HELPER" provision "$HERDR_LAB_SESSION"
+
+cat > "$FAKEBIN/herdr" <<'SH'
+#!/usr/bin/env bash
+set -u
+args=("$@")
+last=$((${#args[@]} - 1))
+flag=$((last - 1))
+if [ "${#args[@]}" -ge 2 ] \
+  && [ "${args[$flag]}" = --session ] \
+  && [ "${args[$last]}" = "$HERDR_LAB_SESSION" ]; then
+  unset "args[$last]" "args[$flag]"
+fi
+set -- "${args[@]}"
+for arg in "$@"; do
+  case "$arg" in --session|--session=*) exit 9 ;; esac
+done
+exec env PATH="$HERDR_ORIGINAL_PATH" "$HERDR_LAB_HELPER" run "$HERDR_LAB_SESSION" "$@"
+SH
+chmod +x "$FAKEBIN/herdr"
+
+lab() { env PATH="$HERDR_ORIGINAL_PATH" "$HERDR_LAB_HELPER" run "$HERDR_LAB_SESSION" "$@"; }
+
+classify_pane() {  # <pane_id>
+  PATH="$FAKEBIN:$HERDR_ORIGINAL_PATH" bash -c '
+    set -u
+    . "$1/bin/backends/herdr.sh"
+    fm_backend_herdr_pane_agent_state "$2" "$3"
+  ' _ "$ROOT" "$HERDR_LAB_SESSION" "$1"
+}
+
+classify_recovery() {  # <pane_id>
+  PATH="$FAKEBIN:$HERDR_ORIGINAL_PATH" bash -c '
+    set -u
+    . "$1/bin/backends/herdr.sh"
+    fm_backend_herdr_agent_state "$2:$3"
+  ' _ "$ROOT" "$HERDR_LAB_SESSION" "$1"
+}
+
+agent_get_code() {  # <pane_id>
+  local out
+  out=$(lab agent get "$1" 2>&1) || true
+  printf '%s' "$out" | jq -r '.error.code // empty'
+}
+
+agent_get_status() {  # <pane_id>
+  local out
+  out=$(lab agent get "$1" 2>&1) || true
+  printf '%s' "$out" | jq -r '.result.agent.agent_status // empty'
+}
+
+agent_get_kind() {  # <pane_id>
+  local out
+  out=$(lab agent get "$1" 2>&1) || true
+  printf '%s' "$out" | jq -r '.result.agent.agent // empty'
+}
+
+pane_present() {  # <pane_id>
+  lab pane get "$1" >/dev/null 2>&1
+}
+
+pane_agent_status_field() {  # <pane_id>
+  lab pane get "$1" 2>/dev/null | jq -r '.result.pane.agent_status // empty'
+}
+
+wait_until() {  # <pane_id> <idle|gone> [attempts]
+  local pane=$1 want=$2 attempts=${3:-90} i code status
+  for i in $(seq 1 "$attempts"); do
+    code=$(agent_get_code "$pane")
+    status=$(agent_get_status "$pane")
+    case "$want" in
+      idle)
+        case "$status" in idle|done|blocked) return 0 ;; esac
+        ;;
+      gone)
+        [ "$code" = agent_not_found ] && return 0
+        ;;
+    esac
+    sleep 0.5
+  done
+  return 1
+}
+
+assert_live_idle() {  # <pane_id> <label>
+  local pane=$1 label=$2 kind status pane_state recov pane_field
+  pane_present "$pane" || fail "$label: pane disappeared while the agent should still be live"
+  kind=$(agent_get_kind "$pane")
+  status=$(agent_get_status "$pane")
+  [ "$kind" = pi ] || fail "$label: agent get kind was '$kind', want pi"
+  [ "$status" = idle ] || fail "$label: agent get status was '$status', want idle (authority is agent get, not pane get)"
+  pane_state=$(classify_pane "$pane")
+  recov=$(classify_recovery "$pane")
+  [ "$pane_state" = live ] || fail "$label: pane classifier was '$pane_state', want live"
+  [ "$recov" = alive ] || fail "$label: recovery classifier was '$recov', want alive (must not reclaim a live idle agent)"
+  pane_field=$(pane_agent_status_field "$pane")
+  : "$pane_field"
+}
+
+assert_exited_to_shell() {  # <pane_id> <label>
+  local pane=$1 label=$2 code pane_state recov pane_field
+  pane_present "$pane" || fail "$label: pane was reaped; launch used exec or the shell did not survive"
+  code=$(agent_get_code "$pane")
+  [ "$code" = agent_not_found ] || fail "$label: agent get code was '$code', want agent_not_found"
+  pane_state=$(classify_pane "$pane")
+  recov=$(classify_recovery "$pane")
+  [ "$pane_state" = no-agent ] || fail "$label: pane classifier was '$pane_state', want no-agent"
+  [ "$recov" = dead ] || fail "$label: recovery classifier was '$recov', want dead (relaunch-allowed), not alive"
+  # pane get .agent_status may still read idle after the occupant is gone.
+  # Liveness comes from agent get; a lagged idle field must not keep the pane alive.
+  pane_field=$(pane_agent_status_field "$pane")
+  case "$pane_field" in
+    idle|done|blocked|working)
+      [ "$recov" = dead ] || fail "$label: pane get agent_status=$pane_field lagged but recovery was '$recov'"
+      ;;
+  esac
+}
+
+TRUST="$TMP_ROOT/trust.ts"
+cat > "$TRUST" <<'EOF'
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+export default function (pi: ExtensionAPI) {
+  pi.on("project_trust", () => ({ trusted: "yes", remember: false }));
+}
+EOF
+
+# Child of the pane shell, never exec, so /quit and SIGKILL return to zsh.
+PI_CMD=$(printf 'env PI_CODING_AGENT_DIR=%q pi -e %q --no-context-files --no-session' "$PI_DIR" "$TRUST")
+
+CREATE=$(lab workspace create --cwd "$PROJECT" --label 'agent-exit-shell' --no-focus) \
+  || fail 'could not create the lab workspace'
+P_LIVE=$(printf '%s' "$CREATE" | jq -er '.result.root_pane.pane_id') \
+  || fail 'could not read the live pane id'
+WS=$(printf '%s' "$CREATE" | jq -er '.result.workspace.workspace_id') \
+  || fail 'could not read the workspace id'
+
+QUIT_TAB=$(lab tab create --workspace "$WS" --cwd "$PROJECT" --label quit-to-shell --no-focus) \
+  || fail 'could not create the /quit tab'
+P_QUIT=$(printf '%s' "$QUIT_TAB" | jq -er '.result.root_pane.pane_id // .result.pane.pane_id') \
+  || fail 'could not read the /quit pane id'
+KILL_TAB=$(lab tab create --workspace "$WS" --cwd "$PROJECT" --label kill-to-shell --no-focus) \
+  || fail 'could not create the SIGKILL tab'
+P_KILL=$(printf '%s' "$KILL_TAB" | jq -er '.result.root_pane.pane_id // .result.pane.pane_id') \
+  || fail 'could not read the SIGKILL pane id'
+
+lab pane run "$P_LIVE" "$PI_CMD" >/dev/null || fail 'could not launch live-idle Pi'
+lab pane run "$P_QUIT" "$PI_CMD" >/dev/null || fail 'could not launch /quit Pi'
+lab pane run "$P_KILL" "$PI_CMD" >/dev/null || fail 'could not launch SIGKILL Pi'
+
+wait_until "$P_LIVE" idle || fail 'live-idle Pi never became idle on agent get'
+wait_until "$P_QUIT" idle || fail '/quit Pi never became idle on agent get'
+wait_until "$P_KILL" idle || fail 'SIGKILL Pi never became idle on agent get'
+
+assert_live_idle "$P_LIVE" 'before-exit live-idle'
+
+lab pane run "$P_QUIT" '/quit' >/dev/null || fail 'could not send /quit'
+
+KILL_PID=$(lab pane process-info --pane "$P_KILL" | jq -r '
+  .result.process_info.foreground_processes[]?
+  | select((.name // "") == "pi" or ((.argv0 // "") == "pi"))
+  | .pid
+' | head -1)
+[ -n "$KILL_PID" ] && [ "$KILL_PID" != null ] \
+  || fail 'SIGKILL pane had no pi pid in process-info'
+kill -KILL "$KILL_PID" || fail "kill -KILL $KILL_PID failed"
+
+wait_until "$P_QUIT" gone || fail '/quit pane never dropped off agent get'
+wait_until "$P_KILL" gone || fail 'SIGKILL pane never dropped off agent get'
+
+assert_exited_to_shell "$P_QUIT" '/quit leftover shell'
+assert_exited_to_shell "$P_KILL" 'SIGKILL leftover shell'
+assert_live_idle "$P_LIVE" 'sibling live-idle after exits'
+
+pass 'agent get distinguishes leftover-shell (dead/no-agent) from live idle Pi'
+pass 'pane get agent_status lag cannot keep an exited occupant classified alive'

--- a/tests/fm-backend-herdr-agent-exit-shell-e2e.test.sh
+++ b/tests/fm-backend-herdr-agent-exit-shell-e2e.test.sh
@@ -103,8 +103,8 @@ pane_agent_status_field() {  # <pane_id>
 }
 
 wait_until() {  # <pane_id> <idle|gone> [attempts]
-  local pane=$1 want=$2 attempts=${3:-90} i code status
-  for i in $(seq 1 "$attempts"); do
+  local pane=$1 want=$2 attempts=${3:-90} code status
+  for _ in $(seq 1 "$attempts"); do
     code=$(agent_get_code "$pane")
     status=$(agent_get_status "$pane")
     case "$want" in


### PR DESCRIPTION
## Intent

Add only a small isolated Herdr lab regression test that pins this already-true distinction so it cannot silently regress: Herdr 0.9.0 herdr agent get distinguishes a Pi that exits to a leftover shell from a sibling live idle Pi, and the current recovery classifier already consumes that signal, so issue 4115 needs no classifier rewrite.

The test must provision an isolated Herdr lab, launch a real Pi as a child of the pane shell (not via exec, so the shell survives when the agent exits), then assert:
- after the agent exits to a shell via /quit and, separately, via SIGKILL so an exit hook cannot run, with the pane still present: herdr agent get returns agent_not_found, and the classifier (fm_backend_herdr_pane_agent_state / the recovery-grade read) maps that pane to dead/no-agent (relaunch-allowed), not reclaimed as alive.
- a sibling live-but-idle Pi: herdr agent get returns the agent (agent=pi, idle), and the classifier keeps it alive, not reclaimed.

herdr pane get .agent_status can lag at idle after the occupant exits; the test must assert liveness from agent get (the authority), never from pane get .agent_status.

This is a test only. Do not rewrite the classifier, do not add descendant-aware process inspection, and do not add a guarded pane release-agent.

## What Changed

- Add an isolated Herdr regression test covering `/quit` and SIGKILL exits to a surviving shell alongside a live idle Pi.
- Verify `herdr agent get` drives dead/no-agent versus alive classification without relying on the lagging pane status field.
- Register the test in Herdr test lanes and document the versioned runtime evidence.

## Risk Assessment

✅ Low: The change is isolated to a behavioral Herdr regression test, test-runner classification, and supporting documentation, and it satisfies the required exit, SIGKILL, live-idle, and agent-get authority scenarios.

## Testing

Drove the targeted real-product E2E in an isolated Herdr lab: both graceful and unhookable Pi exits became dead/no-agent while the pane shell survived, and the sibling idle Pi remained alive. The canonical run passed without a gate skip, produced transcript and timing evidence, and teardown left no lab session; no classifier source was changed.

- Live validation: ✅ go - 4 of 4 scenarios driven live against the product

| Scenario | Result | Live | Evidence |
| --- | --- | --- | --- |
| Quit Pi with /quit while its parent pane shell survives; agent get reports agent_not_found and recovery classifies the pane no-agent/dead | ✅ pass | live | Real Herdr/Pi E2E transcript |
| SIGKILL Pi so no exit hook can run while its parent pane shell survives; agent get reports agent_not_found and recovery classifies the pane no-agent/dead | ✅ pass | live | Real Herdr/Pi E2E transcript |
| Keep a sibling Pi live but idle; agent get reports agent=pi and idle and recovery keeps the pane live/alive | ✅ pass | live | Real Herdr/Pi E2E transcript |
| Treat agent get as liveness authority so a leftover pane&#39;s potentially lagged pane.agent_status cannot reclaim an exited Pi as alive | ✅ pass | live | Real Herdr/Pi E2E transcript: `ok - pane get agent_status lag cannot keep an exited occupant classified alive` |

<details>
<summary>Evidence: Real Herdr/Pi E2E transcript</summary>

Source: [Real Herdr/Pi E2E transcript](https://github.com/kunchenguid/firstmate/blob/6ad44168882395da04d8328bf14b8995e9662d42/.no-mistakes/evidence/fm/fm-herdr-agent-view-4115-s1/herdr-agent-exit-shell-transcript.log)

```text
FM_TEST_BEGIN 2026-09-10T20:04:36Z tests/fm-backend-herdr-agent-exit-shell-e2e.test.sh family=real-herdr-gated expected_gate_skip=herdr
ok - agent get distinguishes leftover-shell (dead/no-agent) from live idle Pi
ok - pane get agent_status lag cannot keep an exited occupant classified alive
FM_TEST_END 2026-09-10T20:04:45Z tests/fm-backend-herdr-agent-exit-shell-e2e.test.sh exit=0 duration_ms=8344 gate_skip=false
FM_TEST_SUMMARY total=1 failed=0 skipped_gate=0 duration_ms=8416
FM_TEST_SUMMARY_FAMILY family=real-herdr-gated count=1 duration_ms=8344 failed=0
FM_TEST_SLOWEST rank=1 script=tests/fm-backend-herdr-agent-exit-shell-e2e.test.sh duration_ms=8344
fm-test-run: wrote timing artifact: ~/.no-mistakes/evidence/01M26EMGKJYHDYEF0VSAVW8APE/herdr-agent-exit-shell-run.json
```
</details>
<details>
<summary>Evidence: Targeted runner result</summary>

Source: [Targeted runner result](https://github.com/kunchenguid/firstmate/blob/6ad44168882395da04d8328bf14b8995e9662d42/.no-mistakes/evidence/fm/fm-herdr-agent-view-4115-s1/herdr-agent-exit-shell-run.json)

```text
{
  "families": [
    {
      "count": 1,
      "duration_ms": 8344,
      "failed": 0,
      "name": "real-herdr-gated"
    }
  ],
  "finished_at": "2026-09-10T20:04:45Z",
  "run_id": "fm-test-run-1789070676957-37605",
  "scripts": [
    {
      "duration_ms": 8344,
      "exit": 0,
      "expected_gate_skip": "herdr",
      "family": "real-herdr-gated",
      "gate_skip": false,
      "gate_skip_reason": "",
      "path": "tests/fm-backend-herdr-agent-exit-shell-e2e.test.sh"
    }
  ],
  "selection": "scripts;jobs=1",
  "started_at": "2026-09-10T20:04:36Z",
  "summary": {
    "duration_ms": 8416,
    "failed": 0,
    "skipped_gate": 0,
    "total": 1
  }
}
```
</details>


## CI override

Delivery accepted past a cancelled GitHub Actions check, not a test failure.

- **What cancelled:** `Behavior portable parallel 1`
- **Why it is not this PR:** pre-existing ~10-minute runner-time margin on that shard. The job is cancelled by the provider with zero failing tests. This PR is a test-only addition (leftover-shell vs live-idle Herdr e2e); it does not change classifier code.
- **Durable fix:** owned by the separate follow-up `fm-ci-portable-parallel-shard1-timeout-flake`. Do not loop reruns of that shard; it cancels repeatedly under load.

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"58212cac933c98dfd55b9c937787fe9db040a361","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- Live validation: ✅ go - 4 of 4 scenarios driven live against the product

| Scenario | Result | Live | Evidence |
| --- | --- | --- | --- |
| Quit Pi with /quit while its parent pane shell survives; agent get reports agent_not_found and recovery classifies the pane no-agent/dead | ✅ pass | live | Real Herdr/Pi E2E transcript |
| SIGKILL Pi so no exit hook can run while its parent pane shell survives; agent get reports agent_not_found and recovery classifies the pane no-agent/dead | ✅ pass | live | Real Herdr/Pi E2E transcript |
| Keep a sibling Pi live but idle; agent get reports agent=pi and idle and recovery keeps the pane live/alive | ✅ pass | live | Real Herdr/Pi E2E transcript |
| Treat agent get as liveness authority so a leftover pane&#39;s potentially lagged pane.agent_status cannot reclaim an exited Pi as alive | ✅ pass | live | Real Herdr/Pi E2E transcript: `ok - pane get agent_status lag cannot keep an exited occupant classified alive` |

- `./bin/fm-test-run.sh tests/fm-backend-herdr-agent-exit-shell-e2e.test.sh --json ~/.no-mistakes/evidence/01M26EMGKJYHDYEF0VSAVW8APE/herdr-agent-exit-shell-run.json`
- <code>`herdr --version` and `pi --version`</code>
- <code>`git diff --name-status 527aa7c12d25aadbdf3cc56791f87ae71fca5280..3774f11b983cde43e63428957474989b5aaa4fd8` to confirm no classifier implementation changed</code>
- <code>`herdr session list --json | jq ...` to confirm the isolated lab session was removed</code>
- <code>Attempted a tracing-only rerun with `bash -x`; tracing polluted captured JSON substitutions, so it was discarded as invalid instrumentation and its lab session and evidence files were cleaned</code>
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>

