### PR TITLE
fix(bearings): surface return catch-up without blocking snapshots

### DIFF
--- a/.agents/skills/afk/SKILL.md
+++ b/.agents/skills/afk/SKILL.md
@@ -71,7 +71,8 @@ No `/back` is needed. The first genuine message is the return signal:
   The gate keeps every open `blocked:` event until that blocker's own resolution is proven: remediate each immediately through the normal lifecycle, or explicitly reclassify it with a durable reason and close its decision key with `resolved [key=...]`, then run `bin/fm-afk-return.sh check`.
   Captain-verdict outcomes are listed under "waiting on you", but do not exempt open blockers because per-blocker provenance is deferred to phase 4.
   Once the record is archived, resume full per-wake responsiveness through the emitted primary-harness supervision protocol while blocker handling proceeds, so the gate never creates a blind wait.
-  Do not answer a Bearings request or perform any other ordinary captain work until the check exits successfully.
+  A Bearings request may be answered while the gate is open, and the digest surfaces the catch-up state as a Charted Next `(return-catchup)` warning row naming what still holds it.
+  Acting on the fleet - dispatching, steering, merging, or any other ordinary captain work - still waits until the check exits successfully.
 - A message **with** the current operational prefix (`FM_OPERATIONAL_PREFIX`, U+2063 INVISIBLE SEPARATOR followed by `FIRSTMATE_OP: `), or a legacy bare `FM_INJECT_MARK` daemon escalation -> stay away and process it.
 - Re-invoking `/afk` while already away -> stay away (refresh); this does **not** trigger an exit.
 

--- a/.agents/skills/bearings/SKILL.md
+++ b/.agents/skills/bearings/SKILL.md
@@ -107,7 +107,7 @@ Compose the payload from the same snapshot with the same ranking judgment as the
   The snapshot command's header owns its durable-title-or-id normalization; never replace the projected label with run status or invent another label.
 - Every Charted Next row copies the snapshot gate's durable filed date into `filed`, and the board orders the section by it, newest filed first.
   Follow `bin/fm-bearings-board.sh`'s payload contract for the accepted format.
-  Omit it or pass null for a row with no durable filed date - the main-inventory warning, an unavailable secondmate home, or a queued row filed before dates were recorded - and the board keeps those rows in payload order after every dated row.
+  Omit it or pass null for a row with no durable filed date - the main-inventory or return-catchup warning, an unavailable secondmate home, or a queued row filed before dates were recorded - and the board keeps those rows in payload order after every dated row.
 - Every Captain's Call item and every Underway, Recently Landed, and Charted Next row carries an explicit `repo` field. Fill it from the snapshot and task records wherever known; use null or an empty string only as the deliberate genuinely-no-repo marker, in which case the template may show the internal id. Ids otherwise stay in the payload only as the routing channel, and composed reasons name blockers in plain words.
 
 Run `build` once after composing the payload.

--- a/.agents/skills/bearings/SKILL.md
+++ b/.agents/skills/bearings/SKILL.md
@@ -54,6 +54,8 @@ Board answers are acted on later under the normal authority rules; this skill's 
    The `(main-inventory)` gate is an action-free integrity warning rather than queued work.
    Render it under Charted Next with the related `omitted` disclosure, never invent an Underway row from backlog-only state, and never move it into Captain's Call.
    The same holds for a secondmate home whose current state is unavailable, and for a readable home whose `invalidity` reports a backlog-vs-metadata mismatch: the mismatch is a repair notice about that home's own books, not a reason to drop its separately projected decisions, queued, landed, or live work.
+   The `(return-catchup)` gate is the same shape: an action-free notice that an away-return catch-up is still open, naming the blockers left to clear or the reason the catch-up was retained.
+   Render it under Charted Next like any other warning row: reporting is not ordinary work, while acting on the fleet still waits for `bin/fm-afk-return.sh check` (`/afk`).
 
 2. **Record a later reconcile notification for any home whose own books disagree.**
    When the snapshot reports a secondmate home whose `invalidity` is `orphan_in_flight`, `unowned_current`, or `terminal_in_flight`, that home's backlog and its own task metadata disagree and only that home may fix it.
@@ -99,7 +101,7 @@ Compose the payload from the same snapshot with the same ranking judgment as the
 - Decision cards carry agent-authored copy: a short noun-phrase title, one-line `about` and `decide` context rows, and option labels with hints, with the recommended option marked.
 - Card `type` (decision, merge, credential) is your composing judgment from the row's content; no backlog field types a card for you.
 - When the card's task is a captain-gated WORK item (the answer should free it to proceed rather than complete it), set the card's `close: "release"` so the answer lifts the hold instead of closing the task; question-shaped items omit it.
-- A Charted Next row's optional `kind` separates work from alarms: omit it (or set `"queued"`) for real queued work, and set `"warning"` on every action-free fleet-integrity notice - the `(main-inventory)` gate, an unavailable secondmate home, and an inventory-mismatch repair notice. The board badges a warning row `needs repair` instead of `waiting` and leaves it out of the Charted Next count, so those rows never read as dispatchable queued work.
+- A Charted Next row's optional `kind` separates work from alarms: omit it (or set `"queued"`) for real queued work, and set `"warning"` on every action-free fleet-integrity notice - the `(main-inventory)` gate, the `(return-catchup)` gate, an unavailable secondmate home, and an inventory-mismatch repair notice. The board badges a warning row `needs repair` instead of `waiting` and leaves it out of the Charted Next count, so those rows never read as dispatchable queued work.
 - `charted_more` counts omitted queued rows only, while `charted_warning_more` counts omitted warning rows only; keep both counts separate whenever the board payload truncates Charted Next.
 - Every Underway row copies the task-identifying `in_flight.name` from the snapshot into an explicit `name` field, which the board leads with while keeping the run status on its second line.
   The snapshot command's header owns its durable-title-or-id normalization; never replace the projected label with run status or invent another label.

--- a/bin/fm-afk-return.sh
+++ b/bin/fm-afk-return.sh
@@ -6,7 +6,9 @@
 #   fm-afk-return.sh          Stop away mode, render the return brief, and open/check the gate.
 #   fm-afk-return.sh begin    Same as the default command.
 #   fm-afk-return.sh check    Re-render the brief and close the gate only after blockers resolve.
-#   fm-afk-return.sh guard    Read-only refusal while away or catch-up is pending.
+#   fm-afk-return.sh guard    Read-only consult: exit 3 while away mode is still
+#                            active, exit 4 while return catch-up is pending.
+#   fm-afk-return.sh catchup-summary  Read-only catch-up projection for a reporting surface.
 #
 # THE RETURN BRIEF (stdout, on begin and on every check) is rendered from durable
 # records, never from conversation memory: the archived away-posture record
@@ -37,9 +39,12 @@
 # so a crash between stopping, wake presentation, and blocker handling fails
 # closed. It retains the presented wake, buffered-escalation, wedge-marker,
 # health, and posture-record evidence until every live open blocker is closed
-# and `check` succeeds. Repeated begin/check calls are idempotent. `guard`
-# never mutates state and is suitable for ordinary read entrypoints such as
-# fm-bearings-snapshot.sh.
+# and `check` succeeds. Repeated begin/check calls are idempotent. `guard` and
+# `catchup-summary` never mutate state and are suitable for ordinary read
+# entrypoints such as fm-bearings-snapshot.sh. `guard` separates its two
+# refusal branches by exit status so a reporting surface can keep refusing
+# during an active away window while still rendering the catch-up posture as
+# content; this file owns the gate format both branches read.
 set -u
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -59,7 +64,7 @@ RETURN_GRACE=${FM_GUARD_GRACE:-300}
 CONTRACT="$SCRIPT_DIR/fm-afk-contract.sh"
 
 usage() {
-  sed -n '2,9p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+  sed -n '2,11p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
 }
 
 clean_field() {
@@ -245,15 +250,58 @@ clear_delivery_artifacts() {
     "$STATE/.subsuper-inject-wedged"
 }
 
+# The lifecycle retention reasons the gate kept, one per line, empty when the
+# gate was retained for open blockers alone.
+gate_retention_reasons() {  # <file>
+  local file=$1 tag kind text
+  while IFS="$(printf '\t')" read -r tag kind text; do
+    [ "$tag" = evidence ] && [ "$kind" = lifecycle ] || continue
+    printf '%s\n' "$text"
+  done < "$file"
+}
+
+gate_has_blockers() {  # <file>
+  grep -q "^blocker$(printf '\t')" "$1" 2>/dev/null
+}
+
+# Read-only catch-up projection for a reporting surface such as
+# fm-bearings-snapshot.sh: one tab-separated line
+# `<open-blocker-count><TAB><first-retention-reason>`, and exit 1 when no gate
+# is open. The reason field is empty when open blockers alone hold the gate.
+catchup_summary() {
+  local count reason
+  [ -e "$GATE" ] || return 1
+  count=$(grep -c "^blocker$(printf '\t')" "$GATE" 2>/dev/null || true)
+  case "$count" in ''|*[!0-9]*) count=0 ;; esac
+  reason=$(gate_retention_reasons "$GATE" | head -1)
+  printf '%s\t%s\n' "$count" "$reason"
+}
+
 return_guard() {
+  local reasons
   if [ -e "$STATE/.afk" ] || fm_afk_contract_present "$STATE"; then
     printf 'fm-afk-return: away mode is still active; run bin/fm-afk-return.sh before ordinary captain work\n' >&2
     return 3
   fi
   if [ -e "$GATE" ]; then
-    printf 'fm-afk-return: return catch-up is pending; remediate or durably reclassify every listed blocker, then run bin/fm-afk-return.sh check\n' >&2
-    print_blockers "$GATE" >&2
-    return 3
+    if gate_has_blockers "$GATE"; then
+      printf 'fm-afk-return: return catch-up is pending; remediate or durably reclassify every listed blocker, then run bin/fm-afk-return.sh check\n' >&2
+      print_blockers "$GATE" >&2
+    else
+      # No blocker row exists, so naming "every listed blocker" would ask for
+      # something the gate does not list. Name the lifecycle retention reason
+      # that actually holds it instead.
+      printf 'fm-afk-return: return catch-up is pending with no open blocker; clear the retention reason below, then run bin/fm-afk-return.sh check\n' >&2
+      reasons=$(gate_retention_reasons "$GATE")
+      if [ -n "$reasons" ]; then
+        printf '%s\n' "$reasons" | while IFS= read -r text; do
+          printf 'catch-up retained: %s\n' "$text" >&2
+        done
+      else
+        printf 'catch-up retained: the durable gate recorded no retention reason\n' >&2
+      fi
+    fi
+    return 4
   fi
   return 0
 }
@@ -650,6 +698,7 @@ main() {
   case "$mode" in
     begin|check) ;;
     guard) return_guard; return ;;
+    catchup-summary) catchup_summary; return ;;
     -h|--help|help) usage; return 0 ;;
     *) usage >&2; return 2 ;;
   esac

--- a/bin/fm-bearings-snapshot.sh
+++ b/bin/fm-bearings-snapshot.sh
@@ -537,19 +537,19 @@ MODEL=$(printf '%s' "$SNAP" | jq \
      + [ (.secondmate_current.records // [])[] | .queued[]?
          | select(.hold_kind == "captain" and projected_deferred_hold) ]
      | length) as $decisions_marked_deferred
-  | ((if ($return_catchup.pending // false) then
-        [{id:"(return-catchup)",
-          title:((if ($return_catchup.blockers // 0) > 0 then
-                    "\($return_catchup.blockers) blocker(s) to clear before ordinary work"
-                  elif (($return_catchup.reason // "") != "") then
-                    ("catch-up retained: " +
-                     ($return_catchup.reason | sub("[,;] *catch-up stays gated$"; "")))
-                  else "away-return catch-up is still open" end) | trunc(60)),
-          blocked_by:"-",
-          reason:"away-return catch-up",
-          owner:"(main)"}]
-      else [] end)
-     + (if (.main_inventory.valid == false) then
+  | (if ($return_catchup.pending // false) then
+       [{id:"(return-catchup)",
+         title:((if ($return_catchup.blockers // 0) > 0 then
+                   "\($return_catchup.blockers) blocker(s) to clear before ordinary work"
+                 elif (($return_catchup.reason // "") != "") then
+                   ("catch-up retained: " +
+                    ($return_catchup.reason | sub("[,;] *catch-up stays gated$"; "")))
+                 else "away-return catch-up is still open" end) | trunc(60)),
+         blocked_by:"-",
+         reason:"away-return catch-up",
+         owner:"(main)"}]
+     else [] end) as $return_catchup_gate
+  | ((if (.main_inventory.valid == false) then
         [{id:"(main-inventory)",
           title:((.main_inventory.reason // "main inventory invalid") | trunc(60)),
           blocked_by:"-",
@@ -600,8 +600,9 @@ MODEL=$(printf '%s' "$SNAP" | jq \
       decisions_open: (if $all_decisions == 1 then $decisions_all else $decisions_all[:$decisions_n] end),
       landed: ($done | map({id, what:(.title | trunc(70)),
                             artifact:(landed_artifact // "-"),owner:.home_id})),
-      gates: ($gates_all | newest_filed_first
-              | if $all_queued == 1 then . else .[:$gates_n] end),
+      gates: ($return_catchup_gate
+              + ($gates_all | newest_filed_first
+                 | if $all_queued == 1 then . else .[:$gates_n] end)),
       reports: (if $all_reports == 1 then $reports_all else $reports_all[:$reports_n] end),
       recorded_prs: (if $all_recorded_prs == 1 then $recorded_prs_all else $recorded_prs_all[:$recorded_prs_n] end)
     }

--- a/bin/fm-bearings-snapshot.sh
+++ b/bin/fm-bearings-snapshot.sh
@@ -44,9 +44,10 @@
 # Aging is a projection safety net only; the durable
 # deferral remains re-holding with --until.
 #
-# Charted Next gates are ordered by durable filed date, newest first, before the
-# FM_BEARINGS_GATES bound is applied. Gates without a comparable filed date keep
-# their input order after dated gates.
+# Ordinary Charted Next gates are ordered by durable filed date, newest first,
+# before the FM_BEARINGS_GATES bound is applied. Gates without a comparable filed
+# date keep their input order after dated gates. The synthetic (return-catchup)
+# posture row is reserved ahead of that ordering and bound so it always surfaces.
 #
 # Main-home inventory validity comes from the canonical snapshot's main_inventory
 # object (orphan structured in-flight without meta, unstructured current rows).

--- a/bin/fm-bearings-snapshot.sh
+++ b/bin/fm-bearings-snapshot.sh
@@ -54,6 +54,12 @@
 # gaps in omitted[] and, when invalid, a Charted Next gate line so the four-section
 # chat cannot claim an empty fleet while main current state is broken.
 #
+# An open away-return catch-up is disclosed the same way, as a single action-free
+# (return-catchup) gate row naming the blockers left to clear or the reason the
+# catch-up was retained. Reporting is not ordinary captain work, so the gate never
+# suppresses the digest; an ACTIVE away window still refuses, because the right
+# answer there is to run the return first. bin/fm-afk-return.sh owns the gate.
+#
 # The landed section merges this home's Done with the canonical snapshot's
 # secondmate_landed roll-up (fm-fleet-snapshot.sh), so merges a secondmate managed -
 # recorded in ITS OWN backlog, never the main one - are visible. It stays bounded by
@@ -197,10 +203,29 @@ done
 
 command -v jq >/dev/null 2>&1 || { echo "fm-bearings-snapshot: jq not found" >&2; exit 1; }
 
-# The deterministic return-catch-up owner must clear before this or any other
-# ordinary captain request proceeds. Bearings does not reproduce that policy;
-# it only consults the shared read-only gate.
-"$SCRIPT_DIR/fm-afk-return.sh" guard || exit $?
+# The shared read-only away-return owner is consulted, not obeyed. An active
+# away window still refuses here: the correct answer to a bearings request then
+# is to run the return first. Return CATCH-UP is different - the captain is
+# back and asking for the picture, so the catch-up posture is reported as
+# content (a Charted Next gate row) and collection continues. bin/fm-afk-return.sh
+# owns both the gate format and the branch distinction; bearings reproduces
+# neither. Acting on the fleet still waits for its `check`.
+RETURN_CATCHUP=null
+GUARD_RC=0
+GUARD_ERR=$("$SCRIPT_DIR/fm-afk-return.sh" guard 2>&1 >/dev/null) || GUARD_RC=$?
+if [ "$GUARD_RC" -ne 0 ] && [ "$GUARD_RC" -ne 4 ]; then
+  [ -z "$GUARD_ERR" ] || printf '%s\n' "$GUARD_ERR" >&2
+  exit "$GUARD_RC"
+fi
+if [ "$GUARD_RC" -eq 4 ]; then
+  CATCHUP_LINE=$("$SCRIPT_DIR/fm-afk-return.sh" catchup-summary) || CATCHUP_LINE=""
+  CATCHUP_BLOCKERS=${CATCHUP_LINE%%$'\t'*}
+  case "$CATCHUP_BLOCKERS" in ''|*[!0-9]*) CATCHUP_BLOCKERS=0 ;; esac
+  CATCHUP_REASON=""
+  case "$CATCHUP_LINE" in *"$(printf '\t')"*) CATCHUP_REASON=${CATCHUP_LINE#*$'\t'} ;; esac
+  RETURN_CATCHUP=$(jq -n --argjson blockers "$CATCHUP_BLOCKERS" --arg reason "$CATCHUP_REASON" \
+    '{pending:true,blockers:$blockers,reason:$reason}')
+fi
 
 NOW=${FM_BEARINGS_NOW:-$(date -u +%Y-%m-%dT%H:%M:%SZ)}
 if [ "$ALL_LANDED" = 1 ] || [ "$ALL_SECONDMATES" = 1 ]; then
@@ -340,6 +365,7 @@ MODEL=$(printf '%s' "$SNAP" | jq \
   --argjson pr_repos_shown "$PR_REPOS_SHOWN" \
   --argjson pr_rows_capped "$PR_ROWS_CAPPED" \
   --argjson pr_rows_min_total "$PR_ROWS_MIN_TOTAL" \
+  --argjson return_catchup "$RETURN_CATCHUP" \
   --argjson candidate_prs "$CANDIDATE_PRS" "$FM_LANDED_JQ_DEFS"'
   def trunc($n): if . == null then null else
     (tostring | gsub("\\s+"; " ") | if (length > $n) then (.[:$n] + "…") else . end) end;
@@ -511,7 +537,19 @@ MODEL=$(printf '%s' "$SNAP" | jq \
      + [ (.secondmate_current.records // [])[] | .queued[]?
          | select(.hold_kind == "captain" and projected_deferred_hold) ]
      | length) as $decisions_marked_deferred
-  | ((if (.main_inventory.valid == false) then
+  | ((if ($return_catchup.pending // false) then
+        [{id:"(return-catchup)",
+          title:((if ($return_catchup.blockers // 0) > 0 then
+                    "\($return_catchup.blockers) blocker(s) to clear before ordinary work"
+                  elif (($return_catchup.reason // "") != "") then
+                    ("catch-up retained: " +
+                     ($return_catchup.reason | sub("[,;] *catch-up stays gated$"; "")))
+                  else "away-return catch-up is still open" end) | trunc(60)),
+          blocked_by:"-",
+          reason:"away-return catch-up",
+          owner:"(main)"}]
+      else [] end)
+     + (if (.main_inventory.valid == false) then
         [{id:"(main-inventory)",
           title:((.main_inventory.reason // "main inventory invalid") | trunc(60)),
           blocked_by:"-",

--- a/bin/fm-bearings-snapshot.sh
+++ b/bin/fm-bearings-snapshot.sh
@@ -547,7 +547,8 @@ MODEL=$(printf '%s' "$SNAP" | jq \
                  else "away-return catch-up is still open" end) | trunc(60)),
          blocked_by:"-",
          reason:"away-return catch-up",
-         owner:"(main)"}]
+         owner:"(main)",
+         filed:null}]
      else [] end) as $return_catchup_gate
   | ((if (.main_inventory.valid == false) then
         [{id:"(main-inventory)",

--- a/docs/verification/runtime-backends.md
+++ b/docs/verification/runtime-backends.md
@@ -1197,22 +1197,23 @@ A stale-registration pane is never a husk: create, reclaim, presentation recover
 ### Away-mode transport
 
 The away daemon is no longer launched on Pi; the away posture there is the record `bin/fm-afk-contract.sh` owns.
-The Pi/Herdr away posture and return path was verified on 2026-09-08 against a real Pi primary in an isolated Herdr lab session, Herdr 0.9.0 and Pi 0.82.0:
+The Pi/Herdr away posture and return transport was verified on 2026-09-08 against a real Pi primary in an isolated Herdr lab session, Herdr 0.9.0 and Pi 0.82.0:
 
 ```sh
 FM_AFK_PI_HERDR_E2E=1 HERDR_LAB_HELPER=bin/fm-herdr-lab.sh \
   tests/fm-afk-pi-herdr-return-e2e.test.sh
 ```
 
-```
+Relevant transport output:
+
+```text
 ok - real Pi primary: the away posture is recorded with no daemon launched
 ok - real Pi/Herdr: nothing injects into the captain pane under the away posture
-ok - real unmarked Pi return renders the brief, opens catch-up, and blocks Bearings before the unresolved blocker can be deferred
-ok - resolved return catch-up allows Bearings and a clean idempotent away re-entry
 evidence: herdr=herdr 0.9.0 pi=0.82.0 target=fm-lab-fm-afk-pi-return-37189-7133:w1:p1 archived-records=2
 ```
 
-Observed guarantees: `fm-afk-launch.sh start` refused on the Pi primary and `confirm` recorded the posture with no daemon pid, flag, or terminal; a pending real Pi draft was left untouched with nothing submitted into the captain pane; the unmarked return request was recognized as the return, rendered the brief health first, opened the catch-up gate on the live blocker, and refused Bearings; resolving the blocker cleared the gate, and a clean re-entry and return left exactly one archived record per away window.
+Observed guarantees: `fm-afk-launch.sh start` refused on the Pi primary and `confirm` recorded the posture with no daemon pid, flag, or terminal; a pending real Pi draft was left untouched with nothing submitted into the captain pane; the unmarked return request was recognized as the return, rendered the brief health first, and opened the catch-up gate on the live blocker; resolving the blocker cleared the gate, and a clean re-entry and return left exactly one archived record per away window.
+The current catch-up reporting boundary is pinned by `tests/fm-afk-return.test.sh` and the same live entry point: Bearings continues through a pending return catch-up, projects its posture as an action-free warning outside Captain's Call, and drops that warning after the gate clears, while an active away window still refuses.
 The fixture captures submitted input through Pi's `input` extension hook, so the lab agent directory needs no provider credentials.
 The daemon injection transport into a live composer keeps its coverage in `tests/fm-afk-inject-herdr-e2e.test.sh` for the harnesses that still run the daemon, and the dedicated Herdr daemon workspace topology is covered by `tests/fm-afk-launch.test.sh` and preserves the captain tab's pane count.
 

--- a/tests/fm-afk-pi-herdr-return-e2e.test.sh
+++ b/tests/fm-afk-pi-herdr-return-e2e.test.sh
@@ -10,7 +10,8 @@
 #     records the posture with no daemon terminal, pid, or flag;
 #   - a real Pi draft is never touched by away mode (nothing injects on Pi);
 #   - an unmarked return request is recognized as the return, opens the
-#     catch-up gate before Bearings on the live blocker, and renders the brief;
+#     catch-up gate on the live blocker, renders the brief, and still lets
+#     Bearings report that catch-up posture as content;
 #   - remediation/resolution clears the gate, and re-entry is idempotent.
 # The 2026-07-14 two-owner incident's daemon-injection assertions retired with
 # the daemon on Pi; the daemon transport keeps its coverage in
@@ -252,19 +253,23 @@ assert_contains "$RETURN_OUT" 'firstmate-actionable blocker: repair-task [key=sy
 assert_contains "$RETURN_OUT" '=== Return brief (away ' "the return did not render the brief"
 assert_contains "$RETURN_OUT" 'Supervisor health:' "the brief did not lead with supervisor health"
 [ ! -f "$STATE/.afk-contract" ] || fail "the return did not archive the away-posture record"
-set +e
 BEARINGS_OUT=$(PATH="$FAKEBIN:$ORIGINAL_PATH" HERDR_SESSION="$SESSION" FM_ROOT_OVERRIDE="$PROJECT" FM_HOME="$HOME_DIR" FM_STATE_OVERRIDE="$STATE" \
-  "$ROOT/bin/fm-bearings-snapshot.sh" --json 2>&1)
-BEARINGS_RC=$?
-set -e
-[ "$BEARINGS_RC" -eq 3 ] || fail "Bearings bypassed the return gate (rc=$BEARINGS_RC): $BEARINGS_OUT"
-pass "real unmarked Pi return renders the brief, opens catch-up, and blocks Bearings before the unresolved blocker can be deferred"
+  "$ROOT/bin/fm-bearings-snapshot.sh" --json 2>&1) \
+  || fail "Bearings refused behind the return gate instead of reporting it: $BEARINGS_OUT"
+printf '%s' "$BEARINGS_OUT" | jq -e '
+  (.in_flight | any(.id == "repair-task"))
+  and (.gates | any(.id == "(return-catchup)" and .reason == "away-return catch-up"))
+  and ([.decisions_open[].id] | index("(return-catchup)") | not)' >/dev/null \
+  || fail "Bearings did not surface the catch-up posture as content: $BEARINGS_OUT"
+pass "real unmarked Pi return renders the brief, opens catch-up, and reports that posture through Bearings while the blocker stays Firstmate's to remediate"
 
 printf 'resolved [key=synthetic-dependency]: refreshed the synthetic token and resumed the task\n' >> "$STATE/repair-task.status"
 PATH="$FAKEBIN:$ORIGINAL_PATH" HERDR_SESSION="$SESSION" FM_ROOT_OVERRIDE="$PROJECT" FM_HOME="$HOME_DIR" FM_STATE_OVERRIDE="$STATE" \
   "$ROOT/bin/fm-afk-return.sh" check >/dev/null || fail "remediated blocker did not clear return catch-up"
 PATH="$FAKEBIN:$ORIGINAL_PATH" HERDR_SESSION="$SESSION" FM_ROOT_OVERRIDE="$PROJECT" FM_HOME="$HOME_DIR" FM_STATE_OVERRIDE="$STATE" \
-  "$ROOT/bin/fm-bearings-snapshot.sh" --json >/dev/null || fail "Bearings remained gated after blocker remediation"
+  "$ROOT/bin/fm-bearings-snapshot.sh" --json \
+  | jq -e '[.gates[].id] | index("(return-catchup)") | not' >/dev/null \
+  || fail "Bearings kept the catch-up posture row after the gate cleared"
 
 # A clean re-entry records a fresh posture, and an immediate return is
 # idempotently clear because the keyed blocker is resolved.

--- a/tests/fm-afk-return.test.sh
+++ b/tests/fm-afk-return.test.sh
@@ -97,7 +97,7 @@ EOF
 }
 
 test_return_gate_owns_remediation_and_reports_catchup_to_bearings() {
-  local dir out rc gate wake_count i
+  local dir out rc gate wake_count i toon gate_header
   dir="$TMP_ROOT/ordering"
   install_runner "$dir"
   seed_live_blocker "$dir" herdr synthetic-dependency
@@ -147,7 +147,7 @@ test_return_gate_owns_remediation_and_reports_catchup_to_bearings() {
   # do is stop the fleet read, so the worker has to reach Underway at all.
   printf '%s' "$out" | jq -e '
     (.in_flight | any(.id == "repair-task"))
-    and (.gates[0].id == "(return-catchup)")
+    and (.gates[0].id == "(return-catchup)" and .gates[0].filed == null)
     and (.gates | length == 21)
     and ([.gates[] | select(.id | startswith("queued-"))] | length == 20)
     and (.gates | any(.id == "(return-catchup)"
@@ -156,6 +156,11 @@ test_return_gate_owns_remediation_and_reports_catchup_to_bearings() {
                       and (.title | test("^1 blocker"))))
     and ([.decisions_open[].id] | index("(return-catchup)") | not)' >/dev/null \
     || fail "Bearings did not reserve the catch-up posture outside bounded action-free gate rows: $out"
+  toon=$(FM_HOME="$dir/home" FM_STATE_OVERRIDE="$dir/home/state" "$ROOT/bin/fm-bearings-snapshot.sh" 2>&1) \
+    || fail "default Bearings should render behind the return catch-up gate: $toon"
+  gate_header=$(printf '%s\n' "$toon" | awk '/^gates\[[0-9]+\]\{/ { print; exit }')
+  assert_contains "$gate_header" '{id,title,blocked_by,reason,owner,filed}' "catch-up removed filed from the TOON gate schema"
+  assert_contains "$toon" '2026-06-20' "catch-up removed durable gate dates from default Bearings output"
 
   # The guard itself still separates its two branches by exit status, so an
   # active away window keeps refusing while catch-up reports.

--- a/tests/fm-afk-return.test.sh
+++ b/tests/fm-afk-return.test.sh
@@ -4,8 +4,10 @@
 # Covers the second half of the 2026-07-14 incident: an away-mode blocked event
 # survived in durable state, but the ordinary return request could proceed to
 # Bearings before Firstmate owned remediation. The shared script now stops,
-# drains, preserves evidence, and refuses ordinary work until every live open
-# `blocked:` event is resolved or durably reclassified.
+# drains, preserves evidence, and holds ordinary WORK until every live open
+# `blocked:` event is resolved or durably reclassified. Reporting is not work:
+# Bearings renders behind the catch-up gate and surfaces the catch-up posture
+# as content, so a returning captain still gets the picture.
 # The brief cases pin the away-posture redesign's return: the brief is composed
 # from the archived posture record, the outcome store, the held set, and the
 # status logs, health first, and the gate shrinks to what the away session could
@@ -94,7 +96,7 @@ EOF
   printf 'blocked [key=%s]: firstmate can refresh the synthetic token\n' "$key" > "$dir/home/state/repair-task.status"
 }
 
-test_return_gate_orders_catchup_before_bearings() {
+test_return_gate_owns_remediation_and_reports_catchup_to_bearings() {
   local dir out rc gate wake_count
   dir="$TMP_ROOT/ordering"
   install_runner "$dir"
@@ -124,14 +126,32 @@ test_return_gate_orders_catchup_before_bearings() {
   [ -s "$dir/home/state/.fake-drain" ] || fail "blocked return acknowledged its emitted wake before handling completed"
   [ ! -e "$dir/home/state/.fake-drain-acks" ] || fail "blocked return crossed the post-handling acknowledgement boundary"
 
-  # The exact incident regression: Bearings is an ordinary request and must
-  # refuse before reading/rendering while this shared gate remains open.
+  # The captain is back and asking for the picture: Bearings reports the
+  # catch-up posture as content rather than refusing. The blocked worker still
+  # projects as its own Underway row, and the catch-up posture is a separate
+  # action-free Charted Next gate row that never becomes a Captain's Call entry.
+  out=$(FM_HOME="$dir/home" FM_STATE_OVERRIDE="$dir/home/state" "$ROOT/bin/fm-bearings-snapshot.sh" --json 2>&1) \
+    || fail "Bearings should render behind the return catch-up gate: $out"
+  # The live projected state of the blocked worker follows its endpoint, which
+  # this fixture deliberately does not stand up; what the gate must no longer
+  # do is stop the fleet read, so the worker has to reach Underway at all.
+  printf '%s' "$out" | jq -e '
+    (.in_flight | any(.id == "repair-task"))
+    and (.gates | any(.id == "(return-catchup)"
+                      and .owner == "(main)"
+                      and .reason == "away-return catch-up"
+                      and (.title | test("^1 blocker"))))
+    and ([.decisions_open[].id] | index("(return-catchup)") | not)' >/dev/null \
+    || fail "Bearings did not project the catch-up posture as an action-free gate row: $out"
+
+  # The guard itself still separates its two branches by exit status, so an
+  # active away window keeps refusing while catch-up reports.
   set +e
-  out=$(FM_HOME="$dir/home" FM_STATE_OVERRIDE="$dir/home/state" "$ROOT/bin/fm-bearings-snapshot.sh" --json 2>&1)
+  out=$(FM_HOME="$dir/home" FM_STATE_OVERRIDE="$dir/home/state" "$dir/bin/fm-afk-return.sh" guard 2>&1)
   rc=$?
   set -e
-  [ "$rc" -eq 3 ] || fail "Bearings should refuse behind the return gate (rc=$rc): $out"
-  assert_contains "$out" 'return catch-up is pending' "Bearings refusal did not point to the shared return owner"
+  [ "$rc" -eq 4 ] || fail "the catch-up branch should be distinguishable by exit status (rc=$rc): $out"
+  assert_contains "$out" 'return catch-up is pending' "the catch-up refusal did not point to the shared return owner"
 
   # Restart/re-entry is idempotent: no second stop, no duplicate catch-up line,
   # and the same unresolved blocker remains authoritative.
@@ -148,6 +168,9 @@ test_return_gate_orders_catchup_before_bearings() {
 
   printf 'resolved [key=synthetic-dependency]: refreshed the synthetic token and resumed the task\n' >> "$dir/home/state/repair-task.status"
   out=$(run_return "$dir" check) || fail "resolved blocker did not clear return catch-up: $out"
+  FM_HOME="$dir/home" FM_STATE_OVERRIDE="$dir/home/state" "$ROOT/bin/fm-bearings-snapshot.sh" --json \
+    | jq -e '[.gates[].id] | index("(return-catchup)") | not' >/dev/null \
+    || fail "the cleared gate left the catch-up posture row in Bearings"
   assert_contains "$out" 'catch-up clear' "successful check did not announce that ordinary work may proceed"
   [ ! -e "$gate" ] || fail "successful check left the return gate behind"
   [ ! -e "$dir/home/state/.subsuper-escalations" ] || fail "successful check left delivered escalation state behind"
@@ -162,7 +185,7 @@ test_return_gate_orders_catchup_before_bearings() {
 
   out=$(run_return "$dir" check) || fail "an already-clear repeated check should be idempotent: $out"
   [ ! -e "$gate" ] || fail "idempotent clear check recreated a gate"
-  pass "return catch-up precedes Bearings, owns live blocker remediation, preserves evidence once, and clears idempotently"
+  pass "return catch-up owns live blocker remediation, reports itself to Bearings as content, preserves evidence once, and clears idempotently"
 }
 
 test_explicit_reclassification_requires_durable_reason() {
@@ -508,7 +531,7 @@ test_unreadable_outcome_store_keeps_catchup_gated() {
 }
 
 test_failed_held_listing_keeps_catchup_gated() {
-  local dir out waiting rc gate
+  local dir out waiting rc gate guard_out guard_rc
   dir="$TMP_ROOT/held-list-failure"
   install_runner "$dir"
   mkdir -p "$dir/fakebin"
@@ -528,6 +551,21 @@ SH
   set -e
   [ "$rc" -eq 3 ] || fail "a failed held-set read should keep catch-up gated (rc=$rc): $out"
   [ -f "$gate" ] || fail "a failed held-set read did not retain the return gate"
+
+  # A gate retained for a lifecycle reason lists no blocker at all, so the
+  # refusal must name what actually holds it instead of promising a blocker
+  # list it cannot produce, and Bearings must carry that same reason.
+  set +e
+  guard_out=$(FM_HOME="$dir/home" FM_STATE_OVERRIDE="$dir/home/state" "$dir/bin/fm-afk-return.sh" guard 2>&1)
+  guard_rc=$?
+  set -e
+  [ "$guard_rc" -eq 4 ] || fail "a blockerless catch-up gate should use the catch-up branch (rc=$guard_rc): $guard_out"
+  assert_contains "$guard_out" 'no open blocker' "the blockerless refusal did not say the gate lists no blocker"
+  assert_contains "$guard_out" 'catch-up retained: held set unreadable' "the blockerless refusal did not name the retention reason"
+  assert_not_contains "$guard_out" 'every listed blocker' "the blockerless refusal still demanded an empty blocker list"
+  FM_HOME="$dir/home" FM_STATE_OVERRIDE="$dir/home/state" "$ROOT/bin/fm-bearings-snapshot.sh" --json \
+    | jq -e '.gates | any(.id == "(return-catchup)" and (.title | startswith("catch-up retained:")))' >/dev/null \
+    || fail "Bearings did not carry the blockerless catch-up retention reason"
   waiting=$(printf '%s\n' "$out" | awk '/^Waiting on you:/{show=1} /^Tried and failed, or could not be fixed:/{show=0} show')
   assert_contains "$waiting" "held listing unavailable: $dir/home/data/backlog.md: synthetic held backlog failure; catch-up stays gated" "the failed held listing was not disclosed"
   assert_not_contains "$waiting" '(nothing)' "an unavailable held set was also reported as empty"
@@ -693,7 +731,7 @@ test_missing_final_archive_keeps_retained_contract_gated() {
   pass "the retained contract epoch requires its final archive on every check"
 }
 
-test_return_gate_orders_catchup_before_bearings
+test_return_gate_owns_remediation_and_reports_catchup_to_bearings
 test_explicit_reclassification_requires_durable_reason
 test_captain_decision_does_not_masquerade_as_firstmate_blocker
 test_evidence_publication_failure_preserves_wake_for_redrain

--- a/tests/fm-afk-return.test.sh
+++ b/tests/fm-afk-return.test.sh
@@ -97,10 +97,20 @@ EOF
 }
 
 test_return_gate_owns_remediation_and_reports_catchup_to_bearings() {
-  local dir out rc gate wake_count
+  local dir out rc gate wake_count i
   dir="$TMP_ROOT/ordering"
   install_runner "$dir"
   seed_live_blocker "$dir" herdr synthetic-dependency
+  {
+    printf '## In flight\n\n## Queued\n'
+    i=1
+    while [ "$i" -le 20 ]; do
+      printf -- '- [ ] queued-%02d - Queued gate %02d (repo: sample) (kind: ship) (since 2026-06-%02d)\n' \
+        "$i" "$i" "$i"
+      i=$((i + 1))
+    done
+    printf '\n## Done\n'
+  } > "$dir/home/data/backlog.md"
   date +%s > "$dir/home/state/.afk"
   printf 'repair-task.status: blocked synthetic dependency\n' > "$dir/home/state/.subsuper-escalations"
   printf 'fm away-mode inject WEDGED: 4555s undelivered\n' > "$dir/home/state/.subsuper-inject-wedged"
@@ -137,12 +147,15 @@ test_return_gate_owns_remediation_and_reports_catchup_to_bearings() {
   # do is stop the fleet read, so the worker has to reach Underway at all.
   printf '%s' "$out" | jq -e '
     (.in_flight | any(.id == "repair-task"))
+    and (.gates[0].id == "(return-catchup)")
+    and (.gates | length == 21)
+    and ([.gates[] | select(.id | startswith("queued-"))] | length == 20)
     and (.gates | any(.id == "(return-catchup)"
                       and .owner == "(main)"
                       and .reason == "away-return catch-up"
                       and (.title | test("^1 blocker"))))
     and ([.decisions_open[].id] | index("(return-catchup)") | not)' >/dev/null \
-    || fail "Bearings did not project the catch-up posture as an action-free gate row: $out"
+    || fail "Bearings did not reserve the catch-up posture outside bounded action-free gate rows: $out"
 
   # The guard itself still separates its two branches by exit status, so an
   # active away window keeps refusing while catch-up reports.


### PR DESCRIPTION
## Intent

Ship the Bearings afk-return-gate fix at the CATCH-UP-BRANCH-ONLY scope.

The bug: bin/fm-bearings-snapshot.sh runs the afk-return guard with `|| exit $?` BEFORE reading any fleet state, so when the afk-return catch-up gate file (state/.afk-return-catchup) exists, /bearings (every mode, and /ahoy) emits zero bytes - on return from away the captain sees only an error and no picture. The guard refuses on the mere existence of that gate file, which is also written for non-blocker lifecycle retention reasons that list no blocker at all.

The intended fix: Bearings should still generate and report the catch-up blockers as CONTENT, not refuse. Concretely: consult the guard instead of obeying it (capture its status and stderr rather than exiting), continue to the normal fleet collection and projection, and project the catch-up state as one action-free row in `gates` - id "(return-catchup)", a title naming the count of blockers to clear before ordinary work, owner "(main)" - reading the blocker rows from state/.afk-return-catchup, following the existing (main-inventory) synthetic gate-row precedent that renders under Charted Next as a warning rather than dispatchable work. It must NOT be routed into decisions_open / Captain's Call: these blockers are firstmate-actionable, not the captain's own action, and the per-task blockers already appear as Underway rows; the new row is the catch-up POSTURE notice. The skill wording should say bearings may be answered and must surface the catch-up state, while acting on the fleet still waits for `bin/fm-afk-return.sh check`.

SCOPE IS THE CATCH-UP BRANCH ONLY - do NOT change the away-active guard branch (Bearings during an ACTIVE away window); that was deferred as a separate future ask and must stay out of this change. Tests that currently require the refusal are corrected, keeping the assertion that bearings works once the gate clears, and the reproduction becomes a regression test.

Also in scope as a nice-to-have if cheap: the guard's refusal text promises a blocker list that is empty in every lifecycle-retention case, so it should name the retention reason instead when no blocker rows exist.

## What Changed

- Continue Bearings collection when only return catch-up is pending, while preserving refusal during an active away window.
- Project a reserved, action-free `(return-catchup)` gate with the blocker count or lifecycle retention reason, outside Captain’s Call and normal gate truncation.
- Improve blockerless guard messaging and update AFK/Bearings guidance, verification docs, and regression coverage.

## Risk Assessment

✅ Low: The catch-up-only behavior is well bounded, preserves the active-away refusal, guarantees the synthetic row survives gate truncation, and maintains the gate output schema without introducing substantiated defects.

## Testing

Targeted regression tests, a real Pi/Herdr return flow, and direct JSON/TOON CLI checks confirmed Bearings reports catch-up state without suppressing fleet data, preserves the active-away refusal, reserves the synthetic row beyond the gate cap, retains the filed schema, and removes the notice after clearance.

- Live validation: ✅ go - 6 of 6 scenarios driven live against the product

| Scenario | Result | Live | Evidence |
| --- | --- | --- | --- |
| Returning captain receives Bearings content while a live catch-up blocker remains | ✅ pass | live | Real Pi/Herdr E2E reported the return brief, open catch-up posture, normal Bearings projection, and Firstmate-owned blocker remediation. |
| Catch-up posture remains visible beyond the ordinary 20-gate cap and preserves TOON filed dates | ✅ pass | live | Live Bearings catch-up CLI transcript shows 21 gates, `(return-catchup)` first with `filed:null`, all 20 ordinary gates, and the TOON `{id,title,blocked_by,reason,owner,filed}` schema. |
| Catch-up posture stays out of Captain&#39;s Call while blocked work remains visible Underway | ✅ pass | live | Live transcript shows `repair-task` in `in_flight`, the synthetic gate in `gates`, and `catchup_in_decisions:false`. |
| Active away window still refuses Bearings and emits no snapshot | ✅ pass | live | Live transcript records exit 3, zero stdout bytes, and the active-away return instruction. |
| Blockerless lifecycle retention names its cause and still renders as Bearings content | ✅ pass | live | Live transcript records guard exit 4, the held-set retention reason, and the corresponding action-free catch-up gate. |
| Resolving or clearing catch-up removes the synthetic posture row | ✅ pass | live | Real Pi/Herdr E2E completed `fm-afk-return.sh check`; the live CLI transcript subsequently shows `catchup_count: 0` while retaining 20 ordinary gates. |

<details>
<summary>Evidence: Live Bearings catch-up CLI transcript</summary>

Source: [Live Bearings catch-up CLI transcript](https://github.com/kunchenguid/firstmate/blob/b13928d883bf2759b9b0f2944292ff982d832a64/.no-mistakes/evidence/fm/fm-bearings-catchup-gate-consult-r1/bearings-catchup-live-cli.txt)

```text
SCENARIO: returned captain requests Bearings with one catch-up blocker and 20 ordinary dated gates
{
  "schema": "fm-bearings.v1",
  "in_flight": [
    {
      "id": "repair-task",
      "kind": "ship",
      "state": "unknown",
      "repo": "",
      "name": "repair-task",
      "doing": "worktree gone (torn down?)"
    }
  ],
  "catchup": [
    {
      "id": "(return-catchup)",
      "title": "1 blocker(s) to clear before ordinary work",
      "blocked_by": "-",
      "reason": "away-return catch-up",
      "owner": "(main)",
      "filed": null
    }
  ],
  "gate_count": 21,
  "ordinary_gate_count": 20,
  "first_gate": {
    "id": "(return-catchup)",
    "title": "1 blocker(s) to clear before ordinary work",
    "blocked_by": "-",
    "reason": "away-return catch-up",
    "owner": "(main)",
    "filed": null
  },
  "catchup_in_decisions": false
}

SCENARIO: default TOON preserves the filed column and durable dates
gates[21]{id,title,blocked_by,reason,owner,filed}:
  (return-catchup),1 blocker(s) to clear before ordinary work,"-",away-return catch-up,(main),null
  queued-20,Queued gate 20,"-","-",(main),2026-06-20

SCENARIO: an ACTIVE away window still refuses Bearings
exit=3 stdout_bytes=0
stderr: fm-afk-return: away mode is still active; run bin/fm-afk-return.sh before ordinary captain work

SCENARIO: blockerless lifecycle retention is surfaced as content and names its reason
guard_exit=4
fm-afk-return: return catch-up is pending with no open blocker; clear the retention reason below, then run bin/fm-afk-return.sh check
catch-up retained: held set unreadable: synthetic reader failure; catch-up stays gated
{
  "catchup": [
    {
      "id": "(return-catchup)",
      "title": "catch-up retained: held set unreadable: synthetic reader fai…",
      "blocked_by": "-",
      "reason": "away-return catch-up",
      "owner": "(main)",
      "filed": null
    }
  ],
  "catchup_in_decisions": false
}

SCENARIO: clearing the gate removes only the catch-up posture row
{
  "catchup_count": 0,
  "ordinary_gate_count": 20
}
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"b50444c435a856447c4522b19c3d74b9c0519edb","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed (2) ✅</summary>

- 🚨 `bin/fm-bearings-snapshot.sh:540` - The required `(return-catchup)` row is added to the ordinary bounded gate list. Since `newest_filed_first` places every dated gate before this undated synthetic row and line 604 truncates to `FM_BEARINGS_GATES` (default 20), a fleet with 20 dated gates emits no catch-up row without error. This contradicts the requirement that Bearings “must surface the catch-up state.” Reserve the warning outside the ordinary gate cap or otherwise guarantee its inclusion.

🔧 Fix applied.
1 error still open:

- 🚨 `bin/fm-bearings-snapshot.sh:541` - The prepended `(return-catchup)` row omits `filed`, unlike every other gate shape. The default TOON renderer derives the entire gates table schema from `.gates[0]`, so during catch-up its header omits `filed` and silently strips the durable dates from all following gates. This breaks the advertised gate contract and prevents the board from preserving newest-filed ordering. Add `filed:null` to the synthetic row, matching `(main-inventory)`.

🔧 Fix applied.
✅ Re-checked - no issues remain.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- Live validation: ✅ go - 6 of 6 scenarios driven live against the product

| Scenario | Result | Live | Evidence |
| --- | --- | --- | --- |
| Returning captain receives Bearings content while a live catch-up blocker remains | ✅ pass | live | Real Pi/Herdr E2E reported the return brief, open catch-up posture, normal Bearings projection, and Firstmate-owned blocker remediation. |
| Catch-up posture remains visible beyond the ordinary 20-gate cap and preserves TOON filed dates | ✅ pass | live | Live Bearings catch-up CLI transcript shows 21 gates, `(return-catchup)` first with `filed:null`, all 20 ordinary gates, and the TOON `{id,title,blocked_by,reason,owner,filed}` schema. |
| Catch-up posture stays out of Captain&#39;s Call while blocked work remains visible Underway | ✅ pass | live | Live transcript shows `repair-task` in `in_flight`, the synthetic gate in `gates`, and `catchup_in_decisions:false`. |
| Active away window still refuses Bearings and emits no snapshot | ✅ pass | live | Live transcript records exit 3, zero stdout bytes, and the active-away return instruction. |
| Blockerless lifecycle retention names its cause and still renders as Bearings content | ✅ pass | live | Live transcript records guard exit 4, the held-set retention reason, and the corresponding action-free catch-up gate. |
| Resolving or clearing catch-up removes the synthetic posture row | ✅ pass | live | Real Pi/Herdr E2E completed `fm-afk-return.sh check`; the live CLI transcript subsequently shows `catchup_count: 0` while retaining 20 ordinary gates. |

- `./tests/fm-afk-return.test.sh`
- `FM_AFK_PI_HERDR_E2E=1 ./tests/fm-afk-pi-herdr-return-e2e.test.sh`
- <code>Manual isolated `fm-bearings-snapshot.sh --json` and default TOON runs with blocker, blockerless-retention, cleared-gate, 20-gate-cap, and active-away states</code>
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
