### PR TITLE
fix(opencode): deliver actionable wakes to most recently idle session

### DIFF
--- a/.agents/skills/harness-adapters/references/harness/opencode.md
+++ b/.agents/skills/harness-adapters/references/harness/opencode.md
@@ -41,3 +41,22 @@ On native Windows, the operational-input adapter runs its Bash helper through `b
 
 The companion `.opencode/plugins/fm-primary-watch-arm.js` owns normal TUI watcher supervision, wakes it with `client.session.promptAsync`, and coordinates with the guard before a blind-turn follow-up.
 The PreToolUse-equivalent watcher-arm seatbelt blocks by throwing from `tool.execute.before`.
+
+## Session parentage, verified 2026-09-11 with OpenCode 1.18.30
+
+`session.idle` carries only `{ sessionID }`, so the wake router cannot tell a captain's session from a delegated subagent session off the event alone.
+`client.session.get({ path: { id } })` supplies the missing field, and `.opencode/plugins/fm-primary-watch-arm.js` walks `parentID` to the top-level ancestor before it records a wake target.
+
+Probed live against `opencode serve` in a scratch git project:
+
+| Probe | Result |
+|---|---|
+| `POST /session` | `parentID` key absent |
+| `POST /session` with `{"parentID": "<id>"}` | `parentID` returned as sent |
+| `GET /session/{id}` on a top-level session | `parentID` key absent |
+| `GET /session/{id}` on a parented session | `parentID` present |
+| `POST /session/{id}/fork` | `parentID` key **absent** - a fork is top-level, not a child |
+
+The fork row is the one that matters for wake routing: `parentID` marks delegation only, so walking it never retargets a wake away from a session the captain works in.
+Real usage on the verification host agreed - of 56 stored sessions, 4 carried a parent and 3 of those ran as the `explore` subagent; observed nesting never exceeded one level.
+A harness that omits the lookup degrades to plain most-recently-idle routing, which is the behavior the walk refines rather than replaces.

--- a/.opencode/plugins/fm-primary-watch-arm.js
+++ b/.opencode/plugins/fm-primary-watch-arm.js
@@ -13,6 +13,10 @@ const ARM_RETIRE_TIMEOUT_MS = positiveInteger("FM_WATCH_ARM_RETIRE_TIMEOUT_MS", 
 const REARM_RETRY_BASE_MS = positiveInteger("FM_WATCH_REARM_RETRY_BASE_MS", 250);
 const REARM_RETRY_MAX_MS = positiveInteger("FM_WATCH_REARM_RETRY_MAX_MS", 4000);
 const REARM_RETRY_LIMIT = positiveInteger("FM_WATCH_REARM_RETRY_LIMIT", 5);
+// OpenCode's session.idle carries only a sessionID, and a subagent child session
+// emits its own idle, so an ancestor walk is the only way to tell a captain's
+// session from a delegated one. Bounded because the walk is server-supplied.
+const SESSION_ANCESTOR_LIMIT = 4;
 
 let child = null;
 let activeSessionID = "";
@@ -183,6 +187,22 @@ function observeArmOutput(stdout, stderr, settleReadiness) {
     setArmStatus("failed");
     settleReadiness("failed");
   }
+}
+
+async function resolveCaptainSession(client, sessionID) {
+  let current = sessionID;
+  for (let hop = 0; hop < SESSION_ANCESTOR_LIMIT && current; hop += 1) {
+    let parentID = "";
+    try {
+      parentID = (await client.session.get({ path: { id: current } }))?.data?.parentID ?? "";
+    } catch {
+      // A harness without the session lookup keeps the most-recently-idle rule.
+      return current;
+    }
+    if (!parentID) return current;
+    current = parentID;
+  }
+  return current;
 }
 
 async function sendPrompt(paths, client, sessionID, text) {
@@ -486,7 +506,12 @@ export const FmPrimaryWatchArm = async ({ client, directory, worktree }) => {
   const root = worktree ? resolvePath(worktree) : await resolveRoot(directory);
   const paths = effectivePaths(root);
   globalThis[COORDINATOR_KEY] = {
-    ensureArmed: (sessionID, activeClient) => ensureArm(paths, sessionID, activeClient ?? client),
+    ensureArmed: async (sessionID, activeClient) => {
+      const sessionClient = activeClient ?? client;
+      const captainSessionID = await resolveCaptainSession(sessionClient, sessionID);
+      if (captainSessionID) activeSessionID = captainSessionID;
+      return ensureArm(paths, captainSessionID, sessionClient);
+    },
   };
 
   return {
@@ -494,11 +519,13 @@ export const FmPrimaryWatchArm = async ({ client, directory, worktree }) => {
       if (event.type !== "session.idle") return;
       const sessionID = event.properties?.sessionID;
       if (!sessionID) return;
-      // Remember the most recently idle session so an actionable wake is
-      // delivered to the captain's active session even when another session
-      // in this home armed the watcher first.
-      activeSessionID = sessionID;
-      void ensureArm(paths, sessionID, client);
+      // Remember the most recently idle captain session so an actionable wake is
+      // delivered to the session the captain is watching even when another
+      // session in this home armed the watcher first. A subagent child's idle
+      // resolves to the captain session that delegated it, never to the
+      // finished child transcript.
+      activeSessionID = await resolveCaptainSession(client, sessionID);
+      void ensureArm(paths, activeSessionID, client);
     },
   };
 };

--- a/.opencode/plugins/fm-primary-watch-arm.js
+++ b/.opencode/plugins/fm-primary-watch-arm.js
@@ -15,6 +15,7 @@ const REARM_RETRY_MAX_MS = positiveInteger("FM_WATCH_REARM_RETRY_MAX_MS", 4000);
 const REARM_RETRY_LIMIT = positiveInteger("FM_WATCH_REARM_RETRY_LIMIT", 5);
 
 let child = null;
+let activeSessionID = "";
 let armStatus = "idle";
 let retryTimer = null;
 let retryFailures = 0;
@@ -396,12 +397,16 @@ function spawnArm(paths, sessionID, client, predecessorArmPid = "") {
       if (restorationInFlight) return;
       retryFailures = 0;
       setArmStatus("wake");
-      const restoration = restoreAfterActionableClose(paths, sessionID, client, predecessor);
+      // Deliver to the session that most recently went idle, not the one that
+      // first armed this watcher: a home can host more than one OpenCode
+      // session, and the captain watches whichever is active.
+      const deliverTo = activeSessionID || sessionID;
+      const restoration = restoreAfterActionableClose(paths, deliverTo, client, predecessor);
       restorationInFlight = restoration;
       void restoration.then(async (result) => {
         try {
           const message = result.failure ? `${classification.message}\n\n${result.failure}` : classification.message;
-          await deliverActionableWake(paths, client, sessionID, message, result.recovery);
+          await deliverActionableWake(paths, client, deliverTo, message, result.recovery);
         } finally {
           if (restorationInFlight === restoration) restorationInFlight = null;
         }
@@ -410,7 +415,7 @@ function spawnArm(paths, sessionID, client, predecessorArmPid = "") {
         surfaceFailure(
           paths,
           client,
-          sessionID,
+          deliverTo,
           `watcher: FAILED - OpenCode could not deliver an actionable wake\n${String(error?.message ?? error)}`,
         );
       });
@@ -420,7 +425,7 @@ function spawnArm(paths, sessionID, client, predecessorArmPid = "") {
       setArmStatus("failed");
       return;
     }
-    void scheduleRetry(paths, sessionID, client, classification.message, predecessor);
+    void scheduleRetry(paths, activeSessionID || sessionID, client, classification.message, predecessor);
   });
   armChild.on("error", (error) => {
     if (settled) return;
@@ -434,7 +439,7 @@ function spawnArm(paths, sessionID, client, predecessorArmPid = "") {
     }
     void scheduleRetry(
       paths,
-      sessionID,
+      activeSessionID || sessionID,
       client,
       `watcher: FAILED - OpenCode arm child failed: ${error.message}`,
       String(armChild.pid ?? ""),
@@ -489,6 +494,10 @@ export const FmPrimaryWatchArm = async ({ client, directory, worktree }) => {
       if (event.type !== "session.idle") return;
       const sessionID = event.properties?.sessionID;
       if (!sessionID) return;
+      // Remember the most recently idle session so an actionable wake is
+      // delivered to the captain's active session even when another session
+      // in this home armed the watcher first.
+      activeSessionID = sessionID;
       void ensureArm(paths, sessionID, client);
     },
   };

--- a/.opencode/plugins/fm-primary-watch-arm.js
+++ b/.opencode/plugins/fm-primary-watch-arm.js
@@ -354,7 +354,7 @@ async function scheduleRetry(paths, sessionID, client, reason, predecessorArmPid
   retryTimer = timer;
 }
 
-function spawnArm(paths, sessionID, client, predecessorArmPid = "") {
+function spawnArm(paths, client, predecessorArmPid = "") {
   setArmStatus("starting");
   const env = {
     ...process.env,
@@ -420,7 +420,7 @@ function spawnArm(paths, sessionID, client, predecessorArmPid = "") {
       // Deliver to the session that most recently went idle, not the one that
       // first armed this watcher: a home can host more than one OpenCode
       // session, and the captain watches whichever is active.
-      const deliverTo = activeSessionID || sessionID;
+      const deliverTo = activeSessionID;
       const restoration = restoreAfterActionableClose(paths, deliverTo, client, predecessor);
       restorationInFlight = restoration;
       void restoration.then(async (result) => {
@@ -445,7 +445,7 @@ function spawnArm(paths, sessionID, client, predecessorArmPid = "") {
       setArmStatus("failed");
       return;
     }
-    void scheduleRetry(paths, activeSessionID || sessionID, client, classification.message, predecessor);
+    void scheduleRetry(paths, activeSessionID, client, classification.message, predecessor);
   });
   armChild.on("error", (error) => {
     if (settled) return;
@@ -459,7 +459,7 @@ function spawnArm(paths, sessionID, client, predecessorArmPid = "") {
     }
     void scheduleRetry(
       paths,
-      activeSessionID || sessionID,
+      activeSessionID,
       client,
       `watcher: FAILED - OpenCode arm child failed: ${error.message}`,
       String(armChild.pid ?? ""),
@@ -475,7 +475,7 @@ async function beginArm(paths, sessionID, client, predecessorArmPid) {
   if (child) return { status: "existing", armChild: child };
   if (retryTimer) return { status: "retrying", armChild: null };
   if (!shouldArm(paths)) return { status: "not-needed", armChild: null };
-  return { status: "spawned", armChild: spawnArm(paths, sessionID, client, predecessorArmPid) };
+  return { status: "spawned", armChild: spawnArm(paths, client, predecessorArmPid) };
 }
 
 function armAttempt(status, armChild, includeArmChild) {

--- a/tests/fm-pi-watch-extension.test.sh
+++ b/tests/fm-pi-watch-extension.test.sh
@@ -4049,6 +4049,88 @@ EOF
   pass "OpenCode actionable wake follows the most recently idle session"
 }
 
+test_opencode_actionable_wake_skips_subagent_child_session() {
+  local plugin repo home log stop out status
+  plugin="$ROOT/.opencode/plugins/fm-primary-watch-arm.js"
+  repo="$TMP_ROOT/opencode-child-session-root"
+  home="$TMP_ROOT/opencode-child-session-home"
+  log="$TMP_ROOT/opencode-child-session.log"
+  stop="$TMP_ROOT/opencode-child-session.stop"
+  mkdir -p "$repo/bin" "$home/state" "$home/config"
+  git init -q "$repo"
+  : > "$repo/AGENTS.md"
+  : > "$home/state/task.meta"
+  cat > "$repo/bin/fm-watch-arm.sh" <<'SH'
+#!/usr/bin/env bash
+printf 'arm\n' >> "${FM_ARM_LOG:?}"
+count=$(wc -l < "$FM_ARM_LOG" | tr -d '[:space:]')
+if [ "$count" -eq 1 ]; then
+  sleep 0.5
+  printf 'signal: subagent wake\n'
+  exit 0
+fi
+printf 'watcher: started pid=%s (beacon fresh)\n' "$$"
+trap 'exit 0' TERM INT
+while [ ! -e "$FM_STOP_FILE" ]; do sleep 0.02; done
+SH
+  chmod +x "$repo/bin/fm-watch-arm.sh"
+  out=$(PLUGIN="$plugin" WORKTREE="$repo" FM_HOME="$home" FM_ARM_LOG="$log" FM_STOP_FILE="$stop" node 2>&1 <<'EOF'
+import { existsSync, writeFileSync } from "node:fs";
+import { pathToFileURL } from "node:url";
+
+const mod = await import(pathToFileURL(process.env.PLUGIN).href);
+// Mirrors OpenCode's GET /session/{id}: a delegated subagent session carries a
+// parentID, a captain's own top-level session does not.
+const sessions = {
+  "session-captain": { id: "session-captain" },
+  "session-subagent": { id: "session-subagent", parentID: "session-captain" },
+};
+const deliveries = [];
+const client = {
+  session: {
+    get: async (request) => ({ data: sessions[request.path.id] }),
+    promptAsync: async (request) => {
+      deliveries.push({ sessionID: request.path?.id, text: request.body.parts[0].text });
+    },
+  },
+};
+const hooks = await mod.FmPrimaryWatchArm({
+  client,
+  directory: process.env.WORKTREE,
+  worktree: process.env.WORKTREE,
+});
+writeFileSync(`${process.env.FM_HOME}/state/.lock`, `${process.pid}\n`);
+await hooks.event({ event: { type: "session.idle", properties: { sessionID: "session-captain" } } });
+for (let i = 0; i < 250 && !existsSync(process.env.FM_ARM_LOG); i += 1) {
+  await new Promise((resolve) => setTimeout(resolve, 20));
+}
+if (!existsSync(process.env.FM_ARM_LOG)) {
+  console.error("captain session did not arm the watcher");
+  process.exit(1);
+}
+await hooks.event({ event: { type: "session.idle", properties: { sessionID: "session-subagent" } } });
+for (let i = 0; i < 500; i += 1) {
+  if (deliveries.some((delivery) => delivery.text.includes("subagent wake"))) break;
+  await new Promise((resolve) => setTimeout(resolve, 10));
+}
+const wake = deliveries.find((delivery) => delivery.text.includes("subagent wake"));
+if (!wake) {
+  console.error(`actionable wake was never delivered: ${JSON.stringify(deliveries)}`);
+  process.exit(1);
+}
+if (wake.sessionID !== "session-captain") {
+  console.error(`actionable wake went to a delegated subagent session: ${wake.sessionID}`);
+  process.exit(1);
+}
+writeFileSync(process.env.FM_STOP_FILE, "stop\n");
+EOF
+  )
+  status=$?
+  expect_code 0 "$status" "OpenCode must not retarget an actionable wake at a subagent child session"
+  [ -z "$out" ] || fail "OpenCode child-session test printed output: $out"
+  pass "OpenCode actionable wake skips a subagent child session"
+}
+
 test_pi_extension_reports_external_healthy_watcher
 test_pi_tool_returns_agent_tool_result
 test_pi_redundant_tool_call_is_owned_noop
@@ -4098,3 +4180,4 @@ test_opencode_actionable_close_rechecks_session_lock
 test_opencode_watch_arm_coordinates_with_turnend_guard
 test_opencode_healthy_arm_output_does_not_suppress_guard
 test_opencode_actionable_wake_follows_most_recent_idle_session
+test_opencode_actionable_wake_skips_subagent_child_session

--- a/tests/fm-pi-watch-extension.test.sh
+++ b/tests/fm-pi-watch-extension.test.sh
@@ -3974,6 +3974,81 @@ EOF
   pass "OpenCode healthy arm output does not suppress the turn-end guard"
 }
 
+test_opencode_actionable_wake_follows_most_recent_idle_session() {
+  local plugin repo home log stop out status
+  plugin="$ROOT/.opencode/plugins/fm-primary-watch-arm.js"
+  repo="$TMP_ROOT/opencode-active-session-root"
+  home="$TMP_ROOT/opencode-active-session-home"
+  log="$TMP_ROOT/opencode-active-session.log"
+  stop="$TMP_ROOT/opencode-active-session.stop"
+  mkdir -p "$repo/bin" "$home/state" "$home/config"
+  git init -q "$repo"
+  : > "$repo/AGENTS.md"
+  : > "$home/state/task.meta"
+  cat > "$repo/bin/fm-watch-arm.sh" <<'SH'
+#!/usr/bin/env bash
+printf 'arm\n' >> "${FM_ARM_LOG:?}"
+count=$(wc -l < "$FM_ARM_LOG" | tr -d '[:space:]')
+if [ "$count" -eq 1 ]; then
+  sleep 0.5
+  printf 'signal: multi-session wake\n'
+  exit 0
+fi
+printf 'watcher: started pid=%s (beacon fresh)\n' "$$"
+trap 'exit 0' TERM INT
+while [ ! -e "$FM_STOP_FILE" ]; do sleep 0.02; done
+SH
+  chmod +x "$repo/bin/fm-watch-arm.sh"
+  out=$(PLUGIN="$plugin" WORKTREE="$repo" FM_HOME="$home" FM_ARM_LOG="$log" FM_STOP_FILE="$stop" node 2>&1 <<'EOF'
+import { existsSync, writeFileSync } from "node:fs";
+import { pathToFileURL } from "node:url";
+
+const mod = await import(pathToFileURL(process.env.PLUGIN).href);
+const deliveries = [];
+const client = {
+  session: {
+    promptAsync: async (request) => {
+      deliveries.push({ sessionID: request.path?.id, text: request.body.parts[0].text });
+    },
+  },
+};
+const hooks = await mod.FmPrimaryWatchArm({
+  client,
+  directory: process.env.WORKTREE,
+  worktree: process.env.WORKTREE,
+});
+writeFileSync(`${process.env.FM_HOME}/state/.lock`, `${process.pid}\n`);
+await hooks.event({ event: { type: "session.idle", properties: { sessionID: "session-first" } } });
+for (let i = 0; i < 250 && !existsSync(process.env.FM_ARM_LOG); i += 1) {
+  await new Promise((resolve) => setTimeout(resolve, 20));
+}
+if (!existsSync(process.env.FM_ARM_LOG)) {
+  console.error("first session did not arm the watcher");
+  process.exit(1);
+}
+await hooks.event({ event: { type: "session.idle", properties: { sessionID: "session-second" } } });
+for (let i = 0; i < 500; i += 1) {
+  if (deliveries.some((delivery) => delivery.text.includes("multi-session wake"))) break;
+  await new Promise((resolve) => setTimeout(resolve, 10));
+}
+const wake = deliveries.find((delivery) => delivery.text.includes("multi-session wake"));
+if (!wake) {
+  console.error(`actionable wake was never delivered: ${JSON.stringify(deliveries)}`);
+  process.exit(1);
+}
+if (wake.sessionID !== "session-second") {
+  console.error(`actionable wake went to the arming session, not the active one: ${wake.sessionID}`);
+  process.exit(1);
+}
+writeFileSync(process.env.FM_STOP_FILE, "stop\n");
+EOF
+  )
+  status=$?
+  expect_code 0 "$status" "OpenCode must deliver an actionable wake to the most recently idle session"
+  [ -z "$out" ] || fail "OpenCode active-session test printed output: $out"
+  pass "OpenCode actionable wake follows the most recently idle session"
+}
+
 test_pi_extension_reports_external_healthy_watcher
 test_pi_tool_returns_agent_tool_result
 test_pi_redundant_tool_call_is_owned_noop
@@ -4022,3 +4097,4 @@ test_opencode_established_empty_close_honors_retry_limit
 test_opencode_actionable_close_rechecks_session_lock
 test_opencode_watch_arm_coordinates_with_turnend_guard
 test_opencode_healthy_arm_output_does_not_suppress_guard
+test_opencode_actionable_wake_follows_most_recent_idle_session


### PR DESCRIPTION
In a home with more than one OpenCode session, the primary watcher delivered every actionable wake to the session that first armed it, not the one in use. This tracks the most recently idle top-level session (resolving subagent child idles to the delegating top-level session via a bounded parentID walk) and uses it for actionable-wake delivery; a child/subagent idle never retargets delivery.

Coverage: behavioral plugin tests (most-recent-idle delivery, subagent-child skip) plus neighboring continuity tests green; busy-adapter wiring suite green; lint and doc-audience checks clean.