### PR TITLE
fix(bin): allow Claude spawns in secondmate pool worktrees

### DIFF
--- a/bin/fm-claude-trust.sh
+++ b/bin/fm-claude-trust.sh
@@ -48,24 +48,25 @@
 # never hold there even though the worktree is entirely legitimate. This accepts
 # exactly that shape and nothing wider: <home> must be given, <project> must be
 # one of that home's OWN registered project clones (home/projects/<name> with
-# <name> listed in home/data/projects.md), and <worktree> must be a linked
-# worktree of the ROOT home's clone of that SAME project (the root home resolved
-# through the owned fm_firstmate_root_home). A worktree of any other repo has a
-# different common dir and is still refused; an unregistered project is refused
-# before the root clone is ever consulted; and when <home> is absent or any link
-# in that chain cannot be established, the ordinary same-project refusal stands.
-# This never trusts a directory that is not a firstmate-managed linked worktree.
+# <name> listed in home/data/projects.md), both project clones must resolve to the
+# same repository identity, and <worktree> must be a genuine Treehouse pool slot
+# linked to the ROOT home's clone (the root home resolved through the owned
+# fm_firstmate_root_home and pool membership through fm_treehouse_pool_slot).
+# A worktree of any other repository, a different-origin same-name repository,
+# and a root-clone worktree outside the pool are still refused; an unregistered
+# project is refused before the root clone is ever consulted; and when <home> is
+# absent or any link in that chain cannot be established, the ordinary
+# same-project refusal stands.
 #
-# The test is deliberately NOT a treehouse or orca path prefix. Treehouse's
-# docs/orca-backend.md calls it an "independent worktree", which does not
-# establish a shared git common dir, and orca is macOS-only and was not installed
-# where this was written. If Orca clones instead of linking, its git dir equals
-# its common dir, so this refuses it as a primary checkout and an orca claude
-# spawn fails loudly here rather than wedging on the dialog later. fm-spawn.sh's
-# own validate_spawn_worktree would not catch that case first: it compares the
-# worktree root against the primary and never compares common dirs, so an
-# independent clone passes it. Close this on a box that has Orca through the live
-# opt-in guard family (FM_*_LIVE_E2E=1) and record the result in
+# docs/orca-backend.md calls Orca's allocation an "independent worktree", which
+# does not establish a shared git common dir, and Orca is macOS-only and was not
+# installed where this was written. If Orca clones instead of linking, its git
+# dir equals its common dir, so this refuses it as a primary checkout and an Orca
+# Claude spawn fails loudly here rather than wedging on the dialog later.
+# fm-spawn.sh's own validate_spawn_worktree would not catch that case first: it
+# compares the worktree root against the primary and never compares common dirs,
+# so an independent clone passes it. Close this on a box that has Orca through
+# the live opt-in guard family (FM_*_LIVE_E2E=1) and record the result in
 # docs/verification/runtime-backends.md, rather than assuming the shape here.
 #
 # Only the launching user's own store is written: the projects entry for the
@@ -247,8 +248,8 @@ WT_COMMON=$(common_dir_of "$WT_REAL") || true
 PROJ_COMMON=$(common_dir_of "$PROJ_REAL") || true
 [ -n "$PROJ_COMMON" ] || refuse "project '$PROJ_REAL' is not inside a git repository"
 # The worktree must belong to <project> itself, or - only for a launching home's
-# own registered project - to the ROOT home's clone of that same project, which
-# is where a secondmate's shared-pool slots live. Any other worktree is refused.
+# own registered project clone - be a genuine shared-pool slot of the ROOT
+# home's same-origin clone. Any other worktree is refused.
 if [ "$WT_COMMON" != "$PROJ_COMMON" ] \
   && ! home_owns_pool_worktree "$HOME_ARG" "$PROJ_REAL" "$WT_REAL" "$WT_COMMON"; then
   refuse "'$WT_REAL' is not a worktree of project '$PROJ_REAL'"

--- a/bin/fm-claude-trust.sh
+++ b/bin/fm-claude-trust.sh
@@ -119,6 +119,25 @@ common_dir_of() {
   (cd -P -- "$dir" && real_dir "$common")
 }
 
+repository_identity() {  # <project-dir>
+  local project=$1 origin top
+  origin=$(git -C "$project" remote get-url origin 2>/dev/null || true)
+  if [ -n "$origin" ]; then
+    case "$origin" in
+      /*) origin=$(real_dir "$origin") || return 1 ;;
+      *://* | *:*) ;;
+      *) origin=$(cd -P -- "$project" && real_dir "$origin") || return 1 ;;
+    esac
+    [ -n "$origin" ] || return 1
+    printf '%s\n' "$origin"
+    return 0
+  fi
+  top=$(git -C "$project" rev-parse --show-toplevel 2>/dev/null) || return 1
+  top=$(real_dir "$top") || return 1
+  [ -n "$top" ] || return 1
+  printf '%s\n' "$top"
+}
+
 # Whether the registry file lists a project by exactly this name. A membership
 # test only: the delivery-posture contract this registry also carries is owned by
 # bin/fm-project-mode.sh and is not consulted here.
@@ -148,7 +167,7 @@ resolve_root_home() {  # <home>
 # ROOT home's clone of that SAME project. Any missing link fails closed.
 home_owns_pool_worktree() {  # <home> <project-real> <worktree-common>
   local home=$1 proj_real=$2 wt_common=$3
-  local home_real proj_parent name root root_common
+  local home_real proj_parent name root root_project root_common proj_identity root_identity
   [ -n "$home" ] || return 1
   home_real=$(real_dir "$home") || return 1
   [ -n "$home_real" ] || return 1
@@ -160,8 +179,12 @@ home_owns_pool_worktree() {  # <home> <project-real> <worktree-common>
   name=$(basename -- "$proj_real")
   registry_lists_project "$home_real/data/projects.md" "$name" || return 1
   root=$(resolve_root_home "$home_real") || return 1
-  [ -d "$root/projects/$name" ] || return 1
-  root_common=$(common_dir_of "$root/projects/$name") || return 1
+  root_project="$root/projects/$name"
+  [ -d "$root_project" ] || return 1
+  proj_identity=$(repository_identity "$proj_real") || return 1
+  root_identity=$(repository_identity "$root_project") || return 1
+  [ -n "$proj_identity" ] && [ "$proj_identity" = "$root_identity" ] || return 1
+  root_common=$(common_dir_of "$root_project") || return 1
   [ -n "$root_common" ] || return 1
   [ "$root_common" = "$wt_common" ]
 }

--- a/bin/fm-claude-trust.sh
+++ b/bin/fm-claude-trust.sh
@@ -3,9 +3,13 @@
 # ship/scout spawn is about to launch a claude crewmate into, so the worker
 # reaches its brief instead of wedging on the trust dialog.
 #
-# Usage: fm-claude-trust.sh <worktree> <project>
+# Usage: fm-claude-trust.sh <worktree> <project> [<home>]
 #   <worktree>  the isolated task worktree this spawn launches into
-#   <project>   the primary checkout that worktree belongs to
+#   <project>   the project clone that worktree belongs to
+#   <home>      the launching firstmate home (FM_HOME). Optional, and consulted
+#               only to accept a secondmate's shared-pool worktree, see the
+#               SECONDMATE case in THE SCOPE TEST below. Absent it, only a
+#               worktree of <project> itself is accepted.
 # Prints one line naming what it registered; refuses loudly on anything else.
 #
 # WHY THIS EXISTS. Claude Code gates a folder it has never seen behind an
@@ -33,7 +37,26 @@
 # in-project pool), so a prefix check would refuse legitimate roots, accept
 # whatever a mutable env var names, and add exactly the policy surface this
 # registration must not grow. The structural test is verified for treehouse
-# worktrees, which are linked git worktrees. Orca's worktree shape is UNVERIFIED:
+# worktrees, which are linked git worktrees.
+#
+# THE SECONDMATE case is the one deliberate widening of the equality above, and
+# it stays structural. A secondmate home clones each of its OWN registered
+# projects, but its crewmate worktrees come from the shared Treehouse pool, whose
+# slots are linked worktrees of the ROOT firstmate home's clone of the same
+# project - not of the secondmate's clone. So <worktree>'s git common dir is the
+# ROOT clone's while <project> is the secondmate's clone, and the equality can
+# never hold there even though the worktree is entirely legitimate. This accepts
+# exactly that shape and nothing wider: <home> must be given, <project> must be
+# one of that home's OWN registered project clones (home/projects/<name> with
+# <name> listed in home/data/projects.md), and <worktree> must be a linked
+# worktree of the ROOT home's clone of that SAME project (the root home resolved
+# through the owned fm_firstmate_root_home). A worktree of any other repo has a
+# different common dir and is still refused; an unregistered project is refused
+# before the root clone is ever consulted; and when <home> is absent or any link
+# in that chain cannot be established, the ordinary same-project refusal stands.
+# This never trusts a directory that is not a firstmate-managed linked worktree.
+#
+# The test is deliberately NOT a treehouse or orca path prefix. Treehouse's
 # docs/orca-backend.md calls it an "independent worktree", which does not
 # establish a shared git common dir, and orca is macOS-only and was not installed
 # where this was written. If Orca clones instead of linking, its git dir equals
@@ -69,9 +92,15 @@ unset CDPATH \
   GIT_DISCOVERY_ACROSS_FILESYSTEM GIT_CONFIG GIT_CONFIG_GLOBAL \
   GIT_CONFIG_SYSTEM GIT_CONFIG_NOSYSTEM GIT_CONFIG_COUNT
 
-[ "$#" -eq 2 ] || { echo "usage: fm-claude-trust.sh <worktree> <project>" >&2; exit 2; }
+SCRIPT_DIR=$(cd -P -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)
+
+case "$#" in
+  2 | 3) ;;
+  *) echo "usage: fm-claude-trust.sh <worktree> <project> [<home>]" >&2; exit 2 ;;
+esac
 WT_ARG=$1
 PROJ_ARG=$2
+HOME_ARG=${3:-}
 
 refuse() { echo "error: refusing to pre-register Claude trust: $1" >&2; exit 1; }
 
@@ -88,6 +117,53 @@ common_dir_of() {
   local dir=$1 common
   common=$(git -C "$dir" rev-parse --git-common-dir 2>/dev/null) || return 1
   (cd -P -- "$dir" && real_dir "$common")
+}
+
+# Whether the registry file lists a project by exactly this name. A membership
+# test only: the delivery-posture contract this registry also carries is owned by
+# bin/fm-project-mode.sh and is not consulted here.
+registry_lists_project() {  # <registry-file> <name>
+  local reg=$1 name=$2
+  [ -f "$reg" ] || return 1
+  awk -v n="$name" '$1=="-" && $2==n { found=1; exit } END { exit(found ? 0 : 1) }' "$reg"
+}
+
+# The launching home's ROOT firstmate home, resolved through the one owner of
+# that traversal (fm_firstmate_root_home in bin/fm-wake-lib.sh). Sourced in a
+# subshell so the library's globals and mkdir never touch this security script's
+# own environment, which the unset block above keeps clean; set +u there because
+# the library predates this script's set -u.
+resolve_root_home() {  # <home>
+  local home=$1 root
+  # shellcheck source=bin/fm-wake-lib.sh
+  root=$( set +u; FM_HOME="$home" . "$SCRIPT_DIR/fm-wake-lib.sh" >/dev/null 2>&1 \
+          && fm_firstmate_root_home "$home" 2>/dev/null ) || return 1
+  [ -n "$root" ] || return 1
+  printf '%s\n' "$root"
+}
+
+# The secondmate shared-pool acceptance documented in THE SCOPE TEST. Returns 0
+# only when <project> is one of <home>'s OWN registered project clones and
+# <worktree> (via its already-resolved common dir) is a linked worktree of the
+# ROOT home's clone of that SAME project. Any missing link fails closed.
+home_owns_pool_worktree() {  # <home> <project-real> <worktree-common>
+  local home=$1 proj_real=$2 wt_common=$3
+  local home_real proj_parent name root root_common
+  [ -n "$home" ] || return 1
+  home_real=$(real_dir "$home") || return 1
+  [ -n "$home_real" ] || return 1
+  # <project> must be home/projects/<name>, resolved so a symlinked projects dir
+  # is still judged against the real launching home.
+  proj_parent=$(dirname -- "$proj_real")
+  [ "$(basename -- "$proj_parent")" = projects ] || return 1
+  [ "$(real_dir "$proj_parent")" = "$(real_dir "$home_real/projects")" ] || return 1
+  name=$(basename -- "$proj_real")
+  registry_lists_project "$home_real/data/projects.md" "$name" || return 1
+  root=$(resolve_root_home "$home_real") || return 1
+  [ -d "$root/projects/$name" ] || return 1
+  root_common=$(common_dir_of "$root/projects/$name") || return 1
+  [ -n "$root_common" ] || return 1
+  [ "$root_common" = "$wt_common" ]
 }
 
 WT_REAL=$(real_dir "$WT_ARG") || true
@@ -139,7 +215,13 @@ WT_COMMON=$(common_dir_of "$WT_REAL") || true
 
 PROJ_COMMON=$(common_dir_of "$PROJ_REAL") || true
 [ -n "$PROJ_COMMON" ] || refuse "project '$PROJ_REAL' is not inside a git repository"
-[ "$WT_COMMON" = "$PROJ_COMMON" ] || refuse "'$WT_REAL' is not a worktree of project '$PROJ_REAL'"
+# The worktree must belong to <project> itself, or - only for a launching home's
+# own registered project - to the ROOT home's clone of that same project, which
+# is where a secondmate's shared-pool slots live. Any other worktree is refused.
+if [ "$WT_COMMON" != "$PROJ_COMMON" ] \
+  && ! home_owns_pool_worktree "$HOME_ARG" "$PROJ_REAL" "$WT_COMMON"; then
+  refuse "'$WT_REAL' is not a worktree of project '$PROJ_REAL'"
+fi
 
 # The store write needs node, and a missing interpreter refuses like every other
 # failure here. Degrading instead would launch a worker straight into the dialog

--- a/bin/fm-claude-trust.sh
+++ b/bin/fm-claude-trust.sh
@@ -161,12 +161,19 @@ resolve_root_home() {  # <home>
   printf '%s\n' "$root"
 }
 
+is_treehouse_pool_slot() {  # <home> <project> <worktree>
+  local home=$1 project=$2 worktree=$3
+  # shellcheck source=bin/fm-wake-lib.sh
+  ( set +u; FM_HOME="$home" . "$SCRIPT_DIR/fm-wake-lib.sh" >/dev/null 2>&1 \
+    && fm_treehouse_pool_slot "$project" "$worktree" 2>/dev/null )
+}
+
 # The secondmate shared-pool acceptance documented in THE SCOPE TEST. Returns 0
 # only when <project> is one of <home>'s OWN registered project clones and
-# <worktree> (via its already-resolved common dir) is a linked worktree of the
-# ROOT home's clone of that SAME project. Any missing link fails closed.
-home_owns_pool_worktree() {  # <home> <project-real> <worktree-common>
-  local home=$1 proj_real=$2 wt_common=$3
+# <worktree> is a genuine Treehouse pool slot linked to the ROOT home's clone of
+# that SAME project. Any missing link fails closed.
+home_owns_pool_worktree() {  # <home> <project-real> <worktree-real> <worktree-common>
+  local home=$1 proj_real=$2 wt_real=$3 wt_common=$4
   local home_real proj_parent name root root_project root_common proj_identity root_identity
   [ -n "$home" ] || return 1
   home_real=$(real_dir "$home") || return 1
@@ -186,7 +193,8 @@ home_owns_pool_worktree() {  # <home> <project-real> <worktree-common>
   [ -n "$proj_identity" ] && [ "$proj_identity" = "$root_identity" ] || return 1
   root_common=$(common_dir_of "$root_project") || return 1
   [ -n "$root_common" ] || return 1
-  [ "$root_common" = "$wt_common" ]
+  [ "$root_common" = "$wt_common" ] || return 1
+  is_treehouse_pool_slot "$home_real" "$root_project" "$wt_real"
 }
 
 WT_REAL=$(real_dir "$WT_ARG") || true
@@ -242,7 +250,7 @@ PROJ_COMMON=$(common_dir_of "$PROJ_REAL") || true
 # own registered project - to the ROOT home's clone of that same project, which
 # is where a secondmate's shared-pool slots live. Any other worktree is refused.
 if [ "$WT_COMMON" != "$PROJ_COMMON" ] \
-  && ! home_owns_pool_worktree "$HOME_ARG" "$PROJ_REAL" "$WT_COMMON"; then
+  && ! home_owns_pool_worktree "$HOME_ARG" "$PROJ_REAL" "$WT_REAL" "$WT_COMMON"; then
   refuse "'$WT_REAL' is not a worktree of project '$PROJ_REAL'"
 fi
 

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -3231,7 +3231,7 @@ fi
 if [ "$KIND" != secondmate ]; then
   case "$HARNESS" in
     claude*)
-      if ! "$FM_ROOT/bin/fm-claude-trust.sh" "$WT" "$PROJ_ABS" >/dev/null; then
+      if ! "$FM_ROOT/bin/fm-claude-trust.sh" "$WT" "$PROJ_ABS" "$FM_HOME" >/dev/null; then
         echo "error: could not pre-register Claude workspace trust for $WT; refusing to launch a claude worker that would wedge on the trust dialog; inspect window $T" >&2
         exit 1
       fi

--- a/docs/orca-backend.md
+++ b/docs/orca-backend.md
@@ -72,7 +72,7 @@ It never raw-deletes an Orca worktree.
 - Escape is unsupported.
 - Orca exposes no stable CLI version or protocol marker, so readiness is the compatibility gate rather than a version floor.
 - Only the verified terminal-handle and worktree result fields are accepted; speculative response shapes are rejected.
-- Orca's worktree shape is unverified against the spawn-time Claude workspace-trust check in `bin/fm-claude-trust.sh`, which refuses any path that is not a linked git worktree sharing the project's git common dir, so a claude spawn on Orca fails loudly at that check rather than launching if Orca clones instead of linking.
+- Orca's worktree shape is unverified against the spawn-time Claude workspace-trust check in `bin/fm-claude-trust.sh`, which refuses any path that is not a linked git worktree sharing the project's git common dir (or, only for a launching home's own registered project, the root home's clone of that project), so a claude spawn on Orca fails loudly at that check rather than launching if Orca clones instead of linking.
 
 ## Regression entry points
 

--- a/docs/orca-backend.md
+++ b/docs/orca-backend.md
@@ -72,7 +72,7 @@ It never raw-deletes an Orca worktree.
 - Escape is unsupported.
 - Orca exposes no stable CLI version or protocol marker, so readiness is the compatibility gate rather than a version floor.
 - Only the verified terminal-handle and worktree result fields are accepted; speculative response shapes are rejected.
-- Orca's worktree shape is unverified against the spawn-time Claude workspace-trust check in `bin/fm-claude-trust.sh`, which refuses any path that is not a linked git worktree sharing the project's git common dir (or, only for a launching home's own registered project, the root home's clone of that project), so a claude spawn on Orca fails loudly at that check rather than launching if Orca clones instead of linking.
+- Orca's worktree shape is unverified against the spawn-time Claude workspace-trust check in `bin/fm-claude-trust.sh`, which refuses any path that is not a linked git worktree sharing the project's git common dir or a genuine shared Treehouse pool slot of the same-origin root-home clone for one of the launching home's own registered projects, so a claude spawn on Orca fails loudly at that check rather than launching if Orca clones instead of linking.
 
 ## Regression entry points
 

--- a/docs/verification/runtime-backends.md
+++ b/docs/verification/runtime-backends.md
@@ -301,7 +301,7 @@ That gate is not a production blocker, because a normal environment has already 
 This change does not address that warning and does not claim to.
 
 `bin/fm-spawn.sh` therefore pre-registers the task worktree through `bin/fm-claude-trust.sh` before launch, and `tests/fm-claude-trust.test.sh` pins both halves of the scope contract: a fresh worktree is trusted, and an out-of-scope path is refused.
-The scope test also accepts one narrow structural case so a claude crewmate can spawn in a secondmate home: a shared Treehouse pool worktree of the ROOT home's clone, when the passed project is one of the launching home's own registered projects, while still refusing an unregistered project or an unrelated repo's worktree.
+The scope test also accepts one narrow structural case so a claude crewmate can spawn in a secondmate home: a genuine shared Treehouse pool slot of the same-origin ROOT-home clone, when the passed project is one of the launching home's own registered project clones, while still refusing an unregistered project, a different-origin same-name repository, an unrelated repository's worktree, or a root-clone worktree outside the pool.
 That automated spawn case runs against a fake claude, so it asserts the store entry and the launch command and nothing more; the live arms above are what establish that the entry actually suppresses the dialog.
 The composer-classification record below observes the same gate from the other side, where an untrusted worktree left Claude, Grok, and Muse unverified because the guard reads a first-launch trust dialog as an unreadable composer.
 

--- a/docs/verification/runtime-backends.md
+++ b/docs/verification/runtime-backends.md
@@ -301,6 +301,7 @@ That gate is not a production blocker, because a normal environment has already 
 This change does not address that warning and does not claim to.
 
 `bin/fm-spawn.sh` therefore pre-registers the task worktree through `bin/fm-claude-trust.sh` before launch, and `tests/fm-claude-trust.test.sh` pins both halves of the scope contract: a fresh worktree is trusted, and an out-of-scope path is refused.
+The scope test also accepts one narrow structural case so a claude crewmate can spawn in a secondmate home: a shared Treehouse pool worktree of the ROOT home's clone, when the passed project is one of the launching home's own registered projects, while still refusing an unregistered project or an unrelated repo's worktree.
 That automated spawn case runs against a fake claude, so it asserts the store entry and the launch command and nothing more; the live arms above are what establish that the entry actually suppresses the dialog.
 The composer-classification record below observes the same gate from the other side, where an untrusted worktree left Claude, Grok, and Muse unverified because the guard reads a first-launch trust dialog as an unreadable composer.
 

--- a/tests/fm-claude-trust.test.sh
+++ b/tests/fm-claude-trust.test.sh
@@ -47,7 +47,8 @@ make_secondmate_case() {  # <name> [registered=1] [same-origin=1]
   home="$case_dir/subhome"
   SM_NAME=proj
   SM_CONFIG="$case_dir/claude-config"
-  mkdir -p "$SM_CONFIG" "$root/projects" "$root/data" "$home/projects" "$home/data"
+  mkdir -p "$SM_CONFIG" "$root/projects" "$root/data" "$root/state" \
+    "$home/projects" "$home/data"
   seed="$case_dir/root-seed"
   origin="$case_dir/root-origin.git"
   fm_git_init_commit "$seed"
@@ -533,6 +534,32 @@ test_root_clone_worktree_outside_pool_is_refused() {
   pass "fm-claude-trust.sh: refuses a root-clone worktree outside the shared pool"
 }
 
+# Drive the actual spawn entry point through the widened topology.
+# This proves fm-spawn forwards the launching secondmate home to the trust
+# registrar before it sends Claude the brief, rather than proving only the
+# registrar in isolation.
+test_secondmate_claude_spawn_pretrusts_its_pool_worktree() {
+  local fakebin launch_log out id
+  id=smtrustspawn
+  make_secondmate_case sm-spawn
+  launch_log="$TMP_ROOT/sm-spawn/launch.log"
+  fakebin=$(make_spawn_fakebin "$TMP_ROOT/sm-spawn/fake" claude)
+  fm_test_spawn_home "$SM_HOME" claude
+  fm_test_spawn_brief "$SM_HOME" "$id"
+  out=$(FM_TEST_CLAUDE_CONFIG_DIR="$SM_CONFIG" FM_FAKE_LAUNCH_LOG="$launch_log" \
+    fm_test_run_spawn "$SM_HOME" "$SM_WT" "$fakebin" "$id" "$SM_PROJ" claude \
+    --mode no-mistakes --yolo off)
+  expect_code 0 $? "a Claude spawn from a secondmate home must accept its shared-pool worktree: $out"
+  assert_trusted "$SM_CONFIG/.claude.json" "$SM_WT" \
+    "the secondmate spawn did not pre-register its shared-pool worktree"
+  assert_present "$launch_log" "the secondmate spawn sent no Claude launch command"
+  assert_grep "$SM_HOME/data/$id/launch-brief.md" "$launch_log" \
+    "the secondmate spawn did not send the brief after trust registration"
+  assert_grep "CLAUDE_CONFIG_DIR='$SM_CONFIG'" "$launch_log" \
+    "the secondmate worker did not read the store containing its pool-worktree trust"
+  pass "fm-spawn.sh: a secondmate Claude spawn pre-trusts its shared-pool worktree and sends the brief"
+}
+
 # The spawn half: a real fm-spawn of a claude worker must pre-register the
 # worktree AND deliver the launch command carrying the brief, with no dialog to
 # answer and no human in the loop.
@@ -583,6 +610,7 @@ test_secondmate_pool_worktree_for_unregistered_project_is_refused
 test_unrelated_repo_worktree_with_home_is_refused
 test_same_name_project_from_different_origin_is_refused
 test_root_clone_worktree_outside_pool_is_refused
+test_secondmate_claude_spawn_pretrusts_its_pool_worktree
 test_worktree_subdirectory_is_refused
 test_unrelated_store_content_is_preserved
 test_symlinked_store_to_a_foreign_owned_target_is_refused

--- a/tests/fm-claude-trust.test.sh
+++ b/tests/fm-claude-trust.test.sh
@@ -34,25 +34,39 @@ EOF
 }
 
 # make_secondmate_case <name> [registered]: build the secondmate shared-pool
-# topology and set SM_* globals. A ROOT firstmate home clones project "proj"; a
-# secondmate home below it (via a local .fm-secondmate-parent marker) has its OWN
-# separate clone of "proj"; and SM_WT is a linked worktree of the ROOT clone,
-# exactly as a Treehouse pool slot is. When <registered> is 0 the secondmate's
-# data/projects.md omits the project so the ownership check must refuse it.
-make_secondmate_case() {  # <name> [registered=1]
-  local name=$1 registered=${2:-1} case_dir root home
+# topology and set SM_* globals. A ROOT firstmate home and a secondmate home
+# below it each clone project "proj" from the same origin; SM_WT is a linked
+# worktree of the ROOT clone, exactly as a Treehouse pool slot is. When
+# <registered> is 0 the secondmate's data/projects.md omits the project. When
+# <same-origin> is 0 the secondmate clone has an unrelated origin with the same
+# project basename, so repository identity must refuse it.
+make_secondmate_case() {  # <name> [registered=1] [same-origin=1]
+  local name=$1 registered=${2:-1} same_origin=${3:-1} case_dir root home seed origin
   case_dir="$TMP_ROOT/$name"
   root="$case_dir/root"
   home="$case_dir/subhome"
   SM_NAME=proj
   SM_CONFIG="$case_dir/claude-config"
   mkdir -p "$SM_CONFIG" "$root/projects" "$root/data" "$home/projects" "$home/data"
+  seed="$case_dir/root-seed"
+  origin="$case_dir/root-origin.git"
+  fm_git_init_commit "$seed"
+  git clone --quiet --bare "$seed" "$origin"
+  git clone --quiet "$origin" "$root/projects/$SM_NAME"
   # The ROOT clone plus its shared-pool worktree.
-  fm_git_worktree "$root/projects/$SM_NAME" "$case_dir/pool-slot" "wt-$name"
+  git -C "$root/projects/$SM_NAME" worktree add --quiet -b "wt-$name" "$case_dir/pool-slot"
   SM_WT="$case_dir/pool-slot"
   printf -- '- %s - root project (added 2026-01-01)\n' "$SM_NAME" > "$root/data/projects.md"
-  # The secondmate's OWN separate clone of the same-named project.
-  fm_git_init_commit "$home/projects/$SM_NAME"
+  # The secondmate's OWN separate clone of the same project origin.
+  if [ "$same_origin" = 1 ]; then
+    git clone --quiet "$origin" "$home/projects/$SM_NAME"
+  else
+    seed="$case_dir/unrelated-seed"
+    origin="$case_dir/unrelated-origin.git"
+    fm_git_init_commit "$seed"
+    git clone --quiet --bare "$seed" "$origin"
+    git clone --quiet "$origin" "$home/projects/$SM_NAME"
+  fi
   SM_PROJ="$home/projects/$SM_NAME"
   # The durable local parent binding fm_firstmate_root_home walks to the root.
   cat > "$home/.fm-secondmate-parent" <<EOF
@@ -492,6 +506,16 @@ test_unrelated_repo_worktree_with_home_is_refused() {
   pass "fm-claude-trust.sh: refuses an unrelated repo's worktree even with a valid home and registered project"
 }
 
+test_same_name_project_from_different_origin_is_refused() {
+  local out
+  make_secondmate_case sm-same-name-different-origin 1 0
+  out=$(run_trust "$SM_CONFIG" "$SM_WT" "$SM_PROJ" "$SM_CONFIG" "$SM_HOME")
+  expect_code 1 $? "a same-named project from a different origin must be refused: $out"
+  assert_contains "$out" "is not a worktree of project" "the refusal did not name the project mismatch"
+  assert_not_trusted "$SM_CONFIG/.claude.json" "$SM_WT" "a different-origin pool worktree was trusted by basename"
+  pass "fm-claude-trust.sh: refuses a same-named pool worktree from a different origin"
+}
+
 # The spawn half: a real fm-spawn of a claude worker must pre-register the
 # worktree AND deliver the launch command carrying the brief, with no dialog to
 # answer and no human in the loop.
@@ -540,6 +564,7 @@ test_foreign_project_worktree_is_refused
 test_secondmate_pool_worktree_is_trusted
 test_secondmate_pool_worktree_for_unregistered_project_is_refused
 test_unrelated_repo_worktree_with_home_is_refused
+test_same_name_project_from_different_origin_is_refused
 test_worktree_subdirectory_is_refused
 test_unrelated_store_content_is_preserved
 test_symlinked_store_to_a_foreign_owned_target_is_refused

--- a/tests/fm-claude-trust.test.sh
+++ b/tests/fm-claude-trust.test.sh
@@ -41,7 +41,7 @@ EOF
 # <same-origin> is 0 the secondmate clone has an unrelated origin with the same
 # project basename, so repository identity must refuse it.
 make_secondmate_case() {  # <name> [registered=1] [same-origin=1]
-  local name=$1 registered=${2:-1} same_origin=${3:-1} case_dir root home seed origin
+  local name=$1 registered=${2:-1} same_origin=${3:-1} case_dir root home seed origin pool
   case_dir="$TMP_ROOT/$name"
   root="$case_dir/root"
   home="$case_dir/subhome"
@@ -54,8 +54,12 @@ make_secondmate_case() {  # <name> [registered=1] [same-origin=1]
   git clone --quiet --bare "$seed" "$origin"
   git clone --quiet "$origin" "$root/projects/$SM_NAME"
   # The ROOT clone plus its shared-pool worktree.
-  git -C "$root/projects/$SM_NAME" worktree add --quiet -b "wt-$name" "$case_dir/pool-slot"
-  SM_WT="$case_dir/pool-slot"
+  pool="$case_dir/pool"
+  SM_WT="$pool/slot/$SM_NAME"
+  mkdir -p "$pool/slot"
+  printf '%s\n' '{}' > "$pool/treehouse-state.json"
+  git -C "$root/projects/$SM_NAME" worktree add --quiet -b "wt-$name" "$SM_WT"
+  SM_ROOT_PROJ="$root/projects/$SM_NAME"
   printf -- '- %s - root project (added 2026-01-01)\n' "$SM_NAME" > "$root/data/projects.md"
   # The secondmate's OWN separate clone of the same project origin.
   if [ "$same_origin" = 1 ]; then
@@ -516,6 +520,19 @@ test_same_name_project_from_different_origin_is_refused() {
   pass "fm-claude-trust.sh: refuses a same-named pool worktree from a different origin"
 }
 
+test_root_clone_worktree_outside_pool_is_refused() {
+  local out unmanaged
+  make_secondmate_case sm-outside-pool
+  unmanaged="$TMP_ROOT/sm-outside-pool/unmanaged/slot/$SM_NAME"
+  mkdir -p "$(dirname -- "$unmanaged")"
+  git -C "$SM_ROOT_PROJ" worktree add --quiet -b wt-sm-outside-pool-unmanaged "$unmanaged"
+  out=$(run_trust "$SM_CONFIG" "$unmanaged" "$SM_PROJ" "$SM_CONFIG" "$SM_HOME")
+  expect_code 1 $? "a root-clone worktree outside the shared pool must be refused: $out"
+  assert_contains "$out" "is not a worktree of project" "the refusal did not name the project mismatch"
+  assert_not_trusted "$SM_CONFIG/.claude.json" "$unmanaged" "an unmanaged root-clone worktree was trusted"
+  pass "fm-claude-trust.sh: refuses a root-clone worktree outside the shared pool"
+}
+
 # The spawn half: a real fm-spawn of a claude worker must pre-register the
 # worktree AND deliver the launch command carrying the brief, with no dialog to
 # answer and no human in the loop.
@@ -565,6 +582,7 @@ test_secondmate_pool_worktree_is_trusted
 test_secondmate_pool_worktree_for_unregistered_project_is_refused
 test_unrelated_repo_worktree_with_home_is_refused
 test_same_name_project_from_different_origin_is_refused
+test_root_clone_worktree_outside_pool_is_refused
 test_worktree_subdirectory_is_refused
 test_unrelated_store_content_is_preserved
 test_symlinked_store_to_a_foreign_owned_target_is_refused

--- a/tests/fm-claude-trust.test.sh
+++ b/tests/fm-claude-trust.test.sh
@@ -33,10 +33,52 @@ $1
 EOF
 }
 
-# run_trust <config> <worktree> <project> [home]: invoke with an isolated store.
+# make_secondmate_case <name> [registered]: build the secondmate shared-pool
+# topology and set SM_* globals. A ROOT firstmate home clones project "proj"; a
+# secondmate home below it (via a local .fm-secondmate-parent marker) has its OWN
+# separate clone of "proj"; and SM_WT is a linked worktree of the ROOT clone,
+# exactly as a Treehouse pool slot is. When <registered> is 0 the secondmate's
+# data/projects.md omits the project so the ownership check must refuse it.
+make_secondmate_case() {  # <name> [registered=1]
+  local name=$1 registered=${2:-1} case_dir root home
+  case_dir="$TMP_ROOT/$name"
+  root="$case_dir/root"
+  home="$case_dir/subhome"
+  SM_NAME=proj
+  SM_CONFIG="$case_dir/claude-config"
+  mkdir -p "$SM_CONFIG" "$root/projects" "$root/data" "$home/projects" "$home/data"
+  # The ROOT clone plus its shared-pool worktree.
+  fm_git_worktree "$root/projects/$SM_NAME" "$case_dir/pool-slot" "wt-$name"
+  SM_WT="$case_dir/pool-slot"
+  printf -- '- %s - root project (added 2026-01-01)\n' "$SM_NAME" > "$root/data/projects.md"
+  # The secondmate's OWN separate clone of the same-named project.
+  fm_git_init_commit "$home/projects/$SM_NAME"
+  SM_PROJ="$home/projects/$SM_NAME"
+  # The durable local parent binding fm_firstmate_root_home walks to the root.
+  cat > "$home/.fm-secondmate-parent" <<EOF
+schema=fm-secondmate-parent.v1
+route=local
+parent_home=$(cd "$root" && pwd -P)
+EOF
+  if [ "$registered" = 1 ]; then
+    printf -- '- %s [no-mistakes] - secondmate project (added 2026-01-01)\n' "$SM_NAME" \
+      > "$home/data/projects.md"
+  else
+    printf -- '- other - an unrelated project (added 2026-01-01)\n' > "$home/data/projects.md"
+  fi
+  SM_HOME="$home"
+}
+
+# run_trust <config> <worktree> <project> [home] [fmhome]: invoke with an
+# isolated store. <home> sets HOME for the run (the config dir by default), and
+# <fmhome>, when given, is passed as the launching firstmate home argument.
 run_trust() {
-  local config=$1 wt=$2 proj=$3 home=${4:-$1}
-  CLAUDE_CONFIG_DIR="$config" HOME="$home" "$TRUST" "$wt" "$proj" 2>&1
+  local config=$1 wt=$2 proj=$3 home=${4:-$1} fmhome=${5:-}
+  if [ -n "$fmhome" ]; then
+    CLAUDE_CONFIG_DIR="$config" HOME="$home" "$TRUST" "$wt" "$proj" "$fmhome" 2>&1
+  else
+    CLAUDE_CONFIG_DIR="$config" HOME="$home" "$TRUST" "$wt" "$proj" 2>&1
+  fi
 }
 
 trusted_paths() {  # <store>
@@ -406,6 +448,50 @@ test_refused_spawn_leaves_no_task_state() {
   pass "fm-spawn.sh: a trust-refused claude spawn leaves no task state behind"
 }
 
+# A secondmate's crewmate worktree comes from the shared Treehouse pool, whose
+# slots are linked worktrees of the ROOT home's clone while the project passed is
+# the secondmate's OWN clone. The common dirs differ, yet this is a legitimate
+# worktree of one of the home's registered projects and must be trusted so a
+# claude crewmate can spawn in a secondmate home at all.
+test_secondmate_pool_worktree_is_trusted() {
+  local out
+  make_secondmate_case sm-accept
+  out=$(run_trust "$SM_CONFIG" "$SM_WT" "$SM_PROJ" "$SM_CONFIG" "$SM_HOME")
+  expect_code 0 $? "a secondmate's shared-pool worktree of a registered project must be trusted: $out"
+  assert_contains "$out" "trusted:" "the secondmate pool worktree registration reported nothing"
+  assert_trusted "$SM_CONFIG/.claude.json" "$SM_WT" "the secondmate pool worktree was not recorded as trusted"
+  pass "fm-claude-trust.sh: trusts a secondmate's shared-pool worktree of a registered project"
+}
+
+# The relaxation is scoped to the home's OWN registered projects. The exact same
+# worktree, home, and project clone are refused when the project is not listed in
+# the launching home's registry, so the widening cannot become blanket.
+test_secondmate_pool_worktree_for_unregistered_project_is_refused() {
+  local out
+  make_secondmate_case sm-unregistered 0
+  out=$(run_trust "$SM_CONFIG" "$SM_WT" "$SM_PROJ" "$SM_CONFIG" "$SM_HOME")
+  expect_code 1 $? "an unregistered project's pool worktree must be refused: $out"
+  assert_contains "$out" "is not a worktree of project" "the refusal did not name the project mismatch"
+  assert_not_trusted "$SM_CONFIG/.claude.json" "$SM_WT" "an unregistered project's pool worktree was trusted"
+  pass "fm-claude-trust.sh: refuses a pool worktree for a project the home has not registered"
+}
+
+# The launching home does not widen the boundary to any repo. A worktree of an
+# unrelated repo is still refused even when a valid home and a registered project
+# clone are passed, because its common dir is not the ROOT clone's.
+test_unrelated_repo_worktree_with_home_is_refused() {
+  local out other other_wt
+  make_secondmate_case sm-unrelated
+  other="$TMP_ROOT/sm-unrelated/other-project"
+  other_wt="$TMP_ROOT/sm-unrelated/other-wt"
+  fm_git_worktree "$other" "$other_wt" wt-other
+  out=$(run_trust "$SM_CONFIG" "$other_wt" "$SM_PROJ" "$SM_CONFIG" "$SM_HOME")
+  expect_code 1 $? "an unrelated repo's worktree must be refused even with a valid home: $out"
+  assert_contains "$out" "is not a worktree of project" "the refusal did not name the project mismatch"
+  assert_not_trusted "$SM_CONFIG/.claude.json" "$other_wt" "an unrelated repo's worktree was trusted via the home path"
+  pass "fm-claude-trust.sh: refuses an unrelated repo's worktree even with a valid home and registered project"
+}
+
 # The spawn half: a real fm-spawn of a claude worker must pre-register the
 # worktree AND deliver the launch command carrying the brief, with no dialog to
 # answer and no human in the loop.
@@ -451,6 +537,9 @@ test_relative_config_dir_is_refused
 test_non_git_directory_is_refused
 test_missing_directory_is_refused
 test_foreign_project_worktree_is_refused
+test_secondmate_pool_worktree_is_trusted
+test_secondmate_pool_worktree_for_unregistered_project_is_refused
+test_unrelated_repo_worktree_with_home_is_refused
 test_worktree_subdirectory_is_refused
 test_unrelated_store_content_is_preserved
 test_symlinked_store_to_a_foreign_owned_target_is_refused


### PR DESCRIPTION
## Intent

Fix the durable limitation that Claude crewmates cannot spawn in secondmate homes (e.g. agent-env), which forces those homes to Codex-only and blocks the Claude fallback during the Codex-conservation window. Keep it narrow: the Claude workspace-trust pre-registration (bin/fm-claude-trust.sh) should additionally accept a shared Treehouse pool worktree rooted at the MAIN firstmate clone, but ONLY when the passed project is one of the launching home's OWN registered projects - never a blanket relaxation. Root cause: the trust pre-registration required the task worktree's git common dir to equal the passed project's common dir; that holds for the main home, but fails for a secondmate whose crewmate worktrees come from the shared pool (linked worktrees of the MAIN clone) while the project passed is the secondmate's own clone - so the check refused, the Claude trust dialog was never pre-registered, and the spawn wedged. The fix must preserve every existing refusal (primary checkout, worktree of an unrelated repo, subdirectory of a worktree, plain/home/config directory, unregistered project) and fail closed when the launching home or any link in the chain cannot be soundly established. This is a security boundary, so the widening must stay exactly one narrow structural case.

## What Changed

- Allow Claude trust pre-registration for genuine shared Treehouse pool worktrees when the project belongs to the launching secondmate home.
- Keep the widened trust path fail-closed by verifying project registration, root-home linkage, matching repository origins, and pool-slot membership.
- Pass the launching home through `fm-spawn.sh` and add regression coverage and documentation for the accepted and refused topologies.

## Risk Assessment

✅ Low: The trust widening is narrowly bounded by launching-home registration, normalized origin equality, root-clone common-directory identity, and genuine Treehouse pool-slot structure, while existing refusal paths remain intact.

## Testing

No baseline test command was supplied. The targeted behavior suite exercised real Git clones, linked pool worktrees, the executable trust registrar, persisted Claude trust state, adversarial refusal boundaries, and the real spawn orchestration with a stubbed Claude harness; all exercised checks passed, while an actual token-spending Claude launch remains explicitly untested.

- Live validation: ✅ go - 3 of 4 scenarios driven live against the product

| Scenario | Result | Live | Evidence |
| --- | --- | --- | --- |
| Register a genuine shared Treehouse pool worktree for a secondmate-owned project and persist Claude trust | ✅ pass | live | Final targeted Claude trust transcript |
| Attempt registration for an unregistered project, unrelated repository identity, or unmanaged non-pool worktree and observe refusal without trust-store mutation | ✅ pass | live | Final targeted Claude trust transcript |
| Use primary, foreign, subdirectory, plain, home, and config paths and preserve every existing refusal | ✅ pass | live | Final targeted Claude trust transcript |
| Spawn a real Claude crewmate from a secondmate home and reach its brief without a workspace-trust dialog | ⏸️ untested | no | Launching a real Claude crewmate would create another agent and spend Claude credentials, which was not explicitly authorized for this test phase. Authorize one isolated real Claude worker launch with… |

<details>
<summary>Evidence: Final targeted Claude trust transcript</summary>

Source: [Final targeted Claude trust transcript](https://github.com/haroarthur/firstmate/blob/b1a089f71ba46b785b6903eccfa82d538b3f4828/.no-mistakes/evidence/fm/fix-claude-trust-secondmate-worktrees/fm-claude-trust-targeted-final.log)

```text
ok - fm-claude-trust.sh: a fresh task worktree is trusted
ok - fm-claude-trust.sh: repeat registration is idempotent
ok - fm-claude-trust.sh: refuses the primary checkout
ok - fm-claude-trust.sh: an exported CDPATH cannot defeat the scope refusal
ok - fm-claude-trust.sh: inherited git environment overrides cannot defeat the scope refusal
ok - fm-claude-trust.sh: refuses a home directory the git checks would accept
ok - fm-claude-trust.sh: refuses the Claude config directory
ok - fm-claude-trust.sh: refuses a relative CLAUDE_CONFIG_DIR
ok - fm-claude-trust.sh: refuses a directory that is not a git worktree
ok - fm-claude-trust.sh: refuses a path that does not exist
ok - fm-claude-trust.sh: refuses a worktree belonging to another project
ok - fm-claude-trust.sh: trusts a secondmate's shared-pool worktree of a registered project
ok - fm-claude-trust.sh: refuses a pool worktree for a project the home has not registered
ok - fm-claude-trust.sh: refuses an unrelated repo's worktree even with a valid home and registered project
ok - fm-claude-trust.sh: refuses a same-named pool worktree from a different origin
ok - fm-claude-trust.sh: refuses a root-clone worktree outside the shared pool
ok - fm-spawn.sh: a secondmate Claude spawn pre-trusts its shared-pool worktree and sends the brief
ok - fm-claude-trust.sh: refuses a subdirectory of the worktree
ok - fm-claude-trust.sh: preserves unrelated store content
ok - fm-claude-trust.sh: refuses a store symlinked to another user's file
ok - fm-claude-trust.sh: follows a store symlink to this user's own file and leaves the link intact
ok - fm-claude-trust.sh: refuses an unparseable store and leaves it untouched
ok - fm-claude-trust.sh: a missing node is refused rather than degraded
ok - fm-claude-trust.sh: a scope refusal stays fail-closed without node
ok - fm-spawn.sh: a claude spawn pre-trusts its worktree and launches with the brief
ok - fm-spawn.sh: a trust-refused claude spawn leaves no task state behind
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"68d0debf9688d59ca6cb941402340eb293cec9a9","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed (2) ✅</summary>

- 🚨 `bin/fm-claude-trust.sh:163` - The intent requires accepting only the root clone of the SAME project and preserving refusal of unrelated repositories, but this path establishes sameness only through the directory basename. Concrete sequence: register `home/projects/proj` from repository A, place an unrelated repository B at `root/projects/proj`, and pass a linked worktree of B. Lines 163-166 compare only B&#39;s common directory with the worktree, so the script records B as trusted despite the passed project being A. The new passing fixture even constructs the two `proj` repositories independently. Confirm repository identity at this shared boundary, using the normalized origin identity already used by `fm_treehouse_project_lock_path`, before writing Claude&#39;s trust store.

🔧 Fix applied.
1 error still open:

- 🚨 `bin/fm-claude-trust.sh:187` - The required widening is only for a shared Treehouse pool worktree, but this accepts every linked worktree of the root clone because it checks only the Git common directory. A stable stale pane path or direct invocation using an arbitrary root-clone worktree passes origin, registry, and common-dir checks and gets added to Claude&#39;s trust store. Require the existing Treehouse pool-state check against `root_project` and the worktree before accepting this branch.

🔧 Fix applied.
✅ Re-checked - no issues remain.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- Live validation: ✅ go - 3 of 4 scenarios driven live against the product

| Scenario | Result | Live | Evidence |
| --- | --- | --- | --- |
| Register a genuine shared Treehouse pool worktree for a secondmate-owned project and persist Claude trust | ✅ pass | live | Final targeted Claude trust transcript |
| Attempt registration for an unregistered project, unrelated repository identity, or unmanaged non-pool worktree and observe refusal without trust-store mutation | ✅ pass | live | Final targeted Claude trust transcript |
| Use primary, foreign, subdirectory, plain, home, and config paths and preserve every existing refusal | ✅ pass | live | Final targeted Claude trust transcript |
| Spawn a real Claude crewmate from a secondmate home and reach its brief without a workspace-trust dialog | ⏸️ untested | no | Launching a real Claude crewmate would create another agent and spend Claude credentials, which was not explicitly authorized for this test phase. Authorize one isolated real Claude worker launch with… |

- `bash tests/fm-claude-trust.test.sh 2>&1 | tee ~/.local/state/agent-env/no-mistakes/evidence/01M29ETTV5MW3BSSHA6PGG1ZX9/fm-claude-trust-targeted.log`
- <code>Added `test_secondmate_claude_spawn_pretrusts_its_pool_worktree` to drive the real spawn entry point through the changed secondmate topology</code>
- `bash tests/fm-claude-trust.test.sh 2>&1 | tee ~/.local/state/agent-env/no-mistakes/evidence/01M29ETTV5MW3BSSHA6PGG1ZX9/fm-claude-trust-targeted-with-secondmate-spawn.log`
- <code>Corrected the focused fixture by adding the root home&#39;s required `state/` directory</code>
- `bash tests/fm-claude-trust.test.sh 2>&1 | tee ~/.local/state/agent-env/no-mistakes/evidence/01M29ETTV5MW3BSSHA6PGG1ZX9/fm-claude-trust-targeted-final.log`
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
