### PR TITLE
fix(fm-spawn): pass --trust so grok's project-content dialog cannot wedge workers

### DIFF
--- a/.agents/skills/harness-adapters/references/common/control-and-recovery.md
+++ b/.agents/skills/harness-adapters/references/common/control-and-recovery.md
@@ -19,7 +19,7 @@ No observed dialog proves only that launch.
 Each supported harness handles its folder-trust gate differently, and the tool reference owns the detail.
 For Claude, load `references/harness/claude.md`; its workspace-trust section owns the non-key-answerable gate and spawn-time pre-registration for every spawn kind.
 Cursor suppresses its dialog with launch-time `--trust`, and Muse suppresses its own with `--yolo`.
-Grok dodges its gate instead of granting trust, because its project picker appears only outside a project and the spawn starts in the isolated git root.
+Grok also suppresses its project-content trust dialog with launch-time `--trust`; `references/harness/grok.md` owns the prompt and why a key is not sent.
 Pi gates the fresh-worktree case too, but unlike Claude its dialog is answered with Enter, and `references/harness/pi.md` owns that recipe and where the decision persists.
 Codex shows a directory-trust dialog on the first run for a repository root.
 

--- a/.agents/skills/harness-adapters/references/harness/grok.md
+++ b/.agents/skills/harness-adapters/references/harness/grok.md
@@ -2,7 +2,7 @@
 
 The xAI `grok` TUI is Claude-Code-compatible.
 Verified initially on 2026-06-29 with 0.2.73, slash submission on 2026-07-03 with 0.2.82, effort on 2026-07-13 with 0.2.99, and exit on 2026-07-19 with 0.2.103.
-Launch shape: `grok --always-approve "$(cat <brief>)"`.
+Launch shape: `grok --trust --always-approve "$(cat <brief>)"`.
 
 ## Operating facts
 
@@ -13,6 +13,7 @@ Launch shape: `grok --always-approve "$(cat <brief>)"`.
 | Interrupt | Single `Ctrl+C`; Escape only focuses scrollback. |
 | Skill | `/<skill>`, for example `/no-mistakes`, with end-to-end user-skill discovery, invocation, and real `no-mistakes axi run` evidence; the popup may consume Enter and fill an argument placeholder, requiring a real second Enter. |
 | Autonomy | `--always-approve`, footer `· always-approve`, verified unattended; `--permission-mode bypassPermissions` is stronger equivalent. |
+| Trust | `--trust` suppresses the project-content dialog; `--always-approve` does not. |
 | Marker | `GROK_AGENT=1` on child or tool processes in 0.2.73 and no `CLAUDECODE`; a 1.0.0 hook instead had `GROK_HOOK_EVENT`, `GROK_HOOK_NAME`, `GROK_SESSION_ID`, and `GROK_WORKSPACE_ROOT` without `GROK_AGENT`, so ancestry guarantees identity. |
 | Resume | `grok --resume <session-id>`, or `grok -c` / `--continue` for cwd latest; `--fork-session` creates a new id. |
 | Model | `--model <model>`; discover current account models with `grok models`. |
@@ -31,9 +32,11 @@ Old Herdr logic treated any pane delta as submission, including popup closure an
 Tmux and Herdr now route captures through `../../../bin/fm-composer-lib.sh`, which classifies real text on every proven content row.
 `../../../docs/herdr-backend.md` owns the boundary and `../../../tests/fm-backend-herdr.test.sh` covers it.
 
-The "Run Grok Build in a project directory?" picker appears only outside a project, such as home, Desktop, Downloads, or `/tmp`.
-The spawn starts in the isolated git root, so Grok trusts it and needs no key.
-For unavoidable non-project launch, `[hints] project_picker_disabled = true` in `~/.grok/config.toml` suppresses the picker.
+A project-content trust dialog can appear on a fresh git project that has project instructions or hooks: `Do you trust the contents of this directory?`, with `Yes, proceed` / `y` and `No, quit` / `n`.
+`--always-approve` does not suppress it; `--trust` does, and remains accepted at launch even when `grok --help` omits the flag.
+The spawn therefore passes `--trust` on the grok template used by every spawn-capable backend, so a worker does not wait on `y`.
+This is not the older non-project directory picker; that prompt was not observed on grok 1.0.25 in git or non-git paths including `/tmp`.
+`../../../docs/verification/runtime-backends.md` owns the dated probe.
 
 ## Composer
 

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -1541,13 +1541,14 @@ launch_template() {
       fi
       ;;
     # grok (Grok Build TUI): a positional prompt starts the supervised interactive
-    # session. --always-approve auto-approves every tool execution (verified: the
-    # crewmate runs fully autonomously, no permission gate), which an unattended
-    # crewmate needs; it is the targeted equivalent of claude's
+    # session. --trust suppresses the project-content trust dialog on a fresh
+    # worktree (harness-adapters grok reference owns the prompt); --always-approve
+    # auto-approves every tool execution and does not cover that dialog, which an
+    # unattended crewmate still needs as the targeted equivalent of claude's
     # --dangerously-skip-permissions. grok's turn-end signal does NOT ride the
     # launch command - it is a Stop-event hook installed below (global hook +
     # per-task pointer), so the template is identical for ship/scout/secondmate.
-    grok) printf '%s' 'grok --always-approve __MODELFLAG____EFFORTFLAG__"$(__OPINPUT__ encode launch-brief < __BRIEF__)"' ;;
+    grok) printf '%s' 'grok --trust --always-approve __MODELFLAG____EFFORTFLAG__"$(__OPINPUT__ encode launch-brief < __BRIEF__)"' ;;
     # Cursor Agent CLI. --trust suppresses the workspace-trust prompt, which
     # --yolo does NOT cover and which would otherwise block every spawn, since
     # each task gets a fresh worktree path cursor has never seen. --yolo is the
@@ -3534,19 +3535,19 @@ EOF
       ;;
     grok*)
       # grok fires a Stop hook at every turn boundary (verified, grok 0.2.73), the
-      # clean equivalent of codex's notify= and pi's turn_end. But grok only loads
+      # clean equivalent of codex's notify= and pi's turn_end. grok only loads
       # PROJECT hooks (<worktree>/.grok/hooks/, <worktree>/.claude/settings.local.json)
-      # after the folder is granted hook-trust, which is not automatic and which
-      # firstmate cannot establish at launch without editing grok's own managed
-      # trust store (a high-blast-radius write). GLOBAL hooks in ~/.grok/hooks/ are
-      # always trusted and load on first launch with no gate. So the turn-end hook
-      # lives OUTSIDE the worktree as a single firstmate-owned global hook that is a
+      # after folder trust. Launch-time --trust is the vendor grant that also
+      # suppresses the project-content dialog; firstmate still does not hand-edit
+      # grok's managed trust store. GLOBAL hooks in ~/.grok/hooks/ are always
+      # trusted and load on first launch with no gate. So the turn-end hook lives
+      # OUTSIDE the worktree as a single firstmate-owned global hook that is a
       # guarded no-op for every non-firstmate grok session: it fires only when the
       # current workspace holds a .fm-grok-turnend token pointer that matches the
       # firstmate-owned hook registry. firstmate then drops that per-task pointer
       # (gitignored, like the other harnesses' worktree hook files).
-      # Result: the hook is outside the worktree, needs no trust grant, and never
-      # touches grok's managed config - only firstmate-owned files.
+      # Result: the hook is outside the worktree, does not depend on project-hook
+      # load, and never touches grok's managed config - only firstmate-owned files.
       GROK_HOOKS_DIR="${GROK_HOME:-$HOME/.grok}/hooks"
       GROK_AUTH_DIR="$GROK_HOOKS_DIR/fm-turn-end.d"
       mkdir -p "$GROK_AUTH_DIR"

--- a/docs/verification/runtime-backends.md
+++ b/docs/verification/runtime-backends.md
@@ -345,6 +345,34 @@ The lab home was deleted and the test entry was removed from the store and verif
 That automated spawn case runs against a fake claude, so it asserts the store entry and the launch command and nothing more; the live arms above are what establish that the entry actually suppresses the dialog.
 The composer-classification record below observes the same gate from the other side, where an untrusted worktree left Claude, Grok, and Muse unverified because the guard reads a first-launch trust dialog as an unreadable composer.
 
+## Grok project-content trust
+
+Verified 2026-09-11 on grok 1.0.25 (f7e67d6988e2) [stable], tmux, Linux.
+`--trust` is omitted from `grok --help` on this build and remains accepted: `grok --trust --version` printed the same version line and exited 0.
+The grok spawn template is backend-independent, so this probe covers the launch used by every spawn-capable session provider.
+
+Isolated tmux windows launched `grok --always-approve` with no prompt in throwaway directories, then captured the pane without sending keys and without inspecting Grok's managed trust store.
+
+A fresh git project with `AGENTS.md`, and a fresh git project with `AGENTS.md` plus `.grok/hooks`, both rendered the project-content dialog:
+
+```text
+Do you trust the contents of this directory?
+<fresh-git-project>
+Grok Build may run or modify contents in this directory,
+posing security risks.
+Yes, proceed                 y
+No, quit                     n
+```
+
+A fresh git project with only a README, a non-git directory under a home-cache path, and a non-git directory under `/tmp` reached the idle composer instead.
+None of those launches rendered the older `Run Grok Build in a project directory?` picker.
+
+The same `AGENTS.md` git-project shape launched as `grok --trust --always-approve` skipped the dialog and reached the idle composer with footer `always-approve`.
+
+`bin/fm-spawn.sh` therefore passes `--trust` on the grok template.
+`tests/fm-spawn-dispatch-profile.test.sh` pins that launch command through the fake-tmux send log.
+Do not hand-edit Grok's managed trust files to refresh this record; rerun the isolated TUI probe after a Grok upgrade.
+
 ## Composer classification matrix
 
 The shared composer classifier (`bin/fm-composer-lib.sh`, `fm_composer_classify_screen`) owns every composer shape fleet-wide; each backend contributes only a capture and a capability descriptor.

--- a/tests/fm-send-inbox-doorbell-live-e2e.test.sh
+++ b/tests/fm-send-inbox-doorbell-live-e2e.test.sh
@@ -85,7 +85,7 @@ launch_cmd() {  # <name>
     codex) printf '%s' 'codex --dangerously-bypass-approvals-and-sandbox' ;;
     opencode) printf '%s' "OPENCODE_CONFIG_CONTENT='{\"permission\":{\"*\":\"allow\"}}' opencode" ;;
     pi|pi-signed) printf '%s' "$1" ;;
-    grok) printf '%s' 'grok --always-approve' ;;
+    grok) printf '%s' 'grok --trust --always-approve' ;;
     kimi) printf '%s' 'kimi --auto' ;;
     muse) printf '%s' 'MUSE_EXPERIMENTAL_FOREIGN_PERSONAL_CONTEXT_KILL=on muse --yolo' ;;
     *) return 1 ;;

--- a/tests/fm-spawn-dispatch-profile.test.sh
+++ b/tests/fm-spawn-dispatch-profile.test.sh
@@ -434,6 +434,21 @@ test_codex_omits_invalid_max_effort() {
   pass "codex omits unsupported max effort instead of passing a bad config value"
 }
 
+test_grok_launch_passes_trust() {
+  local rec id out status launch
+  id=profile-grok-trust
+  rec=$(make_spawn_case profile-grok-trust grok "$id")
+  read_case_record "$rec"
+
+  out=$(run_ship_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" "$id" "$PROJ_DIR")
+  status=$?
+  expect_code 0 "$status" "grok spawn should succeed"
+  launch=$(cat "$LAUNCH_LOG")
+  assert_contains "$launch" "grok --trust --always-approve" \
+    "grok launch must pass --trust so a fresh worktree does not wedge on the project-content trust dialog"
+  pass "grok launch passes --trust before --always-approve"
+}
+
 test_grok_threads_model_and_reasoning_effort() {
   local rec id out status launch
   id=profile-grok-z5
@@ -445,8 +460,8 @@ test_grok_threads_model_and_reasoning_effort() {
   expect_code 0 "$status" "grok spawn with profile flags should succeed"
   assert_meta_profile "$HOME_DIR/state/$id.meta" grok grok-4 high
   launch=$(cat "$LAUNCH_LOG")
-  assert_contains "$launch" "grok --always-approve --model 'grok-4' --reasoning-effort 'high'" \
-    "grok launch did not thread model and reasoning-effort flags"
+  assert_contains "$launch" "grok --trust --always-approve --model 'grok-4' --reasoning-effort 'high'" \
+    "grok launch did not thread --trust, model, and reasoning-effort flags"
   assert_not_contains "$launch" "--effort" "grok launch must use --reasoning-effort, not --effort"
   pass "grok receives --model and --reasoning-effort profile flags"
 }
@@ -462,8 +477,8 @@ test_grok_omits_invalid_max_reasoning_effort() {
   expect_code 0 "$status" "grok spawn with unsupported max reasoning effort should omit the effort flag"
   assert_meta_profile "$HOME_DIR/state/$id.meta" grok grok-4 max
   launch=$(cat "$LAUNCH_LOG")
-  assert_contains "$launch" "grok --always-approve --model 'grok-4' \"\$('${ROOT}/bin/fm-operational-input.sh' encode launch-brief < " \
-    "grok launch did not preserve the model flag and typed brief when max effort was omitted"
+  assert_contains "$launch" "grok --trust --always-approve --model 'grok-4' \"\$('${ROOT}/bin/fm-operational-input.sh' encode launch-brief < " \
+    "grok launch did not preserve --trust, the model flag, and typed brief when max effort was omitted"
   assert_not_contains "$launch" "--reasoning-effort" "grok launch must omit unsupported max reasoning effort"
   assert_not_contains "$launch" "--effort" "grok launch must not fall back to --effort for reasoning effort"
   pass "grok omits unsupported max reasoning effort"
@@ -481,8 +496,8 @@ test_grok_omits_invalid_xhigh_reasoning_effort() {
   expect_code 0 "$status" "grok spawn with unsupported xhigh reasoning effort should omit the effort flag"
   assert_meta_profile "$HOME_DIR/state/$id.meta" grok grok-4 xhigh
   launch=$(cat "$LAUNCH_LOG")
-  assert_contains "$launch" "grok --always-approve --model 'grok-4' \"\$('${ROOT}/bin/fm-operational-input.sh' encode launch-brief < " \
-    "grok launch did not preserve the model flag and typed brief when xhigh effort was omitted"
+  assert_contains "$launch" "grok --trust --always-approve --model 'grok-4' \"\$('${ROOT}/bin/fm-operational-input.sh' encode launch-brief < " \
+    "grok launch did not preserve --trust, the model flag, and typed brief when xhigh effort was omitted"
   assert_not_contains "$launch" "--reasoning-effort" "grok launch must omit unsupported xhigh reasoning effort"
   assert_not_contains "$launch" "--effort" "grok launch must not fall back to --effort for reasoning effort"
   pass "grok omits unsupported xhigh reasoning effort"
@@ -1311,6 +1326,7 @@ test_active_dispatch_profile_allows_raw_launch_command
 test_claude_threads_model_and_effort
 test_codex_threads_model_and_effort
 test_codex_omits_invalid_max_effort
+test_grok_launch_passes_trust
 test_grok_threads_model_and_reasoning_effort
 test_grok_omits_invalid_max_reasoning_effort
 test_grok_omits_invalid_xhigh_reasoning_effort


### PR DESCRIPTION
## Intent

Verify and correct Firstmate's shared facts about the current Grok Build project-content trust dialog, then ship the correction through the full validation path.

Before editing any tracked Firstmate material, load and follow firstmate-coding-guidelines.

Establish the installed Grok Build version and empirically test a real launch in a fresh, isolated Git project path. Distinguish a project-content trust prompt from the non-project directory picker. Treat the backlog report that Grok Build 1.0.25 displayed a project-content trust dialog as a lead to verify, not as sufficient proof. Capture only non-sensitive commands and rendered prompt facts; never inspect, copy, commit, or expose credentials or private managed trust-store contents.

Locate the single authoritative owners for Grok trust behavior, spawn-time prompt handling, tests, and dated maintainer verification. Correct or replace stale claims rather than duplicating them. Update implementation only if current behavior proves deterministic handling is required.

Review all affected supported worker runtimes and session providers as required by the coding guidelines. Add or update executable-interface regression coverage for any behavior change; do not write tests that assert source bytes.

Run the relevant focused tests, bin/fm-doc-audience-check.sh for maintained prose, and bin/fm-lint.sh if any shell code changes. Record current dated/versioned evidence in the existing maintainer-verification owner, not in general user docs.

Keep the change narrowly scoped to the current trust-dialog fact and its required handling. Do not modify Grok's managed trust files by hand, do not add an agent co-author, and do not alter the primary Firstmate copy's pre-existing uncommitted material.

Accepted empirical form of that verification: grok 1.0.25 (f7e67d6988e2) [stable] rendered "Do you trust the contents of this directory?" with Yes, proceed / y and No, quit / n on a fresh git project with AGENTS.md or hooks. --always-approve does not suppress it; --trust does, and remains accepted even when grok --help omits the flag. The older "Run Grok Build in a project directory?" picker was not observed on git or non-git paths including /tmp. Deterministic spawn handling is required: pass --trust on the grok template used by every spawn-capable backend.

## What Changed

- `bin/fm-spawn.sh`: grok launch template now passes `--trust --always-approve` (was `--always-approve` alone), since `--always-approve` does not suppress grok's project-content trust dialog on a fresh worktree; updated the surrounding comments to reflect that `--trust` is the vendor-granted suppression rather than relying on hook-trust workarounds.
- `.agents/skills/harness-adapters/references/harness/grok.md` and `references/common/control-and-recovery.md`: replaced the stale claim that Grok "dodges its gate" via the old non-project directory picker with the verified fact that a project-content trust dialog (`Do you trust the contents of this directory?`) can appear on a fresh git project, and that `--trust` (not `--always-approve`) suppresses it.
- `docs/verification/runtime-backends.md`: added a dated, versioned verification record (grok 1.0.25) documenting the empirical probe distinguishing the project-content trust dialog from the older non-project picker, and confirming `--trust` suppression.
- `tests/fm-spawn-dispatch-profile.test.sh`: added `test_grok_launch_passes_trust` and updated existing grok profile/effort tests to assert `--trust` appears in the launch command.
- `tests/fm-send-inbox-doorbell-live-e2e.test.sh`: updated the expected grok launch command to include `--trust`.

## Risk Assessment

✅ Low: The change is a single, well-evidenced flag addition (--trust) to the grok launch template plus matching doc updates and an executable-interface regression test; it is narrowly scoped, backed by dated empirical verification matching the stated intent, avoids duplicating facts across owners, and touches no other subsystem.

## Testing

Live-drove the grok --trust trust-dialog fix and its turn-end hook lifecycle end-to-end against the real grok binary in disposable isolated homes, confirming both the code fix and the maintainer-doc claims hold. Two scenarios remain untested with no live evidence: the fm-spawn dispatch-profile fixture (only run against a fake-tmux harness, not a live grok process) and the fleet-doorbell round trip (structurally blocked by fm-send.sh's own gate-agent guard from this gate worktree, not a fixable setup gap).

- Live validation: ⚠️ inconclusive - 4 of 6 scenarios driven live against the product

| Scenario | Result | Live | Evidence |
| --- | --- | --- | --- |
| real grok CLI accepts --trust and suppresses the fresh-project trust dialog | ✅ pass | live | Isolated GROK_HOME/HOME, fresh git project with AGENTS.md on real grok 1.0.30: baseline `grok --always-approve` (no --trust) wedged on &#39;Do you trust the contents of this directory?&#39;; the exact spawn-t… |
| --trust is accepted even though grok --help omits it, matching the doc&#39;s claim | ✅ pass | live | `grok --trust --version` on installed grok 1.0.30 printed the same version line and exited 0; `grok --help \| grep -i trust` returned nothing, confirming the flag is undocumented but accepted, consiste… |
| fm-spawn.sh grok launch template threads --trust before --always-approve, including model/reasoning-effort flags (fixture regression) | ⏸️ untested | no | Prior payload only exercised this against a fake-tmux fixture (`tests/fm-spawn-dispatch-profile.test.sh`), which asserts the constructed launch string rather than driving a real grok process, so it do… |
| turn-end Stop hook (installed by fm-spawn.sh&#39;s grok* block) still registers, fires, and tears down after the comment-only rewrite around it | ✅ pass | live | Reproduced fm-spawn.sh&#39;s exact (unchanged) hook-install snippet in an isolated GROK_HOME/state/worktree, then ran a real single-turn `grok --trust --always-approve --reasoning-effort low -p ...` from… |
| live steering-inbox doorbell round-trip through the real grok harness with the new --trust launch string | ⏸️ untested | no | bin/fm-send.sh&#39;s fm_refuse_if_gate_agent guard (bin/fm-gate-refuse-lib.sh) unconditionally refuses fleet-lifecycle actions when the invoked fm-send.sh script itself resolves inside a no-mistakes gate… |
| grok-relevant maintainer reference docs (grok.md, control-and-recovery.md, runtime-backends.md) match the empirically observed behavior | ✅ pass | live | Every claim checked against the real binary matched: the project-content dialog wording and Yes/No options exactly matched the doc&#39;s captured text; --trust suppresses it while --always-approve does no… |

<details>
<summary>Evidence: Baseline: grok --always-approve (no --trust) wedges on project-content trust dialog, fresh git project with AGENTS.md, isolated GROK_HOME/HOME</summary>

```text
Do you trust the contents of this directory?
/tmp/fm-grok-live-test.sQTcP4/proj

Grok Build may run or modify contents in this directory,
posing security risks.

Yes, proceed y
No, quit n

(Grok Build 1.0.30 [stable])
```
</details>
<details>
<summary>Evidence: Real spawn template `grok --trust --always-approve --model &#39;grok-4.6&#39; --reasoning-effort &#39;low&#39;` suppresses the dialog, reaches idle composer, completes a real turn</summary>

```text
❯ Reply with exactly: TRUST_OK
◆ Thought for 0.2s
TRUST_OK
Worked for 1.8s
...
╰─ Grok 4.6 (low) · always-approve ─╯
```
</details>
<details>
<summary>Evidence: Live turn-end Stop hook fires and touches the turn-ended marker; teardown removes the registry auth file</summary>

```text
grok --trust --always-approve --reasoning-effort low -p "Reply with exactly: HOOK_OK" -> HOOK_OK (exit 0)
TURNEND FILE EXISTS (hook fired)
remove_grok_turnend_auth: before -> fm.UYqif5AC30Se present; after -> removed
pointer removed
```
</details>
- Outcome: ⚠️ 1 warning across 1 run (15m20s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"f336aeac9793e94c0414df3d9c72d4fa5cbd9350","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}],"live_validation":{"verdict":"inconclusive","live":4,"total":6}} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>⚠️ **Test** - 1 warning</summary>

- ⚠️ live validation verdict: inconclusive (4 of 6 scenarios were driven live against the product); untested: fm-spawn.sh grok launch template threads --trust before --always-approve, including model/reasoning-effort flags (fixture regression), live steering-inbox doorbell round-trip through the real grok harness with the new --trust launch string
- Live validation: ⚠️ inconclusive - 4 of 6 scenarios driven live against the product

| Scenario | Result | Live | Evidence |
| --- | --- | --- | --- |
| real grok CLI accepts --trust and suppresses the fresh-project trust dialog | ✅ pass | live | Isolated GROK_HOME/HOME, fresh git project with AGENTS.md on real grok 1.0.30: baseline `grok --always-approve` (no --trust) wedged on &#39;Do you trust the contents of this directory?&#39;; the exact spawn-t… |
| --trust is accepted even though grok --help omits it, matching the doc&#39;s claim | ✅ pass | live | `grok --trust --version` on installed grok 1.0.30 printed the same version line and exited 0; `grok --help \| grep -i trust` returned nothing, confirming the flag is undocumented but accepted, consiste… |
| fm-spawn.sh grok launch template threads --trust before --always-approve, including model/reasoning-effort flags (fixture regression) | ⏸️ untested | no | Prior payload only exercised this against a fake-tmux fixture (`tests/fm-spawn-dispatch-profile.test.sh`), which asserts the constructed launch string rather than driving a real grok process, so it do… |
| turn-end Stop hook (installed by fm-spawn.sh&#39;s grok* block) still registers, fires, and tears down after the comment-only rewrite around it | ✅ pass | live | Reproduced fm-spawn.sh&#39;s exact (unchanged) hook-install snippet in an isolated GROK_HOME/state/worktree, then ran a real single-turn `grok --trust --always-approve --reasoning-effort low -p ...` from… |
| live steering-inbox doorbell round-trip through the real grok harness with the new --trust launch string | ⏸️ untested | no | bin/fm-send.sh&#39;s fm_refuse_if_gate_agent guard (bin/fm-gate-refuse-lib.sh) unconditionally refuses fleet-lifecycle actions when the invoked fm-send.sh script itself resolves inside a no-mistakes gate… |
| grok-relevant maintainer reference docs (grok.md, control-and-recovery.md, runtime-backends.md) match the empirically observed behavior | ✅ pass | live | Every claim checked against the real binary matched: the project-content dialog wording and Yes/No options exactly matched the doc&#39;s captured text; --trust suppresses it while --always-approve does no… |

- <code>Live: fresh isolated git project + AGENTS.md, GROK_HOME/HOME redirected, real grok 1.0.30 — baseline `grok --always-approve` wedges on the project-content trust dialog</code>
- <code>Live: same project shape with `grok --trust --always-approve --model &#39;grok-4.6&#39; --reasoning-effort &#39;low&#39;` — dialog suppressed, real model turn completed</code>
- <code>Live: `grok --trust --version` on the installed binary — flag accepted though absent from `grok --help`</code>
- <code>Live: reproduced fm-spawn.sh&#39;s grok* turn-end hook install snippet in an isolated GROK_HOME/worktree, ran a real single-turn grok invocation, confirmed the Stop hook touched the turn-ended marker, then called the real `remove_grok_turnend_auth` teardown function and confirmed the auth file and pointer were removed</code>
- <code>`bash tests/fm-spawn-dispatch-profile.test.sh` (grok cases only): test_grok_launch_passes_trust, test_grok_threads_model_and_reasoning_effort, test_grok_omits_invalid_max_reasoning_effort, test_grok_omits_invalid_xhigh_reasoning_effort (fake-tmux fixture, not a live grok process)</code>
- <code>Attempted: FM_HOME-isolated `bin/fm-send.sh` call from this gate worktree — confirmed the gate-agent refusal guard blocks it, establishing the doorbell scenario&#39;s untested reason</code>
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>⚠️ **Lint** - 1 warning</summary>

- ⚠️ linter found issues (exit code 1)
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
