### PR TITLE
fix(omp): deliver watcher wakes as hidden custom messages to preserve captain drafts

### DIFF
--- a/.omp/extensions/fm-primary-omp-watch.ts
+++ b/.omp/extensions/fm-primary-omp-watch.ts
@@ -6,9 +6,9 @@
 //   - omp auto-discovers this file from <cwd>/.omp/extensions with no trust
 //     gate, so an omp primary or secondmate started inside its home loads it
 //     without -e (naming it both ways loads it twice - verified, omp 18.1.11).
-//   - pi.sendUserMessage returns synchronously (no promise) in omp, so "Pi
+//   - pi.sendMessage returns synchronously (no promise) in omp, so "Pi
 //     accepted the follow-up" collapses to "the call returned"; consumption is
-//     still tracked at before_agent_start / message_start exactly as on Pi.
+//     still tracked at before_agent_start / custom message_start exactly as on Pi.
 //   - omp reports no session_shutdown reason, so EVERY shutdown with a pending
 //     actionable close persists the replacement handoff and the next owning
 //     session_start, in this process or a later one, replays it. Replaying a
@@ -31,15 +31,15 @@
 // Stale callbacks from a prior generation are no-ops against the active replacement.
 //
 // Delivery versus consumption (stated once here):
-// A main follow-up is delivered once omp accepts it (sendUserMessage returns).
-// The successor pipeline never waits for the model to read it: a follow-up
-// queued while main is streaming joins the running run without ever raising
-// before_agent_start, so waiting on that event stalls every later close.
-// Consumption is tracked only so a replacement can replay a follow-up omp had
-// not consumed. An idle main consumes at before_agent_start; a streaming main
-// consumes at the user message_start carrying the exact wake text; either
-// event finishes the pending record, and a still-unconsumed record rides the
-// replacement handoff.
+// A main follow-up is delivered once omp accepts the hidden custom message
+// (sendMessage returns). The successor pipeline never waits for the model to
+// read it: a follow-up queued while main is streaming joins the running run
+// without ever raising before_agent_start, so waiting on that event stalls
+// every later close. Consumption is tracked only so a replacement can replay
+// a follow-up omp had not consumed. An idle main consumes at
+// before_agent_start; a streaming main consumes at the custom message_start
+// carrying the exact wake text; either event finishes the pending record, and
+// a still-unconsumed record rides the replacement handoff.
 import { spawn, spawnSync, type ChildProcess } from "node:child_process";
 import { createHash } from "node:crypto";
 import { mkdirSync, readFileSync, renameSync, unlinkSync, writeFileSync } from "node:fs";
@@ -58,7 +58,10 @@ import { encodeFirstmateOperationalInput } from "../../.pi/extensions/lib/fm-ope
 // rather than imported from the Pi package name.
 type ExtensionAPI = {
   on?: (event: string, handler: (event: any, ctx: any) => unknown) => void;
-  sendUserMessage: (content: string, options?: { deliverAs?: string }) => unknown;
+  sendMessage: (
+    message: { customType: string; content: string; display: boolean },
+    options?: { deliverAs?: string; triggerTurn?: boolean },
+  ) => unknown;
   registerCommand?: (name: string, command: { description: string; handler: (args: string, ctx: any) => Promise<void> | void }) => void;
   registerTool?: (tool: Record<string, unknown>) => void;
 };
@@ -141,6 +144,7 @@ const armReadyTimeoutMs = positiveInteger(
 const armRetireTimeoutMs = positiveInteger("FM_WATCH_ARM_RETIRE_TIMEOUT_MS", 1000);
 const repairOnlyHint = "call fm_watch_arm_omp again only after a later notification says the cycle is missing, failed, or unhealthy";
 const shuttingDownMessage = "watcher: not armed - omp session is shutting down";
+const watcherWakeCustomType = "firstmate-primary-omp-watcher-wake";
 
 let nextGenerationId = 0;
 let nextHandoffId = 0;
@@ -235,24 +239,6 @@ function actionableLine(output: string): string {
 function completedActionableLine(output: string): string {
   const newline = output.lastIndexOf("\n");
   return newline < 0 ? "" : actionableLine(output.slice(0, newline + 1));
-}
-
-// The text omp carries in a user message_start: sendUserMessage wraps a string
-// as one text part, so the joined text parts equal the sent content.
-function userMessageText(content: unknown): string {
-  if (typeof content === "string") return content;
-  if (!Array.isArray(content)) return "";
-  const parts: string[] = [];
-  for (const part of content) {
-    if (
-      typeof part === "object" && part !== null &&
-      (part as { type?: unknown }).type === "text" &&
-      typeof (part as { text?: unknown }).text === "string"
-    ) {
-      parts.push((part as { text: string }).text);
-    }
-  }
-  return parts.join("\n");
 }
 
 function nodeErrorCode(error: unknown): string {
@@ -499,12 +485,15 @@ export default function (pi: ExtensionAPI) {
     );
     if (pending) owner.unconsumedWakes.set(pending.token, { content, pending });
     try {
-      await pi.sendUserMessage(content, { deliverAs: "followUp" });
+      await pi.sendMessage(
+        { customType: watcherWakeCustomType, content, display: false },
+        { deliverAs: "followUp", triggerTurn: true },
+      );
     } catch (error) {
       if (pending) owner.unconsumedWakes.delete(pending.token);
       throw error;
     }
-    // Accepted by omp (sendUserMessage returns synchronously there; awaiting a
+    // Accepted by omp (sendMessage returns synchronously there; awaiting a
     // non-promise resolves at once). A generation replaced while omp was
     // accepting it may have lost the follow-up with the old session, so report
     // it undelivered and let the replacement replay the still-pending record.
@@ -512,7 +501,7 @@ export default function (pi: ExtensionAPI) {
   }
 
   // omp consumed a main follow-up: an idle main at before_agent_start, a
-  // streaming main at the user message_start that joins the running run.
+  // streaming main at the custom message_start that joins the running run.
   function consumeWake(owner: SessionGeneration, text: string): void {
     for (const [token, wake] of owner.unconsumedWakes) {
       if (wake.content !== text) continue;
@@ -1023,9 +1012,18 @@ export default function (pi: ExtensionAPI) {
     consumeWake(generation, String((event as { prompt?: unknown })?.prompt ?? ""));
   });
   pi.on?.("message_start", (event) => {
-    const message = (event as { message?: { role?: unknown; content?: unknown } })?.message;
-    if (!message || message.role !== "user") return;
-    consumeWake(generation, userMessageText(message.content));
+    const message: unknown = event?.message;
+    if (
+      typeof message !== "object" ||
+      message === null ||
+      !("role" in message) ||
+      message.role !== "custom" ||
+      !("customType" in message) ||
+      message.customType !== watcherWakeCustomType ||
+      !("content" in message) ||
+      typeof message.content !== "string"
+    ) return;
+    consumeWake(generation, message.content);
   });
 
   pi.on?.("session_start", async () => {

--- a/docs/verification/supervision.md
+++ b/docs/verification/supervision.md
@@ -57,12 +57,12 @@ A file named both by `-e` and by auto-discovery loads twice (two factory calls, 
 
 ### omp watcher composer preservation, 2026-09-11
 
-The omp watcher transport was verified against omp 18.1.17 in the named isolated Herdr lab `fm-lab-pam-prompt-loss-258002-23766` with the tracked `.omp/extensions/fm-primary-omp-watch.ts` implementation and a deterministic watcher-arm fixture.
-The lab exercised an idle multiline draft, a running turn followed by one locally queued captain message and a second multiline draft, and two successive actionable watcher closes.
-The exact draft remained visible before and after every watcher delivery, the queued captain message entered the session once before the watcher wake, both repeated wakes entered once in their original order, and no partial draft text entered the session.
+The prompt-safe watcher transport was verified on 2026-09-11 against omp 18.1.17 with the portable fake-API guard and the real-provider live guard below.
 The watcher wake is a hidden `firstmate-primary-omp-watcher-wake` custom message with `deliverAs: "followUp"` and `triggerTurn: true`, so operational input remains model-visible without claiming the captain-owned user role that clears the editor on `message_start`.
 `bash tests/fm-omp-harness.test.sh` pins the custom message type, hidden display, follow-up delivery, turn trigger, exact content, and wake consumption over a fake omp API.
+Its relevant output is `ok - .omp watch extension: fm_watch_arm_omp arms once, repeats as a no-op, and delivers an actionable close as one hidden custom follow-up`.
 `FM_OMP_LIVE_E2E=1 bash tests/fm-omp-primary-live-e2e.test.sh` verifies through a real omp provider turn that the actionable watcher close reaches the model exactly once as hidden custom input and never as a user message.
+Its relevant outputs are `ok - omp omp/18.1.17: an actionable close spawned a ledger-linked successor and woke main exactly once through hidden custom input` and `# omp omp/18.1.17 model=openai-codex/gpt-6-astra: every live omp primary assertion passed`.
 The tracked extension remains auto-discovered with no config or installation change, but an omp process that loaded the previous extension must restart normally after the updated file lands.
 
 ### Run-tier source vocabulary and context-reset injection

--- a/docs/verification/supervision.md
+++ b/docs/verification/supervision.md
@@ -55,6 +55,16 @@ Both tracked `.omp/extensions/*.ts` files loaded by auto-discovery alone (no `-e
 omp's `session_start` payload carries no reason field, so the adapter derives the source: the first start of the process is `startup` (or `resume` from a `--continue`/`--resume` launch line) and a later in-process start is `clear`; `tests/fm-omp-harness.test.sh` pins that mapping over a fake omp API.
 A file named both by `-e` and by auto-discovery loads twice (two factory calls, doubled `session_stop` continuations), which is why the secondmate launch names no `-e` and the per-task worker extension lives in `state/`.
 
+### omp watcher composer preservation, 2026-09-11
+
+The omp watcher transport was verified against omp 18.1.17 in the named isolated Herdr lab `fm-lab-pam-prompt-loss-258002-23766` with the tracked `.omp/extensions/fm-primary-omp-watch.ts` implementation and a deterministic watcher-arm fixture.
+The lab exercised an idle multiline draft, a running turn followed by one locally queued captain message and a second multiline draft, and two successive actionable watcher closes.
+The exact draft remained visible before and after every watcher delivery, the queued captain message entered the session once before the watcher wake, both repeated wakes entered once in their original order, and no partial draft text entered the session.
+The watcher wake is a hidden `firstmate-primary-omp-watcher-wake` custom message with `deliverAs: "followUp"` and `triggerTurn: true`, so operational input remains model-visible without claiming the captain-owned user role that clears the editor on `message_start`.
+`bash tests/fm-omp-harness.test.sh` pins the custom message type, hidden display, follow-up delivery, turn trigger, exact content, and wake consumption over a fake omp API.
+`FM_OMP_LIVE_E2E=1 bash tests/fm-omp-primary-live-e2e.test.sh` verifies through a real omp provider turn that the actionable watcher close reaches the model exactly once as hidden custom input and never as a user message.
+The tracked extension remains auto-discovered with no config or installation change, but an omp process that loaded the previous extension must restart normally after the updated file lands.
+
 ### Run-tier source vocabulary and context-reset injection
 
 The run tier depends on three facts only the vendor can supply: the session-open source it reports, whether hook stdout reaches model context on a context-RESET open rather than only a cold one, and whether a worker the hook detaches survives the hook returning.

--- a/tests/fm-omp-harness.test.sh
+++ b/tests/fm-omp-harness.test.sh
@@ -564,7 +564,7 @@ if (sent[0].m.display !== false) throw new Error("watcher wake must stay hidden 
 if (!sent[0].m.content.startsWith("⁣FIRSTMATE_OP: v1 watcher: FIRSTMATE WATCHER WAKE: signal: omp-e2e done")) throw new Error(`unexpected wake text: ${sent[0].m.content}`);
 if (sent[0].o?.deliverAs !== "followUp" || sent[0].o?.triggerTurn !== true) throw new Error("wake must be a turn-triggering follow-up");
 // A streaming delivery is consumed by its hidden custom message, without using
-// the user role that owns the captain's composer.
+// the user role reserved for captain-authored input.
 await handlers.get("message_start")({
   type: "message_start",
   message: { role: "custom", ...sent[0].m },

--- a/tests/fm-omp-harness.test.sh
+++ b/tests/fm-omp-harness.test.sh
@@ -28,7 +28,7 @@
 #   6. The turn-end guard extension compels one continuation on exit 2 and
 #      stands down when the payload already carries stop_hook_active.
 #   7. The watch extension arms through fm_watch_arm_omp and delivers an
-#      actionable close as one follow-up.
+#      actionable close as one hidden custom follow-up, never a user message.
 set -u
 
 # shellcheck source=tests/fixtures.sh
@@ -543,8 +543,8 @@ const pi = {
   on(e, h) { handlers.set(e, h); },
   registerCommand(n, o) { if (n === "fm-watch-arm-omp") command = o.handler; },
   registerTool(t) { tool = t; },
-  // omp sendUserMessage returns synchronously, not a promise.
-  sendUserMessage(m, o) { sent.push({ m, o }); return undefined; },
+  // omp sendMessage returns synchronously, not a promise.
+  sendMessage(m, o) { sent.push({ m, o }); return undefined; },
 };
 const mod = await import(pathToFileURL(process.env.EXT).href);
 mod.default(pi);
@@ -559,10 +559,16 @@ const again = await tool.execute();
 if (!/^watcher: unchanged - omp extension already owns an arm child/.test(again.content[0].text)) throw new Error(`redundant arm was not an ownership no-op: ${again.content[0].text}`);
 await new Promise((r) => setTimeout(r, 2500));
 if (sent.length !== 1) throw new Error(`expected one follow-up wake, saw ${sent.length}: ${JSON.stringify(sent)}`);
-if (!sent[0].m.startsWith("⁣FIRSTMATE_OP: v1 watcher: FIRSTMATE WATCHER WAKE: signal: omp-e2e done")) throw new Error(`unexpected wake text: ${sent[0].m}`);
-if (sent[0].o?.deliverAs !== "followUp") throw new Error("wake must be delivered as a follow-up");
-// The wake is consumed when omp starts the next run with that exact prompt.
-await handlers.get("before_agent_start")({ type: "before_agent_start", prompt: sent[0].m }, {});
+if (sent[0].m.customType !== "firstmate-primary-omp-watcher-wake") throw new Error(`unexpected wake type: ${sent[0].m.customType}`);
+if (sent[0].m.display !== false) throw new Error("watcher wake must stay hidden from the captain transcript");
+if (!sent[0].m.content.startsWith("⁣FIRSTMATE_OP: v1 watcher: FIRSTMATE WATCHER WAKE: signal: omp-e2e done")) throw new Error(`unexpected wake text: ${sent[0].m.content}`);
+if (sent[0].o?.deliverAs !== "followUp" || sent[0].o?.triggerTurn !== true) throw new Error("wake must be a turn-triggering follow-up");
+// A streaming delivery is consumed by its hidden custom message, without using
+// the user role that owns the captain's composer.
+await handlers.get("message_start")({
+  type: "message_start",
+  message: { role: "custom", ...sent[0].m },
+}, {});
 await handlers.get("session_shutdown")({}, {});
 if (existsSync(`${process.env.FM_HOME}/state/extensions/omp-primary-watch/session-replacement-actionable.json`)) throw new Error("a consumed wake must not ride the replacement handoff");
 process.exit(0);
@@ -571,7 +577,7 @@ EOF
   status=$?
   expect_code 0 "$status" "omp watch extension contract: $out"
   [ -z "$out" ] || fail "omp watch extension test printed output: $out"
-  pass ".omp watch extension: fm_watch_arm_omp arms once, repeats as a no-op, and delivers an actionable close as one follow-up"
+  pass ".omp watch extension: fm_watch_arm_omp arms once, repeats as a no-op, and delivers an actionable close as one hidden custom follow-up"
 }
 
 test_detection_anchored_name_and_marker_precedence

--- a/tests/fm-omp-primary-live-e2e.test.sh
+++ b/tests/fm-omp-primary-live-e2e.test.sh
@@ -10,7 +10,7 @@
 #   2. the session-start digest reaches model context before the first turn
 #      and the session lock names the omp process (ancestry detection);
 #   3. fm_watch_arm_omp starts a real watcher, an actionable close spawns a
-#      ledger-linked successor, and the wake arrives as one follow-up turn;
+#      ledger-linked successor, and the wake arrives once as hidden custom input;
 #   4. with the successor watcher frozen until its beacon passes the lab grace,
 #      the next turn end is genuinely unsupervised, so session_stop must compel
 #      the turn-end guard continuation and the model reaches for the tool.
@@ -240,9 +240,13 @@ grep -Eq 'reason=actionable-signal.*successor=started:[0-9]+' "$PROJECT/state/.w
   || fail "omp extension did not start and ledger-link a successor after the actionable close"
 wait_for_log "FIRSTMATE WATCHER WAKE: signal:" 240 || fail "the actionable close was not delivered to main as a watcher follow-up"
 wait_for_agent_ends 3 360 || fail "omp did not finish the wake turn"
+custom_wake_count=$(jq -r 'select(.type == "message_start" and .message.role == "custom" and .message.customType == "firstmate-primary-omp-watcher-wake" and (.message.content | contains("FIRSTMATE WATCHER WAKE: signal:"))) | .type' "$RPC_LOG" 2>/dev/null | grep -c . 2>/dev/null) || true
+user_wake_count=$(jq -r 'select(.type == "message_start" and .message.role == "user" and (([.message.content[]? | select(.type == "text") | .text] | join("\n")) | contains("FIRSTMATE WATCHER WAKE: signal:"))) | .type' "$RPC_LOG" 2>/dev/null | grep -c . 2>/dev/null) || true
+[ "${custom_wake_count:-0}" -eq 1 ] || fail "the watcher wake did not enter the model exactly once as hidden custom input (count ${custom_wake_count:-0})"
+[ "${user_wake_count:-0}" -eq 0 ] || fail "the watcher wake entered through the captain-owned user role (count ${user_wake_count:-0})"
 arm_calls=$(tool_call_count fm_watch_arm_omp)
 [ "$arm_calls" -eq 1 ] || fail "the model re-armed from memory instead of the extension (fm_watch_arm_omp call count $arm_calls)"
-pass "omp $OMP_VERSION: an actionable close spawned a ledger-linked successor and woke main exactly once"
+pass "omp $OMP_VERSION: an actionable close spawned a ledger-linked successor and woke main exactly once through hidden custom input"
 
 # --- 3. the compelled turn-end guard continuation -------------------------------
 # Freeze the successor watcher (SIGSTOP) so its beacon goes stale past the lab
@@ -258,7 +262,7 @@ kill -STOP "$successor_pid" 2>/dev/null || fail "could not freeze the successor 
 thaw() { kill -CONT "$successor_pid" 2>/dev/null || true; }
 i=0
 while [ "$i" -lt 60 ]; do
-  age=$(( $(date +%s) - $(stat -f %m "$PROJECT/state/.last-watcher-beat" 2>/dev/null || stat -c %Y "$PROJECT/state/.last-watcher-beat" 2>/dev/null || date +%s) ))
+  age=$(( $(date +%s) - $(stat -c %Y "$PROJECT/state/.last-watcher-beat" 2>/dev/null || stat -f %m "$PROJECT/state/.last-watcher-beat" 2>/dev/null || date +%s) ))
   [ "$age" -gt "$GUARD_GRACE" ] && break
   sleep 1
   i=$((i + 1))


### PR DESCRIPTION
## Intent

Prevent OMP prompt loss when Firstmate watcher notifications arrive while the captain is typing. Preserve any partially typed multiline draft while the model still receives the operational notification. Preserve FIFO ordering relative to a captain message already submitted and a later active draft, and deliver watcher notifications exactly once without loss, duplication, or reordering when idle, during a running turn, at turn completion, and across repeated watcher closes. Keep the fix narrow in Firstmate shared code when that is the root cause. Do not change or restart the live primary, and use the existing persistent OMP extension discovery without extra config when safe. Run the no-mistakes pipeline on branch fm/pam-prompt-loss so PR https://github.com/kunchenguid/firstmate/pull/4187 receives the required no-mistakes attestation. Address the Behavior portable parallel 1 ten-minute job-cap timeout by retrying it, or split or shard the job if the cap is structural, without lowering test coverage. Report checks green when complete. Do not merge; an upstream maintainer owns merge.

## What Changed
- `.omp/extensions/fm-primary-omp-watch.ts` now sends watcher wakes via `pi.sendMessage` as a hidden `firstmate-primary-omp-watcher-wake` custom message (`deliverAs: "followUp"`, `triggerTurn: true`) instead of `pi.sendUserMessage`, so an in-flight captain draft in the composer is no longer cleared; wake consumption during a streaming turn now matches on the custom `message_start` (role/customType/content) rather than user-message text.
- `tests/fm-omp-harness.test.sh` and `tests/fm-omp-primary-live-e2e.test.sh` pin the new transport: exactly one hidden custom wake reaches the model, never through the captain-owned user role; the harness fake API uses `sendMessage`, and the live e2e's beacon-age check prefers `stat -c` (GNU-first ordering) for bash 3.2 portability.
- `docs/verification/supervision.md` records the 2026-09-11 verification of the prompt-safe watcher transport against omp 18.1.17.

## Risk Assessment

✅ Low: Narrow single-file transport swap (user-role follow-up to hidden custom message) that preserves the existing delivery/consumption/replay structure, with the fake-API harness and live e2e assertions updated to pin the new contract; residual reliance on omp sendMessage semantics is documented as live-verified against omp 18.1.17.

## Testing

Exercised the omp watcher wake transport three ways: the portable fake-API harness pinning the hidden custom follow-up contract, the credentialed live e2e against real omp 18.1.17 proving exactly-once hidden delivery through a full watcher close cycle, and a manual real-TUI session showing a multiline captain draft surviving a wake (with the legacy user-role transport reproducing the loss as a contrast). All passed; the fake-API harness checks are not live product runs and are reported as untested for live purposes. No visual screenshot of the TUI beyond tmux pane text captures because the surface is a terminal UI and pane transcripts are its native rendering.

- Live validation: ✅ go - 3 of 5 scenarios driven live against the product

| Scenario | Result | Live | Evidence |
| --- | --- | --- | --- |
| Captain typing a multiline draft when a watcher wake arrives keeps the draft in the composer while the model receives and acts on the wake, which never appears in the transcript | ✅ pass | live | composer-after-wake-new-transport.txt: draft lines still in composer, model output WAKE-ACK, no visible FIRSTMATE_OP text (real omp 18.1.17 TUI in tmux, real provider turn) |
| Adversarial contrast: the pre-fix user-role transport wipes the typed draft and leaks the wake into the visible transcript, proving the fix targets the real failure mode | ✅ pass | live | composer-cleared-legacy-user-transport.txt: after a sendUserMessage wake the composer is empty and the FIRSTMATE_OP wake text renders as a visible user message |
| An actionable watcher close on a live omp primary spawns a ledger-linked successor and wakes main exactly once as hidden custom input with zero user-role deliveries, ordered as a follow-up turn | ✅ pass | live | omp-live-e2e.log: custom wake count asserted ==1, user-role wake count asserted ==0, wake turn completed, successor ledger-linked (FM_OMP_LIVE_E2E=1 bash tests/fm-omp-primary-live-e2e.test.sh) |
| Repeated arms are ownership no-ops, an idle wake is consumed at before_agent_start / a streaming wake at its custom message_start, and a consumed wake never replays across a session replacement | ⏸️ untested | no | Only exercised through the fm-omp-harness fake-API test (real extension code over a stubbed omp API), which is not a live product run under the validation contract; a live pass here would require driv… |
| Behavior portable parallel 1 CI job finishes within its ten-minute cap (retry or reshard) | ⏸️ untested | no | This is a GitHub Actions job runtime concern owned by the outer no-mistakes CI phase; the local test step cannot drive the hosted runner. The outer executor&#39;s CI phase will surface it when the pipelin… |

<details>
<summary>Evidence: omp live e2e transcript (omp 18.1.17, real provider)</summary>

Source: [omp live e2e transcript (omp 18.1.17, real provider)](https://github.com/Andrew-Pynch/firstmate/blob/5002269e6a735f17996f94df563f7c7bc246dff8/.no-mistakes/evidence/fm/pam-prompt-loss/omp-live-e2e.log)

```text
Note: switching to '146efc70b4c9adecd7debeb1721f9e69bf89210f'.

You are in 'detached HEAD' state. You can look around, make experimental
changes and commit them, and you can discard any commits you make in this
state without impacting any branches by switching back to a branch.

If you want to create a new branch to retain commits you create, you may
do so (now or later) by using -c with the switch command. Example:

  git switch -c <new-branch-name>

Or undo this operation with:

  git switch -

Turn off this advice by setting config variable advice.detachedHead to false

ok - omp omp/18.1.17: both tracked .omp/extensions loaded by auto-discovery with no -e and no trust dialog
ok - omp omp/18.1.17: before_agent_start delivered the digest into model context and the lock names the omp process
ok - omp omp/18.1.17: fm_watch_arm_omp started a live watcher through the extension
ok - omp omp/18.1.17: an actionable close spawned a ledger-linked successor and woke main exactly once through hidden custom input
ok - omp omp/18.1.17: session_stop compelled the guard continuation (guard rc=2, then a stop_hook_active stop) and the model reached for fm_watch_arm_omp
# omp omp/18.1.17 exited on its own after its rpc stdin closed
# omp omp/18.1.17 model=openai-codex/gpt-6-astra: every live omp primary assertion passed
```
</details>
<details>
<summary>Evidence: TUI capture: multiline draft intact after hidden custom wake, model replied WAKE-ACK, wake hidden</summary>

Source: [TUI capture: multiline draft intact after hidden custom wake, model replied WAKE-ACK, wake hidden](https://github.com/Andrew-Pynch/firstmate/blob/5002269e6a735f17996f94df563f7c7bc246dff8/.no-mistakes/evidence/fm/pam-prompt-loss/composer-after-wake-new-transport.txt)

```text

╭─── omp v18.1.17 ─────────────────────────────────────────────────────────────────────────────────╮
│                          │ Tips                                                                  │
│      Welcome back!       │ # for prompt actions                                                  │
│                          │ / for commands                                                        │
│       ████████████       │ ! to run bash                                                         │
│          ██  ██          │ $ to run python                                                       │
│          ██  ██          │ ───────────────────────────────────────────────────────────────────── │
│          ▒▒  ██          │ LSP Servers                                                           │
│              ██          │ ● vscode-html-language-server .html .htm                              │
│                          │ ● vscode-css-language-server .css .scss .sass                         │
│       GPT-6-Astra        │ ● vscode-json-language-server .json .jsonc                            │
│       openai-codex       │ ● bashls .sh .bash .zsh                                               │
│                          │ ───────────────────────────────────────────────────────────────────── │
│                          │ Recent sessions                                                       │
│                          │ No recent sessions                                                    │
│                          │                                                                       │
│                          │                                                                       │
│                          │                                                                       │
│                          │                                                                       │
╰──────────────────────────┴───────────────────────────────────────────────────────────────────────╯
 Tip: Please use nerdfont 😭.

 MCP finished with failures. Connected: drive. Failed: granola [config: ~/.omp/agent/mcp.json]: HTTP 401:
 {"message":"Unauthorized"} [WWW-Authenticate: Bearer [redacted], erro…

 WAKE-ACK

╭── π > ◒ GPT-6-Astra 🙈 > 📁 …WP49TGD615YBDFVX73BR/.composer-lab/proj > ⑂ master > S0.55 ▶────20%─────────╎─┃──272K───╮
│  draft line one: refactor the parser                                                                                 │
╰─ draft line two: still typing this out                                                                              ─╯
```
</details>
<details>
<summary>Evidence: TUI capture: legacy user-role wake wiped the draft and leaked FIRSTMATE_OP text into the transcript (bug reproduction)</summary>

Source: [TUI capture: legacy user-role wake wiped the draft and leaked FIRSTMATE_OP text into the transcript (bug reproduction)](https://github.com/Andrew-Pynch/firstmate/blob/5002269e6a735f17996f94df563f7c7bc246dff8/.no-mistakes/evidence/fm/pam-prompt-loss/composer-cleared-legacy-user-transport.txt)

```text
│          ██  ██          │ ───────────────────────────────────────────────────────────────────── │
│          ▒▒  ██          │ LSP Servers                                                           │
│              ██          │ ● vscode-html-language-server .html .htm                              │
│                          │ ● vscode-css-language-server .css .scss .sass                         │
│       GPT-6-Astra        │ ● vscode-json-language-server .json .jsonc                            │
│       openai-codex       │ ● bashls .sh .bash .zsh                                               │
│                          │ ───────────────────────────────────────────────────────────────────── │
│                          │ Recent sessions                                                       │
│                          │ No recent sessions                                                    │
│                          │                                                                       │
│                          │                                                                       │
│                          │                                                                       │
│                          │                                                                       │
╰──────────────────────────┴───────────────────────────────────────────────────────────────────────╯
 Tip: Please use nerdfont 😭.


 MCP finished with failures. Connected: drive. Failed: granola [config: ~/.omp/agent/mcp.json]: HTTP 401:
 {"message":"Unauthorized"} [WWW-Authenticate: Bearer [redacted], erro…

 WAKE-ACK


 draft line one: refactor the parser
 draft line two: still typing this out/lab-user-wake


 Captain, finish the draft. These lines are notes, not authorization to change the parser.


 ⁣FIRSTMATE_OP: v1 watcher: FIRSTMATE WATCHER WAKE: signal: composer-lab done. Reply with exactly: WAKE-ACK


 WAKE-ACK

 ◎ Refactor Parser Draft In Progress
╭── π > ◒ GPT-6-Astra 🙈 > 📁 …WP49TGD615YBDFVX73BR/.composer-lab/proj > ⑂ master > S0.63 ▶─14%╎┃272K─◀ Refactor Pa… ──╮
╰─                                                                                                                    ─╯
```
</details>
<details>
<summary>Evidence: key live e2e assertions</summary>

```text
ok - omp omp/18.1.17: an actionable close spawned a ledger-linked successor and woke main exactly once through hidden custom input
ok - omp omp/18.1.17: session_stop compelled the guard continuation (guard rc=2, then a stop_hook_active stop) and the model reached for fm_watch_arm_omp
# omp omp/18.1.17 model=openai-codex/gpt-6-astra: every live omp primary assertion passed
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"146efc70b4c9adecd7debeb1721f9e69bf89210f","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}],"live_validation":{"verdict":"go","live":3,"total":5}} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>⚠️ **Review** - 2 infos</summary>

- ℹ️ `.omp/extensions/fm-primary-omp-watch.ts:503` - Comments still state &#34;an idle main consumes at before_agent_start&#34; (also header lines 39-40), but wakes are no longer user prompts, so the before_agent_start consumeWake match at line 1011 can no longer see wake content; idle consumption now happens via the custom message_start (as the live e2e observed). The retained prompt-match path is harmless (wake content contains an invisible separator no captain types) but the comment is stale and the match is effectively dead for wakes.
- ℹ️ `docs/verification/supervision.md:57` - Commit 146efc7 is titled &#34;test(omp): restore bash 3.2 parsing&#34; but its content is docs rewording plus a comment tweak; no parsing change. Purely cosmetic history mismatch, no action needed.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- Live validation: ✅ go - 3 of 5 scenarios driven live against the product

| Scenario | Result | Live | Evidence |
| --- | --- | --- | --- |
| Captain typing a multiline draft when a watcher wake arrives keeps the draft in the composer while the model receives and acts on the wake, which never appears in the transcript | ✅ pass | live | composer-after-wake-new-transport.txt: draft lines still in composer, model output WAKE-ACK, no visible FIRSTMATE_OP text (real omp 18.1.17 TUI in tmux, real provider turn) |
| Adversarial contrast: the pre-fix user-role transport wipes the typed draft and leaks the wake into the visible transcript, proving the fix targets the real failure mode | ✅ pass | live | composer-cleared-legacy-user-transport.txt: after a sendUserMessage wake the composer is empty and the FIRSTMATE_OP wake text renders as a visible user message |
| An actionable watcher close on a live omp primary spawns a ledger-linked successor and wakes main exactly once as hidden custom input with zero user-role deliveries, ordered as a follow-up turn | ✅ pass | live | omp-live-e2e.log: custom wake count asserted ==1, user-role wake count asserted ==0, wake turn completed, successor ledger-linked (FM_OMP_LIVE_E2E=1 bash tests/fm-omp-primary-live-e2e.test.sh) |
| Repeated arms are ownership no-ops, an idle wake is consumed at before_agent_start / a streaming wake at its custom message_start, and a consumed wake never replays across a session replacement | ⏸️ untested | no | Only exercised through the fm-omp-harness fake-API test (real extension code over a stubbed omp API), which is not a live product run under the validation contract; a live pass here would require driv… |
| Behavior portable parallel 1 CI job finishes within its ten-minute cap (retry or reshard) | ⏸️ untested | no | This is a GitHub Actions job runtime concern owned by the outer no-mistakes CI phase; the local test step cannot drive the hosted runner. The outer executor&#39;s CI phase will surface it when the pipelin… |

- `bash tests/fm-omp-harness.test.sh (all 11 checks green, including the updated watch-extension contract: arm once, no-op repeat, one hidden custom follow-up, streaming consumption at custom message_start, no replay of a consumed wake)`
- `FM_OMP_LIVE_E2E=1 bash tests/fm-omp-primary-live-e2e.test.sh against installed omp 18.1.17 with model openai-codex/gpt-6-astra (auto-discovery, digest delivery, live watcher arm, actionable close -> ledger-linked successor, wake exactly once as hidden custom input, zero user-role wakes, compelled turn-end guard continuation)`
- `Manual TUI lab: real omp 18.1.17 in tmux with a test extension sending the exact new-transport wake while a multiline draft sat in the composer; model replied WAKE-ACK, draft intact, wake absent from transcript`
- `Manual TUI contrast: same lab using legacy sendUserMessage transport; composer draft was wiped and the FIRSTMATE_OP wake text appeared visibly as a user message, reproducing the reported prompt loss`
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
