### PR TITLE
fix(bin): bind and fold Muse 1.1.1 session logs regardless of field order

### DIFF
--- a/.agents/skills/harness-adapters/references/harness/muse.md
+++ b/.agents/skills/harness-adapters/references/harness/muse.md
@@ -46,7 +46,7 @@ Logs live at `${XDG_DATA_HOME:-$HOME/.local/share}/muse/sessions/YYYY/MM/DD/<ses
 The spawn writes `state/<id>.muse-session` with root, worktree, binding incarnation, and pre-existing matching main logs, then unique resolution pins `state/<id>.muse-session-current`.
 It folds that path while the bounded current-day main namespace is unchanged and resolves again if the namespace changes, path disappears, or a newer binding wins.
 
-Turns are bracketed by `{"payload":{"kind":"run","run_id":"<uuid>","event":{"kind":"started"` and matching `"event":{"kind":"terminal"`, observed as `completed` or `cancelled`.
+Turns are bracketed by a payload whose kind is `run`, with a `started` event and a matching `terminal` event observed as `completed` or `cancelled`, regardless of JSON field order.
 Interrupt therefore has a real terminal, unlike Claude Stop.
 Never use `--no-session-log`, which removes Muse's only busy source.
 

--- a/bin/fm-busy-lib.sh
+++ b/bin/fm-busy-lib.sh
@@ -278,10 +278,13 @@ fm_busy_record_read() {  # <state-dir> <id>
 # muse persists an append-only session event log per session at
 # <sessions-root>/YYYY/MM/DD/<session-uuid>/session.jsonl, and brackets every
 # submitted turn with one run lifecycle pair. Verified live on muse
-# 0.1.0-R708.1 across completed, interrupted, and killed-mid-turn turns:
-#   {"payload":{"kind":"run","run_id":"<uuid>","event":{"kind":"started",...
-#   {"payload":{"kind":"run","run_id":"<uuid>","event":{"kind":"terminal",
-#     "terminal":"completed"|"cancelled",...
+# 0.1.0-R708.1 across completed, interrupted, and killed-mid-turn turns.
+# Muse Code 1.1.1-R2514.1 keeps that lifecycle and writes the same fields in a
+# different order, with a leading retained_frame before session metadata; the
+# fold and log discovery match those fields structurally rather than by byte
+# prefix:
+#   payload.kind=run, payload.run_id, payload.event.kind=started|terminal
+#   payload.event.terminal=completed|cancelled
 # An Escape interrupt closes its run with terminal=cancelled, so unlike Claude's
 # Stop hook this source covers the interrupt path itself. Any later
 # run_retracted records follow the terminal rather than replacing it.
@@ -330,7 +333,9 @@ fm_busy_muse_binding_field() {  # <state-dir> <id> <key>
 }
 
 # fm_busy_muse_matching_logs: every MAIN session log whose recorded
-# workspace_root is this task's worktree. The depth bounds are what exclude
+# workspace_root is this task's worktree. Session metadata is matched
+# structurally on payload_type, whether it is the first record or follows a
+# leading retained_frame wrapper. The depth bounds are what exclude
 # muse's own native sub-agent logs, which live one directory deeper under
 # subagent/<child-session-id>/session.jsonl and carry their own independent run
 # lifecycle - folding a child's log would report the parent busy long after the
@@ -360,10 +365,23 @@ function metadataWorkspace(file) {
     descriptor = fs.openSync(file, "r");
     const buffer = Buffer.alloc(65536);
     const length = fs.readSync(descriptor, buffer, 0, buffer.length, 0);
-    const newline = buffer.indexOf(10, 0);
-    if (newline < 0 || newline >= length) return null;
-    const record = JSON.parse(buffer.subarray(0, newline).toString("utf8"));
-    return record?.payload?.record?.workspace_root ?? null;
+    const text = buffer.subarray(0, length).toString("utf8");
+    const truncated = length === buffer.length && !text.endsWith("\n");
+    const lines = text.split("\n");
+    if (truncated) lines.pop();
+    for (const line of lines) {
+      if (!line) continue;
+      let record;
+      try {
+        record = JSON.parse(line);
+      } catch {
+        continue;
+      }
+      if (record?.payload_type === "runtime.session.metadata") {
+        return record?.payload?.record?.workspace_root ?? null;
+      }
+    }
+    return null;
   } catch {
     return null;
   } finally {
@@ -528,45 +546,169 @@ EOF
   printf '%s' "$selected"
 }
 
+# fm_busy_muse_run_events: emit tab-separated run_id, event kind, and
+# terminal value for each structurally valid run started/terminal record.
+# Field order inside the JSON object is not part of the match. A nested
+# cleanup "record":{"kind":"terminal"} and text inside an event never count.
+# Malformed lines contribute nothing. jq is used when present; otherwise an
+# awk JSON tokenizer matches the same fields.
 fm_busy_muse_run_events() {  # <session-log>
   [ -f "$1" ] || return 1
-  LC_ALL=C awk '
-    BEGIN { OFS = "\t"; pre = "\"payload\":{\"kind\":\"run\",\"run_id\":\"" }
-    {
-      p = index($0, pre)
-      if (p == 0) next
-      rest = substr($0, p + length(pre))
-      q = index(rest, "\"")
-      if (q == 0) next
-      rid = substr(rest, 1, q - 1)
-      rest = substr(rest, q)
-      head = "\",\"event\":{\"kind\":\""
-      if (substr(rest, 1, length(head)) != head) next
-      rest = substr(rest, length(head) + 1)
-      q = index(rest, "\"")
-      if (q == 0) next
-      ev = substr(rest, 1, q - 1)
-      terminal = ""
-      if (ev == "terminal") {
-        marker = "\"terminal\":\""
-        p = index(rest, marker)
-        if (p != 0) {
-          value = substr(rest, p + length(marker))
-          q = index(value, "\"")
-          if (q != 0) terminal = substr(value, 1, q - 1)
+  if command -v jq >/dev/null 2>&1; then
+    LC_ALL=C jq -Rr '
+      try (
+        fromjson
+        | if type == "object"
+            and .payload_type? == "runtime.session"
+            and (.payload | type) == "object"
+            and .payload.kind? == "run"
+            and (.payload.run_id | type) == "string"
+            and .payload.run_id != ""
+            and ((.payload.event.kind? == "started") or (.payload.event.kind? == "terminal"))
+          then
+            [
+              .payload.run_id,
+              .payload.event.kind,
+              (if .payload.event.kind == "terminal" and (.payload.event.terminal | type) == "string"
+               then .payload.event.terminal else "" end)
+            ] | @tsv
+          else empty
+          end
+      ) catch empty
+    ' "$1"
+  else
+    LC_ALL=C awk '
+      BEGIN { OFS = "\t" }
+      function ws(    c) {
+        while (p <= n) {
+          c = substr(line, p, 1)
+          if (c != " " && c != "\t" && c != "\r") break
+          p++
         }
       }
-      if (ev == "started" || ev == "terminal") print rid, ev, terminal
-    }
-  ' "$1"
+      function hex(c) {
+        if (c >= "0" && c <= "9") return c + 0
+        c = tolower(c)
+        return index("abcdef", c) + 9
+      }
+      function string(    c, e, h, i, code, out) {
+        if (substr(line, p, 1) != "\"") return 0
+        p++; out = ""
+        while (p <= n) {
+          c = substr(line, p++, 1)
+          if (c == "\"") { value = out; kind = "string"; return 1 }
+          if (c ~ /[[:cntrl:]]/) return 0
+          if (c != "\\") { out = out c; continue }
+          if (p > n) return 0
+          e = substr(line, p++, 1)
+          if (e == "\"" || e == "\\" || e == "/") out = out e
+          else if (e ~ /^[bfnrt]$/) out = out "?"
+          else if (e == "u") {
+            h = substr(line, p, 4)
+            if (length(h) != 4 || h !~ /^[0-9A-Fa-f][0-9A-Fa-f][0-9A-Fa-f][0-9A-Fa-f]$/) return 0
+            code = 0
+            for (i = 1; i <= 4; i++) code = code * 16 + hex(substr(h, i, 1))
+            out = out (code < 128 ? sprintf("%c", code) : "?")
+            p += 4
+          } else return 0
+        }
+        return 0
+      }
+      function number(    c) {
+        if (substr(line, p, 1) == "-") p++
+        c = substr(line, p, 1)
+        if (c == "0") {
+          p++
+          if (substr(line, p, 1) ~ /^[0-9]$/) return 0
+        } else if (c ~ /^[1-9]$/) {
+          do { p++; c = substr(line, p, 1) } while (c ~ /^[0-9]$/)
+        } else return 0
+        if (substr(line, p, 1) == ".") {
+          p++
+          if (substr(line, p, 1) !~ /^[0-9]$/) return 0
+          while (substr(line, p, 1) ~ /^[0-9]$/) p++
+        }
+        c = substr(line, p, 1)
+        if (c == "e" || c == "E") {
+          p++; c = substr(line, p, 1)
+          if (c == "+" || c == "-") p++
+          if (substr(line, p, 1) !~ /^[0-9]$/) return 0
+          while (substr(line, p, 1) ~ /^[0-9]$/) p++
+        }
+        kind = "number"; value = ""
+        return 1
+      }
+      function array(depth, path,    c) {
+        p++; ws()
+        if (substr(line, p, 1) == "]") { p++; return 1 }
+        while (p <= n) {
+          if (!json(depth + 1, path)) return 0
+          ws(); c = substr(line, p, 1)
+          if (c == "]") { p++; return 1 }
+          if (c != ",") return 0
+          p++; ws()
+        }
+        return 0
+      }
+      function object(depth, path,    c, key, vkind, vvalue, nested) {
+        p++; ws()
+        if (substr(line, p, 1) == "}") { p++; kind = "object"; return 1 }
+        while (p <= n) {
+          if (!string()) return 0
+          key = value; ws()
+          if (substr(line, p, 1) != ":") return 0
+          p++; ws()
+          nested = (path == "" ? key : path "." key)
+          if (!json(depth + 1, nested)) return 0
+          vkind = kind; vvalue = value
+          if (path == "" && key == "payload_type" && vkind == "string") ptype = vvalue
+          if (path == "payload" && key == "kind" && vkind == "string") pkind = vvalue
+          if (path == "payload" && key == "run_id" && vkind == "string") rid = vvalue
+          if (path == "payload.event" && key == "kind" && vkind == "string") ekind = vvalue
+          if (path == "payload.event" && key == "terminal" && vkind == "string") terminal = vvalue
+          ws(); c = substr(line, p, 1)
+          if (c == "}") {
+            p++; kind = "object"; value = ""
+            return 1
+          }
+          if (c != ",") return 0
+          p++; ws()
+        }
+        return 0
+      }
+      function json(depth, path,    c, word) {
+        ws(); c = substr(line, p, 1)
+        if (c == "\"") return string()
+        if (c == "{") return object(depth, path)
+        if (c == "[") { kind = "array"; value = ""; return array(depth, path) }
+        if (c == "-" || c ~ /^[0-9]$/) return number()
+        word = substr(line, p)
+        if (substr(word, 1, 4) == "true" || substr(word, 1, 4) == "null") { p += 4; kind = "literal"; value = ""; return 1 }
+        if (substr(word, 1, 5) == "false") { p += 5; kind = "literal"; value = ""; return 1 }
+        return 0
+      }
+      {
+        line = $0; p = 1; n = length(line)
+        ptype = ""; pkind = ""; rid = ""; ekind = ""; terminal = ""
+        kind = ""; value = ""
+        valid = json(0, "")
+        ws()
+        if (!valid || p <= n) next
+        if (ptype == "runtime.session" && pkind == "run" && rid != "" \
+            && (ekind == "started" || ekind == "terminal")) {
+          print rid, ekind, (ekind == "terminal" ? terminal : "")
+        }
+      }
+    ' "$1"
+  fi
 }
 
 # fm_busy_muse_run_state: fold one session log to busy|settled|none.
 #   busy     at least one run started with no matching terminal
 #   settled  every started run reached a terminal
 #   none     the log holds no run lifecycle records at all
-# The match is anchored on the exact structural prefix rather than a bare
-# "kind":"terminal" search, because muse also emits nested "record":{"kind":
+# The match is structural on payload.kind=run and payload.event.kind, never a
+# bare "kind":"terminal" search, because muse also emits nested "record":{"kind":
 # "terminal"} cleanup-effect payloads that are NOT run terminals and would
 # otherwise close a run that is still in flight.
 fm_busy_muse_run_state() {  # <session-log>

--- a/bin/fm-busy-lib.sh
+++ b/bin/fm-busy-lib.sh
@@ -297,7 +297,7 @@ fm_busy_record_read() {  # <state-dir> <id>
 # Pi push sources. A version allowlist would be false precision and a maintenance
 # treadmill for an auto-updating vendor binary: busy classification receives
 # only the normalized muse harness identity, while session metadata records
-# semver 0.1.0 plus a build SHA that cannot be matched against it. Resolution
+# a Muse semver plus a build SHA that cannot be matched against it. Resolution
 # failures - no sidecar, no matching log, an unreadable or run-free log - remain
 # unknown because those prove nothing about the turn either way. See
 # docs/verification/muse.md for the evidence.

--- a/docs/verification/muse.md
+++ b/docs/verification/muse.md
@@ -224,16 +224,15 @@ $ muse --version
 Muse Code 1.1.1 (1.1.1-R2514.1)
 
 $ FM_MUSE_SIGNALS_LIVE=1 bin/fm-test-run.sh tests/fm-muse-signals-live-e2e.test.sh
-FM_TEST_BEGIN 2026-09-11T08:14:53Z tests/fm-muse-signals-live-e2e.test.sh family=live-harness-optin expected_gate_skip=live-capability
+FM_TEST_BEGIN 2026-09-11T08:46:05Z tests/fm-muse-signals-live-e2e.test.sh family=live-harness-optin expected_gate_skip=live-capability
 ok - Muse's real session protocol on Muse Code 1.1.1 (1.1.1-R2514.1) classifies busy in flight
 ok - Muse's real session protocol on Muse Code 1.1.1 (1.1.1-R2514.1) binds the workspace log
 ok - Muse's real session protocol on Muse Code 1.1.1 (1.1.1-R2514.1) emits one matched run bracket
-ok - the shared classifier read Muse's real idle composer as empty
-ok - Muse Code 1.1.1 (1.1.1-R2514.1) session-log folding held; prompt glyph color is unverified
-FM_TEST_END 2026-09-11T08:14:53Z tests/fm-muse-signals-live-e2e.test.sh exit=0 duration_ms=635 gate_skip=false
-FM_TEST_SUMMARY total=1 failed=0 skipped_gate=0 duration_ms=684
-FM_TEST_SUMMARY_FAMILY family=live-harness-optin count=1 duration_ms=635 failed=0
-FM_TEST_SLOWEST rank=1 script=tests/fm-muse-signals-live-e2e.test.sh duration_ms=635
+ok - Muse's real prompt glyph color on Muse Code 1.1.1 (1.1.1-R2514.1) # SKIP composer glyph out of scope; 1.1.1 drift tracked as follow-up muse-111-composer-glyph-drift
+FM_TEST_END 2026-09-11T08:46:06Z tests/fm-muse-signals-live-e2e.test.sh exit=0 duration_ms=551 gate_skip=false
+FM_TEST_SUMMARY total=1 failed=0 skipped_gate=0 duration_ms=595
+FM_TEST_SUMMARY_FAMILY family=live-harness-optin count=1 duration_ms=551 failed=0
+FM_TEST_SLOWEST rank=1 script=tests/fm-muse-signals-live-e2e.test.sh duration_ms=551
 ```
 
 ## Refreshing this record
@@ -246,8 +245,7 @@ FM_MUSE_SIGNALS_LIVE=1 bin/fm-test-run.sh tests/fm-muse-signals-live-e2e.test.sh
 ```
 
 The Muse signals guard requires a real `muse` binary and tmux but uses `--provider echo`, so it does not require `META_API_KEY` and cannot re-check the real-model turn-to-run relationship on its own.
-On Muse Code 0.1.0 the same guard also followed SGR state through the final prompt glyph and rejected both bright-then-dark and malformed-RGB negative controls before accepting that glyph's effective luminance.
-On Muse Code 1.1.1 it refreshes session-log folding only and records prompt-glyph color as unverified.
+The guard follows SGR state through the final prompt glyph and rejects both bright-then-dark and malformed-RGB negative controls before accepting that glyph's effective luminance.
 
 muse's launcher can replace the running binary underneath the fleet, so an upgrade that changes the session protocol also invalidates the credentialed evidence above.
 Repeat that smoke after a protocol-affecting upgrade: run one real multi-step tool-loop turn with credentials in place, confirm the run-scoped `started`/`terminal` counts are still exactly one each, and confirm an Escape still yields `terminal` with `cancelled`.

--- a/docs/verification/muse.md
+++ b/docs/verification/muse.md
@@ -202,6 +202,40 @@ That is the same terminal shape the `echo`-provider interrupt produced, now conf
 
 `tests/fm-muse-harness.test.sh` pins the resulting classifier behavior: a log settled by either terminal reads `idle`, an open run reads `busy`, and only a resolution failure reads `unknown`.
 
+## Session-log folding on Muse Code 1.1.1 (verified 2026-09-11)
+
+This entry records session-log discovery and run-event folding only.
+It does not refresh the 0.1.0 process-identity, trust-dialog, interrupt, composer, or credentialed multi-step evidence above.
+
+| Field | Value |
+|---|---|
+| Version | `Muse Code 1.1.1 (1.1.1-R2514.1)` |
+| Verified | 2026-09-11 |
+| What | workspace binding after a leading `retained_frame`, and run-event folding independent of JSON field order |
+
+Muse Code 1.1.1 writes a leading `retained_frame` before `runtime.session.metadata`, and serializes each run payload with `event` before `kind`.
+The lifecycle is unchanged: one `started` event pairs with one `terminal` event whose `terminal` value is `completed` or `cancelled`.
+`workspace_root` on the metadata record still matches the task worktree, so binding is a read of that record rather than a change to how the sidecar is written.
+
+Portable regressions in `tests/fm-muse-harness.test.sh` feed 0.1.x-ordered and 1.1.1-ordered fixtures, each with and without `jq`, and keep the 0.1.x verdicts unchanged.
+
+```
+$ muse --version
+Muse Code 1.1.1 (1.1.1-R2514.1)
+
+$ FM_MUSE_SIGNALS_LIVE=1 bin/fm-test-run.sh tests/fm-muse-signals-live-e2e.test.sh
+FM_TEST_BEGIN 2026-09-11T08:14:53Z tests/fm-muse-signals-live-e2e.test.sh family=live-harness-optin expected_gate_skip=live-capability
+ok - Muse's real session protocol on Muse Code 1.1.1 (1.1.1-R2514.1) classifies busy in flight
+ok - Muse's real session protocol on Muse Code 1.1.1 (1.1.1-R2514.1) binds the workspace log
+ok - Muse's real session protocol on Muse Code 1.1.1 (1.1.1-R2514.1) emits one matched run bracket
+ok - the shared classifier read Muse's real idle composer as empty
+ok - Muse Code 1.1.1 (1.1.1-R2514.1) session-log folding held; prompt glyph color is unverified
+FM_TEST_END 2026-09-11T08:14:53Z tests/fm-muse-signals-live-e2e.test.sh exit=0 duration_ms=635 gate_skip=false
+FM_TEST_SUMMARY total=1 failed=0 skipped_gate=0 duration_ms=684
+FM_TEST_SUMMARY_FAMILY family=live-harness-optin count=1 duration_ms=635 failed=0
+FM_TEST_SLOWEST rank=1 script=tests/fm-muse-signals-live-e2e.test.sh duration_ms=635
+```
+
 ## Refreshing this record
 
 Run both live guards after any muse upgrade, because the version-suffixed process name, session protocol, and styled composer are vendor-controlled surfaces:
@@ -212,7 +246,8 @@ FM_MUSE_SIGNALS_LIVE=1 bin/fm-test-run.sh tests/fm-muse-signals-live-e2e.test.sh
 ```
 
 The Muse signals guard requires a real `muse` binary and tmux but uses `--provider echo`, so it does not require `META_API_KEY` and cannot re-check the real-model turn-to-run relationship on its own.
-The guard follows SGR state through the final prompt glyph and rejects both bright-then-dark and malformed-RGB negative controls before accepting that glyph's effective luminance.
+On Muse Code 0.1.0 the same guard also followed SGR state through the final prompt glyph and rejected both bright-then-dark and malformed-RGB negative controls before accepting that glyph's effective luminance.
+On Muse Code 1.1.1 it refreshes session-log folding only and records prompt-glyph color as unverified.
 
 muse's launcher can replace the running binary underneath the fleet, so an upgrade that changes the session protocol also invalidates the credentialed evidence above.
 Repeat that smoke after a protocol-affecting upgrade: run one real multi-step tool-loop turn with credentials in place, confirm the run-scoped `started`/`terminal` counts are still exactly one each, and confirm an Escape still yields `terminal` with `cancelled`.

--- a/tests/fm-muse-harness.test.sh
+++ b/tests/fm-muse-harness.test.sh
@@ -4,10 +4,11 @@
 # session-log busy source, and teardown cleanup of the busy binding.
 #
 # The session-log fixtures below reproduce muse 0.1.0-R708.1's real record
-# shapes, including the nested "record":{"kind":"terminal"} cleanup payload that
-# is NOT a run terminal. That decoy is the whole reason the fold matches an
-# anchored structural prefix instead of searching for "kind":"terminal", so a
-# fixture without it would let a naive implementation pass.
+# shapes and Muse Code 1.1.1's equivalent field order, including the nested
+# "record":{"kind":"terminal"} cleanup payload that is NOT a run terminal.
+# That decoy is the whole reason the fold matches payload.event.kind
+# structurally instead of searching for "kind":"terminal", so a fixture
+# without it would let a naive implementation pass.
 set -u
 
 # shellcheck source=tests/lib.sh
@@ -51,6 +52,33 @@ muse_log_noise() {  # <run-id>
   printf '{"schema_version":1,"payload_type":"runtime.session","payload":{"kind":"run","run_id":"%s","event":{"kind":"context_block_diagnostic","block_id":"rules_file","message":"mentions kind terminal and kind started in prose"}}}\n' "$1"
 }
 
+# Muse Code 1.1.1 writes a leading retained_frame before session metadata and
+# serializes run payload fields with event before kind. Fixtures are synthetic
+# and carry no real session content.
+muse_log_retained_frame() {
+  printf '{"retained_frame":"session_permission_transaction","frame_schema_version":1,"outer_log_ordinal":0,"transaction_id":"synthetic","children":[],"content_sha256":"0"}\n'
+}
+
+muse_log_run_started_111() {  # <run-id>
+  printf '{"schema_version":1,"payload_type":"runtime.session","payload":{"event":{"kind":"started","prompt":"launch brief"},"kind":"run","run_id":"%s"}}\n' "$1"
+}
+
+muse_log_run_terminal_111() {  # <run-id> <completed|cancelled>
+  printf '{"schema_version":1,"payload_type":"runtime.session","payload":{"event":{"kind":"terminal","terminal":"%s","reason":null,"turn_duration_ms":8152},"kind":"run","run_id":"%s"}}\n' "$2" "$1"
+}
+
+muse_log_cleanup_terminal_decoy_111() {  # <run-id>
+  printf '{"schema_version":1,"payload_type":"runtime.session","payload":{"record":{"kind":"terminal","cleanup_effect_id":1,"outcome":{"kind":"applied"}},"kind":"reminder_cleanup_effect","run_id":"%s"}}\n' "$1"
+}
+
+muse_log_noise_111() {  # <run-id>
+  printf '{"schema_version":1,"payload_type":"runtime.session","payload":{"event":{"kind":"context_block_diagnostic","block_id":"rules_file","message":"mentions \\"kind\\":\\"terminal\\" and \\"kind\\":\\"started\\" in prose"},"kind":"run","run_id":"%s"}}\n' "$1"
+}
+
+muse_log_started_prompt_trap_111() {  # <run-id>
+  printf '{"schema_version":1,"payload_type":"runtime.session","payload":{"event":{"kind":"started","prompt":"please ignore \\"kind\\":\\"terminal\\" inside this prompt"},"kind":"run","run_id":"%s"}}\n' "$1"
+}
+
 # write_session_log <sessions-root> <yyyy> <mm> <dd> <uuid> <workspace-root>
 # Body records are read from stdin. Writes the log at muse's real depth
 # (<root>/YYYY/MM/DD/<uuid>/session.jsonl) and echoes the path.
@@ -60,6 +88,19 @@ write_session_log() {
   mkdir -p "$dir"
   path="$dir/session.jsonl"
   muse_log_metadata "$ws" > "$path"
+  cat >> "$path"
+  printf '%s\n' "$path"
+}
+
+# write_session_log_111: 1.1.1 shape with a leading retained_frame, then the
+# same metadata record, then stdin body records.
+write_session_log_111() {
+  local root=$1 y=$2 m=$3 d=$4 uuid=$5 ws=$6 dir path
+  dir="$root/$y/$m/$d/$uuid"
+  mkdir -p "$dir"
+  path="$dir/session.jsonl"
+  muse_log_retained_frame > "$path"
+  muse_log_metadata "$ws" >> "$path"
   cat >> "$path"
   printf '%s\n' "$path"
 }
@@ -547,6 +588,69 @@ run_state() {  # <log>
   )
 }
 
+run_events() {  # <log>
+  (
+    # shellcheck source=bin/fm-busy-lib.sh
+    . "$ROOT/bin/fm-busy-lib.sh"
+    fm_busy_muse_run_events "$1"
+  )
+}
+
+run_terminal_of() {  # <log> <run-id>
+  (
+    # shellcheck source=bin/fm-busy-lib.sh
+    . "$ROOT/bin/fm-busy-lib.sh"
+    fm_busy_muse_run_terminal "$1" "$2"
+  )
+}
+
+run_active_id() {  # <log>
+  (
+    # shellcheck source=bin/fm-busy-lib.sh
+    . "$ROOT/bin/fm-busy-lib.sh"
+    fm_busy_muse_active_run_id "$1"
+  )
+}
+
+no_jq_path() {
+  local awk_bin dir
+  awk_bin=$(command -v awk) || fail "awk is required to exercise Muse's fallback run-event parser"
+  dir="$TMP_ROOT/no-jq-bin"
+  mkdir -p "$dir"
+  ln -sf "$awk_bin" "$dir/awk"
+  printf '%s' "$dir"
+}
+
+run_state_no_jq() {  # <log>
+  local bin
+  bin=$(no_jq_path)
+  (
+    # shellcheck source=bin/fm-busy-lib.sh
+    . "$ROOT/bin/fm-busy-lib.sh"
+    PATH="$bin" fm_busy_muse_run_state "$1"
+  )
+}
+
+run_events_no_jq() {  # <log>
+  local bin
+  bin=$(no_jq_path)
+  (
+    # shellcheck source=bin/fm-busy-lib.sh
+    . "$ROOT/bin/fm-busy-lib.sh"
+    PATH="$bin" fm_busy_muse_run_events "$1"
+  )
+}
+
+run_terminal_no_jq() {  # <log> <run-id>
+  local bin
+  bin=$(no_jq_path)
+  (
+    # shellcheck source=bin/fm-busy-lib.sh
+    . "$ROOT/bin/fm-busy-lib.sh"
+    PATH="$bin" fm_busy_muse_run_terminal "$1" "$2"
+  )
+}
+
 test_run_fold_tracks_open_and_settled_turns() {
   local dir log out
   dir="$TMP_ROOT/fold"
@@ -912,6 +1016,143 @@ test_muse_trusts_no_record_sources() {
   pass "muse trusts no busy record source"
 }
 
+assert_fold_both_parsers() {  # <log> <expected-state> <label>
+  local log=$1 expected=$2 label=$3 out events_jq events_awk
+  command -v jq >/dev/null 2>&1 || fail "jq is required to exercise Muse's primary run-event parser"
+  out=$(run_state "$log")
+  [ "$out" = "$expected" ] || fail "$label with jq folded to '$out', expected $expected"
+  out=$(run_state_no_jq "$log")
+  [ "$out" = "$expected" ] || fail "$label without jq folded to '$out', expected $expected"
+  events_jq=$(run_events "$log")
+  events_awk=$(run_events_no_jq "$log")
+  [ "$events_jq" = "$events_awk" ] \
+    || fail "$label jq and awk parsers emitted different events"
+}
+
+test_run_fold_is_independent_of_field_order() {
+  local dir log_old log_new events_old events_new terminal
+  dir="$TMP_ROOT/fold-order"
+  mkdir -p "$dir"
+  command -v jq >/dev/null 2>&1 || fail "jq is required to exercise Muse's primary run-event parser"
+
+  log_old=$(write_session_log "$dir/old-busy" 2026 09 11 oldbusy "$dir/ws-busy" <<EOF
+$(muse_log_run_started run-1)
+$(muse_log_noise run-1)
+EOF
+)
+  log_new=$(write_session_log_111 "$dir/new-busy" 2026 09 11 newbusy "$dir/ws-busy" <<EOF
+$(muse_log_run_started_111 run-1)
+$(muse_log_noise_111 run-1)
+EOF
+)
+  assert_fold_both_parsers "$log_old" busy "0.1.x open run"
+  assert_fold_both_parsers "$log_new" busy "1.1.1 open run"
+  events_old=$(run_events "$log_old")
+  events_new=$(run_events "$log_new")
+  [ "$events_old" = "$events_new" ] \
+    || fail "1.1.1 open-run events differed from the 0.1.x equivalent"
+  [ "$(run_active_id "$log_new")" = run-1 ] \
+    || fail "1.1.1 open run did not report the active run id"
+
+  log_old=$(write_session_log "$dir/old-none" 2026 09 11 oldnone "$dir/ws-none" </dev/null)
+  log_new=$(write_session_log_111 "$dir/new-none" 2026 09 11 newnone "$dir/ws-none" </dev/null)
+  assert_fold_both_parsers "$log_old" none "0.1.x run-free log"
+  assert_fold_both_parsers "$log_new" none "1.1.1 run-free log"
+  events_old=$(run_events "$log_old")
+  events_new=$(run_events "$log_new")
+  [ -z "$events_old" ] && [ "$events_old" = "$events_new" ] \
+    || fail "run-free logs must emit no events in either field order"
+
+  for terminal in completed cancelled; do
+    log_old=$(write_session_log "$dir/old-$terminal" 2026 09 11 "old$terminal" "$dir/ws-$terminal" <<EOF
+$(muse_log_run_started run-1)
+$(muse_log_run_terminal run-1 "$terminal")
+EOF
+)
+    log_new=$(write_session_log_111 "$dir/new-$terminal" 2026 09 11 "new$terminal" "$dir/ws-$terminal" <<EOF
+$(muse_log_run_started_111 run-1)
+$(muse_log_run_terminal_111 run-1 "$terminal")
+EOF
+)
+    assert_fold_both_parsers "$log_old" settled "0.1.x $terminal run"
+    assert_fold_both_parsers "$log_new" settled "1.1.1 $terminal run"
+    events_old=$(run_events "$log_old")
+    events_new=$(run_events "$log_new")
+    [ "$events_old" = "$events_new" ] \
+      || fail "1.1.1 $terminal events differed from the 0.1.x equivalent"
+    [ "$(run_terminal_of "$log_old" run-1)" = "$terminal" ] \
+      || fail "0.1.x $terminal run_terminal was '$(run_terminal_of "$log_old" run-1)'"
+    [ "$(run_terminal_of "$log_new" run-1)" = "$terminal" ] \
+      || fail "1.1.1 $terminal run_terminal was '$(run_terminal_of "$log_new" run-1)'"
+    [ "$(run_terminal_no_jq "$log_new" run-1)" = "$terminal" ] \
+      || fail "1.1.1 $terminal run_terminal without jq was '$(run_terminal_no_jq "$log_new" run-1)'"
+  done
+  pass "the run fold matches 0.1.x and 1.1.1 field order with and without jq"
+}
+
+test_nested_terminal_record_does_not_settle_a_run_in_111_order() {
+  local dir log out
+  dir="$TMP_ROOT/decoy-111"
+  mkdir -p "$dir"
+  log=$(write_session_log_111 "$dir/root" 2026 09 11 decoy111 "$dir/ws" <<EOF
+$(muse_log_run_started_111 run-1)
+$(muse_log_cleanup_terminal_decoy_111 run-1)
+$(muse_log_noise_111 run-1)
+EOF
+)
+  assert_fold_both_parsers "$log" busy "1.1.1 nested cleanup terminal"
+  out=$(run_state "$log")
+  [ "$out" = busy ] \
+    || fail "a 1.1.1 nested cleanup 'terminal' record settled an open run (folded '$out', expected busy)"
+  pass "a nested terminal record never settles an in-flight 1.1.1 run"
+}
+
+test_prompt_text_and_malformed_lines_do_not_close_a_run() {
+  local dir log
+  dir="$TMP_ROOT/traps"
+  mkdir -p "$dir"
+  log=$(write_session_log_111 "$dir/root" 2026 09 11 traps "$dir/ws" <<EOF
+$(muse_log_started_prompt_trap_111 run-1)
+{"payload":{"event":{"kind":"terminal","terminal":"completed"},"kind":"run","run_id":"run-1"
+not json
+{"payload":{"event":{"kind":"terminal","terminal":"completed"},"kind":"run","run_id":"run-1"}
+EOF
+)
+  assert_fold_both_parsers "$log" busy "prompt-trap and malformed 1.1.1 lines"
+  pass "prompt text and malformed lines never open or close a run"
+}
+
+test_binding_finds_metadata_after_retained_frame() {
+  local dir state id verdict root
+  dir="$TMP_ROOT/bind-111"
+  state="$dir/state"
+  root="$dir/sessions"
+  id=bind111
+  mkdir -p "$state"
+
+  write_session_log "$root" 2026 09 11 other "$dir/other-ws" >/dev/null <<EOF
+$(muse_log_run_started other-run)
+EOF
+  write_session_log_111 "$root" 2026 09 11 mine "$dir/my-ws" >/dev/null <<EOF
+$(muse_log_run_started_111 my-run)
+$(muse_log_run_terminal_111 my-run completed)
+EOF
+
+  printf 'sessions_root=%s\nworkspace_root=%s\n' "$root" "$dir/my-ws" > "$state/$id.muse-session"
+  verdict=$(classify_muse "$state" "$id")
+  [ "$verdict" = "idle muse-session-log" ] \
+    || fail "1.1.1 metadata after retained_frame did not bind: got '$verdict'"
+
+  write_session_log_111 "$root" 2026 09 11 open "$dir/open-ws" >/dev/null <<EOF
+$(muse_log_run_started_111 open-run)
+EOF
+  printf 'sessions_root=%s\nworkspace_root=%s\n' "$root" "$dir/open-ws" > "$state/$id.muse-session"
+  verdict=$(classify_muse "$state" "$id")
+  [ "$verdict" = "busy muse-session-log" ] \
+    || fail "1.1.1 open run after retained_frame did not fold busy: got '$verdict'"
+  pass "session binding finds metadata after a leading retained_frame"
+}
+
 test_spawn_environment_allowlist_credential_preflight() {
   local setting rec case_dir home proj wt fakebin id out status
   for setting in withheld allowed stored; do
@@ -957,6 +1198,10 @@ test_non_muse_escape_does_not_clear
 test_failed_clear_is_reported
 test_run_fold_tracks_open_and_settled_turns
 test_nested_terminal_record_does_not_settle_a_run
+test_run_fold_is_independent_of_field_order
+test_nested_terminal_record_does_not_settle_a_run_in_111_order
+test_prompt_text_and_malformed_lines_do_not_close_a_run
+test_binding_finds_metadata_after_retained_frame
 test_binding_selects_the_matching_main_log
 test_workspace_binding_treats_glob_characters_literally
 test_binding_excludes_preexisting_log_when_mtimes_tie

--- a/tests/fm-muse-harness.test.sh
+++ b/tests/fm-muse-harness.test.sh
@@ -28,8 +28,8 @@ TMP_ROOT=$(fm_test_tmproot fm-muse-harness)
 
 # --- session-log fixtures ---------------------------------------------------
 
-# muse_log_metadata <workspace-root>: the first record of every session log,
-# which is what binds a log to a task worktree.
+# muse_log_metadata <workspace-root>: the session metadata record that binds a
+# log to a task worktree.
 muse_log_metadata() {
   printf '{"schema_version":1,"id":"d77de583","stream":{"kind":"session","id":"52f21aea"},"sequence":1,"record_type":"event","durability":"durable","payload_type":"runtime.session.metadata","payload":{"kind":"metadata","record":{"workspace_root":"%s","provider_id":"meta","build":{"sha":"427a430436","semver":"0.1.0"}}}}\n' "$1"
 }

--- a/tests/fm-muse-signals-live-e2e.test.sh
+++ b/tests/fm-muse-signals-live-e2e.test.sh
@@ -121,6 +121,8 @@ fi
 
 fm_live_gate opt-in FM_MUSE_SIGNALS_LIVE muse tmux node
 
+MUSE_VERSION=$("$MUSE_BIN" --version)
+
 LAB=$(mktemp -d "${TMPDIR:-/tmp}/fm-muse-signals.XXXXXX") || fail "could not create the isolated Muse lab"
 trap cleanup EXIT
 mkdir -p "$LAB/bin" "$LAB/config" "$LAB/data" "$LAB/workspace"
@@ -148,22 +150,35 @@ export PATH
   "$MUSE_BIN" --provider echo --yolo "firstmate Muse signal drift guard" \
   || fail "could not launch Muse with the echo provider"
 
+# Muse 1.1.1 can flush a started record and complete the echo turn inside
+# one matching_logs walk, so watch the main session file as it grows instead
+# of waiting for workspace binding before the first fold sample.
 SESSION_LOG=
-for _ in $(seq 1 150); do
-  SESSION_LOG=$(fm_busy_muse_matching_logs "$LAB/data/muse/sessions" "$WORKSPACE" 2>/dev/null | head -1)
-  [ -z "$SESSION_LOG" ] || break
-  sleep 0.2
-done
-[ -n "$SESSION_LOG" ] || fail "real Muse produced no workspace-bound session.jsonl"
-
 RUN_STATE=
+for _ in $(seq 1 2000); do
+  if [ -z "$SESSION_LOG" ]; then
+    SESSION_LOG=$(find "$LAB/data/muse/sessions" -mindepth 5 -maxdepth 5 -type f -name session.jsonl 2>/dev/null | head -1)
+  fi
+  if [ -n "$SESSION_LOG" ]; then
+    RUN_STATE=$(fm_busy_muse_run_state "$SESSION_LOG" 2>/dev/null || true)
+    [ "$RUN_STATE" = busy ] && break
+  fi
+  sleep 0.01
+done
+[ -n "$SESSION_LOG" ] || fail "real Muse produced no session.jsonl"
+[ "$RUN_STATE" = busy ] || fail "fm_busy_muse_run_state never observed the real echo turn in flight"
+pass "Muse's real session protocol on $MUSE_VERSION classifies busy in flight"
+
+BOUND_LOG=
 for _ in $(seq 1 150); do
-  RUN_STATE=$(fm_busy_muse_run_state "$SESSION_LOG" 2>/dev/null || true)
-  [ "$RUN_STATE" = busy ] && break
+  BOUND_LOG=$(fm_busy_muse_matching_logs "$LAB/data/muse/sessions" "$WORKSPACE" 2>/dev/null | head -1)
+  [ -z "$BOUND_LOG" ] || break
   sleep 0.2
 done
-[ "$RUN_STATE" = busy ] || fail "fm_busy_muse_run_state never observed the real echo turn in flight"
-pass "Muse's real session protocol classifies busy in flight"
+[ -n "$BOUND_LOG" ] || fail "real Muse produced no workspace-bound session.jsonl"
+[ "$BOUND_LOG" = "$SESSION_LOG" ] \
+  || fail "workspace binding selected a different session log than the live fold"
+pass "Muse's real session protocol on $MUSE_VERSION binds the workspace log"
 
 for _ in $(seq 1 300); do
   RUN_STATE=$(fm_busy_muse_run_state "$SESSION_LOG" 2>/dev/null || true)
@@ -180,7 +195,7 @@ const started = lifecycle.filter((record) => record.payload.event.kind === "star
 const terminal = lifecycle.filter((record) => record.payload.event.kind === "terminal");
 if (started.length !== 1 || terminal.length !== 1 || started[0].payload.run_id !== terminal[0].payload.run_id) process.exit(1);
 NODE
-pass "Muse's real session protocol emits one matched run bracket"
+pass "Muse's real session protocol on $MUSE_VERSION emits one matched run bracket"
 
 COMPOSER_STATE=
 for _ in $(seq 1 100); do
@@ -189,13 +204,18 @@ for _ in $(seq 1 100); do
   sleep 0.2
 done
 [ "$COMPOSER_STATE" = empty ] || fail "the shared classifier read Muse's real idle composer as '$COMPOSER_STATE'"
+pass "the shared classifier read Muse's real idle composer as empty"
 
 CAPTURE="$LAB/muse-pane.ansi"
 tmux capture-pane -e -p -t "$TARGET" -S 0 -E - > "$CAPTURE" \
   || fail "could not capture Muse's styled pane"
-muse_prompt_glyph_is_bright "$CAPTURE" \
-  || fail "Muse's real prompt glyph is missing a bright effective truecolor foreground"
-pass "Muse's real bright prompt glyph classifies as an empty composer"
+if muse_prompt_glyph_is_bright "$CAPTURE" 2>/dev/null; then
+  pass "Muse's real bright prompt glyph classifies as an empty composer"
+else
+  # Session-log folding is the proof this guard owns on Muse Code 1.1.1.
+  # Prompt-glyph color is a separate composer signal and is not claimed here.
+  pass "$MUSE_VERSION session-log folding held; prompt glyph color is unverified"
+fi
 
 cleanup
 trap - EXIT

--- a/tests/fm-muse-signals-live-e2e.test.sh
+++ b/tests/fm-muse-signals-live-e2e.test.sh
@@ -204,17 +204,17 @@ for _ in $(seq 1 100); do
   sleep 0.2
 done
 [ "$COMPOSER_STATE" = empty ] || fail "the shared classifier read Muse's real idle composer as '$COMPOSER_STATE'"
-pass "the shared classifier read Muse's real idle composer as empty"
 
-CAPTURE="$LAB/muse-pane.ansi"
-tmux capture-pane -e -p -t "$TARGET" -S 0 -E - > "$CAPTURE" \
-  || fail "could not capture Muse's styled pane"
-if muse_prompt_glyph_is_bright "$CAPTURE" 2>/dev/null; then
-  pass "Muse's real bright prompt glyph classifies as an empty composer"
+if [ "$MUSE_VERSION" = "Muse Code 1.1.1 (1.1.1-R2514.1)" ]; then
+  printf 'ok - %s # SKIP %s\n' "Muse's real prompt glyph color on $MUSE_VERSION" \
+    "composer glyph out of scope; 1.1.1 drift tracked as follow-up muse-111-composer-glyph-drift"
 else
-  # Session-log folding is the proof this guard owns on Muse Code 1.1.1.
-  # Prompt-glyph color is a separate composer signal and is not claimed here.
-  pass "$MUSE_VERSION session-log folding held; prompt glyph color is unverified"
+  CAPTURE="$LAB/muse-pane.ansi"
+  tmux capture-pane -e -p -t "$TARGET" -S 0 -E - > "$CAPTURE" \
+    || fail "could not capture Muse's styled pane"
+  muse_prompt_glyph_is_bright "$CAPTURE" \
+    || fail "Muse's real prompt glyph is missing a bright effective truecolor foreground"
+  pass "Muse's real bright prompt glyph classifies as an empty composer"
 fi
 
 cleanup


### PR DESCRIPTION
## Intent

The request, verbatim: "How complex is the fix for muse ? Can we build it and push upstream ?" - followed, after the scope below was explained, by: "go".

### Outcome

On Muse Code 1.1.1, Firstmate binds a Muse task to its session log AND reports that worker as busy while a turn runs and as settled after the turn ends, exactly as it did on Muse Code 0.1.0. AMENDED 2026-09-11 after the reproduce step: Muse 1.1.1 changed the log in two ways, a new leading `retained_frame` wrapper that moved session metadata off line 1 and the run-event field order, so both the log-binding discovery and the run-event fold must become format-independent for the outcome to hold. Firstmate authorised expanding to the binding after verifying the finding.

**Nearest contrast:** session logs written by the older Muse Code 0.1.x must still be read exactly as they are today - the same run events extracted, and the same busy, settled and none verdicts.

### Problem

**Why now.** Muse Code 1.1.1 (build 1.1.1-R2514.1) serialises each session-log run event with `"event"` before `"kind":"run"`, for example `{"payload":{"event":{"kind":"started",...},"kind":"run","run_id":"..."}}`, where Muse Code 0.1.0 wrote `"kind":"run","run_id"` first and `"event"` last.

**What is missing.** `fm_busy_muse_run_events` in `bin/fm-busy-lib.sh` matches the 0.1.0 byte order, so on a 1.1.1 log it extracts no events at all.
Observed on two real Muse Code 1.1.1 logs holding complete run lifecycles - two started with two terminal, and one started with one terminal, with terminal values `completed` and `cancelled` - the fold extracted zero events and `fm_busy_muse_run_state` returned `none` for both.
Because Muse has no hook surface and its session log is the only busy source, Firstmate cannot tell a running Muse worker from a finished one on 1.1.1.

**What already exists.** In the same file, `fm_busy_cursor_turn_state` folds a JSONL transcript structurally: with `jq` when it is installed and an awk JSON tokenizer otherwise, matching top-level fields of structurally valid JSON so text inside a record can never close a turn.
The Muse run lifecycle itself is unchanged in 1.1.1: each turn is a `started` event paired with a `terminal` event whose `terminal` field is `completed` or `cancelled`, and cleanup records still carry a nested `"record":{"kind":"terminal"}` that is not a run ending.

### Contract

Must:

- Extract the same run id, event kind and terminal value from a 1.1.1-ordered log as from the equivalent 0.1.x-ordered log.
- Keep the existing output that `fm_busy_muse_run_state`, `fm_busy_muse_active_run_id` and `fm_busy_muse_run_terminal` consume, so no caller changes.
- Work both with and without `jq` installed, as the Cursor fold does.
- Treat a malformed line as contributing nothing, never as opening or closing a run.

Must not:

- Count a nested cleanup record's `terminal` as a run ending, in either field order.
- Count text inside an event, such as a prompt that contains `"kind":"terminal"`, as a run ending.
- Change any other busy source. (The Muse log-binding discovery is now IN scope by the 2026-09-11 amendment: it must find the log whether session metadata is on line 1 or after a leading `retained_frame`, without changing how a task's session sidecar is written.)

### Scope and authority

**Authorized:** the Muse run-event fold AND the Muse session-log discovery/binding path in `bin/fm-busy-lib.sh` (the functions that locate a task's session log and fold its run events); the Muse cases in `tests/fm-muse-harness.test.sh` and the live guard `tests/fm-muse-signals-live-e2e.test.sh`; the two documentation places that state the old byte order as fact, the comment block above the Muse fold and the Muse harness reference; one dated Muse Code 1.1.1 log-folding entry in the maintainer verification records.

**Out of scope:** the Cursor, Grok and every other busy source; Muse interrupt, exit, trust-dialog, composer and process-identity handling; the Grok reasoning-effort ceiling, which a separate open pull request already covers; refactoring the Cursor tokenizer into a shared helper.

**Return before:** changing the fold's output format or any of its callers; changing how a Muse task's session sidecar is WRITTEN by fm-spawn rather than how the log is READ (metadata now reports `workspace_root` as the parent directory of the checkout, e.g. `.../Documents/git`, not the worktree, so if correct binding cannot be achieved by reading alone, stop and return); adding a newly required tool dependency; accepting any change outside the Muse fold that review proposes; claiming Muse Code 1.1.1 is verified for anything beyond session-log folding.

### Completion proof

- A portable regression feeding both 0.1.x-ordered and 1.1.1-ordered fixtures, each with and without `jq`, asserting the busy, settled and none verdicts and the terminal values.
- **Negative proof of the nearest contrast:** the existing 0.1.x fixtures pass unchanged, with identical fold output before and after the change.
- The nested cleanup-record trap asserted in the 1.1.1 order.
- The live Muse guard run against a real installed Muse Code 1.1.1: failing without the change, passing with it, with the Muse version named in its output.
- A dated maintainer-verification entry recording Muse Code 1.1.1 session-log folding, and only that.

### Expected change envelope

**Class:** making one existing parser independent of field order.
**Surface:** one function in the busy library, its tests, the two documentation places above, and one verification entry.
**Not expected:** no new service, state, protocol, privilege, repository or required dependency, and no behaviour change for any other harness.

## What Changed

- `fm_busy_muse_run_events` in `bin/fm-busy-lib.sh` no longer matches a fixed byte prefix. It now parses each session-log line as JSON, using `jq` when it is installed and an awk JSON tokenizer when it is not. It then matches `payload_type=runtime.session`, `payload.kind=run`, `payload.run_id` and `payload.event.kind`/`terminal` by structure. As a result, Muse Code 1.1.1's `event`-before-`kind` order produces the same tab-separated run_id, kind and terminal output as 0.1.x, so callers are unchanged. Malformed lines, nested cleanup `record.kind=terminal` payloads, and prompt text that contains `"kind":"terminal"` add nothing.
- Muse session-log discovery used to parse only the first line of a log. It now scans the lines in the first 64 KiB for the `runtime.session.metadata` record, so a 1.1.1 log that starts with a `retained_frame` record still binds to its task through `workspace_root`. The session sidecar is written the same way as before.
- Tests and docs:
  - `tests/fm-muse-harness.test.sh` adds 1.1.1-shaped fixtures. New cases assert the busy, settled and none verdicts and the terminal values, with and without `jq`, against the matching 0.1.x output. They also cover the nested cleanup trap in 1.1.1 order, prompt-text and malformed lines, and binding after a `retained_frame`.
  - The live guard `tests/fm-muse-signals-live-e2e.test.sh` puts the Muse version in its output and samples the fold while the session file grows. Only after that does it check that workspace binding picked the same log. On exactly `Muse Code 1.1.1 (1.1.1-R2514.1)` it skips the prompt-glyph check with a TAP `# SKIP`.
  - The Muse harness reference and the fold comment no longer describe the old field order. `docs/verification/muse.md` gains a dated entry covering only Muse Code 1.1.1 session-log folding.

## Risk Assessment

✅ Low: The change is bounded to the Muse fold and binding path. It matches recorded 0.1.0 shapes, and on every real 1.1.1 log on this host the jq and awk paths produced identical events and verdicts. The fix round implements the user's six live-guard instructions exactly, with no extra machinery.

## Testing

Real Muse Code 1.1.1 is installed here, so every scenario that needs it was driven live in an isolated tmux server and XDG data tree, each with and without the change. The live guard failed on the base commit: the old guard could not bind a log, and the new guard with the old library never saw the turn busy. At 1d1b809 it passed, naming the version, and it passed 10 of 10 back-to-back repeats, so it is not flaky. A live end-to-end driver used a real git worktree, a predecessor Muse session, and a binding written exactly as fm-spawn writes it. It held an echo turn open for 12 s and sampled the shared meta classifier: unknown, then busy muse-session-log for the whole turn, then idle muse-session-log, identically with jq and with a PATH that has no jq. Two real Escape interrupts were each read as cancelled and then idle, in both PATH modes. On the base tree the same flow stayed unknown throughout. The real bin/fm-control.sh interrupt command could not be run because its NO_MISTAKES_GATE guard refuses gate agents, so its key sequence was sent to the pane directly and its acknowledgement reads were checked. A fold-comparison driver showed identical base and new output on 0.1.x fixtures and on 0.1.x-ordered rewrites of the host's real logs. It reproduced the bug on the unmodified real 1.1.1 logs (0 events, none) and showed the fix (settled, with terminals completed and cancelled). Nine adversarial trap lines held with and without jq. The portable harness regression passed, and a version-string wrapper confirmed the glyph check still fails loudly off the exact 1.1.1 build. The fold comparison, the portable regression, and the docs diff review were offline checks, not runs against the live product, so they are recorded as untested for live validation. This change has no rendered UI, so the evidence is CLI transcripts plus captures of Muse's own terminal UI at each point. Scratch trees and the stale tmux socket files my runs left were removed, and the worktree is clean.

- Live validation: ✅ go - 6 of 12 scenarios driven live against the product

| Scenario | Result | Live | Evidence |
| --- | --- | --- | --- |
| Live guard on real Muse Code 1.1.1 fails without the change and passes with it, naming the Muse version in its output | ✅ pass | live | live-guard-without-change.log (both base variants fail), live-guard-with-change.log (all ok lines name &#39;Muse Code 1.1.1 (1.1.1-R2514.1)&#39;), live-guard-repeat-10x.log (10/10) |
| A Firstmate-bound Muse 1.1.1 task reads &#39;busy muse-session-log&#39; for the whole running turn and &#39;idle muse-session-log&#39; once it ends (jq installed) | ✅ pass | live | muse-111-live-classify-with-change-interrupt.log section 3: unknown, then 10 busy samples across the 12s turn, then idle. The base tree stays unknown throughout (muse-111-live-classify-without-change-… |
| The same busy then idle verdicts on a host without jq (PATH with every tool except jq) | ✅ pass | live | muse-111-live-classify-with-change-interrupt.log section 3, no-jq column identical to the jq column. &#39;the jq-free PATH really has no jq&#39; check passes |
| Log discovery on 1.1.1: spawn-time discovery finds a predecessor log whose metadata follows retained_frame and records it as prior_log, and the classifier binds the task&#39;s own new log in a real git wo… | ✅ pass | live | muse-111-live-classify-with-change-interrupt.log sections 1-3: line 1 is retained_frame, metadata is on line 2, prior_log recorded, bound log differs from the predecessor. Base tree: nothing discovere… |
| Interrupting a real Muse 1.1.1 turn: the active run id is reported while busy, fm_busy_muse_run_terminal then reads &#39;cancelled&#39;, and the worker reads idle, with and without jq | ✅ pass | live | muse-111-live-classify-with-change-interrupt.log sections 4-5 (Escape+C-u sent to the isolated pane; the pane capture shows Muse&#39;s &#39;Interrupted&#39;; the library extracts completed, cancelled, cancelled) |
| The real `bin/fm-control.sh &lt;id&gt; interrupt` command confirms cancellation from the 1.1.1 session terminal | ⏸️ untested | no | fm-control.sh deliberately refuses to run inside a no-mistakes gate agent (NO_MISTAKES_GATE is set in this environment), and bypassing that guard is not appropriate. To drive it, run ~ |
| Reported bug on the host&#39;s real Muse 1.1.1 session logs: the base library extracts 0 events and folds none, and the change extracts the run pairs (completed, cancelled) and folds settled, jq equal to… | ⏸️ untested | no | The prior payload did not establish a live result: it ran fold-compare.sh offline against 3 session logs Muse 1.1.1 had recorded to disk earlier, not against a running Muse session. The same bug and f… |
| Nearest contrast: 0.1.x-ordered logs produce identical fold output (events, state, active run id, run terminal) before and after the change, with and without jq | ⏸️ untested | no | The prior payload did not establish a live result: it compared base and new folds offline on 0.1.x fixtures and on 0.1.x-ordered rewrites of recorded logs, and did not drive a running Muse 0.1.x sessi… |
| Adversarial 1.1.1-order lines appended to a real log never open or close a run: nested cleanup terminal, event text containing &#34;kind&#34;:&#34;terminal&#34;, truncated terminal or started with the full schema pre… | ⏸️ untested | no | The prior payload did not establish a live result: the nine trap lines were appended by fold-compare.sh to a recorded log file offline. They are synthetic inputs that a running Muse session does not e… |
| Portable regression tests/fm-muse-harness.test.sh passes with the new 1.1.1 cases and the unchanged 0.1.x cases | ⏸️ untested | no | The prior payload did not establish a live result: tests/fm-muse-harness.test.sh is a portable fixture-based test suite run through bin/fm-test-run.sh, not a run against a live Muse product. |
| User decision: the composer-glyph check is skipped only on the exact 1.1.1-R2514.1 version string, and any other version still hard-fails with the checker&#39;s diagnostic visible | ✅ pass | live | live-guard-glyph-nonexact-version.log (the real Muse binary reporting 1.1.1-R2514.2 fails with &#39;the final Muse prompt glyph has no effective truecolor foreground&#39;; the ANSI self-test passes) |
| The dated verification entry records only Muse Code 1.1.1 session-log folding, and the &#39;Refreshing this record&#39; paragraph is unchanged | ⏸️ untested | no | The prior payload did not establish a live result: this was a code reading of `git diff 869ae90..1d1b809 -- docs/verification/muse.md` compared with the live guard transcript. A documentation file has… |

<details>
<summary>Evidence: Live guard WITH the change on real Muse Code 1.1.1 (passes, names the version)</summary>

<code>ok - Muse&#39;s real session protocol on Muse Code 1.1.1 (1.1.1-R2514.1) classifies busy in flight&#10;ok - Muse&#39;s real session protocol on Muse Code 1.1.1 (1.1.1-R2514.1) binds the workspace log&#10;ok - Muse&#39;s real session protocol on Muse Code 1.1.1 (1.1.1-R2514.1) emits one matched run bracket&#10;ok - Muse&#39;s real prompt glyph color on Muse Code 1.1.1 (1.1.1-R2514.1) # SKIP composer glyph out of scope; 1.1.1 drift tracked as follow-up muse-111-composer-glyph-drift&#10;exit=0</code>

```text
$ git rev-parse --short HEAD
1d1b809
$ muse --version
Muse Code 1.1.1 (1.1.1-R2514.1)
$ FM_MUSE_SIGNALS_LIVE=1 bin/fm-test-run.sh tests/fm-muse-signals-live-e2e.test.sh
FM_TEST_BEGIN 2026-09-11T08:59:01Z tests/fm-muse-signals-live-e2e.test.sh family=live-harness-optin expected_gate_skip=live-capability
ok - Muse's real session protocol on Muse Code 1.1.1 (1.1.1-R2514.1) classifies busy in flight
ok - Muse's real session protocol on Muse Code 1.1.1 (1.1.1-R2514.1) binds the workspace log
ok - Muse's real session protocol on Muse Code 1.1.1 (1.1.1-R2514.1) emits one matched run bracket
ok - Muse's real prompt glyph color on Muse Code 1.1.1 (1.1.1-R2514.1) # SKIP composer glyph out of scope; 1.1.1 drift tracked as follow-up muse-111-composer-glyph-drift
FM_TEST_END 2026-09-11T08:59:01Z tests/fm-muse-signals-live-e2e.test.sh exit=0 duration_ms=545 gate_skip=false
FM_TEST_SUMMARY total=1 failed=0 skipped_gate=0 duration_ms=593
FM_TEST_SUMMARY_FAMILY family=live-harness-optin count=1 duration_ms=545 failed=0
FM_TEST_SLOWEST rank=1 script=tests/fm-muse-signals-live-e2e.test.sh duration_ms=545
exit=0
```
</details>
<details>
<summary>Evidence: Live guard WITHOUT the change (base 869ae90): old guard cannot bind, new guard with old library never sees busy</summary>

<code># base guard + base library&#10;not ok - real Muse produced no workspace-bound session.jsonl&#10;exit=1&#10;# new guard + base library&#10;not ok - fm_busy_muse_run_state never observed the real echo turn in flight&#10;exit=1</code>

```text
# WITHOUT the change: base commit 869ae90 tree, unchanged base live guard
$ muse --version
Muse Code 1.1.1 (1.1.1-R2514.1)
$ FM_MUSE_SIGNALS_LIVE=1 bin/fm-test-run.sh tests/fm-muse-signals-live-e2e.test.sh   # base guard + base bin/fm-busy-lib.sh
FM_TEST_BEGIN 2026-09-11T08:59:31Z tests/fm-muse-signals-live-e2e.test.sh family=live-harness-optin expected_gate_skip=live-capability
not ok - real Muse produced no workspace-bound session.jsonl
FM_TEST_END 2026-09-11T09:00:14Z tests/fm-muse-signals-live-e2e.test.sh exit=1 duration_ms=42423 gate_skip=false
FM_TEST_SUMMARY total=1 failed=1 skipped_gate=0 duration_ms=42465
FM_TEST_SUMMARY_FAMILY family=live-harness-optin count=1 duration_ms=42423 failed=1
FM_TEST_SLOWEST rank=1 script=tests/fm-muse-signals-live-e2e.test.sh duration_ms=42423
exit=1

# WITHOUT the change: base bin/fm-busy-lib.sh driven by the NEW live guard from 1d1b809
$ FM_MUSE_SIGNALS_LIVE=1 bin/fm-test-run.sh tests/fm-muse-signals-live-e2e.test.sh   # new guard + base bin/fm-busy-lib.sh
FM_TEST_BEGIN 2026-09-11T09:00:14Z tests/fm-muse-signals-live-e2e.test.sh family=live-harness-optin expected_gate_skip=live-capability
not ok - fm_busy_muse_run_state never observed the real echo turn in flight
FM_TEST_END 2026-09-11T09:00:41Z tests/fm-muse-signals-live-e2e.test.sh exit=1 duration_ms=27634 gate_skip=false
FM_TEST_SUMMARY total=1 failed=1 skipped_gate=0 duration_ms=27677
FM_TEST_SUMMARY_FAMILY family=live-harness-optin count=1 duration_ms=27634 failed=1
FM_TEST_SLOWEST rank=1 script=tests/fm-muse-signals-live-e2e.test.sh duration_ms=27634
exit=1
```
</details>
<details>
<summary>Evidence: Live guard repeated 10x at 1d1b809 (10/10 pass, no flakiness)</summary>

```text
# repeat the live guard 10x on real Muse Code 1.1.1 (1.1.1-R2514.1) at 1d1b809 to check the busy-in-flight sample for flakiness
--- run 1
ok - Muse's real session protocol on Muse Code 1.1.1 (1.1.1-R2514.1) classifies busy in flight
ok - Muse's real session protocol on Muse Code 1.1.1 (1.1.1-R2514.1) binds the workspace log
ok - Muse's real session protocol on Muse Code 1.1.1 (1.1.1-R2514.1) emits one matched run bracket
ok - Muse's real prompt glyph color on Muse Code 1.1.1 (1.1.1-R2514.1) # SKIP composer glyph out of scope; 1.1.1 drift tracked as follow-up muse-111-composer-glyph-drift
exit=0
--- run 2
ok - Muse's real session protocol on Muse Code 1.1.1 (1.1.1-R2514.1) classifies busy in flight
ok - Muse's real session protocol on Muse Code 1.1.1 (1.1.1-R2514.1) binds the workspace log
ok - Muse's real session protocol on Muse Code 1.1.1 (1.1.1-R2514.1) emits one matched run bracket
ok - Muse's real prompt glyph color on Muse Code 1.1.1 (1.1.1-R2514.1) # SKIP composer glyph out of scope; 1.1.1 drift tracked as follow-up muse-111-composer-glyph-drift
exit=0
--- run 3
ok - Muse's real session protocol on Muse Code 1.1.1 (1.1.1-R2514.1) classifies busy in flight
ok - Muse's real session protocol on Muse Code 1.1.1 (1.1.1-R2514.1) binds the workspace log
ok - Muse's real session protocol on Muse Code 1.1.1 (1.1.1-R2514.1) emits one matched run bracket
ok - Muse's real prompt glyph color on Muse Code 1.1.1 (1.1.1-R2514.1) # SKIP composer glyph out of scope; 1.1.1 drift tracked as follow-up muse-111-composer-glyph-drift
exit=0
--- run 4
ok - Muse's real session protocol on Muse Code 1.1.1 (1.1.1-R2514.1) classifies busy in flight
ok - Muse's real session protocol on Muse Code 1.1.1 (1.1.1-R2514.1) binds the workspace log
ok - Muse's real session protocol on Muse Code 1.1.1 (1.1.1-R2514.1) emits one matched run bracket
ok - Muse's real prompt glyph color on Muse Code 1.1.1 (1.1.1-R2514.1) # SKIP composer glyph out of scope; 1.1.1 drift tracked as follow-up muse-111-composer-glyph-drift
exit=0
--- run 5
ok - Muse's real session protocol on Muse Code 1.1.1 (1.1.1-R2514.1) classifies busy in flight
ok - Muse's real session protocol on Muse Code 1.1.1 (1.1.1-R2514.1) binds the workspace log
ok - Muse's real session protocol on Muse Code 1.1.1 (1.1.1-R2514.1) emits one matched run bracket
ok - Muse's real prompt glyph color on Muse Code 1.1.1 (1.1.1-R2514.1) # SKIP composer glyph out of scope; 1.1.1 drift tracked as follow-up muse-111-composer-glyph-drift
exit=0
--- run 6
ok - Muse's real session protocol on Muse Code 1.1.1 (1.1.1-R2514.1) classifies busy in flight
ok - Muse's real session protocol on Muse Code 1.1.1 (1.1.1-R2514.1) binds the workspace log
ok - Muse's real session protocol on Muse Code 1.1.1 (1.1.1-R2514.1) emits one matched run bracket
ok - Muse's real prompt glyph color on Muse Code 1.1.1 (1.1.1-R2514.1) # SKIP composer glyph out of scope; 1.1.1 drift tracked as follow-up muse-111-composer-glyph-drift
exit=0
--- run 7
ok - Muse's real session protocol on Muse Code 1.1.1 (1.1.1-R2514.1) classifies busy in flight
ok - Muse's real session protocol on Muse Code 1.1.1 (1.1.1-R2514.1) binds the workspace log
ok - Muse's real session protocol on Muse Code 1.1.1 (1.1.1-R2514.1) emits one matched run bracket
ok - Muse's real prompt glyph color on Muse Code 1.1.1 (1.1.1-R2514.1) # SKIP composer glyph out of scope; 1.1.1 drift tracked as follow-up muse-111-composer-glyph-drift
exit=0
--- run 8
ok - Muse's real session protocol on Muse Code 1.1.1 (1.1.1-R2514.1) classifies busy in flight
ok - Muse's real session protocol on Muse Code 1.1.1 (1.1.1-R2514.1) binds the workspace log
ok - Muse's real session protocol on Muse Code 1.1.1 (1.1.1-R2514.1) emits one matched run bracket
ok - Muse's real prompt glyph color on Muse Code 1.1.1 (1.1.1-R2514.1) # SKIP composer glyph out of scope; 1.1.1 drift tracked as follow-up muse-111-composer-glyph-drift
exit=0
--- run 9
ok - Muse's real session protocol on Muse Code 1.1.1 (1.1.1-R2514.1) classifies busy in flight
ok - Muse's real session protocol on Muse Code 1.1.1 (1.1.1-R2514.1) binds the workspace log
ok - Muse's real session protocol on Muse Code 1.1.1 (1.1.1-R2514.1) emits one matched run bracket
ok - Muse's real prompt glyph color on Muse Code 1.1.1 (1.1.1-R2514.1) # SKIP composer glyph out of scope; 1.1.1 drift tracked as follow-up muse-111-composer-glyph-drift
exit=0
--- run 10
ok - Muse's real session protocol on Muse Code 1.1.1 (1.1.1-R2514.1) classifies busy in flight
ok - Muse's real session protocol on Muse Code 1.1.1 (1.1.1-R2514.1) binds the workspace log
ok - Muse's real session protocol on Muse Code 1.1.1 (1.1.1-R2514.1) emits one matched run bracket
ok - Muse's real prompt glyph color on Muse Code 1.1.1 (1.1.1-R2514.1) # SKIP composer glyph out of scope; 1.1.1 drift tracked as follow-up muse-111-composer-glyph-drift
exit=0
```
</details>
<details>
<summary>Evidence: Live end-to-end WITH the change: binding, busy then idle with and without jq, two real interrupts read cancelled, Muse pane captures</summary>

```text
$ muse-111-live-classify.sh   # WITH the change (1d1b809); NO_MISTAKES_GATE=set
PASS  the jq-free PATH really has no jq
== muse: Muse Code 1.1.1 (1.1.1-R2514.1)   library: ~/.no-mistakes/worktrees/66fd3a9e27ba/01M27RVY95GVXH6K2MN222T3BN/bin/fm-busy-lib.sh (1d1b809)
== task worktree (git worktree, .git is a pointer-file): /tmp/fm-muse-e2e.Dv4rPt/worktrees/musee2e

== 1. predecessor Muse session in the same worktree (a prior incarnation fm-spawn must exclude)
   predecessor log: xdgdata/muse/sessions/2026/09/11/01a08fbf-24ba-7d40-99bb-0f384c9fa147/session.jsonl
   line 1: retained_frame=session_permission_transaction
PASS  fm_busy_muse_matching_logs discovers the predecessor's 1.1.1 log by workspace_root

== 2. binding written exactly as bin/fm-spawn.sh writes it, then meta
   sessions_root=<lab>/xdgdata/muse/sessions
   workspace_root=<lab>/worktrees/musee2e
   binding_id=4110513.29082.1789118063
   prior_log=<lab>/xdgdata/muse/sessions/2026/09/11/01a08fbf-24ba-7d40-99bb-0f384c9fa147/session.jsonl
PASS  the spawn-time binding records the predecessor log as prior_log
   verdict before the task pane exists: jq=[unknown muse-session-log] no-jq=[unknown muse-session-log]

== 3. task Muse launched with a 12s held-open echo turn; sampling the classifier
   14:44:24.526  jq=[unknown muse-session-log]  no-jq=[unknown muse-session-log]
   14:44:25.716  jq=[busy muse-session-log]  no-jq=[busy muse-session-log]
   14:44:26.812  jq=[busy muse-session-log]  no-jq=[busy muse-session-log]
   14:44:27.901  jq=[busy muse-session-log]  no-jq=[busy muse-session-log]
   14:44:28.995  jq=[busy muse-session-log]  no-jq=[busy muse-session-log]
   14:44:30.088  jq=[busy muse-session-log]  no-jq=[busy muse-session-log]
   14:44:31.182  jq=[busy muse-session-log]  no-jq=[busy muse-session-log]
   14:44:32.276  jq=[busy muse-session-log]  no-jq=[busy muse-session-log]
   14:44:33.370  jq=[busy muse-session-log]  no-jq=[busy muse-session-log]
   14:44:34.465  jq=[busy muse-session-log]  no-jq=[busy muse-session-log]
   14:44:35.558  jq=[busy muse-session-log]  no-jq=[busy muse-session-log]
   14:44:36.655  jq=[idle muse-session-log]  no-jq=[idle muse-session-log]
   bound log: xdgdata/muse/sessions/2026/09/11/01a08fbf-2726-7151-bd22-07e9030ec215/session.jsonl (predecessor: xdgdata/muse/sessions/2026/09/11/01a08fbf-24ba-7d40-99bb-0f384c9fa147/session.jsonl)
   bound log line 1: retained_frame=session_permission_transaction; metadata on line 2
PASS  the classifier binds the task's own new log, not the predecessor
PASS  turn 1 in flight reads 'busy muse-session-log' with jq
PASS  turn 1 in flight reads 'busy muse-session-log' without jq
PASS  turn 1 finished reads 'idle muse-session-log' with and without jq

== 4. second turn, then interrupted (jq present)
   14:44:37.064  verdict=[busy muse-session-log]  active run=c9a32227-1da8-4b00-bbf4-4ad2f4af455d
PASS  4. second turn, then interrupted (jq present): submitted turn reads busy with an active run id
   NO_MISTAKES_GATE is set, so fm-control.sh refuses here; sending the muse adapter keys Escape, C-u to the isolated pane
   14:44:37.117  after interrupt: run_terminal(c9a32227-1da8-4b00-bbf4-4ad2f4af455d)=cancelled  verdict=[idle muse-session-log]
PASS  4. second turn, then interrupted (jq present): fm_busy_muse_run_terminal reads cancelled (the ack fm-control confirms on)
PASS  4. second turn, then interrupted (jq present): interrupted turn reads idle

== 5. third turn, then interrupted (no jq on PATH)
   14:44:37.596  verdict=[busy muse-session-log]  active run=cb78b55a-c6bc-4edc-acce-076816352b54
PASS  5. third turn, then interrupted (no jq on PATH): submitted turn reads busy with an active run id
   NO_MISTAKES_GATE is set, so fm-control.sh refuses here; sending the muse adapter keys Escape, C-u to the isolated pane
   14:44:37.749  after interrupt: run_terminal(cb78b55a-c6bc-4edc-acce-076816352b54)=cancelled  verdict=[idle muse-session-log]
PASS  5. third turn, then interrupted (no jq on PATH): fm_busy_muse_run_terminal reads cancelled (the ack fm-control confirms on)
PASS  5. third turn, then interrupted (no jq on PATH): interrupted turn reads idle

== 6. the task log's own run brackets (read with jq, independent of the library)
   e6cd84b3-fabc-41e1-9add-2c8f31c3ac4b  started     raw order: event,kind,run_id,source_run_record_id,source_run_record_sequence
   e6cd84b3-fabc-41e1-9add-2c8f31c3ac4b  terminal  completed   raw order: event,kind,run_id,source_run_record_id,source_run_record_sequence
   c9a32227-1da8-4b00-bbf4-4ad2f4af455d  started     raw order: event,kind,run_id,source_run_record_id,source_run_record_sequence
   c9a32227-1da8-4b00-bbf4-4ad2f4af455d  terminal  cancelled   raw order: event,kind,run_id,source_run_record_id,source_run_record_sequence
   cb78b55a-c6bc-4edc-acce-076816352b54  started     raw order: event,kind,run_id,source_run_record_id,source_run_record_sequence
   cb78b55a-c6bc-4edc-acce-076816352b54  terminal  cancelled   raw order: event,kind,run_id,source_run_record_id,source_run_record_sequence
   library events (jq):
     e6cd84b3-fabc-41e1-9add-2c8f31c3ac4b	started	
     e6cd84b3-fabc-41e1-9add-2c8f31c3ac4b	terminal	completed
     c9a32227-1da8-4b00-bbf4-4ad2f4af455d	started	
     c9a32227-1da8-4b00-bbf4-4ad2f4af455d	terminal	cancelled
     cb78b55a-c6bc-4edc-acce-076816352b54	started	
     cb78b55a-c6bc-4edc-acce-076816352b54	terminal	cancelled
PASS  library extracts completed, cancelled, cancelled in order

== pane captures (Muse's own TUI at each point)
--- pane-turn1-busy
     Muse Code 1.1.1
   ❯ firstmate e2e launch brief
   ◈ Thinking (1s · esc to interrupt)
   ────────────────────────────────────────────────────────────────────────────────
   ❯
   ────────────────────────────────────────────────────────────────────────────────
     echo · /tmp/fm-muse-e2e.Dv4rPt/worktrees/musee2e · YOLO
--- pane-turn1-idle
     Muse Code 1.1.1
   ❯ firstmate e2e launch brief
   ◆ echo: firstmate e2e launch brief
   ────────────────────────────────────────────────────────────────────────────────
   ❯
   ────────────────────────────────────────────────────────────────────────────────
     echo · /tmp/fm-muse-e2e.Dv4rPt/worktrees/musee2e · YOLO
--- pane-turn2-interrupted
     Muse Code 1.1.1
   ❯ firstmate e2e launch brief
   ◆ echo: firstmate e2e launch brief
   ◆ Interrupted · Report issues with /feedback
   ────────────────────────────────────────────────────────────────────────────────
   ❯
   ────────────────────────────────────────────────────────────────────────────────
     echo · /tmp/fm-muse-e2e.Dv4rPt/worktrees/musee2e · YOLO

RESULT: all checks passed
exit=0
```
</details>
<details>
<summary>Evidence: Live end-to-end WITHOUT the change: verdict stays &#39;unknown muse-session-log&#39; for the whole session, run_terminal empty</summary>

```text
$ muse-111-live-classify.sh /tmp/fm-muse-base-tree   # WITHOUT the change (base 869ae90 tree); NO_MISTAKES_GATE=set
PASS  the jq-free PATH really has no jq
== muse: Muse Code 1.1.1 (1.1.1-R2514.1)   library: /tmp/fm-muse-base-tree/bin/fm-busy-lib.sh (base-tree)
== task worktree (git worktree, .git is a pointer-file): /tmp/fm-muse-e2e.oZ9kz7/worktrees/musee2e

== 1. predecessor Muse session in the same worktree (a prior incarnation fm-spawn must exclude)
   predecessor log: 
   line 1: 
FAIL  fm_busy_muse_matching_logs discovers the predecessor's 1.1.1 log by workspace_root

== 2. binding written exactly as bin/fm-spawn.sh writes it, then meta
   sessions_root=<lab>/xdgdata/muse/sessions
   workspace_root=<lab>/worktrees/musee2e
   binding_id=4118191.24457.1789118136
FAIL  the spawn-time binding records the predecessor log as prior_log
   verdict before the task pane exists: jq=[unknown muse-session-log] no-jq=[unknown muse-session-log]

== 3. task Muse launched with a 12s held-open echo turn; sampling the classifier
   14:45:37.424  jq=[unknown muse-session-log]  no-jq=[unknown muse-session-log]
   14:45:38.648  jq=[unknown muse-session-log]  no-jq=[unknown muse-session-log]
   14:45:39.876  jq=[unknown muse-session-log]  no-jq=[unknown muse-session-log]
   14:45:41.103  jq=[unknown muse-session-log]  no-jq=[unknown muse-session-log]
   14:45:42.329  jq=[unknown muse-session-log]  no-jq=[unknown muse-session-log]
   14:45:43.554  jq=[unknown muse-session-log]  no-jq=[unknown muse-session-log]
   14:45:44.783  jq=[unknown muse-session-log]  no-jq=[unknown muse-session-log]
   14:45:46.009  jq=[unknown muse-session-log]  no-jq=[unknown muse-session-log]
   14:45:47.231  jq=[unknown muse-session-log]  no-jq=[unknown muse-session-log]
   14:45:48.465  jq=[unknown muse-session-log]  no-jq=[unknown muse-session-log]
   14:45:49.692  jq=[unknown muse-session-log]  no-jq=[unknown muse-session-log]
   14:45:50.918  jq=[unknown muse-session-log]  no-jq=[unknown muse-session-log]
   14:45:52.145  jq=[unknown muse-session-log]  no-jq=[unknown muse-session-log]
   14:45:53.378  jq=[unknown muse-session-log]  no-jq=[unknown muse-session-log]
   14:45:54.609  jq=[unknown muse-session-log]  no-jq=[unknown muse-session-log]
   14:45:55.833  jq=[unknown muse-session-log]  no-jq=[unknown muse-session-log]
   14:45:57.058  jq=[unknown muse-session-log]  no-jq=[unknown muse-session-log]
   14:45:58.280  jq=[unknown muse-session-log]  no-jq=[unknown muse-session-log]
   14:45:59.514  jq=[unknown muse-session-log]  no-jq=[unknown muse-session-log]
   14:46:00.740  jq=[unknown muse-session-log]  no-jq=[unknown muse-session-log]
   14:46:01.968  jq=[unknown muse-session-log]  no-jq=[unknown muse-session-log]
   14:46:03.196  jq=[unknown muse-session-log]  no-jq=[unknown muse-session-log]
   14:46:04.438  jq=[unknown muse-session-log]  no-jq=[unknown muse-session-log]
   14:46:05.661  jq=[unknown muse-session-log]  no-jq=[unknown muse-session-log]
   14:46:06.890  jq=[unknown muse-session-log]  no-jq=[unknown muse-session-log]
   14:46:08.118  jq=[unknown muse-session-log]  no-jq=[unknown muse-session-log]
   14:46:09.348  jq=[unknown muse-session-log]  no-jq=[unknown muse-session-log]
   14:46:10.577  jq=[unknown muse-session-log]  no-jq=[unknown muse-session-log]
   14:46:11.800  jq=[unknown muse-session-log]  no-jq=[unknown muse-session-log]
   14:46:13.027  jq=[unknown muse-session-log]  no-jq=[unknown muse-session-log]
   14:46:14.252  jq=[unknown muse-session-log]  no-jq=[unknown muse-session-log]
   14:46:15.498  jq=[unknown muse-session-log]  no-jq=[unknown muse-session-log]
   14:46:16.723  jq=[unknown muse-session-log]  no-jq=[unknown muse-session-log]
   14:46:17.952  jq=[unknown muse-session-log]  no-jq=[unknown muse-session-log]
   14:46:19.180  jq=[unknown muse-session-log]  no-jq=[unknown muse-session-log]
   14:46:20.406  jq=[unknown muse-session-log]  no-jq=[unknown muse-session-log]
   14:46:21.634  jq=[unknown muse-session-log]  no-jq=[unknown muse-session-log]
   14:46:22.859  jq=[unknown muse-session-log]  no-jq=[unknown muse-session-log]
   14:46:24.089  jq=[unknown muse-session-log]  no-jq=[unknown muse-session-log]
   14:46:25.315  jq=[unknown muse-session-log]  no-jq=[unknown muse-session-log]
   14:46:26.572  jq=[unknown muse-session-log]  no-jq=[unknown muse-session-log]
   14:46:27.801  jq=[unknown muse-session-log]  no-jq=[unknown muse-session-log]
   14:46:29.028  jq=[unknown muse-session-log]  no-jq=[unknown muse-session-log]
   14:46:30.258  jq=[unknown muse-session-log]  no-jq=[unknown muse-session-log]
   14:46:31.484  jq=[unknown muse-session-log]  no-jq=[unknown muse-session-log]
   14:46:32.713  jq=[unknown muse-session-log]  no-jq=[unknown muse-session-log]
   14:46:33.944  jq=[unknown muse-session-log]  no-jq=[unknown muse-session-log]
   14:46:35.171  jq=[unknown muse-session-log]  no-jq=[unknown muse-session-log]
   14:46:36.398  jq=[unknown muse-session-log]  no-jq=[unknown muse-session-log]
   14:46:37.636  jq=[unknown muse-session-log]  no-jq=[unknown muse-session-log]
   14:46:38.864  jq=[unknown muse-session-log]  no-jq=[unknown muse-session-log]
   14:46:40.093  jq=[unknown muse-session-log]  no-jq=[unknown muse-session-log]
   14:46:41.322  jq=[unknown muse-session-log]  no-jq=[unknown muse-session-log]
   14:46:42.546  jq=[unknown muse-session-log]  no-jq=[unknown muse-session-log]
   14:46:43.775  jq=[unknown muse-session-log]  no-jq=[unknown muse-session-log]
   14:46:45.005  jq=[unknown muse-session-log]  no-jq=[unknown muse-session-log]
   14:46:46.234  jq=[unknown muse-session-log]  no-jq=[unknown muse-session-log]
   14:46:47.462  jq=[unknown muse-session-log]  no-jq=[unknown muse-session-log]
   14:46:48.692  jq=[unknown muse-session-log]  no-jq=[unknown muse-session-log]
   14:46:49.922  jq=[unknown muse-session-log]  no-jq=[unknown muse-session-log]
   14:46:51.148  jq=[unknown muse-session-log]  no-jq=[unknown muse-session-log]
   14:46:52.374  jq=[unknown muse-session-log]  no-jq=[unknown muse-session-log]
   14:46:53.608  jq=[unknown muse-session-log]  no-jq=[unknown muse-session-log]
   14:46:54.835  jq=[unknown muse-session-log]  no-jq=[unknown muse-session-log]
   14:46:56.065  jq=[unknown muse-session-log]  no-jq=[unknown muse-session-log]
   14:46:57.290  jq=[unknown muse-session-log]  no-jq=[unknown muse-session-log]
   14:46:58.516  jq=[unknown muse-session-log]  no-jq=[unknown muse-session-log]
   14:46:59.738  jq=[unknown muse-session-log]  no-jq=[unknown muse-session-log]
   14:47:00.966  jq=[unknown muse-session-log]  no-jq=[unknown muse-session-log]
   14:47:02.194  jq=[unknown muse-session-log]  no-jq=[unknown muse-session-log]
   14:47:03.422  jq=[unknown muse-session-log]  no-jq=[unknown muse-session-log]
   14:47:04.648  jq=[unknown muse-session-log]  no-jq=[unknown muse-session-log]
   14:47:05.874  jq=[unknown muse-session-log]  no-jq=[unknown muse-session-log]
   14:47:07.102  jq=[unknown muse-session-log]  no-jq=[unknown muse-session-log]
   14:47:08.329  jq=[unknown muse-session-log]  no-jq=[unknown muse-session-log]
   14:47:09.560  jq=[unknown muse-session-log]  no-jq=[unknown muse-session-log]
   14:47:10.787  jq=[unknown muse-session-log]  no-jq=[unknown muse-session-log]
   14:47:12.012  jq=[unknown muse-session-log]  no-jq=[unknown muse-session-log]
   14:47:13.237  jq=[unknown muse-session-log]  no-jq=[unknown muse-session-log]
   14:47:14.464  jq=[unknown muse-session-log]  no-jq=[unknown muse-session-log]
   14:47:15.691  jq=[unknown muse-session-log]  no-jq=[unknown muse-session-log]
   14:47:16.921  jq=[unknown muse-session-log]  no-jq=[unknown muse-session-log]
   14:47:18.148  jq=[unknown muse-session-log]  no-jq=[unknown muse-session-log]
   14:47:19.371  jq=[unknown muse-session-log]  no-jq=[unknown muse-session-log]
   14:47:20.598  jq=[unknown muse-session-log]  no-jq=[unknown muse-session-log]
   14:47:21.828  jq=[unknown muse-session-log]  no-jq=[unknown muse-session-log]
   14:47:23.054  jq=[unknown muse-session-log]  no-jq=[unknown muse-session-log]
   14:47:24.283  jq=[unknown muse-session-log]  no-jq=[unknown muse-session-log]
   14:47:25.509  jq=[unknown muse-session-log]  no-jq=[unknown muse-session-log]
   14:47:26.735  jq=[unknown muse-session-log]  no-jq=[unknown muse-session-log]
   14:47:27.962  jq=[unknown muse-session-log]  no-jq=[unknown muse-session-log]
   14:47:29.196  jq=[unknown muse-session-log]  no-jq=[unknown muse-session-log]
   14:47:30.424  jq=[unknown muse-session-log]  no-jq=[unknown muse-session-log]
   14:47:31.652  jq=[unknown muse-session-log]  no-jq=[unknown muse-session-log]
   14:47:32.874  jq=[unknown muse-session-log]  no-jq=[unknown muse-session-log]
   14:47:34.101  jq=[unknown muse-session-log]  no-jq=[unknown muse-session-log]
   14:47:35.327  jq=[unknown muse-session-log]  no-jq=[unknown muse-session-log]
   14:47:36.557  jq=[unknown muse-session-log]  no-jq=[unknown muse-session-log]
   14:47:37.786  jq=[unknown muse-session-log]  no-jq=[unknown muse-session-log]
   14:47:39.009  jq=[unknown muse-session-log]  no-jq=[unknown muse-session-log]
   14:47:40.240  jq=[unknown muse-session-log]  no-jq=[unknown muse-session-log]
   14:47:41.466  jq=[unknown muse-session-log]  no-jq=[unknown muse-session-log]
   14:47:42.693  jq=[unknown muse-session-log]  no-jq=[unknown muse-session-log]
   14:47:43.918  jq=[unknown muse-session-log]  no-jq=[unknown muse-session-log]
   14:47:45.146  jq=[unknown muse-session-log]  no-jq=[unknown muse-session-log]
   14:47:46.374  jq=[unknown muse-session-log]  no-jq=[unknown muse-session-log]
   14:47:47.601  jq=[unknown muse-session-log]  no-jq=[unknown muse-session-log]
   14:47:48.828  jq=[unknown muse-session-log]  no-jq=[unknown muse-session-log]
   14:47:50.054  jq=[unknown muse-session-log]  no-jq=[unknown muse-session-log]
   14:47:51.280  jq=[unknown muse-session-log]  no-jq=[unknown muse-session-log]
   14:47:52.502  jq=[unknown muse-session-log]  no-jq=[unknown muse-session-log]
   14:47:53.729  jq=[unknown muse-session-log]  no-jq=[unknown muse-session-log]
   14:47:54.956  jq=[unknown muse-session-log]  no-jq=[unknown muse-session-log]
   14:47:56.185  jq=[unknown muse-session-log]  no-jq=[unknown muse-session-log]
   14:47:57.409  jq=[unknown muse-session-log]  no-jq=[unknown muse-session-log]
   14:47:58.634  jq=[unknown muse-session-log]  no-jq=[unknown muse-session-log]
   14:47:59.860  jq=[unknown muse-session-log]  no-jq=[unknown muse-session-log]
   14:48:01.086  jq=[unknown muse-session-log]  no-jq=[unknown muse-session-log]
   14:48:02.312  jq=[unknown muse-session-log]  no-jq=[unknown muse-session-log]
   14:48:03.535  jq=[unknown muse-session-log]  no-jq=[unknown muse-session-log]
   bound log:  (predecessor: )
head: cannot open '' for reading: No such file or directory
jq: error: Could not open file : No such file or directory
   bound log line 1: ; metadata on line 
FAIL  the classifier binds the task's own new log, not the predecessor
FAIL  turn 1 in flight reads 'busy muse-session-log' with jq
FAIL  turn 1 in flight reads 'busy muse-session-log' without jq
FAIL  turn 1 finished reads 'idle muse-session-log' with and without jq

== 4. second turn, then interrupted (jq present)
   14:48:36.614  verdict=[unknown muse-session-log]  active run=
FAIL  4. second turn, then interrupted (jq present): submitted turn reads busy with an active run id
   NO_MISTAKES_GATE is set, so fm-control.sh refuses here; sending the muse adapter keys Escape, C-u to the isolated pane
   14:49:02.519  after interrupt: run_terminal()=  verdict=[unknown muse-session-log]
FAIL  4. second turn, then interrupted (jq present): fm_busy_muse_run_terminal reads cancelled (the ack fm-control confirms on)
FAIL  4. second turn, then interrupted (jq present): interrupted turn reads idle

== 5. third turn, then interrupted (no jq on PATH)
   14:49:34.446  verdict=[unknown muse-session-log]  active run=
FAIL  5. third turn, then interrupted (no jq on PATH): submitted turn reads busy with an active run id
   NO_MISTAKES_GATE is set, so fm-control.sh refuses here; sending the muse adapter keys Escape, C-u to the isolated pane
   14:50:00.378  after interrupt: run_terminal()=  verdict=[unknown muse-session-log]
FAIL  5. third turn, then interrupted (no jq on PATH): fm_busy_muse_run_terminal reads cancelled (the ack fm-control confirms on)
FAIL  5. third turn, then interrupted (no jq on PATH): interrupted turn reads idle

== 6. the task log's own run brackets (read with jq, independent of the library)
jq: error: Could not open file : No such file or directory
   library events (jq):
FAIL  library extracts completed, cancelled, cancelled in order

== pane captures (Muse's own TUI at each point)
--- pane-turn1-busy
--- pane-turn1-idle
     Muse Code 1.1.1
   ❯ firstmate e2e launch brief
   ◆ echo: firstmate e2e launch brief
   ────────────────────────────────────────────────────────────────────────────────
   ❯ Type @ to search and insert workspace file paths
   ────────────────────────────────────────────────────────────────────────────────
     echo · /tmp/fm-muse-e2e.oZ9kz7/worktrees/musee2e · YOLO
--- pane-turn2-interrupted
     Muse Code 1.1.1
   ❯ firstmate e2e launch brief
   ◆ echo: firstmate e2e launch brief
   ❯ second turn to interrupt
   ◆ echo: second turn to interrupt
   ────────────────────────────────────────────────────────────────────────────────
   ❯ Type @ to search and insert workspace file paths
   ────────────────────────────────────────────────────────────────────────────────
     echo · /tmp/fm-muse-e2e.oZ9kz7/worktrees/musee2e · YOLO

RESULT: 13 check(s) FAILED
exit=13
```
</details>

- Evidence: First live end-to-end runs (with and without the change), recording bin/fm-control.sh refused by NO_MISTAKES_GATE; its FAIL lines are that refusal, not the fold (local file: <code>~/.no-mistakes/evidence/01M27RVY95GVXH6K2MN222T3BN/muse-111-live-classify-with-change.log</code>)
- Evidence: First live end-to-end run without the change (fm-control refusal plus unknown-throughout samples) (local file: <code>~/.no-mistakes/evidence/01M27RVY95GVXH6K2MN222T3BN/muse-111-live-classify-without-change.log</code>)
- Evidence: Live end-to-end driver script (re-runnable; uses the real fm-control.sh when NO_MISTAKES_GATE is unset) (local file: <code>~/.no-mistakes/evidence/01M27RVY95GVXH6K2MN222T3BN/muse-111-live-classify.sh</code>)
- Evidence: Fold comparison: 0.1.x identical before/after, real 1.1.1 logs bug reproduced and fixed, adversarial traps hold, with and without jq (local file: <code>~/.no-mistakes/evidence/01M27RVY95GVXH6K2MN222T3BN/fold-compare.log</code>)
- Evidence: Fold comparison driver script (local file: <code>~/.no-mistakes/evidence/01M27RVY95GVXH6K2MN222T3BN/fold-compare.sh</code>)

<details>
<summary>Evidence: Glyph check off the exact 1.1.1-R2514.1 version string: still a hard failure with its diagnostic visible</summary>

<code>Muse Code 1.1.1 (1.1.1-R2514.2)&#10;the final Muse prompt glyph has no effective truecolor foreground&#10;not ok - Muse&#39;s real prompt glyph is missing a bright effective truecolor foreground&#10;exit=1</code>

```text
# adversarial: the same real Muse 1.1.1 binary, but --version reports a string that is NOT the exact skipped '1.1.1-R2514.1'
$ muse --version   # via version wrapper
Muse Code 1.1.1 (1.1.1-R2514.2)
$ FM_MUSE_SIGNALS_LIVE=1 bin/fm-test-run.sh tests/fm-muse-signals-live-e2e.test.sh
FM_TEST_BEGIN 2026-09-11T09:02:47Z tests/fm-muse-signals-live-e2e.test.sh family=live-harness-optin expected_gate_skip=live-capability
ok - Muse's real session protocol on Muse Code 1.1.1 (1.1.1-R2514.2) classifies busy in flight
ok - Muse's real session protocol on Muse Code 1.1.1 (1.1.1-R2514.2) binds the workspace log
ok - Muse's real session protocol on Muse Code 1.1.1 (1.1.1-R2514.2) emits one matched run bracket
the final Muse prompt glyph has no effective truecolor foreground
not ok - Muse's real prompt glyph is missing a bright effective truecolor foreground
FM_TEST_END 2026-09-11T09:02:48Z tests/fm-muse-signals-live-e2e.test.sh exit=1 duration_ms=624 gate_skip=false
FM_TEST_SUMMARY total=1 failed=1 skipped_gate=0 duration_ms=667
FM_TEST_SUMMARY_FAMILY family=live-harness-optin count=1 duration_ms=624 failed=1
FM_TEST_SLOWEST rank=1 script=tests/fm-muse-signals-live-e2e.test.sh duration_ms=624
exit=1

$ tests/fm-muse-signals-live-e2e.test.sh --ansi-self-test
ok - Muse glyph color parser follows effective foreground state
exit=0
```
</details>

- Evidence: Portable Muse harness regression (local file: <code>~/.no-mistakes/evidence/01M27RVY95GVXH6K2MN222T3BN/fm-muse-harness-portable.log</code>)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"8d890e77d22530a543a194c7e8ea99a0170b790e","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>🔧 **Review** - 4 issues found → auto-fixed ✅</summary>

- ⚠️ `bin/fm-busy-lib.sh:473` - On the 1.1.1 layout the binding cache no longer fails closed when a second main session appears in the same worktree. fm_busy_muse_namespace_signature still hashes only line 1 of each log (`sed -n &#39;1p&#39;`). On Muse 1.1.1 that line is the retained_frame, but binding now reads the metadata record after it (metadataWorkspace, lines 362-384). The real 1.1.1 logs on this host were created at the frame&#39;s timestamp, and their metadata record was written 1.1-1.5 s later. The failure sequence: session A is cached, and a second session B in the same worktree is first seen holding only its frame. B resolves as non-matching, and A is cached with a signature that includes B&#39;s frame line. B&#39;s later metadata append does not change line 1, so the cache is never invalidated. Ad-hoc reproduction: A settled, B created frame-only, then B appended metadata for the same workspace plus an open run. The 1.1.1 layout kept returning A as &#39;settled&#39; (idle muse-session-log) while B was busy. The 0.1.x layout of the same sequence returned unknown. This breaks the invariant pinned by test_cached_session_revalidates_after_namespace_change and the intent&#39;s &#39;exactly as it did on Muse Code 0.1.0&#39;. Fix inside the authorized binding path: derive each log&#39;s signature entry from the prefix through the first runtime.session.metadata record, or from the binding result metadataWorkspace computes, so a later metadata append invalidates the cache. Add a 1.1.1 variant of that test: a frame-only second log, then metadata appended, expecting unknown.
- ⚠️ `tests/fm-muse-harness.test.sh:1116` - test_prompt_text_and_malformed_lines_do_not_close_a_run cannot fail on a malformed-line regression. Both truncated terminal lines (1116 and 1118) also omit schema_version and payload_type. So even if the jq or awk parser accepted a truncated object, the payload_type == &#34;runtime.session&#34; filter would still drop it and the fold would still read busy. The contract item &#39;Treat a malformed line as contributing nothing, never as opening or closing a run&#39; is therefore not actually proven. Give the truncated lines the same {&#34;schema_version&#34;:1,&#34;payload_type&#34;:&#34;runtime.session&#34;,...} prefix as a real 1.1.1 terminal, so truncation is the only disqualifier. Also add a truncated started line to cover &#39;never as opening&#39;.
- ⚠️ `tests/fm-muse-signals-live-e2e.test.sh:212` - The live guard&#39;s prompt-glyph check can no longer fail on any Muse version. Both branches print &#39;ok&#39;, and `2&gt;/dev/null` discards the checker&#39;s diagnostic (for example, the dark RGB value). So a composer-glyph drift on 0.1.x or any future version now passes silently, and the 1.1.1 run records an &#39;ok&#39; line for a check that actually failed. This exceeds the intent: composer handling is out of scope, and &#39;claiming Muse Code 1.1.1 is verified for anything beyond session-log folding&#39; is a return-before item. The change also adds a new &#39;ok - the shared classifier read Muse&#39;s real idle composer as empty&#39; line to the 1.1.1 verification transcript. It also rewrites the &#39;Refreshing this record&#39; paragraph in docs/verification/muse.md (lines 250-251), which is outside the one authorized dated entry. Narrower options: keep the hard failure and file the 1.1.1 glyph drift as a separate composer follow-up, or limit the soft path to the exact 1.1.1 version string and report it as a TAP skip/TODO instead of ok. The author has to choose, because the completion proof also requires this guard to pass on 1.1.1.
- ℹ️ `bin/fm-busy-lib.sh:580` - The no-jq fallback runs a per-character awk tokenizer over the whole session log on every classify, and again in fm-control&#39;s interrupt path (active_run_id, then run_terminal). On a real 273 KB Muse 1.1.1 log it took 48 ms under gawk versus 6 ms with jq, with identical output. The cost grows linearly with session length, so multi-MB sessions on hosts without jq will cost roughly a second per fold. This mirrors the Cursor fold the intent names as the model, so it is an accepted tradeoff and needs no action.

🔧 Fix applied.
✅ Re-checked - no issues remain.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- Live validation: ✅ go - 6 of 12 scenarios driven live against the product

| Scenario | Result | Live | Evidence |
| --- | --- | --- | --- |
| Live guard on real Muse Code 1.1.1 fails without the change and passes with it, naming the Muse version in its output | ✅ pass | live | live-guard-without-change.log (both base variants fail), live-guard-with-change.log (all ok lines name &#39;Muse Code 1.1.1 (1.1.1-R2514.1)&#39;), live-guard-repeat-10x.log (10/10) |
| A Firstmate-bound Muse 1.1.1 task reads &#39;busy muse-session-log&#39; for the whole running turn and &#39;idle muse-session-log&#39; once it ends (jq installed) | ✅ pass | live | muse-111-live-classify-with-change-interrupt.log section 3: unknown, then 10 busy samples across the 12s turn, then idle. The base tree stays unknown throughout (muse-111-live-classify-without-change-… |
| The same busy then idle verdicts on a host without jq (PATH with every tool except jq) | ✅ pass | live | muse-111-live-classify-with-change-interrupt.log section 3, no-jq column identical to the jq column. &#39;the jq-free PATH really has no jq&#39; check passes |
| Log discovery on 1.1.1: spawn-time discovery finds a predecessor log whose metadata follows retained_frame and records it as prior_log, and the classifier binds the task&#39;s own new log in a real git wo… | ✅ pass | live | muse-111-live-classify-with-change-interrupt.log sections 1-3: line 1 is retained_frame, metadata is on line 2, prior_log recorded, bound log differs from the predecessor. Base tree: nothing discovere… |
| Interrupting a real Muse 1.1.1 turn: the active run id is reported while busy, fm_busy_muse_run_terminal then reads &#39;cancelled&#39;, and the worker reads idle, with and without jq | ✅ pass | live | muse-111-live-classify-with-change-interrupt.log sections 4-5 (Escape+C-u sent to the isolated pane; the pane capture shows Muse&#39;s &#39;Interrupted&#39;; the library extracts completed, cancelled, cancelled) |
| The real `bin/fm-control.sh &lt;id&gt; interrupt` command confirms cancellation from the 1.1.1 session terminal | ⏸️ untested | no | fm-control.sh deliberately refuses to run inside a no-mistakes gate agent (NO_MISTAKES_GATE is set in this environment), and bypassing that guard is not appropriate. To drive it, run ~ |
| Reported bug on the host&#39;s real Muse 1.1.1 session logs: the base library extracts 0 events and folds none, and the change extracts the run pairs (completed, cancelled) and folds settled, jq equal to… | ⏸️ untested | no | The prior payload did not establish a live result: it ran fold-compare.sh offline against 3 session logs Muse 1.1.1 had recorded to disk earlier, not against a running Muse session. The same bug and f… |
| Nearest contrast: 0.1.x-ordered logs produce identical fold output (events, state, active run id, run terminal) before and after the change, with and without jq | ⏸️ untested | no | The prior payload did not establish a live result: it compared base and new folds offline on 0.1.x fixtures and on 0.1.x-ordered rewrites of recorded logs, and did not drive a running Muse 0.1.x sessi… |
| Adversarial 1.1.1-order lines appended to a real log never open or close a run: nested cleanup terminal, event text containing &#34;kind&#34;:&#34;terminal&#34;, truncated terminal or started with the full schema pre… | ⏸️ untested | no | The prior payload did not establish a live result: the nine trap lines were appended by fold-compare.sh to a recorded log file offline. They are synthetic inputs that a running Muse session does not e… |
| Portable regression tests/fm-muse-harness.test.sh passes with the new 1.1.1 cases and the unchanged 0.1.x cases | ⏸️ untested | no | The prior payload did not establish a live result: tests/fm-muse-harness.test.sh is a portable fixture-based test suite run through bin/fm-test-run.sh, not a run against a live Muse product. |
| User decision: the composer-glyph check is skipped only on the exact 1.1.1-R2514.1 version string, and any other version still hard-fails with the checker&#39;s diagnostic visible | ✅ pass | live | live-guard-glyph-nonexact-version.log (the real Muse binary reporting 1.1.1-R2514.2 fails with &#39;the final Muse prompt glyph has no effective truecolor foreground&#39;; the ANSI self-test passes) |
| The dated verification entry records only Muse Code 1.1.1 session-log folding, and the &#39;Refreshing this record&#39; paragraph is unchanged | ⏸️ untested | no | The prior payload did not establish a live result: this was a code reading of `git diff 869ae90..1d1b809 -- docs/verification/muse.md` compared with the live guard transcript. A documentation file has… |

- <code>`bin/fm-test-run.sh tests/fm-muse-harness.test.sh` (portable regression: 0.1.x and 1.1.1 order, with and without jq, cleanup trap in 1.1.1 order, prompt and malformed lines, binding after retained_frame)</code>
- <code>`FM_MUSE_SIGNALS_LIVE=1 bin/fm-test-run.sh tests/fm-muse-signals-live-e2e.test.sh` at 1d1b809 on real Muse Code 1.1.1 (1.1.1-R2514.1)</code>
- <code>Same live guard on a `git archive 869ae90` tree: the unchanged base guard, then the new guard with the base bin/fm-busy-lib.sh</code>
- <code>`FM_MUSE_SIGNALS_LIVE=1 tests/fm-muse-signals-live-e2e.test.sh` repeated 10x back to back (flakiness check of the busy-in-flight sample)</code>
- <code>Live guard with a `muse` wrapper whose `--version` reports `Muse Code 1.1.1 (1.1.1-R2514.2)` (glyph check must hard-fail off the exact version), plus `tests/fm-muse-signals-live-e2e.test.sh --ansi-self-test`</code>
- <code>`muse-111-live-classify.sh` at 1d1b809: real git worktree, predecessor Muse session, fm-spawn-identical binding, `fm_busy_classify_meta` sampled across a 12s `--echo-delay-ms` turn with jq and with a jq-free PATH, two real Escape+C-u interrupts read through `fm_busy_muse_session_log`/`fm_busy_muse_active_run_id`/`fm_busy_muse_run_terminal`</code>
- <code>`muse-111-live-classify.sh /tmp/fm-muse-base-tree` (same live flow without the change)</code>
- <code>`bin/fm-control.sh musee2e interrupt` against the isolated lab (refused by the NO_MISTAKES_GATE guard, exit 3)</code>
- <code>`fold-compare.sh`: base vs new fold (events, state, active run id, run terminal) with and without jq on 0.1.x fixtures, 0.1.x-ordered rewrites of real host logs, unmodified real 1.1.1 host logs, and 9 adversarial lines appended to a real log</code>
- <code>Reviewed `git diff 869ae90..1d1b809 -- docs/verification/muse.md`: the only change is the added dated 1.1.1 entry, and its transcript matches the live run output</code>
</details>

<details>
<summary>⚠️ **Document** - 1 info</summary>

- ℹ️ `docs/verification/muse.md:186` - The 0.1.0 credentialed-smoke section records its run counts with byte-ordered greps (lines 174-176: &#39;&#34;kind&#34;:&#34;run&#34;,&#34;run_id&#34;:&#34;[^&#34;]*&#34;,&#34;event&#34;:\{&#34;kind&#34;:&#34;started&#34;&#39;), and line 186 says to scope the count &#39;as above&#39;. Those regexes match zero records on a Muse 1.1.1 log, which writes event before kind. The refresh step at line 251 asks for exactly these started/terminal counts, so repeating the recorded recipe on 1.1.1 would read 0/0 and falsely suggest the protocol broke. Left unedited: the user limited changes to this record to the single dated 1.1.1 entry, and that entry explicitly does not refresh the credentialed evidence. Follow-up: make the refresh count structural (for example jq on payload.kind and payload.event.kind) when the credentialed smoke is next repeated.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
