### PR TITLE
feat(herdr): add guarded foreground viewer for live validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -310,6 +310,9 @@ jobs:
           bin/fm-test-run.sh --family real-herdr-gated \
             --fail-on-gate-skip 'herdr not found' \
             --json "$RUNNER_TEMP/fm-test/fm-test-timing-herdr.json"
+          bin/fm-test-run.sh tests/fm-herdr-attached-viewer-live-e2e.test.sh \
+            --fail-on-gate-skip 'herdr not found' \
+            --json "$RUNNER_TEMP/fm-test/fm-test-timing-herdr-attached-viewer.json"
       - name: Cleanup job-owned Herdr lab sessions
         if: always()
         run: |
@@ -327,6 +330,7 @@ jobs:
           name: fm-test-timing-herdr
           path: |
             ${{ runner.temp }}/fm-test/fm-test-timing-herdr.json
+            ${{ runner.temp }}/fm-test/fm-test-timing-herdr-attached-viewer.json
             ${{ runner.temp }}/fm-herdr/sessions-before.json
             ${{ runner.temp }}/fm-herdr/default-server.log
           if-no-files-found: warn

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -310,9 +310,6 @@ jobs:
           bin/fm-test-run.sh --family real-herdr-gated \
             --fail-on-gate-skip 'herdr not found' \
             --json "$RUNNER_TEMP/fm-test/fm-test-timing-herdr.json"
-          bin/fm-test-run.sh tests/fm-herdr-attached-viewer-live-e2e.test.sh \
-            --fail-on-gate-skip 'herdr not found' \
-            --json "$RUNNER_TEMP/fm-test/fm-test-timing-herdr-attached-viewer.json"
       - name: Cleanup job-owned Herdr lab sessions
         if: always()
         run: |
@@ -330,7 +327,6 @@ jobs:
           name: fm-test-timing-herdr
           path: |
             ${{ runner.temp }}/fm-test/fm-test-timing-herdr.json
-            ${{ runner.temp }}/fm-test/fm-test-timing-herdr-attached-viewer.json
             ${{ runner.temp }}/fm-herdr/sessions-before.json
             ${{ runner.temp }}/fm-herdr/default-server.log
           if-no-files-found: warn

--- a/bin/fm-herdr-lab-viewer.py
+++ b/bin/fm-herdr-lab-viewer.py
@@ -54,9 +54,11 @@ TERMINATE_GRACE_SECONDS = 5.0
 READ_CHUNK = 65536
 ROWS = 40
 COLS = 120
+TERMINATION_SIGNALS = (signal.SIGTERM, signal.SIGINT, signal.SIGHUP)
 
 
 def _child(slave, master, session):
+    signal.pthread_sigmask(signal.SIG_UNBLOCK, TERMINATION_SIGNALS)
     os.setsid()
     try:
         fcntl.ioctl(slave, termios.TIOCSCTTY, 0)
@@ -133,9 +135,11 @@ def main(argv):
     # Before the fork, so the TUI's first grid read already sees a real size.
     fcntl.ioctl(master, termios.TIOCSWINSZ, struct.pack("HHHH", ROWS, COLS, 0, 0))
 
+    signal.pthread_sigmask(signal.SIG_BLOCK, TERMINATION_SIGNALS)
     try:
         viewer_pid = os.fork()
     except OSError as error:
+        signal.pthread_sigmask(signal.SIG_UNBLOCK, TERMINATION_SIGNALS)
         sys.stderr.write("fm-herdr-lab-viewer: could not fork the viewer: %s\n" % error)
         return 3
     if viewer_pid == 0:
@@ -151,6 +155,7 @@ def main(argv):
     signal.signal(signal.SIGTERM, _cancel_before_record)
     signal.signal(signal.SIGINT, _cancel_before_record)
     signal.signal(signal.SIGHUP, _cancel_before_record)
+    signal.pthread_sigmask(signal.SIG_UNBLOCK, TERMINATION_SIGNALS)
 
     os.close(slave)
     try:

--- a/bin/fm-herdr-lab-viewer.py
+++ b/bin/fm-herdr-lab-viewer.py
@@ -18,11 +18,11 @@ The child also drops the inherited ``HERDR_*`` variables listed in
 ``SCRUBBED_ENV`` below. Herdr refuses to launch a nested viewer inside one of
 its own panes, and this helper normally runs from exactly there.
 
-Usage: fm-herdr-lab-viewer.py <session> <rows> <cols> <pidfile>
+Usage: fm-herdr-lab-viewer.py <session> <pidfile>
 
 Exit status:
   0  the viewer ran and exited;
-  2  arguments were invalid;
+  2  the session or pidfile was invalid;
   3  the pty or the viewer process could not be created.
 """
 
@@ -52,14 +52,8 @@ SCRUBBED_ENV = (
 SESSION_PATTERN = re.compile(r"\Afm-lab-[A-Za-z0-9][A-Za-z0-9_-]*\Z")
 TERMINATE_GRACE_SECONDS = 5.0
 READ_CHUNK = 65536
-
-
-def _positive_int(raw):
-    try:
-        value = int(raw, 10)
-    except ValueError:
-        return None
-    return value if value > 0 else None
+ROWS = 40
+COLS = 120
 
 
 def _child(slave, master, session):
@@ -120,17 +114,12 @@ def _drain(master):
 
 
 def main(argv):
-    if len(argv) != 5:
-        sys.stderr.write("fm-herdr-lab-viewer: usage: <session> <rows> <cols> <pidfile>\n")
+    if len(argv) != 3:
+        sys.stderr.write("fm-herdr-lab-viewer: usage: <session> <pidfile>\n")
         return 2
-    session, raw_rows, raw_cols, pidfile = argv[1:]
+    session, pidfile = argv[1:]
     if session == "default" or not SESSION_PATTERN.match(session):
         sys.stderr.write("fm-herdr-lab-viewer: refusing session %r\n" % session)
-        return 2
-    rows = _positive_int(raw_rows)
-    cols = _positive_int(raw_cols)
-    if rows is None or cols is None:
-        sys.stderr.write("fm-herdr-lab-viewer: rows and cols must be positive integers\n")
         return 2
     if not os.path.isabs(pidfile):
         sys.stderr.write("fm-herdr-lab-viewer: pidfile must be an absolute path\n")
@@ -142,7 +131,7 @@ def main(argv):
         sys.stderr.write("fm-herdr-lab-viewer: could not create a pty: %s\n" % error)
         return 3
     # Before the fork, so the TUI's first grid read already sees a real size.
-    fcntl.ioctl(master, termios.TIOCSWINSZ, struct.pack("HHHH", rows, cols, 0, 0))
+    fcntl.ioctl(master, termios.TIOCSWINSZ, struct.pack("HHHH", ROWS, COLS, 0, 0))
 
     try:
         viewer_pid = os.fork()
@@ -151,6 +140,17 @@ def main(argv):
         return 3
     if viewer_pid == 0:
         _child(slave, master, session)
+
+    def _cancel_before_record(signum, _frame):
+        try:
+            os.kill(viewer_pid, signal.SIGKILL)
+        except OSError:
+            pass
+        os._exit(128 + signum)
+
+    signal.signal(signal.SIGTERM, _cancel_before_record)
+    signal.signal(signal.SIGINT, _cancel_before_record)
+    signal.signal(signal.SIGHUP, _cancel_before_record)
 
     os.close(slave)
     try:

--- a/bin/fm-herdr-lab-viewer.py
+++ b/bin/fm-herdr-lab-viewer.py
@@ -14,9 +14,9 @@ this helper existed. The fix is ordering as much as sizing: the window size is
 set on the master fd BEFORE the fork, so the TUI cannot read the grid until it
 is already non-zero.
 
-The child also drops every inherited ``HERDR_*`` variable. Herdr refuses to
-launch a nested viewer inside one of its own panes, and this helper normally
-runs from exactly there.
+The child also drops the inherited ``HERDR_*`` variables listed in
+``SCRUBBED_ENV`` below. Herdr refuses to launch a nested viewer inside one of
+its own panes, and this helper normally runs from exactly there.
 
 Usage: fm-herdr-lab-viewer.py <session> <rows> <cols> <pidfile>
 
@@ -135,16 +135,20 @@ def main(argv):
     os.close(slave)
     _write_pidfile(pidfile, os.getpid(), viewer_pid)
 
-    def _terminate(_signum, _frame):
+    def _signal_viewer(number):
+        # The viewer may already be gone; that is the outcome we wanted anyway.
         try:
-            os.kill(viewer_pid, signal.SIGTERM)
+            os.kill(viewer_pid, number)
         except OSError:
             pass
+
+    def _terminate(_signum, _frame):
+        _signal_viewer(signal.SIGTERM)
 
     signal.signal(signal.SIGTERM, _terminate)
     signal.signal(signal.SIGINT, _terminate)
     signal.signal(signal.SIGHUP, _terminate)
-    signal.signal(signal.SIGALRM, lambda _s, _f: os.kill(viewer_pid, signal.SIGKILL))
+    signal.signal(signal.SIGALRM, lambda _s, _f: _signal_viewer(signal.SIGKILL))
 
     _drain(master)
     _terminate(None, None)

--- a/bin/fm-herdr-lab-viewer.py
+++ b/bin/fm-herdr-lab-viewer.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+"""Attach one real foreground Herdr viewer to a named lab session over a pty.
+
+bin/fm-herdr-lab.sh's ``viewer start`` is the only supported caller; run this
+through that guard rather than directly, so the lab's ownership tripwire and
+refuse-default checks still apply.
+
+Herdr registers a foreground client only when the attaching terminal reports a
+usable window grid. A pty created by ``script`` or a bare ``pty.fork()`` from a
+non-tty parent starts at 0x0, which makes Herdr report a zero-sized grid and
+keeps ``client.window_title.clear`` answering ``no_foreground_client``. That is
+why firstmate could not drive the attached-viewer teardown cases live before
+this helper existed. The fix is ordering as much as sizing: the window size is
+set on the master fd BEFORE the fork, so the TUI cannot read the grid until it
+is already non-zero.
+
+The child also drops every inherited ``HERDR_*`` variable. Herdr refuses to
+launch a nested viewer inside one of its own panes, and this helper normally
+runs from exactly there.
+
+Usage: fm-herdr-lab-viewer.py <session> <rows> <cols> <pidfile>
+
+Exit status:
+  0  the viewer ran and exited;
+  2  arguments were invalid;
+  3  the pty or the viewer process could not be created.
+"""
+
+import errno
+import fcntl
+import os
+import re
+import signal
+import struct
+import sys
+import termios
+
+# Herdr inherits these from the pane this helper runs in, and a nested viewer
+# is refused outright. HERDR_SESSION is scrubbed with them so the explicit
+# --session argument stays the viewer's only session source.
+SCRUBBED_ENV = (
+    "HERDR_ENV",
+    "HERDR_PANE_ID",
+    "HERDR_TAB_ID",
+    "HERDR_WORKSPACE_ID",
+    "HERDR_SOCKET_PATH",
+    "HERDR_BIN_PATH",
+    "HERDR_SESSION",
+)
+
+SESSION_PATTERN = re.compile(r"\Afm-lab-[A-Za-z0-9][A-Za-z0-9_-]*\Z")
+TERMINATE_GRACE_SECONDS = 5.0
+READ_CHUNK = 65536
+
+
+def _positive_int(raw):
+    try:
+        value = int(raw, 10)
+    except ValueError:
+        return None
+    return value if value > 0 else None
+
+
+def _child(slave, master, session):
+    os.setsid()
+    try:
+        fcntl.ioctl(slave, termios.TIOCSCTTY, 0)
+    except OSError:
+        pass
+    for target in (0, 1, 2):
+        os.dup2(slave, target)
+    if slave > 2:
+        os.close(slave)
+    os.close(master)
+    env = {key: value for key, value in os.environ.items() if key not in SCRUBBED_ENV}
+    env.setdefault("TERM", "xterm-256color")
+    try:
+        os.execvpe("herdr", ["herdr", "--session", session], env)
+    except OSError:
+        pass
+    os._exit(127)
+
+
+def _write_pidfile(path, launcher_pid, viewer_pid):
+    temporary = "%s.%d.tmp" % (path, launcher_pid)
+    with open(temporary, "w", encoding="utf-8") as handle:
+        handle.write("launcher=%d\nviewer=%d\n" % (launcher_pid, viewer_pid))
+    os.rename(temporary, path)
+
+
+def _drain(master):
+    while True:
+        try:
+            if not os.read(master, READ_CHUNK):
+                return
+        except OSError as error:
+            if error.errno == errno.EINTR:
+                continue
+            return
+
+
+def main(argv):
+    if len(argv) != 5:
+        sys.stderr.write("fm-herdr-lab-viewer: usage: <session> <rows> <cols> <pidfile>\n")
+        return 2
+    session, raw_rows, raw_cols, pidfile = argv[1:]
+    if session == "default" or not SESSION_PATTERN.match(session):
+        sys.stderr.write("fm-herdr-lab-viewer: refusing session %r\n" % session)
+        return 2
+    rows = _positive_int(raw_rows)
+    cols = _positive_int(raw_cols)
+    if rows is None or cols is None:
+        sys.stderr.write("fm-herdr-lab-viewer: rows and cols must be positive integers\n")
+        return 2
+    if not os.path.isabs(pidfile):
+        sys.stderr.write("fm-herdr-lab-viewer: pidfile must be an absolute path\n")
+        return 2
+
+    try:
+        master, slave = os.openpty()
+    except OSError as error:
+        sys.stderr.write("fm-herdr-lab-viewer: could not create a pty: %s\n" % error)
+        return 3
+    # Before the fork, so the TUI's first grid read already sees a real size.
+    fcntl.ioctl(master, termios.TIOCSWINSZ, struct.pack("HHHH", rows, cols, 0, 0))
+
+    try:
+        viewer_pid = os.fork()
+    except OSError as error:
+        sys.stderr.write("fm-herdr-lab-viewer: could not fork the viewer: %s\n" % error)
+        return 3
+    if viewer_pid == 0:
+        _child(slave, master, session)
+
+    os.close(slave)
+    _write_pidfile(pidfile, os.getpid(), viewer_pid)
+
+    def _terminate(_signum, _frame):
+        try:
+            os.kill(viewer_pid, signal.SIGTERM)
+        except OSError:
+            pass
+
+    signal.signal(signal.SIGTERM, _terminate)
+    signal.signal(signal.SIGINT, _terminate)
+    signal.signal(signal.SIGHUP, _terminate)
+    signal.signal(signal.SIGALRM, lambda _s, _f: os.kill(viewer_pid, signal.SIGKILL))
+
+    _drain(master)
+    _terminate(None, None)
+    signal.setitimer(signal.ITIMER_REAL, TERMINATE_GRACE_SECONDS)
+    try:
+        _, status = os.waitpid(viewer_pid, 0)
+    except OSError:
+        status = 0
+    signal.setitimer(signal.ITIMER_REAL, 0)
+    return 0 if os.WIFSIGNALED(status) else os.WEXITSTATUS(status)
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/bin/fm-herdr-lab-viewer.py
+++ b/bin/fm-herdr-lab-viewer.py
@@ -32,6 +32,7 @@ import os
 import re
 import signal
 import struct
+import subprocess
 import sys
 import termios
 
@@ -81,10 +82,29 @@ def _child(slave, master, session):
     os._exit(127)
 
 
+def _process_start(pid):
+    result = subprocess.run(
+        ["ps", "-p", str(pid), "-o", "lstart="],
+        check=True,
+        capture_output=True,
+        text=True,
+        env={**os.environ, "LC_ALL": "C"},
+    )
+    value = result.stdout.strip()
+    if not value:
+        raise RuntimeError("process start time unavailable")
+    return value
+
+
 def _write_pidfile(path, launcher_pid, viewer_pid):
+    launcher_start = _process_start(launcher_pid)
+    viewer_start = _process_start(viewer_pid)
     temporary = "%s.%d.tmp" % (path, launcher_pid)
     with open(temporary, "w", encoding="utf-8") as handle:
-        handle.write("launcher=%d\nviewer=%d\n" % (launcher_pid, viewer_pid))
+        handle.write("launcher_pid=%d\n" % launcher_pid)
+        handle.write("launcher_start=%s\n" % launcher_start)
+        handle.write("viewer_pid=%d\n" % viewer_pid)
+        handle.write("viewer_start=%s\n" % viewer_start)
     os.rename(temporary, path)
 
 
@@ -133,7 +153,20 @@ def main(argv):
         _child(slave, master, session)
 
     os.close(slave)
-    _write_pidfile(pidfile, os.getpid(), viewer_pid)
+    try:
+        _write_pidfile(pidfile, os.getpid(), viewer_pid)
+    except (OSError, RuntimeError, subprocess.SubprocessError) as error:
+        sys.stderr.write("fm-herdr-lab-viewer: could not record process identity: %s\n" % error)
+        try:
+            os.kill(viewer_pid, signal.SIGKILL)
+        except OSError:
+            pass
+        os.close(master)
+        try:
+            os.waitpid(viewer_pid, 0)
+        except OSError:
+            pass
+        return 3
 
     def _signal_viewer(number):
         # The viewer may already be gone; that is the outcome we wanted anyway.

--- a/bin/fm-herdr-lab-viewer.py
+++ b/bin/fm-herdr-lab-viewer.py
@@ -177,6 +177,7 @@ def main(argv):
 
     def _terminate(_signum, _frame):
         _signal_viewer(signal.SIGTERM)
+        signal.setitimer(signal.ITIMER_REAL, TERMINATE_GRACE_SECONDS)
 
     signal.signal(signal.SIGTERM, _terminate)
     signal.signal(signal.SIGINT, _terminate)

--- a/bin/fm-herdr-lab.sh
+++ b/bin/fm-herdr-lab.sh
@@ -26,8 +26,15 @@
 # Provision records the running default session as a fleet-state tripwire and
 # teardown requires that record to be identical afterward.
 # The viewer command attaches or detaches one real foreground Herdr client on
-# an owned lab session; bin/fm-herdr-lab-viewer.py owns the pty mechanics and
-# teardown refuses while an owned viewer is still attached.
+# an owned lab session over a fixed 40-row by 120-column pty;
+# bin/fm-herdr-lab-viewer.py owns the pty mechanics.
+# Start succeeds only when that session reports a foreground client and the
+# recorded viewer process still matches its launch identity.
+# Stop signals only identity-matched recorded processes and retains its
+# ownership record until detach is confirmed or the session is stopped or
+# absent; teardown refuses when that stop cannot be confirmed.
+# FM_HERDR_LAB_VIEWER_TIMEOUT sets the positive-integer wait in seconds for
+# viewer start and stop, and defaults to 30 when unset or empty.
 set -u
 
 fm_herdr_lab_error() {

--- a/bin/fm-herdr-lab.sh
+++ b/bin/fm-herdr-lab.sh
@@ -173,6 +173,8 @@ fm_herdr_lab_cli() { # <session> <herdr arguments...>
 # environment mechanics; the guards below own who may be attached to.
 # Per-session locks are deliberately absent: generated fm-lab-<label>-$$-$RANDOM
 # names have no caller that starts one viewer concurrently, so locks add risk.
+# A subsecond interrupt window and SIGKILL residue are accepted in this isolated
+# lab helper because teardown drops any stray viewer connection with the session.
 
 readonly fm_herdr_lab_viewer_timeout_seconds=5
 readonly fm_herdr_lab_viewer_launcher_grace_seconds=6
@@ -286,13 +288,14 @@ fm_herdr_lab_viewer_start() { # <session>
   [ -f "$launcher" ] || { fm_herdr_lab_error "missing viewer launcher at $launcher"; return 1; }
   log=$(fm_herdr_lab_viewer_log_path "$name")
   mkdir -p "$(fm_herdr_lab_state_dir)" || return 1
-  nohup python3 "$launcher" "$name" "$record" >"$log" 2>&1 &
-  launcher_pid=$!
+  launcher_pid=
   if [ "${BASH_SOURCE[0]}" = "$0" ]; then
     interrupt_traps=1
-    trap 'trap - INT TERM; fm_herdr_lab_cancel_viewer_launcher "$launcher_pid"; exit 130' INT
-    trap 'trap - INT TERM; fm_herdr_lab_cancel_viewer_launcher "$launcher_pid"; exit 143' TERM
+    trap 'trap - INT TERM; [ -z "${launcher_pid:-}" ] || fm_herdr_lab_cancel_viewer_launcher "$launcher_pid"; exit 130' INT
+    trap 'trap - INT TERM; [ -z "${launcher_pid:-}" ] || fm_herdr_lab_cancel_viewer_launcher "$launcher_pid"; exit 143' TERM
   fi
+  nohup python3 "$launcher" "$name" "$record" >"$log" 2>&1 &
+  launcher_pid=$!
 
   waited=0
   attempt=$((timeout * 5))

--- a/bin/fm-herdr-lab.sh
+++ b/bin/fm-herdr-lab.sh
@@ -173,6 +173,7 @@ fm_herdr_lab_cli() { # <session> <herdr arguments...>
 # environment mechanics; the guards below own who may be attached to.
 
 readonly fm_herdr_lab_viewer_timeout_seconds=5
+readonly fm_herdr_lab_viewer_launcher_grace_seconds=6
 
 fm_herdr_lab_viewer_record_path() { # <session>
   printf '%s/%s.viewer' "$(fm_herdr_lab_state_dir)" "$1"
@@ -305,7 +306,7 @@ fm_herdr_lab_viewer_start_locked() { # <session>
     sleep 0.2
     waited=$((waited + 1))
   done
-  fm_herdr_lab_cancel_provision "$launcher_pid"
+  fm_herdr_lab_cancel_viewer_launcher "$launcher_pid"
   fm_herdr_lab_error "lab viewer did not become the foreground client of '$name' within $timeout seconds (last reason: ${reason:-<unreadable>})"
   [ ! -s "$log" ] || fm_herdr_lab_error "viewer log: $(tail -n 5 "$log" | tr '\n' ' ')"
   fm_herdr_lab_viewer_stop_locked "$name" >/dev/null 2>&1 || true
@@ -366,30 +367,53 @@ fm_herdr_lab_viewer_unlock() { # <session>
   }
 }
 
-fm_herdr_lab_viewer_start() { # <session>
-  local name=$1 status
-  fm_herdr_lab_validate_name "$name" || return 1
+fm_herdr_lab_viewer_restore_traps() {
+  trap - EXIT INT TERM
+  if [ "$restore_saved_traps" = 1 ]; then
+    [ -z "$saved_exit" ] || eval "$saved_exit"
+    [ -z "$saved_int" ] || eval "$saved_int"
+    [ -z "$saved_term" ] || eval "$saved_term"
+  fi
+}
+
+fm_herdr_lab_viewer_lock_abort() { # <signal> <status>
+  local signal=$1 status=$2
+  fm_herdr_lab_viewer_unlock "$name" >/dev/null 2>&1 || true
+  fm_herdr_lab_viewer_restore_traps
+  if [ "$signal" != EXIT ]; then
+    kill -s "$signal" "$$"
+  fi
+  exit "$status"
+}
+
+fm_herdr_lab_viewer_locked_call() { # <start_locked|stop_locked> <session>
+  local operation=$1 name=$2 status saved_exit saved_int saved_term restore_saved_traps=1
+  [ "$BASH_SUBSHELL" -eq 0 ] || restore_saved_traps=0
+  saved_exit=$(trap -p EXIT)
+  saved_int=$(trap -p INT)
+  saved_term=$(trap -p TERM)
   fm_herdr_lab_viewer_lock "$name" || return 1
-  if fm_herdr_lab_viewer_start_locked "$name"; then
+  trap 'fm_herdr_lab_viewer_lock_abort EXIT $?' EXIT
+  trap 'fm_herdr_lab_viewer_lock_abort INT 130' INT
+  trap 'fm_herdr_lab_viewer_lock_abort TERM 143' TERM
+  if "$operation" "$name"; then
     status=0
   else
     status=$?
   fi
-  fm_herdr_lab_viewer_unlock "$name" || return 1
+  fm_herdr_lab_viewer_unlock "$name" || status=1
+  fm_herdr_lab_viewer_restore_traps
   return "$status"
 }
 
+fm_herdr_lab_viewer_start() { # <session>
+  fm_herdr_lab_validate_name "$1" || return 1
+  fm_herdr_lab_viewer_locked_call fm_herdr_lab_viewer_start_locked "$1"
+}
+
 fm_herdr_lab_viewer_stop() { # <session>
-  local name=$1 status
-  fm_herdr_lab_validate_name "$name" || return 1
-  fm_herdr_lab_viewer_lock "$name" || return 1
-  if fm_herdr_lab_viewer_stop_locked "$name"; then
-    status=0
-  else
-    status=$?
-  fi
-  fm_herdr_lab_viewer_unlock "$name" || return 1
-  return "$status"
+  fm_herdr_lab_validate_name "$1" || return 1
+  fm_herdr_lab_viewer_locked_call fm_herdr_lab_viewer_stop_locked "$1"
 }
 
 fm_herdr_lab_viewer() { # <start|stop> <session>
@@ -401,6 +425,21 @@ fm_herdr_lab_viewer() { # <start|stop> <session>
       return 2
       ;;
   esac
+}
+
+fm_herdr_lab_cancel_viewer_launcher() { # <pid>
+  local pid=$1 attempt=0 max_attempts=$((fm_herdr_lab_viewer_launcher_grace_seconds * 10))
+  if kill -0 "$pid" 2>/dev/null; then
+    kill -TERM "$pid" 2>/dev/null || true
+    while kill -0 "$pid" 2>/dev/null && [ "$attempt" -lt "$max_attempts" ]; do
+      sleep 0.1
+      attempt=$((attempt + 1))
+    done
+    if kill -0 "$pid" 2>/dev/null; then
+      kill -KILL "$pid" 2>/dev/null || true
+    fi
+  fi
+  wait "$pid" 2>/dev/null || true
 }
 
 fm_herdr_lab_cancel_provision() { # <pid>

--- a/bin/fm-herdr-lab.sh
+++ b/bin/fm-herdr-lab.sh
@@ -215,21 +215,32 @@ fm_herdr_lab_viewer_recorded_value() { # <session> <key>
   printf '%s' "$value"
 }
 
-fm_herdr_lab_viewer_owned_pid() { # <session> <launcher|viewer>
-  local pid recorded_start current_start launcher_pid parent_pid
-  pid=$(fm_herdr_lab_viewer_recorded_value "$1" "$2_pid") || return 1
-  case "$pid" in
-    ''|*[!0-9]*) return 1 ;;
+fm_herdr_lab_viewer_owned_pair() { # <session>
+  local launcher_pid viewer_pid launcher_start viewer_start current_start parent_pid
+  launcher_pid=$(fm_herdr_lab_viewer_recorded_value "$1" launcher_pid) || return 1
+  viewer_pid=$(fm_herdr_lab_viewer_recorded_value "$1" viewer_pid) || return 1
+  case "$launcher_pid:$viewer_pid" in
+    *[!0-9:]*) return 1 ;;
   esac
-  recorded_start=$(fm_herdr_lab_viewer_recorded_value "$1" "$2_start") || return 1
-  current_start=$(fm_herdr_lab_process_start "$pid") || return 1
-  [ -n "$current_start" ] && [ "$current_start" = "$recorded_start" ] || return 1
-  if [ "$2" = viewer ]; then
-    launcher_pid=$(fm_herdr_lab_viewer_owned_pid "$1" launcher) || return 1
-    parent_pid=$(fm_herdr_lab_process_parent "$pid") || return 1
-    [ "$parent_pid" = "$launcher_pid" ] || return 1
-  fi
-  printf '%s' "$pid"
+  launcher_start=$(fm_herdr_lab_viewer_recorded_value "$1" launcher_start) || return 1
+  viewer_start=$(fm_herdr_lab_viewer_recorded_value "$1" viewer_start) || return 1
+  current_start=$(fm_herdr_lab_process_start "$launcher_pid") || return 1
+  [ -n "$current_start" ] && [ "$current_start" = "$launcher_start" ] || return 1
+  current_start=$(fm_herdr_lab_process_start "$viewer_pid") || return 1
+  [ -n "$current_start" ] && [ "$current_start" = "$viewer_start" ] || return 1
+  parent_pid=$(fm_herdr_lab_process_parent "$viewer_pid") || return 1
+  [ "$parent_pid" = "$launcher_pid" ] || return 1
+  printf '%s %s' "$launcher_pid" "$viewer_pid"
+}
+
+fm_herdr_lab_viewer_owned_pid() { # <session> <launcher|viewer>
+  local pair
+  pair=$(fm_herdr_lab_viewer_owned_pair "$1") || return 1
+  case "$2" in
+    launcher) printf '%s' "${pair%% *}" ;;
+    viewer) printf '%s' "${pair#* }" ;;
+    *) return 1 ;;
+  esac
 }
 
 fm_herdr_lab_viewer_signal() { # <session> <launcher|viewer> <signal>
@@ -240,11 +251,7 @@ fm_herdr_lab_viewer_signal() { # <session> <launcher|viewer> <signal>
 
 # True while this lab owns a viewer process that is still running.
 fm_herdr_lab_viewer_owned_alive() { # <session>
-  local role
-  for role in viewer launcher; do
-    fm_herdr_lab_viewer_owned_pid "$1" "$role" >/dev/null && return 0
-  done
-  return 1
+  fm_herdr_lab_viewer_owned_pair "$1" >/dev/null
 }
 
 fm_herdr_lab_viewer_session_stopped_or_absent() { # <session>
@@ -363,8 +370,11 @@ fm_herdr_lab_viewer_start() { # <session>
   local name=$1 status
   fm_herdr_lab_validate_name "$name" || return 1
   fm_herdr_lab_viewer_lock "$name" || return 1
-  fm_herdr_lab_viewer_start_locked "$name"
-  status=$?
+  if fm_herdr_lab_viewer_start_locked "$name"; then
+    status=0
+  else
+    status=$?
+  fi
   fm_herdr_lab_viewer_unlock "$name" || return 1
   return "$status"
 }
@@ -373,8 +383,11 @@ fm_herdr_lab_viewer_stop() { # <session>
   local name=$1 status
   fm_herdr_lab_validate_name "$name" || return 1
   fm_herdr_lab_viewer_lock "$name" || return 1
-  fm_herdr_lab_viewer_stop_locked "$name"
-  status=$?
+  if fm_herdr_lab_viewer_stop_locked "$name"; then
+    status=0
+  else
+    status=$?
+  fi
   fm_herdr_lab_viewer_unlock "$name" || return 1
   return "$status"
 }

--- a/bin/fm-herdr-lab.sh
+++ b/bin/fm-herdr-lab.sh
@@ -182,6 +182,10 @@ fm_herdr_lab_viewer_log_path() { # <session>
   printf '%s/%s.viewer.log' "$(fm_herdr_lab_state_dir)" "$1"
 }
 
+fm_herdr_lab_viewer_lock_path() { # <session>
+  printf '%s/%s.viewer.lock' "$(fm_herdr_lab_state_dir)" "$1"
+}
+
 fm_herdr_lab_viewer_launcher_path() {
   printf '%s/fm-herdr-lab-viewer.py' "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 }
@@ -198,6 +202,10 @@ fm_herdr_lab_process_start() { # <pid>
   LC_ALL=C ps -p "$1" -o lstart= 2>/dev/null | sed 's/^[[:space:]]*//;s/[[:space:]]*$//'
 }
 
+fm_herdr_lab_process_parent() { # <pid>
+  LC_ALL=C ps -p "$1" -o ppid= 2>/dev/null | sed 's/^[[:space:]]*//;s/[[:space:]]*$//'
+}
+
 fm_herdr_lab_viewer_recorded_value() { # <session> <key>
   local record value
   record=$(fm_herdr_lab_viewer_record_path "$1")
@@ -208,7 +216,7 @@ fm_herdr_lab_viewer_recorded_value() { # <session> <key>
 }
 
 fm_herdr_lab_viewer_owned_pid() { # <session> <launcher|viewer>
-  local pid recorded_start current_start
+  local pid recorded_start current_start launcher_pid parent_pid
   pid=$(fm_herdr_lab_viewer_recorded_value "$1" "$2_pid") || return 1
   case "$pid" in
     ''|*[!0-9]*) return 1 ;;
@@ -216,6 +224,11 @@ fm_herdr_lab_viewer_owned_pid() { # <session> <launcher|viewer>
   recorded_start=$(fm_herdr_lab_viewer_recorded_value "$1" "$2_start") || return 1
   current_start=$(fm_herdr_lab_process_start "$pid") || return 1
   [ -n "$current_start" ] && [ "$current_start" = "$recorded_start" ] || return 1
+  if [ "$2" = viewer ]; then
+    launcher_pid=$(fm_herdr_lab_viewer_owned_pid "$1" launcher) || return 1
+    parent_pid=$(fm_herdr_lab_process_parent "$pid") || return 1
+    [ "$parent_pid" = "$launcher_pid" ] || return 1
+  fi
   printf '%s' "$pid"
 }
 
@@ -243,7 +256,7 @@ fm_herdr_lab_viewer_session_stopped_or_absent() { # <session>
   [ "$running" = false ] || [ "$running" = absent ]
 }
 
-fm_herdr_lab_viewer_start() { # <session>
+fm_herdr_lab_viewer_start_locked() { # <session>
   local name=$1 record log launcher launcher_pid waited attempt reason pid timeout=$fm_herdr_lab_viewer_timeout_seconds
   fm_herdr_lab_validate_name "$name" || return 1
   command -v herdr >/dev/null 2>&1 || { fm_herdr_lab_error "herdr is required"; return 1; }
@@ -288,11 +301,11 @@ fm_herdr_lab_viewer_start() { # <session>
   fm_herdr_lab_cancel_provision "$launcher_pid"
   fm_herdr_lab_error "lab viewer did not become the foreground client of '$name' within $timeout seconds (last reason: ${reason:-<unreadable>})"
   [ ! -s "$log" ] || fm_herdr_lab_error "viewer log: $(tail -n 5 "$log" | tr '\n' ' ')"
-  fm_herdr_lab_viewer_stop "$name" >/dev/null 2>&1 || true
+  fm_herdr_lab_viewer_stop_locked "$name" >/dev/null 2>&1 || true
   return 1
 }
 
-fm_herdr_lab_viewer_stop() { # <session>
+fm_herdr_lab_viewer_stop_locked() { # <session>
   local name=$1 record log role waited attempt reason timeout=$fm_herdr_lab_viewer_timeout_seconds
   fm_herdr_lab_validate_name "$name" || return 1
   record=$(fm_herdr_lab_viewer_record_path "$name")
@@ -327,6 +340,43 @@ fm_herdr_lab_viewer_stop() { # <session>
   done
   fm_herdr_lab_error "lab viewer for '$name' did not detach within $timeout seconds (last reason: ${reason:-<unreadable>})"
   return 1
+}
+
+fm_herdr_lab_viewer_lock() { # <session>
+  local lock
+  mkdir -p "$(fm_herdr_lab_state_dir)" || return 1
+  lock=$(fm_herdr_lab_viewer_lock_path "$1")
+  mkdir "$lock" 2>/dev/null || {
+    fm_herdr_lab_error "a viewer transition is already in progress for '$1'"
+    return 1
+  }
+}
+
+fm_herdr_lab_viewer_unlock() { # <session>
+  rmdir "$(fm_herdr_lab_viewer_lock_path "$1")" 2>/dev/null || {
+    fm_herdr_lab_error "could not release the viewer transition for '$1'"
+    return 1
+  }
+}
+
+fm_herdr_lab_viewer_start() { # <session>
+  local name=$1 status
+  fm_herdr_lab_validate_name "$name" || return 1
+  fm_herdr_lab_viewer_lock "$name" || return 1
+  fm_herdr_lab_viewer_start_locked "$name"
+  status=$?
+  fm_herdr_lab_viewer_unlock "$name" || return 1
+  return "$status"
+}
+
+fm_herdr_lab_viewer_stop() { # <session>
+  local name=$1 status
+  fm_herdr_lab_validate_name "$name" || return 1
+  fm_herdr_lab_viewer_lock "$name" || return 1
+  fm_herdr_lab_viewer_stop_locked "$name"
+  status=$?
+  fm_herdr_lab_viewer_unlock "$name" || return 1
+  return "$status"
 }
 
 fm_herdr_lab_viewer() { # <start|stop> <session>

--- a/bin/fm-herdr-lab.sh
+++ b/bin/fm-herdr-lab.sh
@@ -285,6 +285,9 @@ fm_herdr_lab_viewer_stop() { # <session>
     fm_herdr_lab_viewer_signal_pid "$pid" KILL
   done
 
+  # Both recorded processes are already gone by here, so an unreadable reason
+  # means the session itself is stopped or absent rather than a viewer this
+  # helper still has to detach.
   waited=0
   attempt=$((timeout * 5))
   while [ "$waited" -lt "$attempt" ]; do

--- a/bin/fm-herdr-lab.sh
+++ b/bin/fm-herdr-lab.sh
@@ -171,6 +171,8 @@ fm_herdr_lab_cli() { # <session> <herdr arguments...>
 # real viewer is what lets a test drive the live-client teardown paths instead
 # of only their detached halves. bin/fm-herdr-lab-viewer.py owns the pty and
 # environment mechanics; the guards below own who may be attached to.
+# Per-session locks are deliberately absent: generated fm-lab-<label>-$$-$RANDOM
+# names have no caller that starts one viewer concurrently, so locks add risk.
 
 readonly fm_herdr_lab_viewer_timeout_seconds=5
 readonly fm_herdr_lab_viewer_launcher_grace_seconds=6
@@ -181,10 +183,6 @@ fm_herdr_lab_viewer_record_path() { # <session>
 
 fm_herdr_lab_viewer_log_path() { # <session>
   printf '%s/%s.viewer.log' "$(fm_herdr_lab_state_dir)" "$1"
-}
-
-fm_herdr_lab_viewer_lock_path() { # <session>
-  printf '%s/%s.viewer.lock' "$(fm_herdr_lab_state_dir)" "$1"
 }
 
 fm_herdr_lab_viewer_launcher_path() {
@@ -264,8 +262,8 @@ fm_herdr_lab_viewer_session_stopped_or_absent() { # <session>
   [ "$running" = false ] || [ "$running" = absent ]
 }
 
-fm_herdr_lab_viewer_start_locked() { # <session>
-  local name=$1 record log launcher launcher_pid waited attempt reason pid timeout=$fm_herdr_lab_viewer_timeout_seconds
+fm_herdr_lab_viewer_start() { # <session>
+  local name=$1 record log launcher launcher_pid waited attempt reason pid interrupt_traps=0 timeout=$fm_herdr_lab_viewer_timeout_seconds
   fm_herdr_lab_validate_name "$name" || return 1
   command -v herdr >/dev/null 2>&1 || { fm_herdr_lab_error "herdr is required"; return 1; }
   command -v jq >/dev/null 2>&1 || { fm_herdr_lab_error "jq is required"; return 1; }
@@ -290,6 +288,11 @@ fm_herdr_lab_viewer_start_locked() { # <session>
   mkdir -p "$(fm_herdr_lab_state_dir)" || return 1
   nohup python3 "$launcher" "$name" "$record" >"$log" 2>&1 &
   launcher_pid=$!
+  if [ "${BASH_SOURCE[0]}" = "$0" ]; then
+    interrupt_traps=1
+    trap 'trap - INT TERM; fm_herdr_lab_cancel_viewer_launcher "$launcher_pid"; exit 130' INT
+    trap 'trap - INT TERM; fm_herdr_lab_cancel_viewer_launcher "$launcher_pid"; exit 143' TERM
+  fi
 
   waited=0
   attempt=$((timeout * 5))
@@ -298,6 +301,7 @@ fm_herdr_lab_viewer_start_locked() { # <session>
     if [ "$reason" = cleared ]; then
       pid=$(fm_herdr_lab_viewer_owned_pid "$name" viewer) || pid=
       if [ -n "$pid" ]; then
+        [ "$interrupt_traps" = 0 ] || trap - INT TERM
         disown "$launcher_pid" 2>/dev/null || true
         printf 'viewer attached to %s (pid %s)\n' "$name" "$pid"
         return 0
@@ -307,13 +311,14 @@ fm_herdr_lab_viewer_start_locked() { # <session>
     waited=$((waited + 1))
   done
   fm_herdr_lab_cancel_viewer_launcher "$launcher_pid"
+  [ "$interrupt_traps" = 0 ] || trap - INT TERM
   fm_herdr_lab_error "lab viewer did not become the foreground client of '$name' within $timeout seconds (last reason: ${reason:-<unreadable>})"
   [ ! -s "$log" ] || fm_herdr_lab_error "viewer log: $(tail -n 5 "$log" | tr '\n' ' ')"
-  fm_herdr_lab_viewer_stop_locked "$name" >/dev/null 2>&1 || true
+  fm_herdr_lab_viewer_stop "$name" >/dev/null 2>&1 || true
   return 1
 }
 
-fm_herdr_lab_viewer_stop_locked() { # <session>
+fm_herdr_lab_viewer_stop() { # <session>
   local name=$1 record log role waited attempt reason timeout=$fm_herdr_lab_viewer_timeout_seconds
   fm_herdr_lab_validate_name "$name" || return 1
   record=$(fm_herdr_lab_viewer_record_path "$name")
@@ -348,72 +353,6 @@ fm_herdr_lab_viewer_stop_locked() { # <session>
   done
   fm_herdr_lab_error "lab viewer for '$name' did not detach within $timeout seconds (last reason: ${reason:-<unreadable>})"
   return 1
-}
-
-fm_herdr_lab_viewer_lock() { # <session>
-  local lock
-  mkdir -p "$(fm_herdr_lab_state_dir)" || return 1
-  lock=$(fm_herdr_lab_viewer_lock_path "$1")
-  mkdir "$lock" 2>/dev/null || {
-    fm_herdr_lab_error "a viewer transition is already in progress for '$1'"
-    return 1
-  }
-}
-
-fm_herdr_lab_viewer_unlock() { # <session>
-  rmdir "$(fm_herdr_lab_viewer_lock_path "$1")" 2>/dev/null || {
-    fm_herdr_lab_error "could not release the viewer transition for '$1'"
-    return 1
-  }
-}
-
-fm_herdr_lab_viewer_restore_traps() {
-  trap - EXIT INT TERM
-  if [ "$restore_saved_traps" = 1 ]; then
-    [ -z "$saved_exit" ] || eval "$saved_exit"
-    [ -z "$saved_int" ] || eval "$saved_int"
-    [ -z "$saved_term" ] || eval "$saved_term"
-  fi
-}
-
-fm_herdr_lab_viewer_lock_abort() { # <signal> <status>
-  local signal=$1 status=$2
-  fm_herdr_lab_viewer_unlock "$name" >/dev/null 2>&1 || true
-  fm_herdr_lab_viewer_restore_traps
-  if [ "$signal" != EXIT ]; then
-    kill -s "$signal" "$$"
-  fi
-  exit "$status"
-}
-
-fm_herdr_lab_viewer_locked_call() { # <start_locked|stop_locked> <session>
-  local operation=$1 name=$2 status saved_exit saved_int saved_term restore_saved_traps=1
-  [ "$BASH_SUBSHELL" -eq 0 ] || restore_saved_traps=0
-  saved_exit=$(trap -p EXIT)
-  saved_int=$(trap -p INT)
-  saved_term=$(trap -p TERM)
-  fm_herdr_lab_viewer_lock "$name" || return 1
-  trap 'fm_herdr_lab_viewer_lock_abort EXIT $?' EXIT
-  trap 'fm_herdr_lab_viewer_lock_abort INT 130' INT
-  trap 'fm_herdr_lab_viewer_lock_abort TERM 143' TERM
-  if "$operation" "$name"; then
-    status=0
-  else
-    status=$?
-  fi
-  fm_herdr_lab_viewer_unlock "$name" || status=1
-  fm_herdr_lab_viewer_restore_traps
-  return "$status"
-}
-
-fm_herdr_lab_viewer_start() { # <session>
-  fm_herdr_lab_validate_name "$1" || return 1
-  fm_herdr_lab_viewer_locked_call fm_herdr_lab_viewer_start_locked "$1"
-}
-
-fm_herdr_lab_viewer_stop() { # <session>
-  fm_herdr_lab_validate_name "$1" || return 1
-  fm_herdr_lab_viewer_locked_call fm_herdr_lab_viewer_stop_locked "$1"
 }
 
 fm_herdr_lab_viewer() { # <start|stop> <session>

--- a/bin/fm-herdr-lab.sh
+++ b/bin/fm-herdr-lab.sh
@@ -33,8 +33,6 @@
 # Stop signals only identity-matched recorded processes and retains its
 # ownership record until detach is confirmed or the session is stopped or
 # absent; teardown refuses when that stop cannot be confirmed.
-# FM_HERDR_LAB_VIEWER_TIMEOUT sets the positive-integer wait in seconds for
-# viewer start and stop, and defaults to 30 when unset or empty.
 set -u
 
 fm_herdr_lab_error() {
@@ -174,6 +172,8 @@ fm_herdr_lab_cli() { # <session> <herdr arguments...>
 # of only their detached halves. bin/fm-herdr-lab-viewer.py owns the pty and
 # environment mechanics; the guards below own who may be attached to.
 
+readonly fm_herdr_lab_viewer_timeout_seconds=2
+
 fm_herdr_lab_viewer_record_path() { # <session>
   printf '%s/%s.viewer' "$(fm_herdr_lab_state_dir)" "$1"
 }
@@ -243,24 +243,9 @@ fm_herdr_lab_viewer_session_stopped_or_absent() { # <session>
   [ "$running" = false ] || [ "$running" = absent ]
 }
 
-fm_herdr_lab_viewer_timeout() {
-  local raw=${FM_HERDR_LAB_VIEWER_TIMEOUT:-30}
-  if [[ ! "$raw" =~ ^[0-9]+$ ]] || [[ ! "$raw" =~ [1-9] ]]; then
-    fm_herdr_lab_error "FM_HERDR_LAB_VIEWER_TIMEOUT must be a positive integer"
-    return 1
-  fi
-  raw=${raw#"${raw%%[!0]*}"}
-  [ "${#raw}" -le 9 ] || {
-    fm_herdr_lab_error "FM_HERDR_LAB_VIEWER_TIMEOUT is too large"
-    return 1
-  }
-  printf '%s' "$raw"
-}
-
 fm_herdr_lab_viewer_start() { # <session>
-  local name=$1 record log launcher waited attempt reason pid timeout
+  local name=$1 record log launcher waited attempt reason pid timeout=$fm_herdr_lab_viewer_timeout_seconds
   fm_herdr_lab_validate_name "$name" || return 1
-  timeout=$(fm_herdr_lab_viewer_timeout) || return 1
   command -v herdr >/dev/null 2>&1 || { fm_herdr_lab_error "herdr is required"; return 1; }
   command -v jq >/dev/null 2>&1 || { fm_herdr_lab_error "jq is required"; return 1; }
   command -v python3 >/dev/null 2>&1 || { fm_herdr_lab_error "python3 is required for the lab viewer"; return 1; }
@@ -307,9 +292,8 @@ fm_herdr_lab_viewer_start() { # <session>
 }
 
 fm_herdr_lab_viewer_stop() { # <session>
-  local name=$1 record log role waited attempt reason timeout
+  local name=$1 record log role waited attempt reason timeout=$fm_herdr_lab_viewer_timeout_seconds
   fm_herdr_lab_validate_name "$name" || return 1
-  timeout=$(fm_herdr_lab_viewer_timeout) || return 1
   record=$(fm_herdr_lab_viewer_record_path "$name")
   log=$(fm_herdr_lab_viewer_log_path "$name")
   # An absent record means this lab owns no viewer. Any client attached in that

--- a/bin/fm-herdr-lab.sh
+++ b/bin/fm-herdr-lab.sh
@@ -236,10 +236,24 @@ fm_herdr_lab_viewer_session_stopped_or_absent() { # <session>
   [ "$running" = false ] || [ "$running" = absent ]
 }
 
+fm_herdr_lab_viewer_timeout() {
+  local raw=${FM_HERDR_LAB_VIEWER_TIMEOUT:-30}
+  if [[ ! "$raw" =~ ^[0-9]+$ ]] || [[ ! "$raw" =~ [1-9] ]]; then
+    fm_herdr_lab_error "FM_HERDR_LAB_VIEWER_TIMEOUT must be a positive integer"
+    return 1
+  fi
+  raw=${raw#"${raw%%[!0]*}"}
+  [ "${#raw}" -le 9 ] || {
+    fm_herdr_lab_error "FM_HERDR_LAB_VIEWER_TIMEOUT is too large"
+    return 1
+  }
+  printf '%s' "$raw"
+}
+
 fm_herdr_lab_viewer_start() { # <session>
-  local name=$1 record log launcher waited attempt reason pid
-  local timeout=${FM_HERDR_LAB_VIEWER_TIMEOUT:-30}
+  local name=$1 record log launcher waited attempt reason pid timeout
   fm_herdr_lab_validate_name "$name" || return 1
+  timeout=$(fm_herdr_lab_viewer_timeout) || return 1
   command -v herdr >/dev/null 2>&1 || { fm_herdr_lab_error "herdr is required"; return 1; }
   command -v jq >/dev/null 2>&1 || { fm_herdr_lab_error "jq is required"; return 1; }
   command -v python3 >/dev/null 2>&1 || { fm_herdr_lab_error "python3 is required for the lab viewer"; return 1; }
@@ -270,9 +284,11 @@ fm_herdr_lab_viewer_start() { # <session>
   while [ "$waited" -lt "$attempt" ]; do
     reason=$(fm_herdr_lab_viewer_reason "$name") || reason=
     if [ "$reason" = cleared ]; then
-      pid=$(fm_herdr_lab_viewer_owned_pid "$name" viewer) || pid=unknown
-      printf 'viewer attached to %s (pid %s)\n' "$name" "$pid"
-      return 0
+      pid=$(fm_herdr_lab_viewer_owned_pid "$name" viewer) || pid=
+      if [ -n "$pid" ]; then
+        printf 'viewer attached to %s (pid %s)\n' "$name" "$pid"
+        return 0
+      fi
     fi
     sleep 0.2
     waited=$((waited + 1))
@@ -284,9 +300,9 @@ fm_herdr_lab_viewer_start() { # <session>
 }
 
 fm_herdr_lab_viewer_stop() { # <session>
-  local name=$1 record log role waited attempt reason
-  local timeout=${FM_HERDR_LAB_VIEWER_TIMEOUT:-30}
+  local name=$1 record log role waited attempt reason timeout
   fm_herdr_lab_validate_name "$name" || return 1
+  timeout=$(fm_herdr_lab_viewer_timeout) || return 1
   record=$(fm_herdr_lab_viewer_record_path "$name")
   log=$(fm_herdr_lab_viewer_log_path "$name")
   # An absent record means this lab owns no viewer. Any client attached in that

--- a/bin/fm-herdr-lab.sh
+++ b/bin/fm-herdr-lab.sh
@@ -187,30 +187,53 @@ fm_herdr_lab_viewer_reason() { # <session>
   printf '%s' "$out" | jq -r '.result.reason // empty' 2>/dev/null
 }
 
-fm_herdr_lab_viewer_recorded_pid() { # <session> <launcher|viewer>
-  local record pid
+fm_herdr_lab_process_start() { # <pid>
+  LC_ALL=C ps -p "$1" -o lstart= 2>/dev/null | sed 's/^[[:space:]]*//;s/[[:space:]]*$//'
+}
+
+fm_herdr_lab_viewer_recorded_value() { # <session> <key>
+  local record value
   record=$(fm_herdr_lab_viewer_record_path "$1")
   [ -f "$record" ] || return 1
-  pid=$(sed -n "s/^$2=//p" "$record" | head -n 1)
+  value=$(sed -n "s/^$2=//p" "$record" | head -n 1)
+  [ -n "$value" ] || return 1
+  printf '%s' "$value"
+}
+
+fm_herdr_lab_viewer_owned_pid() { # <session> <launcher|viewer>
+  local pid recorded_start current_start
+  pid=$(fm_herdr_lab_viewer_recorded_value "$1" "$2_pid") || return 1
   case "$pid" in
     ''|*[!0-9]*) return 1 ;;
   esac
+  recorded_start=$(fm_herdr_lab_viewer_recorded_value "$1" "$2_start") || return 1
+  current_start=$(fm_herdr_lab_process_start "$pid") || return 1
+  [ -n "$current_start" ] && [ "$current_start" = "$recorded_start" ] || return 1
   printf '%s' "$pid"
 }
 
-fm_herdr_lab_viewer_signal_pid() { # <pid> <signal>
-  kill -0 "$1" 2>/dev/null || return 0
-  kill "-$2" "$1" 2>/dev/null || true
+fm_herdr_lab_viewer_signal() { # <session> <launcher|viewer> <signal>
+  local pid
+  pid=$(fm_herdr_lab_viewer_owned_pid "$1" "$2") || return 0
+  kill "-$3" "$pid" 2>/dev/null || true
 }
 
 # True while this lab owns a viewer process that is still running.
 fm_herdr_lab_viewer_owned_alive() { # <session>
-  local role pid
+  local role
   for role in viewer launcher; do
-    pid=$(fm_herdr_lab_viewer_recorded_pid "$1" "$role") || continue
-    kill -0 "$pid" 2>/dev/null && return 0
+    fm_herdr_lab_viewer_owned_pid "$1" "$role" >/dev/null && return 0
   done
   return 1
+}
+
+fm_herdr_lab_viewer_session_stopped_or_absent() { # <session>
+  local sessions running
+  sessions=$(fm_herdr_lab_session_list "$1" 2>/dev/null) || return 1
+  running=$(printf '%s' "$sessions" | jq -r --arg name "$1" \
+    '[.sessions[]? | select(.name == $name) | .running] | if length == 0 then "absent" elif length == 1 then .[0] else "ambiguous" end' \
+    2>/dev/null) || return 1
+  [ "$running" = false ] || [ "$running" = absent ]
 }
 
 fm_herdr_lab_viewer_start() { # <session>
@@ -238,8 +261,7 @@ fm_herdr_lab_viewer_start() { # <session>
   [ -f "$launcher" ] || { fm_herdr_lab_error "missing viewer launcher at $launcher"; return 1; }
   log=$(fm_herdr_lab_viewer_log_path "$name")
   mkdir -p "$(fm_herdr_lab_state_dir)" || return 1
-  nohup python3 "$launcher" "$name" \
-    "${FM_HERDR_LAB_VIEWER_ROWS:-40}" "${FM_HERDR_LAB_VIEWER_COLS:-120}" "$record" \
+  nohup python3 "$launcher" "$name" 40 120 "$record" \
     >"$log" 2>&1 &
   disown 2>/dev/null || true
 
@@ -248,7 +270,7 @@ fm_herdr_lab_viewer_start() { # <session>
   while [ "$waited" -lt "$attempt" ]; do
     reason=$(fm_herdr_lab_viewer_reason "$name") || reason=
     if [ "$reason" = cleared ]; then
-      pid=$(fm_herdr_lab_viewer_recorded_pid "$name" viewer) || pid=unknown
+      pid=$(fm_herdr_lab_viewer_owned_pid "$name" viewer) || pid=unknown
       printf 'viewer attached to %s (pid %s)\n' "$name" "$pid"
       return 0
     fi
@@ -262,7 +284,7 @@ fm_herdr_lab_viewer_start() { # <session>
 }
 
 fm_herdr_lab_viewer_stop() { # <session>
-  local name=$1 record log role pid waited attempt reason
+  local name=$1 record log role waited attempt reason
   local timeout=${FM_HERDR_LAB_VIEWER_TIMEOUT:-30}
   fm_herdr_lab_validate_name "$name" || return 1
   record=$(fm_herdr_lab_viewer_record_path "$name")
@@ -272,8 +294,7 @@ fm_herdr_lab_viewer_stop() { # <session>
   [ -f "$record" ] || return 0
 
   for role in viewer launcher; do
-    pid=$(fm_herdr_lab_viewer_recorded_pid "$name" "$role") || continue
-    fm_herdr_lab_viewer_signal_pid "$pid" TERM
+    fm_herdr_lab_viewer_signal "$name" "$role" TERM
   done
   waited=0
   while fm_herdr_lab_viewer_owned_alive "$name" && [ "$waited" -lt 50 ]; do
@@ -281,18 +302,15 @@ fm_herdr_lab_viewer_stop() { # <session>
     waited=$((waited + 1))
   done
   for role in viewer launcher; do
-    pid=$(fm_herdr_lab_viewer_recorded_pid "$name" "$role") || continue
-    fm_herdr_lab_viewer_signal_pid "$pid" KILL
+    fm_herdr_lab_viewer_signal "$name" "$role" KILL
   done
 
-  # Both recorded processes are already gone by here, so an unreadable reason
-  # means the session itself is stopped or absent rather than a viewer this
-  # helper still has to detach.
   waited=0
   attempt=$((timeout * 5))
   while [ "$waited" -lt "$attempt" ]; do
     reason=$(fm_herdr_lab_viewer_reason "$name") || reason=
-    if [ "$reason" = no_foreground_client ] || [ -z "$reason" ]; then
+    if [ "$reason" = no_foreground_client ] \
+      || { [ -z "$reason" ] && fm_herdr_lab_viewer_session_stopped_or_absent "$name"; }; then
       rm -f "$record" "$log"
       return 0
     fi

--- a/bin/fm-herdr-lab.sh
+++ b/bin/fm-herdr-lab.sh
@@ -172,7 +172,7 @@ fm_herdr_lab_cli() { # <session> <herdr arguments...>
 # of only their detached halves. bin/fm-herdr-lab-viewer.py owns the pty and
 # environment mechanics; the guards below own who may be attached to.
 
-readonly fm_herdr_lab_viewer_timeout_seconds=2
+readonly fm_herdr_lab_viewer_timeout_seconds=5
 
 fm_herdr_lab_viewer_record_path() { # <session>
   printf '%s/%s.viewer' "$(fm_herdr_lab_state_dir)" "$1"
@@ -244,7 +244,7 @@ fm_herdr_lab_viewer_session_stopped_or_absent() { # <session>
 }
 
 fm_herdr_lab_viewer_start() { # <session>
-  local name=$1 record log launcher waited attempt reason pid timeout=$fm_herdr_lab_viewer_timeout_seconds
+  local name=$1 record log launcher launcher_pid waited attempt reason pid timeout=$fm_herdr_lab_viewer_timeout_seconds
   fm_herdr_lab_validate_name "$name" || return 1
   command -v herdr >/dev/null 2>&1 || { fm_herdr_lab_error "herdr is required"; return 1; }
   command -v jq >/dev/null 2>&1 || { fm_herdr_lab_error "jq is required"; return 1; }
@@ -267,9 +267,8 @@ fm_herdr_lab_viewer_start() { # <session>
   [ -f "$launcher" ] || { fm_herdr_lab_error "missing viewer launcher at $launcher"; return 1; }
   log=$(fm_herdr_lab_viewer_log_path "$name")
   mkdir -p "$(fm_herdr_lab_state_dir)" || return 1
-  nohup python3 "$launcher" "$name" 40 120 "$record" \
-    >"$log" 2>&1 &
-  disown 2>/dev/null || true
+  nohup python3 "$launcher" "$name" "$record" >"$log" 2>&1 &
+  launcher_pid=$!
 
   waited=0
   attempt=$((timeout * 5))
@@ -278,6 +277,7 @@ fm_herdr_lab_viewer_start() { # <session>
     if [ "$reason" = cleared ]; then
       pid=$(fm_herdr_lab_viewer_owned_pid "$name" viewer) || pid=
       if [ -n "$pid" ]; then
+        disown "$launcher_pid" 2>/dev/null || true
         printf 'viewer attached to %s (pid %s)\n' "$name" "$pid"
         return 0
       fi
@@ -285,6 +285,7 @@ fm_herdr_lab_viewer_start() { # <session>
     sleep 0.2
     waited=$((waited + 1))
   done
+  fm_herdr_lab_cancel_provision "$launcher_pid"
   fm_herdr_lab_error "lab viewer did not become the foreground client of '$name' within $timeout seconds (last reason: ${reason:-<unreadable>})"
   [ ! -s "$log" ] || fm_herdr_lab_error "viewer log: $(tail -n 5 "$log" | tr '\n' ' ')"
   fm_herdr_lab_viewer_stop "$name" >/dev/null 2>&1 || true

--- a/bin/fm-herdr-lab.sh
+++ b/bin/fm-herdr-lab.sh
@@ -7,6 +7,8 @@
 #   fm-herdr-lab.sh prepare <session>
 #   fm-herdr-lab.sh provision <session>
 #   fm-herdr-lab.sh run <session> <herdr arguments...>
+#   fm-herdr-lab.sh viewer start <session>
+#   fm-herdr-lab.sh viewer stop <session>
 #   fm-herdr-lab.sh stop <session>
 #   fm-herdr-lab.sh teardown <session>
 #
@@ -23,6 +25,9 @@
 # destructive call.
 # Provision records the running default session as a fleet-state tripwire and
 # teardown requires that record to be identical afterward.
+# The viewer command attaches or detaches one real foreground Herdr client on
+# an owned lab session; bin/fm-herdr-lab-viewer.py owns the pty mechanics and
+# teardown refuses while an owned viewer is still attached.
 set -u
 
 fm_herdr_lab_error() {
@@ -153,6 +158,159 @@ fm_herdr_lab_cli() { # <session> <herdr arguments...>
   fm_herdr_lab_raw "$name" "$@"
 }
 
+# --- foreground viewer ------------------------------------------------------
+#
+# Herdr counts a client as the session's foreground viewer only once that
+# client reports a usable window grid, so a zero-sized pty attaches nothing and
+# leaves `terminal title clear` answering no_foreground_client. Attaching a
+# real viewer is what lets a test drive the live-client teardown paths instead
+# of only their detached halves. bin/fm-herdr-lab-viewer.py owns the pty and
+# environment mechanics; the guards below own who may be attached to.
+
+fm_herdr_lab_viewer_record_path() { # <session>
+  printf '%s/%s.viewer' "$(fm_herdr_lab_state_dir)" "$1"
+}
+
+fm_herdr_lab_viewer_log_path() { # <session>
+  printf '%s/%s.viewer.log' "$(fm_herdr_lab_state_dir)" "$1"
+}
+
+fm_herdr_lab_viewer_launcher_path() {
+  printf '%s/fm-herdr-lab-viewer.py' "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+}
+
+# Prints the session's current foreground-client reason, or nothing when it
+# cannot be read.
+fm_herdr_lab_viewer_reason() { # <session>
+  local name=$1 out
+  out=$(fm_herdr_lab_cli "$name" terminal title clear 2>/dev/null) || return 1
+  printf '%s' "$out" | jq -r '.result.reason // empty' 2>/dev/null
+}
+
+fm_herdr_lab_viewer_recorded_pid() { # <session> <launcher|viewer>
+  local record pid
+  record=$(fm_herdr_lab_viewer_record_path "$1")
+  [ -f "$record" ] || return 1
+  pid=$(sed -n "s/^$2=//p" "$record" | head -n 1)
+  case "$pid" in
+    ''|*[!0-9]*) return 1 ;;
+  esac
+  printf '%s' "$pid"
+}
+
+fm_herdr_lab_viewer_signal_pid() { # <pid> <signal>
+  kill -0 "$1" 2>/dev/null || return 0
+  kill "-$2" "$1" 2>/dev/null || true
+}
+
+# True while this lab owns a viewer process that is still running.
+fm_herdr_lab_viewer_owned_alive() { # <session>
+  local role pid
+  for role in viewer launcher; do
+    pid=$(fm_herdr_lab_viewer_recorded_pid "$1" "$role") || continue
+    kill -0 "$pid" 2>/dev/null && return 0
+  done
+  return 1
+}
+
+fm_herdr_lab_viewer_start() { # <session>
+  local name=$1 record log launcher waited attempt reason pid
+  local timeout=${FM_HERDR_LAB_VIEWER_TIMEOUT:-30}
+  fm_herdr_lab_validate_name "$name" || return 1
+  command -v herdr >/dev/null 2>&1 || { fm_herdr_lab_error "herdr is required"; return 1; }
+  command -v jq >/dev/null 2>&1 || { fm_herdr_lab_error "jq is required"; return 1; }
+  command -v python3 >/dev/null 2>&1 || { fm_herdr_lab_error "python3 is required for the lab viewer"; return 1; }
+
+  [ -f "$(fm_herdr_lab_tripwire_path "$name")" ] || {
+    fm_herdr_lab_error "missing fleet-state tripwire for '$name'; refusing to attach a viewer to a session this lab does not own"
+    return 1
+  }
+  fm_herdr_lab_refuse_if_default "$name" || return 1
+
+  record=$(fm_herdr_lab_viewer_record_path "$name")
+  if fm_herdr_lab_viewer_owned_alive "$name"; then
+    fm_herdr_lab_error "a lab viewer is already attached to '$name'; stop it before starting another"
+    return 1
+  fi
+  rm -f "$record"
+
+  launcher=$(fm_herdr_lab_viewer_launcher_path)
+  [ -f "$launcher" ] || { fm_herdr_lab_error "missing viewer launcher at $launcher"; return 1; }
+  log=$(fm_herdr_lab_viewer_log_path "$name")
+  mkdir -p "$(fm_herdr_lab_state_dir)" || return 1
+  nohup python3 "$launcher" "$name" \
+    "${FM_HERDR_LAB_VIEWER_ROWS:-40}" "${FM_HERDR_LAB_VIEWER_COLS:-120}" "$record" \
+    >"$log" 2>&1 &
+  disown 2>/dev/null || true
+
+  waited=0
+  attempt=$((timeout * 5))
+  while [ "$waited" -lt "$attempt" ]; do
+    reason=$(fm_herdr_lab_viewer_reason "$name") || reason=
+    if [ "$reason" = cleared ]; then
+      pid=$(fm_herdr_lab_viewer_recorded_pid "$name" viewer) || pid=unknown
+      printf 'viewer attached to %s (pid %s)\n' "$name" "$pid"
+      return 0
+    fi
+    sleep 0.2
+    waited=$((waited + 1))
+  done
+  fm_herdr_lab_error "lab viewer did not become the foreground client of '$name' within $timeout seconds (last reason: ${reason:-<unreadable>})"
+  [ ! -s "$log" ] || fm_herdr_lab_error "viewer log: $(tail -n 5 "$log" | tr '\n' ' ')"
+  fm_herdr_lab_viewer_stop "$name" >/dev/null 2>&1 || true
+  return 1
+}
+
+fm_herdr_lab_viewer_stop() { # <session>
+  local name=$1 record log role pid waited attempt reason
+  local timeout=${FM_HERDR_LAB_VIEWER_TIMEOUT:-30}
+  fm_herdr_lab_validate_name "$name" || return 1
+  record=$(fm_herdr_lab_viewer_record_path "$name")
+  log=$(fm_herdr_lab_viewer_log_path "$name")
+  # An absent record means this lab owns no viewer. Any client attached in that
+  # case belongs to someone else and must never be signalled from here.
+  [ -f "$record" ] || return 0
+
+  for role in viewer launcher; do
+    pid=$(fm_herdr_lab_viewer_recorded_pid "$name" "$role") || continue
+    fm_herdr_lab_viewer_signal_pid "$pid" TERM
+  done
+  waited=0
+  while fm_herdr_lab_viewer_owned_alive "$name" && [ "$waited" -lt 50 ]; do
+    sleep 0.1
+    waited=$((waited + 1))
+  done
+  for role in viewer launcher; do
+    pid=$(fm_herdr_lab_viewer_recorded_pid "$name" "$role") || continue
+    fm_herdr_lab_viewer_signal_pid "$pid" KILL
+  done
+
+  waited=0
+  attempt=$((timeout * 5))
+  while [ "$waited" -lt "$attempt" ]; do
+    reason=$(fm_herdr_lab_viewer_reason "$name") || reason=
+    if [ "$reason" = no_foreground_client ] || [ -z "$reason" ]; then
+      rm -f "$record" "$log"
+      return 0
+    fi
+    sleep 0.2
+    waited=$((waited + 1))
+  done
+  fm_herdr_lab_error "lab viewer for '$name' did not detach within $timeout seconds (last reason: ${reason:-<unreadable>})"
+  return 1
+}
+
+fm_herdr_lab_viewer() { # <start|stop> <session>
+  case "${1:-}" in
+    start) fm_herdr_lab_viewer_start "$2" ;;
+    stop) fm_herdr_lab_viewer_stop "$2" ;;
+    *)
+      fm_herdr_lab_error "viewer takes 'start' or 'stop'"
+      return 2
+      ;;
+  esac
+}
+
 fm_herdr_lab_cancel_provision() { # <pid>
   local pid=$1 attempt=0
   if kill -0 "$pid" 2>/dev/null; then
@@ -261,6 +419,10 @@ fm_herdr_lab_teardown() { # <session>
     fm_herdr_lab_error "missing fleet-state tripwire for '$name'; refusing destructive calls"
     return 1
   }
+  fm_herdr_lab_viewer_stop "$name" || {
+    fm_herdr_lab_error "refusing teardown of '$name' while this lab's viewer is still attached"
+    return 1
+  }
   sessions=$(fm_herdr_lab_session_list "$name" 2>/dev/null) || {
     fm_herdr_lab_error "cannot list Herdr sessions before teardown"
     return 1
@@ -299,7 +461,7 @@ fm_herdr_lab_name() { # <label>
 }
 
 fm_herdr_lab_usage() {
-  sed -n '2,13p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+  sed -n '2,15p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
 }
 
 fm_herdr_lab_main() {
@@ -321,6 +483,10 @@ fm_herdr_lab_main() {
       [ "$#" -ge 3 ] || { fm_herdr_lab_usage >&2; return 2; }
       shift
       fm_herdr_lab_cli "$@"
+      ;;
+    viewer)
+      [ "$#" -eq 3 ] || { fm_herdr_lab_usage >&2; return 2; }
+      fm_herdr_lab_viewer "$2" "$3"
       ;;
     stop)
       [ "$#" -eq 2 ] || { fm_herdr_lab_usage >&2; return 2; }

--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -338,6 +338,7 @@ family_for_basename() {
     fm-grok-stop-live-e2e.test.sh|fm-harness-adapter-instructions-live-e2e.test.sh|\
     fm-harness-liveness-drift-live-e2e.test.sh|\
     fm-muse-signals-live-e2e.test.sh|fm-rovo-signals-live-e2e.test.sh|\
+    fm-herdr-attached-viewer-live-e2e.test.sh|\
     fm-herdr-version-floor-live-e2e.test.sh|\
     fm-herdr-pi-stale-registration-live-e2e.test.sh|\
     fm-opencode-primary-live-e2e.test.sh|fm-pi-branch-live-e2e.test.sh|\
@@ -491,7 +492,7 @@ tests/fm-composer-lib.test.sh 4798
 tests/fm-crew-state.test.sh 11557
 tests/fm-ensure-agents-md.test.sh 901
 tests/fm-grok-harness.test.sh 6563
-tests/fm-herdr-lab.test.sh 6936
+tests/fm-herdr-lab.test.sh 9800
 tests/fm-lint.test.sh 164262
 tests/fm-pi-primary-types.test.sh 8624
 tests/fm-pr-merge.test.sh 111145
@@ -696,6 +697,7 @@ tests/fm-guard-stale-banner.test.sh 32981
 tests/fm-harness-adapter-instructions-live-e2e.test.sh 20
 tests/fm-harness-adapter-references.test.sh 55
 tests/fm-harness-liveness-drift-live-e2e.test.sh 21
+tests/fm-herdr-attached-viewer-live-e2e.test.sh 19000
 tests/fm-herdr-session-cleanup.test.sh 6704
 tests/fm-herdr-submit-confirm-live-e2e.test.sh 23
 tests/fm-herdr-version-floor-live-e2e.test.sh 23

--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -304,7 +304,7 @@ family_for_basename() {
     fm-backend-herdr-focus-flash-e2e.test.sh|\
     fm-backend-herdr-stale-active-tab-e2e.test.sh|\
     fm-backend-herdr-agent-exit-shell-e2e.test.sh|\
-    fm-herdr-session-cleanup-e2e.test.sh|\
+    fm-herdr-attached-viewer-live-e2e.test.sh|fm-herdr-session-cleanup-e2e.test.sh|\
     fm-backend-herdr-smoke.test.sh|fm-backend-herdr-workspace-per-home-e2e.test.sh|\
     fm-control-herdr-smoke.test.sh)
       printf '%s\n' real-herdr-gated
@@ -338,7 +338,6 @@ family_for_basename() {
     fm-grok-stop-live-e2e.test.sh|fm-harness-adapter-instructions-live-e2e.test.sh|\
     fm-harness-liveness-drift-live-e2e.test.sh|\
     fm-muse-signals-live-e2e.test.sh|fm-rovo-signals-live-e2e.test.sh|\
-    fm-herdr-attached-viewer-live-e2e.test.sh|\
     fm-herdr-version-floor-live-e2e.test.sh|\
     fm-herdr-pi-stale-registration-live-e2e.test.sh|\
     fm-opencode-primary-live-e2e.test.sh|fm-pi-branch-live-e2e.test.sh|\

--- a/docs/herdr-backend.md
+++ b/docs/herdr-backend.md
@@ -370,6 +370,7 @@ tests/fm-backend-herdr-eventwait-smoke.test.sh
 tests/fm-control-herdr-smoke.test.sh
 tests/fm-herdr-session-cleanup.test.sh
 tests/fm-herdr-session-cleanup-e2e.test.sh
+tests/fm-herdr-attached-viewer-live-e2e.test.sh
 tests/fm-afk-inject-herdr-e2e.test.sh
 tests/fm-afk-pi-herdr-return-e2e.test.sh
 ```

--- a/docs/herdr-backend.md
+++ b/docs/herdr-backend.md
@@ -185,6 +185,7 @@ Operational compromises:
 `tests/fm-herdr-session-cleanup-e2e.test.sh` covers the restored-shell cleanup in a guarded non-default named lab.
 `tests/fm-backend-herdr-focus-flash-e2e.test.sh` reproduces the raw explicit-close focus steal on the installed release and proves the focus-safe emptying-close plan removes a doomed workspace with no wrong-focus interval; [`verification/runtime-backends.md`](verification/runtime-backends.md#workspace-removal-focus-safety) owns the active versioned evidence.
 `tests/fm-backend-herdr-stale-active-tab-e2e.test.sh` proves a persisted-focused tab still closes when no foreground client is attached.
+`tests/fm-herdr-attached-viewer-live-e2e.test.sh` proves the other half against a real attached viewer, which `bin/fm-herdr-lab.sh viewer start` supplies over a pty sized before the fork; [`verification/runtime-backends.md`](verification/runtime-backends.md#attached-foreground-viewer) owns the active versioned evidence and the re-run trigger.
 
 ## Default-tab prune safety
 

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -35,6 +35,7 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-brief.sh`            | Scaffold ship (explicit `--mode`), scout, secondmate-charter, and Herdr-lab briefs, with Captain's intent and Firstmate spec subsections on ship/scout |
 | [`fm-dod-lib.sh`](../bin/fm-dod-lib.sh) | Own ship/scout worker role scope, ship definitions of done, and the no-mistakes `--intent` contract |
 | `fm-herdr-lab.sh`        | Provision and guardedly operate an isolated, never-default Herdr lab session         |
+| `fm-herdr-lab-viewer.py` | The pty engine behind `fm-herdr-lab.sh viewer`: one real foreground Herdr client on a non-zero window grid |
 | `fm-install-herdr.sh`    | Install CI's exact-version Herdr pin with official asset URL, SHA-256, and protocol checks |
 | `fm-install-treehouse.sh`| Install CI's exact-version Treehouse pin for real-Herdr E2E that needs spawn worktrees |
 | `fm-herdr-ci-cleanup.sh` | Snapshot and tear down only job-owned `fm-lab-*` sessions in the Herdr CI lane       |

--- a/docs/verification/runtime-backends.md
+++ b/docs/verification/runtime-backends.md
@@ -888,7 +888,7 @@ The suite also cross-checks its own Part A measurement against the floor classif
 
 A pseudo-terminal registers as a Herdr foreground client only when its window grid is non-zero.
 `script` and a bare `pty.fork()` from a non-tty parent both start at 0x0, which is why PR #4131 could validate only the detached half of the teardown focus guard and left its four attached-client scenarios untested.
-`bin/fm-herdr-lab-viewer.py` sets the size on the master fd before the fork and scrubs the inherited `HERDR_*` variables, which makes the attached scenarios reachable from a headless runner.
+The guarded `viewer start` path fixes the pty at the proven 40-row by 120-column grid, sets that size on the master fd before the fork, and scrubs inherited `HERDR_*` variables, which makes the attached scenarios reachable from a headless runner.
 
 Measured on 2026-09-11 against Herdr 0.9.0 protocol 22 on macOS 26.5.2 aarch64 with Python 3.14.6:
 

--- a/docs/verification/runtime-backends.md
+++ b/docs/verification/runtime-backends.md
@@ -907,10 +907,9 @@ ok - attached viewer: detaching releases the refusal, so the guard tracks the cl
 ```
 
 Both halves of the recipe are load-bearing, and each was measured by removing it from the helper and re-running the guard on the same host and release.
-Dropping the `TIOCSWINSZ` call and dropping the environment scrub each produced the same failure the untested scenarios reported:
+Dropping the `TIOCSWINSZ` call and dropping the environment scrub each left startup reporting `no_foreground_client`, followed by the guard failure:
 
 ```text
-fm-herdr-lab: lab viewer did not become the foreground client of 'fm-lab-fm-herdr-attache-71064-7965' within 8 seconds (last reason: no_foreground_client)
 not ok - could not attach a real foreground Herdr viewer over a sized pty
 ```
 

--- a/docs/verification/runtime-backends.md
+++ b/docs/verification/runtime-backends.md
@@ -884,6 +884,39 @@ Part C is the case the suite could not reach before: a doomed pane whose shell h
 On 0.7.5 that fallback exposed a bounded four-sample wrong-focus window and restored the anchor exactly; on 0.8.0 the same fallback exposed none, which is why default-on projection is floored at 0.8.0 rather than mitigated further below it.
 The suite also cross-checks its own Part A measurement against the floor classifier on whatever release it runs, so a drifted protocol-to-release mapping fails there rather than silently gating on the wrong thing.
 
+### Attached foreground viewer
+
+A pseudo-terminal registers as a Herdr foreground client only when its window grid is non-zero.
+`script` and a bare `pty.fork()` from a non-tty parent both start at 0x0, which is why PR #4131 could validate only the detached half of the teardown focus guard and left its four attached-client scenarios untested.
+`bin/fm-herdr-lab-viewer.py` sets the size on the master fd before the fork and scrubs the inherited `HERDR_*` variables, which makes the attached scenarios reachable from a headless runner.
+
+Measured on 2026-09-11 against Herdr 0.9.0 protocol 22 on macOS 26.5.2 aarch64 with Python 3.14.6:
+
+```sh
+HERDR_LAB_HELPER=bin/fm-herdr-lab.sh \
+  tests/fm-herdr-attached-viewer-live-e2e.test.sh
+```
+
+```text
+ok - attached viewer: a pty sized before the fork registers as a real Herdr foreground client
+ok - attached viewer: a live client on the target tab refuses the close and keeps the pane
+ok - attached viewer: focus moving onto the target between planning and mutation still blocks the close
+ok - attached viewer: a close preserves the fresh non-target focus the viewer moved to
+ok - attached viewer: the projection seeded-tab prune refuses while a live client watches it
+ok - attached viewer: detaching releases the refusal, so the guard tracks the client and not the pointer
+```
+
+Both halves of the recipe are load-bearing, and each was measured by removing it from the helper and re-running the guard on the same host and release.
+Dropping the `TIOCSWINSZ` call and dropping the environment scrub each produced the same failure the untested scenarios reported:
+
+```text
+fm-herdr-lab: lab viewer did not become the foreground client of 'fm-lab-fm-herdr-attache-71064-7965' within 8 seconds (last reason: no_foreground_client)
+not ok - could not attach a real foreground Herdr viewer over a sized pty
+```
+
+Re-run this guard after every Herdr upgrade.
+A release that changed the foreground-client contract, the window-grid requirement, or the nested-viewer refusal would fail here first, and the detached regressions would keep passing while saying nothing about it.
+
 ### Presentation version floor
 
 Default-on presentation projection is floored at Herdr 0.8.0.

--- a/tests/fm-herdr-attached-viewer-live-e2e.test.sh
+++ b/tests/fm-herdr-attached-viewer-live-e2e.test.sh
@@ -117,54 +117,54 @@ drive() { # <function> <argument...>
   ' _ "$ROOT" "$@" 2>&1
 }
 
+# These run inside command substitutions, where `fail` would exit only the
+# subshell and let the script carry on with empty ids. They return non-zero
+# instead, and every call site carries its own `|| fail`.
 new_workspace() { # <label> -> "<workspace>\t<tab>\t<pane>"
   local out
-  out=$(lab workspace create --cwd "$ROOT" --label "$1" --no-focus) \
-    || fail "could not create the $1 workspace"
+  out=$(lab workspace create --cwd "$ROOT" --label "$1" --no-focus) || return 1
   printf '%s' "$out" | jq -er '
     [.result.workspace.workspace_id, .result.tab.tab_id, .result.root_pane.pane_id] | @tsv
-  ' || fail "could not read the $1 workspace ids"
+  '
 }
 
 new_tab() { # <workspace> <label> -> "<tab>\t<pane>"
   local out
-  out=$(lab tab create --workspace "$1" --label "$2" --cwd "$ROOT") \
-    || fail "could not create the $2 tab"
-  printf '%s' "$out" | jq -er '[.result.tab.tab_id, .result.root_pane.pane_id] | @tsv' \
-    || fail "could not read the $2 tab ids"
+  out=$(lab tab create --workspace "$1" --label "$2" --cwd "$ROOT") || return 1
+  printf '%s' "$out" | jq -er '[.result.tab.tab_id, .result.root_pane.pane_id] | @tsv'
 }
 
 focused_tab() {
   lab workspace list | jq -er '
     [.result.workspaces[] | select(.focused == true)] | select(length == 1) | .[0].active_tab_id
-  ' || fail "could not read the session's focused tab"
+  '
 }
 
 pane_exists() { lab pane get "$1" >/dev/null 2>&1; }
 
 foreground_reason() {
-  lab terminal title clear | jq -er '.result.reason' \
-    || fail "could not probe the session's foreground client"
+  lab terminal title clear | jq -er '.result.reason'
 }
 
 # --- the attachment itself, which is what #4131 could not do ----------------
 
-REASON=$(foreground_reason)
+REASON=$(foreground_reason) || fail "could not probe the session's foreground client"
 [ "$REASON" = no_foreground_client ] \
   || fail "the fresh lab already had a foreground client (reason=$REASON)"
 
 "$LAB_HELPER" viewer start "$LAB_SESSION" >/dev/null \
   || fail "could not attach a real foreground Herdr viewer over a sized pty"
-REASON=$(foreground_reason)
+REASON=$(foreground_reason) || fail "could not probe the session's foreground client"
 [ "$REASON" = cleared ] \
   || fail "the attached pty viewer did not register as a foreground client (reason=$REASON)"
 pass "attached viewer: a pty sized before the fork registers as a real Herdr foreground client"
 
 # --- scenario 3: a viewer on the target tab blocks the close ---------------
 
-IFS=$'\t' read -r WS_THREE TAB_THREE_A PANE_THREE_A <<<"$(new_workspace viewer-active)"
+FIXTURE=$(new_workspace viewer-active) || fail "could not create the scenario 3 workspace"
+IFS=$'\t' read -r WS_THREE TAB_THREE_A PANE_THREE_A <<<"$FIXTURE"
 # A second tab keeps the close a plain one rather than an emptying-workspace plan.
-IFS=$'\t' read -r _ _ <<<"$(new_tab "$WS_THREE" viewer-active-b)"
+new_tab "$WS_THREE" viewer-active-b >/dev/null || fail "could not create the scenario 3 companion tab"
 lab tab focus "$TAB_THREE_A" >/dev/null || fail "could not focus the scenario 3 target tab"
 [ "$(focused_tab)" = "$TAB_THREE_A" ] || fail "scenario 3 did not start focused on the target tab"
 
@@ -179,8 +179,10 @@ pass "attached viewer: a live client on the target tab refuses the close and kee
 
 # --- scenario 4: the viewer moves ONTO the target mid-close ----------------
 
-IFS=$'\t' read -r WS_FOUR TAB_FOUR_A PANE_FOUR_A <<<"$(new_workspace viewer-late-on)"
-IFS=$'\t' read -r TAB_FOUR_B _ <<<"$(new_tab "$WS_FOUR" viewer-late-on-b)"
+FIXTURE=$(new_workspace viewer-late-on) || fail "could not create the scenario 4 workspace"
+IFS=$'\t' read -r WS_FOUR TAB_FOUR_A PANE_FOUR_A <<<"$FIXTURE"
+FIXTURE=$(new_tab "$WS_FOUR" viewer-late-on-b) || fail "could not create the scenario 4 companion tab"
+IFS=$'\t' read -r TAB_FOUR_B _ <<<"$FIXTURE"
 lab tab focus "$TAB_FOUR_B" >/dev/null || fail "could not focus away from the scenario 4 target"
 [ "$(focused_tab)" = "$TAB_FOUR_B" ] || fail "scenario 4 did not start focused off the target tab"
 
@@ -198,8 +200,10 @@ pass "attached viewer: focus moving onto the target between planning and mutatio
 
 # --- scenario 5: the viewer moves OFF the target mid-close -----------------
 
-IFS=$'\t' read -r WS_FIVE TAB_FIVE_A PANE_FIVE_A <<<"$(new_workspace viewer-late-off)"
-IFS=$'\t' read -r TAB_FIVE_B _ <<<"$(new_tab "$WS_FIVE" viewer-late-off-b)"
+FIXTURE=$(new_workspace viewer-late-off) || fail "could not create the scenario 5 workspace"
+IFS=$'\t' read -r WS_FIVE TAB_FIVE_A PANE_FIVE_A <<<"$FIXTURE"
+FIXTURE=$(new_tab "$WS_FIVE" viewer-late-off-b) || fail "could not create the scenario 5 companion tab"
+IFS=$'\t' read -r TAB_FIVE_B _ <<<"$FIXTURE"
 lab tab focus "$TAB_FIVE_A" >/dev/null || fail "could not focus the scenario 5 target tab"
 [ "$(focused_tab)" = "$TAB_FIVE_A" ] || fail "scenario 5 did not start focused on the target tab"
 
@@ -218,8 +222,10 @@ pass "attached viewer: a close preserves the fresh non-target focus the viewer m
 
 # --- scenario 7: the projection's seeded-tab prune inherits the refusal ----
 
-IFS=$'\t' read -r WS_SEVEN TAB_SEVEN_SEEDED PANE_SEVEN_SEEDED <<<"$(new_workspace viewer-seeded)"
-IFS=$'\t' read -r _ PANE_SEVEN_TASK <<<"$(new_tab "$WS_SEVEN" fm-viewer-seeded-task)"
+FIXTURE=$(new_workspace viewer-seeded) || fail "could not create the scenario 7 workspace"
+IFS=$'\t' read -r WS_SEVEN TAB_SEVEN_SEEDED PANE_SEVEN_SEEDED <<<"$FIXTURE"
+FIXTURE=$(new_tab "$WS_SEVEN" fm-viewer-seeded-task) || fail "could not create the scenario 7 task tab"
+IFS=$'\t' read -r _ PANE_SEVEN_TASK <<<"$FIXTURE"
 lab tab list --workspace "$WS_SEVEN" \
   | jq -e --arg tab "$TAB_SEVEN_SEEDED" '.result.tabs[] | select(.tab_id == $tab) | .label == "1"' >/dev/null \
   || fail "the seeded tab is not the label-1 default tab the prune identifies"
@@ -241,7 +247,7 @@ pass "attached viewer: the projection seeded-tab prune refuses while a live clie
 
 "$LAB_HELPER" viewer stop "$LAB_SESSION" >/dev/null \
   || fail "could not detach the lab viewer"
-REASON=$(foreground_reason)
+REASON=$(foreground_reason) || fail "could not probe the session's foreground client"
 [ "$REASON" = no_foreground_client ] \
   || fail "the lab still reported a foreground client after the viewer stopped (reason=$REASON)"
 OUT=$(drive fm_backend_herdr_projection_close_pane_focus_preserving "$LAB_SESSION" "$PANE_THREE_A")

--- a/tests/fm-herdr-attached-viewer-live-e2e.test.sh
+++ b/tests/fm-herdr-attached-viewer-live-e2e.test.sh
@@ -1,0 +1,253 @@
+#!/usr/bin/env bash
+# Live attached-viewer regression for the Herdr teardown focus guard.
+#
+# PR #4131 gated the active-tab close refusal on a LIVE foreground client
+# instead of the persisted `.focused` pointer, but only its two detached
+# scenarios could be driven live: every pseudo-terminal the runner built
+# started at a zero-sized window grid, so Herdr registered no foreground client
+# and `terminal title clear` kept answering `no_foreground_client`. That was a
+# harness limit, not a product one. `fm-herdr-lab.sh viewer start` now attaches
+# a real Herdr TUI over a pty sized before the fork, which turns those
+# untestable cases into this regression:
+#
+#   3. a viewer sitting on the target tab blocks the close;
+#   4. a viewer that moves ONTO the target between planning and the mutation
+#      boundary still blocks it, because the guard re-reads focus there;
+#   5. a viewer that moves OFF the target instead keeps its fresh non-target
+#      focus after the close, rather than being dragged back to a stale
+#      pre-planning pointer;
+#   7. the projection's seeded-tab prune inherits the same refusal.
+#
+# Scenarios 4 and 5 need a focus change at one exact product boundary, so a
+# PATH shim performs the real `tab focus` when the close helper issues its
+# planning `pane get`. Every Herdr call, the shim's included, still routes
+# through the guarded lab helper against a named non-default session.
+#
+# The guard submits no model prompts, so the shared live gate runs it wherever
+# herdr, jq, and python3 exist. Re-run it after every Herdr upgrade: a release
+# that changed the foreground-client contract would surface here first.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+LAB_HELPER=${HERDR_LAB_HELPER:-$ROOT/bin/fm-herdr-lab.sh}
+
+fm_live_gate default-on FM_HERDR_ATTACHED_VIEWER_LIVE_E2E herdr jq python3
+
+[ -x "$LAB_HELPER" ] || { echo "skip: Herdr lab helper not executable at $LAB_HELPER"; exit 0; }
+
+TMP_ROOT=$(fm_test_tmproot fm-herdr-attached-viewer)
+FAKEBIN=$(fm_fakebin "$TMP_ROOT")
+FOCUS_SWITCH_CONTROL="$TMP_ROOT/focus-switch"
+ORIGINAL_PATH=$PATH
+LAB_SESSION=$("$LAB_HELPER" name fm-herdr-attached-viewer)
+export LAB_HELPER LAB_SESSION ORIGINAL_PATH FOCUS_SWITCH_CONTROL
+
+cleanup() {
+  local status=$?
+  env PATH="$ORIGINAL_PATH" "$LAB_HELPER" viewer stop "$LAB_SESSION" >/dev/null 2>&1 || status=1
+  env PATH="$ORIGINAL_PATH" "$LAB_HELPER" teardown "$LAB_SESSION" || status=1
+  fm_test_cleanup
+  exit "$status"
+}
+trap cleanup EXIT
+"$LAB_HELPER" provision "$LAB_SESSION" || fail "could not provision the isolated Herdr lab"
+
+lab() { env PATH="$ORIGINAL_PATH" "$LAB_HELPER" run "$LAB_SESSION" "$@"; }
+
+# The adapter under test calls `herdr` by name. This shim strips the trailing
+# session flag the helper will re-append, refuses any caller-supplied one, and
+# optionally performs one real focus change at the requested product boundary
+# before forwarding the call.
+cat > "$FAKEBIN/herdr" <<'SH'
+#!/usr/bin/env bash
+set -u
+args=("$@")
+last=$((${#args[@]} - 1))
+flag=$((last - 1))
+if [ "${#args[@]}" -ge 2 ] \
+  && [ "${args[$flag]}" = --session ] \
+  && [ "${args[$last]}" = "$LAB_SESSION" ]; then
+  unset "args[$last]" "args[$flag]"
+fi
+set -- "${args[@]}"
+for arg in "$@"; do
+  case "$arg" in --session|--session=*) exit 9 ;; esac
+done
+if [ -f "$FOCUS_SWITCH_CONTROL/trigger" ] && [ "$*" = "$(cat "$FOCUS_SWITCH_CONTROL/trigger")" ]; then
+  rm -f "$FOCUS_SWITCH_CONTROL/trigger"
+  env PATH="$ORIGINAL_PATH" "$LAB_HELPER" run "$LAB_SESSION" \
+    tab focus "$(cat "$FOCUS_SWITCH_CONTROL/tab")" >/dev/null 2>&1
+  printf '%s\n' switched > "$FOCUS_SWITCH_CONTROL/done"
+fi
+exec env PATH="$ORIGINAL_PATH" "$LAB_HELPER" run "$LAB_SESSION" "$@"
+SH
+chmod +x "$FAKEBIN/herdr"
+
+mkdir -p "$FOCUS_SWITCH_CONTROL"
+
+# Arm the shim to run `tab focus <tab>` immediately before the adapter's own
+# `pane get <pane>` planning read, which is the last product call before the
+# close helper re-reads focus at its mutation boundary.
+arm_focus_switch() { # <tab-id> <pane-id>
+  rm -f "$FOCUS_SWITCH_CONTROL/done"
+  printf '%s\n' "$1" > "$FOCUS_SWITCH_CONTROL/tab"
+  printf 'pane get %s\n' "$2" > "$FOCUS_SWITCH_CONTROL/trigger"
+}
+
+assert_focus_switch_fired() { # <label>
+  [ -f "$FOCUS_SWITCH_CONTROL/done" ] \
+    || fail "$1: the mid-close focus switch never ran, so the timing boundary was not exercised"
+  rm -f "$FOCUS_SWITCH_CONTROL/done" "$FOCUS_SWITCH_CONTROL/trigger"
+}
+
+# Drive one real adapter entry point with the shim on PATH.
+drive() { # <function> <argument...>
+  PATH="$FAKEBIN:$ORIGINAL_PATH" bash -c '
+    . "$1/bin/backends/herdr.sh"
+    fm_backend_herdr_cli() {
+      local session=$1
+      shift
+      HERDR_SESSION="$session" herdr "$@" --session "$session"
+    }
+    fn=$2
+    shift 2
+    "$fn" "$@"
+  ' _ "$ROOT" "$@" 2>&1
+}
+
+new_workspace() { # <label> -> "<workspace>\t<tab>\t<pane>"
+  local out
+  out=$(lab workspace create --cwd "$ROOT" --label "$1" --no-focus) \
+    || fail "could not create the $1 workspace"
+  printf '%s' "$out" | jq -er '
+    [.result.workspace.workspace_id, .result.tab.tab_id, .result.root_pane.pane_id] | @tsv
+  ' || fail "could not read the $1 workspace ids"
+}
+
+new_tab() { # <workspace> <label> -> "<tab>\t<pane>"
+  local out
+  out=$(lab tab create --workspace "$1" --label "$2" --cwd "$ROOT") \
+    || fail "could not create the $2 tab"
+  printf '%s' "$out" | jq -er '[.result.tab.tab_id, .result.root_pane.pane_id] | @tsv' \
+    || fail "could not read the $2 tab ids"
+}
+
+focused_tab() {
+  lab workspace list | jq -er '
+    [.result.workspaces[] | select(.focused == true)] | select(length == 1) | .[0].active_tab_id
+  ' || fail "could not read the session's focused tab"
+}
+
+pane_exists() { lab pane get "$1" >/dev/null 2>&1; }
+
+foreground_reason() {
+  lab terminal title clear | jq -er '.result.reason' \
+    || fail "could not probe the session's foreground client"
+}
+
+# --- the attachment itself, which is what #4131 could not do ----------------
+
+REASON=$(foreground_reason)
+[ "$REASON" = no_foreground_client ] \
+  || fail "the fresh lab already had a foreground client (reason=$REASON)"
+
+"$LAB_HELPER" viewer start "$LAB_SESSION" >/dev/null \
+  || fail "could not attach a real foreground Herdr viewer over a sized pty"
+REASON=$(foreground_reason)
+[ "$REASON" = cleared ] \
+  || fail "the attached pty viewer did not register as a foreground client (reason=$REASON)"
+pass "attached viewer: a pty sized before the fork registers as a real Herdr foreground client"
+
+# --- scenario 3: a viewer on the target tab blocks the close ---------------
+
+IFS=$'\t' read -r WS_THREE TAB_THREE_A PANE_THREE_A <<<"$(new_workspace viewer-active)"
+# A second tab keeps the close a plain one rather than an emptying-workspace plan.
+IFS=$'\t' read -r _ _ <<<"$(new_tab "$WS_THREE" viewer-active-b)"
+lab tab focus "$TAB_THREE_A" >/dev/null || fail "could not focus the scenario 3 target tab"
+[ "$(focused_tab)" = "$TAB_THREE_A" ] || fail "scenario 3 did not start focused on the target tab"
+
+OUT=$(drive fm_backend_herdr_projection_close_pane_focus_preserving "$LAB_SESSION" "$PANE_THREE_A")
+STATUS=$?
+[ "$STATUS" -ne 0 ] || fail "a live viewer on the target tab did not block the close: $OUT"
+assert_contains "$OUT" "target is the captain's active tab" \
+  "the live-viewer refusal did not name the captain's active tab: $OUT"
+pane_exists "$PANE_THREE_A" \
+  || fail "the close proceeded and destroyed the tab the live viewer was watching"
+pass "attached viewer: a live client on the target tab refuses the close and keeps the pane"
+
+# --- scenario 4: the viewer moves ONTO the target mid-close ----------------
+
+IFS=$'\t' read -r WS_FOUR TAB_FOUR_A PANE_FOUR_A <<<"$(new_workspace viewer-late-on)"
+IFS=$'\t' read -r TAB_FOUR_B _ <<<"$(new_tab "$WS_FOUR" viewer-late-on-b)"
+lab tab focus "$TAB_FOUR_B" >/dev/null || fail "could not focus away from the scenario 4 target"
+[ "$(focused_tab)" = "$TAB_FOUR_B" ] || fail "scenario 4 did not start focused off the target tab"
+
+arm_focus_switch "$TAB_FOUR_A" "$PANE_FOUR_A"
+OUT=$(drive fm_backend_herdr_projection_close_pane_focus_preserving "$LAB_SESSION" "$PANE_FOUR_A")
+STATUS=$?
+assert_focus_switch_fired "scenario 4"
+[ "$STATUS" -ne 0 ] \
+  || fail "a viewer that moved onto the target after planning did not block the close: $OUT"
+assert_contains "$OUT" "target is the captain's active tab" \
+  "the late-switch refusal did not come from the fresh active-tab check: $OUT"
+pane_exists "$PANE_FOUR_A" \
+  || fail "the close destroyed a tab the viewer had moved onto before the mutation boundary"
+pass "attached viewer: focus moving onto the target between planning and mutation still blocks the close"
+
+# --- scenario 5: the viewer moves OFF the target mid-close -----------------
+
+IFS=$'\t' read -r WS_FIVE TAB_FIVE_A PANE_FIVE_A <<<"$(new_workspace viewer-late-off)"
+IFS=$'\t' read -r TAB_FIVE_B _ <<<"$(new_tab "$WS_FIVE" viewer-late-off-b)"
+lab tab focus "$TAB_FIVE_A" >/dev/null || fail "could not focus the scenario 5 target tab"
+[ "$(focused_tab)" = "$TAB_FIVE_A" ] || fail "scenario 5 did not start focused on the target tab"
+
+arm_focus_switch "$TAB_FIVE_B" "$PANE_FIVE_A"
+OUT=$(drive fm_backend_herdr_projection_close_pane_focus_preserving "$LAB_SESSION" "$PANE_FIVE_A")
+STATUS=$?
+assert_focus_switch_fired "scenario 5"
+[ "$STATUS" -eq 0 ] \
+  || fail "the close was refused even though the live viewer had moved off the target: $OUT"
+if pane_exists "$PANE_FIVE_A"; then
+  fail "the close reported success but left the target pane behind"
+fi
+[ "$(focused_tab)" = "$TAB_FIVE_B" ] \
+  || fail "the close did not preserve the viewer's fresh non-target focus (focus is $(focused_tab), expected $TAB_FIVE_B)"
+pass "attached viewer: a close preserves the fresh non-target focus the viewer moved to"
+
+# --- scenario 7: the projection's seeded-tab prune inherits the refusal ----
+
+IFS=$'\t' read -r WS_SEVEN TAB_SEVEN_SEEDED PANE_SEVEN_SEEDED <<<"$(new_workspace viewer-seeded)"
+IFS=$'\t' read -r _ PANE_SEVEN_TASK <<<"$(new_tab "$WS_SEVEN" fm-viewer-seeded-task)"
+lab tab list --workspace "$WS_SEVEN" \
+  | jq -e --arg tab "$TAB_SEVEN_SEEDED" '.result.tabs[] | select(.tab_id == $tab) | .label == "1"' >/dev/null \
+  || fail "the seeded tab is not the label-1 default tab the prune identifies"
+lab tab focus "$TAB_SEVEN_SEEDED" >/dev/null || fail "could not focus the seeded tab"
+[ "$(focused_tab)" = "$TAB_SEVEN_SEEDED" ] || fail "scenario 7 did not start focused on the seeded tab"
+
+OUT=$(drive fm_backend_herdr_workspace_prune_seeded_default_tab \
+  "$LAB_SESSION" "$WS_SEVEN" "$TAB_SEVEN_SEEDED" focus-preserving)
+STATUS=$?
+[ "$STATUS" -ne 0 ] || fail "the seeded prune did not refuse the tab a live viewer was watching: $OUT"
+assert_contains "$OUT" "target is the captain's active tab" \
+  "the seeded prune refusal did not come from the live-viewer guard: $OUT"
+pane_exists "$PANE_SEVEN_SEEDED" \
+  || fail "the seeded prune closed the tab the live viewer was watching"
+pane_exists "$PANE_SEVEN_TASK" || fail "the seeded prune disturbed the task pane"
+pass "attached viewer: the projection seeded-tab prune refuses while a live client watches it"
+
+# --- detaching restores the no-client contract the detached tests rely on ---
+
+"$LAB_HELPER" viewer stop "$LAB_SESSION" >/dev/null \
+  || fail "could not detach the lab viewer"
+REASON=$(foreground_reason)
+[ "$REASON" = no_foreground_client ] \
+  || fail "the lab still reported a foreground client after the viewer stopped (reason=$REASON)"
+OUT=$(drive fm_backend_herdr_projection_close_pane_focus_preserving "$LAB_SESSION" "$PANE_THREE_A")
+STATUS=$?
+[ "$STATUS" -eq 0 ] || fail "the same close was still refused after the viewer detached: $OUT"
+if pane_exists "$PANE_THREE_A"; then
+  fail "the detached close reported success but left the pane behind"
+fi
+pass "attached viewer: detaching releases the refusal, so the guard tracks the client and not the pointer"

--- a/tests/fm-herdr-lab.test.sh
+++ b/tests/fm-herdr-lab.test.sh
@@ -66,12 +66,6 @@ case "$1 ${2:-}" in
     ;;
   "terminal title")
     [ "${FM_FAKE_HERDR_TITLE_FAIL:-}" != 1 ] || exit 94
-    if [ -n "${FM_FAKE_HERDR_TITLE_ENTERED:-}" ]; then
-      : > "$FM_FAKE_HERDR_TITLE_ENTERED"
-      while [ ! -f "$FM_FAKE_HERDR_TITLE_RELEASE" ]; do
-        "$FM_FAKE_HERDR_REAL_SLEEP" 0.01
-      done
-    fi
     reason=no_foreground_client
     [ ! -f "$state/$session.foreground" ] || reason=$(cat "$state/$session.foreground")
     jq -nc --arg reason "$reason" '{result:{reason:$reason,type:"client_window_title"}}'
@@ -95,8 +89,6 @@ run_with_fake() {
     FM_FAKE_HERDR_FAST_POLL="${FM_FAKE_HERDR_FAST_POLL:-}" \
     FM_FAKE_HERDR_DELETE_FAIL="${FM_FAKE_HERDR_DELETE_FAIL:-}" \
     FM_FAKE_HERDR_TITLE_FAIL="${FM_FAKE_HERDR_TITLE_FAIL:-}" \
-    FM_FAKE_HERDR_TITLE_ENTERED="${FM_FAKE_HERDR_TITLE_ENTERED:-}" \
-    FM_FAKE_HERDR_TITLE_RELEASE="${FM_FAKE_HERDR_TITLE_RELEASE:-}" \
     FM_HERDR_LAB_STATE_DIR="$TRIPWIRES" \
     "$@"
 }
@@ -341,35 +333,6 @@ SH
   pass "fm-herdr-lab: startup timeout allows launcher child escalation"
 }
 
-test_concurrent_viewer_start_is_refused() {
-  local name="fm-lab-viewer-concurrent-$$" status=0 first_status=0 first_pid
-  local entered="$TMP_ROOT/viewer-title-entered" release="$TMP_ROOT/viewer-title-release"
-  local launches="$TMP_ROOT/viewer-launches" out="$TMP_ROOT/viewer-first.out"
-  run_with_fake fm_herdr_lab_provision "$name" || fail "viewer-concurrent fixture provision failed"
-  cat > "$FAKEBIN/python3" <<'SH'
-#!/usr/bin/env bash
-printf 'launched\n' >> "$FM_FAKE_VIEWER_LAUNCHES"
-exec "$FM_FAKE_HERDR_REAL_SLEEP" 20
-SH
-  chmod +x "$FAKEBIN/python3"
-  FM_FAKE_HERDR_FAST_POLL=1 FM_FAKE_HERDR_TITLE_ENTERED="$entered" \
-    FM_FAKE_HERDR_TITLE_RELEASE="$release" FM_FAKE_VIEWER_LAUNCHES="$launches" \
-    run_with_fake fm_herdr_lab_viewer_start "$name" >"$out" 2>&1 &
-  first_pid=$!
-  while [ ! -f "$entered" ]; do
-    "$REAL_SLEEP" 0.01
-  done
-  run_with_fake fm_herdr_lab_viewer_start "$name" >/dev/null 2>&1 || status=$?
-  expect_code 1 "$status" "a concurrent viewer start must be refused"
-  : > "$release"
-  wait "$first_pid" || first_status=$?
-  rm -f "$FAKEBIN/python3"
-  expect_code 1 "$first_status" "the blocked viewer fixture unexpectedly attached"
-  [ "$(wc -l < "$launches" | tr -d ' ')" = 1 ] || fail "concurrent starts launched more than one viewer"
-  run_with_fake fm_herdr_lab_teardown "$name" || fail "viewer-concurrent fixture teardown failed"
-  pass "fm-herdr-lab: concurrent viewer starts serialize before launch"
-}
-
 test_viewer_start_requires_its_owned_process() {
   local name="fm-lab-viewer-ownership-$$" out status=0 marker="$TMP_ROOT/viewer-launched"
   run_with_fake fm_herdr_lab_provision "$name" || fail "viewer-ownership fixture provision failed"
@@ -452,21 +415,24 @@ test_viewer_stop_requires_the_recorded_parent() {
   pass "fm-herdr-lab: viewer ownership requires the recorded parent"
 }
 
-test_viewer_interruption_releases_transition_lock() {
-  local name="fm-lab-viewer-interrupt-$$" lock command_pid launcher_pid status=0
-  local started="$TMP_ROOT/viewer-interrupt-started" out="$TMP_ROOT/viewer-interrupt.out"
+test_interrupted_viewer_start_cancels_launcher() {
+  local name="fm-lab-viewer-interrupt-$$" command_pid launcher_pid status=0
+  local started="$TMP_ROOT/viewer-interrupt-started" attached="$TMP_ROOT/viewer-interrupt-attached"
   run_with_fake fm_herdr_lab_provision "$name" || fail "viewer-interrupt fixture provision failed"
-  lock=$(run_with_fake fm_herdr_lab_viewer_lock_path "$name")
   cat > "$FAKEBIN/python3" <<'SH'
 #!/usr/bin/env bash
 printf '%s\n' "$$" > "$FM_FAKE_VIEWER_STARTED"
+"$FM_FAKE_HERDR_REAL_SLEEP" 0.5
+: > "$FM_FAKE_VIEWER_ATTACHED"
+printf '%s\n' cleared > "$FM_FAKE_HERDR_STATE/$FM_FAKE_VIEWER_SESSION.foreground"
 exec "$FM_FAKE_HERDR_REAL_SLEEP" 20
 SH
   chmod +x "$FAKEBIN/python3"
-  FM_FAKE_VIEWER_STARTED="$started" run_with_fake exec "$ROOT/bin/fm-herdr-lab.sh" \
-    viewer start "$name" >"$out" 2>&1 &
+  FM_FAKE_VIEWER_STARTED="$started" FM_FAKE_VIEWER_ATTACHED="$attached" \
+    FM_FAKE_VIEWER_SESSION="$name" run_with_fake exec "$ROOT/bin/fm-herdr-lab.sh" \
+    viewer start "$name" >/dev/null 2>&1 &
   command_pid=$!
-  while [ ! -f "$started" ] || [ ! -d "$lock" ]; do
+  while [ ! -f "$started" ]; do
     "$REAL_SLEEP" 0.01
   done
   launcher_pid=$(cat "$started")
@@ -474,29 +440,12 @@ SH
   wait "$command_pid" || status=$?
   rm -f "$FAKEBIN/python3"
   [ "$status" -ne 0 ] || fail "interrupted viewer start unexpectedly succeeded"
-  assert_absent "$lock" "interrupted viewer start leaked its transition lock"
-  kill "$launcher_pid" 2>/dev/null || true
-  wait "$launcher_pid" 2>/dev/null || true
+  "$REAL_SLEEP" 0.6
+  kill -0 "$launcher_pid" 2>/dev/null && fail "interrupted viewer start left its launcher running"
+  assert_absent "$attached" "interrupted viewer start attached after its command exited"
+  [ ! -f "$FAKE_STATE/$name.foreground" ] || fail "interrupted viewer start left a foreground client"
   run_with_fake fm_herdr_lab_teardown "$name" || fail "viewer-interrupt fixture teardown failed"
-  pass "fm-herdr-lab: interrupted viewer transitions release their lock"
-}
-
-test_viewer_failure_releases_transition_lock() {
-  local name="fm-lab-viewer-unlock-$$" record lock status=0 pair="$TMP_ROOT/viewer-unlock-pair"
-  run_with_fake fm_herdr_lab_provision "$name" || fail "viewer-unlock fixture provision failed"
-  record=$(run_with_fake fm_herdr_lab_viewer_record_path "$name")
-  lock=$(run_with_fake fm_herdr_lab_viewer_lock_path "$name")
-  start_viewer_fixture "$pair"
-  write_viewer_record "$record" "$FIXTURE_LAUNCHER_PID" "$FIXTURE_VIEWER_PID"
-  run_with_fake "$ROOT/bin/fm-herdr-lab.sh" viewer start "$name" >/dev/null 2>&1 || status=$?
-  expect_code 1 "$status" "starting an already-running viewer must fail"
-  assert_absent "$lock" "failed viewer start leaked its transition lock"
-  printf '%s\n' no_foreground_client > "$FAKE_STATE/$name.foreground"
-  run_with_fake "$ROOT/bin/fm-herdr-lab.sh" viewer stop "$name" || fail "stop remained blocked after failed start"
-  wait "$FIXTURE_LAUNCHER_PID" 2>/dev/null || true
-  assert_absent "$lock" "successful viewer stop leaked its transition lock"
-  run_with_fake fm_herdr_lab_teardown "$name" || fail "viewer-unlock fixture teardown failed"
-  pass "fm-herdr-lab: viewer failures release the transition lock under errexit"
+  pass "fm-herdr-lab: interrupted viewer start cancels its launcher"
 }
 
 test_teardown_refuses_while_viewer_attached() {
@@ -559,12 +508,10 @@ test_timed_out_provision_cancels_late_launch
 test_viewer_refuses_unowned_sessions
 test_viewer_start_cancels_an_unrecorded_launcher
 test_viewer_timeout_allows_launcher_escalation
-test_concurrent_viewer_start_is_refused
 test_viewer_start_requires_its_owned_process
 test_viewer_stop_only_signals_owned_processes
 test_viewer_stop_requires_the_recorded_parent
-test_viewer_interruption_releases_transition_lock
-test_viewer_failure_releases_transition_lock
+test_interrupted_viewer_start_cancels_launcher
 test_teardown_refuses_while_viewer_attached
 test_viewer_stop_retains_record_when_detach_is_unreadable
 test_viewer_launcher_refuses_unsafe_arguments

--- a/tests/fm-herdr-lab.test.sh
+++ b/tests/fm-herdr-lab.test.sh
@@ -90,7 +90,6 @@ run_with_fake() {
     FM_FAKE_HERDR_DELETE_FAIL="${FM_FAKE_HERDR_DELETE_FAIL:-}" \
     FM_FAKE_HERDR_TITLE_FAIL="${FM_FAKE_HERDR_TITLE_FAIL:-}" \
     FM_HERDR_LAB_STATE_DIR="$TRIPWIRES" \
-    FM_HERDR_LAB_VIEWER_TIMEOUT="${FM_HERDR_LAB_VIEWER_TIMEOUT:-1}" \
     "$@"
 }
 
@@ -269,21 +268,6 @@ write_viewer_record() {
     "$pid" "$start" "$pid" "$start" > "$record"
 }
 
-test_viewer_start_validates_timeout_before_launch() {
-  local name="fm-lab-viewer-timeout-$$" log out status value
-  run_with_fake fm_herdr_lab_provision "$name" || fail "viewer-timeout fixture provision failed"
-  log=$(run_with_fake fm_herdr_lab_viewer_log_path "$name")
-  for value in 0 -1 0.5; do
-    status=0
-    out=$(FM_HERDR_LAB_VIEWER_TIMEOUT="$value" run_with_fake fm_herdr_lab_viewer_start "$name" 2>&1) || status=$?
-    expect_code 1 "$status" "invalid viewer timeout '$value' must be refused"
-    assert_contains "$out" "must be a positive integer" "invalid viewer timeout refusal was unclear"
-    assert_absent "$log" "invalid viewer timeout '$value' launched the viewer"
-  done
-  run_with_fake fm_herdr_lab_teardown "$name" || fail "viewer-timeout fixture teardown failed"
-  pass "fm-herdr-lab: viewer timeout is validated before launch"
-}
-
 test_viewer_start_requires_its_owned_process() {
   local name="fm-lab-viewer-ownership-$$" out status=0 marker="$TMP_ROOT/viewer-launched"
   run_with_fake fm_herdr_lab_provision "$name" || fail "viewer-ownership fixture provision failed"
@@ -294,7 +278,8 @@ test_viewer_start_requires_its_owned_process() {
 exit 0
 SH
   chmod +x "$FAKEBIN/python3"
-  out=$(FM_FAKE_VIEWER_MARKER="$marker" run_with_fake fm_herdr_lab_viewer_start "$name" 2>&1) || status=$?
+  out=$(FM_FAKE_HERDR_FAST_POLL=1 FM_FAKE_VIEWER_MARKER="$marker" \
+    run_with_fake fm_herdr_lab_viewer_start "$name" 2>&1) || status=$?
   rm -f "$FAKEBIN/python3"
   expect_code 1 "$status" "a foreign foreground client must not satisfy viewer start"
   assert_present "$marker" "viewer ownership fixture did not launch"
@@ -323,7 +308,8 @@ test_viewer_stop_only_signals_owned_processes() {
   holder_pid=$!
   write_viewer_record "$record" "$holder_pid"
   status=0
-  run_with_fake fm_herdr_lab_viewer_stop "$name" >/dev/null 2>&1 || status=$?
+  FM_FAKE_HERDR_FAST_POLL=1 run_with_fake fm_herdr_lab_viewer_stop "$name" \
+    >/dev/null 2>&1 || status=$?
   expect_code 1 "$status" "stop must fail while the session still reports a foreground client"
   wait "$holder_pid" 2>/dev/null || true
   kill -0 "$holder_pid" 2>/dev/null && fail "stop left the recorded viewer process running"
@@ -354,7 +340,8 @@ test_teardown_refuses_while_viewer_attached() {
   holder_pid=$!
   write_viewer_record "$record" "$holder_pid"
   : > "$FAKE_LOG"
-  run_with_fake fm_herdr_lab_teardown "$name" >/dev/null 2>&1 || status=$?
+  FM_FAKE_HERDR_FAST_POLL=1 run_with_fake fm_herdr_lab_teardown "$name" \
+    >/dev/null 2>&1 || status=$?
   expect_code 1 "$status" "teardown must refuse while an owned viewer is still attached"
   [ "$(cat "$FAKE_STATE/$name")" = running ] \
     || fail "the refused teardown stopped the lab session anyway"
@@ -371,7 +358,8 @@ test_viewer_stop_retains_record_when_detach_is_unreadable() {
   run_with_fake fm_herdr_lab_provision "$name" || fail "unreadable-detach fixture provision failed"
   record=$(run_with_fake fm_herdr_lab_viewer_record_path "$name")
   printf 'launcher_pid=99999999\nlauncher_start=stale\nviewer_pid=99999999\nviewer_start=stale\n' > "$record"
-  FM_FAKE_HERDR_TITLE_FAIL=1 run_with_fake fm_herdr_lab_viewer_stop "$name" >/dev/null 2>&1 || status=$?
+  FM_FAKE_HERDR_FAST_POLL=1 FM_FAKE_HERDR_TITLE_FAIL=1 \
+    run_with_fake fm_herdr_lab_viewer_stop "$name" >/dev/null 2>&1 || status=$?
   expect_code 1 "$status" "an unreadable detach result on a running session must fail closed"
   assert_present "$record" "an unreadable detach result discarded the ownership record"
   printf '%s\n' no_foreground_client > "$FAKE_STATE/$name.foreground"
@@ -408,7 +396,6 @@ test_stopped_owned_lab_can_reprovision
 test_failed_delete_retains_tripwire
 test_timed_out_provision_cancels_late_launch
 test_viewer_refuses_unowned_sessions
-test_viewer_start_validates_timeout_before_launch
 test_viewer_start_requires_its_owned_process
 test_viewer_stop_only_signals_owned_processes
 test_teardown_refuses_while_viewer_attached

--- a/tests/fm-herdr-lab.test.sh
+++ b/tests/fm-herdr-lab.test.sh
@@ -65,6 +65,7 @@ case "$1 ${2:-}" in
     printf '%s\n' deleted > "$state/$session"
     ;;
   "terminal title")
+    [ "${FM_FAKE_HERDR_TITLE_FAIL:-}" != 1 ] || exit 94
     reason=no_foreground_client
     [ ! -f "$state/$session.foreground" ] || reason=$(cat "$state/$session.foreground")
     jq -nc --arg reason "$reason" '{result:{reason:$reason,type:"client_window_title"}}'
@@ -87,6 +88,7 @@ run_with_fake() {
     FM_FAKE_HERDR_SERVER_DELAY="${FM_FAKE_HERDR_SERVER_DELAY:-0}" \
     FM_FAKE_HERDR_FAST_POLL="${FM_FAKE_HERDR_FAST_POLL:-}" \
     FM_FAKE_HERDR_DELETE_FAIL="${FM_FAKE_HERDR_DELETE_FAIL:-}" \
+    FM_FAKE_HERDR_TITLE_FAIL="${FM_FAKE_HERDR_TITLE_FAIL:-}" \
     FM_HERDR_LAB_STATE_DIR="$TRIPWIRES" \
     FM_HERDR_LAB_VIEWER_TIMEOUT="${FM_HERDR_LAB_VIEWER_TIMEOUT:-1}" \
     "$@"
@@ -260,6 +262,13 @@ test_viewer_refuses_unowned_sessions() {
   pass "fm-herdr-lab: the viewer attaches only to a session this lab owns"
 }
 
+write_viewer_record() {
+  local record=$1 pid=$2 start
+  start=$(fm_herdr_lab_process_start "$pid") || fail "could not identify viewer fixture process"
+  printf 'launcher_pid=%s\nlauncher_start=%s\nviewer_pid=%s\nviewer_start=%s\n' \
+    "$pid" "$start" "$pid" "$start" > "$record"
+}
+
 test_viewer_stop_only_signals_owned_processes() {
   local name="fm-lab-viewer-stop-$$" record status=0 holder_pid
   run_with_fake fm_herdr_lab_provision "$name" || fail "viewer-stop fixture provision failed"
@@ -276,14 +285,24 @@ test_viewer_stop_only_signals_owned_processes() {
   # foreground client again.
   sleep 20 &
   holder_pid=$!
-  printf 'launcher=%s\nviewer=%s\n' "$holder_pid" "$holder_pid" > "$record"
+  write_viewer_record "$record" "$holder_pid"
   status=0
   run_with_fake fm_herdr_lab_viewer_stop "$name" >/dev/null 2>&1 || status=$?
   expect_code 1 "$status" "stop must fail while the session still reports a foreground client"
+  wait "$holder_pid" 2>/dev/null || true
   kill -0 "$holder_pid" 2>/dev/null && fail "stop left the recorded viewer process running"
   assert_present "$record" "a failed detach discarded the viewer record it still needs"
 
+  sleep 20 &
+  holder_pid=$!
+  printf 'launcher_pid=%s\nlauncher_start=not-this-process\nviewer_pid=%s\nviewer_start=not-this-process\n' \
+    "$holder_pid" "$holder_pid" > "$record"
   printf '%s\n' no_foreground_client > "$FAKE_STATE/$name.foreground"
+  run_with_fake fm_herdr_lab_viewer_stop "$name" || fail "stop rejected a stale process record"
+  kill -0 "$holder_pid" 2>/dev/null || fail "stop signalled a PID whose recorded identity did not match"
+  kill "$holder_pid" 2>/dev/null || true
+  wait "$holder_pid" 2>/dev/null || true
+
   run_with_fake fm_herdr_lab_viewer_stop "$name" || fail "stop failed once the client had detached"
   assert_absent "$record" "a confirmed detach left the viewer record behind"
   run_with_fake fm_herdr_lab_teardown "$name" || fail "teardown after viewer stop failed"
@@ -297,7 +316,7 @@ test_teardown_refuses_while_viewer_attached() {
   printf '%s\n' cleared > "$FAKE_STATE/$name.foreground"
   sleep 20 &
   holder_pid=$!
-  printf 'launcher=%s\nviewer=%s\n' "$holder_pid" "$holder_pid" > "$record"
+  write_viewer_record "$record" "$holder_pid"
   : > "$FAKE_LOG"
   run_with_fake fm_herdr_lab_teardown "$name" >/dev/null 2>&1 || status=$?
   expect_code 1 "$status" "teardown must refuse while an owned viewer is still attached"
@@ -309,6 +328,19 @@ test_teardown_refuses_while_viewer_attached() {
   printf '%s\n' no_foreground_client > "$FAKE_STATE/$name.foreground"
   run_with_fake fm_herdr_lab_teardown "$name" || fail "teardown after the viewer detached failed"
   pass "fm-herdr-lab: teardown refuses to destroy a session an attached viewer still holds"
+}
+
+test_viewer_stop_retains_record_when_detach_is_unreadable() {
+  local name="fm-lab-viewer-unreadable-$$" record status=0
+  run_with_fake fm_herdr_lab_provision "$name" || fail "unreadable-detach fixture provision failed"
+  record=$(run_with_fake fm_herdr_lab_viewer_record_path "$name")
+  printf 'launcher_pid=99999999\nlauncher_start=stale\nviewer_pid=99999999\nviewer_start=stale\n' > "$record"
+  FM_FAKE_HERDR_TITLE_FAIL=1 run_with_fake fm_herdr_lab_viewer_stop "$name" >/dev/null 2>&1 || status=$?
+  expect_code 1 "$status" "an unreadable detach result on a running session must fail closed"
+  assert_present "$record" "an unreadable detach result discarded the ownership record"
+  printf '%s\n' no_foreground_client > "$FAKE_STATE/$name.foreground"
+  run_with_fake fm_herdr_lab_teardown "$name" || fail "teardown after a confirmed detach failed"
+  pass "fm-herdr-lab: unreadable detach results fail closed on running sessions"
 }
 
 test_viewer_launcher_refuses_unsafe_arguments() {
@@ -342,4 +374,5 @@ test_timed_out_provision_cancels_late_launch
 test_viewer_refuses_unowned_sessions
 test_viewer_stop_only_signals_owned_processes
 test_teardown_refuses_while_viewer_attached
+test_viewer_stop_retains_record_when_detach_is_unreadable
 test_viewer_launcher_refuses_unsafe_arguments

--- a/tests/fm-herdr-lab.test.sh
+++ b/tests/fm-herdr-lab.test.sh
@@ -66,6 +66,12 @@ case "$1 ${2:-}" in
     ;;
   "terminal title")
     [ "${FM_FAKE_HERDR_TITLE_FAIL:-}" != 1 ] || exit 94
+    if [ -n "${FM_FAKE_HERDR_TITLE_ENTERED:-}" ]; then
+      : > "$FM_FAKE_HERDR_TITLE_ENTERED"
+      while [ ! -f "$FM_FAKE_HERDR_TITLE_RELEASE" ]; do
+        "$FM_FAKE_HERDR_REAL_SLEEP" 0.01
+      done
+    fi
     reason=no_foreground_client
     [ ! -f "$state/$session.foreground" ] || reason=$(cat "$state/$session.foreground")
     jq -nc --arg reason "$reason" '{result:{reason:$reason,type:"client_window_title"}}'
@@ -89,6 +95,8 @@ run_with_fake() {
     FM_FAKE_HERDR_FAST_POLL="${FM_FAKE_HERDR_FAST_POLL:-}" \
     FM_FAKE_HERDR_DELETE_FAIL="${FM_FAKE_HERDR_DELETE_FAIL:-}" \
     FM_FAKE_HERDR_TITLE_FAIL="${FM_FAKE_HERDR_TITLE_FAIL:-}" \
+    FM_FAKE_HERDR_TITLE_ENTERED="${FM_FAKE_HERDR_TITLE_ENTERED:-}" \
+    FM_FAKE_HERDR_TITLE_RELEASE="${FM_FAKE_HERDR_TITLE_RELEASE:-}" \
     FM_HERDR_LAB_STATE_DIR="$TRIPWIRES" \
     "$@"
 }
@@ -264,38 +272,77 @@ test_viewer_refuses_unowned_sessions() {
   pass "fm-herdr-lab: the viewer attaches only to a session this lab owns"
 }
 
+start_viewer_fixture() {
+  local pair=$1
+  (
+    "$REAL_SLEEP" 20 &
+    printf '%s\n' "$!" > "$pair"
+    wait
+  ) &
+  FIXTURE_LAUNCHER_PID=$!
+  while [ ! -s "$pair" ]; do
+    "$REAL_SLEEP" 0.01
+  done
+  FIXTURE_VIEWER_PID=$(cat "$pair")
+}
+
 write_viewer_record() {
-  local record=$1 pid=$2 start
-  start=$(fm_herdr_lab_process_start "$pid") || fail "could not identify viewer fixture process"
+  local record=$1 launcher_pid=$2 viewer_pid=$3 launcher_start viewer_start
+  launcher_start=$(fm_herdr_lab_process_start "$launcher_pid") || fail "could not identify launcher fixture process"
+  viewer_start=$(fm_herdr_lab_process_start "$viewer_pid") || fail "could not identify viewer fixture process"
   printf 'launcher_pid=%s\nlauncher_start=%s\nviewer_pid=%s\nviewer_start=%s\n' \
-    "$pid" "$start" "$pid" "$start" > "$record"
+    "$launcher_pid" "$launcher_start" "$viewer_pid" "$viewer_start" > "$record"
 }
 
 test_viewer_start_cancels_an_unrecorded_launcher() {
   local name="fm-lab-viewer-late-$$" out status=0 launcher_pid
-  local started="$TMP_ROOT/viewer-launcher-started" attached="$TMP_ROOT/viewer-late-attach"
+  local started="$TMP_ROOT/viewer-launcher-started"
   run_with_fake fm_herdr_lab_provision "$name" || fail "viewer-late fixture provision failed"
   cat > "$FAKEBIN/python3" <<'SH'
 #!/usr/bin/env bash
 printf '%s\n' "$$" > "$FM_FAKE_VIEWER_STARTED"
-"$FM_FAKE_HERDR_REAL_SLEEP" 0.5
-: > "$FM_FAKE_VIEWER_ATTACHED"
 exec "$FM_FAKE_HERDR_REAL_SLEEP" 20
 SH
   chmod +x "$FAKEBIN/python3"
   out=$(FM_FAKE_HERDR_FAST_POLL=1 FM_FAKE_HERDR_WAIT_MARKER="$started" \
-    FM_FAKE_VIEWER_STARTED="$started" FM_FAKE_VIEWER_ATTACHED="$attached" \
-    run_with_fake fm_herdr_lab_viewer_start "$name" 2>&1) || status=$?
+    FM_FAKE_VIEWER_STARTED="$started" run_with_fake fm_herdr_lab_viewer_start "$name" 2>&1) || status=$?
   rm -f "$FAKEBIN/python3"
   expect_code 1 "$status" "an unrecorded launcher must not outlive viewer start"
   assert_present "$started" "delayed viewer launcher did not start"
   launcher_pid=$(cat "$started")
   kill -0 "$launcher_pid" 2>/dev/null && fail "timed-out viewer launcher remained alive"
-  "$REAL_SLEEP" 0.6
-  assert_absent "$attached" "timed-out viewer launcher attached after start failed"
   assert_contains "$out" "did not become the foreground client" "launcher timeout was unclear"
   run_with_fake fm_herdr_lab_teardown "$name" || fail "viewer-late fixture teardown failed"
   pass "fm-herdr-lab: timed-out viewer startup cancels its exact launcher"
+}
+
+test_concurrent_viewer_start_is_refused() {
+  local name="fm-lab-viewer-concurrent-$$" status=0 first_status=0 first_pid
+  local entered="$TMP_ROOT/viewer-title-entered" release="$TMP_ROOT/viewer-title-release"
+  local launches="$TMP_ROOT/viewer-launches" out="$TMP_ROOT/viewer-first.out"
+  run_with_fake fm_herdr_lab_provision "$name" || fail "viewer-concurrent fixture provision failed"
+  cat > "$FAKEBIN/python3" <<'SH'
+#!/usr/bin/env bash
+printf 'launched\n' >> "$FM_FAKE_VIEWER_LAUNCHES"
+exec "$FM_FAKE_HERDR_REAL_SLEEP" 20
+SH
+  chmod +x "$FAKEBIN/python3"
+  FM_FAKE_HERDR_FAST_POLL=1 FM_FAKE_HERDR_TITLE_ENTERED="$entered" \
+    FM_FAKE_HERDR_TITLE_RELEASE="$release" FM_FAKE_VIEWER_LAUNCHES="$launches" \
+    run_with_fake fm_herdr_lab_viewer_start "$name" >"$out" 2>&1 &
+  first_pid=$!
+  while [ ! -f "$entered" ]; do
+    "$REAL_SLEEP" 0.01
+  done
+  run_with_fake fm_herdr_lab_viewer_start "$name" >/dev/null 2>&1 || status=$?
+  expect_code 1 "$status" "a concurrent viewer start must be refused"
+  : > "$release"
+  wait "$first_pid" || first_status=$?
+  rm -f "$FAKEBIN/python3"
+  expect_code 1 "$first_status" "the blocked viewer fixture unexpectedly attached"
+  [ "$(wc -l < "$launches" | tr -d ' ')" = 1 ] || fail "concurrent starts launched more than one viewer"
+  run_with_fake fm_herdr_lab_teardown "$name" || fail "viewer-concurrent fixture teardown failed"
+  pass "fm-herdr-lab: concurrent viewer starts serialize before launch"
 }
 
 test_viewer_start_requires_its_owned_process() {
@@ -321,7 +368,7 @@ SH
 }
 
 test_viewer_stop_only_signals_owned_processes() {
-  local name="fm-lab-viewer-stop-$$" record status=0 holder_pid
+  local name="fm-lab-viewer-stop-$$" record status=0 holder_pid pair="$TMP_ROOT/viewer-stop-pair"
   run_with_fake fm_herdr_lab_provision "$name" || fail "viewer-stop fixture provision failed"
   record=$(run_with_fake fm_herdr_lab_viewer_record_path "$name")
 
@@ -334,15 +381,14 @@ test_viewer_stop_only_signals_owned_processes() {
 
   # A recorded viewer is signalled until it exits and the session reports no
   # foreground client again.
-  sleep 20 &
-  holder_pid=$!
-  write_viewer_record "$record" "$holder_pid"
+  start_viewer_fixture "$pair"
+  write_viewer_record "$record" "$FIXTURE_LAUNCHER_PID" "$FIXTURE_VIEWER_PID"
   status=0
   FM_FAKE_HERDR_FAST_POLL=1 run_with_fake fm_herdr_lab_viewer_stop "$name" \
     >/dev/null 2>&1 || status=$?
   expect_code 1 "$status" "stop must fail while the session still reports a foreground client"
-  wait "$holder_pid" 2>/dev/null || true
-  kill -0 "$holder_pid" 2>/dev/null && fail "stop left the recorded viewer process running"
+  wait "$FIXTURE_LAUNCHER_PID" 2>/dev/null || true
+  kill -0 "$FIXTURE_VIEWER_PID" 2>/dev/null && fail "stop left the recorded viewer process running"
   assert_present "$record" "a failed detach discarded the viewer record it still needs"
 
   sleep 20 &
@@ -361,14 +407,32 @@ test_viewer_stop_only_signals_owned_processes() {
   pass "fm-herdr-lab: viewer stop signals only recorded processes and confirms the detach"
 }
 
+test_viewer_stop_requires_the_recorded_parent() {
+  local name="fm-lab-viewer-parent-$$" record launcher_pid viewer_pid
+  run_with_fake fm_herdr_lab_provision "$name" || fail "viewer-parent fixture provision failed"
+  record=$(run_with_fake fm_herdr_lab_viewer_record_path "$name")
+  sleep 20 &
+  launcher_pid=$!
+  sleep 20 &
+  viewer_pid=$!
+  write_viewer_record "$record" "$launcher_pid" "$viewer_pid"
+  printf '%s\n' no_foreground_client > "$FAKE_STATE/$name.foreground"
+  run_with_fake fm_herdr_lab_viewer_stop "$name" || fail "parent-mismatch stop failed"
+  kill -0 "$viewer_pid" 2>/dev/null || fail "stop signalled a viewer outside the recorded launcher"
+  wait "$launcher_pid" 2>/dev/null || true
+  kill "$viewer_pid" 2>/dev/null || true
+  wait "$viewer_pid" 2>/dev/null || true
+  run_with_fake fm_herdr_lab_teardown "$name" || fail "viewer-parent fixture teardown failed"
+  pass "fm-herdr-lab: viewer ownership requires the recorded parent"
+}
+
 test_teardown_refuses_while_viewer_attached() {
-  local name="fm-lab-viewer-teardown-$$" record status=0 holder_pid
+  local name="fm-lab-viewer-teardown-$$" record status=0 pair="$TMP_ROOT/viewer-teardown-pair"
   run_with_fake fm_herdr_lab_provision "$name" || fail "viewer-teardown fixture provision failed"
   record=$(run_with_fake fm_herdr_lab_viewer_record_path "$name")
   printf '%s\n' cleared > "$FAKE_STATE/$name.foreground"
-  sleep 20 &
-  holder_pid=$!
-  write_viewer_record "$record" "$holder_pid"
+  start_viewer_fixture "$pair"
+  write_viewer_record "$record" "$FIXTURE_LAUNCHER_PID" "$FIXTURE_VIEWER_PID"
   : > "$FAKE_LOG"
   FM_FAKE_HERDR_FAST_POLL=1 run_with_fake fm_herdr_lab_teardown "$name" \
     >/dev/null 2>&1 || status=$?
@@ -421,8 +485,10 @@ test_failed_delete_retains_tripwire
 test_timed_out_provision_cancels_late_launch
 test_viewer_refuses_unowned_sessions
 test_viewer_start_cancels_an_unrecorded_launcher
+test_concurrent_viewer_start_is_refused
 test_viewer_start_requires_its_owned_process
 test_viewer_stop_only_signals_owned_processes
+test_viewer_stop_requires_the_recorded_parent
 test_teardown_refuses_while_viewer_attached
 test_viewer_stop_retains_record_when_detach_is_unreadable
 test_viewer_launcher_refuses_unsafe_arguments

--- a/tests/fm-herdr-lab.test.sh
+++ b/tests/fm-herdr-lab.test.sh
@@ -220,6 +220,9 @@ test_timed_out_provision_cancels_late_launch() {
   cat > "$FAKEBIN/sleep" <<'SH'
 #!/usr/bin/env bash
 if [ "${FM_FAKE_HERDR_FAST_POLL:-}" = 1 ]; then
+  while [ -n "${FM_FAKE_HERDR_WAIT_MARKER:-}" ] && [ ! -f "$FM_FAKE_HERDR_WAIT_MARKER" ]; do
+    "$FM_FAKE_HERDR_REAL_SLEEP" 0.01
+  done
   exit 0
 fi
 exec "$FM_FAKE_HERDR_REAL_SLEEP" "$@"
@@ -266,6 +269,33 @@ write_viewer_record() {
   start=$(fm_herdr_lab_process_start "$pid") || fail "could not identify viewer fixture process"
   printf 'launcher_pid=%s\nlauncher_start=%s\nviewer_pid=%s\nviewer_start=%s\n' \
     "$pid" "$start" "$pid" "$start" > "$record"
+}
+
+test_viewer_start_cancels_an_unrecorded_launcher() {
+  local name="fm-lab-viewer-late-$$" out status=0 launcher_pid
+  local started="$TMP_ROOT/viewer-launcher-started" attached="$TMP_ROOT/viewer-late-attach"
+  run_with_fake fm_herdr_lab_provision "$name" || fail "viewer-late fixture provision failed"
+  cat > "$FAKEBIN/python3" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n' "$$" > "$FM_FAKE_VIEWER_STARTED"
+"$FM_FAKE_HERDR_REAL_SLEEP" 0.5
+: > "$FM_FAKE_VIEWER_ATTACHED"
+exec "$FM_FAKE_HERDR_REAL_SLEEP" 20
+SH
+  chmod +x "$FAKEBIN/python3"
+  out=$(FM_FAKE_HERDR_FAST_POLL=1 FM_FAKE_HERDR_WAIT_MARKER="$started" \
+    FM_FAKE_VIEWER_STARTED="$started" FM_FAKE_VIEWER_ATTACHED="$attached" \
+    run_with_fake fm_herdr_lab_viewer_start "$name" 2>&1) || status=$?
+  rm -f "$FAKEBIN/python3"
+  expect_code 1 "$status" "an unrecorded launcher must not outlive viewer start"
+  assert_present "$started" "delayed viewer launcher did not start"
+  launcher_pid=$(cat "$started")
+  kill -0 "$launcher_pid" 2>/dev/null && fail "timed-out viewer launcher remained alive"
+  "$REAL_SLEEP" 0.6
+  assert_absent "$attached" "timed-out viewer launcher attached after start failed"
+  assert_contains "$out" "did not become the foreground client" "launcher timeout was unclear"
+  run_with_fake fm_herdr_lab_teardown "$name" || fail "viewer-late fixture teardown failed"
+  pass "fm-herdr-lab: timed-out viewer startup cancels its exact launcher"
 }
 
 test_viewer_start_requires_its_owned_process() {
@@ -370,22 +400,16 @@ test_viewer_stop_retains_record_when_detach_is_unreadable() {
 test_viewer_launcher_refuses_unsafe_arguments() {
   local launcher="$ROOT/bin/fm-herdr-lab-viewer.py" status=0
   command -v python3 >/dev/null 2>&1 || { pass "fm-herdr-lab: viewer launcher argument guard (skipped, no python3)"; return; }
-  python3 "$launcher" default 40 120 "$TMP_ROOT/pid" >/dev/null 2>&1 || status=$?
+  python3 "$launcher" default "$TMP_ROOT/pid" >/dev/null 2>&1 || status=$?
   expect_code 2 "$status" "the launcher must refuse the default session"
   status=0
-  python3 "$launcher" arbitrary-session 40 120 "$TMP_ROOT/pid" >/dev/null 2>&1 || status=$?
+  python3 "$launcher" arbitrary-session "$TMP_ROOT/pid" >/dev/null 2>&1 || status=$?
   expect_code 2 "$status" "the launcher must refuse a non-lab session name"
   status=0
-  python3 "$launcher" fm-lab-args 0 120 "$TMP_ROOT/pid" >/dev/null 2>&1 || status=$?
-  expect_code 2 "$status" "a zero-row grid is the exact defect this helper exists to avoid"
-  status=0
-  python3 "$launcher" fm-lab-args 40 0 "$TMP_ROOT/pid" >/dev/null 2>&1 || status=$?
-  expect_code 2 "$status" "a zero-column grid is the exact defect this helper exists to avoid"
-  status=0
-  python3 "$launcher" fm-lab-args 40 120 relative-pidfile >/dev/null 2>&1 || status=$?
+  python3 "$launcher" fm-lab-args relative-pidfile >/dev/null 2>&1 || status=$?
   expect_code 2 "$status" "the launcher must refuse a relative pidfile path"
   assert_absent "$TMP_ROOT/pid" "a refused launch still wrote a pid record"
-  pass "fm-herdr-lab: the viewer launcher refuses unsafe sessions and zero-sized grids"
+  pass "fm-herdr-lab: the viewer launcher refuses unsafe sessions and pidfiles"
 }
 
 test_refuses_unsafe_names
@@ -396,6 +420,7 @@ test_stopped_owned_lab_can_reprovision
 test_failed_delete_retains_tripwire
 test_timed_out_provision_cancels_late_launch
 test_viewer_refuses_unowned_sessions
+test_viewer_start_cancels_an_unrecorded_launcher
 test_viewer_start_requires_its_owned_process
 test_viewer_stop_only_signals_owned_processes
 test_teardown_refuses_while_viewer_attached

--- a/tests/fm-herdr-lab.test.sh
+++ b/tests/fm-herdr-lab.test.sh
@@ -316,6 +316,31 @@ SH
   pass "fm-herdr-lab: timed-out viewer startup cancels its exact launcher"
 }
 
+test_viewer_timeout_allows_launcher_escalation() {
+  local launcher_pid started="$TMP_ROOT/viewer-grace-started"
+  local terminating="$TMP_ROOT/viewer-grace-terminating" completed="$TMP_ROOT/viewer-grace-completed"
+  cat > "$FAKEBIN/viewer-launcher" <<'SH'
+#!/usr/bin/env bash
+trap 'printf "" > "$FM_FAKE_VIEWER_TERMINATING"; "$FM_FAKE_HERDR_REAL_SLEEP" 1.2; printf "" > "$FM_FAKE_VIEWER_COMPLETED"; exit 0' TERM
+printf '' > "$FM_FAKE_VIEWER_STARTED"
+while :; do
+  "$FM_FAKE_HERDR_REAL_SLEEP" 0.1
+done
+SH
+  chmod +x "$FAKEBIN/viewer-launcher"
+  FM_FAKE_HERDR_REAL_SLEEP="$REAL_SLEEP" FM_FAKE_VIEWER_STARTED="$started" \
+    FM_FAKE_VIEWER_TERMINATING="$terminating" FM_FAKE_VIEWER_COMPLETED="$completed" \
+    "$FAKEBIN/viewer-launcher" &
+  launcher_pid=$!
+  while [ ! -f "$started" ]; do
+    "$REAL_SLEEP" 0.01
+  done
+  run_with_fake fm_herdr_lab_cancel_viewer_launcher "$launcher_pid"
+  assert_present "$terminating" "timed-out viewer launcher did not receive TERM"
+  assert_present "$completed" "viewer launcher was killed before completing child escalation"
+  pass "fm-herdr-lab: startup timeout allows launcher child escalation"
+}
+
 test_concurrent_viewer_start_is_refused() {
   local name="fm-lab-viewer-concurrent-$$" status=0 first_status=0 first_pid
   local entered="$TMP_ROOT/viewer-title-entered" release="$TMP_ROOT/viewer-title-release"
@@ -427,6 +452,35 @@ test_viewer_stop_requires_the_recorded_parent() {
   pass "fm-herdr-lab: viewer ownership requires the recorded parent"
 }
 
+test_viewer_interruption_releases_transition_lock() {
+  local name="fm-lab-viewer-interrupt-$$" lock command_pid launcher_pid status=0
+  local started="$TMP_ROOT/viewer-interrupt-started" out="$TMP_ROOT/viewer-interrupt.out"
+  run_with_fake fm_herdr_lab_provision "$name" || fail "viewer-interrupt fixture provision failed"
+  lock=$(run_with_fake fm_herdr_lab_viewer_lock_path "$name")
+  cat > "$FAKEBIN/python3" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n' "$$" > "$FM_FAKE_VIEWER_STARTED"
+exec "$FM_FAKE_HERDR_REAL_SLEEP" 20
+SH
+  chmod +x "$FAKEBIN/python3"
+  FM_FAKE_VIEWER_STARTED="$started" run_with_fake exec "$ROOT/bin/fm-herdr-lab.sh" \
+    viewer start "$name" >"$out" 2>&1 &
+  command_pid=$!
+  while [ ! -f "$started" ] || [ ! -d "$lock" ]; do
+    "$REAL_SLEEP" 0.01
+  done
+  launcher_pid=$(cat "$started")
+  kill -TERM "$command_pid"
+  wait "$command_pid" || status=$?
+  rm -f "$FAKEBIN/python3"
+  [ "$status" -ne 0 ] || fail "interrupted viewer start unexpectedly succeeded"
+  assert_absent "$lock" "interrupted viewer start leaked its transition lock"
+  kill "$launcher_pid" 2>/dev/null || true
+  wait "$launcher_pid" 2>/dev/null || true
+  run_with_fake fm_herdr_lab_teardown "$name" || fail "viewer-interrupt fixture teardown failed"
+  pass "fm-herdr-lab: interrupted viewer transitions release their lock"
+}
+
 test_viewer_failure_releases_transition_lock() {
   local name="fm-lab-viewer-unlock-$$" record lock status=0 pair="$TMP_ROOT/viewer-unlock-pair"
   run_with_fake fm_herdr_lab_provision "$name" || fail "viewer-unlock fixture provision failed"
@@ -504,10 +558,12 @@ test_failed_delete_retains_tripwire
 test_timed_out_provision_cancels_late_launch
 test_viewer_refuses_unowned_sessions
 test_viewer_start_cancels_an_unrecorded_launcher
+test_viewer_timeout_allows_launcher_escalation
 test_concurrent_viewer_start_is_refused
 test_viewer_start_requires_its_owned_process
 test_viewer_stop_only_signals_owned_processes
 test_viewer_stop_requires_the_recorded_parent
+test_viewer_interruption_releases_transition_lock
 test_viewer_failure_releases_transition_lock
 test_teardown_refuses_while_viewer_attached
 test_viewer_stop_retains_record_when_detach_is_unreadable

--- a/tests/fm-herdr-lab.test.sh
+++ b/tests/fm-herdr-lab.test.sh
@@ -269,6 +269,42 @@ write_viewer_record() {
     "$pid" "$start" "$pid" "$start" > "$record"
 }
 
+test_viewer_start_validates_timeout_before_launch() {
+  local name="fm-lab-viewer-timeout-$$" log out status value
+  run_with_fake fm_herdr_lab_provision "$name" || fail "viewer-timeout fixture provision failed"
+  log=$(run_with_fake fm_herdr_lab_viewer_log_path "$name")
+  for value in 0 -1 0.5; do
+    status=0
+    out=$(FM_HERDR_LAB_VIEWER_TIMEOUT="$value" run_with_fake fm_herdr_lab_viewer_start "$name" 2>&1) || status=$?
+    expect_code 1 "$status" "invalid viewer timeout '$value' must be refused"
+    assert_contains "$out" "must be a positive integer" "invalid viewer timeout refusal was unclear"
+    assert_absent "$log" "invalid viewer timeout '$value' launched the viewer"
+  done
+  run_with_fake fm_herdr_lab_teardown "$name" || fail "viewer-timeout fixture teardown failed"
+  pass "fm-herdr-lab: viewer timeout is validated before launch"
+}
+
+test_viewer_start_requires_its_owned_process() {
+  local name="fm-lab-viewer-ownership-$$" out status=0 marker="$TMP_ROOT/viewer-launched"
+  run_with_fake fm_herdr_lab_provision "$name" || fail "viewer-ownership fixture provision failed"
+  printf '%s\n' cleared > "$FAKE_STATE/$name.foreground"
+  cat > "$FAKEBIN/python3" <<'SH'
+#!/usr/bin/env bash
+: > "$FM_FAKE_VIEWER_MARKER"
+exit 0
+SH
+  chmod +x "$FAKEBIN/python3"
+  out=$(FM_FAKE_VIEWER_MARKER="$marker" run_with_fake fm_herdr_lab_viewer_start "$name" 2>&1) || status=$?
+  rm -f "$FAKEBIN/python3"
+  expect_code 1 "$status" "a foreign foreground client must not satisfy viewer start"
+  assert_present "$marker" "viewer ownership fixture did not launch"
+  assert_contains "$out" "did not become the foreground client" "ownership failure did not time out clearly"
+  assert_not_contains "$out" "viewer attached" "start claimed a foreign foreground client as its own"
+  printf '%s\n' no_foreground_client > "$FAKE_STATE/$name.foreground"
+  run_with_fake fm_herdr_lab_teardown "$name" || fail "viewer-ownership fixture teardown failed"
+  pass "fm-herdr-lab: viewer start requires an identity-matched owned process"
+}
+
 test_viewer_stop_only_signals_owned_processes() {
   local name="fm-lab-viewer-stop-$$" record status=0 holder_pid
   run_with_fake fm_herdr_lab_provision "$name" || fail "viewer-stop fixture provision failed"
@@ -372,6 +408,8 @@ test_stopped_owned_lab_can_reprovision
 test_failed_delete_retains_tripwire
 test_timed_out_provision_cancels_late_launch
 test_viewer_refuses_unowned_sessions
+test_viewer_start_validates_timeout_before_launch
+test_viewer_start_requires_its_owned_process
 test_viewer_stop_only_signals_owned_processes
 test_teardown_refuses_while_viewer_attached
 test_viewer_stop_retains_record_when_detach_is_unreadable

--- a/tests/fm-herdr-lab.test.sh
+++ b/tests/fm-herdr-lab.test.sh
@@ -418,12 +418,31 @@ test_viewer_stop_requires_the_recorded_parent() {
   write_viewer_record "$record" "$launcher_pid" "$viewer_pid"
   printf '%s\n' no_foreground_client > "$FAKE_STATE/$name.foreground"
   run_with_fake fm_herdr_lab_viewer_stop "$name" || fail "parent-mismatch stop failed"
+  kill -0 "$launcher_pid" 2>/dev/null || fail "stop signalled a launcher without its recorded child"
   kill -0 "$viewer_pid" 2>/dev/null || fail "stop signalled a viewer outside the recorded launcher"
+  kill "$launcher_pid" "$viewer_pid" 2>/dev/null || true
   wait "$launcher_pid" 2>/dev/null || true
-  kill "$viewer_pid" 2>/dev/null || true
   wait "$viewer_pid" 2>/dev/null || true
   run_with_fake fm_herdr_lab_teardown "$name" || fail "viewer-parent fixture teardown failed"
   pass "fm-herdr-lab: viewer ownership requires the recorded parent"
+}
+
+test_viewer_failure_releases_transition_lock() {
+  local name="fm-lab-viewer-unlock-$$" record lock status=0 pair="$TMP_ROOT/viewer-unlock-pair"
+  run_with_fake fm_herdr_lab_provision "$name" || fail "viewer-unlock fixture provision failed"
+  record=$(run_with_fake fm_herdr_lab_viewer_record_path "$name")
+  lock=$(run_with_fake fm_herdr_lab_viewer_lock_path "$name")
+  start_viewer_fixture "$pair"
+  write_viewer_record "$record" "$FIXTURE_LAUNCHER_PID" "$FIXTURE_VIEWER_PID"
+  run_with_fake "$ROOT/bin/fm-herdr-lab.sh" viewer start "$name" >/dev/null 2>&1 || status=$?
+  expect_code 1 "$status" "starting an already-running viewer must fail"
+  assert_absent "$lock" "failed viewer start leaked its transition lock"
+  printf '%s\n' no_foreground_client > "$FAKE_STATE/$name.foreground"
+  run_with_fake "$ROOT/bin/fm-herdr-lab.sh" viewer stop "$name" || fail "stop remained blocked after failed start"
+  wait "$FIXTURE_LAUNCHER_PID" 2>/dev/null || true
+  assert_absent "$lock" "successful viewer stop leaked its transition lock"
+  run_with_fake fm_herdr_lab_teardown "$name" || fail "viewer-unlock fixture teardown failed"
+  pass "fm-herdr-lab: viewer failures release the transition lock under errexit"
 }
 
 test_teardown_refuses_while_viewer_attached() {
@@ -489,6 +508,7 @@ test_concurrent_viewer_start_is_refused
 test_viewer_start_requires_its_owned_process
 test_viewer_stop_only_signals_owned_processes
 test_viewer_stop_requires_the_recorded_parent
+test_viewer_failure_releases_transition_lock
 test_teardown_refuses_while_viewer_attached
 test_viewer_stop_retains_record_when_detach_is_unreadable
 test_viewer_launcher_refuses_unsafe_arguments

--- a/tests/fm-herdr-lab.test.sh
+++ b/tests/fm-herdr-lab.test.sh
@@ -64,6 +64,11 @@ case "$1 ${2:-}" in
     [ "${FM_FAKE_HERDR_DELETE_FAIL:-}" != 1 ] || exit 93
     printf '%s\n' deleted > "$state/$session"
     ;;
+  "terminal title")
+    reason=no_foreground_client
+    [ ! -f "$state/$session.foreground" ] || reason=$(cat "$state/$session.foreground")
+    jq -nc --arg reason "$reason" '{result:{reason:$reason,type:"client_window_title"}}'
+    ;;
   *)
     printf '%s\n' '{"ok":true}'
     ;;
@@ -83,6 +88,7 @@ run_with_fake() {
     FM_FAKE_HERDR_FAST_POLL="${FM_FAKE_HERDR_FAST_POLL:-}" \
     FM_FAKE_HERDR_DELETE_FAIL="${FM_FAKE_HERDR_DELETE_FAIL:-}" \
     FM_HERDR_LAB_STATE_DIR="$TRIPWIRES" \
+    FM_HERDR_LAB_VIEWER_TIMEOUT="${FM_HERDR_LAB_VIEWER_TIMEOUT:-1}" \
     "$@"
 }
 
@@ -234,6 +240,98 @@ SH
   pass "fm-herdr-lab: timed-out provisioning cancels the launch before teardown"
 }
 
+
+# The pty attachment itself needs a real Herdr client, so the live guard
+# tests/fm-herdr-attached-viewer-live-e2e.test.sh owns that proof. What is
+# portable is who the helper will ever attach to, and who it will signal.
+test_viewer_refuses_unowned_sessions() {
+  local name="fm-lab-viewer-guard-$$" status=0 out
+  : > "$FAKE_LOG"
+  out=$(run_with_fake fm_herdr_lab_viewer_start "$name" 2>&1) || status=$?
+  expect_code 1 "$status" "a session without an ownership tripwire must not be attached to"
+  assert_contains "$out" "does not own" \
+    "the viewer refusal did not name the missing ownership record"
+  [ ! -s "$FAKE_LOG" ] \
+    || fail "the unowned-session refusal reached Herdr instead of refusing first"
+
+  status=0
+  run_with_fake fm_herdr_lab_viewer_start default >/dev/null 2>&1 || status=$?
+  expect_code 1 "$status" "the default session must never be attached to"
+  pass "fm-herdr-lab: the viewer attaches only to a session this lab owns"
+}
+
+test_viewer_stop_only_signals_owned_processes() {
+  local name="fm-lab-viewer-stop-$$" record status=0 holder_pid
+  run_with_fake fm_herdr_lab_provision "$name" || fail "viewer-stop fixture provision failed"
+  record=$(run_with_fake fm_herdr_lab_viewer_record_path "$name")
+
+  # No record: a client attached by someone else is not ours to kill.
+  printf '%s\n' cleared > "$FAKE_STATE/$name.foreground"
+  run_with_fake fm_herdr_lab_viewer_stop "$name" \
+    || fail "stopping with no recorded viewer must succeed without touching a foreign client"
+  [ "$(cat "$FAKE_STATE/$name.foreground")" = cleared ] \
+    || fail "an unrecorded foreground client was detached by the lab helper"
+
+  # A recorded viewer is signalled until it exits and the session reports no
+  # foreground client again.
+  sleep 20 &
+  holder_pid=$!
+  printf 'launcher=%s\nviewer=%s\n' "$holder_pid" "$holder_pid" > "$record"
+  status=0
+  run_with_fake fm_herdr_lab_viewer_stop "$name" >/dev/null 2>&1 || status=$?
+  expect_code 1 "$status" "stop must fail while the session still reports a foreground client"
+  kill -0 "$holder_pid" 2>/dev/null && fail "stop left the recorded viewer process running"
+  assert_present "$record" "a failed detach discarded the viewer record it still needs"
+
+  printf '%s\n' no_foreground_client > "$FAKE_STATE/$name.foreground"
+  run_with_fake fm_herdr_lab_viewer_stop "$name" || fail "stop failed once the client had detached"
+  assert_absent "$record" "a confirmed detach left the viewer record behind"
+  run_with_fake fm_herdr_lab_teardown "$name" || fail "teardown after viewer stop failed"
+  pass "fm-herdr-lab: viewer stop signals only recorded processes and confirms the detach"
+}
+
+test_teardown_refuses_while_viewer_attached() {
+  local name="fm-lab-viewer-teardown-$$" record status=0 holder_pid
+  run_with_fake fm_herdr_lab_provision "$name" || fail "viewer-teardown fixture provision failed"
+  record=$(run_with_fake fm_herdr_lab_viewer_record_path "$name")
+  printf '%s\n' cleared > "$FAKE_STATE/$name.foreground"
+  sleep 20 &
+  holder_pid=$!
+  printf 'launcher=%s\nviewer=%s\n' "$holder_pid" "$holder_pid" > "$record"
+  : > "$FAKE_LOG"
+  run_with_fake fm_herdr_lab_teardown "$name" >/dev/null 2>&1 || status=$?
+  expect_code 1 "$status" "teardown must refuse while an owned viewer is still attached"
+  [ "$(cat "$FAKE_STATE/$name")" = running ] \
+    || fail "the refused teardown stopped the lab session anyway"
+  assert_no_grep "session delete $name" "$FAKE_LOG" \
+    "the refused teardown still reached the destructive delete"
+
+  printf '%s\n' no_foreground_client > "$FAKE_STATE/$name.foreground"
+  run_with_fake fm_herdr_lab_teardown "$name" || fail "teardown after the viewer detached failed"
+  pass "fm-herdr-lab: teardown refuses to destroy a session an attached viewer still holds"
+}
+
+test_viewer_launcher_refuses_unsafe_arguments() {
+  local launcher="$ROOT/bin/fm-herdr-lab-viewer.py" status=0
+  command -v python3 >/dev/null 2>&1 || { pass "fm-herdr-lab: viewer launcher argument guard (skipped, no python3)"; return; }
+  python3 "$launcher" default 40 120 "$TMP_ROOT/pid" >/dev/null 2>&1 || status=$?
+  expect_code 2 "$status" "the launcher must refuse the default session"
+  status=0
+  python3 "$launcher" arbitrary-session 40 120 "$TMP_ROOT/pid" >/dev/null 2>&1 || status=$?
+  expect_code 2 "$status" "the launcher must refuse a non-lab session name"
+  status=0
+  python3 "$launcher" fm-lab-args 0 120 "$TMP_ROOT/pid" >/dev/null 2>&1 || status=$?
+  expect_code 2 "$status" "a zero-row grid is the exact defect this helper exists to avoid"
+  status=0
+  python3 "$launcher" fm-lab-args 40 0 "$TMP_ROOT/pid" >/dev/null 2>&1 || status=$?
+  expect_code 2 "$status" "a zero-column grid is the exact defect this helper exists to avoid"
+  status=0
+  python3 "$launcher" fm-lab-args 40 120 relative-pidfile >/dev/null 2>&1 || status=$?
+  expect_code 2 "$status" "the launcher must refuse a relative pidfile path"
+  assert_absent "$TMP_ROOT/pid" "a refused launch still wrote a pid record"
+  pass "fm-herdr-lab: the viewer launcher refuses unsafe sessions and zero-sized grids"
+}
+
 test_refuses_unsafe_names
 test_provision_run_and_guarded_teardown
 test_missing_tripwire_blocks_destruction
@@ -241,3 +339,7 @@ test_changed_default_trips_after_teardown
 test_stopped_owned_lab_can_reprovision
 test_failed_delete_retains_tripwire
 test_timed_out_provision_cancels_late_launch
+test_viewer_refuses_unowned_sessions
+test_viewer_stop_only_signals_owned_processes
+test_teardown_refuses_while_viewer_attached
+test_viewer_launcher_refuses_unsafe_arguments


### PR DESCRIPTION
## Intent

The captain gives the GO (post-reboot) to close the #4131 live-validation gap for the Herdr foreground viewer, shipping a firstmate PR.

Context/proof: a fresh MacBook scout PROVED the headless no-mistakes runner CAN host a real Herdr foreground viewer. #4131's live validation failed ONLY because its pty had a ZERO-SIZED window grid (a `script`/bare forkpty from a non-tty parent makes herdr report a "terminal reported a zero-sized grid" and yields `no_foreground_client`). This is NOT a fundamental limitation.

The captain's ask is to add a guarded viewer helper that starts a real attached Herdr viewer with a non-zero pty grid, plus a live end-to-end regression that drives the attached-viewer scenarios and asserts the #4131 close refusal - turning the reproduction into the regression.

Explicitly out of scope: no GUI-terminal / osascript fallback, and no launchd change; the pty path works.

Report the PR when CI is green and HOLD for the captain's merge (yolo off - the captain merges).

So this intent stands alone, here is the substance of the #4131 reference above. #4131 is the merged firstmate PR "fix(herdr): allow detached teardown of persisted-focused tabs". It gated the Herdr teardown active-tab close refusal on a LIVE foreground client (`herdr terminal title clear` answering `cleared` rather than `no_foreground_client`) instead of the persisted `.focused` pointer, which survives client detach; teardown of a pane on a stale focused tab therefore stops being spuriously blocked, while a tab a live viewer is actually on still defers. Its live validation reached only 2 of its 7 scenarios, both of them detached-client cases. The attached-viewer scenarios this task must now drive live, and the refusal each one asserts, are:

- Scenario 3: attach a live client focused on the target tab and request teardown; the close is refused and the pane remains.
- Scenario 4: start with target A non-active, switch a live viewer onto A during teardown planning, then reach the mutation boundary; A is not closed.
- Scenario 5: start with the target persisted active, switch a live viewer to another tab during planning, then close the target; the viewer's fresh non-target focus is preserved.
- Scenario 7: the projection's seeded default-tab prune inherits the same live-viewer refusal.

Scenario 6 (making a real Herdr server emit an invalid protocol reason) needs a fault-injectable Herdr build, is still out of reach, and is not part of this ask.

## What Changed

- Add guarded `viewer start` and `viewer stop` lab commands backed by a PTY launcher that pre-sizes the terminal grid and scrubs inherited Herdr environment variables.
- Track launcher and viewer process identities, restrict attachment to owned non-default sessions, confirm detachment, and refuse teardown while a viewer remains attached.
- Add live Herdr regression coverage for active-tab close refusal, focus changes during planning, fresh-focus preservation, and seeded-tab pruning, with supporting unit coverage and documentation.

## Risk Assessment

✅ Low: The change is confined to an isolated guarded lab helper, exercises all required live-viewer scenarios, and the remaining narrow interruption risk is explicitly authorized containment.

## Testing

Drove Herdr 0.9.0 end-to-end through a real sized PTY and exercised required scenarios 3, 4, 5, and 7 plus detach, duplicate-start, unsafe-session, and interruption behavior; the focused helper contract test also passed, cleanup left no sessions or processes, and all scenarios passed. Evidence is CLI protocol/state transcripts rather than screenshots because the viewer is intentionally hosted in a headless internal PTY.

- Live validation: ✅ go - 9 of 9 scenarios driven live against the product

| Scenario | Result | Live | Evidence |
| --- | --- | --- | --- |
| Attach a real Herdr viewer through a pre-sized PTY and observe it register as the foreground client | ✅ pass | live | Artifact “Real Herdr attached-viewer scenarios 3, 4, 5, and 7” records `cleared` foreground-client behavior on Herdr 0.9.0. |
| Scenario 3: request teardown while the live viewer focuses the target tab; refusal leaves the pane intact | ✅ pass | live | `herdr-attached-viewer-live-e2e.log`: “a live client on the target tab refuses the close and keeps the pane”. |
| Scenario 4: move the live viewer onto target A between planning and mutation; the fresh focus check refuses closure | ✅ pass | live | `herdr-attached-viewer-live-e2e.log`: “focus moving onto the target between planning and mutation still blocks the close”. |
| Scenario 5: move the live viewer away from target A during planning; A closes while fresh non-target focus is preserved | ✅ pass | live | `herdr-attached-viewer-live-e2e.log`: “a close preserves the fresh non-target focus the viewer moved to”. |
| Scenario 7: prune a seeded default tab watched by the live viewer; refusal preserves both seeded and task panes | ✅ pass | live | `herdr-attached-viewer-live-e2e.log`: “the projection seeded-tab prune refuses while a live client watches it”. |
| Detach the viewer and retry the formerly refused close; the guard follows the live client rather than stale persisted focus | ✅ pass | live | `herdr-attached-viewer-live-e2e.log`: detachment restored `no_foreground_client` and released the refusal. |
| Adversarial guard: attempt attachment to the default and an unowned lab session; both requests fail closed | ✅ pass | live | Artifact “Default and unowned-session guard refusals” records nonzero statuses and explicit safety refusals. |
| Adversarial duplicate start: attempt a second viewer on one session; it is refused without disrupting the existing viewer | ✅ pass | live | Artifact “Duplicate real viewer-start refusal and detach” records status 1, foreground reason `cleared` after refusal, and `no_foreground_client` after stop. |
| Adversarial interruption: terminate viewer start after its launcher spawns; the helper cancels the launcher and leaves no attached client | ✅ pass | live | Artifact “Interrupted real viewer-start cleanup” records command status 143, launcher `gone`, and foreground reason `no_foreground_client`. |

<details>
<summary>Evidence: Real Herdr attached-viewer scenarios 3, 4, 5, and 7</summary>

Source: [Real Herdr attached-viewer scenarios 3, 4, 5, and 7](https://github.com/kunchenguid/firstmate/blob/db7f6457fb6b63ed3d596459f1eb3ce85ba4b6c2/.no-mistakes/evidence/fm/fm-nm-liveval-foreground-viewer-fix-r1-reship/herdr-attached-viewer-live-e2e.log)

```text
COMMAND: FM_HERDR_ATTACHED_VIEWER_LIVE_E2E=1 bin/fm-test-run.sh --per-script-timeout-secs 180 tests/fm-herdr-attached-viewer-live-e2e.test.sh
ENVIRONMENT: herdr 0.9.0
python: Python 3.14.6
jq: jq-1.8.1
FM_TEST_BEGIN 2026-09-11T21:42:20Z tests/fm-herdr-attached-viewer-live-e2e.test.sh family=real-herdr-gated expected_gate_skip=herdr
ok - attached viewer: a pty sized before the fork registers as a real Herdr foreground client
ok - attached viewer: a live client on the target tab refuses the close and keeps the pane
ok - attached viewer: focus moving onto the target between planning and mutation still blocks the close
ok - attached viewer: a close preserves the fresh non-target focus the viewer moved to
ok - attached viewer: the projection seeded-tab prune refuses while a live client watches it
ok - attached viewer: detaching releases the refusal, so the guard tracks the client and not the pointer
FM_TEST_END 2026-09-11T21:42:26Z tests/fm-herdr-attached-viewer-live-e2e.test.sh exit=0 duration_ms=5965 gate_skip=false
FM_TEST_SUMMARY total=1 failed=0 skipped_gate=0 duration_ms=6025
FM_TEST_SUMMARY_FAMILY family=real-herdr-gated count=1 duration_ms=5965 failed=0
FM_TEST_SLOWEST rank=1 script=tests/fm-herdr-attached-viewer-live-e2e.test.sh duration_ms=5965
```
</details>
<details>
<summary>Evidence: Interrupted real viewer-start cleanup</summary>

Source: [Interrupted real viewer-start cleanup](https://github.com/kunchenguid/firstmate/blob/db7f6457fb6b63ed3d596459f1eb3ce85ba4b6c2/.no-mistakes/evidence/fm/fm-nm-liveval-foreground-viewer-fix-r1-reship/herdr-viewer-interrupt-live.log)

```text
COMMAND: real Herdr interrupted viewer-start lifecycle probe
SESSION: fm-lab-interrupt-live-76009-5965
OBSERVED: command_pid=76799 launcher_pid=76873; sending TERM to viewer-start command
RESULT: command_status=143 launcher=gone foreground_reason=no_foreground_client
RESULT: teardown=complete
```
</details>
<details>
<summary>Evidence: Duplicate real viewer-start refusal and detach</summary>

Source: [Duplicate real viewer-start refusal and detach](https://github.com/kunchenguid/firstmate/blob/db7f6457fb6b63ed3d596459f1eb3ce85ba4b6c2/.no-mistakes/evidence/fm/fm-nm-liveval-foreground-viewer-fix-r1-reship/herdr-viewer-duplicate-refusal-live.log)

```text
COMMAND: real Herdr duplicate viewer-start refusal probe
SESSION: fm-lab-duplicate-live-97335-6091
FIRST: viewer attached to fm-lab-duplicate-live-97335-6091 (pid 98038)
SECOND_STATUS: 1
SECOND: fm-herdr-lab: a lab viewer is already attached to 'fm-lab-duplicate-live-97335-6091'; stop it before starting another
AFTER_REFUSAL: cleared
AFTER_STOP: no_foreground_client
RESULT: teardown=complete
```
</details>
<details>
<summary>Evidence: Default and unowned-session guard refusals</summary>

Source: [Default and unowned-session guard refusals](https://github.com/kunchenguid/firstmate/blob/db7f6457fb6b63ed3d596459f1eb3ce85ba4b6c2/.no-mistakes/evidence/fm/fm-nm-liveval-foreground-viewer-fix-r1-reship/herdr-viewer-guard-refusals-live.log)

```text
COMMAND: guarded viewer rejects default and unowned session names
DEFAULT_STATUS: 1
DEFAULT: fm-herdr-lab: refusing session name 'default'
UNOWNED_STATUS: 1
UNOWNED: fm-herdr-lab: missing fleet-state tripwire for 'fm-lab-unowned-81471-3974'; refusing to attach a viewer to a session this lab does not own
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"4f602054321ba69e9ed6c6c26b8775a5326b189a","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed (7) ✅</summary>

- ⚠️ `bin/fm-herdr-lab.sh:246` - The new FM_HERDR_LAB_VIEWER_TIMEOUT option is not required by the intent, which only requires a guarded viewer with a non-zero PTY and the live regression. It expands the supported surface with parsing, documentation, and tests; remove the option and use one fixed bounded timeout.

🔧 Fix applied.
2 issues (1 error, 1 warning) still open:

- 🚨 `bin/fm-herdr-lab.sh:270` - The launcher is backgrounded without retaining `$!`, while its ownership record is written later by Python. If startup or `_write_pidfile` takes longer than the fixed two-second poll, line 290 calls `viewer_stop`, which returns immediately when the record is absent; the delayed launcher can then attach and remain running after `viewer start` reports failure. Retain and cancel the exact background launch until the ownership record is established, preserving the fail-closed ownership checks.
- ⚠️ `bin/fm-herdr-lab-viewer.py:21` - The launcher still exposes rows and columns as positional options and carries parsing, validation, and tests for them, although its only supported caller always passes 40x120. No intent requirement needs a configurable grid, and the standing decision requires unrequested configuration surfaces to use fixed values. Remove these positional parameters and define the fixed grid once inside the launcher.

🔧 Fix applied.
2 errors still open:

- 🚨 `bin/fm-herdr-lab.sh:214` - Process ownership compares only PID and `ps ... lstart`, whose timestamp has one-second resolution. If a recorded viewer exits and its PID is reused within that second, `viewer stop` treats the unrelated process as owned and sends TERM/KILL. Fail closed unless the live launcher and its parent-child relationship also identify the viewer, or use an identity primitive that cannot collide this way.
- 🚨 `bin/fm-herdr-lab.sh:260` - The existing-viewer check, record removal, and launch are not atomic. Two concurrent `viewer start` calls can both pass the check, launch separate viewers, overwrite the shared record, and both report success using whichever viewer PID was recorded last. `viewer stop` can then signal only that recorded viewer, leaving the other attached and teardown permanently refused. Serialize the per-session start/stop transition or atomically reserve the ownership record before launching.

🔧 Fix applied.
3 issues (2 errors, 1 warning) still open:

- 🚨 `bin/fm-herdr-lab.sh:366` - The executable enables `set -e`, so a nonzero result from `fm_herdr_lab_viewer_start_locked` or `fm_herdr_lab_viewer_stop_locked` exits before the following status capture and unlock. For example, starting while a viewer is already attached leaves `&lt;session&gt;.viewer.lock` behind, after which stop and teardown permanently refuse that session. Ensure the locked operation runs in an errexit-safe conditional and always releases the lock before returning its status.
- 🚨 `bin/fm-herdr-lab.sh:237` - The new parent-child check applies only when resolving `viewer`; `launcher` is still accepted and signalled using only PID plus one-second-resolution `lstart`. If the recorded launcher exits and its PID is reused within that second, `viewer stop` reaches the launcher iteration at lines 317-319 and signals the unrelated process even though no valid viewer-parent pair exists. Require the recorded live parent-child pair before treating either PID as signalable, rather than independently signalling a timestamp-matched launcher.
- ⚠️ `.github/workflows/ci.yml:313` - The attached-viewer regression is already classified into `real-herdr-gated` at `bin/fm-test-run.sh:341`, so the family command immediately above executes it once before this explicit second invocation. No intent requirement needs duplicate execution; remove the explicit invocation and its separate timing artifact entry.

🔧 Fix applied.
2 errors still open:

- 🚨 `bin/fm-herdr-lab.sh:372` - The mkdir lock is released only after the locked operation returns. If an interactive `viewer start` or `viewer stop` receives SIGINT/SIGTERM while polling, the shell exits without removing `&lt;session&gt;.viewer.lock`; every later stop and teardown then permanently refuses the session. Install scoped signal/exit cleanup after acquiring the lock so interruption always releases it.
- 🚨 `bin/fm-herdr-lab.sh:308` - Startup timeout delegates cancellation to `fm_herdr_lab_cancel_provision`, which kills the Python launcher after only one second, while the launcher intentionally allows its viewer five seconds before SIGKILL. If the viewer takes more than one second to honor TERM, its supervisor is killed before escalation; the viewer can remain attached as an orphan, and the parent-child ownership check then prevents `stop_locked` from signaling it. Keep the launcher alive through its five-second child grace period or otherwise let it complete its own escalation.

🔧 Fix applied.
3 errors still open:

- 🚨 `bin/fm-herdr-lab.sh:392` - `trap -p` runs inside command substitution, whose subshell resets inherited caught traps, so these assignments generally save empty strings. A sourced caller with an EXIT/INT/TERM cleanup trap that invokes viewer stop or teardown therefore returns with its trap permanently cleared. Capture traps without command substitution, or scope the lock cleanup in a subshell so caller traps are never replaced.
- 🚨 `bin/fm-herdr-lab.sh:381` - After `viewer start` launches the nohup supervisor, SIGTERM of the command shell reaches this abort handler, which only unlocks and exits. The supervisor can continue attaching a viewer even though start returned 143; the new test manually kills that surviving launcher rather than asserting cleanup. Cancel the in-flight launcher before exiting an interrupted start.
- 🚨 `bin/fm-herdr-lab.sh:357` - The lock directory contains no owner identity or stale-lock recovery. If the transition process is killed with SIGKILL after `mkdir`, every later viewer stop and teardown permanently refuses the session. Closing this requires owner metadata or another stale-lock mechanism, which extends the locking state despite the stated constraint against a new state format, so the remedy needs authorization.

🔧 Fix applied.
2 errors still open:

- 🚨 `bin/fm-herdr-lab.sh:289` - The command starts the nohup launcher before installing its INT/TERM traps. If SIGTERM arrives after line 289 but before line 293, the shell exits under the default disposition and leaves the launcher running, so the accepted interrupted-start failure remains reachable. Install scoped cancellation handling before spawning the launcher and retain it until startup is no longer in flight.
- 🚨 `bin/fm-herdr-lab-viewer.py:137` - After forking the viewer, the launcher does not install its cancellation handlers until line 151. If the shell cancels the launcher during that interval, Python terminates by default while the viewer continues without a pidfile; the shell can then neither identify nor stop that orphan. Block termination signals across the fork until handlers owning `viewer_pid` are installed, then unblock them.

🔧 Fix applied.
✅ Re-checked - no issues remain.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- Live validation: ✅ go - 9 of 9 scenarios driven live against the product

| Scenario | Result | Live | Evidence |
| --- | --- | --- | --- |
| Attach a real Herdr viewer through a pre-sized PTY and observe it register as the foreground client | ✅ pass | live | Artifact “Real Herdr attached-viewer scenarios 3, 4, 5, and 7” records `cleared` foreground-client behavior on Herdr 0.9.0. |
| Scenario 3: request teardown while the live viewer focuses the target tab; refusal leaves the pane intact | ✅ pass | live | `herdr-attached-viewer-live-e2e.log`: “a live client on the target tab refuses the close and keeps the pane”. |
| Scenario 4: move the live viewer onto target A between planning and mutation; the fresh focus check refuses closure | ✅ pass | live | `herdr-attached-viewer-live-e2e.log`: “focus moving onto the target between planning and mutation still blocks the close”. |
| Scenario 5: move the live viewer away from target A during planning; A closes while fresh non-target focus is preserved | ✅ pass | live | `herdr-attached-viewer-live-e2e.log`: “a close preserves the fresh non-target focus the viewer moved to”. |
| Scenario 7: prune a seeded default tab watched by the live viewer; refusal preserves both seeded and task panes | ✅ pass | live | `herdr-attached-viewer-live-e2e.log`: “the projection seeded-tab prune refuses while a live client watches it”. |
| Detach the viewer and retry the formerly refused close; the guard follows the live client rather than stale persisted focus | ✅ pass | live | `herdr-attached-viewer-live-e2e.log`: detachment restored `no_foreground_client` and released the refusal. |
| Adversarial guard: attempt attachment to the default and an unowned lab session; both requests fail closed | ✅ pass | live | Artifact “Default and unowned-session guard refusals” records nonzero statuses and explicit safety refusals. |
| Adversarial duplicate start: attempt a second viewer on one session; it is refused without disrupting the existing viewer | ✅ pass | live | Artifact “Duplicate real viewer-start refusal and detach” records status 1, foreground reason `cleared` after refusal, and `no_foreground_client` after stop. |
| Adversarial interruption: terminate viewer start after its launcher spawns; the helper cancels the launcher and leaves no attached client | ✅ pass | live | Artifact “Interrupted real viewer-start cleanup” records command status 143, launcher `gone`, and foreground reason `no_foreground_client`. |

- `FM_HERDR_ATTACHED_VIEWER_LIVE_E2E=1 bin/fm-test-run.sh --per-script-timeout-secs 180 tests/fm-herdr-attached-viewer-live-e2e.test.sh`
- <code>Real Herdr lifecycle probe: provision a lab, observe the viewer launcher, terminate `viewer start`, then verify exit 143, no launcher, and `no_foreground_client`</code>
- `Real Herdr duplicate-start probe: attach a viewer, attempt a second start, verify refusal and retained foreground attachment, then stop and verify detachment`
- <code>Real helper guard probe: attempt `viewer start default` and an unowned `fm-lab-*` session and verify both refuse</code>
- `bin/fm-test-run.sh --per-script-timeout-secs 120 tests/fm-herdr-lab.test.sh`
- `Post-test checks for remaining test sessions, viewer-launcher processes, and worktree changes`
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
