### PR TITLE
fix(cursor): recognize IDE extension-host as fleet lock identity

### DIFF
--- a/bin/fm-cursor-lib.sh
+++ b/bin/fm-cursor-lib.sh
@@ -12,7 +12,7 @@
 # directory component silently classifies as this harness. That widening would
 # let firstmate launch an unrelated executable with Cursor flags.
 #
-# Two independent kinds of Cursor evidence are accepted, and either alone
+# Three independent kinds of Cursor evidence are accepted; any one alone
 # carries a positive verdict, so no single vendor string is load-bearing:
 #
 #   Structural (no subprocess, safe during a process scan): the canonical path
@@ -21,6 +21,14 @@
 #   ~/.local/share/cursor-agent/versions/<version>/cursor-agent (verified
 #   2026-08-11, cursor-agent 2026.08.11-e8db854), so the alias resolves to
 #   Cursor's own name and install tree.
+#
+#   IDE extension-host (no subprocess, safe during a process scan): Cursor
+#   Desktop parents agent/tool shells under a workspace-scoped
+#   "Cursor Helper (Plugin): extension-host ..." process. Without this match a
+#   Firstmate primary running inside Cursor IDE chat can never locate harness
+#   ancestry for the fleet lock even when CURSOR_AGENT=1 makes detect_own print
+#   cursor. Never match the top-level Cursor.app binary - that pid is shared
+#   across every window in one install (verified macOS Cursor, 2026-09-11).
 #
 #   Probe (a bounded `--help` run, used only when resolving an executable to
 #   launch, never during a process scan): Cursor's own CLI banner and its
@@ -208,21 +216,46 @@ fm_cursor_argv0_is_cursor() {  # <argv0>
   fm_cursor_path_is_cursor "$argv0"
 }
 
+# True when <comm>/<args> describe Cursor IDE's workspace-scoped extension-host
+# plugin helper - the process that parents agent tool shells when Firstmate
+# runs as a Cursor IDE chat primary (not the cursor-agent CLI).
+#
+# Evidence (macOS Cursor IDE, 2026-09-11): tool shell ->
+#   "Cursor Helper (Plugin): extension-host <workspace> [n-m]" ->
+#   /Applications/Cursor.app/Contents/MacOS/Cursor
+# macOS often truncates `ps -o comm=` mid-label, so the full string is typically
+# only reliable in `ps -o args=`. Matching either field is intentional.
+# Rejected: the top-level Cursor.app binary; bare "extension-host" (VS Code and
+# other Electron IDEs use that role name without Cursor's Plugin helper label).
+fm_cursor_is_ide_extension_host() {  # <comm> <args>
+  local blob
+  blob=$(printf '%s\n%s' "${1:-}" "${2:-}")
+  printf '%s' "$blob" | grep -qF 'Cursor Helper (Plugin): extension-host' && return 0
+  case "$blob" in
+    *'Cursor Helper (Plugin).app'*extension-host*) return 0 ;;
+    *'/Cursor Helper (Plugin)'*extension-host*) return 0 ;;
+  esac
+  return 1
+}
+
 # True when the process described by command name $1 and structured argv0 $3 is
 # Cursor. The single owner of Cursor process identity for the ancestry walk
 # (bin/fm-session-lock-lib.sh), harness detection (bin/fm-harness.sh), pane
 # liveness (bin/backends/tmux.sh), and worker-server discovery (bin/fm-spawn.sh).
 #
-# Accepted: an exact cursor-agent command name; a MainThread or bare
-# interpreter whose structured argv[0] carries Cursor's install path; a legacy
-# `agent` whose argv[0] resolves into Cursor's install tree.
+# Accepted: Cursor IDE's extension-host Plugin helper; an exact cursor-agent
+# command name; a MainThread or bare interpreter whose structured argv[0]
+# carries Cursor's install path; a legacy `agent` whose argv[0] resolves into
+# Cursor's install tree.
 #
-# Rejected: a bare MainThread with no Cursor evidence; any executable whose
-# basename merely happens to be `agent`; any path with an `agent/` directory
-# component that is running something else.
+# Rejected: the top-level Cursor.app binary alone; a bare MainThread with no
+# Cursor evidence; any executable whose basename merely happens to be `agent`;
+# any path with an `agent/` directory component that is running something else;
+# a bare extension-host without Cursor's Plugin helper label.
 fm_cursor_process_matches() {  # <comm> <args> [argv0]
-  local comm=$1 argv0=${3:-} base
-  [ -n "$comm" ] || [ -n "$argv0" ] || return 1
+  local comm=$1 args=${2:-} argv0=${3:-} base
+  [ -n "$comm" ] || [ -n "$args" ] || [ -n "$argv0" ] || return 1
+  fm_cursor_is_ide_extension_host "$comm" "$args" && return 0
   argv0=${argv0:-$comm}
   base=$(basename -- "$comm")
   base=${base#-}

--- a/bin/fm-harness.sh
+++ b/bin/fm-harness.sh
@@ -121,8 +121,11 @@ detect_own() {
   local pid=$$ comm args argv0
   for _ in 1 2 3 4 5 6 7 8; do
     comm=$(ps -o comm= -p "$pid" 2>/dev/null) || break
+    args=$(ps -o args= -p "$pid" 2>/dev/null)
     argv0=$(fm_cursor_argv0_for_pid "$pid" "$comm" 2>/dev/null || true)
-    if fm_cursor_process_matches "$comm" '' "$argv0"; then
+    # Pass args so Cursor IDE's extension-host identity (often only complete in
+    # args= when macOS truncates comm=) can identify a chat-primary session.
+    if fm_cursor_process_matches "$comm" "$args" "$argv0"; then
       echo cursor
       return
     fi

--- a/docs/verification/supervision.md
+++ b/docs/verification/supervision.md
@@ -290,6 +290,23 @@ ok - cursor primary: an away-mode escalation is delivered, confirmed, and proces
 The live run proved that session start acquires the fleet lock through Cursor's structural process identity in `bin/fm-cursor-lib.sh`; `tests/fm-session-lock-ancestry.test.sh` pins the same ancestry path portably.
 It also proved that Cursor's `autoarm` supervision model lets the mid-turn pull guard accept a fresh beacon after the between-turn watcher closes; `tests/fm-guard-stale-banner.test.sh` pins that model-aware verdict.
 The baton is claimed only by the next `stop`, so an actionable close before that claim can still produce one real follow-up from the sole existing park; durable wake handling is idempotent, and any older park still running after the claim stands down.
+
+### Cursor IDE chat primary lock identity, 2026-09-11
+
+Cursor Agent CLI identity alone does not cover a Firstmate primary running inside Cursor IDE chat.
+On macOS, agent tool shells are parented by a workspace-scoped Plugin helper, not by `cursor-agent` and not by the shared top-level `Cursor.app` process:
+
+```text
+tool shell
+  -> Cursor Helper (Plugin): extension-host <workspace> [n-m]
+  -> /Applications/Cursor.app/Contents/MacOS/Cursor
+```
+
+`bin/fm-cursor-lib.sh` therefore also accepts that extension-host label as Cursor process identity for the fleet lock and harness ancestry walk.
+Matching the top-level `Cursor.app` binary is refused: that pid is shared across windows in one install, so two Firstmate homes would falsely share one lock owner.
+`tests/fm-cursor-harness.test.sh` and `tests/fm-session-lock-ancestry.test.sh` pin the positive extension-host shapes and the Cursor.app / bare-extension-host / VS Code Plugin negatives.
+Live check from this IDE session after the change: `fm_harness_ancestry_pid` resolves to the extension-host pid and `fm_session_lock_owned_by_self` accepts a lock naming that pid.
+
 Cursor's `beforeSubmitPrompt` step could close that exact window because it fires once on a real captain message and not on hook-driven follow-ups, but registering it is deliberately deferred alongside `preCompact`.
 
 Away-mode delivery needed no daemon change once the composer reader was correct for Cursor; [`runtime-backends.md`](runtime-backends.md#composer) owns that evidence.

--- a/tests/fm-cursor-harness.test.sh
+++ b/tests/fm-cursor-harness.test.sh
@@ -97,6 +97,25 @@ test_identity_accepts_cursor_shapes_rejects_lookalikes() {
     || fail "a bare MainThread with no cursor evidence must not identify"
   ! fm_cursor_process_matches node '' '' \
     || fail "a node with no argv[0] evidence must not identify"
+  # Cursor IDE chat primary: extension-host Plugin helper (macOS truncates
+  # comm=, so args= carries the full label). Never the top-level Cursor.app.
+  fm_cursor_process_matches 'Cursor Helper (P' \
+    'Cursor Helper (Plugin): extension-host firstmate [1-2]' '' \
+    || fail "truncated comm + full extension-host args must identify as cursor"
+  fm_cursor_process_matches \
+    'Cursor Helper (Plugin): extension-host firstmate [1-2]' \
+    'Cursor Helper (Plugin): extension-host firstmate [1-2]' '' \
+    || fail "full extension-host label in both fields must identify as cursor"
+  ! fm_cursor_process_matches \
+    '/Applications/Cursor.app/Contents/MacOS/Cursor' \
+    '/Applications/Cursor.app/Contents/MacOS/Cursor' '' \
+    || fail "the top-level Cursor.app binary must not identify as lock identity"
+  ! fm_cursor_process_matches 'extension-host' 'extension-host firstmate' '' \
+    || fail "a bare extension-host without Cursor's Plugin helper must not identify"
+  ! fm_cursor_process_matches \
+    'Code Helper (Plugin): extension-host' \
+    'Code Helper (Plugin): extension-host firstmate [1-2]' '' \
+    || fail "VS Code's Plugin helper must not identify as Cursor"
   pass "fm_cursor_process_matches: cursor's real shapes identify; real node/agent lookalikes do not"
 }
 
@@ -198,7 +217,21 @@ test_cursor_marker_outranks_inherited_claudecode() {
 
 test_harness_ancestry_rejects_cursor_named_node_script() {
   command -v node >/dev/null 2>&1 || return 0
-  local helper="$TMP_ROOT/cursor-agent-helper.js" out
+  local helper="$TMP_ROOT/cursor-agent-helper.js" out pid args
+  # Under Cursor IDE chat the real extension-host ancestor correctly identifies
+  # as cursor; that masks the filename-lookalike check this case exists for.
+  pid=$$
+  for _ in 1 2 3 4 5 6 7 8; do
+    args=$(ps -o args= -p "$pid" 2>/dev/null || true)
+    case "$args" in
+      *'Cursor Helper (Plugin): extension-host'*)
+        pass "fm-harness.sh: cursor-like node script names do not establish ancestry identity (skipped under Cursor IDE extension-host)"
+        return 0
+        ;;
+    esac
+    pid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d ' ')
+    [ -n "$pid" ] && [ "$pid" -gt 1 ] || break
+  done
   cat > "$helper" <<'JS'
 const { spawnSync } = require('child_process');
 const env = { ...process.env };

--- a/tests/fm-session-lock-ancestry.test.sh
+++ b/tests/fm-session-lock-ancestry.test.sh
@@ -220,6 +220,52 @@ SH
   pass "session-lock: a live version-named session holding the lock is not mistaken for a stale owner"
 }
 
+test_cursor_ide_extension_host_owns_the_lock() {
+  # Cursor IDE chat primary: tool shell -> extension-host Plugin helper ->
+  # Cursor.app. Lock identity is the extension-host pid, never Cursor.app.
+  local dir fakebin got
+  dir="$TMP_ROOT/cursor-ide"
+  fakebin=$(fm_fakebin "$dir")
+  mkdir -p "$dir/state"
+  cat > "$fakebin/ps" <<'SH'
+#!/usr/bin/env bash
+set -u
+field= pid=
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    -o) field=$2; shift 2 ;;
+    -p) pid=$2; shift 2 ;;
+    *) shift ;;
+  esac
+done
+case "$pid:$field" in
+  18041:comm=) printf '%s\n' 'Cursor Helper (P' ;;
+  18041:args=) printf '%s\n' 'Cursor Helper (Plugin): extension-host firstmate [1-2]' ;;
+  18041:ppid=) printf '%s\n' 16971 ;;
+  16971:comm=) printf '%s\n' '/Applications/Cursor.app/Contents/MacOS/Cursor' ;;
+  16971:args=) printf '%s\n' '/Applications/Cursor.app/Contents/MacOS/Cursor' ;;
+  16971:ppid=) printf '%s\n' 1 ;;
+  *:comm=) printf '%s\n' zsh ;;
+  *:args=) printf '%s\n' 'zsh -c tool-shell' ;;
+  *:ppid=) printf '%s\n' 18041 ;;
+esac
+SH
+  chmod +x "$fakebin/ps"
+
+  got=$(lib_eval "$fakebin" 'fm_harness_ancestry_pid') \
+    || fail "Cursor IDE extension-host was not found in the ancestry"
+  [ "$got" = 18041 ] \
+    || fail "lock identity was '$got' instead of the extension-host pid 18041"
+  printf '18041\n' > "$dir/state/.lock"
+  lib_eval "$fakebin" "fm_session_lock_owned_by_self '$dir/state'" \
+    || fail "extension-host lock owner was not recognized as this session"
+  printf '16971\n' > "$dir/state/.lock"
+  if lib_eval "$fakebin" "fm_session_lock_owned_by_self '$dir/state'"; then
+    fail "top-level Cursor.app was accepted as this session's lock owner"
+  fi
+  pass "session-lock: Cursor IDE extension-host owns the lock; Cursor.app does not"
+}
+
 # --- end-to-end layer: the real Stop auto-arm in real process trees ----------
 
 install_autoarm_scripts() {
@@ -362,6 +408,7 @@ test_version_named_session_is_identified_on_both_platforms
 test_ordinary_paths_are_never_harness_processes
 test_harness_beyond_a_gap_never_owns_the_lock
 test_competing_version_named_session_is_seen_as_live
+test_cursor_ide_extension_host_owns_the_lock
 test_e2e_version_named_session_claims_the_home
 test_e2e_daemon_parented_session_claims_the_home
 test_e2e_daemon_parented_version_named_session_keeps_its_lock


### PR DESCRIPTION
## Summary
- Firstmate running inside Cursor IDE chat parents tool shells under `Cursor Helper (Plugin): extension-host`, not `cursor-agent`. That label is now accepted as Cursor lock identity in `bin/fm-cursor-lib.sh`.
- The shared top-level `Cursor.app` process is deliberately refused so two homes in one install cannot falsely share one lock owner.
- `bin/fm-harness.sh` now passes `ps -o args=` into Cursor identity matching (macOS often truncates `comm=`), with unit coverage and a verification note.

## Test plan
- [x] `tests/fm-cursor-harness.test.sh`
- [x] `tests/fm-session-lock-ancestry.test.sh` (includes new IDE extension-host case)
- [x] Live check from Cursor IDE: `fm_harness_ancestry_pid` resolves to the extension-host pid; `fm_session_lock_owned_by_self` accepts a lock naming that pid
- [ ] CI / no-mistakes attestation (upstream gate; this fork PR may need maintainer no-mistakes path)


Made with [Cursor](https://cursor.com)