### PR TITLE
WIP: fm-recover-missing-endpoint-k15

### DIFF
--- a/.agents/skills/stuck-crewmate-recovery/SKILL.md
+++ b/.agents/skills/stuck-crewmate-recovery/SKILL.md
@@ -36,6 +36,7 @@ Use `treehouse status` for treehouse-backed tmux, herdr, zellij, or cmux tasks, 
 Do not sweep another home's endpoints or infer ownership from a matching window label.
 
 Before relaunch, prove that no live agent still owns the recorded task and that the existing worktree remains available.
+A recorded endpoint the backend reports positively "missing" (not merely agent-free) is not a dead end: `bin/fm-control.sh <task-id> relaunch` itself opens a fresh endpoint bound to that same recorded worktree in this case (bin/fm-control.sh and bin/fm-spawn.sh own the exact mechanics), so it needs no separate recovery step here.
 Preserve its uncommitted changes and commits, keep the same task identity, and resume or relaunch the recorded harness in that existing worktree with the same brief plus a concise progress note.
 Do not use a fresh generic spawn while the recorded worktree is unaccounted for, because allocating another worktree can split one task across two copies.
 If the worktree or ownership cannot be reconciled safely, leave all state intact and report the task failed or blocked with the conflicting evidence.

--- a/bin/fm-control.sh
+++ b/bin/fm-control.sh
@@ -32,9 +32,14 @@
 #              the backend's recovery-grade classifier reports the agent gone.
 #              Already-stopped is success (idempotent).
 #   relaunch   Transactionally replace the running agent with a new one, in the
-#              SAME endpoint and SAME worktree, on the same or a newly chosen
-#              harness/model/effort - so switching harness is one ordinary use
-#              of this verb. An explicit `default` model or effort clears that
+#              SAME worktree, on the same or a newly chosen harness/model/
+#              effort - so switching harness is one ordinary use of this verb.
+#              Normally this reuses the SAME endpoint too; the one exception is
+#              a recorded endpoint the backend positively reports "missing"
+#              (authoritatively gone, not merely agent-free), where relaunch
+#              opens a FRESH endpoint bound to the same recorded worktree and
+#              task identity instead, since there is nothing left to adopt.
+#              An explicit `default` model or effort clears that
 #              axis for the replacement. With no explicit axis, a secondmate
 #              re-resolves its durable config/secondmate-harness pin (harness
 #              plus its optional model and effort tokens) exactly as any other
@@ -46,12 +51,12 @@
 #              inherits the local copy but none of the conversation; a
 #              secondmate reconciles its own home's records at startup, so its
 #              standing charter is never rewritten.
-#              Records a durable checkpoint and that note, exits the old agent,
-#              then delegates the launch to its single owner,
-#              bin/fm-spawn.sh --relaunch. A failure before publication keeps
-#              the prior durable record in place and reports the concrete
-#              state; it never leaves a half-transitioned task claiming to be
-#              running.
+#              Records a durable checkpoint and that note, exits the old agent
+#              (skipped when its endpoint is already positively missing), then
+#              delegates the launch to its single owner, bin/fm-spawn.sh
+#              --relaunch. A failure before publication keeps the prior
+#              durable record in place and reports the concrete state; it
+#              never leaves a half-transitioned task claiming to be running.
 #
 # Teardown and discard are NOT verbs here and never will be. `exit` stops an
 # agent and preserves everything else; removing a worktree, killing an
@@ -787,7 +792,7 @@ record_note() {
 }
 
 do_relaunch() {
-  local exit_result state note_line
+  local exit_result state note_line endpoint_was_missing=0
   local -a spawn_args
 
   require_state_verified_backend relaunch
@@ -825,7 +830,19 @@ do_relaunch() {
   journal_write noted "${CHECKPOINT_LINES[@]}" "$note_line"
 
   journal_write stopping "${CHECKPOINT_LINES[@]}" "$note_line"
-  exit_result=$(do_exit)
+  # A positively "missing" endpoint has no agent to stop - do_exit would only
+  # die on it. bin/fm-spawn.sh's --relaunch is the recovery owner: given
+  # RELAUNCH_STATE=missing it opens a FRESH endpoint bound to this same
+  # recorded worktree instead of adopting the (gone) one. Every other
+  # non-"alive" state (ambiguous, unreadable, unverified) still refuses
+  # exactly as do_exit already refuses it.
+  case "$(agent_state)" in
+    missing)
+      endpoint_was_missing=1
+      exit_result="not-needed: endpoint already missing"
+      ;;
+    *) exit_result=$(do_exit) ;;
+  esac
   journal_write exited "${CHECKPOINT_LINES[@]}" "$note_line" "exit_result=$exit_result"
 
   # The launch owner (fm-spawn --relaunch) clears the previous incarnation's
@@ -842,6 +859,17 @@ do_relaunch() {
     [ "$(fm_meta_get "$META" control_relaunch_tx)" != "$RELAUNCH_TX" ] \
       || RELAUNCH_META_PUBLISHED=1
     die "the replacement agent for $ID could not be launched on $TARGET_HARNESS"
+  fi
+
+  if [ "$endpoint_was_missing" = 1 ]; then
+    # The recovery launch opened a FRESH endpoint, not the one T/BACKEND were
+    # bound to at the top of this script (the now-gone recorded endpoint).
+    # Re-read the just-published record so the postcondition poll below
+    # watches the endpoint that actually exists.
+    fm_backend_validate_task_endpoint "$META" "$ID" \
+      || die "$ID's replacement was launched on $TARGET_HARNESS, but its freshly published endpoint could not be re-validated"
+    BACKEND=$FM_BACKEND_VALIDATED_BACKEND
+    T=$FM_BACKEND_VALIDATED_TARGET
   fi
 
   state=$(wait_agent_state "$LAUNCH_WAIT" alive) || {

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -28,21 +28,29 @@
 #   instruction files or a secondmate's charter.
 #        fm-spawn.sh <task-id> --relaunch [--harness <name>] [--model <name>] [--effort <level>]
 #   --relaunch launches a replacement agent for an EXISTING task into that
-#   task's own recorded endpoint and worktree instead of creating either. It is
-#   the launch half of the control plane (bin/fm-control.sh relaunch), which
-#   owns the checkpoint, the progress note, stopping the previous agent, and the
-#   transaction; call fm-control rather than this flag directly unless you are
-#   deliberately re-launching an already-stopped task. Every identity axis -
-#   backend, kind, project or home, worktree, endpoint - comes from the task's
-#   validated state/<id>.meta, so --backend, --scout, --secondmate, a project
+#   task's own recorded worktree, normally reusing its recorded endpoint too,
+#   instead of creating either. It is the launch half of the control plane
+#   (bin/fm-control.sh relaunch), which owns the checkpoint, the progress note,
+#   stopping the previous agent, and the transaction; call fm-control rather
+#   than this flag directly unless you are deliberately re-launching an
+#   already-stopped task. Every identity axis - backend, kind, project or
+#   home, worktree, endpoint - comes from the task's validated
+#   state/<id>.meta, so --backend, --scout, --secondmate, a project
 #   positional, and batch pairs are all refused alongside it; only harness,
 #   model, and effort may change, which is what makes a harness switch one
 #   ordinary relaunch. It refuses unless the recorded endpoint is positively
 #   agent-free on a backend with a recovery-grade agent-state classifier (tmux
 #   or herdr), and clears the previous harness's per-task wiring before arming
-#   the new incarnation. The replacement still never starts outside the copy
-#   holding the work: a Herdr shell that has drifted out of the recorded
-#   worktree is told once to return, and only a shell that will not go refuses.
+#   the new incarnation. When that endpoint reads positively "missing" (the
+#   backend confirms it is gone outright, not merely agent-free - a vanished
+#   Herdr pane after its runtime ran out of credits, for example), relaunch
+#   instead opens a FRESH endpoint on the same backend, bound to the SAME
+#   recorded worktree and task identity, and publishes it atomically: never a
+#   second worktree, never discarded or reset work. Every other non-"dead"
+#   state (alive, ambiguous, unreadable, unverified) still refuses. The
+#   replacement still never starts outside the copy holding the work: a Herdr
+#   shell that has drifted out of the recorded worktree is told once to
+#   return, and only a shell that will not go refuses.
 #   --harness <name> is the explicit per-spawn harness/profile adapter. The old
 #   positional harness arg still works for back-compat.
 #   --model <name> and --effort <low|medium|high|xhigh|max|ultra> are concrete profile
@@ -1249,6 +1257,14 @@ RAW_LAUNCH=0
 # validation teardown uses, so a malformed, ambiguous, or foreign record
 # refuses here exactly as it refuses there.
 RELAUNCH_PRIOR_HARNESS=
+# RELAUNCH_ENDPOINT_MISSING=1 marks the recovery case: the backend positively
+# confirms the recorded endpoint itself is gone (state "missing"), not merely
+# agent-free (state "dead"). Adoption is impossible with nothing to adopt, so
+# this drives the endpoint-creation step below to open a FRESH endpoint bound
+# to the task's already-recorded worktree instead of reusing RELAUNCH_TARGET.
+# Every other non-"dead" state (alive, ambiguous, unreadable, unverified)
+# still refuses exactly as before.
+RELAUNCH_ENDPOINT_MISSING=0
 if [ "$RELAUNCH" -eq 1 ]; then
   [ "${#POS[@]}" -eq 1 ] || {
     echo "error: --relaunch takes the task id only; its project or home comes from the task's own record" >&2
@@ -1283,10 +1299,14 @@ if [ "$RELAUNCH" -eq 1 ]; then
     exit 1
   }
   RELAUNCH_STATE=$(fm_backend_agent_state "$BACKEND" "$RELAUNCH_TARGET")
-  [ "$RELAUNCH_STATE" = dead ] || {
-    echo "error: task $ID's endpoint reads '$RELAUNCH_STATE'; a relaunch requires a positively agent-free endpoint (stop the agent first with bin/fm-control.sh $ID exit)" >&2
-    exit 1
-  }
+  case "$RELAUNCH_STATE" in
+    dead) ;;
+    missing) RELAUNCH_ENDPOINT_MISSING=1 ;;
+    *)
+      echo "error: task $ID's endpoint reads '$RELAUNCH_STATE'; a relaunch requires a positively agent-free endpoint (stop the agent first with bin/fm-control.sh $ID exit)" >&2
+      exit 1
+      ;;
+  esac
   RELAUNCH_PRIOR_HARNESS=$(fm_meta_get "$RELAUNCH_META" harness)
   KIND=$(fm_meta_get "$RELAUNCH_META" kind)
   [ -n "$KIND" ] || KIND=ship
@@ -2603,16 +2623,64 @@ fi
 
 W="fm-$ID"
 if [ "$RELAUNCH" -eq 1 ]; then
-  # Adopt the recorded endpoint instead of creating one. This is what keeps a
-  # relaunch a REPLACEMENT rather than a second copy of the task: no new
-  # terminal, no second worktree, and every uncommitted change left exactly
-  # where the previous agent left it.
-  T=$RELAUNCH_TARGET
   # A secondmate's home already resolved WT above through the same validation a
   # fresh secondmate spawn uses; every other kind takes the recorded worktree.
   [ "$KIND" = secondmate ] || WT=$RELAUNCH_WT
-  WT_TARGET=$T
-  SES=${T%%:*}
+  if [ "$RELAUNCH_ENDPOINT_MISSING" -eq 1 ]; then
+    # Recovery: the recorded endpoint is authoritatively gone, so there is
+    # nothing to adopt. Open a FRESH endpoint bound to the SAME already-
+    # recorded worktree (never a new one) using each backend's ordinary
+    # task-creation primitive, passing WT itself as the initial cwd so the
+    # replacement lands directly in the recorded local copy with no
+    # `treehouse get` and no new worktree allocation. Presentation/projection
+    # placement (herdr) is deliberately skipped here: the prior placement
+    # record may itself be stale, and this is a narrow recovery corridor
+    # where a flat placement is correct and simplest.
+    case "$BACKEND" in
+      tmux)
+        SES=$(fm_backend_tmux_container_ensure)
+        WID=$(fm_backend_tmux_create_task "$SES" "$W" "$WT") || exit 1
+        T="$SES:$W"
+        WT_TARGET="$WID"
+        ;;
+      herdr)
+        HERDR_LABEL_HOME=$FM_HOME
+        HERDR_LAUNCHER_RELATIONSHIP=launcher-home
+        if [ "$KIND" = secondmate ]; then
+          HERDR_LABEL_HOME=$WT
+          HERDR_LAUNCHER_RELATIONSHIP=other-home
+        fi
+        HERDR_CONTAINER_RAW=$(FM_HOME="$HERDR_LABEL_HOME" fm_backend_herdr_container_ensure "$WT" "$HERDR_LAUNCHER_RELATIONSHIP") || exit 1
+        CONTAINER=${HERDR_CONTAINER_RAW%%$'\t'*}
+        HERDR_SEEDED_DEFAULT_TAB_ID=${HERDR_CONTAINER_RAW#*$'\t'}
+        HERDR_SES=${CONTAINER%%:*}
+        HERDR_WORKSPACE_ID=${CONTAINER#*:}
+        HERDR_TASK_IDS=$(FM_HOME="$HERDR_LABEL_HOME" fm_backend_herdr_create_task "$CONTAINER" "$W" "$WT" "$HERDR_SEEDED_DEFAULT_TAB_ID") || exit 1
+        read -r HERDR_TAB_ID HERDR_PANE_ID <<EOF
+$HERDR_TASK_IDS
+EOF
+        [ -n "$HERDR_TAB_ID" ] && [ -n "$HERDR_PANE_ID" ] || {
+          echo "error: herdr did not return a tab/pane id for $W" >&2
+          exit 1
+        }
+        T="$HERDR_SES:$HERDR_PANE_ID"
+        ;;
+      *)
+        echo "error: backend '$BACKEND' cannot recover a missing endpoint; only tmux and herdr have verified recovery mechanics" >&2
+        exit 1
+        ;;
+    esac
+    WT_TARGET=$T
+    SES=${T%%:*}
+  else
+    # Adopt the recorded endpoint instead of creating one. This is what keeps a
+    # relaunch a REPLACEMENT rather than a second copy of the task: no new
+    # terminal, no second worktree, and every uncommitted change left exactly
+    # where the previous agent left it.
+    T=$RELAUNCH_TARGET
+    WT_TARGET=$T
+    SES=${T%%:*}
+  fi
 else
 case "$BACKEND" in
   tmux)

--- a/tests/fm-control-relaunch.test.sh
+++ b/tests/fm-control-relaunch.test.sh
@@ -111,6 +111,19 @@ case "${1:-}" in
     printf 'fakepane\n'; exit 0 ;;
   capture-pane) printf '╭────╮\n│    │\n╰────╯\n'; exit 0 ;;
   list-windows) [ -f "$D/windows" ] && cat "$D/windows"; exit 0 ;;
+  has-session|new-session|set-window-option) exit 0 ;;
+  new-window)
+    shift
+    wname=""
+    while [ $# -gt 0 ]; do
+      case "$1" in
+        -n) wname=$2; shift 2 ;;
+        *) shift ;;
+      esac
+    done
+    [ -z "$wname" ] || printf '%s\n' "$wname" >> "$D/windows"
+    printf '@fresh\n'
+    exit 0 ;;
 esac
 exit 0
 SH
@@ -1400,6 +1413,82 @@ test_spawn_relaunch_refuses_a_live_agent() {
   pass "fm-spawn --relaunch: refuses to launch a second agent into a live endpoint"
 }
 
+# --- 7. recovering a positively MISSING endpoint (glint-sld-proof-k4) --------
+#
+# The stranding this covers: the recorded endpoint (the tmux window in this
+# hermetic suite) is not merely agent-free, it is authoritatively GONE - a
+# Herdr pane vanishing after its runtime ran out of credits is the real
+# incident this models, but tmux is the reference backend the state machine
+# is pinned against here. Every prior verb refused this ("dead" was the only
+# license to relaunch); now "missing" opens a FRESH endpoint bound to the
+# SAME recorded worktree instead of adopting the (gone) one, never a second
+# worktree, never discarded work.
+
+test_spawn_relaunch_recovers_a_positively_missing_endpoint() {
+  local dir out rc new_window
+  dir=$(new_case missing-spawn rl60)
+  add_ship_task "$dir" rl60 claude
+  # The recorded window is now gone: not in the session's window list at all.
+  : > "$dir/fake/windows"
+  printf 'unfinished task work\n' > "$dir/wt/task.txt"
+
+  out=$(run_spawn "$dir" rl60 --relaunch --harness claude); rc=$?
+  expect_code 0 "$rc" "relaunching a positively missing endpoint should recover it"$'\n'"$out"
+  new_window=$(meta_field "$dir" rl60 window)
+  [ "$new_window" != "fmses:fm-rl60" ] \
+    || fail "recovery must open a FRESH endpoint, not claim to reuse the one that is gone"
+  [ -n "$new_window" ] || fail "recovery did not record a new endpoint at all"
+  [ "$(meta_field "$dir" rl60 worktree)" = "$dir/wt" ] \
+    || fail "recovery must reuse the SAME recorded worktree, never allocate a new one"
+  [ "$(meta_field "$dir" rl60 kind)" = ship ] || fail "kind must survive missing-endpoint recovery"
+  assert_grep "unfinished task work" "$dir/wt/task.txt" \
+    "recovery discarded uncommitted work in the recorded worktree"
+  pass "fm-spawn --relaunch: recovers a positively missing endpoint by opening a fresh one bound to the same worktree"
+}
+
+test_control_relaunch_recovers_a_positively_missing_endpoint() {
+  local dir out rc new_window
+  dir=$(new_case missing-control rl61)
+  add_ship_task "$dir" rl61 claude
+  : > "$dir/fake/windows"
+
+  out=$(run_control "$dir" rl61 relaunch --note "recovering from a vanished pane"); rc=$?
+  expect_code 0 "$rc" "fm-control relaunch should recover a positively missing endpoint"$'\n'"$out"
+  assert_contains "$out" "relaunched rl61 harness=claude" "the outcome should report success"
+  new_window=$(meta_field "$dir" rl61 window)
+  [ "$new_window" != "fmses:fm-rl61" ] \
+    || fail "recovery must open a fresh endpoint, not claim to reuse the one that is gone"
+  [ "$(meta_field "$dir" rl61 worktree)" = "$dir/wt" ] \
+    || fail "recovery must reuse the SAME recorded worktree"
+  [ "$(journal_field "$dir" rl61 phase)" = complete ] \
+    || fail "the transaction journal should end complete"
+  assert_no_grep "/exit" "$dir/fake/literal" \
+    "there is no agent at a missing endpoint, so no exit command should ever be sent"
+  assert_grep "encode launch-brief" "$dir/fake/literal" "the replacement should have been launched"
+  pass "fm-control relaunch: recovers a positively missing endpoint end to end (skips the exit step, opens a fresh endpoint, confirms it comes up alive)"
+}
+
+test_spawn_relaunch_still_refuses_an_ambiguous_or_unreadable_endpoint() {
+  local dir out rc
+  dir=$(new_case unreadable-spawn rl62)
+  add_ship_task "$dir" rl62 claude
+  mv "$dir/fakebin/tmux" "$dir/fakebin/tmux-real"
+  cat > "$dir/fakebin/tmux" <<SH
+#!/usr/bin/env bash
+if [ "\${1:-}" = list-windows ]; then
+  echo "some other tmux failure" >&2
+  exit 1
+fi
+exec "$dir/fakebin/tmux-real" "\$@"
+SH
+  chmod +x "$dir/fakebin/tmux"
+
+  out=$(run_spawn "$dir" rl62 --relaunch --harness claude); rc=$?
+  expect_code 1 "$rc" "relaunching an unreadable endpoint must still refuse, never guess recovery"
+  assert_contains "$out" "positively agent-free endpoint" "the refusal should demand an agent-free endpoint"
+  pass "fm-spawn --relaunch: an ambiguous or unreadable endpoint state still refuses, only 'missing' recovers"
+}
+
 test_spawn_relaunch_refuses_a_symlinked_task_record_before_inspection() {
   local dir meta target out rc
   dir=$(new_case symlink-meta rl37)
@@ -1611,3 +1700,8 @@ test_spawn_relaunch_refuses_an_unrecorded_task
 test_spawn_relaunch_refuses_a_pane_outside_the_worktree
 test_relaunch_reverifies_an_already_in_flight_item_instead_of_rewriting_it
 test_relaunch_moves_a_drifted_item_back_in_flight
+test_spawn_relaunch_recovers_a_positively_missing_endpoint
+test_control_relaunch_recovers_a_positively_missing_endpoint
+test_spawn_relaunch_still_refuses_an_ambiguous_or_unreadable_endpoint
+
+echo "# all fm-control-relaunch tests passed"


### PR DESCRIPTION
## Handoff (captain quota pause, mid-task)

**Task**: Add the smallest supported recovery path for a task whose recorded
endpoint the backend positively reports as gone ("missing", not merely
agent-free "dead", and not "unknown"/"unreadable"): `relaunch` should open a
FRESH endpoint bound to the SAME recorded worktree and task identity instead
of refusing, publish it atomically, and never allocate a second worktree or
discard/reset work.

Concrete motivating case: task `glint-sld-proof-k4` is stranded - its Herdr
pane vanished after its runtime ran out of credits, while its worktree
(clean, branch `fm/glint-sld-proof-k4`) and its parked no-mistakes run
survive. Every existing verb refused it (`fm-control.sh ... exit`,
`fm-control.sh ... relaunch`, `fm-spawn.sh ... --relaunch` all refused for
the same "missing endpoint" reason).

### Done

- `bin/fm-spawn.sh`: `--relaunch` now distinguishes `RELAUNCH_STATE=missing`
  from `dead`. On `missing` it opens a fresh tmux window / herdr pane rooted
  directly at the recorded worktree (skipping `treehouse get` and herdr
  presentation/projection) instead of adopting the gone endpoint. Every
  other non-`dead` state (alive, ambiguous, unreadable, unverified) still
  refuses exactly as before.
- `bin/fm-control.sh`: `do_relaunch` skips the exit step entirely when the
  endpoint already reads positively `missing` (there is nothing to stop),
  and re-reads the freshly published endpoint from metadata before its
  final "came up alive" postcondition poll, since the fresh endpoint is not
  the one the script bound at start.
- `.agents/skills/stuck-crewmate-recovery/SKILL.md`: one line noting
  relaunch now self-recovers a positively missing endpoint, per the
  one-owner rule (mechanics stay owned by the two scripts above).
- `tests/fm-control-relaunch.test.sh`: hermetic tmux coverage (tmux is the
  reference backend) - a positively missing endpoint recovers correctly via
  both `fm-spawn.sh --relaunch` directly and `fm-control.sh relaunch`
  end-to-end, preserving the worktree's uncommitted work and never touching
  a second worktree; a regression test confirms an ambiguous/unreadable
  endpoint state still refuses.
- `bin/fm-lint.sh` passed on the changed scripts.

### Remaining / not yet verified

- The extended `tests/fm-control-relaunch.test.sh` suite was still running
  in the background at handoff time (not yet confirmed green end to end) -
  re-run it before merge: `bash tests/fm-control-relaunch.test.sh`.
- **No herdr-specific automated test was added.** The herdr recovery code
  path in `bin/fm-spawn.sh` (mirrors the existing fresh-spawn herdr branch
  almost verbatim, substituting the recorded worktree for the project
  directory as the pane's cwd and skipping presentation/projection) is
  currently unverified by any test. A live-herdr smoke test
  (`tests/fm-control-herdr-smoke.test.sh`-style) was deliberately not
  added or run in this session because the launch brief was not
  `--herdr-lab`-enabled, so driving live Herdr lifecycle actions was out of
  scope; a hermetic backend-level test (`tests/fm-backend-herdr.test.sh`'s
  `make_herdr_statefake` pattern, exercising
  `fm_backend_herdr_container_ensure`/`fm_backend_herdr_create_task` called
  with the recorded worktree as cwd) was scoped but not completed before
  handoff.
- No no-mistakes run was started for this task yet.

### Open questions

- Should the herdr coverage be a live smoke test (needs `--herdr-lab`) or a
  hermetic stateful-fake test, or both?
- Is skipping herdr presentation/projection placement for this narrow
  recovery corridor (flat placement instead of preserving prior visual tab
  arrangement) an acceptable simplification, or does it need to attempt
  presentation recovery too?