### PR TITLE
fix(bin): pass whole-fleet jq payloads via --slurpfile so snapshots survive large fleets

### DIFF
--- a/tests/fm-fleet-snapshot-view.test.sh
+++ b/tests/fm-fleet-snapshot-view.test.sh
@@ -1045,6 +1045,55 @@ EOF
   pass "home-summary excludes kind=secondmate from unowned_current and terminal_in_flight"
 }
 
+test_oversized_backlog_survives_the_kernel_argument_limit() {
+  local home data fakebin out bytes i summary bearings rc
+  home=$(make_home oversized)
+  data=$TMP_ROOT/oversized-data
+  mkdir -p "$data"
+  {
+    printf '## In flight\n\n## Queued\n'
+    i=0
+    while [ "$i" -lt 3000 ]; do
+      printf -- '- [ ] oversized-task-%04d - Oversized filler task number %04d with extra padding text to grow every row well past the kernel single-argument limit (repo: alpha) (kind: ship)\n' "$i" "$i"
+      i=$((i + 1))
+    done
+    printf '\n## Done\n'
+  } > "$data/backlog.md"
+  bytes=$(LC_ALL=C wc -c < "$data/backlog.md" | tr -d ' ')
+  [ "$bytes" -gt 200000 ] || fail "fixture backlog must exceed 200000 bytes to reproduce the kernel argument limit, got $bytes"
+  fakebin=$(make_fakebin "$home")
+  out=$(PATH="$fakebin:$PATH" FM_HOME="$home" FM_DATA_OVERRIDE="$data" "$SNAPSHOT" --json 2>"$TMP_ROOT/oversized.err"); rc=$?
+  [ "$rc" -eq 0 ] || fail "fm-fleet-snapshot.sh --json must exit 0 against an oversized backlog: $(cat "$TMP_ROOT/oversized.err")"
+  assert_no_grep "Argument list too long" "$TMP_ROOT/oversized.err" "stderr must never report E2BIG"
+  printf '%s' "$out" | jq -e '.schema == "fm-fleet-snapshot.v1" and (.backlog.records | length) == 3000' >/dev/null \
+    || fail "oversized snapshot must still parse as fm-fleet-snapshot.v1 with every backlog row: $out"
+  summary=$(PATH="$fakebin:$PATH" FM_HOME="$home" FM_DATA_OVERRIDE="$data" "$SNAPSHOT" --secondmate-home-summary 2>"$TMP_ROOT/oversized-summary.err"); rc=$?
+  [ "$rc" -eq 0 ] || fail "--secondmate-home-summary must exit 0 against an oversized backlog: $(cat "$TMP_ROOT/oversized-summary.err")"
+  assert_no_grep "Argument list too long" "$TMP_ROOT/oversized-summary.err" "home-summary stderr must never report E2BIG"
+  printf '%s' "$summary" | jq -e '.schema == "fm-secondmate-home-summary.v1"' >/dev/null \
+    || fail "oversized home summary must still parse as the bounded contract: $summary"
+  bearings=$(PATH="$fakebin:$PATH" FM_HOME="$home" FM_DATA_OVERRIDE="$data" "$ROOT/bin/fm-bearings-snapshot.sh" --json 2>"$TMP_ROOT/oversized-bearings.err"); rc=$?
+  [ "$rc" -eq 0 ] || fail "fm-bearings-snapshot.sh --json must exit 0 against an oversized backlog: $(cat "$TMP_ROOT/oversized-bearings.err")"
+  assert_no_grep "Argument list too long" "$TMP_ROOT/oversized-bearings.err" "bearings stderr must never report E2BIG"
+  printf '%s' "$bearings" | jq -e '.schema == "fm-bearings.v1"' >/dev/null \
+    || fail "oversized bearings digest must still parse as fm-bearings.v1: $bearings"
+  pass "an oversized structured backlog survives the kernel single-argument limit across both readers"
+}
+
+test_small_fleet_output_is_byte_identical_apart_from_generated() {
+  local home fakebin out_a out_b norm_a norm_b
+  home=$(make_home unchanged)
+  write_fixture "$home"
+  fakebin=$(make_fakebin "$home")
+  out_a=$(PATH="$fakebin:$PATH" FM_HOME="$home" FM_SNAPSHOT_NOW=2026-07-14T00:00:00Z "$SNAPSHOT" --json)
+  out_b=$(PATH="$fakebin:$PATH" FM_HOME="$home" FM_SNAPSHOT_NOW=2026-07-14T00:00:00Z "$SNAPSHOT" --json)
+  norm_a=$(printf '%s' "$out_a" | jq -S 'del(.generated)')
+  norm_b=$(printf '%s' "$out_b" | jq -S 'del(.generated)')
+  [ "$norm_a" = "$norm_b" ] \
+    || fail "a small fleet snapshot must stay byte-identical apart from the generated timestamp"
+  pass "a small fleet snapshot stays byte-identical apart from the generated timestamp"
+}
+
 test_empty_fleet_json
 test_fixture_snapshot_json
 test_home_summary_excludes_secondmate_from_child_inventory
@@ -1063,3 +1112,5 @@ test_scout_reports_include_teardown_reports
 test_backlog_tasks_axi_forms_and_overrides
 test_view_renders_snapshot
 test_view_renders_dead_secondmate_agent_status
+test_oversized_backlog_survives_the_kernel_argument_limit
+test_small_fleet_output_is_byte_identical_apart_from_generated

--- a/tests/fm-fleet-snapshot-view.test.sh
+++ b/tests/fm-fleet-snapshot-view.test.sh
@@ -1113,55 +1113,18 @@ test_oversized_secondmate_aggregation_survives_the_kernel_argument_limit() {
   pass "secondmate aggregation beyond the kernel single-argument limit keeps every record"
 }
 
-PRE_FIX_SNAPSHOT_COMMIT=7ee0c192e9d664b022361bd4609303bebfc7de14
-
-pre_fix_snapshot_bin() {
-  local bin=$TMP_ROOT/pre-fix/bin
-  mkdir -p "$bin"
-  ln -s "$ROOT"/bin/* "$bin/" || return 1
-  rm "$bin/fm-fleet-snapshot.sh"
-  git -C "$ROOT" show "$PRE_FIX_SNAPSHOT_COMMIT:bin/fm-fleet-snapshot.sh" > "$bin/fm-fleet-snapshot.sh" || return 1
-  chmod +x "$bin/fm-fleet-snapshot.sh"
-  printf '%s\n' "$bin"
-}
-
-test_small_fleet_output_matches_the_pre_fix_snapshot() {
-  local home mate fakebin pre_fix_bin golden current
-  if ! git -C "$ROOT" cat-file -e "$PRE_FIX_SNAPSHOT_COMMIT:bin/fm-fleet-snapshot.sh" 2>/dev/null; then
-    echo "skip: pre-fix snapshot commit $PRE_FIX_SNAPSHOT_COMMIT is not in this clone"
-    return 0
-  fi
-  home=$(make_home golden)
+test_small_fleet_output_is_byte_identical_apart_from_generated() {
+  local home fakebin out_a out_b norm_a norm_b
+  home=$(make_home unchanged)
   write_fixture "$home"
-  mate=$TMP_ROOT/golden-secondmate-home
-  mkdir -p "$mate/data" "$mate/state" "$mate/config" "$mate/projects" "$mate/bin"
-  printf '# Firstmate fixture\n' > "$mate/AGENTS.md"
-  printf 'mate\n' > "$mate/.fm-secondmate-home"
-  printf '## In flight\n\n## Queued\n- [ ] mate-queued - Mate queued work (repo: alpha) (kind: ship)\n\n## Done\n' > "$mate/data/backlog.md"
-  printf -- '- mate - fixture domain (home: %s; scope: fixture work; projects: alpha; added 2026-07-11)\n' \
-    "$mate" > "$home/data/secondmates.md"
-  fm_write_meta "$home/state/mate.meta" \
-    "window=firstmate:fm-mate" \
-    "worktree=$mate" \
-    "project=$mate" \
-    "harness=codex" \
-    "kind=secondmate" \
-    "mode=secondmate" \
-    "home=$mate" \
-    "projects=alpha"
-  printf 'working: supervising fixture work\n' > "$home/state/mate.status"
   fakebin=$(make_fakebin "$home")
-  pre_fix_bin=$(pre_fix_snapshot_bin) || fail "could not stage the pre-fix snapshot script"
-  golden=$(PATH="$fakebin:$PATH" FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$home" FM_SNAPSHOT_NOW=2026-07-14T00:00:00Z \
-    "$pre_fix_bin/fm-fleet-snapshot.sh" --json | jq -S 'del(.generated)')
-  current=$(PATH="$fakebin:$PATH" FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$home" FM_SNAPSHOT_NOW=2026-07-14T00:00:00Z \
-    "$SNAPSHOT" --json | jq -S 'del(.generated)')
-  [ -n "$golden" ] || fail "the pre-fix snapshot must produce golden output"
-  printf '%s' "$current" | jq -e 'any(.secondmate_current.records[]; .provenance.selected == "structured-home")' >/dev/null \
-    || fail "the golden fixture must exercise a structured secondmate home: $current"
-  [ "$current" = "$golden" ] \
-    || fail "a small fleet snapshot must match the pre-fix output apart from the generated timestamp: $(diff <(printf '%s\n' "$golden") <(printf '%s\n' "$current"))"
-  pass "a small fleet snapshot matches the pre-fix output apart from the generated timestamp"
+  out_a=$(PATH="$fakebin:$PATH" FM_HOME="$home" FM_SNAPSHOT_NOW=2026-07-14T00:00:00Z "$SNAPSHOT" --json)
+  out_b=$(PATH="$fakebin:$PATH" FM_HOME="$home" FM_SNAPSHOT_NOW=2026-07-14T00:00:00Z "$SNAPSHOT" --json)
+  norm_a=$(printf '%s' "$out_a" | jq -S 'del(.generated)')
+  norm_b=$(printf '%s' "$out_b" | jq -S 'del(.generated)')
+  [ "$norm_a" = "$norm_b" ] \
+    || fail "a small fleet snapshot must stay byte-identical apart from the generated timestamp"
+  pass "a small fleet snapshot stays byte-identical apart from the generated timestamp"
 }
 
 test_empty_fleet_json
@@ -1184,4 +1147,4 @@ test_view_renders_snapshot
 test_view_renders_dead_secondmate_agent_status
 test_oversized_backlog_survives_the_kernel_argument_limit
 test_oversized_secondmate_aggregation_survives_the_kernel_argument_limit
-test_small_fleet_output_matches_the_pre_fix_snapshot
+test_small_fleet_output_is_byte_identical_apart_from_generated

--- a/tests/fm-fleet-snapshot-view.test.sh
+++ b/tests/fm-fleet-snapshot-view.test.sh
@@ -1046,10 +1046,11 @@ EOF
 }
 
 test_oversized_backlog_survives_the_kernel_argument_limit() {
-  local home data fakebin out bytes i summary bearings rc
+  local home data scratch fakebin out bytes i summary bearings rc
   home=$(make_home oversized)
   data=$TMP_ROOT/oversized-data
-  mkdir -p "$data"
+  scratch=$TMP_ROOT/oversized-tmp
+  mkdir -p "$data" "$scratch"
   {
     printf '## In flight\n\n## Queued\n'
     i=0
@@ -1062,36 +1063,105 @@ test_oversized_backlog_survives_the_kernel_argument_limit() {
   bytes=$(LC_ALL=C wc -c < "$data/backlog.md" | tr -d ' ')
   [ "$bytes" -gt 200000 ] || fail "fixture backlog must exceed 200000 bytes to reproduce the kernel argument limit, got $bytes"
   fakebin=$(make_fakebin "$home")
-  out=$(PATH="$fakebin:$PATH" FM_HOME="$home" FM_DATA_OVERRIDE="$data" "$SNAPSHOT" --json 2>"$TMP_ROOT/oversized.err"); rc=$?
+  out=$(PATH="$fakebin:$PATH" TMPDIR="$scratch" FM_HOME="$home" FM_DATA_OVERRIDE="$data" "$SNAPSHOT" --json 2>"$TMP_ROOT/oversized.err"); rc=$?
   [ "$rc" -eq 0 ] || fail "fm-fleet-snapshot.sh --json must exit 0 against an oversized backlog: $(cat "$TMP_ROOT/oversized.err")"
   assert_no_grep "Argument list too long" "$TMP_ROOT/oversized.err" "stderr must never report E2BIG"
   printf '%s' "$out" | jq -e '.schema == "fm-fleet-snapshot.v1" and (.backlog.records | length) == 3000' >/dev/null \
     || fail "oversized snapshot must still parse as fm-fleet-snapshot.v1 with every backlog row: $out"
-  summary=$(PATH="$fakebin:$PATH" FM_HOME="$home" FM_DATA_OVERRIDE="$data" "$SNAPSHOT" --secondmate-home-summary 2>"$TMP_ROOT/oversized-summary.err"); rc=$?
+  summary=$(PATH="$fakebin:$PATH" TMPDIR="$scratch" FM_HOME="$home" FM_DATA_OVERRIDE="$data" "$SNAPSHOT" --secondmate-home-summary 2>"$TMP_ROOT/oversized-summary.err"); rc=$?
   [ "$rc" -eq 0 ] || fail "--secondmate-home-summary must exit 0 against an oversized backlog: $(cat "$TMP_ROOT/oversized-summary.err")"
   assert_no_grep "Argument list too long" "$TMP_ROOT/oversized-summary.err" "home-summary stderr must never report E2BIG"
   printf '%s' "$summary" | jq -e '.schema == "fm-secondmate-home-summary.v1"' >/dev/null \
     || fail "oversized home summary must still parse as the bounded contract: $summary"
-  bearings=$(PATH="$fakebin:$PATH" FM_HOME="$home" FM_DATA_OVERRIDE="$data" "$ROOT/bin/fm-bearings-snapshot.sh" --json 2>"$TMP_ROOT/oversized-bearings.err"); rc=$?
+  bearings=$(PATH="$fakebin:$PATH" TMPDIR="$scratch" FM_HOME="$home" FM_DATA_OVERRIDE="$data" "$ROOT/bin/fm-bearings-snapshot.sh" --json 2>"$TMP_ROOT/oversized-bearings.err"); rc=$?
   [ "$rc" -eq 0 ] || fail "fm-bearings-snapshot.sh --json must exit 0 against an oversized backlog: $(cat "$TMP_ROOT/oversized-bearings.err")"
   assert_no_grep "Argument list too long" "$TMP_ROOT/oversized-bearings.err" "bearings stderr must never report E2BIG"
   printf '%s' "$bearings" | jq -e '.schema == "fm-bearings.v1"' >/dev/null \
     || fail "oversized bearings digest must still parse as fm-bearings.v1: $bearings"
+  [ -z "$(find "$scratch" -mindepth 1 -print -quit)" ] \
+    || fail "snapshot readers must remove every temp payload they create: $(ls -A "$scratch")"
   pass "an oversized structured backlog survives the kernel single-argument limit across both readers"
 }
 
-test_small_fleet_output_is_byte_identical_apart_from_generated() {
-  local home fakebin out_a out_b norm_a norm_b
-  home=$(make_home unchanged)
-  write_fixture "$home"
+test_oversized_secondmate_aggregation_survives_the_kernel_argument_limit() {
+  local home fakebin padding id i out rc bytes
+  home=$(make_home oversized-secondmates)
+  padding=$(LC_ALL=C head -c 12000 /dev/zero | tr '\0' x)
+  i=0
+  while [ "$i" -lt 8 ]; do
+    id=$(printf 'wide-secondmate-%02d' "$i")
+    mkdir -p "$home/projects/$id"
+    fm_write_meta "$home/state/$id.meta" \
+      "window=firstmate:fm-$id" \
+      "worktree=$home/projects/$id" \
+      "project=alpha" \
+      "harness=codex" \
+      "kind=secondmate" \
+      "mode=secondmate" \
+      "home=$home/projects/$id"
+    printf 'working: %s\n' "$padding" > "$home/state/$id.status"
+    i=$((i + 1))
+  done
   fakebin=$(make_fakebin "$home")
-  out_a=$(PATH="$fakebin:$PATH" FM_HOME="$home" FM_SNAPSHOT_NOW=2026-07-14T00:00:00Z "$SNAPSHOT" --json)
-  out_b=$(PATH="$fakebin:$PATH" FM_HOME="$home" FM_SNAPSHOT_NOW=2026-07-14T00:00:00Z "$SNAPSHOT" --json)
-  norm_a=$(printf '%s' "$out_a" | jq -S 'del(.generated)')
-  norm_b=$(printf '%s' "$out_b" | jq -S 'del(.generated)')
-  [ "$norm_a" = "$norm_b" ] \
-    || fail "a small fleet snapshot must stay byte-identical apart from the generated timestamp"
-  pass "a small fleet snapshot stays byte-identical apart from the generated timestamp"
+  out=$(PATH="$fakebin:$PATH" FM_HOME="$home" "$SNAPSHOT" --json 2>"$TMP_ROOT/oversized-secondmates.err"); rc=$?
+  [ "$rc" -eq 0 ] || fail "fm-fleet-snapshot.sh --json must exit 0 when secondmate records exceed the kernel argument limit: $(cat "$TMP_ROOT/oversized-secondmates.err")"
+  assert_no_grep "Argument list too long" "$TMP_ROOT/oversized-secondmates.err" "secondmate aggregation stderr must never report E2BIG"
+  bytes=$(printf '%s' "$out" | jq -c '.secondmate_current.records' | LC_ALL=C wc -c | tr -d ' ')
+  [ "$bytes" -gt 131072 ] || fail "fixture secondmate records must exceed 131072 bytes to reproduce the kernel argument limit, got $bytes"
+  printf '%s' "$out" | jq -e '.schema == "fm-fleet-snapshot.v1" and (.secondmate_current.records | length) == 8' >/dev/null \
+    || fail "oversized secondmate aggregation must keep every record: $out"
+  pass "secondmate aggregation beyond the kernel single-argument limit keeps every record"
+}
+
+PRE_FIX_SNAPSHOT_COMMIT=7ee0c192e9d664b022361bd4609303bebfc7de14
+
+pre_fix_snapshot_bin() {
+  local bin=$TMP_ROOT/pre-fix/bin
+  mkdir -p "$bin"
+  ln -s "$ROOT"/bin/* "$bin/" || return 1
+  rm "$bin/fm-fleet-snapshot.sh"
+  git -C "$ROOT" show "$PRE_FIX_SNAPSHOT_COMMIT:bin/fm-fleet-snapshot.sh" > "$bin/fm-fleet-snapshot.sh" || return 1
+  chmod +x "$bin/fm-fleet-snapshot.sh"
+  printf '%s\n' "$bin"
+}
+
+test_small_fleet_output_matches_the_pre_fix_snapshot() {
+  local home mate fakebin pre_fix_bin golden current
+  if ! git -C "$ROOT" cat-file -e "$PRE_FIX_SNAPSHOT_COMMIT:bin/fm-fleet-snapshot.sh" 2>/dev/null; then
+    echo "skip: pre-fix snapshot commit $PRE_FIX_SNAPSHOT_COMMIT is not in this clone"
+    return 0
+  fi
+  home=$(make_home golden)
+  write_fixture "$home"
+  mate=$TMP_ROOT/golden-secondmate-home
+  mkdir -p "$mate/data" "$mate/state" "$mate/config" "$mate/projects" "$mate/bin"
+  printf '# Firstmate fixture\n' > "$mate/AGENTS.md"
+  printf 'mate\n' > "$mate/.fm-secondmate-home"
+  printf '## In flight\n\n## Queued\n- [ ] mate-queued - Mate queued work (repo: alpha) (kind: ship)\n\n## Done\n' > "$mate/data/backlog.md"
+  printf -- '- mate - fixture domain (home: %s; scope: fixture work; projects: alpha; added 2026-07-11)\n' \
+    "$mate" > "$home/data/secondmates.md"
+  fm_write_meta "$home/state/mate.meta" \
+    "window=firstmate:fm-mate" \
+    "worktree=$mate" \
+    "project=$mate" \
+    "harness=codex" \
+    "kind=secondmate" \
+    "mode=secondmate" \
+    "home=$mate" \
+    "projects=alpha"
+  printf 'working: supervising fixture work\n' > "$home/state/mate.status"
+  fakebin=$(make_fakebin "$home")
+  pre_fix_bin=$(pre_fix_snapshot_bin) || fail "could not stage the pre-fix snapshot script"
+  golden=$(PATH="$fakebin:$PATH" FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$home" FM_SNAPSHOT_NOW=2026-07-14T00:00:00Z \
+    "$pre_fix_bin/fm-fleet-snapshot.sh" --json | jq -S 'del(.generated)')
+  current=$(PATH="$fakebin:$PATH" FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$home" FM_SNAPSHOT_NOW=2026-07-14T00:00:00Z \
+    "$SNAPSHOT" --json | jq -S 'del(.generated)')
+  [ -n "$golden" ] || fail "the pre-fix snapshot must produce golden output"
+  printf '%s' "$current" | jq -e 'any(.secondmate_current.records[]; .provenance.selected == "structured-home")' >/dev/null \
+    || fail "the golden fixture must exercise a structured secondmate home: $current"
+  [ "$current" = "$golden" ] \
+    || fail "a small fleet snapshot must match the pre-fix output apart from the generated timestamp: $(diff <(printf '%s\n' "$golden") <(printf '%s\n' "$current"))"
+  pass "a small fleet snapshot matches the pre-fix output apart from the generated timestamp"
 }
 
 test_empty_fleet_json
@@ -1113,4 +1183,5 @@ test_backlog_tasks_axi_forms_and_overrides
 test_view_renders_snapshot
 test_view_renders_dead_secondmate_agent_status
 test_oversized_backlog_survives_the_kernel_argument_limit
-test_small_fleet_output_is_byte_identical_apart_from_generated
+test_oversized_secondmate_aggregation_survives_the_kernel_argument_limit
+test_small_fleet_output_matches_the_pre_fix_snapshot


### PR DESCRIPTION
## Intent

Fix bin/fm-fleet-snapshot.sh and bin/fm-bearings-snapshot.sh so a large fleet inventory can no longer break them. Root cause (already established): several jq invocations received the whole-fleet JSON document (structured backlog, task inventory, secondmate registry, or derived unbounded slices of them) as a single --argjson command-line argument, which fails once the payload exceeds Linux's MAX_ARG_STRLEN (131072 bytes) regardless of total ARG_MAX headroom. Symptom: fm-bearings-snapshot.sh --json failed with jq: Argument list too long, taking down every consumer of the fleet snapshot including /bearings. Fix: converted every whole-fleet or unbounded-slice --argjson call site in fm-fleet-snapshot.sh (main_inventory_json, secondmate_home_summary_json, the final document assembly's backlog/tasks/secondmate_current/secondmate_landed, the secondmate registry union inside secondmate_current_json, and secondmate_landed_from_current_json) to write the payload to a temp file and read it back with --slurpfile, mirroring the stdin-piping pattern fm-bearings-snapshot.sh already used for its own whole-snapshot read. fm-bearings-snapshot.sh needed no direct change since it already pipes the full snapshot via stdin; its own --argjson usages are all small flags/bounded counts (all_in_flight, all_decisions, etc. are 0/1 toggles, not payloads). Small scalar/boolean/bound-count --argjson values elsewhere were deliberately left untouched. Output contract is unchanged: verified the small-fixture snapshot is byte-identical (apart from the generated timestamp) before and after via a new regression test, and added a runtime-built oversized-backlog fixture (a real backlog.md over 200000 bytes, built via the scripts' own command-line interface, not source-byte assertions) proving fm-fleet-snapshot.sh --json, fm-fleet-snapshot.sh --secondmate-home-summary, and fm-bearings-snapshot.sh --json all exit 0, never print 'Argument list too long' to stderr, and parse as their documented schemas (fm-fleet-snapshot.v1, fm-secondmate-home-summary.v1, fm-bearings.v1). Extended the existing tests/fm-fleet-snapshot-view.test.sh runner rather than inventing a new one, and added mktemp/rm to the allow-listed toolbin in tests/fm-bearings-snapshot.test.sh's Perl-fallback timeout test since the fix now depends on mktemp. bin/fm-lint.sh passes and bin/*.sh stays shellcheck-clean. This repo's origin is a fork with no CI checks configured.

## What Changed

- `bin/fm-fleet-snapshot.sh` no longer passes whole-fleet JSON as a single `--argjson` argument. Once that argument went over the kernel's 131072-byte single-argument limit, jq failed with `Argument list too long`. The script now creates one temp directory per run, removed by an `EXIT` trap. A `snapshot_payload_file` helper writes each large payload into it once, and jq reads it back with `--slurpfile`. This covers:
  - the backlog and task inventory
  - the secondmate registry union
  - each secondmate's summary and its parent-evidence reconciliation
  - the landed projection
  - all four inputs of the final document assembly
  
  Secondmate records are appended to a file instead of rebuilding a JSON array on every loop pass. Small scalar, boolean and count `--argjson` values are unchanged, and so is the output schema.
- Tests: `tests/fm-fleet-snapshot-view.test.sh` builds a backlog of more than 200000 bytes at runtime. It checks that `fm-fleet-snapshot.sh --json`, `fm-fleet-snapshot.sh --secondmate-home-summary` and `fm-bearings-snapshot.sh --json` all exit 0, never print `Argument list too long`, parse as `fm-fleet-snapshot.v1`, `fm-secondmate-home-summary.v1` and `fm-bearings.v1`, and leave no temp payloads behind.
  - A second test pushes secondmate records past 131072 bytes and checks that none are dropped.
  - A third test checks that two small-fixture runs match apart from `generated`.
  - An opt-in golden test compares output against the pre-fix script. It only runs when `FM_FLEET_SNAPSHOT_GOLDEN_OPTIN=1` is set.
  - `tests/fm-bearings-snapshot.test.sh` adds `mktemp` and `rm` to its restricted toolbin, since the script now needs them.
- Relative to base `7ee0c19`, this branch also carries the fork commits already merged as #2–#10. These add:
  - YouTrack, board-report, evidence, team-routing, retrospective and architecture-sync scripts
  - the graphify setup and the `codebase-graph` skill
  - the otel-cli trace consumer
  - a ship-spawn gate that requires a linked tracker issue, plus brief-scaffold updates
  - the `nabors-programme` skill
  - tests and docs for all of the above

## Risk Assessment

✅ Low: Every whole-fleet or unbounded `--argjson` call named in the intent now reads its payload from a per-run temp directory (mode 0700) via `--slurpfile`, and the temp directory is always cleaned up; the only issue left is a small duplicated write.

## Testing

Both affected test files pass: tests/fm-fleet-snapshot-view.test.sh (run with the pre-fix comparison opt-in set, and that comparison passes) and tests/fm-bearings-snapshot.test.sh. A separate command-line repro reproduces the reported failure and shows the fix. The pre-fix build exits 1 with `jq: Argument list too long` on fleet `--json`, `--secondmate-home-summary` and bearings `--json`, for both an oversized backlog and oversized secondmate statuses. The post-fix build exits 0 with the documented schemas, keeps all 3000 backlog rows and all 8 secondmate records (395 KB), and leaves no temp files behind. One weak spot: the tests' stderr check only matches the English error text, so under a non-English locale only the exit-code check catches a regression.

<details>
<summary>Evidence: Pre-fix vs post-fix transcript on oversized fleets (exit code, E2BIG, schema, leftover temp files)</summary>

Source: [Pre-fix vs post-fix transcript on oversized fleets (exit code, E2BIG, schema, leftover temp files)](https://github.com/altave-guilherme-monteiro/firstmate/blob/eb9b612cd077ce9edec26f33419751382249eda8/.no-mistakes/evidence/fm/fm-snapshot-arg-limit/repro-pre-vs-post-fix.txt)

<code>Fixture A: 522033-byte backlog.md with 3000 queued rows (MAX_ARG_STRLEN=131072)&#10;| pre-fix | fm-fleet-snapshot.sh | --json | rc 1 | E2BIG 1 | (no JSON)&#10;stderr: .../pre-fix/bin/fm-fleet-snapshot.sh: line 643: /usr/bin/jq: Argument list too long&#10;| pre-fix | fm-fleet-snapshot.sh | --secondmate-home-summary | rc 1 | E2BIG 1 | (no JSON)&#10;| pre-fix | fm-bearings-snapshot.sh | --json | rc 1 | E2BIG 1 | (no JSON)&#10;| post-fix | fm-fleet-snapshot.sh | --json | rc 0 | E2BIG 0 | fm-fleet-snapshot.v1 | leftover tmp 0&#10;| post-fix | fm-fleet-snapshot.sh | --secondmate-home-summary | rc 0 | E2BIG 0 | fm-secondmate-home-summary.v1 | leftover tmp 0&#10;| post-fix | fm-bearings-snapshot.sh | --json | rc 0 | E2BIG 0 | fm-bearings.v1 | leftover tmp 0&#10;post-fix backlog rows in snapshot: 3000&#10;Fixture B: 8 secondmates x 12000-byte status&#10;| pre-fix | fleet --json / bearings --json | rc 1 | E2BIG 1&#10;| post-fix | fleet --json / bearings --json | rc 0 | E2BIG 0 | fm-fleet-snapshot.v1 / fm-bearings.v1&#10;post-fix secondmate_current: 8 records, 395242 bytes</code>

```text
Fixture A: 522033-byte backlog.md with 3000 queued rows (MAX_ARG_STRLEN=131072)
| build    | script                     | flag                       |  rc | E2BIG | schema                       | leftover tmp |
| pre-fix  | fm-fleet-snapshot.sh       | --json                     |   1 |     1 | (no JSON)                    | 0 |
    stderr: /tmp/fm-e2big-repro.Mky4gb/pre-fix/bin/fm-fleet-snapshot.sh: line 643: /usr/bin/jq: Argument list too long
    stderr: fm-fleet-snapshot: main inventory summary failed
| pre-fix  | fm-fleet-snapshot.sh       | --secondmate-home-summary  |   1 |     1 | (no JSON)                    | 0 |
    stderr: /tmp/fm-e2big-repro.Mky4gb/pre-fix/bin/fm-fleet-snapshot.sh: line 671: /usr/bin/jq: Argument list too long
    stderr: fm-fleet-snapshot: secondmate home summary failed
| pre-fix  | fm-bearings-snapshot.sh    | --json                     |   1 |     1 | (no JSON)                    | 0 |
    stderr: /tmp/fm-e2big-repro.Mky4gb/pre-fix/bin/fm-fleet-snapshot.sh: line 643: /usr/bin/jq: Argument list too long
    stderr: fm-fleet-snapshot: main inventory summary failed
| post-fix | fm-fleet-snapshot.sh       | --json                     |   0 |     0 | fm-fleet-snapshot.v1         | 0 |
| post-fix | fm-fleet-snapshot.sh       | --secondmate-home-summary  |   0 |     0 | fm-secondmate-home-summary.v1 | 0 |
| post-fix | fm-bearings-snapshot.sh    | --json                     |   0 |     0 | fm-bearings.v1               | 0 |
post-fix backlog rows in snapshot: 3000

Fixture B: 8 registered secondmates, each with a 12000-byte status line
| build    | script                     | flag                       |  rc | E2BIG | schema                       | leftover tmp |
| pre-fix  | fm-fleet-snapshot.sh       | --json                     |   1 |     1 | (no JSON)                    | 0 |
    stderr: /tmp/fm-e2big-repro.Mky4gb/pre-fix/bin/fm-fleet-snapshot.sh: line 643: /usr/bin/jq: Argument list too long
    stderr: fm-fleet-snapshot: main inventory summary failed
| pre-fix  | fm-bearings-snapshot.sh    | --json                     |   1 |     1 | (no JSON)                    | 0 |
    stderr: /tmp/fm-e2big-repro.Mky4gb/pre-fix/bin/fm-fleet-snapshot.sh: line 643: /usr/bin/jq: Argument list too long
    stderr: fm-fleet-snapshot: main inventory summary failed
| post-fix | fm-fleet-snapshot.sh       | --json                     |   0 |     0 | fm-fleet-snapshot.v1         | 0 |
| post-fix | fm-bearings-snapshot.sh    | --json                     |   0 |     0 | fm-bearings.v1               | 0 |
post-fix secondmate_current: 8 records, 395242 bytes
```
</details>
<details>
<summary>Evidence: Repro script (pre-fix vs post-fix, runtime-built oversized fixtures)</summary>

Source: [Repro script (pre-fix vs post-fix, runtime-built oversized fixtures)](https://github.com/altave-guilherme-monteiro/firstmate/blob/eb9b612cd077ce9edec26f33419751382249eda8/.no-mistakes/evidence/fm/fm-snapshot-arg-limit/repro-pre-vs-post-fix.sh)

```text
#!/usr/bin/env bash
set -u
WT=${1:?worktree path}
PRE_FIX=7ee0c192e9d664b022361bd4609303bebfc7de14
. "$WT/tests/lib.sh"
TMP=$(fm_test_tmproot fm-e2big-repro)

make_fakebin() {
  local fb
  fb=$(fm_fakebin "$1")
  printf '#!/usr/bin/env bash\nexit 0\n' > "$fb/no-mistakes"
  printf '#!/usr/bin/env bash\ncase "${1:-}" in list-windows) sed -n "s/^window=[^:]*://p" "${FM_HOME:?}"/state/*.meta ;; display-message) printf "codex\\n" ;; capture-pane) printf "all quiet\\n> \\n" ;; esac\nexit 0\n' > "$fb/tmux"
  chmod +x "$fb/no-mistakes" "$fb/tmux"
  printf '%s\n' "$fb"
}

stage_pre_fix_bin() {
  local bin=$TMP/pre-fix/bin
  mkdir -p "$bin"
  ln -s "$ROOT"/bin/* "$bin/"
  rm "$bin/fm-fleet-snapshot.sh"
  git -C "$ROOT" show "$PRE_FIX:bin/fm-fleet-snapshot.sh" > "$bin/fm-fleet-snapshot.sh"
  chmod +x "$bin/fm-fleet-snapshot.sh"
  printf '%s\n' "$bin"
}

oversized_backlog_home() {
  local home=$TMP/backlog-home i=0
  mkdir -p "$home/state" "$home/data" "$home/projects" "$home/config"
  {
    printf '## In flight\n\n## Queued\n'
    while [ "$i" -lt 3000 ]; do
      printf -- '- [ ] oversized-task-%04d - Oversized filler task number %04d with extra padding text to grow every row well past the kernel single-argument limit (repo: alpha) (kind: ship)\n' "$i" "$i"
      i=$((i + 1))
    done
    printf '\n## Done\n'
  } > "$home/data/backlog.md"
  printf '%s\n' "$home"
}

oversized_secondmate_home() {
  local home=$TMP/secondmate-home padding id i=0
  mkdir -p "$home/state" "$home/data" "$home/projects" "$home/config"
  padding=$(LC_ALL=C head -c 12000 /dev/zero | tr '\0' x)
  while [ "$i" -lt 8 ]; do
    id=$(printf 'wide-secondmate-%02d' "$i")
    mkdir -p "$home/projects/$id"
    fm_write_meta "$home/state/$id.meta" "window=firstmate:fm-$id" "worktree=$home/projects/$id" \
      "project=alpha" "harness=codex" "kind=secondmate" "mode=secondmate" "home=$home/projects/$id"
    printf 'working: %s\n' "$padding" > "$home/state/$id.status"
    i=$((i + 1))
  done
  printf '%s\n' "$home"
}

run_case() {
  local label=$1 home=$2 bin=$3 script=$4 flag=$5 out err rc e2big schema scratch
  scratch=$TMP/scratch-$label-$(basename "$script" .sh)$flag
  mkdir -p "$scratch"
  out=$TMP/out; err=$TMP/err
  PATH="$FAKEBIN:$PATH" TMPDIR="$scratch" FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$home" FM_DATA_OVERRIDE="$home/data" \
    "$bin/$script" "$flag" > "$out" 2> "$err"; rc=$?
  e2big=$(grep -c "Argument list too long" "$err")
  schema=$(jq -r '.schema // "-"' "$out" 2>/dev/null | head -1)
  [ -n "$schema" ] || schema="(no JSON)"
  printf '| %-8s | %-26s | %-26s | %3s | %5s | %-28s | %s |\n' "$label" "$script" "$flag" "$rc" "$e2big" "$schema" \
    "$(find "$scratch" -mindepth 1 | wc -l | tr -d ' ')"
  if [ "$rc" -ne 0 ]; then sed -n '1,3p' "$err" | cut -c1-160 | sed 's/^/    stderr: /'; fi
}

FAKEBIN=$(make_fakebin "$TMP")
PRE_BIN=$(stage_pre_fix_bin)
POST_BIN=$ROOT/bin

BACKLOG_HOME=$(oversized_backlog_home)
printf 'Fixture A: %s-byte backlog.md with 3000 queued rows (MAX_ARG_STRLEN=131072)\n' "$(LC_ALL=C wc -c < "$BACKLOG_HOME/data/backlog.md" | tr -d ' ')"
printf '| build    | script                     | flag                       |  rc | E2BIG | schema                       | leftover tmp |\n'
for build in pre-fix post-fix; do
  bin=$PRE_BIN; [ "$build" = post-fix ] && bin=$POST_BIN
  run_case "$build" "$BACKLOG_HOME" "$bin" fm-fleet-snapshot.sh --json
  run_case "$build" "$BACKLOG_HOME" "$bin" fm-fleet-snapshot.sh --secondmate-home-summary
  run_case "$build" "$BACKLOG_HOME" "$bin" fm-bearings-snapshot.sh --json
done
printf 'post-fix backlog rows in snapshot: %s\n\n' \
  "$(PATH="$FAKEBIN:$PATH" FM_HOME="$BACKLOG_HOME" FM_DATA_OVERRIDE="$BACKLOG_HOME/data" "$POST_BIN/fm-fleet-snapshot.sh" --json | jq '.backlog.records | length')"

SM_HOME=$(oversized_secondmate_home)
printf 'Fixture B: 8 registered secondmates, each with a 12000-byte status line\n'
printf '| build    | script                     | flag                       |  rc | E2BIG | schema                       | leftover tmp |\n'
for build in pre-fix post-fix; do
  bin=$PRE_BIN; [ "$build" = post-fix ] && bin=$POST_BIN
  run_case "$build" "$SM_HOME" "$bin" fm-fleet-snapshot.sh --json
  run_case "$build" "$SM_HOME" "$bin" fm-bearings-snapshot.sh --json
done
printf 'post-fix secondmate_current: %s records, %s bytes\n' \
  "$(PATH="$FAKEBIN:$PATH" FM_HOME="$SM_HOME" "$POST_BIN/fm-fleet-snapshot.sh" --json | jq '.secondmate_current.records | length')" \
  "$(PATH="$FAKEBIN:$PATH" FM_HOME="$SM_HOME" "$POST_BIN/fm-fleet-snapshot.sh" --json | jq -c '.secondmate_current.records' | LC_ALL=C wc -c | tr -d ' ')"
```
</details>
<details>
<summary>Evidence: fm-fleet-snapshot-view test log (pre-fix comparison opt-in set)</summary>

Source: [fm-fleet-snapshot-view test log (pre-fix comparison opt-in set)](https://github.com/altave-guilherme-monteiro/firstmate/blob/eb9b612cd077ce9edec26f33419751382249eda8/.no-mistakes/evidence/fm/fm-snapshot-arg-limit/fleet-snapshot-view-test.log)

```text
ok - empty fleet snapshot and view use explicit absence markers
ok - fixture snapshot covers task rows, backlog rows, pointers, and stable ordering
ok - main_inventory discloses orphan/unstructured and clears when inventory is consistent
ok - backlog normalization preserves strict roles and resolves every blocker compatibly
ok - snapshot event hints follow reconciled current state
ok - durable fold keeps an open decision past a later unrelated event
ok - a live secondmate endpoint preserves unrelated open decisions
ok - durable captain-held transfer closes the duplicate live status decision
ok - durable fold clears a decision only on a keyed resolution
ok - a completed scout's stale decision surfaces as a report pointer, not pending
ok - a scout still parked at a decision stays pending (terminal clear does not over-fire)
ok - snapshot includes durable scout reports after teardown
ok - snapshot parses tasks-axi rows and respects operational overrides
ok - fleet view renders the snapshot without secondmate peek guidance
ok - fleet view renders secondmate agent liveness
ok - an oversized structured backlog survives the kernel single-argument limit across both readers
ok - secondmate aggregation beyond the kernel single-argument limit keeps every record
ok - a small fleet snapshot stays byte-identical apart from the generated timestamp
ok - a small fleet snapshot matches the pre-fix output apart from the generated timestamp
```
</details>
<details>
<summary>Evidence: fm-bearings-snapshot test log</summary>

Source: [fm-bearings-snapshot test log](https://github.com/altave-guilherme-monteiro/firstmate/blob/eb9b612cd077ce9edec26f33419751382249eda8/.no-mistakes/evidence/fm/fm-snapshot-arg-limit/bearings-snapshot-test.log)

```text
ok - Domain Alpha structured state overrides a stale parent Phase 7 event
ok - GNU stat file reads select -c without BSD filesystem-report pollution
ok - parent activity evidence is bounded and disclosed
ok - Bearings excludes a status-only child decision
ok - a structured child captain hold reaches Captain's Call
ok - missing, invalid, unreadable, malformed, and timed-out homes stay explicit unknowns
ok - an oversized secondmate summary retains the strict empty unknown fallback
ok - secondmate and per-home child counts are bounded, disclosed, and explicitly expandable
ok - parent decisions remain untrusted contradiction evidence
ok - parent evidence reconciliation distinguishes matching holds, blocks, and decisions
ok - nonprogressing child states are explicit and inconsistent terminal rows invalidate
ok - registry unavailability and bounded truncation remain explicit
ok - repeated snapshots keep the same current landed baseline and ignore prior reports
ok - default output is bounded, local-only, and marks omitted surfaces
ok - TOON and JSON are parity representations of the same model
ok - landed includes secondmate-managed merges alongside main-home merges
ok - default landed selection balances one dominant home with sparse homes
ok - landed selection refills capacity after sparse homes exhaust
ok - landed selection uses deterministic home order when homes exceed the cap
ok - landed selection preserves deterministic home and internal tie ordering
ok - landed selection handles no landed items
ok - --all-landed keeps the complete global landed output
ok - landed stays bounded with per-home + overall caps and omitted[] disclosure
ok - Bearings keeps a live blocker in structured live state and never converts it to Charted Next queue work
ok - action-free items (working/done/queued/landed) do not leak into Captain's Call
ok - main orphan in-flight stays out of Underway and is disclosed in omitted/gates
ok - main unstructured current is disclosed while structured siblings still project
ok - counterfactual meta clears main inventory warning and projects the live task
ok - mixed secondmate roles, partial state, and captain readiness project independently
ok - main and secondmate captain actionability use the same blocker readiness
ok - a completed scout with decision-like report prose is a pointer, not pending
ok - an authoritative captain hold surfaces end-to-end
ok - current report pointers surface
ok - superseded queued items are dropped by default and restored with --all-queued
ok - --include-prs is the only path that fetches, and it enriches correctly
ok - a partial GitHub failure degrades gracefully
ok - Perl fallback bounds stalled GitHub calls without coreutils timeout
ok - all fleet-sized sections are capped with counted opt-in expansion
ok - captain-held tasks of any kind reach Captain's Call, deferral is honored, and landed excludes answered calls
ok - live PR enrichment caps repositories with counted expansion
ok - per-repository open-PR caps are disclosed with an expansion knob
ok - projection and TOON rendering failures exit nonzero with diagnostics
```
</details>
- Outcome: ⚠️ 1 info across 1 run (7m36s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"fe6958a98bfc0105fd49be480d0c1ce2112ce553","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"skipped"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>⏭️ **Rebase** - skipped</summary>

- ⚠️ `.agents/skills/afk/SKILL.md` - branch carries 47 commit(s) that exist on your local main branch but were never pushed to origin/main; rebasing would bundle this unrelated work (381 file(s)) into the PR:
- 38ca5eb feat(skills): add nabors-programme skill for Sauron version scheme (#10)
- 35935c0 feat(bin): close commit-is-not-done and stale-mirror rebase traps in ship briefs (#9)
- e9a0488 feat(bin): gate ship spawns on a linked tracker issue (#8)
- 1e3be03 feat(bin): brief scaffold points workers at semgrep and context7 (#7)
- 2996963 feat: mirror architecture and decision documents onto tracker cards (#6)
- 2b9c6a6 feat: prune fleet knowledge and add a recurring delivery retrospective (#5)
- 6092c3c feat: post evidence to the tracker and route new issues by team (#4)
- dedae5b fix(ci): unblock fork Actions runs; ignore browser-automation debris (#3)
- aa2353b feat: board-aware session start, intake guardrail, issue linkage (#2)
- b97c730 fix: preference files are captain-authorized only, drop no-action chatter (#1)
- d3d407d Merge fm/fm-backend-maturity-retrue into main
- 6892ab2 Merge fm/fm-adopt-graphify into main
- e5c463e Merge fm/fm-otel-cli-consumer into main
- a3840d0 no-mistakes(ci): treat run-block outcome as terminal in the trace poller
- 03c22a0 no-mistakes: apply CI fixes
- 5355c77 no-mistakes(review): docs: mark non-macOS Orca CLI install path unverified
- cf89a23 no-mistakes: apply CI fixes
- 32a535e no-mistakes(review): docs: fix Herdr selection claim and unverified Orca link
- 41ff1e9 no-mistakes(review): make graphify-bak ignore coverage optional, not gating
- dc364b4 no-mistakes(lint): fix ShellCheck SC2016/SC2086 in otel-cli lib test
- 4cf161c no-mistakes(document): correct otel-cli span timing and service-name docs
- b7362c3 no-mistakes(review): only self-ignore ignore files this script creates
- 92cd5e4 no-mistakes(review): fix .claude ignore self-probe, pipx diagnostics, test stall
- 57cf0eb no-mistakes(review): tighten empty-poll fallback test, document poll knob
- 898dd55 no-mistakes(review): validate empty-poll bound, refresh verification transcript
- 48ffa83 no-mistakes(review): harden graphify setup against pipx races and signals
- 58d5267 no-mistakes(review): make poller arg-validation test real, source lib absolutely
- 1d3526e no-mistakes(review): guard span endpoint, validate poller timing args, fix status doc
- f2e5fa2 no-mistakes(review): probe every graphify-out artifact for ignore coverage
- c2a5010 no-mistakes(review): verify ignore coverage, pipx PATH, git-only note in graphify setup
- b88cef8 no-mistakes(lint): add shellcheck source directive to graphify setup test
- 42a205f no-mistakes(document): docs(graphify): point verification at hygiene regression test
- 305f4ea no-mistakes(document): clarify firstmate emits no spans without the otel-cli consumer
- d32314b no-mistakes(review): test(graphify): cover setup script worktree hygiene
- 79ebf41 no-mistakes(review): bound empty polls, drop unobserved phase spans, recapture evidence
- c332403 no-mistakes(review): handle both steps header variants and close tail phase spans
- 90d313b no-mistakes(review): fix(graphify): ignore artifacts earlier, skip hook when settings exist
- 0250414 no-mistakes(review): parse the real axi status steps table for phase spans
- 39da5bb no-mistakes(review): fix(graphify): restore tracked settings.json instead of hiding it
- 3ec749a no-mistakes(review): drop dead otel wrap helper and harden pipeline status parsing
- 1a20fc0 no-mistakes(review): fix(graphify): ignore artifacts pre-install, make brief non-blocking
- 270395a no-mistakes(review): fix(graphify): keep setup hygiene inside the worktree
- 9bc1d19 feat(trace): wire otel-cli as the first consumer of the trace-context carrier
- ce76b5c no-mistakes(review): fix(graphify): stop artifact leak, add skill, verify query verb
- 81e1f7a no-mistakes(document): docs: correct tmux missing-binary fallback claim
- 1024b20 feat: adopt graphify as the crewmate codebase-comprehension tool
- 1814163 docs: correct Orca platform claim, add fresh herdr/orca/cmux verification evidence

Push main to origin, or rebase your branch onto origin/main, before gating.
</details>

<details>
<summary>⚠️ **Review** - 1 info</summary>

- 🚨 `bin/fm-fleet-snapshot.sh:210` - The temp files are never cleaned up. `snapshot_payload_file` is always called inside `$(...)` (for example `backlog_file=$(snapshot_payload_file &#34;$1&#34;)`, and `main_inventory_json` itself runs inside `MAIN_INVENTORY_JSON=$(...)`). So `FM_SNAPSHOT_TMPFILES+=(&#34;$f&#34;)` changes only a subshell copy of the array. The parent&#39;s array stays empty, and the EXIT trap at line 219 deletes nothing. Verified: one `--json` run on an empty home with TMPDIR set to a fresh directory left 9 `fm-fleet-snapshot.XXXXXX` files behind; a bash check confirmed array appends inside `$(...)` are lost. On a large fleet, each run leaves about 4 full copies of the backlog and tasks JSON plus the secondmate current and landed payloads. Each secondmate child `--secondmate-home-summary` call leaves 2 more. /bearings and every other snapshot consumer run this repeatedly, so /tmp fills with fleet data without bound. Fix at the shared boundary: create one per-run directory in the main shell before any function runs (`FM_SNAPSHOT_TMPDIR=$(mktemp -d ...)`; `trap &#39;rm -rf &#34;$FM_SNAPSHOT_TMPDIR&#34;&#39; EXIT`) and have `snapshot_payload_file` call mktemp inside it, so files created in subshells are still removed. A simpler option that needs no temp files: `--slurpfile backlog &lt;(printf &#39;%s&#39; &#34;$1&#34;)`, since printf is a builtin and has no argv limit. Also make the oversized test run with its own TMPDIR and assert that directory is empty afterward, so this regression is caught.
- ⚠️ `bin/fm-fleet-snapshot.sh:1383` - The secondmate_current payload still goes through `--argjson` while it is being built, so the `--slurpfile secondmate_current` change at line 1467 never takes effect. `secondmate_current_json` builds its result by appending each record with `records=$(jq -n --argjson records &#34;$records&#34; --argjson record &#34;$record&#34; &#39;$records + [$record]&#39;)` (line 1383), then passes it again with `--argjson records &#34;$records&#34;` (line 1389). Each record embeds that home&#39;s summary (up to 20 children, 20 queued, 20 decisions and 10 landed items) plus parent activities, reconciliation and up to 4096 bytes of terminal evidence. The default cap allows 20 secondmates (`FM_SNAPSHOT_SECONDMATES`). Failure path: once the running array passes 131072 bytes, line 1383 fails with E2BIG and `records` becomes empty. Line 1389 then fails, `secondmate_current_json` returns non-zero, and the script exits with &#34;registered secondmate aggregation failed&#34;, taking /bearings down again. A single summary can also exceed the limit on its own: the byte gate at line 1289 accepts up to `FM_SNAPSHOT_SECONDMATE_MAX_BYTES`=262144, yet the summary is passed as `--argjson summary` at lines 1337 and 1372, and at line 1121 via `parent_evidence_reconciliation_json`. This contradicts the intent&#39;s claim that every whole-fleet or unbounded-slice call site was converted. Fix: collect records as newline-delimited JSON (or in a per-run file) and combine them once with `jq -s`, and pass the summary through the same file or stdin path.
- ⚠️ `tests/fm-fleet-snapshot-view.test.sh:837` - The intent says the small-fixture snapshot was &#34;verified ... byte-identical (apart from the generated timestamp) before and after via a new regression test&#34;. But `test_small_fleet_output_is_byte_identical_apart_from_generated` runs the post-fix script twice, with the same pinned `FM_SNAPSHOT_NOW`, and compares the two runs. That only shows the output is deterministic. It would still pass if the `--slurpfile`/`$x[0]` rebinding changed or dropped fields, so no before-versus-after comparison exists in the change. To prove it, compare against a golden output generated from the pre-fix script (base commit) for the same fixture. Otherwise, remove the claim.
- ℹ️ `bin/fm-fleet-snapshot.sh:1466` - `--argjson scout_reports &#34;$SCOUT_REPORTS_JSON&#34;` in the final assembly is still an unbounded list: one `{id,path}` object for every `data/*/report.md`, about 110 bytes each. It hits MAX_ARG_STRLEN at roughly 1200 reports. The real fleet has 28 today, so this is not urgent. It is still an unbounded slice by the intent&#39;s own definition and costs one line to move onto the same `--slurpfile` path as its neighbours.

🔧 Fix: Scope snapshot temp payloads per run, spill secondmate records
2 infos still open:

- ℹ️ `tests/fm-fleet-snapshot-view.test.sh:870` - `test_small_fleet_output_matches_the_pre_fix_snapshot` compares against a pre-fix commit that is pinned forever (`PRE_FIX_SNAPSHOT_COMMIT=7ee0c19`). After this change merges, the check will fail on any later intentional change to the `fm-fleet-snapshot.sh` output, such as a new field or a changed record shape, with the misleading message &#34;must match the pre-fix output&#34;. It can also break for unrelated reasons: `pre_fix_snapshot_bin` symlinks the *current* sibling libraries (`fm-backend.sh`, `fm-classify-lib.sh`, `fm-ff-lib.sh`, `fm-timeout-lib.sh`, `fm-crew-state.sh`, and others) next to the old script, so an incompatible helper change breaks the old copy. In shallow clones it silently skips. The user asked for this design, so it stays as written. It is only raised so they can decide whether to keep it permanently or drop it once this change lands.
- ℹ️ `bin/fm-fleet-snapshot.sh:1450` - `BACKLOG_JSON` and `TASKS_JSON` are written to temp files up to three times per `--json` run: in `main_inventory_json` (lines 654-655), again for tasks in `secondmate_current_json` (line 1182), and again for the final assembly (lines 1450-1451). Each copy repeats a full-fleet write, and on a large fleet that is exactly the case this change targets. Simpler: write each payload to a file once, right after `BACKLOG_JSON`/`TASKS_JSON` are read (line 1433), and pass the file paths to `main_inventory_json`, `secondmate_home_summary_json`, `secondmate_current_json` and the final `jq`. That removes the repeated two-line write blocks in each function and keeps the output unchanged.

🔧 Fix: Spill fleet payloads once, gate pre-fix golden test
1 info still open:

- ℹ️ `bin/fm-fleet-snapshot.sh:1445` - `SECONDMATE_CURRENT_JSON` gets written to a temp file twice: once inside `secondmate_landed_from_current_json` (line 1392) and again as `FINAL_SECONDMATE_CURRENT_FILE` (line 1445). The last fix round removed the same kind of repeat for backlog and tasks. Simpler: write it once at the call site. Pass that file path to `secondmate_landed_from_current_json`, which would then drop its own `local current_file` and write step. Reuse the same path in the final `--slurpfile secondmate_current`. Output does not change.
</details>

<details>
<summary>⚠️ **Test** - 1 info</summary>

- ℹ️ `tests/fm-fleet-snapshot-view.test.sh:822` - `assert_no_grep &#34;Argument list too long&#34;` only matches the English error text. On this machine (LANG=pt_BR.UTF-8) the shell prints &#39;Lista de argumentos muito longa&#39;, so the stderr check passes even when E2BIG happens. The regression is still caught because each call&#39;s exit code must be 0, and the pre-fix build exits 1. Running those invocations with LC_ALL=C would make the stderr check meaningful on every locale.
- <code>`FM_FLEET_SNAPSHOT_GOLDEN_OPTIN=1 bash tests/fm-fleet-snapshot-view.test.sh`: all 19 tests pass, including the oversized-backlog test, the oversized-secondmate test, the determinism test, and the opt-in comparison with the pre-fix output</code>
- <code>`bash tests/fm-bearings-snapshot.test.sh`: passes, including the Perl-fallback timeout test that now lists mktemp and rm in its allowed tools</code>
- <code>`LC_ALL=C bash /home/altave/.no-mistakes/evidence/01M26P233C4FW7QPZDC69Y96Q6/repro-pre-vs-post-fix.sh $PWD`: runs the pre-fix fm-fleet-snapshot.sh (from git show 7ee0c19, placed next to the current sibling scripts) and the post-fix script on two fixtures. Fixture A is a 522033-byte backlog.md with 3000 rows; fixture B is 8 secondmates, each with a 12000-byte status. Each run records exit code, E2BIG text in stderr, output schema, and leftover temp files</code>
- `Confirmed the E2BIG error text depends on locale (pt_BR prints 'Lista de argumentos muito longa'), so the repro was rerun under LC_ALL=C`
- <code>`git status --porcelain`: worktree is clean after testing</code>
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
