### PR TITLE
WIP: workspace-context-bundle-k8

### DIFF
--- a/bin/fm-context-bundle.py
+++ b/bin/fm-context-bundle.py
@@ -1,0 +1,185 @@
+#!/usr/bin/env python3
+# fm-context-bundle.py - deterministic, read-only, model-free scoped
+# workspace context bundle.
+#
+# Given a scope root, walks it exactly the way bin/fm-docs-sweep.py does
+# (same file-inventory scan and byte//4 token estimate) and reports, as
+# bounded JSON:
+#   - inventory: file/byte/estimated-token counts for the whole scope, by
+#     top-level bucket - reused verbatim from fm_docs_sweep.build_inventory
+#   - tree: a nested directory/file listing of the scope, sorted and bounded
+#   - selected_files: a deterministic subset of the scope's files (sorted by
+#     relative path) chosen to fit an optional token/file budget, each with
+#     its path, size, estimated tokens, and sha256
+#
+# This never calls a model, never touches the network, never writes into
+# the scanned tree, and never mutates any tracked file (unless --out names
+# a path the caller chose, which is the caller's responsibility to keep
+# outside tracked material). Selection is a pure function of --root,
+# --ext/--include/--exclude, and --budget-tokens/--max-files: the same
+# inputs against an unchanged tree always produce the same bundle.
+#
+# A follow-on stage that packs full file *contents* into one blob (e.g. a
+# Repomix-style packer) is out of scope for this command by design and would
+# add a new install dependency; propose that separately for review rather
+# than bundling it here.
+from __future__ import annotations
+
+import argparse
+import fnmatch
+import importlib.util
+import sys
+import time
+from pathlib import Path
+
+_SWEEP_PATH = Path(__file__).resolve().with_name("fm-docs-sweep.py")
+
+
+def _load_sweep():
+    spec = importlib.util.spec_from_file_location("fm_docs_sweep", _SWEEP_PATH)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"cannot load {_SWEEP_PATH}")
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def eprint(*a, **kw):
+    print(*a, file=sys.stderr, **kw)
+
+
+def build_tree(rel_paths: list, max_items: int) -> tuple:
+    """Nested {name, type, children:[...]} tree from sorted relative paths.
+    Bounded by the number of *files* inserted (directories are free - they
+    only exist to route to the files that were kept), so the bound tracks
+    the same "how many leaves did you actually get" question every other
+    bounded() category in fm-docs-sweep answers."""
+    root = {"name": ".", "type": "dir", "children": {}}
+    inserted = 0
+    truncated = False
+    for rel in rel_paths:
+        if max_items >= 0 and inserted >= max_items:
+            truncated = True
+            break
+        parts = Path(rel).parts
+        node = root
+        for i, part in enumerate(parts):
+            if i == len(parts) - 1:
+                node["children"][part] = {"name": part, "type": "file"}
+            else:
+                node = node["children"].setdefault(part, {"name": part, "type": "dir", "children": {}})
+        inserted += 1
+
+    def finalize(node: dict) -> dict:
+        if node["type"] == "file":
+            return {"name": node["name"], "type": "file"}
+        children = sorted(node["children"].values(), key=lambda c: (c["type"] != "dir", c["name"]))
+        return {"name": node["name"], "type": "dir", "children": [finalize(c) for c in children]}
+
+    return finalize(root), truncated
+
+
+def select_files(records: list, budget_tokens: int, max_files: int) -> dict:
+    """Deterministic, sorted-by-path selection bounded by an optional token
+    budget and/or file count. Both -1 (default) means "no cap": every
+    candidate in scope is selected. Selection order is lexicographic by
+    relative path, so the same scope always yields the same prefix."""
+    ordered = sorted(records, key=lambda r: r.rel)
+    items = []
+    total_tokens = 0
+    for r in ordered:
+        tokens = r.size // 4
+        if max_files >= 0 and len(items) >= max_files:
+            break
+        if budget_tokens >= 0 and items and total_tokens + tokens > budget_tokens:
+            break
+        items.append({
+            "path": r.rel,
+            "bytes": r.size,
+            "estimated_tokens": tokens,
+            "sha256": r.sha256,
+        })
+        total_tokens += tokens
+    truncated = len(items) < len(ordered)
+    return {
+        "total_candidates": len(ordered),
+        "selected": len(items),
+        "truncated": truncated,
+        "estimated_tokens": total_tokens,
+        "items": items,
+    }
+
+
+def main(argv=None):
+    ap = argparse.ArgumentParser(
+        prog="fm-context-bundle.py",
+        description=(
+            "Deterministic, read-only, model-free scoped workspace context bundle. "
+            "Prints bounded JSON (schema fm-context-bundle.v1) to stdout."
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    ap.add_argument("--root", type=Path, default=Path.cwd(), help="Scope root to bundle (default: cwd).")
+    ap.add_argument("--scope", default=None, help="Label for this bundle in the output (default: --root's basename).")
+    ap.add_argument("--ext", action="append", default=None, help="File extension to include, repeatable (default: md).")
+    ap.add_argument("--exclude", action="append", default=None, help="Directory name to exclude, repeatable (adds to defaults).")
+    ap.add_argument("--include", action="append", default=None, help="Glob (fnmatch, matched against the file's path relative to --root), repeatable. Default: every file matched by --ext.")
+    ap.add_argument("--budget-tokens", type=int, default=-1, help="Stop selecting files once the running estimated-token total would exceed this (default: -1, unbounded).")
+    ap.add_argument("--max-files", type=int, default=-1, help="Cap the number of selected files (default: -1, unbounded).")
+    ap.add_argument("--max-tree-items", type=int, default=500, help="Cap on files listed in the tree; -1 for unbounded (default 500).")
+    ap.add_argument("--out", type=Path, default=None, help="Write JSON here instead of stdout. Callers must not point this at a tracked file.")
+    args = ap.parse_args(argv)
+
+    root = args.root.resolve()
+    if not root.is_dir():
+        eprint(f"fm-context-bundle: --root is not a directory: {root}")
+        return 1
+
+    sweep = _load_sweep()
+
+    exts = {e.lower().lstrip(".") for e in (args.ext or ["md"])}
+    exclude_dirs = set(sweep.DEFAULT_EXCLUDE_DIRS) | set(args.exclude or [])
+
+    started = time.time()
+    records = sweep.scan(root, exts, exclude_dirs)
+
+    if args.include:
+        records = [r for r in records if any(fnmatch.fnmatch(r.rel, pat) for pat in args.include)]
+
+    inventory = sweep.build_inventory(records)
+    rel_sorted = sorted((r.rel for r in records))
+    tree, tree_truncated = build_tree(rel_sorted, args.max_tree_items)
+    selected = select_files(records, args.budget_tokens, args.max_files)
+
+    out = {
+        "schema": "fm-context-bundle.v1",
+        "scope": args.scope or root.name,
+        "root": str(root),
+        "generated_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+        "elapsed_seconds": round(time.time() - started, 3),
+        "extensions": sorted(exts),
+        "include": sorted(args.include) if args.include else [],
+        "inventory": inventory,
+        "tree": tree,
+        "tree_truncated": tree_truncated,
+        "selected_files": selected,
+        "notes": [
+            "Read-only and model-free: no network call, no model call, no file in the scope was written or deleted.",
+            "Deterministic: the same --root, --ext/--include/--exclude, and --budget-tokens/--max-files against an unchanged tree always produce the same bundle.",
+            "inventory and the estimated_tokens field reuse fm-docs-sweep's scan and byte//4 estimate rather than a second implementation; run fm-docs-sweep.sh directly for duplicate/conflict/link/TODO analysis over this same scope.",
+            "selected_files is a manifest (path/bytes/tokens/sha256), never file contents - a full-content packer (e.g. a Repomix-style tool) is a separate, explicitly-invoked follow-up, not this command.",
+        ],
+    }
+
+    import json
+    text = json.dumps(out, indent=2, sort_keys=False)
+    if args.out:
+        args.out.write_text(text + "\n")
+        eprint(f"fm-context-bundle: wrote {args.out}")
+    else:
+        print(text)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/bin/fm-context-bundle.sh
+++ b/bin/fm-context-bundle.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# fm-context-bundle.sh - deterministic, read-only, model-free scoped
+# workspace context bundle.
+#
+# Usage:
+#   bin/fm-context-bundle.sh --root <path> [options...]
+#   bin/fm-context-bundle.sh --help
+#
+# Thin wrapper around bin/fm-context-bundle.py, which owns all flags,
+# defaults, and the JSON output schema (`fm-context-bundle.v1`) - run with
+# --help for the full flag list. It reuses bin/fm-docs-sweep.py's file scan
+# and token estimate rather than a second implementation, then adds a
+# bounded, deterministically sorted file tree and a deterministically
+# selected file manifest (path/bytes/estimated tokens/sha256, never file
+# contents) that fits an optional --budget-tokens or --max-files cap.
+#
+# It never calls a model, never touches the network, never writes into the
+# scanned tree, and never mutates any tracked file (unless --out names one -
+# keeping that path outside tracked material is the caller's job). No stage
+# here is applied, routed, or packed into full content; that stays a
+# separately explicit follow-up that consumes this tool's output.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+PY="$(command -v python3 || true)"
+if [ -z "$PY" ]; then
+  echo "fm-context-bundle: python3 required" >&2
+  exit 1
+fi
+
+exec "$PY" "$SCRIPT_DIR/fm-context-bundle.py" "$@"

--- a/bin/fm-docs-sweep.py
+++ b/bin/fm-docs-sweep.py
@@ -1,0 +1,484 @@
+#!/usr/bin/env python3
+# fm-docs-sweep.py - read-only, model-free documentation hygiene scan.
+#
+# Walks a scoped root and reports, as bounded machine-readable JSON:
+#   - inventory (file/byte/estimated-token counts, per top-level bucket)
+#   - exact-duplicate groups (sha256)
+#   - near-duplicate candidates (Jaccard shingle similarity, same basename only
+#     - e.g. AGENTS.md vs AGENTS.md across repos - not all-pairs across every
+#     file, which is not bounded at workspace scale)
+#   - conflict candidates: pairs of canonical instruction files (AGENTS.md/
+#     CLAUDE.md/README.md/CONTRIBUTING.md/SKILL.md by default), in different
+#     repos, that carry a section under the same heading whose body is NOT a
+#     near-identical copy - the shared heading is the structural "same topic"
+#     signal; the file pair, heading, and divergence score are small pointers
+#     for a later, separately explicit semantic-model pass, never full
+#     section text
+#   - broken local relative links
+#   - stale inline code-path references (backtick spans that look like a path
+#     and do not resolve under the nearest repo root)
+#   - open TODO/FIXME/HACK/XXX markers and "- [ ]" checklist items
+#
+# Every stage here is stdlib-only, local-filesystem-only, and read-only: no
+# network call, no model call, no file mutation, no Beads write, no task
+# routing. Run it directly or via bin/fm-docs-sweep.sh; see --help for flags.
+#
+# Output is capped per category via --max-items so a workspace-scale run
+# stays small; each category reports both a "total" count and the (possibly
+# shorter) "items" list, with "truncated" set when items were dropped.
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+import sys
+import time
+from pathlib import Path
+
+DEFAULT_EXCLUDE_DIRS = {
+    ".git", "node_modules", ".build", "DerivedData", ".cache", "dist",
+    "build", "vendor", "Pods", ".venv", "venv", "__pycache__", ".tox",
+}
+DEFAULT_CANONICAL_NAMES = {"AGENTS.md", "CLAUDE.md", "README.md", "CONTRIBUTING.md", "SKILL.md"}
+
+MAX_CONTENT_BYTES = 2_000_000
+MAX_GROUP_SIZE_FOR_PAIRWISE = 150
+MAX_STALE_REF_CHECKS_PER_FILE = 50
+SHINGLE_SIZE = 4
+
+LINK_RE = re.compile(r"\[[^\]\n]*\]\(([^)\s]+)(?:\s+\"[^\"]*\")?\)")
+CODE_SPAN_RE = re.compile(r"`([^`\n]{2,200})`")
+HEADING_RE = re.compile(r"^\s{0,3}#{1,6}\s+(.*)$")
+CHECKLIST_RE = re.compile(r"^\s*[-*]\s*\[\s\]\s*(.*)$")
+TODO_RE = re.compile(r"\b(TODO|FIXME|HACK|XXX)\b[:\s]*(.*)$", re.IGNORECASE)
+PATH_LIKE_RE = re.compile(r"^[A-Za-z0-9_][A-Za-z0-9_./-]*/[A-Za-z0-9_./-]+$")
+
+
+def eprint(*a, **kw):
+    print(*a, file=sys.stderr, **kw)
+
+
+class FileRecord:
+    __slots__ = ("path", "rel", "bucket", "repo", "size", "sha256", "content", "skipped_content")
+
+    def __init__(self, path: Path, rel: str, bucket: str, repo: str, size: int):
+        self.path = path
+        self.rel = rel
+        self.bucket = bucket
+        self.repo = repo
+        self.size = size
+        self.sha256 = ""
+        self.content = None
+        self.skipped_content = False
+
+
+def sha256_of(path: Path) -> str:
+    h = hashlib.sha256()
+    with open(path, "rb") as f:
+        for chunk in iter(lambda: f.read(1024 * 1024), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def read_text(path: Path) -> str:
+    with open(path, "rb") as f:
+        raw = f.read()
+    return raw.decode("utf-8", errors="replace")
+
+
+def find_repo_root(start_dir: Path, scan_root: Path, cache: dict) -> str:
+    """Nearest ancestor of start_dir (inclusive, bounded by scan_root) containing
+    a .git entry, as a path relative to scan_root. Falls back to "." when no
+    repo boundary is found within scope. Memoized per directory."""
+    key = start_dir
+    if key in cache:
+        return cache[key]
+    d = start_dir
+    found = None
+    while True:
+        if (d / ".git").exists():
+            found = d
+            break
+        if d == scan_root or d == d.parent:
+            break
+        d = d.parent
+    result = "." if found is None else str(found.relative_to(scan_root)) or "."
+    cache[key] = result
+    return result
+
+
+def shingles(text: str) -> set:
+    words = re.findall(r"[a-z0-9]+", text.lower())
+    if len(words) < SHINGLE_SIZE:
+        return {" ".join(words)} if words else set()
+    return {" ".join(words[i:i + SHINGLE_SIZE]) for i in range(len(words) - SHINGLE_SIZE + 1)}
+
+
+def jaccard(a: set, b: set) -> float:
+    if not a and not b:
+        return 1.0
+    if not a or not b:
+        return 0.0
+    inter = len(a & b)
+    union = len(a | b)
+    return inter / union if union else 0.0
+
+
+def walk_files(root: Path, exts: set, exclude_dirs: set):
+    for dirpath, dirnames, filenames in _os_walk(root):
+        dirnames[:] = [d for d in dirnames if d not in exclude_dirs and not d.startswith(".git")]
+        for name in filenames:
+            if "." not in name:
+                continue
+            ext = name.rsplit(".", 1)[-1].lower()
+            if ext in exts:
+                p = Path(dirpath) / name
+                if p.is_symlink():
+                    continue
+                yield p
+
+
+def _os_walk(root: Path):
+    import os
+    yield from os.walk(root, topdown=True, followlinks=False)
+
+
+def scan(root: Path, exts: set, exclude_dirs: set) -> list:
+    records = []
+    repo_cache: dict = {}
+    for p in walk_files(root, exts, exclude_dirs):
+        try:
+            size = p.stat().st_size
+        except OSError:
+            continue
+        rel = str(p.relative_to(root))
+        parts = Path(rel).parts
+        bucket = parts[0] if len(parts) > 1 else "."
+        repo = find_repo_root(p.parent, root, repo_cache)
+        rec = FileRecord(p, rel, bucket, repo, size)
+        try:
+            rec.sha256 = sha256_of(p)
+        except OSError as e:
+            eprint(f"fm-docs-sweep: skipping unreadable file {rel}: {e}")
+            continue
+        if size <= MAX_CONTENT_BYTES:
+            try:
+                rec.content = read_text(p)
+            except OSError:
+                rec.skipped_content = True
+        else:
+            rec.skipped_content = True
+        records.append(rec)
+    return records
+
+
+def build_inventory(records: list) -> dict:
+    total_bytes = sum(r.size for r in records)
+    buckets: dict = {}
+    for r in records:
+        b = buckets.setdefault(r.bucket, {"files": 0, "bytes": 0})
+        b["files"] += 1
+        b["bytes"] += r.size
+    bucket_list = sorted(
+        (
+            {
+                "bucket": name,
+                "files": v["files"],
+                "bytes": v["bytes"],
+                "estimated_tokens": v["bytes"] // 4,
+            }
+            for name, v in buckets.items()
+        ),
+        key=lambda x: -x["bytes"],
+    )
+    return {
+        "files": len(records),
+        "bytes": total_bytes,
+        "estimated_tokens": total_bytes // 4,
+        "buckets": bucket_list,
+    }
+
+
+def bounded(items: list, max_items: int):
+    total = len(items)
+    listed = items[:max_items] if max_items >= 0 else items
+    return {"total": total, "truncated": total > len(listed), "items": listed}
+
+
+def find_exact_duplicates(records: list, max_items: int) -> dict:
+    groups: dict = {}
+    for r in records:
+        groups.setdefault(r.sha256, []).append(r)
+    dup_groups = [g for g in groups.values() if len(g) > 1]
+    dup_groups.sort(key=lambda g: -(g[0].size * (len(g) - 1)))
+    redundant_files = sum(len(g) - 1 for g in dup_groups)
+    items = [
+        {
+            "sha256": g[0].sha256,
+            "size": g[0].size,
+            "files": [r.rel for r in g],
+        }
+        for g in dup_groups
+    ]
+    result = bounded(items, max_items)
+    result["groups"] = len(dup_groups)
+    result["redundant_files"] = redundant_files
+    return result
+
+
+def find_near_duplicates(records: list, near_dup_threshold: float, max_items: int) -> tuple:
+    """Whole-file candidates: same basename, different repos, high shingle
+    Jaccard. This is the redundant-copy signal (dedup/consolidate), not the
+    conflict signal - two files that genuinely disagree on a topic tend to
+    share very few exact word-order shingles, so they score *low* here, not
+    mid-band. See find_conflict_candidates for that case."""
+    by_basename: dict = {}
+    for r in records:
+        if r.skipped_content or r.content is None:
+            continue
+        by_basename.setdefault(Path(r.rel).name, []).append(r)
+
+    near_dups = []
+    skipped_groups = []
+    shingle_cache: dict = {}
+
+    def shingles_of(r: FileRecord) -> set:
+        if r.rel not in shingle_cache:
+            shingle_cache[r.rel] = shingles(r.content)
+        return shingle_cache[r.rel]
+
+    for basename, group in by_basename.items():
+        if len(group) < 2:
+            continue
+        if len(group) > MAX_GROUP_SIZE_FOR_PAIRWISE:
+            skipped_groups.append({"basename": basename, "files": len(group)})
+            continue
+        for i in range(len(group)):
+            for j in range(i + 1, len(group)):
+                a, b = group[i], group[j]
+                if a.repo == b.repo or a.sha256 == b.sha256:
+                    continue
+                sim = jaccard(shingles_of(a), shingles_of(b))
+                if sim >= near_dup_threshold:
+                    near_dups.append({
+                        "basename": basename,
+                        "jaccard": round(sim, 4),
+                        "file_a": a.rel,
+                        "file_b": b.rel,
+                        "bytes_a": a.size,
+                        "bytes_b": b.size,
+                    })
+
+    near_dups.sort(key=lambda x: -x["jaccard"])
+    return bounded(near_dups, max_items), skipped_groups
+
+
+def extract_sections(text: str) -> list:
+    """Split text on Markdown heading lines into (normalized_heading, body)
+    pairs. Content before the first heading is dropped - it has no heading to
+    key a cross-file match on."""
+    sections = []
+    heading = None
+    lines: list = []
+    for line in text.splitlines():
+        m = HEADING_RE.match(line)
+        if m:
+            if heading is not None:
+                sections.append((heading, "\n".join(lines)))
+            heading = re.sub(r"\s+", " ", m.group(1).strip().lower())
+            lines = []
+        else:
+            lines.append(line)
+    if heading is not None:
+        sections.append((heading, "\n".join(lines)))
+    return sections
+
+
+def find_conflict_candidates(records: list, canonical_names: set, near_dup_threshold: float, max_items: int) -> tuple:
+    """Candidates for a later, separately explicit semantic-model pass: pairs
+    of canonical instruction files, in different repos, that carry a section
+    under the *same* heading (e.g. "## Merge Authority") whose body text is
+    NOT a near-identical copy. A shared heading across independent repos is
+    the structural signal that they govern the same topic; only a model can
+    judge whether the differing bodies actually contradict, so this stage
+    outputs the file pair, heading, and divergence score only - never body
+    text - keeping the handoff small."""
+    heading_index: dict = {}
+    for r in records:
+        if r.skipped_content or r.content is None:
+            continue
+        if Path(r.rel).name not in canonical_names:
+            continue
+        for heading, body in extract_sections(r.content):
+            if len(heading.split()) < 2:
+                continue  # too generic ("Overview", "Notes") to be a useful key
+            heading_index.setdefault(heading, []).append((r, body))
+
+    conflicts = []
+    skipped_groups = []
+    for heading, entries in heading_index.items():
+        if len(entries) < 2:
+            continue
+        if len(entries) > MAX_GROUP_SIZE_FOR_PAIRWISE:
+            skipped_groups.append({"heading": heading, "files": len(entries)})
+            continue
+        for i in range(len(entries)):
+            for j in range(i + 1, len(entries)):
+                ra, body_a = entries[i]
+                rb, body_b = entries[j]
+                if ra.repo == rb.repo:
+                    continue
+                sim = jaccard(shingles(body_a), shingles(body_b))
+                if sim >= near_dup_threshold:
+                    continue  # near-identical section text: a copy, not a conflict
+                conflicts.append({
+                    "heading": heading,
+                    "jaccard": round(sim, 4),
+                    "file_a": ra.rel,
+                    "file_b": rb.rel,
+                })
+
+    conflicts.sort(key=lambda x: x["jaccard"])
+    return bounded(conflicts, max_items), skipped_groups
+
+
+def find_broken_links(records: list, root: Path, max_items: int) -> dict:
+    items = []
+    for r in records:
+        if r.skipped_content or r.content is None:
+            continue
+        for lineno, line in enumerate(r.content.splitlines(), start=1):
+            for m in LINK_RE.finditer(line):
+                target = m.group(1).strip()
+                if not target or "://" in target or target.startswith(("mailto:", "#", "tel:")):
+                    continue
+                target = target.split("#", 1)[0]
+                if not target:
+                    continue
+                resolved = (r.path.parent / target).resolve()
+                try:
+                    resolved.relative_to(root.resolve())
+                except ValueError:
+                    continue  # link escapes scan root; not this tool's business
+                if not resolved.exists():
+                    items.append({"file": r.rel, "line": lineno, "link": target})
+    return bounded(items, max_items)
+
+
+def find_stale_references(records: list, root: Path, max_items: int) -> dict:
+    items = []
+    for r in records:
+        if r.skipped_content or r.content is None:
+            continue
+        checked = 0
+        repo_dir = root / r.repo if r.repo != "." else root
+        for lineno, line in enumerate(r.content.splitlines(), start=1):
+            if checked >= MAX_STALE_REF_CHECKS_PER_FILE:
+                break
+            for m in CODE_SPAN_RE.finditer(line):
+                if checked >= MAX_STALE_REF_CHECKS_PER_FILE:
+                    break
+                token = m.group(1).strip()
+                if not PATH_LIKE_RE.match(token) or "://" in token:
+                    continue
+                checked += 1
+                candidate = (repo_dir / token).resolve()
+                try:
+                    candidate.relative_to(root.resolve())
+                except ValueError:
+                    continue
+                if not candidate.exists():
+                    items.append({"file": r.rel, "line": lineno, "ref": token, "checked_against": r.repo})
+    return bounded(items, max_items)
+
+
+def find_todos(records: list, max_items: int) -> dict:
+    items = []
+    total = 0
+    for r in records:
+        if r.skipped_content or r.content is None:
+            continue
+        for lineno, line in enumerate(r.content.splitlines(), start=1):
+            cm = CHECKLIST_RE.match(line)
+            tm = TODO_RE.search(line)
+            if cm:
+                total += 1
+                if len(items) < max_items or max_items < 0:
+                    items.append({"file": r.rel, "line": lineno, "kind": "checklist", "text": cm.group(1).strip()[:200]})
+            elif tm:
+                total += 1
+                if len(items) < max_items or max_items < 0:
+                    items.append({"file": r.rel, "line": lineno, "kind": tm.group(1).upper(), "text": line.strip()[:200]})
+    return {"total": total, "truncated": total > len(items), "items": items}
+
+
+def main(argv=None):
+    ap = argparse.ArgumentParser(
+        prog="fm-docs-sweep.py",
+        description="Read-only, model-free documentation hygiene scan. Prints bounded JSON (schema fm-docs-sweep.v1) to stdout.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    ap.add_argument("--root", type=Path, default=Path.cwd(), help="Scope root to scan (default: cwd).")
+    ap.add_argument("--ext", action="append", default=None, help="File extension to include, repeatable (default: md).")
+    ap.add_argument("--exclude", action="append", default=None, help="Directory name to exclude, repeatable (adds to defaults).")
+    ap.add_argument("--near-dup-threshold", type=float, default=0.6, help="Whole-file or section Jaccard >= this counts as a duplicate copy rather than a conflict candidate (default 0.6).")
+    ap.add_argument("--canonical-name", action="append", default=None, help="Canonical instruction filename to consider for conflict candidates, repeatable (default: AGENTS.md, CLAUDE.md, README.md, CONTRIBUTING.md, SKILL.md).")
+    ap.add_argument("--max-items", type=int, default=50, help="Cap on listed items per category; -1 for unbounded (default 50).")
+    ap.add_argument("--out", type=Path, default=None, help="Write JSON here instead of stdout.")
+    args = ap.parse_args(argv)
+
+    root = args.root.resolve()
+    if not root.is_dir():
+        eprint(f"fm-docs-sweep: --root is not a directory: {root}")
+        return 1
+
+    exts = {e.lower().lstrip(".") for e in (args.ext or ["md"])}
+    exclude_dirs = set(DEFAULT_EXCLUDE_DIRS) | set(args.exclude or [])
+    canonical_names = set(args.canonical_name or DEFAULT_CANONICAL_NAMES)
+
+    started = time.time()
+    records = scan(root, exts, exclude_dirs)
+    inventory = build_inventory(records)
+    exact = find_exact_duplicates(records, args.max_items)
+    near, near_skipped = find_near_duplicates(records, args.near_dup_threshold, args.max_items)
+    conflicts, conflict_skipped = find_conflict_candidates(records, canonical_names, args.near_dup_threshold, args.max_items)
+    links = find_broken_links(records, root, args.max_items)
+    stale = find_stale_references(records, root, args.max_items)
+    todos = find_todos(records, args.max_items)
+
+    out = {
+        "schema": "fm-docs-sweep.v1",
+        "root": str(root),
+        "generated_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+        "elapsed_seconds": round(time.time() - started, 3),
+        "extensions": sorted(exts),
+        "inventory": inventory,
+        "exact_duplicates": exact,
+        "near_duplicates": near,
+        "near_duplicate_groups_skipped_too_large": near_skipped,
+        "conflict_candidates": conflicts,
+        "conflict_candidate_groups_skipped_too_large": conflict_skipped,
+        "broken_links": links,
+        "stale_references": stale,
+        "todos": todos,
+        "notes": [
+            "Read-only and model-free: no network call, no model call, no file was written or deleted.",
+            "near_duplicates compares files sharing the same basename across different repos only; conflict_candidates compares canonical instruction files (AGENTS.md/CLAUDE.md/README.md/CONTRIBUTING.md/SKILL.md by default) that share a section heading across different repos. Both are bounded to groups of at most "
+            f"{MAX_GROUP_SIZE_FOR_PAIRWISE} files; larger groups are listed in the matching *_skipped_too_large field without pairwise comparison.",
+            "conflict_candidates names a file pair, its shared heading, and a divergence score only - never section body text; a separately explicit semantic-model pass is required to judge actual contradiction.",
+            "broken_links and stale_references are heuristic candidates, not confirmed dead references: a gitignored runtime path documented but never committed, or a package/module name that happens to look like a path, will show up here and needs human or model triage before acting.",
+        ],
+    }
+
+    text = json.dumps(out, indent=2, sort_keys=False)
+    if args.out:
+        args.out.write_text(text + "\n")
+        eprint(f"fm-docs-sweep: wrote {args.out}")
+    else:
+        print(text)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/bin/fm-docs-sweep.sh
+++ b/bin/fm-docs-sweep.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# fm-docs-sweep.sh - read-only, model-free documentation hygiene scan.
+#
+# Usage:
+#   bin/fm-docs-sweep.sh --root <path> [options...]
+#   bin/fm-docs-sweep.sh --help
+#
+# Thin wrapper around bin/fm-docs-sweep.py, which owns all flags, defaults,
+# and the JSON output schema (`fm-docs-sweep.v1`) - run with --help for the
+# full flag list. The default operation is entirely read-only and model-free:
+# scoped file inventory with byte/token estimates, exact-duplicate groups,
+# near-duplicate and conflict candidates (same-basename files across repos),
+# broken local links, stale inline code-path references, and open TODO/
+# checklist extraction, all as bounded JSON to stdout (or --out <path>).
+#
+# It never calls a model, never touches the network, never deletes or writes
+# a file (unless --out names one), never mutates a Beads store, and never
+# routes anything into a backlog. Any apply/task-routing/external-link/
+# semantic-model stage is out of scope for this command by design; wire it
+# up as a separate, explicitly-invoked step that consumes this output.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+PY="$(command -v python3 || true)"
+if [ -z "$PY" ]; then
+  echo "fm-docs-sweep: python3 required" >&2
+  exit 1
+fi
+
+exec "$PY" "$SCRIPT_DIR/fm-docs-sweep.py" "$@"

--- a/tests/fm-context-bundle.test.sh
+++ b/tests/fm-context-bundle.test.sh
@@ -1,0 +1,172 @@
+#!/usr/bin/env bash
+# Behavior tests for bin/fm-context-bundle.sh / bin/fm-context-bundle.py.
+#
+# fm-context-bundle is a deterministic, read-only, model-free scoped
+# workspace context bundle built on top of fm-docs-sweep's scan: every test
+# here builds a small fixture tree, runs the real executable against it, and
+# asserts on the JSON it prints - never on the Python source.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+BUNDLE="$ROOT/bin/fm-context-bundle.sh"
+
+jget() {
+  python3 -c '
+import json, sys
+d = json.loads(sys.argv[1])
+path = sys.argv[2].split(".")
+for p in path:
+    if isinstance(d, list):
+        d = d[int(p)]
+    else:
+        d = d[p]
+print(d if isinstance(d, str) else json.dumps(d))
+' "$1" "$2"
+}
+
+build_fixture() {
+  local root=$1
+  mkdir -p "$root/repoA/sub" "$root/repoB"
+  git -C "$root/repoA" init -q
+  git -C "$root/repoB" init -q
+
+  printf '# A\nhello world foo bar baz qux\n' > "$root/repoA/AGENTS.md"
+  printf '# Sub\nnested doc body text\n' > "$root/repoA/sub/NOTES.md"
+  printf '# B\nother repo readme text\n' > "$root/repoB/README.md"
+}
+
+test_inventory_and_selected_files_cover_the_whole_scope_by_default() {
+  local tmp out
+  tmp=$(fm_test_tmproot fm-context-bundle)
+  build_fixture "$tmp/fixture"
+
+  out=$("$BUNDLE" --root "$tmp/fixture" 2>&1)
+  expect_code 0 "$?" "bundle must exit 0 on a clean fixture"
+
+  assert_equals "fm-context-bundle.v1" "$(jget "$out" schema)" "output carries the bundle schema tag"
+  assert_equals "3" "$(jget "$out" inventory.files)" "inventory counts every scanned .md file"
+  assert_equals "3" "$(jget "$out" selected_files.total_candidates)" "all three files are candidates"
+  assert_equals "3" "$(jget "$out" selected_files.selected)" "with no budget/cap, every candidate is selected"
+  assert_equals "false" "$(jget "$out" selected_files.truncated)" "unbounded selection is never truncated"
+  pass "fm-context-bundle: unbounded run selects and reports the whole scope"
+}
+
+test_selection_is_deterministic_across_repeated_runs() {
+  local tmp out1 out2
+  tmp=$(fm_test_tmproot fm-context-bundle)
+  build_fixture "$tmp/fixture"
+
+  out1=$("$BUNDLE" --root "$tmp/fixture" --budget-tokens 10 2>&1)
+  out2=$("$BUNDLE" --root "$tmp/fixture" --budget-tokens 10 2>&1)
+  local items1 items2
+  items1=$(jget "$out1" selected_files.items)
+  items2=$(jget "$out2" selected_files.items)
+  assert_equals "$items1" "$items2" "the same scope and budget must select the exact same files in the exact same order"
+  pass "fm-context-bundle: selection is deterministic across repeated runs"
+}
+
+test_budget_tokens_bounds_selection_and_always_keeps_at_least_one_file() {
+  local tmp out
+  tmp=$(fm_test_tmproot fm-context-bundle)
+  build_fixture "$tmp/fixture"
+
+  out=$("$BUNDLE" --root "$tmp/fixture" --budget-tokens 1 2>&1)
+  assert_equals "1" "$(jget "$out" selected_files.selected)" "a budget smaller than any single file still keeps exactly one file"
+  assert_equals "true" "$(jget "$out" selected_files.truncated)" "a tight budget is reported as truncated"
+  assert_equals "repoA/AGENTS.md" "$(jget "$out" selected_files.items.0.path)" "selection is sorted lexicographically by relative path"
+  pass "fm-context-bundle: --budget-tokens bounds selection deterministically and never yields an empty bundle"
+}
+
+test_max_files_bounds_selection_count() {
+  local tmp out
+  tmp=$(fm_test_tmproot fm-context-bundle)
+  build_fixture "$tmp/fixture"
+
+  out=$("$BUNDLE" --root "$tmp/fixture" --max-files 2 2>&1)
+  assert_equals "2" "$(jget "$out" selected_files.selected)" "--max-files caps the selected count"
+  assert_equals "true" "$(jget "$out" selected_files.truncated)" "capping below the candidate count reports truncation"
+  pass "fm-context-bundle: --max-files bounds the selected file count"
+}
+
+test_include_glob_filters_candidates() {
+  local tmp out
+  tmp=$(fm_test_tmproot fm-context-bundle)
+  build_fixture "$tmp/fixture"
+
+  out=$("$BUNDLE" --root "$tmp/fixture" --include 'repoA/*' 2>&1)
+  assert_equals "2" "$(jget "$out" selected_files.total_candidates)" "--include narrows candidates to repoA only"
+  assert_not_contains "$out" "repoB/README.md" "an excluded-by-glob file never appears in the bundle"
+  pass "fm-context-bundle: --include filters candidates by glob before selection"
+}
+
+test_tree_is_nested_sorted_and_bounded() {
+  local tmp out
+  tmp=$(fm_test_tmproot fm-context-bundle)
+  build_fixture "$tmp/fixture"
+
+  out=$("$BUNDLE" --root "$tmp/fixture" 2>&1)
+  assert_equals "repoA" "$(jget "$out" tree.children.0.name)" "the tree lists repoA before repoB (sorted)"
+  assert_equals "dir" "$(jget "$out" tree.children.0.type)" "repoA is reported as a directory"
+  assert_equals "false" "$(jget "$out" tree_truncated)" "the default tree cap is not hit by this small fixture"
+
+  out=$("$BUNDLE" --root "$tmp/fixture" --max-tree-items 1 2>&1)
+  assert_equals "true" "$(jget "$out" tree_truncated)" "a tree item cap smaller than the fixture reports truncation"
+  pass "fm-context-bundle: tree output is nested, sorted, and honors --max-tree-items"
+}
+
+test_no_network_no_model_no_mutation() {
+  local tmp before after
+  tmp=$(fm_test_tmproot fm-context-bundle)
+  build_fixture "$tmp/fixture"
+
+  before=$(find "$tmp/fixture" -type f -exec sha256sum {} \; | sort)
+  "$BUNDLE" --root "$tmp/fixture" >/dev/null 2>&1
+  after=$(find "$tmp/fixture" -type f -exec sha256sum {} \; | sort)
+  assert_equals "$before" "$after" "running the bundle must never change any file under the scanned scope"
+  pass "fm-context-bundle: read-only - the scanned scope is byte-identical before and after"
+}
+
+test_out_flag_writes_file_instead_of_stdout() {
+  local tmp stdout_out
+  tmp=$(fm_test_tmproot fm-context-bundle)
+  build_fixture "$tmp/fixture"
+
+  stdout_out=$("$BUNDLE" --root "$tmp/fixture" --out "$tmp/bundle.json" 2>/dev/null)
+  assert_equals "" "$stdout_out" "with --out, nothing is printed to stdout"
+  assert_present "$tmp/bundle.json" "--out writes the JSON bundle to the named path"
+  assert_contains "$(cat "$tmp/bundle.json")" '"schema": "fm-context-bundle.v1"' "the written bundle carries the schema tag"
+  pass "fm-context-bundle: --out redirects the JSON bundle to a file instead of stdout"
+}
+
+test_help_exits_zero_and_documents_read_only_contract() {
+  local out rc
+  out=$("$BUNDLE" --help 2>&1)
+  rc=$?
+  expect_code 0 "$rc" "--help must exit 0"
+  assert_contains "$out" "read-only" "help text states the read-only contract"
+  assert_contains "$out" "--root" "help text documents --root"
+  assert_contains "$out" "--budget-tokens" "help text documents --budget-tokens"
+  pass "fm-context-bundle: --help exits 0 and documents the read-only contract and flags"
+}
+
+test_invalid_root_fails_cleanly() {
+  local out rc
+  out=$("$BUNDLE" --root "/no/such/path/fm-context-bundle-test" 2>&1)
+  rc=$?
+  expect_code 1 "$rc" "a missing --root must fail rather than scan the wrong tree"
+  assert_contains "$out" "not a directory" "the error names the problem"
+  pass "fm-context-bundle: a nonexistent --root fails cleanly instead of silently scanning elsewhere"
+}
+
+test_inventory_and_selected_files_cover_the_whole_scope_by_default
+test_selection_is_deterministic_across_repeated_runs
+test_budget_tokens_bounds_selection_and_always_keeps_at_least_one_file
+test_max_files_bounds_selection_count
+test_include_glob_filters_candidates
+test_tree_is_nested_sorted_and_bounded
+test_no_network_no_model_no_mutation
+test_out_flag_writes_file_instead_of_stdout
+test_help_exits_zero_and_documents_read_only_contract
+test_invalid_root_fails_cleanly

--- a/tests/fm-docs-sweep.test.sh
+++ b/tests/fm-docs-sweep.test.sh
@@ -1,0 +1,245 @@
+#!/usr/bin/env bash
+# Behavior tests for bin/fm-docs-sweep.sh / bin/fm-docs-sweep.py.
+#
+# fm-docs-sweep is a read-only, model-free documentation hygiene scan: every
+# test here builds a small fixture tree, runs the real executable against it,
+# and asserts on the JSON it prints - never on the Python source.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+SWEEP="$ROOT/bin/fm-docs-sweep.sh"
+
+# jget <json-text> <dotted.path>: pull one field out of the tool's JSON
+# output via a tiny stdlib json walk, so assertions read structured values
+# instead of grepping raw text.
+jget() {
+  python3 -c '
+import json, sys
+d = json.loads(sys.argv[1])
+path = sys.argv[2].split(".")
+for p in path:
+    if isinstance(d, list):
+        d = d[int(p)]
+    else:
+        d = d[p]
+print(d if isinstance(d, str) else json.dumps(d))
+' "$1" "$2"
+}
+
+build_fixture() {
+  local root=$1
+  mkdir -p "$root/repoA" "$root/repoB"
+  git -C "$root/repoA" init -q
+  git -C "$root/repoB" init -q
+
+  cat > "$root/repoA/AGENTS.md" <<'EOF'
+# Agent Rules
+
+## Merge Authority
+Always merge with yolo enabled and never wait for approval.
+Ship fast and trust the pipeline.
+
+## Delivery Mode
+Use direct-PR for everything.
+EOF
+
+  cat > "$root/repoB/AGENTS.md" <<'EOF'
+# Agent Rules
+
+## Merge Authority
+Never merge without explicit captain approval on every single pull request.
+Wait for the human every time before landing anything.
+
+## Delivery Mode
+Use no-mistakes for everything, always.
+EOF
+
+  cp "$root/repoA/AGENTS.md" "$root/repoA/AGENTS_copy.md"
+
+  cat > "$root/repoA/notes.md" <<'EOF'
+# Notes
+
+See [missing](./missing-target.md) and check `bin/does-not-exist.sh`.
+
+- [ ] open task one
+TODO: fix this later
+EOF
+}
+
+test_inventory_counts_files_bytes_and_buckets() {
+  local tmp out
+  tmp=$(fm_test_tmproot fm-docs-sweep)
+  build_fixture "$tmp/fixture"
+
+  out=$("$SWEEP" --root "$tmp/fixture" 2>&1)
+  expect_code 0 "$?" "sweep must exit 0 on a clean fixture"
+
+  assert_equals "4" "$(jget "$out" inventory.files)" "inventory counts every scanned .md file"
+  assert_equals "repoA" "$(jget "$out" inventory.buckets.0.bucket)" "the larger bucket (repoA) sorts first"
+  pass "fm-docs-sweep: inventory reports file count and per-bucket breakdown"
+}
+
+test_exact_duplicate_detected_by_hash() {
+  local tmp out
+  tmp=$(fm_test_tmproot fm-docs-sweep)
+  build_fixture "$tmp/fixture"
+
+  out=$("$SWEEP" --root "$tmp/fixture" 2>&1)
+  assert_equals "1" "$(jget "$out" exact_duplicates.groups)" "AGENTS.md and its byte-identical copy form one exact-duplicate group"
+  assert_contains "$out" "AGENTS_copy.md" "the exact-duplicate group names the copy"
+  pass "fm-docs-sweep: exact duplicates are grouped by sha256"
+}
+
+test_conflict_candidate_needs_same_heading_different_repos_diverging_body() {
+  local tmp out
+  tmp=$(fm_test_tmproot fm-docs-sweep)
+  build_fixture "$tmp/fixture"
+
+  out=$("$SWEEP" --root "$tmp/fixture" 2>&1)
+  local total
+  total=$(jget "$out" conflict_candidates.total)
+  assert_equals "2" "$total" "repoA and repoB AGENTS.md share two headings with diverging bodies"
+  assert_contains "$out" '"heading": "merge authority"' "conflict candidate names the shared heading"
+  assert_contains "$out" '"file_a": "repoA/AGENTS.md"' "conflict candidate names the first file"
+  assert_contains "$out" '"file_b": "repoB/AGENTS.md"' "conflict candidate names the second file"
+  pass "fm-docs-sweep: a shared heading with a diverging body is a conflict candidate, never full section text"
+}
+
+test_conflict_candidates_never_carry_section_body_text() {
+  local tmp out
+  tmp=$(fm_test_tmproot fm-docs-sweep)
+  build_fixture "$tmp/fixture"
+
+  out=$("$SWEEP" --root "$tmp/fixture" 2>&1)
+  assert_not_contains "$out" "yolo enabled" "conflict candidates must never leak repoA's section body text"
+  assert_not_contains "$out" "captain approval on every single" "conflict candidates must never leak repoB's section body text"
+  pass "fm-docs-sweep: conflict candidates stay small - file pair and heading only, never body text"
+}
+
+test_near_identical_section_is_not_a_conflict_candidate() {
+  local tmp out
+  tmp=$(fm_test_tmproot fm-docs-sweep)
+  mkdir -p "$tmp/fixture/repoA" "$tmp/fixture/repoB"
+  git -C "$tmp/fixture/repoA" init -q
+  git -C "$tmp/fixture/repoB" init -q
+  cat > "$tmp/fixture/repoA/AGENTS.md" <<'EOF'
+# Rules
+
+## Merge Authority
+Never merge without explicit captain approval on every pull request opened here.
+EOF
+  cat > "$tmp/fixture/repoB/AGENTS.md" <<'EOF'
+# Rules
+
+## Merge Authority
+Never merge without explicit captain approval on every pull request opened there.
+EOF
+
+  out=$("$SWEEP" --root "$tmp/fixture" 2>&1)
+  assert_equals "0" "$(jget "$out" conflict_candidates.total)" "a near-identical restated section is a duplicate, not a conflict"
+  pass "fm-docs-sweep: near-identical section bodies under a shared heading are excluded from conflict candidates"
+}
+
+test_broken_link_and_stale_reference_detected() {
+  local tmp out
+  tmp=$(fm_test_tmproot fm-docs-sweep)
+  build_fixture "$tmp/fixture"
+
+  out=$("$SWEEP" --root "$tmp/fixture" 2>&1)
+  assert_equals "1" "$(jget "$out" broken_links.total)" "the one dangling relative link is found"
+  assert_contains "$out" "missing-target.md" "broken link names the missing target"
+  assert_equals "1" "$(jget "$out" stale_references.total)" "the one nonexistent backtick path reference is found"
+  assert_contains "$out" "does-not-exist.sh" "stale reference names the missing path"
+  pass "fm-docs-sweep: broken relative links and stale inline path references are both surfaced"
+}
+
+test_todo_and_checklist_extraction() {
+  local tmp out
+  tmp=$(fm_test_tmproot fm-docs-sweep)
+  build_fixture "$tmp/fixture"
+
+  out=$("$SWEEP" --root "$tmp/fixture" 2>&1)
+  assert_equals "2" "$(jget "$out" todos.total)" "one open checklist item and one TODO marker are both counted"
+  assert_contains "$out" "open task one" "checklist item text is extracted"
+  assert_contains "$out" "fix this later" "TODO marker text is extracted"
+  pass "fm-docs-sweep: open checklist items and TODO/FIXME markers are extracted with file:line"
+}
+
+test_max_items_bounds_output_and_reports_truncation() {
+  local tmp out
+  tmp=$(fm_test_tmproot fm-docs-sweep)
+  mkdir -p "$tmp/fixture/repo"
+  git -C "$tmp/fixture/repo" init -q
+  for i in 1 2 3 4 5; do
+    printf 'TODO: item %s\n' "$i" > "$tmp/fixture/repo/f$i.md"
+  done
+
+  out=$("$SWEEP" --root "$tmp/fixture" --max-items 2 2>&1)
+  assert_equals "5" "$(jget "$out" todos.total)" "total count reflects every match regardless of the cap"
+  assert_equals "true" "$(jget "$out" todos.truncated)" "truncated is set once total exceeds max-items"
+  local listed
+  listed=$(jget "$out" todos.items)
+  assert_equals "2" "$(python3 -c "import json,sys; print(len(json.loads(sys.argv[1])))" "$listed")" "listed items are capped at max-items"
+  pass "fm-docs-sweep: --max-items bounds listed items per category and reports truncation separately from total"
+}
+
+test_no_network_no_model_no_mutation() {
+  local tmp out before after
+  tmp=$(fm_test_tmproot fm-docs-sweep)
+  build_fixture "$tmp/fixture"
+  before=$(find "$tmp/fixture" -type f | sort)
+
+  out=$("$SWEEP" --root "$tmp/fixture" 2>&1)
+  expect_code 0 "$?" "default sweep must succeed with no side effects"
+  after=$(find "$tmp/fixture" -type f | sort)
+  assert_equals "$before" "$after" "the default read-only sweep must not create, delete, or move any file in scope"
+  assert_contains "$out" "no network call, no model call" "the tool documents its own read-only/model-free contract in its output"
+  pass "fm-docs-sweep: the default operation is read-only and touches nothing under --root"
+}
+
+test_out_flag_writes_file_instead_of_stdout() {
+  local tmp stdout_out
+  tmp=$(fm_test_tmproot fm-docs-sweep)
+  build_fixture "$tmp/fixture"
+
+  stdout_out=$("$SWEEP" --root "$tmp/fixture" --out "$tmp/report.json" 2>/dev/null)
+  assert_equals "" "$stdout_out" "with --out, nothing is printed to stdout"
+  assert_present "$tmp/report.json" "--out writes the JSON report to the named path"
+  assert_contains "$(cat "$tmp/report.json")" '"schema": "fm-docs-sweep.v1"' "the written report carries the schema tag"
+  pass "fm-docs-sweep: --out redirects the JSON report to a file instead of stdout"
+}
+
+test_help_exits_zero_and_documents_read_only_contract() {
+  local out rc
+  out=$("$SWEEP" --help 2>&1)
+  rc=$?
+  expect_code 0 "$rc" "--help must exit 0"
+  assert_contains "$out" "Read-only" "help text states the read-only contract"
+  assert_contains "$out" "--root" "help text documents --root"
+  assert_contains "$out" "--max-items" "help text documents --max-items"
+  pass "fm-docs-sweep: --help exits 0 and documents the read-only contract and flags"
+}
+
+test_invalid_root_fails_cleanly() {
+  local out rc
+  out=$("$SWEEP" --root "/no/such/path/fm-docs-sweep-test" 2>&1)
+  rc=$?
+  expect_code 1 "$rc" "a missing --root must fail rather than scan the wrong tree"
+  assert_contains "$out" "not a directory" "the error names the problem"
+  pass "fm-docs-sweep: a nonexistent --root fails cleanly instead of silently scanning elsewhere"
+}
+
+test_inventory_counts_files_bytes_and_buckets
+test_exact_duplicate_detected_by_hash
+test_conflict_candidate_needs_same_heading_different_repos_diverging_body
+test_conflict_candidates_never_carry_section_body_text
+test_near_identical_section_is_not_a_conflict_candidate
+test_broken_link_and_stale_reference_detected
+test_todo_and_checklist_extraction
+test_max_items_bounds_output_and_reports_truncation
+test_no_network_no_model_no_mutation
+test_out_flag_writes_file_instead_of_stdout
+test_help_exits_zero_and_documents_read_only_contract
+test_invalid_root_fails_cleanly


### PR DESCRIPTION
## Handoff (WIP)

Session paused mid-task to save memory/quota; Codex takes over after the quota reset. This is a draft handoff PR, not ready for review.

### Done
- `bin/fm-context-bundle.py` / `bin/fm-context-bundle.sh` - deterministic, read-only, model-free scoped workspace context bundle (file tree, deterministically selected file manifest with path/bytes/token-estimate/sha256, and inventory) for a named scope.
- Reuses `bin/fm-docs-sweep.py`'s file scan and byte//4 token estimate directly (via `importlib`) instead of duplicating that logic.
- `tests/fm-context-bundle.test.sh` - 10 behavioral tests (determinism, `--budget-tokens`/`--max-files` bounding, `--include` glob filtering, tree nesting/truncation, read-only guarantee, `--out`, `--help`, invalid-root handling). All passing locally.
- `bin/fm-lint.sh` is clean against the two new shell files.

### Remaining from the brief
- **Rebase blocker**: `bin/fm-docs-sweep` (this PR's base commit) has not landed on `main` yet - it lives on the still-open `fm/firstmate-zero-cost-docs-k9` branch, so this branch was built on top of it to reuse it per the task spec ("reuse the docs sweep tool... and rebase onto it when it lands"). Once that branch merges, this branch needs `git rebase origin/main` so only the `fm-context-bundle` commit remains, then a rerun of `tests/fm-context-bundle.test.sh` and `bin/fm-lint.sh` before shipping.
- No `/no-mistakes` run has been started yet - intentionally paused per the queued instruction to wait for the rebase before validating.
- No `AGENTS.md` update was made; judged proportionate to skip for this addition since `fm-docs-sweep` (the sibling tool it's modeled on) isn't referenced there either. Worth a second look once both tools land together.

### Failing / unrun tests
- None known to be failing; the full suite for this change (`tests/fm-context-bundle.test.sh`) passes. The wider repo test suite and `/no-mistakes` pipeline have not been run against this branch.

### Open questions
- Whether `fm-context-bundle`'s default `--ext` (currently `md`, matching `fm-docs-sweep`) should broaden to cover source files for a "workspace context bundle," or stay doc-scoped as implemented - see the tool's own docstring for the reasoning.
- Whether a full-content packer (e.g. Repomix) is wanted as a genuine follow-up; this PR deliberately leaves that proposal for separate review rather than adding the dependency.
