### PR TITLE
docs: prevent crewmate briefs from widening captain intent

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -533,7 +533,8 @@ Preserve durable structured identifiers, dependencies, and completion artifact l
 ## 11. Crewmate briefs
 
 `bin/fm-brief.sh` and its help own scaffold syntax, generated variants, status protocol, delivery-mode definitions of done, and exact safety mechanics.
-Use its scaffold as the contract, then fill `## Captain's intent` (`{TASK}`) with the captain's own ask plus the context needed to read it, including the substance of any report, decision, or PR the ask refers to, and fill `## Firstmate spec` (`{FIRSTMATE_SPEC}`) with Firstmate's build instructions.
+Use its scaffold as the contract, then fill `## Captain's intent` (`{TASK}`) with the captain's own ask and any boundary the captain stated, plus the context needed to read it, including the substance of any report, decision, or PR the ask refers to; never widen the ask there into a general goal or an enumerated coverage list, because the reviewer treats that subsection as acceptance criteria.
+Fill `## Firstmate spec` (`{FIRSTMATE_SPEC}`) with only the build instructions that ask requires, naming what stays out of scope when the ask is narrow; a generalization, consistency sweep, or extra hardening the captain did not ask for is follow-up work to note, not scope to add.
 `bin/fm-dod-lib.sh` owns what a no-mistakes worker may pass as `--intent` and its rule that the string must be self-sufficient.
 Keep additions task-specific rather than repeating lifecycle instructions, and alter generated sections only when the task genuinely differs from the standard shape.
 


### PR DESCRIPTION
## Intent

The captain approved a small, evidence-backed instruction fix. Firstmate sometimes widens the captain's ask inside a brief's ## Captain's intent subsection, and because the no-mistakes reviewer only ever sees the intent (never firstmate's spec), that widening becomes fleet-wide acceptance criteria and drives over-built work and rework (the #3680 case). Separately, the spec should carry only what the ask requires. The fix is one targeted patch to AGENTS.md section 11's existing brief-fill sentence covering both. The captain did NOT ask for a new YAGNI section or any scaffold change - keep it to this exact patch.

## What Changed
- Require `## Captain's intent` to preserve the captain’s stated ask and boundaries without expanding them into broader acceptance criteria.
- Limit `## Firstmate spec` to required build instructions, keeping unsolicited generalization, consistency sweeps, and hardening out of scope.

## Risk Assessment

✅ Low: The change is a narrowly scoped instruction-only patch that matches the stated intent without altering scaffolds or adding unrelated policy sections.

## Testing

Inspected the baseline-to-target diff and confirmed it changes only the existing brief-fill instruction in AGENTS.md, with no scaffold or other project changes. No live scenarios or visual artifacts were possible because this is a docs-only natural-language behavior change without an executable deterministic interface.

- Live validation: ⚠️ no-surface - 0 of 3 scenarios driven live against the product

| Scenario | Result | Live | Evidence |
| --- | --- | --- | --- |
| Firstmate receives a narrowly bounded captain request and emits a Captain&#39;s intent subsection without converting it into a broader goal or coverage list | ⏸️ untested | no | There is no deterministic executable interface for testing model interpretation of AGENTS.md. Provide a controlled interactive Firstmate session seeded with a narrow captain request and capture its em… |
| Firstmate writes only the build instructions required by the captain and keeps unsolicited generalization, consistency work, and hardening out of scope | ⏸️ untested | no | A running Firstmate model evaluation capable of producing and persisting a brief was not available. Provide that evaluation interface with an adversarial request containing tempting adjacent work. |
| Firstmate preserves explicit captain boundaries in Captain&#39;s intent so the reviewer receives the original acceptance scope | ⏸️ untested | no | The reviewer-facing effect depends on nondeterministic model behavior and cannot be exercised through a repository command. Provide a controlled end-to-end Firstmate-to-reviewer brief-generation sessi… |

<details>
<summary>Evidence: Targeted patch scope</summary>

```text
AGENTS.md | 3 ++-
1 file changed, 2 insertions(+), 1 deletion(-)
```
</details>
- Outcome: ⚠️ 2 warnings across 1 run (1m0s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"8036ada62f224ce307fc6839874c35033026b796","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}],"live_validation":{"verdict":"no-surface","live":0,"total":3}} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>⚠️ **Test** - 2 warnings</summary>

- ⚠️ `AGENTS.md:536` - The change is a natural-language agent instruction with no deterministic executable product surface, so this phase cannot demonstrate that Firstmate will avoid widening a real captain request. A controlled interactive Firstmate evaluation using a narrow, adversarial request is needed before deciding whether to proceed without live validation.
- ⚠️ this change has no live-validatable surface; proceed without live validation? (0 of 3 scenarios were driven live against the product); Firstmate receives a narrowly bounded captain request and emits a Captain&#39;s intent subsection without converting it into a broader goal or coverage list: There is no deterministic executable interface for testing model interpretation of AGENTS.md. Provide a controlled interactive Firstmate session seeded with a narrow captain request and capture its emitted brief.; Firstmate writes only the build instructions required by the captain and keeps unsolicited generalization, consistency work, and hardening out of scope: A running Firstmate model evaluation capable of producing and persisting a brief was not available. Provide that evaluation interface with an adversarial request containing tempting adjacent work.; Firstmate preserves explicit captain boundaries in Captain&#39;s intent so the reviewer receives the original acceptance scope: The reviewer-facing effect depends on nondeterministic model behavior and cannot be exercised through a repository command. Provide a controlled end-to-end Firstmate-to-reviewer brief-generation session.
- Live validation: ⚠️ no-surface - 0 of 3 scenarios driven live against the product

| Scenario | Result | Live | Evidence |
| --- | --- | --- | --- |
| Firstmate receives a narrowly bounded captain request and emits a Captain&#39;s intent subsection without converting it into a broader goal or coverage list | ⏸️ untested | no | There is no deterministic executable interface for testing model interpretation of AGENTS.md. Provide a controlled interactive Firstmate session seeded with a narrow captain request and capture its em… |
| Firstmate writes only the build instructions required by the captain and keeps unsolicited generalization, consistency work, and hardening out of scope | ⏸️ untested | no | A running Firstmate model evaluation capable of producing and persisting a brief was not available. Provide that evaluation interface with an adversarial request containing tempting adjacent work. |
| Firstmate preserves explicit captain boundaries in Captain&#39;s intent so the reviewer receives the original acceptance scope | ⏸️ untested | no | The reviewer-facing effect depends on nondeterministic model behavior and cannot be exercised through a repository command. Provide a controlled end-to-end Firstmate-to-reviewer brief-generation sessi… |

- `git diff --stat 7d14fc126aa8965611f1958a00542d3adc4abdb5..8036ada62f224ce307fc6839874c35033026b796`
- `git diff --unified=80 7d14fc126aa8965611f1958a00542d3adc4abdb5..8036ada62f224ce307fc6839874c35033026b796`
- `git diff --name-only 7d14fc126aa8965611f1958a00542d3adc4abdb5..8036ada62f224ce307fc6839874c35033026b796`
- `git status --short`
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
