### PR TITLE
fix(bin): return treehouse pool slots under their registered path spelling

### DIFF
--- a/bin/fm-home-seed.sh
+++ b/bin/fm-home-seed.sh
@@ -576,13 +576,17 @@ seed_rollback_target() {
 }
 
 seed_return_treehouse_home() {
-  local home=$1 abs_home
+  local home=$1 abs_home slot
   abs_home=$(seed_rollback_target "$home" "treehouse-acquired home") || return 0
   if ! command -v treehouse >/dev/null 2>&1; then
     echo "warning: failed to return treehouse-acquired home $abs_home during seed rollback; treehouse command not found" >&2
     return 0
   fi
-  ( cd "$FM_ROOT" && treehouse return --force "$abs_home" >/dev/null ) || {
+  # Return the lease under the $HOME spelling treehouse registered, since the
+  # rollback path only ever has a resolved path; see bin/fm-wake-lib.sh's
+  # fm_treehouse_return_path.
+  slot=$(fm_treehouse_return_path "$abs_home")
+  ( cd "$FM_ROOT" && treehouse return --force "$slot" >/dev/null ) || {
     echo "warning: failed to return treehouse-acquired home $abs_home during seed rollback; lease may still be held" >&2
     return 0
   }

--- a/bin/fm-home-seed.sh
+++ b/bin/fm-home-seed.sh
@@ -582,8 +582,8 @@ seed_return_treehouse_home() {
     echo "warning: failed to return treehouse-acquired home $abs_home during seed rollback; treehouse command not found" >&2
     return 0
   fi
-  # Return the lease under the $HOME spelling treehouse registered, since the
-  # rollback path only ever has a resolved path; see bin/fm-wake-lib.sh's
+  # Return the lease under the spelling treehouse registered, since the rollback
+  # path only ever has a resolved path; see bin/fm-wake-lib.sh's
   # fm_treehouse_return_path.
   slot=$(fm_treehouse_return_path "$abs_home")
   ( cd "$FM_ROOT" && treehouse return --force "$slot" >/dev/null ) || {

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -166,9 +166,10 @@
 # checks before any destructive return. Teardown output notes every wait, retry, and
 # removal so the operator can see what happened.
 #
-# Slot path spelling: every return hands treehouse the path re-spelled through
-# $HOME by bin/fm-wake-lib.sh's fm_treehouse_return_path. A path outside the
-# resolved $HOME is passed through unchanged, and failures stay loud either way.
+# Slot path spelling: every return hands treehouse the spelling the pool's own
+# treehouse-state.json registered for that slot, resolved by bin/fm-wake-lib.sh's
+# fm_treehouse_return_path. A path no pool registers is passed through unchanged,
+# and failures stay loud either way.
 #
 # Pre-teardown cleanup sequence (runs once every landed/discard-work safety
 # refusal above has already passed, and BEFORE any worktree return, branch
@@ -305,12 +306,10 @@ fm_lease_guard "$ID" "teardown (fm-teardown)"
 # Require both its pool state and the same Git common directory as the recorded
 # project; an ordinary linked worktree is not evidence that Treehouse owns it.
 is_treehouse_pool_slot() {  # <project> <worktree>
-  local project=$1 worktree=$2 slot pool state project_common slot_common
+  local project=$1 worktree=$2 slot project_common slot_common
   [ -d "$project" ] && [ -d "$worktree" ] || return 1
   slot=$(CDPATH='' cd -- "$worktree" 2>/dev/null && pwd -P) || return 1
-  pool=$(dirname "$(dirname "$slot")")
-  state="$pool/treehouse-state.json"
-  [ -f "$state" ] && [ ! -L "$state" ] || return 1
+  fm_treehouse_pool_state_file "$slot" >/dev/null || return 1
   project_common=$(git -C "$project" rev-parse --path-format=absolute --git-common-dir 2>/dev/null) || return 1
   slot_common=$(git -C "$slot" rev-parse --path-format=absolute --git-common-dir 2>/dev/null) || return 1
   project_common=$(CDPATH='' cd -- "$project_common" 2>/dev/null && pwd -P) || return 1

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -166,6 +166,10 @@
 # checks before any destructive return. Teardown output notes every wait, retry, and
 # removal so the operator can see what happened.
 #
+# Slot path spelling: every return hands treehouse the path re-spelled through
+# $HOME by bin/fm-wake-lib.sh's fm_treehouse_return_path. A path outside the
+# resolved $HOME is passed through unchanged, and failures stay loud either way.
+#
 # Pre-teardown cleanup sequence (runs once every landed/discard-work safety
 # refusal above has already passed, and BEFORE any worktree return, branch
 # delete, or backend kill below - a still-active run or a leaked process may
@@ -1567,11 +1571,15 @@ cleanup_stale_lock_for_safety_check() {
 # stale git index.lock left by a killed crew process. See the script header.
 teardown_treehouse_return() {
   local dir=$1 cd_dir=$2 label=$3 post_cleanup_check=${4:-}
-  local out lock attempt=0 max_retries lock_desc
+  local out lock attempt=0 max_retries lock_desc slot
+
+  # Re-spell the path through $HOME at the return boundary; the helper owns the
+  # HOME resolution. It never reports "already reclaimed" - failures stay loud.
+  slot=$(fm_treehouse_return_path "$dir")
 
   # Capture stdout+stderr so non-lock failures stay visible and lock failures can
   # be matched by signature even when the lock file is already gone mid-check.
-  if out=$( ( cd "$cd_dir" && treehouse return --force "$dir" ) 2>&1 ); then
+  if out=$( ( cd "$cd_dir" && treehouse return --force "$slot" ) 2>&1 ); then
     [ -n "$out" ] && printf '%s\n' "$out"
     return 0
   fi
@@ -1596,7 +1604,7 @@ teardown_treehouse_return() {
     echo "teardown: $label return failed with transient git lock ($lock_desc); waiting ${TREEHOUSE_RETURN_LOCK_RETRY_WAIT_SECS}s and retrying ($attempt/${max_retries})" >&2
     sleep "$TREEHOUSE_RETURN_LOCK_RETRY_WAIT_SECS"
 
-    if out=$( ( cd "$cd_dir" && treehouse return --force "$dir" ) 2>&1 ); then
+    if out=$( ( cd "$cd_dir" && treehouse return --force "$slot" ) 2>&1 ); then
       [ -n "$out" ] && printf '%s\n' "$out"
       echo "teardown: $label return succeeded on retry; lock cleared on its own" >&2
       return 0
@@ -1623,7 +1631,7 @@ teardown_treehouse_return() {
           return 1
         fi
       fi
-      if out=$( ( cd "$cd_dir" && treehouse return --force "$dir" ) 2>&1 ); then
+      if out=$( ( cd "$cd_dir" && treehouse return --force "$slot" ) 2>&1 ); then
         [ -n "$out" ] && printf '%s\n' "$out"
         echo "teardown: $label return succeeded after stale-lock cleanup" >&2
         return 0

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -302,9 +302,10 @@ if [ "$FORCE" = --force ] && [ "$(fm_lease_actor)" = branch ]; then
 fi
 fm_lease_guard "$ID" "teardown (fm-teardown)"
 
-# A Treehouse slot has the managed pool's fixed <pool>/<slot>/<repo> layout.
-# Require both its pool state and the same Git common directory as the recorded
-# project; an ordinary linked worktree is not evidence that Treehouse owns it.
+# Require both a pool registry (the managed-pool layout is owned by
+# bin/fm-wake-lib.sh's fm_treehouse_pool_state_file) and the same Git common
+# directory as the recorded project; an ordinary linked worktree is not evidence
+# that Treehouse owns it.
 is_treehouse_pool_slot() {  # <project> <worktree>
   local project=$1 worktree=$2 slot project_common slot_common
   [ -d "$project" ] && [ -d "$worktree" ] || return 1

--- a/bin/fm-wake-lib.sh
+++ b/bin/fm-wake-lib.sh
@@ -1210,6 +1210,49 @@ fm_treehouse_project_lock_path() {  # <project-dir>
   printf '%s/.treehouse-project-%s.lock\n' "$root/state" "$hash"
 }
 
+# The path spelling `treehouse return` accepts for a pool slot.
+#
+# Treehouse matches a return path against the spellings its pool registered
+# after only lexical cleaning - it resolves "." and ".." segments, collapses
+# doubled and trailing slashes, and makes a relative path absolute, but it never
+# resolves symlinks. Its pool root is rooted at $HOME, so that is the spelling it
+# stores. Every worktree path Firstmate captures is physical instead: a pane's
+# OS-level cwd read at spawn, or `pwd -P`. Wherever $HOME reaches the home
+# directory through a symlinked component, the two disagree and `treehouse
+# return` rejects the physical form as "not managed by treehouse" - which on a
+# bootc host, where /home is a symlink to /var/home and $HOME is the /home form,
+# is every pooled slot.
+#
+# So a path under the resolved $HOME is re-spelled through the literal $HOME,
+# which is the same HOME/realpath resolution treehouse itself used to build the
+# pool root. Where $HOME has no symlinked component the resolved and literal
+# forms are equal and this is an identity mapping. A path outside the resolved
+# $HOME is passed through byte-identical rather than guessed at.
+#
+# Always prints a path and succeeds; the return itself stays responsible for
+# reporting failure, and nothing here treats a non-rewritten path as evidence
+# that the slot has already been reclaimed.
+fm_treehouse_return_path() {  # <slot-dir>
+  local dir=$1 home home_real
+  home=${HOME:-}
+  [ -n "$home" ] || { printf '%s\n' "$dir"; return 0; }
+  home_real=$(CDPATH='' cd -- "$home" 2>/dev/null && pwd -P) || {
+    printf '%s\n' "$dir"
+    return 0
+  }
+  home=${home%/}
+  [ -n "$home" ] || home=/
+  case $dir in
+    "$home_real") printf '%s\n' "$home" ;;
+    "$home_real"/*)
+      dir=${dir#"$home_real"}
+      [ "$home" = / ] || dir="$home$dir"
+      printf '%s\n' "$dir"
+      ;;
+    *) printf '%s\n' "$dir" ;;
+  esac
+}
+
 fm_failure_episode_reset() {
   local state=$1 mode=${2:-acquire} lock current pid acquired=0 path
   lock="$state/.turnend-claude-blocks.lock"

--- a/bin/fm-wake-lib.sh
+++ b/bin/fm-wake-lib.sh
@@ -1210,47 +1210,55 @@ fm_treehouse_project_lock_path() {  # <project-dir>
   printf '%s/.treehouse-project-%s.lock\n' "$root/state" "$hash"
 }
 
+# The pool state file that registers a treehouse pool slot, given the slot's
+# resolved path. A managed pool has the fixed <pool>/<slot>/<repo> layout with
+# its registry at the pool root; a plain symlink there is not a pool registry.
+fm_treehouse_pool_state_file() {  # <resolved-slot-dir>
+  local state
+  state="$(dirname "$(dirname "$1")")/treehouse-state.json"
+  [ -f "$state" ] && [ ! -L "$state" ] || return 1
+  printf '%s\n' "$state"
+}
+
 # The path spelling `treehouse return` accepts for a pool slot.
 #
 # Treehouse matches a return path against the spellings its pool registered
 # after only lexical cleaning - it resolves "." and ".." segments, collapses
 # doubled and trailing slashes, and makes a relative path absolute, but it never
-# resolves symlinks. Its pool root is rooted at $HOME, so that is the spelling it
-# stores. Every worktree path Firstmate captures is physical instead: a pane's
-# OS-level cwd read at spawn, or `pwd -P`. Wherever $HOME reaches the home
-# directory through a symlinked component, the two disagree and `treehouse
+# resolves symlinks. Every worktree path Firstmate captures is physical instead:
+# a pane's OS-level cwd read at spawn, or `pwd -P`. Wherever the pool was
+# registered through a symlinked component, the two disagree and `treehouse
 # return` rejects the physical form as "not managed by treehouse" - which on a
-# bootc host, where /home is a symlink to /var/home and $HOME is the /home form,
-# is every pooled slot.
+# bootc host, where /home is a symlink to /var/home and the pool root is $HOME-
+# rooted, is every pooled slot.
 #
-# So a path under the resolved $HOME is re-spelled through the literal $HOME,
-# which is the same HOME/realpath resolution treehouse itself used to build the
-# pool root. Where $HOME has no symlinked component the resolved and literal
-# forms are equal and this is an identity mapping. A path outside the resolved
-# $HOME is passed through byte-identical rather than guessed at.
+# So the spelling comes from the registration itself: the pool's
+# treehouse-state.json is the record treehouse matches against, and the entry
+# whose path resolves to the same directory as the slot is by definition the
+# spelling it will accept. Reading the registration - rather than assuming where
+# the pool root is rooted - is also what makes a symlinked pool root work: the
+# registry is located through the slot's resolved path, and each registered
+# spelling is compared after the same resolution.
+#
+# A path with no pool registry, or none registering it, is passed through
+# byte-identical rather than guessed at.
 #
 # Always prints a path and succeeds; the return itself stays responsible for
 # reporting failure, and nothing here treats a non-rewritten path as evidence
 # that the slot has already been reclaimed.
 fm_treehouse_return_path() {  # <slot-dir>
-  local dir=$1 home home_real
-  home=${HOME:-}
-  [ -n "$home" ] || { printf '%s\n' "$dir"; return 0; }
-  home_real=$(CDPATH='' cd -- "$home" 2>/dev/null && pwd -P) || {
-    printf '%s\n' "$dir"
-    return 0
-  }
-  home=${home%/}
-  [ -n "$home" ] || home=/
-  case $dir in
-    "$home_real") printf '%s\n' "$home" ;;
-    "$home_real"/*)
-      dir=${dir#"$home_real"}
-      [ "$home" = / ] || dir="$home$dir"
-      printf '%s\n' "$dir"
-      ;;
-    *) printf '%s\n' "$dir" ;;
-  esac
+  local dir=$1 slot state registered resolved
+  slot=$(CDPATH='' cd -- "$dir" 2>/dev/null && pwd -P) || { printf '%s\n' "$dir"; return 0; }
+  state=$(fm_treehouse_pool_state_file "$slot") || { printf '%s\n' "$dir"; return 0; }
+  while IFS= read -r registered; do
+    [ -n "$registered" ] || continue
+    resolved=$(CDPATH='' cd -- "$registered" 2>/dev/null && pwd -P) || continue
+    if [ "$resolved" = "$slot" ]; then
+      printf '%s\n' "$registered"
+      return 0
+    fi
+  done < <(jq -r '.worktrees[]?.path // empty' "$state" 2>/dev/null)
+  printf '%s\n' "$dir"
 }
 
 fm_failure_episode_reset() {

--- a/tests/fm-teardown.test.sh
+++ b/tests/fm-teardown.test.sh
@@ -55,14 +55,15 @@
 #   (y) persistent lock (never clears, not provably stale)    -> REFUSE loudly
 #
 # Also covers the spelling treehouse matches a return path against. Treehouse
-# registers its pool under $HOME and never resolves symlinks when matching, so a
-# slot whose $HOME is reached through a symlink is registered under one spelling
-# while the task record holds the physical one.
-#   (z1) slot under a symlinked $HOME          -> ALLOW under the $HOME form
-#   (z2) slot under an unsymlinked $HOME       -> ALLOW unchanged
-#   (z3) slot outside the resolved $HOME       -> ALLOW, byte-identical passthrough
-#   (z4) $HOME cannot be resolved              -> ALLOW, recorded path untouched
-#   (z5) treehouse rejects the spelling given  -> REFUSE loudly (lease not dropped)
+# never resolves symlinks when matching, so a pool reached through a symlinked
+# component is registered under one spelling while the task record - always a
+# physically resolved path - holds the other. The return spelling is therefore
+# read back out of the pool's own treehouse-state.json registration.
+#   (z1) registration holds the symlinked spelling -> ALLOW under that spelling
+#   (z2) registration holds the physical spelling  -> ALLOW under that spelling
+#   (z3) pool registers some other slot            -> ALLOW, byte-identical passthrough
+#   (z4) no pool registry at all                   -> ALLOW, recorded path untouched
+#   (z5) treehouse rejects the spelling given      -> REFUSE loudly (lease not dropped)
 set -u
 
 # shellcheck source=tests/lib.sh disable=SC1091
@@ -534,18 +535,14 @@ SH
   chmod +x "$case_dir/fakebin/treehouse"
 }
 
-# Rebuild the case's task worktree as a real treehouse pool slot living inside a
-# home directory that is reached through a symlink, reproducing a bootc host
-# where /home is a symlink to /var/home and $HOME is the /home form. The slot is
-# created - and reported - under the physical spelling, which is what a pane cwd
-# read yields at spawn time and what the task record therefore holds, while real
-# treehouse registers the pool under its $HOME-rooted spelling.
+# Rebuild the case's task worktree as a treehouse pool slot that is also
+# reachable through a symlinked parent, reproducing a bootc host where /home is
+# a symlink to /var/home. The slot is created under the physical spelling, which
+# is what a pane cwd read yields at spawn time; which spelling treehouse
+# registered is then chosen per case by register_pool_slots.
 #
-# The pool's treehouse-state.json is written empty: only its presence matters,
-# because that is what marks the layout a treehouse pool slot for teardown.
-#
-# Echoes: <physical-slot-path> <symlinked-home> <physical-home>
-make_symlinked_home_pool_slot() {
+# Echoes: <physical-slot-path> <symlinked-slot-path> <pool-dir>
+make_symlinked_pool_slot() {
   local case_dir=$1 case_phys pool slot
   case_phys=$(cd "$case_dir" && pwd -P)
   mkdir -p "$case_phys/real-home"
@@ -553,14 +550,24 @@ make_symlinked_home_pool_slot() {
   pool="$case_phys/real-home/.treehouse/proj-abc"
   slot="$pool/1/repo"
   mkdir -p "$pool"
-  printf '%s\n' '{}' > "$pool/treehouse-state.json"
 
   # is_treehouse_pool_slot proves ownership from the pool layout plus a shared git
   # common dir, so the slot has to be a genuine linked worktree of the project.
   git -C "$case_dir/project" worktree remove --force "$case_dir/wt"
   git -C "$case_dir/project" worktree add -q "$slot" fm/task-x1
 
-  printf '%s %s %s\n' "$slot" "$case_phys/link-home" "$case_phys/real-home"
+  printf '%s %s %s\n' \
+    "$slot" "$case_phys/link-home/.treehouse/proj-abc/1/repo" "$pool"
+}
+
+# Write the pool's treehouse-state.json registering exactly the given slot
+# spellings. This is treehouse's own on-disk registration record - the same
+# shape a live ~/.treehouse pool carries - and the spelling a return is matched
+# against, so teardown derives what it hands over from here.
+register_pool_slots() {
+  local pool=$1; shift
+  jq -n '{worktrees: [$ARGS.positional | to_entries[] | {name: (.key + 1 | tostring), path: .value}]}' \
+    --args "$@" > "$pool/treehouse-state.json"
 }
 
 # A `treehouse` that models the real tool's return matching rule, verified live
@@ -587,13 +594,6 @@ exit 1
 SH
   chmod +x "$case_dir/fakebin/treehouse"
   : > "$case_dir/treehouse.log"
-}
-
-# Run teardown for a pool-slot case under <home> as the OS home directory. The
-# subshell keeps that HOME from leaking into any later case.
-run_teardown_with_home() {
-  local case_dir=$1 home=$2
-  ( export HOME="$home"; run_teardown "$case_dir" )
 }
 
 # Point the task record at <slot> and land its work, so teardown reaches the
@@ -1818,107 +1818,111 @@ test_persistent_index_lock_exhausts_retries_and_refuses_loudly() {
   pass "persistent index.lock exhausts retries and refuses without force-removing the lock"
 }
 
-test_symlinked_home_pool_slot_is_returned_under_its_home_form_spelling() {
-  local case_dir rc slot link_home real_home
-  case_dir=$(make_case symlinked-home-pool-slot-return)
-  read -r slot link_home real_home < <(make_symlinked_home_pool_slot "$case_dir")
-  add_spelling_matching_treehouse "$case_dir" "$link_home/.treehouse/proj-abc/1/repo"
+test_slot_registered_under_symlinked_spelling_is_returned_that_way() {
+  local case_dir rc slot link_slot pool
+  case_dir=$(make_case slot-registered-symlinked)
+  read -r slot link_slot pool < <(make_symlinked_pool_slot "$case_dir")
+  register_pool_slots "$pool" "$link_slot"
+  add_spelling_matching_treehouse "$case_dir" "$link_slot"
   seed_landed_pool_slot_task "$case_dir" "$slot"
 
   set +e
-  run_teardown_with_home "$case_dir" "$link_home" > "$case_dir/stdout" 2> "$case_dir/stderr"
+  run_teardown "$case_dir" > "$case_dir/stdout" 2> "$case_dir/stderr"
   rc=$?
   set -e
 
-  expect_code 0 "$rc" "symlinked-home: teardown should complete when treehouse registered the slot under the \$HOME form"
+  expect_code 0 "$rc" "symlinked-registration: teardown should complete when the pool registered the symlinked spelling"
   assert_not_contains "$(cat "$case_dir/stderr")" "not managed by treehouse" \
-    "symlinked-home: teardown handed treehouse a spelling it does not accept"
-  assert_grep "return --force $link_home/.treehouse/proj-abc/1/repo" "$case_dir/treehouse.log" \
-    "symlinked-home: the return did not re-spell the slot through \$HOME"
-  assert_no_grep "return --force $real_home" "$case_dir/treehouse.log" \
-    "symlinked-home: the return still handed treehouse the physical spelling"
+    "symlinked-registration: teardown handed treehouse a spelling it does not accept"
+  assert_grep "return --force $link_slot" "$case_dir/treehouse.log" \
+    "symlinked-registration: the return did not use the registered spelling"
+  assert_no_grep "return --force $slot" "$case_dir/treehouse.log" \
+    "symlinked-registration: the return still handed treehouse the recorded physical spelling"
   assert_absent "$case_dir/state/task-x1.meta" \
-    "symlinked-home: teardown aborted after killing the worker instead of returning the slot"
-  pass "a pool slot under a symlinked \$HOME is returned under the \$HOME-form spelling"
+    "symlinked-registration: teardown aborted after killing the worker instead of returning the slot"
+  pass "a slot registered under its symlinked spelling is returned under that spelling"
 }
 
-test_unsymlinked_home_pool_slot_still_returns_unchanged() {
-  local case_dir rc slot link_home real_home
-  case_dir=$(make_case physical-home-pool-slot-return)
-  read -r slot link_home real_home < <(make_symlinked_home_pool_slot "$case_dir")
+test_slot_registered_under_physical_spelling_is_returned_that_way() {
+  local case_dir rc slot link_slot pool
+  case_dir=$(make_case slot-registered-physical)
+  read -r slot link_slot pool < <(make_symlinked_pool_slot "$case_dir")
+  register_pool_slots "$pool" "$slot"
+  add_spelling_matching_treehouse "$case_dir" "$slot"
+  seed_landed_pool_slot_task "$case_dir" "$link_slot"
+
+  set +e
+  run_teardown "$case_dir" > "$case_dir/stdout" 2> "$case_dir/stderr"
+  rc=$?
+  set -e
+
+  expect_code 0 "$rc" "physical-registration: teardown should complete when the pool registered the physical spelling"
+  assert_not_contains "$(cat "$case_dir/stderr")" "not managed by treehouse" \
+    "physical-registration: teardown handed treehouse a spelling it does not accept"
+  assert_grep "return --force $slot" "$case_dir/treehouse.log" \
+    "physical-registration: the return did not use the registered spelling"
+  assert_no_grep "return --force $link_slot" "$case_dir/treehouse.log" \
+    "physical-registration: the return handed over the recorded symlinked spelling instead"
+  assert_absent "$case_dir/state/task-x1.meta" \
+    "physical-registration: teardown did not complete"
+  pass "a slot registered under its physical spelling is returned under that spelling"
+}
+
+test_slot_the_pool_does_not_register_is_passed_through_byte_identical() {
+  local case_dir rc slot link_slot pool
+  case_dir=$(make_case slot-not-registered)
+  read -r slot link_slot pool < <(make_symlinked_pool_slot "$case_dir")
+  register_pool_slots "$pool" "$pool/2/repo"
   add_spelling_matching_treehouse "$case_dir" "$slot"
   seed_landed_pool_slot_task "$case_dir" "$slot"
 
   set +e
-  run_teardown_with_home "$case_dir" "$real_home" > "$case_dir/stdout" 2> "$case_dir/stderr"
+  run_teardown "$case_dir" > "$case_dir/stdout" 2> "$case_dir/stderr"
   rc=$?
   set -e
 
-  expect_code 0 "$rc" "physical-home: teardown should complete when \$HOME has no symlinked component"
+  expect_code 0 "$rc" "unregistered-slot: a slot the pool does not register must be handed over untouched"
   assert_grep "return --force $slot" "$case_dir/treehouse.log" \
-    "physical-home: the return did not hand over the recorded path"
-  assert_no_grep "$link_home" "$case_dir/treehouse.log" \
-    "physical-home: the return rewrote a spelling that already matched \$HOME"
+    "unregistered-slot: the return did not pass the recorded path through"
+  assert_no_grep "return --force $pool/2/repo" "$case_dir/treehouse.log" \
+    "unregistered-slot: the return handed over another slot's registered spelling"
   assert_absent "$case_dir/state/task-x1.meta" \
-    "physical-home: teardown did not complete"
-  pass "a pool slot under an unsymlinked \$HOME is returned unchanged"
+    "unregistered-slot: teardown did not complete"
+  pass "a slot the pool does not register is handed to treehouse byte-identical"
 }
 
-test_pool_slot_outside_resolved_home_is_passed_through_byte_identical() {
-  local case_dir rc slot link_home real_home other_home
-  case_dir=$(make_case pool-slot-outside-home)
-  read -r slot link_home real_home < <(make_symlinked_home_pool_slot "$case_dir")
-  other_home="$(dirname "$real_home")/elsewhere"
-  mkdir -p "$other_home"
+test_worktree_without_a_pool_registry_is_returned_unchanged() {
+  local case_dir rc slot link_slot pool
+  case_dir=$(make_case slot-without-pool-registry)
+  read -r slot link_slot pool < <(make_symlinked_pool_slot "$case_dir")
   add_spelling_matching_treehouse "$case_dir" "$slot"
   seed_landed_pool_slot_task "$case_dir" "$slot"
 
   set +e
-  run_teardown_with_home "$case_dir" "$other_home" > "$case_dir/stdout" 2> "$case_dir/stderr"
+  run_teardown "$case_dir" > "$case_dir/stdout" 2> "$case_dir/stderr"
   rc=$?
   set -e
 
-  expect_code 0 "$rc" "outside-home: a slot that does not live under \$HOME must be handed over untouched"
+  expect_code 0 "$rc" "no-registry: a worktree outside any registered pool must not have its path rewritten"
   assert_grep "return --force $slot" "$case_dir/treehouse.log" \
-    "outside-home: the return did not pass the recorded path through"
-  assert_no_grep "$link_home" "$case_dir/treehouse.log" \
-    "outside-home: the return rewrote a path that does not live under \$HOME"
+    "no-registry: the return did not pass the recorded path through"
+  assert_no_grep "link-home" "$case_dir/treehouse.log" \
+    "no-registry: the return rewrote a path no pool registers"
   assert_absent "$case_dir/state/task-x1.meta" \
-    "outside-home: teardown did not complete"
-  pass "a pool slot outside the resolved \$HOME is handed to treehouse byte-identical"
-}
-
-test_unresolvable_home_passes_the_recorded_path_through() {
-  local case_dir rc slot link_home real_home
-  case_dir=$(make_case unresolvable-home-pool-slot)
-  read -r slot link_home real_home < <(make_symlinked_home_pool_slot "$case_dir")
-  add_spelling_matching_treehouse "$case_dir" "$slot"
-  seed_landed_pool_slot_task "$case_dir" "$slot"
-
-  set +e
-  run_teardown_with_home "$case_dir" "$real_home/no-such-home" > "$case_dir/stdout" 2> "$case_dir/stderr"
-  rc=$?
-  set -e
-
-  expect_code 0 "$rc" "unresolvable-home: a \$HOME that cannot be resolved must not break the return"
-  assert_grep "return --force $slot" "$case_dir/treehouse.log" \
-    "unresolvable-home: the return did not pass the recorded path through"
-  assert_no_grep "$link_home" "$case_dir/treehouse.log" \
-    "unresolvable-home: the return rewrote the path against an unresolvable \$HOME"
-  assert_absent "$case_dir/state/task-x1.meta" \
-    "unresolvable-home: teardown did not complete"
-  pass "an unresolvable \$HOME leaves the recorded path untouched"
+    "no-registry: teardown did not complete"
+  pass "a worktree with no pool registry is returned unchanged"
 }
 
 test_rejected_slot_return_still_refuses_loudly() {
-  local case_dir rc slot link_home real_home
+  local case_dir rc slot link_slot pool
   case_dir=$(make_case rejected-slot-return)
-  read -r slot link_home real_home < <(make_symlinked_home_pool_slot "$case_dir")
-  add_spelling_matching_treehouse "$case_dir" "$real_home/.treehouse/other-pool/9/repo"
+  read -r slot link_slot pool < <(make_symlinked_pool_slot "$case_dir")
+  register_pool_slots "$pool" "$slot"
+  add_spelling_matching_treehouse "$case_dir" "$pool/9/repo"
   seed_landed_pool_slot_task "$case_dir" "$slot"
 
   set +e
-  run_teardown_with_home "$case_dir" "$link_home" > "$case_dir/stdout" 2> "$case_dir/stderr"
+  run_teardown "$case_dir" > "$case_dir/stdout" 2> "$case_dir/stderr"
   rc=$?
   set -e
 
@@ -3922,10 +3926,10 @@ test_index_lock_mtime_read_failure_refuses
 test_transient_index_lock_clears_after_first_attempt_and_retry_succeeds
 test_persistent_index_lock_exhausts_retries_and_refuses_loudly
 test_empty_retry_wait_uses_default_without_aborting
-test_symlinked_home_pool_slot_is_returned_under_its_home_form_spelling
-test_unsymlinked_home_pool_slot_still_returns_unchanged
-test_pool_slot_outside_resolved_home_is_passed_through_byte_identical
-test_unresolvable_home_passes_the_recorded_path_through
+test_slot_registered_under_symlinked_spelling_is_returned_that_way
+test_slot_registered_under_physical_spelling_is_returned_that_way
+test_slot_the_pool_does_not_register_is_passed_through_byte_identical
+test_worktree_without_a_pool_registry_is_returned_unchanged
 test_rejected_slot_return_still_refuses_loudly
 test_fractional_legacy_retry_wait_refuses_without_arithmetic_error
 test_parked_own_run_is_aborted_before_teardown

--- a/tests/fm-teardown.test.sh
+++ b/tests/fm-teardown.test.sh
@@ -53,6 +53,16 @@
 #   (w) index.lock mtime read failure                         -> lock kept, REFUSE
 #   (x) transient lock cleared after first failed return      -> retry ALLOW
 #   (y) persistent lock (never clears, not provably stale)    -> REFUSE loudly
+#
+# Also covers the spelling treehouse matches a return path against. Treehouse
+# registers its pool under $HOME and never resolves symlinks when matching, so a
+# slot whose $HOME is reached through a symlink is registered under one spelling
+# while the task record holds the physical one.
+#   (z1) slot under a symlinked $HOME          -> ALLOW under the $HOME form
+#   (z2) slot under an unsymlinked $HOME       -> ALLOW unchanged
+#   (z3) slot outside the resolved $HOME       -> ALLOW, byte-identical passthrough
+#   (z4) $HOME cannot be resolved              -> ALLOW, recorded path untouched
+#   (z5) treehouse rejects the spelling given  -> REFUSE loudly (lease not dropped)
 set -u
 
 # shellcheck source=tests/lib.sh disable=SC1091
@@ -522,6 +532,85 @@ fi
 exit 0
 SH
   chmod +x "$case_dir/fakebin/treehouse"
+}
+
+# Rebuild the case's task worktree as a real treehouse pool slot living inside a
+# home directory that is reached through a symlink, reproducing a bootc host
+# where /home is a symlink to /var/home and $HOME is the /home form. The slot is
+# created - and reported - under the physical spelling, which is what a pane cwd
+# read yields at spawn time and what the task record therefore holds, while real
+# treehouse registers the pool under its $HOME-rooted spelling.
+#
+# The pool's treehouse-state.json is written empty: only its presence matters,
+# because that is what marks the layout a treehouse pool slot for teardown.
+#
+# Echoes: <physical-slot-path> <symlinked-home> <physical-home>
+make_symlinked_home_pool_slot() {
+  local case_dir=$1 case_phys pool slot
+  case_phys=$(cd "$case_dir" && pwd -P)
+  mkdir -p "$case_phys/real-home"
+  ln -s real-home "$case_phys/link-home"
+  pool="$case_phys/real-home/.treehouse/proj-abc"
+  slot="$pool/1/repo"
+  mkdir -p "$pool"
+  printf '%s\n' '{}' > "$pool/treehouse-state.json"
+
+  # is_treehouse_pool_slot proves ownership from the pool layout plus a shared git
+  # common dir, so the slot has to be a genuine linked worktree of the project.
+  git -C "$case_dir/project" worktree remove --force "$case_dir/wt"
+  git -C "$case_dir/project" worktree add -q "$slot" fm/task-x1
+
+  printf '%s %s %s\n' "$slot" "$case_phys/link-home" "$case_phys/real-home"
+}
+
+# A `treehouse` that models the real tool's return matching rule, verified live
+# against treehouse v2.3.0: it makes its path argument absolute and cleans it
+# lexically but never resolves symlinks, then requires an exact match against the
+# one spelling its pool registered, rejecting anything else as "not managed by
+# treehouse". Teardown only ever passes an already-absolute, already-clean path,
+# so an exact string match models it faithfully at that boundary. Every
+# invocation is logged so a test can prove which spelling was handed over, and
+# whether a return was attempted at all.
+add_spelling_matching_treehouse() {
+  local case_dir=$1 registered=$2
+  cat > "$case_dir/fakebin/treehouse" <<SH
+#!/usr/bin/env bash
+printf '%s\n' "\$*" >> "$case_dir/treehouse.log"
+[ "\${1:-}" = return ] || exit 0
+p=\${!#}
+if [ "\$p" = "$registered" ]; then
+  echo "Worktree returned to pool."
+  exit 0
+fi
+echo "worktree \$p is not managed by treehouse" >&2
+exit 1
+SH
+  chmod +x "$case_dir/fakebin/treehouse"
+  : > "$case_dir/treehouse.log"
+}
+
+# Run teardown for a pool-slot case under <home> as the OS home directory. The
+# subshell keeps that HOME from leaking into any later case.
+run_teardown_with_home() {
+  local case_dir=$1 home=$2
+  ( export HOME="$home"; run_teardown "$case_dir" )
+}
+
+# Point the task record at <slot> and land its work, so teardown reaches the
+# treehouse-return step instead of refusing earlier on unlanded work.
+seed_landed_pool_slot_task() {
+  local case_dir=$1 slot=$2
+  fm_write_meta "$case_dir/state/task-x1.meta" \
+    "window=firstmate:fm-task-x1" \
+    "endpoint_task_id=task-x1" \
+    "worktree=$slot" \
+    "project=$case_dir/project" \
+    "kind=ship" \
+    "mode=no-mistakes" \
+    "spawn_gen=teardown-test-task-x1"
+  git -C "$slot" -c user.email=t@t -c user.name=t commit -q --allow-empty -m "shippable work"
+  git -C "$slot" push -q origin fm/task-x1
+  git -C "$case_dir/project" fetch -q origin
 }
 
 git_index_lock_path() {
@@ -1727,6 +1816,120 @@ test_persistent_index_lock_exhausts_retries_and_refuses_loudly() {
   [ -f "$case_dir/state/task-x1.meta" ] \
     || fail "persistent-index-lock: teardown completed despite persistent lock"
   pass "persistent index.lock exhausts retries and refuses without force-removing the lock"
+}
+
+test_symlinked_home_pool_slot_is_returned_under_its_home_form_spelling() {
+  local case_dir rc slot link_home real_home
+  case_dir=$(make_case symlinked-home-pool-slot-return)
+  read -r slot link_home real_home < <(make_symlinked_home_pool_slot "$case_dir")
+  add_spelling_matching_treehouse "$case_dir" "$link_home/.treehouse/proj-abc/1/repo"
+  seed_landed_pool_slot_task "$case_dir" "$slot"
+
+  set +e
+  run_teardown_with_home "$case_dir" "$link_home" > "$case_dir/stdout" 2> "$case_dir/stderr"
+  rc=$?
+  set -e
+
+  expect_code 0 "$rc" "symlinked-home: teardown should complete when treehouse registered the slot under the \$HOME form"
+  assert_not_contains "$(cat "$case_dir/stderr")" "not managed by treehouse" \
+    "symlinked-home: teardown handed treehouse a spelling it does not accept"
+  assert_grep "return --force $link_home/.treehouse/proj-abc/1/repo" "$case_dir/treehouse.log" \
+    "symlinked-home: the return did not re-spell the slot through \$HOME"
+  assert_no_grep "return --force $real_home" "$case_dir/treehouse.log" \
+    "symlinked-home: the return still handed treehouse the physical spelling"
+  assert_absent "$case_dir/state/task-x1.meta" \
+    "symlinked-home: teardown aborted after killing the worker instead of returning the slot"
+  pass "a pool slot under a symlinked \$HOME is returned under the \$HOME-form spelling"
+}
+
+test_unsymlinked_home_pool_slot_still_returns_unchanged() {
+  local case_dir rc slot link_home real_home
+  case_dir=$(make_case physical-home-pool-slot-return)
+  read -r slot link_home real_home < <(make_symlinked_home_pool_slot "$case_dir")
+  add_spelling_matching_treehouse "$case_dir" "$slot"
+  seed_landed_pool_slot_task "$case_dir" "$slot"
+
+  set +e
+  run_teardown_with_home "$case_dir" "$real_home" > "$case_dir/stdout" 2> "$case_dir/stderr"
+  rc=$?
+  set -e
+
+  expect_code 0 "$rc" "physical-home: teardown should complete when \$HOME has no symlinked component"
+  assert_grep "return --force $slot" "$case_dir/treehouse.log" \
+    "physical-home: the return did not hand over the recorded path"
+  assert_no_grep "$link_home" "$case_dir/treehouse.log" \
+    "physical-home: the return rewrote a spelling that already matched \$HOME"
+  assert_absent "$case_dir/state/task-x1.meta" \
+    "physical-home: teardown did not complete"
+  pass "a pool slot under an unsymlinked \$HOME is returned unchanged"
+}
+
+test_pool_slot_outside_resolved_home_is_passed_through_byte_identical() {
+  local case_dir rc slot link_home real_home other_home
+  case_dir=$(make_case pool-slot-outside-home)
+  read -r slot link_home real_home < <(make_symlinked_home_pool_slot "$case_dir")
+  other_home="$(dirname "$real_home")/elsewhere"
+  mkdir -p "$other_home"
+  add_spelling_matching_treehouse "$case_dir" "$slot"
+  seed_landed_pool_slot_task "$case_dir" "$slot"
+
+  set +e
+  run_teardown_with_home "$case_dir" "$other_home" > "$case_dir/stdout" 2> "$case_dir/stderr"
+  rc=$?
+  set -e
+
+  expect_code 0 "$rc" "outside-home: a slot that does not live under \$HOME must be handed over untouched"
+  assert_grep "return --force $slot" "$case_dir/treehouse.log" \
+    "outside-home: the return did not pass the recorded path through"
+  assert_no_grep "$link_home" "$case_dir/treehouse.log" \
+    "outside-home: the return rewrote a path that does not live under \$HOME"
+  assert_absent "$case_dir/state/task-x1.meta" \
+    "outside-home: teardown did not complete"
+  pass "a pool slot outside the resolved \$HOME is handed to treehouse byte-identical"
+}
+
+test_unresolvable_home_passes_the_recorded_path_through() {
+  local case_dir rc slot link_home real_home
+  case_dir=$(make_case unresolvable-home-pool-slot)
+  read -r slot link_home real_home < <(make_symlinked_home_pool_slot "$case_dir")
+  add_spelling_matching_treehouse "$case_dir" "$slot"
+  seed_landed_pool_slot_task "$case_dir" "$slot"
+
+  set +e
+  run_teardown_with_home "$case_dir" "$real_home/no-such-home" > "$case_dir/stdout" 2> "$case_dir/stderr"
+  rc=$?
+  set -e
+
+  expect_code 0 "$rc" "unresolvable-home: a \$HOME that cannot be resolved must not break the return"
+  assert_grep "return --force $slot" "$case_dir/treehouse.log" \
+    "unresolvable-home: the return did not pass the recorded path through"
+  assert_no_grep "$link_home" "$case_dir/treehouse.log" \
+    "unresolvable-home: the return rewrote the path against an unresolvable \$HOME"
+  assert_absent "$case_dir/state/task-x1.meta" \
+    "unresolvable-home: teardown did not complete"
+  pass "an unresolvable \$HOME leaves the recorded path untouched"
+}
+
+test_rejected_slot_return_still_refuses_loudly() {
+  local case_dir rc slot link_home real_home
+  case_dir=$(make_case rejected-slot-return)
+  read -r slot link_home real_home < <(make_symlinked_home_pool_slot "$case_dir")
+  add_spelling_matching_treehouse "$case_dir" "$real_home/.treehouse/other-pool/9/repo"
+  seed_landed_pool_slot_task "$case_dir" "$slot"
+
+  set +e
+  run_teardown_with_home "$case_dir" "$link_home" > "$case_dir/stdout" 2> "$case_dir/stderr"
+  rc=$?
+  set -e
+
+  expect_code 1 "$rc" "rejected-return: a spelling treehouse refuses must not be swallowed as an already-reclaimed slot"
+  assert_grep "not managed by treehouse" "$case_dir/stderr" \
+    "rejected-return: teardown did not surface the return failure"
+  assert_grep "return" "$case_dir/treehouse.log" \
+    "rejected-return: teardown skipped the return"
+  [ -f "$case_dir/state/task-x1.meta" ] \
+    || fail "rejected-return: teardown discarded the task record despite a failed return"
+  pass "a return treehouse rejects keeps the loud failure instead of silently dropping the lease"
 }
 
 test_empty_retry_wait_uses_default_without_aborting() {
@@ -3719,6 +3922,11 @@ test_index_lock_mtime_read_failure_refuses
 test_transient_index_lock_clears_after_first_attempt_and_retry_succeeds
 test_persistent_index_lock_exhausts_retries_and_refuses_loudly
 test_empty_retry_wait_uses_default_without_aborting
+test_symlinked_home_pool_slot_is_returned_under_its_home_form_spelling
+test_unsymlinked_home_pool_slot_still_returns_unchanged
+test_pool_slot_outside_resolved_home_is_passed_through_byte_identical
+test_unresolvable_home_passes_the_recorded_path_through
+test_rejected_slot_return_still_refuses_loudly
 test_fractional_legacy_retry_wait_refuses_without_arithmetic_error
 test_parked_own_run_is_aborted_before_teardown
 test_parked_run_advanced_past_unfetched_head_is_still_aborted


### PR DESCRIPTION
## Intent

Repro on this box (bootc: /home is a symlink to /var/home, HOME=~).

fm-spawn records `worktree=~/.treehouse/<pool>/N/<repo>` in `state/<id>.meta`. treehouse registers its pool under the $HOME form (`treehouse status` prints `~/.treehouse/...`). Once the slot is no longer in-use, `treehouse return --force /var/home/...` fails with `worktree ... is not managed by treehouse`, and `bin/fm-teardown.sh` aborts loudly at its treehouse-return step - AFTER it has already killed the worker's leaked processes. The identical command with the `~` form returns cleanly.

Hit on a task on 2026-09-06. Worked around by rewriting that meta's `worktree=` line to the $HOME form and re-running teardown, which then completed.

All four live task metas in this home carry the /var/home form, so this reproduces on every treehouse-backed teardown here whose pool slot has already gone available.

Fix candidate: normalise the recorded worktree path - or the path handed to `treehouse return` - through the same HOME/realpath resolution treehouse itself uses, rather than trusting the spawn-time literal.

## What Changed

- Added `fm_treehouse_return_path` and `fm_treehouse_pool_state_file` to `bin/fm-wake-lib.sh`: the return path for a pool slot is now read out of the pool's own `treehouse-state.json` — the registered entry whose path resolves to the same directory as the slot — instead of trusting the physically resolved path recorded at spawn. A slot with no pool registry, or one no pool registers, is passed through byte-identical, and the helper never reports success in place of a failed return.
- Routed both `treehouse return --force` call sites through that helper: every attempt in `bin/fm-teardown.sh`'s `teardown_treehouse_return` (initial, lock retry, and post-stale-lock-cleanup) and the seed-rollback return in `bin/fm-home-seed.sh`. `is_treehouse_pool_slot` now proves pool ownership via `fm_treehouse_pool_state_file` rather than its own inline layout check.
- Added five `tests/fm-teardown.test.sh` cases over a pool slot reachable through a symlinked parent, driven by a fake `treehouse` that models the real tool's lexical-only match: registration under the symlinked spelling, under the physical spelling, an unregistered slot, a worktree with no pool registry, and a rejected spelling that must still fail loudly without dropping the task record.

## Risk Assessment

✅ Low: The fix is a narrow, boundary-local rewrite derived from treehouse's own on-disk registration - verified against live pool state files and traced through four concrete inputs - that degrades to byte-identical pass-through whenever no registration matches, so it cannot make any previously working return fail, and it is covered in both spelling directions plus the rejection case.

## Testing

`Ran the two targeted suites (tests/fm-teardown.test.sh 89/89 and tests/fm-secondmate-safety.test.sh 77/77, the latter covering the fm-home-seed rollback call site), proved the two new regression cases fail on the base commit and pass on the target, and then demonstrated the user intent end-to-end with the real treehouse v2.3.0 binary: with a task meta recording the physically resolved slot path, the base commit aborts teardown with "worktree ... is not managed by treehouse" and leaves the slot leased, while the target commit returns the slot cleanly (status flips leased -> available, meta removed, exit 0) across a symlinked-parent pool root (the reported bootc shape), a physical pool root, and a symlinked pool root. A read-only pass over this host's 20 live pool slots shows every physical /var/home spelling mapping to the registered /home spelling. Transcripts are saved as evidence; no UI surface is involved, so CLI transcripts are the end-user-visible artifact. Everything passed and the worktree was left clean with all scratch dirs removed.`

<details>
<summary>Evidence: fm-teardown.sh end-to-end against the real treehouse binary, before vs after, three pool-root shapes</summary>

Source: [fm-teardown.sh end-to-end against the real treehouse binary, before vs after, three pool-root shapes](https://github.com/Alberto-Codes/firstmate/blob/c7f05542382f20fa76604b0769a048fe56aa45c2/.no-mistakes/evidence/fm/teardown-slot-path-spelling-k17/teardown-real-treehouse-before-after.txt)

```text
bin/fm-teardown.sh end-to-end against the REAL treehouse binary (v2.3.0)
========================================================================
Each block builds an origin + project clone, leases a slot from a real
treehouse pool, commits and pushes the worker's landed work in that slot,
records the slot in state/task-x1.meta exactly the way fm-spawn does (the
pane's physically resolved cwd), and then runs the real bin/fm-teardown.sh.
Only tmux/gh/gh-axi/no-mistakes are stubbed; treehouse and git are real.

Pool-root shapes exercised:
  symlinked-parent     pool reached through a symlinked parent - the bootc
                       shape from the report (/home -> /var/home)
  physical             pool root spelled physically (must not regress)
  symlinked-pool-root  the pool root directory itself is a symlink onto
                       another tree (~/.treehouse -> elsewhere)

BEFORE the fix  (base commit e0d269e)
====================================

  recorded worktree= : /tmp/fm-th-e2e/case-before/real/pool/.treehouse/project-2b98d4/1/project
  treehouse registered: /tmp/fm-th-e2e/case-before/link/pool/.treehouse/project-2b98d4/1/project
  
  $ bin/fm-teardown.sh task-x1   (fm root: /tmp/fm-base)
  worktree /tmp/fm-th-e2e/case-before/real/pool/.treehouse/project-2b98d4/1/project is not managed by treehouse
  error: treehouse return failed for worktree /tmp/fm-th-e2e/case-before/real/pool/.treehouse/project-2b98d4/1/project; teardown aborted
  exit=1
  
  task meta still present? YES
  treehouse status:
    1     leased       /tmp/fm-th-e2e/case-before/link/pool/.treehouse/project-2b98d4/1/project  (held by firstmate)

  ### pool-root shape   : physical   (TREEHOUSE_ROOT=/tmp/fm-th-e2e/before-physical/real/pool)
  meta worktree=        : /tmp/fm-th-e2e/before-physical/real/pool/.treehouse/project-3a1af1/1/project
  treehouse registered  : /tmp/fm-th-e2e/before-physical/real/pool/.treehouse/project-3a1af1/1/project
  
  $ bin/fm-teardown.sh task-x1      [fm root: /tmp/fm-base]
    🌳 Worktree returned to pool.
    /tmp/fm-th-e2e/before-physical/real/project: already current
    teardown task-x1 complete (window firstmate:fm-task-x1, worktree /tmp/fm-th-e2e/before-physical/real/pool/.treehouse/project-3a1af1/1/project)
    Backlog: task-x1 just finished (this home keeps no markdown backlog at /tmp/fm-th-e2e/before-physical/real/data/backlog.md). Update /tmp/fm-th-e2e/before-physical/real/data/backlog.md - move task-x1 to Done, keep Done to the 10 most recent, then re-scan Queued and dispatch only work whose blockers are gone and date is due.
  exit=0
  task meta after teardown: removed (teardown completed)
  treehouse status:
    1     available    /tmp/fm-th-e2e/before-physical/real/pool/.treehouse/project-3a1af1/1/project
  
  rc=0
  ===========
  ### pool-root shape   : symlinked-pool-root   (TREEHOUSE_ROOT=/tmp/fm-th-e2e/before-symlinked-pool-root/real/poolhome)
  meta worktree=        : /tmp/fm-th-e2e/before-symlinked-pool-root/elsewhere/project-c4e1ed/1/project
  treehouse registered  : /tmp/fm-th-e2e/before-symlinked-pool-root/real/poolhome/.treehouse/project-c4e1ed/1/project
  
  $ bin/fm-teardown.sh task-x1      [fm root: /tmp/fm-base]
    worktree /tmp/fm-th-e2e/before-symlinked-pool-root/elsewhere/project-c4e1ed/1/project is not managed by treehouse
    error: treehouse return failed for worktree /tmp/fm-th-e2e/before-symlinked-pool-root/elsewhere/project-c4e1ed/1/project; teardown aborted
  exit=1
  task meta after teardown: still present (teardown aborted)
  treehouse status:
    1     leased       /tmp/fm-th-e2e/before-symlinked-pool-root/real/poolhome/.treehouse/project-c4e1ed/1/project  (held by firstmate)
  
  rc=1
  ===========


AFTER the fix  (target commit 79a6188)
======================================

  ### pool-root shape   : symlinked-parent   (TREEHOUSE_ROOT=/tmp/fm-th-e2e/after-symlinked-parent/link/pool)
  meta worktree=        : /tmp/fm-th-e2e/after-symlinked-parent/real/pool/.treehouse/project-34cc87/1/project
  treehouse registered  : /tmp/fm-th-e2e/after-symlinked-parent/link/pool/.treehouse/project-34cc87/1/project
  
  $ bin/fm-teardown.sh task-x1      [fm root: ~/.no-mistakes/worktrees/d58a82b70cc7/01M28J2SK29R6444KZA8VMA86R]
    🌳 Worktree returned to pool.
    /tmp/fm-th-e2e/after-symlinked-parent/real/project: already current
    teardown task-x1 complete (window firstmate:fm-task-x1, worktree /tmp/fm-th-e2e/after-symlinked-parent/real/pool/.treehouse/project-34cc87/1/project)
    Backlog: task-x1 just finished (this home keeps no markdown backlog at /tmp/fm-th-e2e/after-symlinked-parent/real/data/backlog.md). Update /tmp/fm-th-e2e/after-symlinked-parent/real/data/backlog.md - move task-x1 to Done, keep Done to the 10 most recent, then re-scan Queued and dispatch only work whose blockers are gone and date is due.
  exit=0
  task meta after teardown: removed (teardown completed)
  treehouse status:
    1     available    /tmp/fm-th-e2e/after-symlinked-parent/link/pool/.treehouse/project-34cc87/1/project
  
  rc=0
  ======================================================
  ### pool-root shape   : physical   (TREEHOUSE_ROOT=/tmp/fm-th-e2e/after-physical/real/pool)
  meta worktree=        : /tmp/fm-th-e2e/after-physical/real/pool/.treehouse/project-1cb75c/1/project
  treehouse registered  : /tmp/fm-th-e2e/after-physical/real/pool/.treehouse/project-1cb75c/1/project
  
  $ bin/fm-teardown.sh task-x1      [fm root: ~/.no-mistakes/worktrees/d58a82b70cc7/01M28J2SK29R6444KZA8VMA86R]
    🌳 Worktree returned to pool.
    /tmp/fm-th-e2e/after-physical/real/project: already current
    teardown task-x1 complete (window firstmate:fm-task-x1, worktree /tmp/fm-th-e2e/after-physical/real/pool/.treehouse/project-1cb75c/1/project)
    Backlog: task-x1 just finished (this home keeps no markdown backlog at /tmp/fm-th-e2e/after-physical/real/data/backlog.md). Update /tmp/fm-th-e2e/after-physical/real/data/backlog.md - move task-x1 to Done, keep Done to the 10 most recent, then re-scan Queued and dispatch only work whose blockers are gone and date is due.
  exit=0
  task meta after teardown: removed (teardown completed)
  treehouse status:
    1     available    /tmp/fm-th-e2e/after-physical/real/pool/.treehouse/project-1cb75c/1/project
  
  rc=0
  ======================================================
  ### pool-root shape   : symlinked-pool-root   (TREEHOUSE_ROOT=/tmp/fm-th-e2e/after-symlinked-pool-root/real/poolhome)
  meta worktree=        : /tmp/fm-th-e2e/after-symlinked-pool-root/elsewhere/project-1cfae7/1/project
  treehouse registered  : /tmp/fm-th-e2e/after-symlinked-pool-root/real/poolhome/.treehouse/project-1cfae7/1/project
  
  $ bin/fm-teardown.sh task-x1      [fm root: ~/.no-mistakes/worktrees/d58a82b70cc7/01M28J2SK29R6444KZA8VMA86R]
    🌳 Worktree returned to pool.
    /tmp/fm-th-e2e/after-symlinked-pool-root/real/project: already current
    teardown task-x1 complete (window firstmate:fm-task-x1, worktree /tmp/fm-th-e2e/after-symlinked-pool-root/elsewhere/project-1cfae7/1/project)
    Backlog: task-x1 just finished (this home keeps no markdown backlog at /tmp/fm-th-e2e/after-symlinked-pool-root/real/data/backlog.md). Update /tmp/fm-th-e2e/after-symlinked-pool-root/real/data/backlog.md - move task-x1 to Done, keep Done to the 10 most recent, then re-scan Queued and dispatch only work whose blockers are gone and date is due.
  exit=0
  task meta after teardown: removed (teardown completed)
  treehouse status:
    1     available    /tmp/fm-th-e2e/after-symlinked-pool-root/real/poolhome/.treehouse/project-1cfae7/1/project
  
  rc=0
  ======================================================
```
</details>
<details>
<summary>Evidence: Read-only spelling map over this bootc host&#39;s live treehouse pools, plus the live treehouse return rule</summary>

Source: [Read-only spelling map over this bootc host&#39;s live treehouse pools, plus the live treehouse return rule](https://github.com/Alberto-Codes/firstmate/blob/c7f05542382f20fa76604b0769a048fe56aa45c2/.no-mistakes/evidence/fm/teardown-slot-path-spelling-k17/live-host-pool-spellings.txt)

```text
Read-only check on the reporting host (bootc: /home -> /var/home)
=================================================================
For every slot this machine's live treehouse pools register, the path is
spelled the way fm-spawn would record it (physically resolved, /var/home/...)
and handed to bin/fm-wake-lib.sh's fm_treehouse_return_path - the helper
bin/fm-teardown.sh now uses at its `treehouse return` boundary. Nothing was
returned or mutated; these slots stay leased.

HOME=~  (physically ~)

recorded by fm-spawn (physical)                                          handed to treehouse return
-------------------------------                                          --------------------------
~/.treehouse/alberto-codes-site-be7b5f/1/alberto-codes-site ~/.treehouse/alberto-codes-site-be7b5f/1/alberto-codes-site
                                                                           -> matches the pool registration
~/.treehouse/alberto-codes-site-be7b5f/2/alberto-codes-site ~/.treehouse/alberto-codes-site-be7b5f/2/alberto-codes-site
                                                                           -> matches the pool registration
~/.treehouse/alberto-codes-site-be7b5f/3/alberto-codes-site ~/.treehouse/alberto-codes-site-be7b5f/3/alberto-codes-site
                                                                           -> matches the pool registration
~/.treehouse/docvet-338355/1/docvet                ~/.treehouse/docvet-338355/1/docvet
                                                                           -> matches the pool registration
~/.treehouse/docvet-338355/2/docvet                ~/.treehouse/docvet-338355/2/docvet
                                                                           -> matches the pool registration
~/.treehouse/firstmate-b8697d/1/firstmate          ~/.treehouse/firstmate-b8697d/1/firstmate
                                                                           -> matches the pool registration
~/.treehouse/firstmate-b8697d/2/firstmate          ~/.treehouse/firstmate-b8697d/2/firstmate
                                                                           -> matches the pool registration
~/.treehouse/firstmate-b8697d/3/firstmate          ~/.treehouse/firstmate-b8697d/3/firstmate
                                                                           -> matches the pool registration
~/.treehouse/firstmate-b8697d/4/firstmate          ~/.treehouse/firstmate-b8697d/4/firstmate
                                                                           -> matches the pool registration
~/.treehouse/firstmate-b8697d/5/firstmate          ~/.treehouse/firstmate-b8697d/5/firstmate
                                                                           -> matches the pool registration
~/.treehouse/repro-b69326/1/repro                  ~/.treehouse/repro-b69326/1/repro
                                                                           -> matches the pool registration
~/.treehouse/saucier-6b967b/1/saucier              ~/.treehouse/saucier-6b967b/1/saucier
                                                                           -> matches the pool registration
~/.treehouse/saucier-6b967b/2/saucier              ~/.treehouse/saucier-6b967b/2/saucier
                                                                           -> matches the pool registration
~/.treehouse/saucier-lab-f7bbc8/2/saucier-lab      ~/.treehouse/saucier-lab-f7bbc8/2/saucier-lab
                                                                           -> matches the pool registration
~/.treehouse/vramfit-383298/1/vramfit              ~/.treehouse/vramfit-383298/1/vramfit
                                                                           -> matches the pool registration
~/.treehouse/vramfit-383298/2/vramfit              ~/.treehouse/vramfit-383298/2/vramfit
                                                                           -> matches the pool registration
~/.treehouse/vramfit-383298/3/vramfit              ~/.treehouse/vramfit-383298/3/vramfit
                                                                           -> matches the pool registration
~/.treehouse/vramfit-383298/4/vramfit              ~/.treehouse/vramfit-383298/4/vramfit
                                                                           -> matches the pool registration
~/.treehouse/vramfit-383298/5/vramfit              ~/.treehouse/vramfit-383298/5/vramfit
                                                                           -> matches the pool registration
~/.treehouse/vramfit-383298/6/vramfit              ~/.treehouse/vramfit-383298/6/vramfit
                                                                           -> matches the pool registration
~/.treehouse/vramfit-383298/7/vramfit              ~/.treehouse/vramfit-383298/7/vramfit
                                                                           -> matches the pool registration
~/.treehouse/vramfit-383298/8/vramfit              ~/.treehouse/vramfit-383298/8/vramfit
                                                                           -> matches the pool registration
~/.treehouse/vramfit-383298/9/vramfit              ~/.treehouse/vramfit-383298/9/vramfit
                                                                           -> matches the pool registration

Live confirmation of the underlying treehouse rule (treehouse v2.3.0, scratch pool):
  $ treehouse return --force /tmp/fm-th-probe/real/pool/.treehouse/project-792b2e/1/project
  worktree /tmp/fm-th-probe/real/pool/.treehouse/project-792b2e/1/project is not managed by treehouse   [exit 1]
  $ treehouse return --force /tmp/fm-th-probe/link/pool/.treehouse/project-792b2e/1/project
  🌳 Worktree returned to pool.                                                                          [exit 0]
```
</details>
<details>
<summary>Evidence: The five new teardown cases run against both commits (fail-before / pass-after)</summary>

Source: [The five new teardown cases run against both commits (fail-before / pass-after)](https://github.com/Alberto-Codes/firstmate/blob/c7f05542382f20fa76604b0769a048fe56aa45c2/.no-mistakes/evidence/fm/teardown-slot-path-spelling-k17/regression-tests-fail-before-pass-after.txt)

```text
The five new tests/fm-teardown.test.sh cases, run against both commits
======================================================================
Each case was run on its own against a clean checkout of the base commit
(git archive e0d269e -> /tmp/fm-base, same tests/, base bin/) and then as
part of the full tests/fm-teardown.test.sh run on the target commit.

case                                              base e0d269e   target 79a6188
------------------------------------------------  ------------   -------------
registration holds the symlinked spelling (z1)    not ok         ok
registration holds the physical spelling  (z2)    not ok         ok
pool registers some other slot            (z3)    ok             ok
no pool registry at all                   (z4)    ok             ok
treehouse rejects the spelling given      (z5)    ok             ok

Base-commit output (one invocation per case):

  BASE  test_slot_registered_under_symlinked_spelling_is_returned_that_way
    not ok - symlinked-registration: teardown should complete when the pool registered the symlinked spelling: expected exit 0, got 1
  BASE  test_slot_registered_under_physical_spelling_is_returned_that_way
    not ok - physical-registration: teardown should complete when the pool registered the physical spelling: expected exit 0, got 1
  BASE  test_slot_the_pool_does_not_register_is_passed_through_byte_identical
    ok - a slot the pool does not register is handed to treehouse byte-identical
  BASE  test_worktree_without_a_pool_registry_is_returned_unchanged
    ok - a worktree with no pool registry is returned unchanged
  BASE  test_rejected_slot_return_still_refuses_loudly
    ok - a return treehouse rejects keeps the loud failure instead of silently dropping the lease

Target-commit output (from the full tests/fm-teardown.test.sh run, 89/89 ok):

  ok - a slot registered under its symlinked spelling is returned under that spelling
  ok - a slot registered under its physical spelling is returned under that spelling
  ok - a slot the pool does not register is handed to treehouse byte-identical
  ok - a worktree with no pool registry is returned unchanged
  ok - a return treehouse rejects keeps the loud failure instead of silently dropping the lease
```
</details>
<details>
<summary>Evidence: Reported failure reproduced at base and fixed at target (real treehouse, bootc-shaped symlinked pool root)</summary>

```text
BEFORE (base e0d269e)
meta worktree= : /tmp/.../real/pool/.treehouse/project-2b98d4/1/project
treehouse registered : /tmp/.../link/pool/.treehouse/project-2b98d4/1/project
$ bin/fm-teardown.sh task-x1
worktree /tmp/.../real/pool/.treehouse/project-2b98d4/1/project is not managed by treehouse
error: treehouse return failed for worktree ...; teardown aborted
exit=1 task meta still present: YES
treehouse status: 1 leased /tmp/.../link/pool/.treehouse/project-2b98d4/1/project (held by firstmate)

AFTER (target 79a6188)
$ bin/fm-teardown.sh task-x1
🌳 Worktree returned to pool.
teardown task-x1 complete (window firstmate:fm-task-x1, worktree /tmp/.../real/pool/.treehouse/project-34cc87/1/project)
exit=0 task meta: removed (teardown completed)
treehouse status: 1 available /tmp/.../link/pool/.treehouse/project-34cc87/1/project
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"fd59c6314419806af60778356c33f0f938dad9d0","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>⚠️ **Review** - 1 info</summary>

- ⚠️ `bin/fm-wake-lib.sh:1247` - fm_treehouse_return_path decides treehouse&#39;s registered spelling purely from a $HOME prefix test (the load-bearing claim is stated at line 1218: &#34;Its pool root is rooted at $HOME, so that is the spelling it stores&#34;). Treehouse&#39;s root is configurable (--root, TREEHOUSE_ROOT, config file, relative in-project pool) - this repo documents exactly that at bin/fm-claude-trust.sh:31-33 and deliberately avoids a treehouse path-prefix assumption for the same reason. Two wrong results follow on the very bootc host the intent describes. (a) Regression: with an in-project pool, or TREEHOUSE_ROOT written in the /var/home/... form, for a project that physically lives under the resolved home, treehouse registers slots under the physical spelling and the recorded meta path matches it today, so the return succeeds; after this change line 1247 rewrites it to ~ and `treehouse return` refuses it with &#34;worktree ... is not managed by treehouse&#34;, producing the identical loud abort at bin/fm-teardown.sh:3242 AFTER the worker&#39;s leaked processes were already killed - the same failure this change exists to remove, now in the opposite direction. (b) Remaining gap: if ~/.treehouse is itself a symlink onto another filesystem, the recorded physical slot path is not under the resolved $HOME at all, the `*` branch at line 1252 passes it through unchanged, and the reported failure stays reachable. The remedy - not the defect - is what needs authorization: deriving the spelling from treehouse&#39;s own registration (the pool&#39;s treehouse-state.json, which is_treehouse_pool_slot already locates at bin/fm-teardown.sh:312) or attempting the recorded path first and falling back to the re-spelled form on the &#34;not managed by treehouse&#34; signature both add a lookup or fallback branch beyond the stated intent.

🔧 Fix: derive treehouse return spelling from pool registration
1 info still open:

- ℹ️ `bin/fm-teardown.sh:1575` - The comment above the fm_treehouse_return_path call still describes the abandoned round-1 approach: &#34;Re-spell the path through $HOME at the return boundary; the helper owns the HOME resolution.&#34; The helper no longer does any HOME resolution - it reads the spelling out of the pool&#39;s treehouse-state.json registration (bin/fm-wake-lib.sh:1223-1262), which is why a non-$HOME-rooted or symlinked pool root now works. A maintainer following this comment would look for HOME logic that does not exist and could wrongly conclude the non-$HOME-rooted pool case is unhandled. Replace it with the registration-derived description already used at bin/fm-teardown.sh:169-172 and bin/fm-home-seed.sh:585-587. The second sentence (&#34;It never reports &#39;already reclaimed&#39; - failures stay loud&#34;) remains accurate.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`bin/fm-test-run.sh tests/fm-teardown.test.sh` - 89/89 ok, including the five new spelling cases (z1-z5)</code>
- <code>`bin/fm-test-run.sh tests/fm-secondmate-safety.test.sh` - 77/77 ok, covers the fm-home-seed.sh treehouse-return rollback call site</code>
- <code>Each new case run individually against a clean base-commit tree (`git archive e0d269e | tar -x -C /tmp/fm-base`): `test_slot_registered_under_symlinked_spelling_is_returned_that_way` and `test_slot_registered_under_physical_spelling_is_returned_that_way` fail at base, pass at target; the three guardrail cases pass on both</code>
- <code>Manual end-to-end: real `treehouse get --lease` pool + real `bin/fm-teardown.sh task-x1` (only tmux/gh/gh-axi/no-mistakes stubbed), base vs target, pool-root shapes `symlinked-parent`, `physical`, `symlinked-pool-root`; verified exit code, `treehouse status` slot state (leased -&gt; available), and removal of `state/task-x1.meta`</code>
- <code>Live treehouse rule check: `treehouse return --force &lt;physical-spelling&gt;` -&gt; &#34;is not managed by treehouse&#34; (exit 1) vs `treehouse return --force &lt;registered-spelling&gt;` -&gt; returned to pool (exit 0)</code>
- <code>Read-only pass of `fm_treehouse_return_path` over every slot registered in this bootc host&#39;s live `~/.treehouse` pools (20 slots, all mapped to the registered $HOME spelling; nothing returned or mutated)</code>
</details>

<details>
<summary>⚠️ **Document** - 1 info</summary>

- ℹ️ `tests/fm-teardown.test.sh:62` - The new test stub records that treehouse&#39;s return-matching rule (lexical cleaning, no symlink resolution, exact match against the one registered spelling) was &#34;verified live against treehouse v2.3.0&#34;, but bin/fm-install-treehouse.sh pins CI to v2.0.1, and no maintainer-verification doc records whether the pinned version shares that rule. The fact is external-tool- and version-dependent, which is the material docs/documentation-audiences.md routes to a maintainer-verification surface, yet the only existing candidate (docs/verification/runtime-backends.md) owns backend/harness evidence rather than treehouse path semantics. Resolving this needs either a live v2.0.1 observation or a decision to open a treehouse-specific verification surface, so I left the test comment as the sole owner rather than creating a documentation surface here. Judgment call worth a follow-up, not something this change made stale.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
