### PR TITLE
fix(bin): run git/awk under LC_ALL=C where output is parsed

### DIFF
--- a/bin/backends/herdr.sh
+++ b/bin/backends/herdr.sh
@@ -3284,7 +3284,7 @@ FM_BACKEND_HERDR_SUBMIT_POLLS=${FM_BACKEND_HERDR_SUBMIT_POLLS:-6}
 FM_BACKEND_HERDR_SUBMIT_MIN_SLEEP=${FM_BACKEND_HERDR_SUBMIT_MIN_SLEEP:-0.6}
 
 fm_backend_herdr_submit_confirm_budget() {  # <caller-budget-seconds>
-  awk -v b="${1:-0}" -v m="$FM_BACKEND_HERDR_SUBMIT_MIN_SLEEP" 'BEGIN {
+  LC_ALL=C awk -v b="${1:-0}" -v m="$FM_BACKEND_HERDR_SUBMIT_MIN_SLEEP" 'BEGIN {
     b += 0
     m += 0
     if (b < 0) b = 0
@@ -3297,7 +3297,7 @@ fm_backend_herdr_submit_confirm_budget() {  # <caller-budget-seconds>
 fm_backend_herdr_wait_for_working() {  # <session> <pane_id> <budget-seconds> <polls>
   local session=$1 pane_id=$2 budget=$3 polls=${4:-1} i interval raw bs saw_idle=0
   case "$polls" in ''|*[!0-9]*|0) polls=1 ;; esac
-  interval=$(awk -v b="$budget" -v p="$polls" 'BEGIN { d = p - 1; if (d < 1) d = 1; v = b / d; if (v < 0) v = 0; printf "%.4f", v }' 2>/dev/null)
+  interval=$(LC_ALL=C awk -v b="$budget" -v p="$polls" 'BEGIN { d = p - 1; if (d < 1) d = 1; v = b / d; if (v < 0) v = 0; printf "%.4f", v }' 2>/dev/null)
   case "$interval" in ''|*[!0-9.]*) interval=0 ;; esac
   for ((i = 0; i < polls; i++)); do
     if [ "$polls" -eq 1 ] || [ "$i" -gt 0 ]; then

--- a/bin/fm-fleet-sync.sh
+++ b/bin/fm-fleet-sync.sh
@@ -140,8 +140,8 @@ first_line() {
 # e.g. "could not delete reference ...:"). Other "File exists" errors must not match.
 # Matches git's own English text, so every fetch this guards runs under LC_ALL=C -
 # a non-English operator locale otherwise makes this recognize nothing and the
-# whole stale-lock recovery silently never fires (confirmed 2026-08-24 under
-# de_DE.UTF-8: git's fetch error localizes and this guard never matches it).
+# whole stale-lock recovery silently never fires (pinned by
+# test_transient_packed_refs_lock_self_clears in tests/fm-fleet-sync.test.sh).
 is_packed_refs_lock_error() {
   printf '%s\n' "$1" | grep -Eq "Unable to create ['\"].*packed-refs\\.lock['\"]: File exists"
 }

--- a/bin/fm-fleet-sync.sh
+++ b/bin/fm-fleet-sync.sh
@@ -138,6 +138,10 @@ first_line() {
 # True when git stderr shows the packed-refs.lock "File exists" race. The lock
 # path can appear anywhere in the message (git prefixes it with the failed ref op,
 # e.g. "could not delete reference ...:"). Other "File exists" errors must not match.
+# Matches git's own English text, so every fetch this guards runs under LC_ALL=C -
+# a non-English operator locale otherwise makes this recognize nothing and the
+# whole stale-lock recovery silently never fires (confirmed 2026-08-24 under
+# de_DE.UTF-8: git's fetch error localizes and this guard never matches it).
 is_packed_refs_lock_error() {
   printf '%s\n' "$1" | grep -Eq "Unable to create ['\"].*packed-refs\\.lock['\"]: File exists"
 }
@@ -169,7 +173,7 @@ packed_refs_lock_path() {
 # a session-start refresh (which discards fleet-sync stderr) still surfaces it.
 fetch_with_packed_refs_lock_guard() {
   local rc attempt=0 lock lock_desc
-  FETCH_OUTPUT=$(git -C "$PROJ" fetch origin --prune --quiet 2>&1); rc=$?
+  FETCH_OUTPUT=$(LC_ALL=C git -C "$PROJ" fetch origin --prune --quiet 2>&1); rc=$?
   [ "$rc" -eq 0 ] && return 0
   is_packed_refs_lock_error "$FETCH_OUTPUT" || return "$rc"
 
@@ -179,7 +183,7 @@ fetch_with_packed_refs_lock_guard() {
     attempt=$(( attempt + 1 ))
     echo "$label: fetch blocked by packed-refs lock ($lock_desc); waiting ${FLEET_SYNC_PACKED_REFS_LOCK_RETRY_WAIT_SECS}s and retrying ($attempt/${FLEET_SYNC_PACKED_REFS_LOCK_RETRIES}) (owning process may be exiting)" >&2
     sleep "$FLEET_SYNC_PACKED_REFS_LOCK_RETRY_WAIT_SECS"
-    FETCH_OUTPUT=$(git -C "$PROJ" fetch origin --prune --quiet 2>&1); rc=$?
+    FETCH_OUTPUT=$(LC_ALL=C git -C "$PROJ" fetch origin --prune --quiet 2>&1); rc=$?
     if [ "$rc" -eq 0 ]; then
       echo "$label: fetch succeeded on retry; packed-refs lock cleared on its own" >&2
       # One stdout summary so a session-start refresh (which discards fleet-sync
@@ -203,7 +207,7 @@ fetch_with_packed_refs_lock_guard() {
         return "$rc"
       fi
       echo "$label: removed provably-stale packed-refs lock $lock (age >= ${FLEET_SYNC_PACKED_REFS_LOCK_AGE_SECS}s, no live holder) and retrying fetch" >&2
-      FETCH_OUTPUT=$(git -C "$PROJ" fetch origin --prune --quiet 2>&1); rc=$?
+      FETCH_OUTPUT=$(LC_ALL=C git -C "$PROJ" fetch origin --prune --quiet 2>&1); rc=$?
       if [ "$rc" -eq 0 ]; then
         echo "$label: fetch succeeded after stale packed-refs lock cleanup" >&2
         echo "$label: recovered: removed a stale packed-refs lock (no live holder)"

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -1571,7 +1571,7 @@ teardown_treehouse_return() {
 
   # Capture stdout+stderr so non-lock failures stay visible and lock failures can
   # be matched by signature even when the lock file is already gone mid-check.
-  if out=$( ( cd "$cd_dir" && treehouse return --force "$dir" ) 2>&1 ); then
+  if out=$( ( cd "$cd_dir" && LC_ALL=C treehouse return --force "$dir" ) 2>&1 ); then
     [ -n "$out" ] && printf '%s\n' "$out"
     return 0
   fi
@@ -1596,7 +1596,7 @@ teardown_treehouse_return() {
     echo "teardown: $label return failed with transient git lock ($lock_desc); waiting ${TREEHOUSE_RETURN_LOCK_RETRY_WAIT_SECS}s and retrying ($attempt/${max_retries})" >&2
     sleep "$TREEHOUSE_RETURN_LOCK_RETRY_WAIT_SECS"
 
-    if out=$( ( cd "$cd_dir" && treehouse return --force "$dir" ) 2>&1 ); then
+    if out=$( ( cd "$cd_dir" && LC_ALL=C treehouse return --force "$dir" ) 2>&1 ); then
       [ -n "$out" ] && printf '%s\n' "$out"
       echo "teardown: $label return succeeded on retry; lock cleared on its own" >&2
       return 0
@@ -1623,7 +1623,7 @@ teardown_treehouse_return() {
           return 1
         fi
       fi
-      if out=$( ( cd "$cd_dir" && treehouse return --force "$dir" ) 2>&1 ); then
+      if out=$( ( cd "$cd_dir" && LC_ALL=C treehouse return --force "$dir" ) 2>&1 ); then
         [ -n "$out" ] && printf '%s\n' "$out"
         echo "teardown: $label return succeeded after stale-lock cleanup" >&2
         return 0

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -1506,6 +1506,9 @@ TEARDOWN_PROCEVENT_RESTORE_FAILED=4
 
 # True when treehouse/git stderr shows the transient index.lock "File exists" race.
 # Other return failures must not enter the retry path.
+# Matches git's own English text, so every `treehouse return` this guards runs
+# under LC_ALL=C - a non-English operator locale otherwise disables the retry
+# (pinned by test_transient_index_lock_retry_is_locale_independent).
 treehouse_return_is_index_lock_error() {
   local text=$1
   printf '%s\n' "$text" | grep -Eq "Unable to create ['\"].*index\\.lock['\"]: File exists"

--- a/tests/fm-backend-herdr.test.sh
+++ b/tests/fm-backend-herdr.test.sh
@@ -3826,9 +3826,11 @@ test_wait_for_working_samples_budget_endpoint_without_final_sleep() {
   pass "fm_backend_herdr_wait_for_working: spreads six samples across the full budget endpoint without a final trailing sleep"
 }
 
-test_send_text_submit_applies_herdr_minimum_confirm_budget() {
+# assert_submit_min_confirm_budget <case>: a 0.4s caller budget is expanded to the
+# 0.6s herdr floor and spread as five 0.1200s sleeps, in the caller's locale.
+assert_submit_min_confirm_budget() {
   local dir log resp fb out sleep_log sleeps
-  dir="$TMP_ROOT/submit-min-budget"; mkdir -p "$dir/responses"; log="$dir/log"; resp="$dir/responses"; sleep_log="$dir/sleeps"; : > "$log"; : > "$sleep_log"
+  dir="$TMP_ROOT/$1"; mkdir -p "$dir/responses"; log="$dir/log"; resp="$dir/responses"; sleep_log="$dir/sleeps"; : > "$log"; : > "$sleep_log"
   printf '{"result":{"agent":{"agent_status":"idle"}}}\n' > "$resp/2.out"
   printf '{"result":{"agent":{"agent_status":"idle"}}}\n' > "$resp/4.out"
   printf '{"result":{"agent":{"agent_status":"idle"}}}\n' > "$resp/5.out"
@@ -3843,7 +3845,16 @@ test_send_text_submit_applies_herdr_minimum_confirm_budget() {
   sleeps=$(grep -c '^sleep:0.1200$' "$sleep_log")
   [ "$sleeps" -eq 5 ] || fail "a 0.4s caller budget should be expanded to five 0.1200s sleeps across the 0.6s herdr floor, got $sleeps; log: $(cat "$sleep_log")"
   [ "$(grep -c '^sleep:0.0800$' "$sleep_log")" -eq 0 ] || fail "send_text_submit used the caller's too-short 0.4s budget instead of the herdr floor: $(cat "$sleep_log")"
+}
+
+test_send_text_submit_applies_herdr_minimum_confirm_budget() {
+  assert_submit_min_confirm_budget submit-min-budget
   pass "fm_backend_herdr_send_text_submit: applies the herdr minimum confirmation budget before polling agent-state"
+}
+
+test_send_text_submit_confirm_budget_ignores_decimal_comma_locale() {
+  LC_ALL=de_DE.UTF-8 assert_submit_min_confirm_budget submit-min-budget-de
+  pass "fm_backend_herdr_send_text_submit: the herdr minimum confirmation budget holds under a decimal-comma locale"
 }
 
 test_wait_for_working_returns_idle_when_never_busy_but_readable() {
@@ -5035,6 +5046,7 @@ test_wait_for_working_returns_busy_on_first_poll
 test_wait_for_working_catches_a_slow_transition_mid_window
 test_wait_for_working_samples_budget_endpoint_without_final_sleep
 test_send_text_submit_applies_herdr_minimum_confirm_budget
+test_send_text_submit_confirm_budget_ignores_decimal_comma_locale
 test_wait_for_working_returns_idle_when_never_busy_but_readable
 test_wait_for_working_returns_unknown_when_never_readable
 test_wait_for_working_treats_blocked_as_submit_active

--- a/tests/fm-fleet-sync.test.sh
+++ b/tests/fm-fleet-sync.test.sh
@@ -617,7 +617,7 @@ test_transient_packed_refs_lock_self_clears() {
 
   # A German operator shell: the guard must still see git's English signature.
   set +e
-  LC_ALL= LANG=de_DE.UTF-8 \
+  LC_ALL='' LANG=de_DE.UTF-8 \
   GIT_FETCH_COUNTER="$counter" \
   FM_FLEET_SYNC_PACKED_REFS_LOCK_RETRIES=3 \
   FM_FLEET_SYNC_PACKED_REFS_LOCK_RETRY_WAIT_SECS=0 \

--- a/tests/fm-fleet-sync.test.sh
+++ b/tests/fm-fleet-sync.test.sh
@@ -90,10 +90,14 @@ advance_origin() {
 head_sha() { git -C "$1" rev-parse HEAD; }
 
 # run_sync <home> [args...]: run fleet-sync against an isolated home, stdout only.
+# LC_ALL=C so a relayed git error (e.g. "untracked working tree files would be
+# overwritten") is asserted in its stable English form regardless of the host
+# shell's locale - fm-fleet-sync.sh's own behavior is not locale-sensitive,
+# only the exact text of a message it relays from git is.
 run_sync() {
   local home=$1
   shift
-  FM_HOME="$home" FM_ROOT_OVERRIDE="$ROOT" "$ROOT/bin/fm-fleet-sync.sh" "$@" 2>/dev/null
+  LC_ALL=C FM_HOME="$home" FM_ROOT_OVERRIDE="$ROOT" "$ROOT/bin/fm-fleet-sync.sh" "$@" 2>/dev/null
 }
 
 # build_enclosing_home <name>: an FM_HOME that is itself nested inside another git

--- a/tests/fm-fleet-sync.test.sh
+++ b/tests/fm-fleet-sync.test.sh
@@ -202,6 +202,8 @@ SH
 # git shim: fail the FIRST `fetch` with the packed-refs.lock signature and drop
 # the lock (simulating the dying ref-rewrite finishing), then delegate every
 # later call - including the retried fetch - to the real git so the sync completes.
+# Like real git, the signature is English only under LC_ALL=C and localized
+# (German) otherwise.
 git_transient_packed_refs_lock() {
   cat > "$1/git" <<'SH'
 #!/usr/bin/env bash
@@ -215,7 +217,11 @@ if [ "$is_fetch" = 1 ]; then
   printf '%s\n' "$n" > "$GIT_FETCH_COUNTER"
   if [ "$n" -eq 1 ]; then
     lock="$dir/.git/packed-refs.lock"
-    echo "error: could not delete reference refs/remotes/origin/feature: Unable to create '$lock': File exists." >&2
+    if [ "${LC_ALL:-}" = C ]; then
+      echo "error: could not delete reference refs/remotes/origin/feature: Unable to create '$lock': File exists." >&2
+    else
+      echo "error: Konnte Referenz refs/remotes/origin/feature nicht entfernen: Konnte '$lock' nicht erstellen: Die Datei existiert bereits." >&2
+    fi
     rm -f "$lock"
     exit 1
   fi
@@ -609,7 +615,9 @@ test_transient_packed_refs_lock_self_clears() {
   counter="$home/git-fetch-count"; : > "$counter"
   out="$home/out-locktrans"; err="$home/err-locktrans"
 
+  # A German operator shell: the guard must still see git's English signature.
   set +e
+  LC_ALL= LANG=de_DE.UTF-8 \
   GIT_FETCH_COUNTER="$counter" \
   FM_FLEET_SYNC_PACKED_REFS_LOCK_RETRIES=3 \
   FM_FLEET_SYNC_PACKED_REFS_LOCK_RETRY_WAIT_SECS=0 \

--- a/tests/fm-teardown.test.sh
+++ b/tests/fm-teardown.test.sh
@@ -449,7 +449,8 @@ SH
 # (simulating a dying crew git process finishing) so the next retry succeeds.
 # The first failure always reports the lock path even if the file is removed in
 # the same attempt - matching the production race where the lock self-clears
-# between the failed return and the supervisor's existence check.
+# between the failed return and the supervisor's existence check. Like real git,
+# the signature is English only under LC_ALL=C and localized (German) otherwise.
 add_transient_lock_treehouse() {
   local case_dir=$1
   cat > "$case_dir/fakebin/treehouse" <<'SH'
@@ -478,12 +479,13 @@ if [ "${1:-}" = return ]; then
   if [ "$count" -eq 1 ]; then
     # Emit the real git signature, then drop the lock so a lock-existence-only
     # recovery path would wrongly abort without retrying.
-    if [ -n "$lock" ]; then
-      echo "fatal: Unable to create '$lock': File exists." >&2
-      rm -f "$lock"
+    shown=${lock:-index.lock}
+    if [ "${LC_ALL:-}" = C ]; then
+      echo "fatal: Unable to create '$shown': File exists." >&2
     else
-      echo "fatal: Unable to create 'index.lock': File exists." >&2
+      echo "fatal: Konnte '$shown' nicht erstellen: Die Datei existiert bereits." >&2
     fi
+    [ -n "$lock" ] && rm -f "$lock"
     exit 128
   fi
   exit 0
@@ -1729,30 +1731,39 @@ test_persistent_index_lock_exhausts_retries_and_refuses_loudly() {
   pass "persistent index.lock exhausts retries and refuses without force-removing the lock"
 }
 
-# treehouse_return_is_index_lock_error: the English-text regex must match the
-# English git signature and must NOT match the German locale variant. The
-# LC_ALL=C prefix on treehouse return (teardown_treehouse_return) guarantees
-# the subprocess always emits English, but the unit test pins the regex
-# contract itself so it cannot silently lose the pattern.
-test_index_lock_error_match_and_no_match() {
-  # Inline the function under test so we can exercise it in isolation.
-  treehouse_return_is_index_lock_error() {
-    local text=$1
-    printf '%s\n' "$text" | grep -Eq "Unable to create ['\"].*index\\.lock['\"\]: File exists"
-  }
+test_transient_index_lock_retry_is_locale_independent() {
+  local case_dir rc lock attempt_file
+  case_dir=$(make_case transient-index-lock-locale)
+  write_meta "$case_dir" no-mistakes ship
+  wt_commit "$case_dir" "shippable work"
+  git -C "$case_dir/wt" push -q origin fm/task-x1
+  git -C "$case_dir/project" fetch -q origin
 
-  # English text - the exact format git emits under LC_ALL=C
-  treehouse_return_is_index_lock_error "fatal: Unable to create 'index.lock': File exists."
-  expect_code 0 $? "English: regex should match the English git error signature"
+  add_transient_lock_treehouse "$case_dir"
+  add_lsof_no_holder "$case_dir"
 
-  treehouse_return_is_index_lock_error "fatal: Unable to create '/tmp/repo/.git/index.lock': File exists."
-  expect_code 0 $? "English: regex should match the English git error with full path"
+  lock=$(git_index_lock_path "$case_dir/wt")
+  mkdir -p "$(dirname "$lock")"
+  : > "$lock"
+  touch "$lock"
 
-  # German locale text - what git emits under de_DE.UTF-8 without LC_ALL=C
-  treehouse_return_is_index_lock_error "fatal: Konnte '/tmp/repo/.git/index.lock' nicht erstellen: Die Datei existiert bereits." && rc=0 || rc=$?
-  expect_code 1 "$rc" "German: regex must NOT match the German locale git error (LC_ALL=C is required)"
+  attempt_file="$case_dir/treehouse-attempts"
+  : > "$attempt_file"
 
-  pass "treehouse_return_is_index_lock_error correctly matches English and rejects German text"
+  set +e
+  LC_ALL= LANG=de_DE.UTF-8 \
+  TREEHOUSE_ATTEMPT_FILE="$attempt_file" \
+  FM_TREEHOUSE_RETURN_LOCK_RETRIES=2 \
+  FM_TREEHOUSE_RETURN_LOCK_RETRY_WAIT_SECS=0 \
+  FM_STALE_WORKTREE_LOCK_AGE_SECS=3600 \
+    run_teardown "$case_dir" > "$case_dir/stdout" 2> "$case_dir/stderr"
+  rc=$?
+  set -e
+
+  expect_code 0 "$rc" "locale-index-lock: teardown under a German shell locale should still recognize the lock and succeed on retry"
+  assert_grep "succeeded on retry" "$case_dir/stderr" \
+    "locale-index-lock: teardown under a German shell locale did not retry the transient lock"
+  pass "transient index.lock is recognized and retried regardless of the operator's shell locale"
 }
 
 test_empty_retry_wait_uses_default_without_aborting() {
@@ -3744,7 +3755,7 @@ test_non_linked_index_lock_path_is_checked_from_worktree
 test_index_lock_mtime_read_failure_refuses
 test_transient_index_lock_clears_after_first_attempt_and_retry_succeeds
 test_persistent_index_lock_exhausts_retries_and_refuses_loudly
-test_index_lock_error_match_and_no_match
+test_transient_index_lock_retry_is_locale_independent
 test_empty_retry_wait_uses_default_without_aborting
 test_fractional_legacy_retry_wait_refuses_without_arithmetic_error
 test_parked_own_run_is_aborted_before_teardown

--- a/tests/fm-teardown.test.sh
+++ b/tests/fm-teardown.test.sh
@@ -1751,7 +1751,7 @@ test_transient_index_lock_retry_is_locale_independent() {
   : > "$attempt_file"
 
   set +e
-  LC_ALL= LANG=de_DE.UTF-8 \
+  LC_ALL='' LANG=de_DE.UTF-8 \
   TREEHOUSE_ATTEMPT_FILE="$attempt_file" \
   FM_TREEHOUSE_RETURN_LOCK_RETRIES=2 \
   FM_TREEHOUSE_RETURN_LOCK_RETRY_WAIT_SECS=0 \

--- a/tests/fm-teardown.test.sh
+++ b/tests/fm-teardown.test.sh
@@ -1729,6 +1729,32 @@ test_persistent_index_lock_exhausts_retries_and_refuses_loudly() {
   pass "persistent index.lock exhausts retries and refuses without force-removing the lock"
 }
 
+# treehouse_return_is_index_lock_error: the English-text regex must match the
+# English git signature and must NOT match the German locale variant. The
+# LC_ALL=C prefix on treehouse return (teardown_treehouse_return) guarantees
+# the subprocess always emits English, but the unit test pins the regex
+# contract itself so it cannot silently lose the pattern.
+test_index_lock_error_match_and_no_match() {
+  # Inline the function under test so we can exercise it in isolation.
+  treehouse_return_is_index_lock_error() {
+    local text=$1
+    printf '%s\n' "$text" | grep -Eq "Unable to create ['\"].*index\\.lock['\"\]: File exists"
+  }
+
+  # English text - the exact format git emits under LC_ALL=C
+  treehouse_return_is_index_lock_error "fatal: Unable to create 'index.lock': File exists."
+  expect_code 0 $? "English: regex should match the English git error signature"
+
+  treehouse_return_is_index_lock_error "fatal: Unable to create '/tmp/repo/.git/index.lock': File exists."
+  expect_code 0 $? "English: regex should match the English git error with full path"
+
+  # German locale text - what git emits under de_DE.UTF-8 without LC_ALL=C
+  treehouse_return_is_index_lock_error "fatal: Konnte '/tmp/repo/.git/index.lock' nicht erstellen: Die Datei existiert bereits." && rc=0 || rc=$?
+  expect_code 1 "$rc" "German: regex must NOT match the German locale git error (LC_ALL=C is required)"
+
+  pass "treehouse_return_is_index_lock_error correctly matches English and rejects German text"
+}
+
 test_empty_retry_wait_uses_default_without_aborting() {
   local case_dir rc lock attempt_file
   case_dir=$(make_case empty-retry-wait)
@@ -3718,6 +3744,7 @@ test_non_linked_index_lock_path_is_checked_from_worktree
 test_index_lock_mtime_read_failure_refuses
 test_transient_index_lock_clears_after_first_attempt_and_retry_succeeds
 test_persistent_index_lock_exhausts_retries_and_refuses_loudly
+test_index_lock_error_match_and_no_match
 test_empty_retry_wait_uses_default_without_aborting
 test_fractional_legacy_retry_wait_refuses_without_arithmetic_error
 test_parked_own_run_is_aborted_before_teardown


### PR DESCRIPTION
## Intent

Diagnostic output that this code parses is locale-dependent, so a contributor or CI runner with a
non-English locale silently loses the behaviour these call sites rely on.

`bin/fm-fleet-sync.sh` and `bin/fm-teardown.sh` match git and treehouse error text to detect a
transient `packed-refs.lock` and retry; `bin/backends/herdr.sh` parses `awk` output for its submit
and wait budgets. Under a different locale the matched strings never appear, so the retry never
happens and the budget parse goes wrong - without any visible failure.

This pins those specific call sites to `LC_ALL=C` so they parse what they were written against.

## What Changed

- `bin/fm-fleet-sync.sh` now runs every `git fetch` guarded by the packed-refs.lock retry under `LC_ALL=C`. `bin/fm-teardown.sh` does the same for every `treehouse return --force` guarded by the index.lock retry. Both scripts spot the lock race by matching git's English `Unable to create '...lock': File exists` message. Under a non-English operator locale git prints a translated message, the match never succeeds, and the stale-lock retry and recovery never ran. New comments on both matchers explain why they depend on `LC_ALL=C`.
- In `bin/backends/herdr.sh`, the `awk` calls in `fm_backend_herdr_submit_confirm_budget` and `fm_backend_herdr_wait_for_working` now run under `LC_ALL=C`. Under a decimal-comma locale, awk no longer misreads or misprints the fractional budget and sleep-interval values.
- Tests: the fake git and treehouse helpers now print the lock error in English only under `LC_ALL=C` and in German otherwise, like real git. `test_transient_packed_refs_lock_self_clears` now runs under a German shell locale. New tests `test_transient_index_lock_retry_is_locale_independent` (teardown) and `test_send_text_submit_confirm_budget_ignores_decimal_comma_locale` (herdr, runs under `de_DE.UTF-8`) were added. `run_sync` in the fleet-sync tests runs with `LC_ALL=C`, so the git error messages it passes through always come out in English and the tests can match them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Risk Assessment

✅ Low: The change only adds LC_ALL=C to commands whose output is matched or parsed: the three git fetch calls, the three treehouse return calls and the two herdr awk calls. The rest of the diff is behavioral regression tests that fail without the fix and pass with it. The last fix round replaced the tautological test correctly, and no reachable locale-dependent sibling path remains.

## Testing

I drove all three changed code paths live from a German operator shell, with real git, treehouse, lsof and herdr, on both base 4768e98 and this branch. On base, git and treehouse lock errors come out in German, fleet-sync and teardown give up without retrying, and the herdr budget prints as '0,6000' so the confirmation window shrinks to about 280–480 ms. On this branch fleet-sync recovers both stale and transient packed-refs.lock cases and fast-forwards. Teardown removes a stale index.lock and returns the real treehouse slot to 'available'. The herdr window stays about 850–940 ms under de_DE, the same as under C. Adversarial checks passed: a lock held by a live process is kept (fleet-sync skips the project, teardown refuses), and a fetch failure unrelated to the lock is not retried. On this host's German locale, the three changed test files pass on this branch and fail against base's bin/. That run is a unit-test check, not a live product scenario, so it is recorded as untested under the live-validation contract. There is no UI in this change, so the evidence is CLI transcripts. All temporary sandboxes, the base export and the herdr lab sessions were removed, and the worktree is clean.

- Live validation: ✅ go - 7 of 8 scenarios driven live against the product

| Scenario | Result | Live | Evidence |
| --- | --- | --- | --- |
| Operator in a German locale runs fleet-sync while an orphaned, stale .git/packed-refs.lock blocks `git fetch --prune`: the lock is recognized, removed as provably stale, and the clone fast-forwards (b… | ✅ pass | live | fleet-sync-live-stale.target.txt: &#39;recovered: removed a stale packed-refs lock&#39;, &#39;synced 1d53b5a..e18b5db&#39;, lock gone, origin/feature pruned. fleet-sync-live-stale.base.txt: &#39;skipped: fetch failed: er… |
| Operator in a German locale runs fleet-sync while a transient packed-refs.lock is released during the retry wait: fetch succeeds on retry without force-removing anything | ✅ pass | live | fleet-sync-live-transient.target.txt: &#39;fetch blocked by packed-refs lock ... retrying (1/2)&#39;, &#39;fetch succeeded on retry; packed-refs lock cleared on its own&#39;, &#39;synced&#39;. Base skips with the German erro… |
| Adversarial: German-locale fleet-sync against a packed-refs.lock held open by a live process never removes it | ✅ pass | live | fleet-sync-live-live-holder.target.txt: retries 2/2, then &#39;not provably stale (may belong to a live process); leaving it in place&#39;, lock_present=yes, no fast-forward |
| Adversarial: a fetch failure unrelated to the lock (missing remote) is still reported once, with no lock retry | ✅ pass | live | fleet-sync-live-non-lock.target.txt: single &#39;skipped: fetch failed: fatal: ... does not appear to be a git repository&#39;, no &#39;fetch blocked&#39; lines |
| Operator in a German locale tears down a task whose real treehouse worktree is blocked by a stale git index.lock: the lock error is recognized, the lock removed, and the slot returned to the pool (bas… | ✅ pass | live | teardown-live-stale.target.txt: exit 0, &#39;removed provably-stale git lock ... retrying worktree return&#39;, &#39;return succeeded after stale-lock cleanup&#39;, treehouse status leased -&gt; available. teardown-live… |
| Adversarial: German-locale teardown against an index.lock held by a live process retries, then refuses and leaves the lock | ✅ pass | live | teardown-live-live-holder.target.txt: &#39;retrying (1/1)&#39;, then &#39;not provably stale (may belong to a live process); leaving it in place&#39;, exit 1, lock_present=yes, slot still leased |
| herdr submit confirmation on a real herdr pane under a decimal-comma locale keeps the 0.6s minimum budget spread over the polls instead of collapsing to 0 | ✅ pass | live | herdr-live.target.txt: LC_ALL=de_DE.UTF-8 confirm_budget=0.6000, window 849-937ms (C: 725-1159ms). herdr-live.base.txt: de_DE confirm_budget=0,6000, window 281-484ms |
| The new locale regression tests pass on this branch and fail against base&#39;s bin/ on a German host | ⏸️ untested | no | The earlier payload recorded this scenario as a unit-test run (live=false), not as a run against the live product, so it did not establish a live result. The live behaviour these tests cover is alread… |

<details>
<summary>Evidence: fleet-sync, stale packed-refs.lock, German shell: this branch recovers and fast-forwards</summary>

Source: [fleet-sync, stale packed-refs.lock, German shell: this branch recovers and fast-forwards](https://github.com/MLA82/firstmate/blob/cb71ddd7cd051e0e9f64d245b1457142188175a6/.no-mistakes/evidence/publish/1-locale/fleet-sync-live-stale.target.txt)

```text
\### case=stale root=~/.no-mistakes/worktrees/c9a671237ef3/01M26WQGNENK3KX04JA6E7CEH7 shell: LC_ALL='' LANG=de_DE.UTF-8
\### before: clone HEAD=1d53b5a origin/main=e18b5db lock_present=yes
\### exit=0
\### stdout:
  demo: recovered: removed a stale packed-refs lock (no live holder)
  demo: synced 1d53b5a..e18b5db
\### stderr:
  demo: fetch blocked by packed-refs lock (/tmp/fleet-live.9Npg/home/projects/demo/.git/packed-refs.lock); waiting 0s and retrying (1/2) (owning process may be exiting)
  demo: fetch blocked by packed-refs lock (/tmp/fleet-live.9Npg/home/projects/demo/.git/packed-refs.lock); waiting 0s and retrying (2/2) (owning process may be exiting)
  demo: removed provably-stale packed-refs lock /tmp/fleet-live.9Npg/home/projects/demo/.git/packed-refs.lock (age >= 60s, no live holder) and retrying fetch
  demo: fetch succeeded after stale packed-refs lock cleanup
\### after: clone HEAD=e18b5db fast_forwarded=yes lock_present=no origin/feature_pruned=yes
```
</details>
<details>
<summary>Evidence: fleet-sync, stale packed-refs.lock, German shell: base skips with the German git error</summary>

Source: [fleet-sync, stale packed-refs.lock, German shell: base skips with the German git error](https://github.com/MLA82/firstmate/blob/cb71ddd7cd051e0e9f64d245b1457142188175a6/.no-mistakes/evidence/publish/1-locale/fleet-sync-live-stale.base.txt)

```text
\### case=stale root=/tmp/locale-base.tpLN shell: LC_ALL='' LANG=de_DE.UTF-8
\### before: clone HEAD=2f3fb6b origin/main=c8530a9 lock_present=yes
\### exit=0
\### stdout:
  demo: skipped: fetch failed: error: konnte Referenz refs/remotes/origin/feature nicht entfernen: Konnte '/tmp/fleet-live.2j2Q/home/projects/demo/.git/packed-refs.lock' nicht erstellen: Die Datei existiert bereits.
\### stderr:
\### after: clone HEAD=2f3fb6b fast_forwarded=no lock_present=yes origin/feature_pruned=no
```
</details>
<details>
<summary>Evidence: fleet-sync, transient lock released during the retry wait: this branch</summary>

Source: [fleet-sync, transient lock released during the retry wait: this branch](https://github.com/MLA82/firstmate/blob/cb71ddd7cd051e0e9f64d245b1457142188175a6/.no-mistakes/evidence/publish/1-locale/fleet-sync-live-transient.target.txt)

```text
\### case=transient root=~/.no-mistakes/worktrees/c9a671237ef3/01M26WQGNENK3KX04JA6E7CEH7 shell: LC_ALL='' LANG=de_DE.UTF-8
\### before: clone HEAD=b3c257a origin/main=3826c4b lock_present=yes
\### exit=0
\### stdout:
  demo: recovered: packed-refs lock cleared on its own during retry
  demo: synced b3c257a..3826c4b
\### stderr:
  demo: fetch blocked by packed-refs lock (/tmp/fleet-live.XJAZ/home/projects/demo/.git/packed-refs.lock); waiting 2s and retrying (1/2) (owning process may be exiting)
  demo: fetch succeeded on retry; packed-refs lock cleared on its own
\### after: clone HEAD=3826c4b fast_forwarded=yes lock_present=no origin/feature_pruned=yes
```
</details>
<details>
<summary>Evidence: fleet-sync, transient lock: base</summary>

Source: [fleet-sync, transient lock: base](https://github.com/MLA82/firstmate/blob/cb71ddd7cd051e0e9f64d245b1457142188175a6/.no-mistakes/evidence/publish/1-locale/fleet-sync-live-transient.base.txt)

```text
\### case=transient root=/tmp/locale-base.tpLN shell: LC_ALL='' LANG=de_DE.UTF-8
\### before: clone HEAD=a506480 origin/main=7372665 lock_present=yes
\### exit=0
\### stdout:
  demo: skipped: fetch failed: error: konnte Referenz refs/remotes/origin/feature nicht entfernen: Konnte '/tmp/fleet-live.9kRy/home/projects/demo/.git/packed-refs.lock' nicht erstellen: Die Datei existiert bereits.
\### stderr:
\### after: clone HEAD=a506480 fast_forwarded=no lock_present=yes origin/feature_pruned=no
```
</details>
<details>
<summary>Evidence: fleet-sync, lock held by a live process: this branch retries and leaves the lock in place</summary>

Source: [fleet-sync, lock held by a live process: this branch retries and leaves the lock in place](https://github.com/MLA82/firstmate/blob/cb71ddd7cd051e0e9f64d245b1457142188175a6/.no-mistakes/evidence/publish/1-locale/fleet-sync-live-live-holder.target.txt)

```text
\### case=live-holder root=~/.no-mistakes/worktrees/c9a671237ef3/01M26WQGNENK3KX04JA6E7CEH7 shell: LC_ALL='' LANG=de_DE.UTF-8
\### before: clone HEAD=ceb72e2 origin/main=8e33ea3 lock_present=yes
\### exit=0
\### stdout:
  demo: skipped: fetch failed: error: could not delete reference refs/remotes/origin/feature: Unable to create '/tmp/fleet-live.C1mB/home/projects/demo/.git/packed-refs.lock': File exists.
\### stderr:
  demo: fetch blocked by packed-refs lock (/tmp/fleet-live.C1mB/home/projects/demo/.git/packed-refs.lock); waiting 0s and retrying (1/2) (owning process may be exiting)
  demo: fetch blocked by packed-refs lock (/tmp/fleet-live.C1mB/home/projects/demo/.git/packed-refs.lock); waiting 0s and retrying (2/2) (owning process may be exiting)
  demo: fetch blocked by packed-refs lock /tmp/fleet-live.C1mB/home/projects/demo/.git/packed-refs.lock that persisted across 2 retries and is not provably stale (may belong to a live process); leaving it in place
\### after: clone HEAD=ceb72e2 fast_forwarded=no lock_present=yes origin/feature_pruned=no
```
</details>
<details>
<summary>Evidence: fleet-sync, fetch failure unrelated to the lock: no retry on this branch</summary>

Source: [fleet-sync, fetch failure unrelated to the lock: no retry on this branch](https://github.com/MLA82/firstmate/blob/cb71ddd7cd051e0e9f64d245b1457142188175a6/.no-mistakes/evidence/publish/1-locale/fleet-sync-live-non-lock.target.txt)

```text
\### case=non-lock root=~/.no-mistakes/worktrees/c9a671237ef3/01M26WQGNENK3KX04JA6E7CEH7 shell: LC_ALL='' LANG=de_DE.UTF-8
\### before: clone HEAD=61743d0 origin/main=51d5386 lock_present=no
\### exit=0
\### stdout:
  demo: skipped: fetch failed: fatal: '/tmp/fleet-live.2xeF/does-not-exist.git' does not appear to be a git repository
\### stderr:
\### after: clone HEAD=61743d0 fast_forwarded=no lock_present=no origin/feature_pruned=no
```
</details>
<details>
<summary>Evidence: teardown, real treehouse slot with a stale index.lock, German shell: this branch completes and the slot is &#39;available&#39; again</summary>

Source: [teardown, real treehouse slot with a stale index.lock, German shell: this branch completes and the slot is &#39;available&#39; again](https://github.com/MLA82/firstmate/blob/cb71ddd7cd051e0e9f64d245b1457142188175a6/.no-mistakes/evidence/publish/1-locale/teardown-live-stale.target.txt)

```text
\### case=stale root=~/.no-mistakes/worktrees/c9a671237ef3/01M26WQGNENK3KX04JA6E7CEH7 shell: LC_ALL='' LANG=de_DE.UTF-8
\### worktree (real treehouse slot): /tmp/td-live.CpRK/pool/.treehouse/project-54ec45/1/project
\### before: index.lock present=yes age=10min live_holder=no
\### treehouse status before:
  1     leased       /tmp/td-live.CpRK/pool/.treehouse/project-54ec45/1/project
\### exit=0
\### stdout:
  🌳 Worktree returned to pool.
  /tmp/td-live.CpRK/project: already current
  teardown task-x1 complete (window firstmate:fm-task-x1, worktree /tmp/td-live.CpRK/pool/.treehouse/project-54ec45/1/project)
  Backlog: task-x1 just finished (this home keeps no markdown backlog at /tmp/td-live.CpRK/data/backlog.md). Update /tmp/td-live.CpRK/data/backlog.md - move task-x1 to Done, keep Done to the 10 most recent, then re-scan Queued and dispatch only work whose blockers are gone and date is due.
\### stderr:
  failed to return worktree: git read-tree --reset -u 8587d4284526aca2c070769de728b2160034c650: fatal: Unable to create '/tmp/td-live.CpRK/project/.git/worktrees/project/index.lock': File exists.
  
  Another git process seems to be running in this repository, e.g.
  an editor opened by 'git commit'. Please make sure all processes
  are terminated then try again. If it still fails, a git process
  may have crashed in this repository earlier:
  remove the file manually to continue.
  teardown: worktree return failed with transient git lock (/tmp/td-live.CpRK/project/.git/worktrees/project/index.lock); waiting 0s and retrying (1/1)
  failed to return worktree: git read-tree --reset -u 8587d4284526aca2c070769de728b2160034c650: fatal: Unable to create '/tmp/td-live.CpRK/project/.git/worktrees/project/index.lock': File exists.
  
  Another git process seems to be running in this repository, e.g.
  an editor opened by 'git commit'. Please make sure all processes
  are terminated then try again. If it still fails, a git process
  may have crashed in this repository earlier:
  remove the file manually to continue.
  teardown: removed provably-stale git lock /tmp/td-live.CpRK/project/.git/worktrees/project/index.lock (age >= 60s, no live holder) and retrying worktree return
  teardown: worktree return succeeded after stale-lock cleanup
\### after: index.lock present=no meta_present=no
\### treehouse status after:
  1     available    /tmp/td-live.CpRK/pool/.treehouse/project-54ec45/1/project
```
</details>
<details>
<summary>Evidence: teardown, stale index.lock, German shell: base aborts on the German treehouse/git error</summary>

Source: [teardown, stale index.lock, German shell: base aborts on the German treehouse/git error](https://github.com/MLA82/firstmate/blob/cb71ddd7cd051e0e9f64d245b1457142188175a6/.no-mistakes/evidence/publish/1-locale/teardown-live-stale.base.txt)

```text
\### case=stale root=/tmp/locale-base.tpLN shell: LC_ALL='' LANG=de_DE.UTF-8
\### worktree (real treehouse slot): /tmp/td-live.Fnme/pool/.treehouse/project-e59357/1/project
\### before: index.lock present=yes age=10min live_holder=no
\### treehouse status before:
  1     leased       /tmp/td-live.Fnme/pool/.treehouse/project-e59357/1/project
\### exit=1
\### stdout:
\### stderr:
  failed to return worktree: git read-tree --reset -u 2dc19c593c8606c32521b8212cd81587aa58f666: fatal: Konnte '/tmp/td-live.Fnme/project/.git/worktrees/project/index.lock' nicht erstellen: Die Datei existiert bereits.
  
  Ein anderer Git-Prozess scheint in diesem Repository ausgeführt
  zu werden, zum Beispiel ein noch offener Editor von 'git commit'.
  Bitte stellen Sie sicher, dass alle Prozesse beendet wurden und
  versuchen Sie es erneut. Falls es immer noch fehlschlägt, könnte
  ein früherer Git-Prozess in diesem Repository abgestürzt sein:
  Löschen Sie die Datei manuell um fortzufahren.
  error: treehouse return failed for worktree /tmp/td-live.Fnme/pool/.treehouse/project-e59357/1/project; teardown aborted
\### after: index.lock present=yes meta_present=yes
\### treehouse status after:
  1     leased       /tmp/td-live.Fnme/pool/.treehouse/project-e59357/1/project
```
</details>
<details>
<summary>Evidence: teardown, index.lock held by a live process: this branch retries, refuses and keeps the lock</summary>

Source: [teardown, index.lock held by a live process: this branch retries, refuses and keeps the lock](https://github.com/MLA82/firstmate/blob/cb71ddd7cd051e0e9f64d245b1457142188175a6/.no-mistakes/evidence/publish/1-locale/teardown-live-live-holder.target.txt)

```text
\### case=live-holder root=~/.no-mistakes/worktrees/c9a671237ef3/01M26WQGNENK3KX04JA6E7CEH7 shell: LC_ALL='' LANG=de_DE.UTF-8
\### worktree (real treehouse slot): /tmp/td-live.yPzC/pool/.treehouse/project-6beccb/1/project
\### before: index.lock present=yes age=10min live_holder=yes
\### treehouse status before:
  1     leased       /tmp/td-live.yPzC/pool/.treehouse/project-6beccb/1/project
\### exit=1
\### stdout:
\### stderr:
  failed to return worktree: git read-tree --reset -u aea9de34801a96b15af1faa406d1b3b83a1c607d: fatal: Unable to create '/tmp/td-live.yPzC/project/.git/worktrees/project/index.lock': File exists.
  
  Another git process seems to be running in this repository, e.g.
  an editor opened by 'git commit'. Please make sure all processes
  are terminated then try again. If it still fails, a git process
  may have crashed in this repository earlier:
  remove the file manually to continue.
  teardown: worktree return failed with transient git lock (/tmp/td-live.yPzC/project/.git/worktrees/project/index.lock); waiting 0s and retrying (1/1)
  failed to return worktree: git read-tree --reset -u aea9de34801a96b15af1faa406d1b3b83a1c607d: fatal: Unable to create '/tmp/td-live.yPzC/project/.git/worktrees/project/index.lock': File exists.
  
  Another git process seems to be running in this repository, e.g.
  an editor opened by 'git commit'. Please make sure all processes
  are terminated then try again. If it still fails, a git process
  may have crashed in this repository earlier:
  remove the file manually to continue.
  teardown: worktree return failed: git lock /tmp/td-live.yPzC/project/.git/worktrees/project/index.lock persisted across 1 retries (waiting 0s each) and is not provably stale (may belong to a live process); leaving it in place
  error: treehouse return failed for worktree /tmp/td-live.yPzC/pool/.treehouse/project-6beccb/1/project; teardown aborted
\### after: index.lock present=yes meta_present=yes
\### treehouse status after:
  1     leased       /tmp/td-live.yPzC/pool/.treehouse/project-6beccb/1/project
```
</details>
<details>
<summary>Evidence: herdr real server, confirmation window: this branch keeps 0.6000 and about 850-940ms under de_DE</summary>

Source: [herdr real server, confirmation window: this branch keeps 0.6000 and about 850-940ms under de_DE](https://github.com/MLA82/firstmate/blob/cb71ddd7cd051e0e9f64d245b1457142188175a6/.no-mistakes/evidence/publish/1-locale/herdr-live.target.txt)

```text
\### root=~/.no-mistakes/worktrees/c9a671237ef3/01M26WQGNENK3KX04JA6E7CEH7
\### real herdr: herdr 0.9.0; lab session=fm-lab-locale-1672515 tab=w1:t2 pane=w1:p2
\### pane agent status (raw): 
\### FM_BACKEND_HERDR_SUBMIT_MIN_SLEEP=0.6 polls=6 caller budget=0.4s (expected: 0.6s floor spread as 5 x 0.12s sleeps)
LC_ALL=C            run=1 confirm_budget=0.6000  verdict=unknown  confirmation_window_ms=1159
LC_ALL=C            run=2 confirm_budget=0.6000  verdict=unknown  confirmation_window_ms=902
LC_ALL=C            run=3 confirm_budget=0.6000  verdict=unknown  confirmation_window_ms=725
LC_ALL=de_DE.UTF-8  run=1 confirm_budget=0.6000  verdict=unknown  confirmation_window_ms=937
LC_ALL=de_DE.UTF-8  run=2 confirm_budget=0.6000  verdict=unknown  confirmation_window_ms=849
LC_ALL=de_DE.UTF-8  run=3 confirm_budget=0.6000  verdict=unknown  confirmation_window_ms=898
```
</details>
<details>
<summary>Evidence: herdr real server, confirmation window: base prints &#39;0,6000&#39; and shrinks to about 280-480ms under de_DE</summary>

Source: [herdr real server, confirmation window: base prints &#39;0,6000&#39; and shrinks to about 280-480ms under de_DE](https://github.com/MLA82/firstmate/blob/cb71ddd7cd051e0e9f64d245b1457142188175a6/.no-mistakes/evidence/publish/1-locale/herdr-live.base.txt)

```text
\### root=/tmp/locale-base.tpLN
\### real herdr: herdr 0.9.0; lab session=fm-lab-locale-1682120 tab=w1:t2 pane=w1:p2
\### pane agent status (raw): 
\### FM_BACKEND_HERDR_SUBMIT_MIN_SLEEP=0.6 polls=6 caller budget=0.4s (expected: 0.6s floor spread as 5 x 0.12s sleeps)
LC_ALL=C            run=1 confirm_budget=0.6000  verdict=unknown  confirmation_window_ms=1102
LC_ALL=C            run=2 confirm_budget=0.6000  verdict=unknown  confirmation_window_ms=747
LC_ALL=C            run=3 confirm_budget=0.6000  verdict=unknown  confirmation_window_ms=1044
LC_ALL=de_DE.UTF-8  run=1 confirm_budget=0,6000  verdict=unknown  confirmation_window_ms=300
LC_ALL=de_DE.UTF-8  run=2 confirm_budget=0,6000  verdict=unknown  confirmation_window_ms=484
LC_ALL=de_DE.UTF-8  run=3 confirm_budget=0,6000  verdict=unknown  confirmation_window_ms=281
```
</details>
<details>
<summary>Evidence: live driver scripts</summary>

Source: [live driver scripts](https://github.com/MLA82/firstmate/blob/cb71ddd7cd051e0e9f64d245b1457142188175a6/.no-mistakes/evidence/publish/1-locale/fleet-sync-live.sh)

```text
#!/usr/bin/env bash
# Live driver: run the real bin/fm-fleet-sync.sh from <firstmate-root> against a
# real clone whose `git fetch --prune` hits a real .git/packed-refs.lock, from a
# German operator shell (LC_ALL unset, LANG=de_DE.UTF-8). No git/lsof fakes.
# Usage: fleet-sync-live.sh <firstmate-root> <case: stale|transient|live-holder|non-lock>
set -u
ROOTDIR=$1 CASE=$2
T=$(mktemp -d /tmp/fleet-live.XXXX)
export GIT_AUTHOR_NAME=t GIT_AUTHOR_EMAIL=t@e.invalid GIT_COMMITTER_NAME=t GIT_COMMITTER_EMAIL=t@e.invalid
home="$T/home"; mkdir -p "$home/projects"
git init -q "$T/work"; git -C "$T/work" symbolic-ref HEAD refs/heads/main
echo v0 > "$T/work/f"; git -C "$T/work" add f; git -C "$T/work" commit -qm C0
git -C "$T/work" branch feature
git clone -q --bare "$T/work" "$T/origin.git"
git clone -q "file://$T/origin.git" "$home/projects/demo"
clone="$home/projects/demo"
git -C "$clone" pack-refs --all                      # origin/feature now lives in packed-refs
git -C "$T/origin.git" branch -q -D feature           # so --prune must rewrite packed-refs
echo v1 > "$T/work/f"; git -C "$T/work" commit -qam C1
git -C "$T/work" push -q "$T/origin.git" main         # origin one commit ahead: sync must fast-forward
want=$(git -C "$T/origin.git" rev-parse main)
lock="$clone/.git/packed-refs.lock"
holder=
wait_secs=0
case "$CASE" in
  stale)       : > "$lock"; touch -d '10 minutes ago' "$lock" ;;
  # fresh lock (not provably stale) that the "dying owner" releases only once
  # fleet-sync has reported the first blocked fetch, i.e. during its retry wait
  transient)   : > "$lock"; wait_secs=2
               ( for _ in $(seq 150); do grep -q 'fetch blocked' "$T/err" 2>/dev/null && { rm -f "$lock"; break; }; sleep 0.1; done ) & ;;
  live-holder) touch -d '10 minutes ago' "$lock"; sleep 60 9>>"$lock" & holder=$!; touch -d '10 minutes ago' "$lock" ;;
  non-lock)    git -C "$clone" remote set-url origin "file://$T/does-not-exist.git" ;;
esac
echo "### case=$CASE root=$ROOTDIR shell: LC_ALL='' LANG=de_DE.UTF-8"
echo "### before: clone HEAD=$(git -C "$clone" rev-parse --short HEAD) origin/main=$(git -C "$T/origin.git" rev-parse --short main) lock_present=$([ -e "$lock" ] && echo yes || echo no)"
env LC_ALL= LC_MESSAGES= LANG=de_DE.UTF-8 \
  FM_HOME="$home" FM_ROOT_OVERRIDE="$ROOTDIR" \
  FM_FLEET_SYNC_PACKED_REFS_LOCK_RETRIES=2 \
  FM_FLEET_SYNC_PACKED_REFS_LOCK_RETRY_WAIT_SECS=$wait_secs \
  FM_FLEET_SYNC_PACKED_REFS_LOCK_AGE_SECS=60 \
  "$ROOTDIR/bin/fm-fleet-sync.sh" demo > "$T/out" 2> "$T/err"
rc=$?
echo "### exit=$rc"
echo "### stdout:"; sed 's/^/  /' "$T/out"
echo "### stderr:"; sed 's/^/  /' "$T/err"
head_now=$(git -C "$clone" rev-parse HEAD)
echo "### after: clone HEAD=$(git -C "$clone" rev-parse --short HEAD) fast_forwarded=$([ "$head_now" = "$want" ] && echo yes || echo no) lock_present=$([ -e "$lock" ] && echo yes || echo no) origin/feature_pruned=$(git -C "$clone" show-ref -q refs/remotes/origin/feature && echo no || echo yes)"
[ -z "$holder" ] || kill "$holder" 2>/dev/null
wait 2>/dev/null
rm -rf "$T"
```
</details>
<details>
<summary>Evidence: live teardown driver script</summary>

Source: [live teardown driver script](https://github.com/MLA82/firstmate/blob/cb71ddd7cd051e0e9f64d245b1457142188175a6/.no-mistakes/evidence/publish/1-locale/teardown-live.sh)

```text
#!/usr/bin/env bash
# Live driver: run the real bin/fm-teardown.sh from <firstmate-root> on a task
# whose worktree is a REAL treehouse pool slot (leased with the real treehouse
# binary in an isolated pool/HOME) blocked by a real git index.lock, from a German
# operator shell (LC_ALL unset, LANG=de_DE.UTF-8). treehouse, git and lsof are
# real; only tmux/gh/gh-axi/no-mistakes are stubbed so nothing touches the
# operator's live sessions, GitHub, or the active no-mistakes pipeline.
# Usage: teardown-live.sh <firstmate-root> <case: stale|live-holder>
set -u
ROOTDIR=$1 CASE=$2
T=$(mktemp -d /tmp/td-live.XXXX)
export HOME="$T/home" XDG_CONFIG_HOME="$T/home/.config" XDG_STATE_HOME="$T/home/.state" \
  XDG_DATA_HOME="$T/home/.data" XDG_CACHE_HOME="$T/home/.cache" TREEHOUSE_ROOT="$T/pool"
mkdir -p "$HOME" "$T/state" "$T/data" "$T/config" "$T/fakebin"
export GIT_AUTHOR_NAME=t GIT_AUTHOR_EMAIL=t@e.invalid GIT_COMMITTER_NAME=t GIT_COMMITTER_EMAIL=t@e.invalid
for s in tmux gh-axi gh no-mistakes; do printf '#!/usr/bin/env bash\nexit 0\n' > "$T/fakebin/$s"; done
printf '#!/usr/bin/env bash\ncase "${1:-} ${2:-}" in "pr list") printf "%%s\\n" "count: 0 (showing first 0)" "pull_requests[]: []";; "pr view") exit 1;; esac\nexit 0\n' > "$T/fakebin/gh-axi"
chmod +x "$T/fakebin"/*
git init -q --bare "$T/origin.git"; git -C "$T/origin.git" symbolic-ref HEAD refs/heads/main
git clone -q "$T/origin.git" "$T/_seed" 2>/dev/null
git -C "$T/_seed" commit -q --allow-empty -m baseline; git -C "$T/_seed" push -q origin main; rm -rf "$T/_seed"
git clone -q "$T/origin.git" "$T/project"; git -C "$T/project" remote set-head origin main
WT=$(cd "$T/project" && treehouse get --lease --no-fetch 2>/dev/null) || { echo "treehouse get failed"; exit 1; }
touch "$T/state/.last-watcher-beat"
printf '%s\n' "window=firstmate:fm-task-x1" "endpoint_task_id=task-x1" "worktree=$WT" \
  "project=$T/project" "kind=ship" "mode=no-mistakes" "spawn_gen=live-task-x1" > "$T/state/task-x1.meta"
lock=$(git -C "$WT" rev-parse --path-format=absolute --git-path index.lock)
: > "$lock"; touch -d '10 minutes ago' "$lock"
holder=
if [ "$CASE" = live-holder ]; then sleep 60 9<"$lock" & holder=$!; fi
echo "### case=$CASE root=$ROOTDIR shell: LC_ALL='' LANG=de_DE.UTF-8"
echo "### worktree (real treehouse slot): $WT"
echo "### before: index.lock present=$([ -e "$lock" ] && echo yes || echo no) age=10min live_holder=$([ -n "$holder" ] && echo yes || echo no)"
echo "### treehouse status before:"; (cd "$T/project" && treehouse status 2>&1 | sed 's/^/  /')
# FM_GATE_REFUSE_BYPASS=1: the same exemption tests/lib.sh gives firstmate's own
# suite when a no-mistakes gate runs it; this sandbox never touches the live fleet.
(cd "$T/project" && env LC_ALL= LC_MESSAGES= LANG=de_DE.UTF-8 FM_GATE_REFUSE_BYPASS=1 \
  PATH="$T/fakebin:$PATH" \
  FM_ROOT_OVERRIDE="$ROOTDIR" FM_STATE_OVERRIDE="$T/state" FM_DATA_OVERRIDE="$T/data" FM_CONFIG_OVERRIDE="$T/config" \
  FM_TREEHOUSE_RETURN_LOCK_RETRIES=1 FM_TREEHOUSE_RETURN_LOCK_RETRY_WAIT_SECS=0 FM_STALE_WORKTREE_LOCK_AGE_SECS=60 \
  "$ROOTDIR/bin/fm-teardown.sh" task-x1 > "$T/out" 2> "$T/err")
rc=$?
echo "### exit=$rc"
echo "### stdout:"; sed 's/^/  /' "$T/out"
echo "### stderr:"; sed 's/^/  /' "$T/err"
echo "### after: index.lock present=$([ -e "$lock" ] && echo yes || echo no) meta_present=$([ -e "$T/state/task-x1.meta" ] && echo yes || echo no)"
echo "### treehouse status after:"; (cd "$T/project" && treehouse status 2>&1 | sed 's/^/  /')
[ -z "$holder" ] || kill "$holder" 2>/dev/null
wait 2>/dev/null
rm -rf "$T"
```
</details>
<details>
<summary>Evidence: live herdr driver script</summary>

Source: [live herdr driver script](https://github.com/MLA82/firstmate/blob/cb71ddd7cd051e0e9f64d245b1457142188175a6/.no-mistakes/evidence/publish/1-locale/herdr-live.sh)

```text
#!/usr/bin/env bash
# Live driver: against a REAL herdr server on an isolated fm-lab-* session (never
# the default session; provisioned and torn down through bin/fm-herdr-lab.sh's
# guarded helpers), create a real task pane and run the exact pair
# fm_backend_herdr_send_text_submit uses after Enter -
#   confirm=$(fm_backend_herdr_submit_confirm_budget <caller-budget>)
#   fm_backend_herdr_wait_for_working <session> <pane> "$confirm" $FM_BACKEND_HERDR_SUBMIT_POLLS
# - under LC_ALL=C and LC_ALL=de_DE.UTF-8 (decimal comma), timing the real
# confirmation window. Usage: herdr-live.sh <firstmate-root>
set -u
ROOTDIR=$1
# shellcheck source=/dev/null
. "$ROOTDIR/tests/herdr-test-safety.sh"
herdr_forget_inherited_pane
SESSION="fm-lab-locale-$$"
export HERDR_SESSION="$SESSION"
cleanup() { herdr_safe_stop_and_delete "$SESSION" >/dev/null 2>&1; }
trap cleanup EXIT
fm_herdr_lab_prepare "$SESSION" || { echo "lab prepare failed"; exit 1; }
# shellcheck source=/dev/null
. "$ROOTDIR/bin/fm-backend.sh"
fm_backend_source herdr || { echo "fm_backend_source herdr failed"; exit 1; }
RAW=$(fm_backend_herdr_container_ensure /tmp) || { echo "container_ensure failed"; exit 1; }
CONTAINER=${RAW%%$'\t'*}; SEED=${RAW#*$'\t'}
IDS=$(fm_backend_herdr_create_task "$CONTAINER" fm-locale-probe /tmp "$SEED") || { echo "create_task failed"; exit 1; }
read -r TAB_ID PANE_ID <<<"$IDS"
echo "### root=$ROOTDIR"
echo "### real herdr: $(herdr --version 2>&1 | head -1); lab session=$SESSION tab=$TAB_ID pane=$PANE_ID"
echo "### pane agent status (raw): $(fm_backend_herdr_agent_status_raw "$SESSION" "$PANE_ID")"
echo "### FM_BACKEND_HERDR_SUBMIT_MIN_SLEEP=$FM_BACKEND_HERDR_SUBMIT_MIN_SLEEP polls=$FM_BACKEND_HERDR_SUBMIT_POLLS caller budget=0.4s (expected: 0.6s floor spread as 5 x 0.12s sleeps)"
for loc in C de_DE.UTF-8; do
  for run in 1 2 3; do
    budget=$(LC_ALL=$loc fm_backend_herdr_submit_confirm_budget 0.4)
    t0=$(date +%s%N)
    verdict=$(LC_ALL=$loc fm_backend_herdr_wait_for_working "$SESSION" "$PANE_ID" "$budget" "$FM_BACKEND_HERDR_SUBMIT_POLLS")
    t1=$(date +%s%N)
    printf 'LC_ALL=%-12s run=%s confirm_budget=%-7s verdict=%-8s confirmation_window_ms=%s\n' \
      "$loc" "$run" "$budget" "$verdict" "$(( (t1 - t0) / 1000000 ))"
  done
done
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"d7daf96d8dede3454861fa51f4533b732a508607","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>🔧 **Review** - 3 issues found → auto-fixed ✅</summary>

- ⚠️ `tests/fm-teardown.test.sh:1737` - test_index_lock_error_match_and_no_match redefines its own inline copy of treehouse_return_is_index_lock_error and only exercises that copy; it never runs bin/fm-teardown.sh. It therefore stays green if the LC_ALL=C prefix on `treehouse return` is reverted, or if the production regex at bin/fm-teardown.sh:1511 is changed or deleted. Its comment (&#39;pins the regex contract itself so it cannot silently lose the pattern&#39;) is false, and the test gives no evidence the fix works. Replace it with a behavioral regression test: add a fake treehouse, modeled on add_transient_lock_treehouse, that prints `fatal: Unable to create &#39;&lt;lock&gt;&#39;: File exists.` only when `[ &#34;${LC_ALL:-}&#34; = C ]` and a German message (e.g. `Konnte &#39;&lt;lock&gt;&#39; nicht erstellen: Die Datei existiert bereits.`) otherwise. Run run_teardown with LC_ALL unset and LANG=de_DE.UTF-8 and assert exit 0 plus &#39;succeeded on retry&#39;. That test fails before the fix and passes after it. If no behavioral test is wanted, delete this one rather than keep a proxy.
- ⚠️ `tests/fm-fleet-sync.test.sh:218` - No test fails when the fleet-sync or herdr LC_ALL=C prefixes are reverted. The fleet-sync fake git (git_transient_packed_refs_lock) prints the English packed-refs.lock error regardless of LC_ALL, so is_packed_refs_lock_error matches either way. The herdr tests run in whatever locale the machine inherits (tests/lib.sh and fm-test-run.sh do not pin it). Both failures can be reproduced portably. Fleet-sync: make the fake git print the English signature only when LC_ALL=C (German text otherwise) and run run_sync_guarded with LANG=de_DE.UTF-8; the retry/recovery assertions then fail without bin/fm-fleet-sync.sh:176/186/210. herdr: add a variant of test_send_text_submit_applies_herdr_minimum_confirm_budget run under LC_ALL=de_DE.UTF-8. Checked on this host: mawk under de_DE.utf8 prints &#39;0,6000&#39;, and wait_for_working&#39;s `*[!0-9.]*` guard turns that into a 0 interval, so the 0.1200 sleep assertion would fail without the fix wherever that locale is installed and pass harmlessly elsewhere.
- ⚠️ `tests/fm-fleet-sync.test.sh:100` - Simplification: forcing LC_ALL=C in run_sync is not required by the intent (LC_ALL=C on the git/awk calls whose error text is matched). It makes the git merge message that fleet-sync relays (e.g. &#39;untracked working tree files would be overwritten&#39;) English so those assertions pass on a non-English machine. It also means every run_sync-based test can never observe a locale-dependent regression in fm-fleet-sync.sh. Recommend removing it from this PR unless the suite fails without it on the author&#39;s machine; if so, it belongs in a separate test-portability change.

🔧 Fix applied.
✅ Re-checked - no issues remain.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- Live validation: ✅ go - 7 of 8 scenarios driven live against the product

| Scenario | Result | Live | Evidence |
| --- | --- | --- | --- |
| Operator in a German locale runs fleet-sync while an orphaned, stale .git/packed-refs.lock blocks `git fetch --prune`: the lock is recognized, removed as provably stale, and the clone fast-forwards (b… | ✅ pass | live | fleet-sync-live-stale.target.txt: &#39;recovered: removed a stale packed-refs lock&#39;, &#39;synced 1d53b5a..e18b5db&#39;, lock gone, origin/feature pruned. fleet-sync-live-stale.base.txt: &#39;skipped: fetch failed: er… |
| Operator in a German locale runs fleet-sync while a transient packed-refs.lock is released during the retry wait: fetch succeeds on retry without force-removing anything | ✅ pass | live | fleet-sync-live-transient.target.txt: &#39;fetch blocked by packed-refs lock ... retrying (1/2)&#39;, &#39;fetch succeeded on retry; packed-refs lock cleared on its own&#39;, &#39;synced&#39;. Base skips with the German erro… |
| Adversarial: German-locale fleet-sync against a packed-refs.lock held open by a live process never removes it | ✅ pass | live | fleet-sync-live-live-holder.target.txt: retries 2/2, then &#39;not provably stale (may belong to a live process); leaving it in place&#39;, lock_present=yes, no fast-forward |
| Adversarial: a fetch failure unrelated to the lock (missing remote) is still reported once, with no lock retry | ✅ pass | live | fleet-sync-live-non-lock.target.txt: single &#39;skipped: fetch failed: fatal: ... does not appear to be a git repository&#39;, no &#39;fetch blocked&#39; lines |
| Operator in a German locale tears down a task whose real treehouse worktree is blocked by a stale git index.lock: the lock error is recognized, the lock removed, and the slot returned to the pool (bas… | ✅ pass | live | teardown-live-stale.target.txt: exit 0, &#39;removed provably-stale git lock ... retrying worktree return&#39;, &#39;return succeeded after stale-lock cleanup&#39;, treehouse status leased -&gt; available. teardown-live… |
| Adversarial: German-locale teardown against an index.lock held by a live process retries, then refuses and leaves the lock | ✅ pass | live | teardown-live-live-holder.target.txt: &#39;retrying (1/1)&#39;, then &#39;not provably stale (may belong to a live process); leaving it in place&#39;, exit 1, lock_present=yes, slot still leased |
| herdr submit confirmation on a real herdr pane under a decimal-comma locale keeps the 0.6s minimum budget spread over the polls instead of collapsing to 0 | ✅ pass | live | herdr-live.target.txt: LC_ALL=de_DE.UTF-8 confirm_budget=0.6000, window 849-937ms (C: 725-1159ms). herdr-live.base.txt: de_DE confirm_budget=0,6000, window 281-484ms |
| The new locale regression tests pass on this branch and fail against base&#39;s bin/ on a German host | ⏸️ untested | no | The earlier payload recorded this scenario as a unit-test run (live=false), not as a run against the live product, so it did not establish a live result. The live behaviour these tests cover is alread… |

- <code>`bash fleet-sync-live.sh &lt;root&gt; stale|transient|live-holder|non-lock` - runs the real bin/fm-fleet-sync.sh against a real clone whose `git fetch --prune` hits a real .git/packed-refs.lock, from a German shell (LC_ALL unset, LANG=de_DE.UTF-8), on base 4768e98 and on this branch</code>
- <code>`bash teardown-live.sh &lt;root&gt; stale|live-holder` - runs the real bin/fm-teardown.sh on a task whose worktree is a real treehouse pool slot (real treehouse &#39;get --lease&#39; in an isolated pool/HOME) blocked by a real git index.lock, from a German shell, with real git, lsof and treehouse, on base and on this branch</code>
- <code>`bash herdr-live.sh &lt;root&gt;` - on a real herdr 0.9.0 server in an isolated fm-lab-* session with a real task pane, times fm_backend_herdr_submit_confirm_budget 0.4 followed by fm_backend_herdr_wait_for_working (6 polls) under LC_ALL=C and LC_ALL=de_DE.UTF-8, on base and on this branch</code>
- <code>Checked by hand that on this host real git (`git fetch --prune`) and real `treehouse return --force` print the lock error in German unless LC_ALL=C is set</code>
- <code>`bash tests/fm-fleet-sync.test.sh`, `bash tests/fm-teardown.test.sh`, `bash tests/fm-backend-herdr.test.sh` on this branch (all pass, including the new locale regression tests), and the same new test files run against base&#39;s bin/ (each suite fails)</code>
</details>

<details>
<summary>🔧 **Document** - 1 issue found → auto-fixed ✅</summary>

- ⚠️ `tests/fm-teardown.test.sh:1754` - bin/fm-lint.sh fails (rc=1) on the new locale regression tests with SC1007 on the empty assignment prefix `LC_ALL= LANG=de_DE.UTF-8 \` at tests/fm-teardown.test.sh:1754. The same warning fires at tests/fm-fleet-sync.test.sh:620. These are the only locations the lint flags, and the document phase cannot fix them because it must not change tests. The fix keeps the same behavior: write `LC_ALL=&#39;&#39; LANG=de_DE.UTF-8 \` in both places so the tests still clear LC_ALL and inherit the German LANG.

🔧 Fix applied.
✅ Re-checked - no issues remain.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>

