### PR TITLE
fix(bin): select suites that read a changed top-level test fixture

### DIFF
--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -1547,7 +1547,7 @@ families_for_changed_path() {
       families_for_test_reference git-config-helpers.sh lib.sh herdr-test-safety.sh \
         || printf '%s\n' "__unmapped__:$path"
       ;;
-    tests/lib.sh|tests/*-helpers.sh|tests/fixtures.sh)
+    tests/lib.sh|tests/*-helpers.sh|tests/fixtures.sh|tests/*-fixture.sh)
       families_for_test_reference "$(basename "$path")" \
         || printf '%s\n' "__unmapped__:$path"
       ;;

--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -1547,10 +1547,6 @@ families_for_changed_path() {
       families_for_test_reference git-config-helpers.sh lib.sh herdr-test-safety.sh \
         || printf '%s\n' "__unmapped__:$path"
       ;;
-    tests/lib.sh|tests/*-helpers.sh|tests/fixtures.sh|tests/*-fixture.sh)
-      families_for_test_reference "$(basename "$path")" \
-        || printf '%s\n' "__unmapped__:$path"
-      ;;
     tests/fixtures/*/*)
       # A fixture belongs to whichever suite reads its directory, found by the
       # same reference scan used for shared helpers. Keyed on the directory
@@ -1562,6 +1558,10 @@ families_for_changed_path() {
         families_for_test_reference "fixtures/$fixture_ref" \
           || printf '%s\n' "__unmapped__:$path"
       fi
+      ;;
+    tests/lib.sh|tests/*-helpers.sh|tests/fixtures.sh|tests/*-fixture.sh)
+      families_for_test_reference "$(basename "$path")" \
+        || printf '%s\n' "__unmapped__:$path"
       ;;
     bin/*)
       # A deleted script has no consuming suite left to select, the same rule

--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -141,11 +141,10 @@
 # that names it is selected as that SCRIPT, because the reference is per-script
 # evidence. Consumer bin/ scripts still resolve through the curated map, so
 # recorded family-level coupling still expands to the whole family.
-# A shared file directly under tests/ maps to the suites that name it, but only
-# at tests/lib.sh, tests/fixtures.sh, *-helpers.sh, or *-fixture.sh. Any other
-# non-.test.sh file directly under tests/ stays unmapped and refuses the run,
-# so a new shared helper or fixture has to carry one of those names; a fixture
-# under tests/fixtures/<dir>/ is mapped by that directory instead.
+# tests/lib.sh, tests/fixtures.sh, tests/*-helpers.sh and tests/*-fixture.sh are
+# shared files that map to the suites naming them; a fixture under
+# tests/fixtures/<dir>/ is mapped by that directory instead. Curated family arms
+# above those also name individual tests/ files explicitly.
 set -eu
 
 now_ms() {

--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -141,6 +141,11 @@
 # that names it is selected as that SCRIPT, because the reference is per-script
 # evidence. Consumer bin/ scripts still resolve through the curated map, so
 # recorded family-level coupling still expands to the whole family.
+# A shared file directly under tests/ maps to the suites that name it, but only
+# at tests/lib.sh, tests/fixtures.sh, *-helpers.sh, or *-fixture.sh. Any other
+# non-.test.sh file directly under tests/ stays unmapped and refuses the run,
+# so a new shared helper or fixture has to carry one of those names; a fixture
+# under tests/fixtures/<dir>/ is mapped by that directory instead.
 set -eu
 
 now_ms() {
@@ -1560,6 +1565,11 @@ families_for_changed_path() {
       fi
       ;;
     tests/lib.sh|tests/*-helpers.sh|tests/fixtures.sh|tests/*-fixture.sh)
+      # Shared top-level test files, selected by the suites that name them.
+      # Must stay below the tests/fixtures/*/* arm: a case glob's * spans /, so
+      # tests/*-fixture.sh would otherwise swallow a nested
+      # tests/fixtures/<dir>/<name>-fixture.sh and scan for its basename
+      # instead of the fixture directory its readers actually name.
       families_for_test_reference "$(basename "$path")" \
         || printf '%s\n' "__unmapped__:$path"
       ;;

--- a/tests/fm-test-run.test.sh
+++ b/tests/fm-test-run.test.sh
@@ -133,6 +133,12 @@ init_changed_fixture_repo() {
   : >"$repo/bin/fm-quota-axi-lib.sh"
   : >"$repo/bin/fm-quota-choose.sh"
   : >"$repo/bin/unmapped-source.sh"
+  # A shared top-level test fixture read by two suites in different families,
+  # beside a tests/ file nothing reads at all.
+  : >"$repo/tests/shared-probe-fixture.sh"
+  : >"$repo/tests/unread-thing.sh"
+  printf '# shared-probe-fixture.sh\n' >>"$repo/tests/fm-pr-merge.test.sh"
+  printf '# shared-probe-fixture.sh\n' >>"$repo/tests/fm-secondmate-safety.test.sh"
   # A shared helper with no curated family of its own, named by exactly ONE
   # script of the expensive real-Herdr family and consumed by one curated
   # watcher script. This is the shape that made a one-line helper change select
@@ -1275,6 +1281,48 @@ test_jobs_admits_a_concurrent_safe_family() {
 # catch-all it was split out of must not: a test nobody has classified yet is
 # exactly the one with no proof, so it has to stay serial rather than inherit
 # concurrency from the family map's default arm.
+test_changed_shared_fixture_selects_its_readers() {
+  local tmp repo listed rc
+  tmp=$(mktemp -d "${TMPDIR:-/tmp}/fm-test-run-fixture.XXXXXX")
+  repo="$tmp/repo"
+  init_changed_fixture_repo "$repo"
+
+  printf '\n' >>"$repo/tests/shared-probe-fixture.sh"
+  listed=$(cd "$repo" && bin/fm-test-run.sh --list --changed --base HEAD)
+  assert_contains "$listed" "tests/fm-pr-merge.test.sh" \
+    "shared test fixture selects its pr-forge reader"
+  assert_contains "$listed" "tests/fm-secondmate-safety.test.sh" \
+    "shared test fixture selects its secondmate reader"
+  case "$listed" in
+    *fm-backend-orca.test.sh*)
+      fail "shared test fixture selection widened past its readers: $listed" ;;
+  esac
+  git -C "$repo" add tests/shared-probe-fixture.sh
+  git -C "$repo" -c user.name=test -c user.email=test@example.invalid commit -qm fixture-change
+
+  printf '\n' >>"$repo/tests/unread-thing.sh"
+  set +e
+  (cd "$repo" && bin/fm-test-run.sh --list --changed --base HEAD) >"$tmp/out" 2>"$tmp/err"
+  rc=$?
+  set -e
+  [ "$rc" -eq 2 ] || fail "an unread tests/ path must still fail with exit 2, got $rc"
+  grep -Fq 'no changed-test mapping for source path: tests/unread-thing.sh' "$tmp/err" \
+    || fail "the refusal did not name the unread tests/ path: $(cat "$tmp/err")"
+  git -C "$repo" checkout -q -- tests/unread-thing.sh
+
+  printf '\n' >>"$repo/bin/fm-quota-choose.sh"
+  listed=$(cd "$repo" && bin/fm-test-run.sh --list --changed --base HEAD)
+  assert_contains "$listed" "tests/fm-quota-choose.test.sh" \
+    "an unrelated changed path keeps its own selection"
+  case "$listed" in
+    *fm-pr-merge.test.sh*)
+      fail "an unrelated changed path picked up the fixture readers: $listed" ;;
+  esac
+
+  rm -rf "$tmp"
+  pass "a changed shared test fixture selects its readers while an unread tests/ path still refuses"
+}
+
 test_unmapped_new_test_never_inherits_family_concurrency() {
   local tmp repo rc script
   tmp=$(mktemp -d "${TMPDIR:-/tmp}/fm-test-run-unmapped.XXXXXX")
@@ -1716,6 +1764,7 @@ test_portable_serial_hint_coverage_is_reported_and_bounded
 test_portable_serial_shard_lane_refusals
 test_jobs_requires_proven_isolated
 test_jobs_admits_a_concurrent_safe_family
+test_changed_shared_fixture_selects_its_readers
 test_unmapped_new_test_never_inherits_family_concurrency
 test_concurrent_runs_are_ordered_longest_first
 test_per_script_timeout_bounds_a_hang

--- a/tests/fm-test-run.test.sh
+++ b/tests/fm-test-run.test.sh
@@ -139,6 +139,11 @@ init_changed_fixture_repo() {
   : >"$repo/tests/unread-thing.sh"
   printf '# shared-probe-fixture.sh\n' >>"$repo/tests/fm-pr-merge.test.sh"
   printf '# shared-probe-fixture.sh\n' >>"$repo/tests/fm-secondmate-safety.test.sh"
+  # A nested fixture whose consuming suite names only the fixture directory,
+  # the shape the tests/fixtures/<dir>/ arm is keyed for.
+  mkdir -p "$repo/tests/fixtures/demo"
+  : >"$repo/tests/fixtures/demo/demo-fixture.sh"
+  printf '# tests/fixtures/demo\n' >>"$repo/tests/fm-backend-orca.test.sh"
   # A shared helper with no curated family of its own, named by exactly ONE
   # script of the expensive real-Herdr family and consumed by one curated
   # watcher script. This is the shape that made a one-line helper change select
@@ -1318,6 +1323,14 @@ test_changed_shared_fixture_selects_its_readers() {
     *fm-pr-merge.test.sh*)
       fail "an unrelated changed path picked up the fixture readers: $listed" ;;
   esac
+  git -C "$repo" checkout -q -- bin/fm-quota-choose.sh
+
+  # A nested tests/fixtures/<dir>/<name>-fixture.sh still reaches the
+  # directory-scan arm rather than the top-level fixture arm's basename scan.
+  printf '\n' >>"$repo/tests/fixtures/demo/demo-fixture.sh"
+  listed=$(cd "$repo" && bin/fm-test-run.sh --list --changed --base HEAD)
+  assert_contains "$listed" "tests/fm-backend-orca.test.sh" \
+    "a nested fixture selects the suite that reads its directory"
 
   rm -rf "$tmp"
   pass "a changed shared test fixture selects its readers while an unread tests/ path still refuses"

--- a/tests/fm-test-run.test.sh
+++ b/tests/fm-test-run.test.sh
@@ -1286,56 +1286,6 @@ test_jobs_admits_a_concurrent_safe_family() {
 # catch-all it was split out of must not: a test nobody has classified yet is
 # exactly the one with no proof, so it has to stay serial rather than inherit
 # concurrency from the family map's default arm.
-test_changed_shared_fixture_selects_its_readers() {
-  local tmp repo listed rc
-  tmp=$(mktemp -d "${TMPDIR:-/tmp}/fm-test-run-fixture.XXXXXX")
-  repo="$tmp/repo"
-  init_changed_fixture_repo "$repo"
-
-  printf '\n' >>"$repo/tests/shared-probe-fixture.sh"
-  listed=$(cd "$repo" && bin/fm-test-run.sh --list --changed --base HEAD)
-  assert_contains "$listed" "tests/fm-pr-merge.test.sh" \
-    "shared test fixture selects its pr-forge reader"
-  assert_contains "$listed" "tests/fm-secondmate-safety.test.sh" \
-    "shared test fixture selects its secondmate reader"
-  case "$listed" in
-    *fm-backend-orca.test.sh*)
-      fail "shared test fixture selection widened past its readers: $listed" ;;
-  esac
-  git -C "$repo" add tests/shared-probe-fixture.sh
-  git -C "$repo" -c user.name=test -c user.email=test@example.invalid commit -qm fixture-change
-
-  printf '\n' >>"$repo/tests/unread-thing.sh"
-  set +e
-  (cd "$repo" && bin/fm-test-run.sh --list --changed --base HEAD) >"$tmp/out" 2>"$tmp/err"
-  rc=$?
-  set -e
-  [ "$rc" -eq 2 ] || fail "an unread tests/ path must still fail with exit 2, got $rc"
-  grep -Fq 'no changed-test mapping for source path: tests/unread-thing.sh' "$tmp/err" \
-    || fail "the refusal did not name the unread tests/ path: $(cat "$tmp/err")"
-  git -C "$repo" checkout -q -- tests/unread-thing.sh
-
-  printf '\n' >>"$repo/bin/fm-quota-choose.sh"
-  listed=$(cd "$repo" && bin/fm-test-run.sh --list --changed --base HEAD)
-  assert_contains "$listed" "tests/fm-quota-choose.test.sh" \
-    "an unrelated changed path keeps its own selection"
-  case "$listed" in
-    *fm-pr-merge.test.sh*)
-      fail "an unrelated changed path picked up the fixture readers: $listed" ;;
-  esac
-  git -C "$repo" checkout -q -- bin/fm-quota-choose.sh
-
-  # A nested tests/fixtures/<dir>/<name>-fixture.sh still reaches the
-  # directory-scan arm rather than the top-level fixture arm's basename scan.
-  printf '\n' >>"$repo/tests/fixtures/demo/demo-fixture.sh"
-  listed=$(cd "$repo" && bin/fm-test-run.sh --list --changed --base HEAD)
-  assert_contains "$listed" "tests/fm-backend-orca.test.sh" \
-    "a nested fixture selects the suite that reads its directory"
-
-  rm -rf "$tmp"
-  pass "a changed shared test fixture selects its readers while an unread tests/ path still refuses"
-}
-
 test_unmapped_new_test_never_inherits_family_concurrency() {
   local tmp repo rc script
   tmp=$(mktemp -d "${TMPDIR:-/tmp}/fm-test-run-unmapped.XXXXXX")
@@ -1385,6 +1335,46 @@ test_unmapped_new_test_never_inherits_family_concurrency() {
     || fail "the unmapped fixture did not land in the catch-all family: $(cat "$tmp/serial.out")"
   rm -rf "$tmp"
   pass "an unclassified new test stays serial while the proven residual family runs concurrently"
+}
+
+test_changed_shared_fixture_selects_its_readers() {
+  local tmp repo listed rc
+  tmp=$(mktemp -d "${TMPDIR:-/tmp}/fm-test-run-fixture.XXXXXX")
+  repo="$tmp/repo"
+  init_changed_fixture_repo "$repo"
+
+  printf '\n' >>"$repo/tests/shared-probe-fixture.sh"
+  listed=$(cd "$repo" && bin/fm-test-run.sh --list --changed --base HEAD)
+  assert_contains "$listed" "tests/fm-pr-merge.test.sh" \
+    "shared test fixture selects its pr-forge reader"
+  assert_contains "$listed" "tests/fm-secondmate-safety.test.sh" \
+    "shared test fixture selects its secondmate reader"
+  case "$listed" in
+    *fm-backend-orca.test.sh*)
+      fail "shared test fixture selection widened past its readers: $listed" ;;
+  esac
+  git -C "$repo" add tests/shared-probe-fixture.sh
+  git -C "$repo" -c user.name=test -c user.email=test@example.invalid commit -qm fixture-change
+
+  printf '\n' >>"$repo/tests/unread-thing.sh"
+  set +e
+  (cd "$repo" && bin/fm-test-run.sh --list --changed --base HEAD) >"$tmp/out" 2>"$tmp/err"
+  rc=$?
+  set -e
+  [ "$rc" -eq 2 ] || fail "an unread tests/ path must still fail with exit 2, got $rc"
+  grep -Fq 'no changed-test mapping for source path: tests/unread-thing.sh' "$tmp/err" \
+    || fail "the refusal did not name the unread tests/ path: $(cat "$tmp/err")"
+  git -C "$repo" checkout -q -- tests/unread-thing.sh
+
+  # A nested tests/fixtures/<dir>/<name>-fixture.sh still reaches the
+  # directory-scan arm rather than the top-level fixture arm's basename scan.
+  printf '\n' >>"$repo/tests/fixtures/demo/demo-fixture.sh"
+  listed=$(cd "$repo" && bin/fm-test-run.sh --list --changed --base HEAD)
+  assert_contains "$listed" "tests/fm-backend-orca.test.sh" \
+    "a nested fixture selects the suite that reads its directory"
+
+  rm -rf "$tmp"
+  pass "a changed shared test fixture selects its readers while an unread tests/ path still refuses"
 }
 
 # Workers are handed scripts in order, so the slowest script must start first or
@@ -1777,8 +1767,8 @@ test_portable_serial_hint_coverage_is_reported_and_bounded
 test_portable_serial_shard_lane_refusals
 test_jobs_requires_proven_isolated
 test_jobs_admits_a_concurrent_safe_family
-test_changed_shared_fixture_selects_its_readers
 test_unmapped_new_test_never_inherits_family_concurrency
+test_changed_shared_fixture_selects_its_readers
 test_concurrent_runs_are_ordered_longest_first
 test_per_script_timeout_bounds_a_hang
 test_max_wall_ms_is_a_result_not_advice


### PR DESCRIPTION
## Intent

Fix https://github.com/kunchenguid/firstmate/issues/4100, which the maintainer confirmed on main and labeled ready-for-pr (contract class restore).

The problem: `bin/fm-test-run.sh --changed` aborts affected-test selection, so zero tests run, when a shared top-level test fixture named `tests/*-fixture.sh` is among the changed paths.
The changed-path mapper recognises shared test helpers by an explicit list, `tests/lib.sh|tests/*-helpers.sh|tests/fixtures.sh`.
Anything else under `tests/` that is not a `.test.sh` and not under `tests/fixtures/` reaches the `tests/*` catch-all, is marked `__unmapped__`, and selection dies with "no changed-test mapping for source path".
`tests/herdr-client-pair-fixture.sh` and `tests/remote-herdr-fixture.sh` are real shared fixtures with real consumers, so any change touching one of them leaves a validation pipeline driving `--changed` with an empty selection: not a missed test but a hard abort.

The maintainer's accepted scope: a changed top-level `tests/*-fixture.sh` selects the suites that read it instead of aborting, the same way a changed `tests/*-helpers.sh` does today, either by extending the helper arm or by the reference scan the `tests/fixtures/*/*` arm already uses.
That restores the affected-test selection `--changed` already promises.
The loud refusal for a genuinely unmapped path stays; only the fixtures that have discoverable consumers stop aborting.

Follow the repository's CONTRIBUTING.md and AGENTS.md.

## What Changed

- `families_for_changed_path` in `bin/fm-test-run.sh` now matches `tests/*-fixture.sh` in the shared top-level test-file arm alongside `tests/lib.sh`, `tests/*-helpers.sh` and `tests/fixtures.sh`, so a changed top-level fixture resolves through the existing `families_for_test_reference` basename scan to the suites naming it instead of falling through to the `tests/*` catch-all and dying with `no changed-test mapping for source path`. A `tests/` path that no suite references still yields `__unmapped__` and the exit-2 refusal.
- That arm was moved below the `tests/fixtures/*/*` arm, because a `case` glob's `*` spans `/`: left above, `tests/*-fixture.sh` would swallow a nested `tests/fixtures/<dir>/<name>-fixture.sh` and scan for its basename rather than the fixture directory its readers actually name. A comment on the arm and a new paragraph in the file's changed-path mapping header record that ordering constraint and the `tests/` shared-file contract.
- Added `test_changed_shared_fixture_selects_its_readers` to `tests/fm-test-run.test.sh`, with `init_changed_fixture_repo` gaining a shared top-level fixture read by two suites in different families, an unreferenced `tests/` file, and a nested `tests/fixtures/demo/demo-fixture.sh` read by directory. The test asserts the changed fixture selects both readers without widening to the unrelated suite, that the unreferenced `tests/` path still exits 2 naming itself, and that the nested fixture still routes through the directory-scan arm.

## Risk Assessment

✅ Low: A one-glob extension plus a behavior-neutral arm reorder in the changed-path mapper, matching the intent's accepted scope exactly, with a regression test that fails before the fix and preserves the required loud refusal.

## Testing

Exercised the runner CLI itself in isolated clones of the repo at the base and target commits, reproducing the issue-4100 abort on base and confirming the fixed selection on target, including a real (non---list) `--changed` run where base executed zero suites and target executed both reader suites. Adversarial cases confirmed the loud refusal still fires for a fixture nobody reads, one referenced only from bin/, and an unrelated tests/ file; regression checks confirmed the curated herdr arm, the pre-existing shared-file arms, and the nested tests/fixtures/ directory scan all select byte-identically to base, and that the fixture-retirement shape refuses the same on both commits. The runner's own suite passes on target and the new case fails against the base runner, so the regression test fails before the fix and passes after. No visual evidence applies: this is a shell CLI change with no rendered surface, so evidence is CLI transcripts.

- Live validation: ✅ go - 7 of 7 scenarios driven live against the product

| Scenario | Result | Live | Evidence |
| --- | --- | --- | --- |
| A maintainer edits the real shared fixture tests/remote-herdr-fixture.sh and --changed selects its reader suites instead of aborting | ✅ pass | live | 30-1-top-level-fixture-before-after.txt: base exits 2 with &#34;no changed-test mapping for source path: tests/remote-herdr-fixture.sh&#34;; target lists 51 suites and exits 0 |
| A pipeline running --changed after a shared-fixture edit actually executes the affected suites instead of running zero tests | ✅ pass | live | 30-5-changed-run-actually-executes-suites.txt: real `bin/fm-test-run.sh --changed --base HEAD` (no --list) runs 0 suites / exit 2 on base, runs both reader suites / exit 0 on target without widening t… |
| Adversarial: a tests/*-fixture.sh no suite reads still refuses loudly with exit 2 | ✅ pass | live | 30-3-loud-refusal-still-stands.txt cases 3a and 3b: a reader-less fixture and one referenced only from bin/fm-lint.sh both exit 2 naming the path; adding a reading suite (3d) flips it to selection |
| Adversarial: an unrelated unmapped tests/ file keeps the pre-existing catch-all refusal | ✅ pass | live | 30-3-loud-refusal-still-stands.txt case 3c: tests/unread-thing.sh exits 2 with the named refusal |
| Adversarial: a nested tests/fixtures/&lt;dir&gt;/&lt;name&gt;-fixture.sh keeps the directory-scan selection the new glob could have swallowed | ✅ pass | live | 30-4-nested-fixture-directory-scan.txt: reader naming only `tests/fixtures/demo` selects its suite, exit 0, identical on base and target |
| Files that already mapped before the fix (curated herdr arm, lib.sh, *-helpers.sh, fixtures.sh, a .test.sh, a bin/ script) keep identical selection | ✅ pass | live | 30-2-curated-and-existing-arms-unchanged.txt: all eight paths report IDENTICAL selection and exit code across base and target |
| Adversarial parity: retiring the fixture plus its references introduces no new abort relative to base | ✅ pass | live | 30-7-retirement-parity-with-base.txt: base and target both exit 2 with identical output (known pre-existing gap the maintainer routed separately) |

<details>
<summary>Evidence: Evidence index for this round</summary>

Source: [Evidence index for this round](https://github.com/tiago-peixoto/firstmate/blob/c03cee7e15ae36e66693e38f5781380551e2c606/.no-mistakes/evidence/fm/fm-4100-changed-fixture-selection/30-README-round3.md)

```text
Live validation of fm/fm-4100-changed-fixture-selection (issue #4100)
base 7d14fc1 vs target 0f647e2, both driven as real `bin/fm-test-run.sh` invocations
in throwaway clones of this repository.

30-1-top-level-fixture-before-after.txt
  Editing the real tests/remote-herdr-fixture.sh: base aborts with exit 2 and zero
  selection; target lists the 51 suites of the families that read it.
30-2-curated-and-existing-arms-unchanged.txt
  tests/herdr-client-pair-fixture.sh (curated herdr arm), tests/lib.sh, *-helpers.sh,
  tests/fixtures.sh, tests/git-config-helpers.sh, a .test.sh and a bin/ script all keep
  byte-identical selection on base and target.
30-3-loud-refusal-still-stands.txt
  A reader-less tests/*-fixture.sh, one referenced only from bin/, and an unrelated
  tests/ file all still exit 2 with the named refusal; adding one reader flips it to
  selection.
30-4-nested-fixture-directory-scan.txt
  A nested tests/fixtures/<dir>/<name>-fixture.sh whose suite names only the directory
  still selects through the directory scan, identically to base.
30-5-changed-run-actually-executes-suites.txt
  Full `--changed` run (no --list): base runs zero suites and exits 2; target really
  executes both reader suites and exits 0, without widening to the unrelated suite.
30-6-regression-test-fails-before-passes-after.txt
  The new case in tests/fm-test-run.test.sh passes on target and fails against the base
  runner.
30-7-retirement-parity-with-base.txt
  Deleting the fixture plus its references refuses identically on base and target: no
  new abort introduced (known pre-existing gap, routed separately by the maintainer).
```
</details>
<details>
<summary>Evidence: Editing the real shared fixture: abort on base, 51 suites selected on target</summary>

Source: [Editing the real shared fixture: abort on base, 51 suites selected on target](https://github.com/tiago-peixoto/firstmate/blob/c03cee7e15ae36e66693e38f5781380551e2c606/.no-mistakes/evidence/fm/fm-4100-changed-fixture-selection/30-1-top-level-fixture-before-after.txt)

```text
\### Scenario 1: a maintainer edits the real shared fixture tests/remote-herdr-fixture.sh
\### and asks the runner which tests are affected: bin/fm-test-run.sh --list --changed --base HEAD

--- BEFORE (base 7d14fc1, the bug in issue #4100) ---
 M tests/remote-herdr-fixture.sh
$ bin/fm-test-run.sh --list --changed --base HEAD
fm-test-run: no changed-test mapping for source path: tests/remote-herdr-fixture.sh
exit=2

--- AFTER (target 0f647e2) ---
 M tests/remote-herdr-fixture.sh
$ bin/fm-test-run.sh --list --changed --base HEAD
tests/fm-backlog-handoff.test.sh
tests/fm-on.test.sh
tests/fm-remote-backlog-handoff.test.sh
tests/fm-remote-doctor.test.sh
tests/fm-remote-herdr-guard.test.sh
tests/fm-remote-job-orphan-reap.test.sh
tests/fm-remote-job.test.sh
tests/fm-remote-reply.test.sh
tests/fm-remote-secondmate-lifecycle-e2e.test.sh
tests/fm-remote-secondmate-trace-context.test.sh
tests/fm-remote-transport-lanes.test.sh
tests/fm-secondmate-harness.test.sh
tests/fm-secondmate-lifecycle-e2e.test.sh
tests/fm-secondmate-liveness.test.sh
tests/fm-secondmate-reconcile.test.sh
tests/fm-secondmate-restart.test.sh
tests/fm-secondmate-safety.test.sh
tests/fm-secondmate-sync.test.sh
tests/fm-send-secondmate-marker.test.sh
tests/fm-shared-captain-inheritance.test.sh
tests/fm-startup-memory-budget.test.sh
tests/fm-stow-cascade.test.sh
tests/fm-branch-supervision.test.sh
tests/fm-busy-adapter-wiring.test.sh
tests/fm-busy-state.test.sh
tests/fm-classify-corr-token.test.sh
tests/fm-claude-stop-autoarm.test.sh
tests/fm-cursor-harness.test.sh
tests/fm-extension-binding.test.sh
tests/fm-gitignore-config.test.sh
tests/fm-live-gate.test.sh
tests/fm-no-mistakes-required.test.sh
tests/fm-peek-remote.test.sh
tests/fm-pending-reply.test.sh
tests/fm-pi-branch-extension.test.sh
tests/fm-procevent-quota.test.sh
tests/fm-procevent-when.test.sh
tests/fm-procevent.test.sh
tests/fm-project-origin.test.sh
tests/fm-public-followup.test.sh
tests/fm-quota-choose.test.sh
tests/fm-remote-entrypoint.test.sh
tests/fm-remote-secondmate-parent-binding.test.sh
tests/fm-send-remote-delivery.test.sh
tests/fm-spawn-pool-base-freshen.test.sh
tests/fm-test-fixture-cleanup.test.sh
tests/fm-test-fixtures.test.sh
tests/fm-voice-relay.test.sh
tests/fm-wake-drain-open-decisions-cursor.test.sh
tests/fm-wake-drain-open-decisions.test.sh
tests/fm-wake-drain-outcome-backstop.test.sh
exit=0
```
</details>
<details>
<summary>Evidence: Curated and pre-existing arms keep byte-identical selection</summary>

Source: [Curated and pre-existing arms keep byte-identical selection](https://github.com/tiago-peixoto/firstmate/blob/c03cee7e15ae36e66693e38f5781380551e2c606/.no-mistakes/evidence/fm/fm-4100-changed-fixture-selection/30-2-curated-and-existing-arms-unchanged.txt)

```text
\### Scenario 2: files that already mapped before the fix keep byte-identical selection
\### (tests/herdr-client-pair-fixture.sh resolves through the curated herdr arm at bin/fm-test-run.sh:1333,
\###  which sits ABOVE the new tests/*-fixture.sh arm; the rest are the pre-existing shared-file arms)
IDENTICAL  tests/herdr-client-pair-fixture.sh   exit=0  suites=67
IDENTICAL  tests/lib.sh                         exit=0  suites=198
IDENTICAL  tests/wake-helpers.sh                exit=0  suites=76
IDENTICAL  tests/secondmate-helpers.sh          exit=0  suites=22
IDENTICAL  tests/fixtures.sh                    exit=0  suites=95
IDENTICAL  tests/git-config-helpers.sh          exit=0  suites=198
IDENTICAL  tests/fm-brief.test.sh               exit=0  suites=1
IDENTICAL  bin/fm-lint.sh                       exit=0  suites=35
```
</details>
<details>
<summary>Evidence: Loud refusal still fires for genuinely unmapped tests/ paths</summary>

Source: [Loud refusal still fires for genuinely unmapped tests/ paths](https://github.com/tiago-peixoto/firstmate/blob/c03cee7e15ae36e66693e38f5781380551e2c606/.no-mistakes/evidence/fm/fm-4100-changed-fixture-selection/30-3-loud-refusal-still-stands.txt)

```text
\### Scenario 3 (adversarial): the loud refusal for a genuinely unmapped tests/ path must survive the new arm

--- 3a: a NEW tests/*-fixture.sh that no suite reads ---
 A tests/nobody-reads-me-fixture.sh
$ bin/fm-test-run.sh --list --changed --base HEAD
fm-test-run: no changed-test mapping for source path: tests/nobody-reads-me-fixture.sh
exit=2

--- 3b: a tests/*-fixture.sh referenced only by a bin/ script, never by a suite ---
$ bin/fm-test-run.sh --list --changed --base HEAD
fm-test-run: no changed-test mapping for source path: tests/binonly-fixture.sh
exit=2

--- 3c: an unrelated unmapped tests/ file (the pre-existing catch-all) ---
$ bin/fm-test-run.sh --list --changed --base HEAD
fm-test-run: no changed-test mapping for source path: tests/unread-thing.sh
exit=2

--- 3d: a suite that DOES read it flips 3a from refusal to selection ---
$ bin/fm-test-run.sh --list --changed --base HEAD
tests/fm-arm-pretool-check.test.sh
tests/fm-ask-user-authority.test.sh
tests/fm-bearings-board.test.sh
tests/fm-brief.test.sh
tests/fm-calm-pi-extension.test.sh
tests/fm-captain-hold-lifecycle.test.sh
exit=0

worktree clean: 0 modified paths
```
</details>
<details>
<summary>Evidence: Nested tests/fixtures/&lt;dir&gt;/ directory scan unchanged</summary>

Source: [Nested tests/fixtures/&lt;dir&gt;/ directory scan unchanged](https://github.com/tiago-peixoto/firstmate/blob/c03cee7e15ae36e66693e38f5781380551e2c606/.no-mistakes/evidence/fm/fm-4100-changed-fixture-selection/30-4-nested-fixture-directory-scan.txt)

```text
\### Scenario 4 (adversarial, regression from review round 1): a nested
\### tests/fixtures/<dir>/<name>-fixture.sh whose reader names only the DIRECTORY
\### must keep the directory-scan selection, not fall into the new basename arm.

--- base (7d14fc1 fix(teardown): leave a Treehouse) ---
reader tests/fm-brief.test.sh names: tests/fixtures/demo
$ bin/fm-test-run.sh --list --changed --base HEAD
tests/fm-arm-pretool-check.test.sh
tests/fm-ask-user-authority.test.sh
tests/fm-bearings-board.test.sh
tests/fm-brief.test.sh
exit=0

--- target (0f647e2 no-mistakes(review): drop vacuou) ---
reader tests/fm-brief.test.sh names: tests/fixtures/demo
$ bin/fm-test-run.sh --list --changed --base HEAD
tests/fm-arm-pretool-check.test.sh
tests/fm-ask-user-authority.test.sh
tests/fm-bearings-board.test.sh
tests/fm-brief.test.sh
exit=0
```
</details>
<details>
<summary>Evidence: Real --changed run: zero suites on base, both readers executed on target</summary>

Source: [Real --changed run: zero suites on base, both readers executed on target](https://github.com/tiago-peixoto/firstmate/blob/c03cee7e15ae36e66693e38f5781380551e2c606/.no-mistakes/evidence/fm/fm-4100-changed-fixture-selection/30-5-changed-run-actually-executes-suites.txt)

```text
\### Scenario 5: the end-user payoff - a pipeline running 'fm-test-run.sh --changed'
\### after a shared-fixture edit must actually EXECUTE the affected suites, not abort with zero tests run.
\### Real runner binary, real suite execution (no --list); synthetic repo so the selected suites are cheap.

--- runner from base (7d14fc1 fix(teardown): leave a T) ---
changed: tests/remote-herdr-probe-fixture.sh
$ bin/fm-test-run.sh --changed --base HEAD
fm-test-run: no changed-test mapping for source path: tests/remote-herdr-probe-fixture.sh
exit=2
suites that really ran: 0

--- runner from target (0f647e2 no-mistakes(review): dro) ---
changed: tests/remote-herdr-probe-fixture.sh
$ bin/fm-test-run.sh --changed --base HEAD
FM_TEST_BEGIN 2026-09-11T23:42:07Z tests/fm-pr-merge.test.sh family=pr-forge expected_gate_skip=none
ok - fm-pr-merge.test.sh really executed
FM_TEST_END 2026-09-11T23:42:07Z tests/fm-pr-merge.test.sh exit=0 duration_ms=220 gate_skip=false
FM_TEST_BEGIN 2026-09-11T23:42:07Z tests/fm-secondmate-safety.test.sh family=secondmate expected_gate_skip=none
ok - fm-secondmate-safety.test.sh really executed
FM_TEST_END 2026-09-11T23:42:08Z tests/fm-secondmate-safety.test.sh exit=0 duration_ms=256 gate_skip=false
FM_TEST_SUMMARY total=2 failed=0 skipped_gate=0 duration_ms=1507
FM_TEST_SUMMARY_FAMILY family=pr-forge count=1 duration_ms=220 failed=0
FM_TEST_SUMMARY_FAMILY family=secondmate count=1 duration_ms=256 failed=0
FM_TEST_SLOWEST rank=1 script=tests/fm-secondmate-safety.test.sh duration_ms=256
FM_TEST_SLOWEST rank=2 script=tests/fm-pr-merge.test.sh duration_ms=220
exit=0
suites that really ran: 2
```
</details>
<details>
<summary>Evidence: New regression test fails before the fix, passes after</summary>

Source: [New regression test fails before the fix, passes after](https://github.com/tiago-peixoto/firstmate/blob/c03cee7e15ae36e66693e38f5781380551e2c606/.no-mistakes/evidence/fm/fm-4100-changed-fixture-selection/30-6-regression-test-fails-before-passes-after.txt)

```text
\### Scenario 6: the new regression test in the runner's own suite

--- AFTER: the suite on the target commit ---
$ bin/fm-test-run.sh tests/fm-test-run.test.sh
exit=0
ok - a changed shared test fixture selects its readers while an unread tests/ path still refuses
FM_TEST_END 2026-09-11T23:45:12Z tests/fm-test-run.test.sh exit=0 duration_ms=172071 gate_skip=false
FM_TEST_SUMMARY total=1 failed=0 skipped_gate=0 duration_ms=172449

--- BEFORE: the same test file run against the BASE runner (fail-before-fix proof) ---
$ bin/fm-test-run.sh tests/fm-test-run.test.sh   # base bin/, target test file
exit=1
fm-test-run: no changed-test mapping for source path: tests/shared-probe-fixture.sh
FM_TEST_END 2026-09-11T23:47:13Z tests/fm-test-run.test.sh exit=2 duration_ms=119852 gate_skip=false
FM_TEST_SUMMARY total=1 failed=1 skipped_gate=0 duration_ms=120202

--- base failure context (the suite dies at the new test, right after the preceding one passes) ---
ok - an unclassified new test stays serial while the proven residual family runs concurrently
fm-test-run: no changed-test mapping for source path: tests/shared-probe-fixture.sh
FM_TEST_END 2026-09-11T23:47:13Z tests/fm-test-run.test.sh exit=2 duration_ms=119852 gate_skip=false
FM_TEST_SUMMARY total=1 failed=1 skipped_gate=0 duration_ms=120202
```
</details>
<details>
<summary>Evidence: Fixture retirement refuses identically on base and target</summary>

Source: [Fixture retirement refuses identically on base and target](https://github.com/tiago-peixoto/firstmate/blob/c03cee7e15ae36e66693e38f5781380551e2c606/.no-mistakes/evidence/fm/fm-4100-changed-fixture-selection/30-7-retirement-parity-with-base.txt)

```text
\### Scenario 7 (adversarial, parity): retiring tests/remote-herdr-fixture.sh and its four
\### references. Known pre-existing gap the maintainer routed separately; checked here only
\### to confirm the change introduces NO NEW abort - base and target must behave identically.
base: exit=2 first line: fm-test-run: no changed-test mapping for source path: tests/remote-herdr-fixture.sh
target: exit=2 first line: fm-test-run: no changed-test mapping for source path: tests/remote-herdr-fixture.sh

IDENTICAL output on base and target: the change adds no new refusal for the retirement shape.
```
</details>
<details>
<summary>Evidence: Key before/after transcript (real execution, no --list)</summary>

```text
--- runner from base 7d14fc1 ---
changed: tests/remote-herdr-probe-fixture.sh
$ bin/fm-test-run.sh --changed --base HEAD
fm-test-run: no changed-test mapping for source path: tests/remote-herdr-probe-fixture.sh
exit=2
suites that really ran: 0

--- runner from target 0f647e2 ---
changed: tests/remote-herdr-probe-fixture.sh
$ bin/fm-test-run.sh --changed --base HEAD
FM_TEST_BEGIN tests/fm-pr-merge.test.sh family=pr-forge expected_gate_skip=none
ok - fm-pr-merge.test.sh really executed
FM_TEST_BEGIN tests/fm-secondmate-safety.test.sh family=secondmate expected_gate_skip=none
ok - fm-secondmate-safety.test.sh really executed
FM_TEST_SUMMARY total=2 failed=0 skipped_gate=0
exit=0
suites that really ran: 2
```
</details>
- Outcome: 🔧 2 issues found → auto-fixed ✅ across 3 runs (54m31s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"0f647e2e3976fc6d69810c68f3f28308937237a2","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}],"live_validation":{"verdict":"go","live":7,"total":7}} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>🔧 **Review** - 3 issues found → auto-fixed ✅</summary>

- ℹ️ `bin/fm-test-run.sh:1524` - Narrower form available. The intent scopes the fix to a changed *top-level* `tests/*-fixture.sh`, but a bash `case` glob&#39;s `*` spans `/`, so `tests/*-fixture.sh` also matches nested paths, and it is placed above the `tests/fixtures/*/*` arm at line 1528 — first match wins, so it shadows that arm. Concrete latent sequence: a contributor adds `tests/fixtures/auth-preflight/session-fixture.sh` (the `tests/fixtures/&lt;dir&gt;/` layout existed historically, added in 28b02d2 and since removed, and the arm is still live for its return). A change to it would resolve on basename `session-fixture.sh` instead of the directory key `fixtures/auth-preflight`, selecting only suites that name the file rather than the suites that read the directory; and on *deletion* it loses that arm&#39;s `[ -d &#34;tests/fixtures/$fixture_ref&#34; ]` retirement guard, so a removed nested fixture with no remaining reader reaches `__unmapped__` and hard-aborts — the exact failure this change exists to remove. Narrower form, one line and no new machinery: move the `tests/fixtures/*/*` arm above the helper arm (which also closes the same latent shadow for the pre-existing `tests/*-helpers.sh`), or move `tests/*-fixture.sh` into its own arm below it. Reported at info because `tests/fixtures/` does not exist in the tree today, so no current path reaches it.
- ℹ️ `tests/fm-test-run.test.sh:1261` - The new test function was inserted between an existing explanatory comment and the function it documents. The block at lines 1261-1264 (&#34;The residual `standalone` family carries a concurrent proof, but the `*)` catch-all it was split out of must not...&#34;) describes `test_unmapped_new_test_never_inherits_family_concurrency` (line 1307), not `test_changed_shared_fixture_selects_its_readers`, which it now heads. A reader lands on the fixture-selection test and gets a rationale about concurrency proofs for unclassified tests. Fix: move `test_changed_shared_fixture_selects_its_readers` below `test_unmapped_new_test_never_inherits_family_concurrency`, or move the comment back down to sit directly above its function.
- ℹ️ `bin/fm-test-run.sh:1313` - Informational, for the PR body rather than the code. The commit message and issue framing assert that both `tests/herdr-client-pair-fixture.sh` and `tests/remote-herdr-fixture.sh` abort selection. Only the latter does. `tests/herdr-client-pair-fixture.sh` is already named explicitly in the curated Herdr arm at bin/fm-test-run.sh:1313 (`bin/backends/herdr*|bin/fm-herdr-lab.sh|tests/herdr-test-safety.sh|tests/herdr-client-pair-fixture.sh`), which precedes the helper arm, so it never reached the `tests/*` catch-all and still resolves through its curated mapping after this change (behavior for it is unchanged, correctly). Every other top-level non-`.test.sh` file under `tests/` was already mapped (`cmux-test-safety.sh`:1327, `zellij-test-safety.sh`:1323, `herdr-test-safety.sh`:1313, `lib.sh`/`fixtures.sh`/`*-helpers.sh`:1524), so `tests/remote-herdr-fixture.sh` is the single path this restores today. The class-level fix is still the right shape for the stated &#34;contract class restore&#34; scope; only the described blast radius is wider than the code supports.

- ⚠️ `bin/fm-test-run.sh:1567` - A *retired* top-level fixture still hard-aborts, the same failure class this change exists to remove. Concrete sequence: a branch deletes tests/remote-herdr-fixture.sh and drops its four `. &#34;$ROOT/tests/remote-herdr-fixture.sh&#34;` references from fm-secondmate-sync / fm-remote-secondmate-{parent-binding,lifecycle-e2e,trace-context}.test.sh. `git diff --name-only` still reports the deleted path, it falls into this arm, `families_for_test_reference remote-herdr-fixture.sh` scans tests/*.test.sh and finds nothing, so `__unmapped__:tests/remote-herdr-fixture.sh` reaches select_changed:1616 and dies with &#34;no changed-test mapping for source path&#34; - zero tests run on a branch that did change four suites. Both sibling arms already guard exactly this: tests/fixtures/*/* checks `[ -d &#34;tests/fixtures/$fixture_ref&#34; ]` (line 1562) and bin/* checks `[ -e &#34;$path&#34; ]` (line 1580) with the comment &#34;Refusing on its absent mapping would make every retirement branch unable to select its changed tests.&#34; The remedy is one `[ -e &#34;$path&#34; ]` wrapper here, but it needs your call rather than an auto-fix: this arm also covers tests/lib.sh, tests/fixtures.sh and *-helpers.sh, so the guard changes the refusal contract for those pre-existing names too, and the intent deliberately keeps &#34;the loud refusal for a genuinely unmapped path&#34;.
- ⚠️ `tests/fm-test-run.test.sh:1318` - Simplification: the bin/fm-quota-choose.sh phase (lines 1318-1326) is a component the change introduced that no intent requirement needs. Its positive assertion duplicates test_changed_dependency_selection_and_unmapped_failure at tests/fm-test-run.test.sh:379-384, and its negative assertion cannot fail: bin/fm-quota-choose.sh has a curated arm at bin/fm-test-run.sh:1408 emitting only `__script__:fm-quota-choose.test.sh`, so fm-pr-merge.test.sh could never appear in that listing with or without this change. The non-widening claim is already carried by the first phase&#39;s orca check at line 1298. Recommend removing the phase rather than strengthening it.
- ℹ️ `bin/fm-test-run.sh:145` - The new header sentence &#34;Any other non-.test.sh file directly under tests/ stays unmapped and refuses the run, so a new shared helper or fixture has to carry one of those names&#34; is false for three files in this tree: tests/herdr-test-safety.sh (mapped at line 1334), tests/zellij-test-safety.sh (line 1345) and tests/cmux-test-safety.sh (line 1348) are all non-.test.sh files directly under tests/ that resolve through curated backend arms above this one. CONTRIBUTING.md:105 names this header as the single owner of the changed-file map, so a contributor adding e.g. tests/orca-test-safety.sh would read this and rename it instead of following the established curated-arm pattern. Add the escape clause, e.g. &#34;...unless a curated family arm above names it explicitly&#34;.
- ℹ️ `tests/fm-test-run.test.sh:1285` - Still present from the previous round. The new function was inserted between an existing explanatory comment and the function it documents. Lines 1285-1288 (&#34;The residual `standalone` family carries a concurrent proof, but the `*)` catch-all it was split out of must not...&#34;) describe test_unmapped_new_test_never_inherits_family_concurrency (line 1339), not test_changed_shared_fixture_selects_its_readers (line 1289), which it now heads. Move the new function below test_unmapped_new_test_never_inherits_family_concurrency, or move the comment back down to sit directly above its own function.

🔧 Fix applied.
✅ Re-checked - no issues remain.
</details>

<details>
<summary>🔧 **Test** - 2 issues found → auto-fixed ✅</summary>

- 🚨 `bin/fm-test-run.sh:1524` - The new `tests/*-fixture.sh` pattern is placed above the `tests/fixtures/*/*` arm, and bash `case` globs match `/`, so it swallows nested fixture files. A fixture at `tests/fixtures/&lt;dir&gt;/&lt;name&gt;-fixture.sh` whose consuming suite references the fixture *directory* (the shape that arm&#39;s own comment says it is keyed for) now falls into the basename reference scan, finds no reader, and aborts `--changed` with exit 2 — the exact failure class this change set out to remove. Driven live: on base `9074f9d` the same path selected `tests/fm-backend-orca.test.sh`; on target `880a9de` it prints `no changed-test mapping for source path: tests/fixtures/demo/demo-fixture.sh` and exits 2. Latent right now because `tests/fixtures/` does not exist in the tree, and bounded to directory-only references (a suite naming the full path still selects). Fix verified live: move the `tests/fixtures/*/*` arm above the `tests/lib.sh|tests/*-helpers.sh|tests/fixtures.sh|tests/*-fixture.sh` arm — the nested case selects its suite again, the top-level fixture still selects its 51 readers, and a reader-less `tests/orphan-fixture.sh` still exits 2.
- 🚨 live validation verdict: no-go (8 of 8 scenarios were driven live against the product); failed: A nested tests/fixtures/&lt;dir&gt;/&lt;x&gt;-fixture.sh keeps the directory-scan selection its arm promises
- Live validation: ❌ no-go - 8 of 8 scenarios driven live against the product

| Scenario | Result | Live | Evidence |
| --- | --- | --- | --- |
| A changed top-level tests/*-fixture.sh no longer aborts affected-test selection | ✅ pass | live | `bin/fm-test-run.sh --list --changed --base HEAD` after touching `tests/remote-herdr-fixture.sh`: base exits 2 with `no changed-test mapping for source path`, target exits 0 with 51 suites — `01-base-… |
| The selection contains every suite that actually reads the changed fixture | ✅ pass | live | cross-checked `grep -l remote-herdr-fixture.sh tests/*.test.sh` against the live selection: all four readers present, and `fm-backend-herdr.test.sh` absent so the expensive real-Herdr lane was not pul… |
| A validation pipeline driving --changed actually runs tests instead of hard-aborting | ✅ pass | live | full `bin/fm-test-run.sh --changed --base HEAD` (no `--list`) with a shared fixture read by one suite: base prints the refusal and runs zero tests, target runs `tests/fm-backend-orca.test.sh` to 51 gr… |
| A genuinely unmapped tests/ path still refuses loudly | ✅ pass | live | untracked `tests/unrelated-thing.sh` → `fm-test-run: no changed-test mapping for source path: tests/unrelated-thing.sh`, exit 2 — `03-guard-still-refuses.txt` |
| A tests/*-fixture.sh with no discoverable reader still refuses loudly | ✅ pass | live | untracked `tests/orphan-fixture.sh` → `no changed-test mapping for source path: tests/orphan-fixture.sh`, exit 2 — `03-guard-still-refuses.txt` |
| The curated tests/herdr-client-pair-fixture.sh mapping is not shadowed by the new glob | ✅ pass | live | `diff` of base vs target `--list --changed` output after touching that fixture: identical 66-script selection — `04-curated-fixture-arm-not-shadowed.txt` |
| A nested tests/fixtures/&lt;dir&gt;/&lt;x&gt;-fixture.sh keeps the directory-scan selection its arm promises | ❌ fail | live | a suite referencing only `tests/fixtures/demo` selected `tests/fm-backend-orca.test.sh` on base and aborts with exit 2 on target; bounded in `06-nested-fixture-shadow-bounds.txt`; reorder fix verified… |
| The change&#39;s own regression test is green in the real checkout | ✅ pass | live | `bin/fm-test-run.sh tests/fm-test-run.test.sh` → `ok - a changed shared test fixture selects its readers while an unread tests/ path still refuses`, `FM_TEST_SUMMARY total=1 failed=0`, exit 0 — `08-fm… |

- <code>`bin/fm-test-run.sh --list --changed --base HEAD` after touching `tests/remote-herdr-fixture.sh`, on a base-commit (9074f9d) checkout — reproduces the exit-2 abort</code>
- <code>`bin/fm-test-run.sh --list --changed --base HEAD` after touching `tests/remote-herdr-fixture.sh`, in the target worktree — 51 suites selected, exit 0</code>
- <code>cross-checked `grep -l remote-herdr-fixture.sh tests/*.test.sh` against that selection: all four real readers present, `fm-backend-herdr.test.sh` absent</code>
- <code>`bin/fm-test-run.sh --changed --base HEAD` (full run, not `--list`) with a shared `tests/zzprobe-fixture.sh` read by exactly one suite: base exits 2 with zero tests, target runs `tests/fm-backend-orca.test.sh` to 51 green assertions, exit 0</code>
- <code>`bin/fm-test-run.sh --list --changed --base HEAD` with an untracked `tests/unrelated-thing.sh` — still `no changed-test mapping for source path`, exit 2</code>
- <code>`bin/fm-test-run.sh --list --changed --base HEAD` with an untracked `tests/orphan-fixture.sh` nobody reads — still exit 2</code>
- <code>`bin/fm-test-run.sh --list --changed --base HEAD` with a deleted `tests/remote-herdr-fixture.sh` whose readers keep the reference — selects the readers, no abort</code>
- <code>diffed base vs target `--list --changed` output after touching `tests/herdr-client-pair-fixture.sh` — identical 66-script selection</code>
- <code>`bin/fm-test-run.sh --list --changed --base HEAD` with `tests/fixtures/demo/demo-fixture.sh` referenced by directory only — base selects `tests/fm-backend-orca.test.sh`, target aborts with exit 2 (the regression)</code>
- <code>same nested fixture referenced by full path, and a nested non-`*-fixture.sh` file — both still select, bounding the regression</code>
- <code>candidate fix probe: reordered the `tests/fixtures/*/*` arm above the new arm in a scratch copy and re-drove all three cases</code>
- <code>`bin/fm-test-run.sh tests/fm-test-run.test.sh` in the worktree — the author&#39;s suite including `a changed shared test fixture selects its readers while an unread tests/ path still refuses`, exit 0, failed=0</code>
- <code>`bash tests/fm-arm-pretool-check.test.sh` in both scratch copies and the real worktree, to prove a stray red script was a scratch-copy artifact rather than a commit regression</code>

🔧 Fix applied.
✅ Re-checked - no issues remain.
- Live validation: ✅ go - 8 of 10 scenarios driven live against the product

| Scenario | Result | Live | Evidence |
| --- | --- | --- | --- |
| A changed tests/remote-herdr-fixture.sh selects its consuming suites instead of aborting | ✅ pass | live | `bin/fm-test-run.sh --list --changed --base HEAD` on a real clone: exit 2 with `no changed-test mapping for source path` at 9074f9d, exit 0 with all four readers (fm-remote-secondmate-trace-context, f… |
| A changed shared fixture makes --changed actually run the reader suites, not just list them | ✅ pass | live | `bin/fm-test-run.sh --changed --base HEAD` (no --list) executed both readers: `FM_TEST_SUMMARY total=2 failed=0 skipped_gate=0` — evidence file 24 |
| ADVERSARIAL: a top-level tests/*-fixture.sh that no suite reads still refuses loudly | ✅ pass | live | changed `tests/orphan-fixture.sh` → `fm-test-run: no changed-test mapping for source path: tests/orphan-fixture.sh`, exit 2, at all three mapper versions — evidence file 23 |
| ADVERSARIAL: a plain unmapped tests/ path keeps the exit-2 refusal | ✅ pass | live | changed `tests/unread-thing.sh` → `no changed-test mapping for source path: tests/unread-thing.sh`, exit 2, unchanged across all three versions — evidence file 23 |
| ADVERSARIAL: a nested tests/fixtures/&lt;dir&gt;/&lt;x&gt;-fixture.sh referenced only by its directory keeps the directory-scan selection | ✅ pass | live | changed `tests/fixtures/demo/demo-fixture.sh` → exit 2 at 880a9de (the round-1 regression), selects `tests/fm-backend-orca.test.sh` with exit 0 at both 9074f9d and a05d0eb — evidence file 23 |
| The curated tests/herdr-client-pair-fixture.sh arm is not shadowed by the new glob | ✅ pass | live | real-repo selection for that path is byte-identical before and after the change (66 scripts); same for `tests/fixtures.sh` (95) and `tests/lib.sh` (197) — evidence file 25 |
| The pre-existing tests/*-helpers.sh arm still selects its reader after being moved below the fixtures arm | ✅ pass | live | changed `tests/probe-helpers.sh` → `tests/fm-brief.test.sh`, exit 0, identical at all three mapper versions — evidence file 23 |
| This branch&#39;s own change set still produces a working --changed selection | ✅ pass | live | `bin/fm-test-run.sh --list --changed --base 9074f9d` at the target commit: exit 0, 35 scripts including `tests/fm-test-run.test.sh` — evidence file 27 |
| The new regression test fails before the fix and passes after it | ⏸️ untested | no | The prior payload recorded this as live=false: it was an execution of the automated test case `test_changed_shared_fixture_selects_its_readers` under a harness, not a drive of the running product, so… |
| The fm-test-run contract suite still passes at the target commit | ⏸️ untested | no | The prior payload recorded this as live=false: it was a run of the automated contract suite `tests/fm-test-run.test.sh`, not a drive of the running product, so it does not establish a live result. To… |

- <code>`bin/fm-test-run.sh --list --changed --base HEAD` on a real clone at 9074f9d with `tests/remote-herdr-fixture.sh` touched (reproduces the exit-2 abort)</code>
- <code>`bin/fm-test-run.sh --list --changed --base HEAD` on a real clone at a05d0eb with `tests/remote-herdr-fixture.sh` touched (selects all four readers)</code>
- <code>`bin/fm-test-run.sh --changed --base HEAD` (no --list) in an isolated repo with a changed shared fixture — the two reader suites actually execute</code>
- <code>`bin/fm-test-run.sh --list --changed --base HEAD` for a changed `tests/orphan-fixture.sh` that no suite reads (must still exit 2)</code>
- <code>`bin/fm-test-run.sh --list --changed --base HEAD` for a changed `tests/unread-thing.sh` (must still exit 2)</code>
- <code>`bin/fm-test-run.sh --list --changed --base HEAD` for a changed `tests/fixtures/demo/demo-fixture.sh` referenced only by its directory</code>
- <code>`bin/fm-test-run.sh --list --changed --base HEAD` for a changed `tests/probe-helpers.sh` (pre-existing helper arm)</code>
- <code>selection diff of `tests/herdr-client-pair-fixture.sh`, `tests/fixtures.sh`, `tests/lib.sh` between 9074f9d and a05d0eb on the real repo</code>
- <code>`bin/fm-test-run.sh --list --changed --base 9074f9d` — this branch&#39;s own changed-file selection</code>

✅ No issues found.
- Live validation: ✅ go - 7 of 7 scenarios driven live against the product

| Scenario | Result | Live | Evidence |
| --- | --- | --- | --- |
| A maintainer edits the real shared fixture tests/remote-herdr-fixture.sh and --changed selects its reader suites instead of aborting | ✅ pass | live | 30-1-top-level-fixture-before-after.txt: base exits 2 with &#34;no changed-test mapping for source path: tests/remote-herdr-fixture.sh&#34;; target lists 51 suites and exits 0 |
| A pipeline running --changed after a shared-fixture edit actually executes the affected suites instead of running zero tests | ✅ pass | live | 30-5-changed-run-actually-executes-suites.txt: real `bin/fm-test-run.sh --changed --base HEAD` (no --list) runs 0 suites / exit 2 on base, runs both reader suites / exit 0 on target without widening t… |
| Adversarial: a tests/*-fixture.sh no suite reads still refuses loudly with exit 2 | ✅ pass | live | 30-3-loud-refusal-still-stands.txt cases 3a and 3b: a reader-less fixture and one referenced only from bin/fm-lint.sh both exit 2 naming the path; adding a reading suite (3d) flips it to selection |
| Adversarial: an unrelated unmapped tests/ file keeps the pre-existing catch-all refusal | ✅ pass | live | 30-3-loud-refusal-still-stands.txt case 3c: tests/unread-thing.sh exits 2 with the named refusal |
| Adversarial: a nested tests/fixtures/&lt;dir&gt;/&lt;name&gt;-fixture.sh keeps the directory-scan selection the new glob could have swallowed | ✅ pass | live | 30-4-nested-fixture-directory-scan.txt: reader naming only `tests/fixtures/demo` selects its suite, exit 0, identical on base and target |
| Files that already mapped before the fix (curated herdr arm, lib.sh, *-helpers.sh, fixtures.sh, a .test.sh, a bin/ script) keep identical selection | ✅ pass | live | 30-2-curated-and-existing-arms-unchanged.txt: all eight paths report IDENTICAL selection and exit code across base and target |
| Adversarial parity: retiring the fixture plus its references introduces no new abort relative to base | ✅ pass | live | 30-7-retirement-parity-with-base.txt: base and target both exit 2 with identical output (known pre-existing gap the maintainer routed separately) |

- <code>`bin/fm-test-run.sh --list --changed --base HEAD` after editing tests/remote-herdr-fixture.sh, run at base 7d14fc1 and target 0f647e2</code>
- <code>`bin/fm-test-run.sh --list --changed --base HEAD` at both commits for tests/herdr-client-pair-fixture.sh, tests/lib.sh, tests/wake-helpers.sh, tests/secondmate-helpers.sh, tests/fixtures.sh, tests/git-config-helpers.sh, tests/fm-brief.test.sh, bin/fm-lint.sh, diffed for byte-identical selection</code>
- <code>`bin/fm-test-run.sh --list --changed --base HEAD` with a reader-less tests/nobody-reads-me-fixture.sh, a bin/-only-referenced tests/binonly-fixture.sh, and an unrelated tests/unread-thing.sh (all expected exit 2), then with one suite reading the fixture (expected exit 0)</code>
- <code>`bin/fm-test-run.sh --list --changed --base HEAD` with tests/fixtures/demo/demo-fixture.sh whose reader names only `tests/fixtures/demo`, at base and target</code>
- <code>`bin/fm-test-run.sh --changed --base HEAD` (real execution, no --list) in a synthetic repo built from each commit&#39;s runner, comparing suites actually executed</code>
- <code>`bin/fm-test-run.sh tests/fm-test-run.test.sh` on target (passes), and the same target test file against the base runner (fails at the new case)</code>
- <code>`bin/fm-test-run.sh --list --changed --base HEAD` after `git rm` of tests/remote-herdr-fixture.sh plus its four references, base vs target output diffed</code>
</details>

<details>
<summary>🔧 **Document** - 2 issues found ✅</summary>

- ℹ️ `CONTRIBUTING.md:116` - CONTRIBUTING.md:116 enumerates shared test helpers as tests/lib.sh, tests/fixtures.sh, tests/wake-helpers.sh, and tests/secondmate-helpers.sh, omitting the two real top-level shared fixtures (tests/herdr-client-pair-fixture.sh, tests/remote-herdr-fixture.sh) that this change promoted to a recognized selection class. The omission predates this change and CONTRIBUTING.md:105 explicitly defers the changed-file map to the runner header, so extending that list here would synchronize a second copy of an owned contract rather than fix an owner. Left for a maintainer call: either add the two fixtures to that reuse inventory, or reduce the sentence to a pointer at `bin/fm-test-run.sh --help`.
- ℹ️ `bin/fm-test-run.sh:1540` - tests/cmux-test-safety.sh, tests/herdr-test-safety.sh, and tests/zellij-test-safety.sh are shared top-level tests/ files with real consumers that still reach the tests/* catch-all and abort --changed, because they match neither *-helpers.sh nor *-fixture.sh. The accepted issue scope was tests/*-fixture.sh only, and widening the glob is executable behavior outside this documentation phase, so it is recorded rather than fixed.

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

✅ No issues found.
</details>
