### PR TITLE
feat: add Antigravity CLI worker adapter

### DIFF
--- a/.agents/skills/harness-adapters/SKILL.md
+++ b/.agents/skills/harness-adapters/SKILL.md
@@ -3,7 +3,7 @@ name: harness-adapters
 description: >-
   Agent-only reference for firstmate harness operations.
   Use before spawning or recovering a crewmate or secondmate, handling a trust dialog, sending a harness-specific skill invocation, interrupting or exiting an agent, resuming an exited agent, or verifying a new harness adapter.
-  Contains verified facts for claude, codex, opencode, pi, pi-signed, grok, kimi, cursor, gemini, muse, rovo, and omp.
+  Contains verified facts for claude, codex, opencode, pi, pi-signed, grok, kimi, cursor, gemini, muse, rovo, omp, and agy.
 user-invocable: false
 metadata:
   internal: true
@@ -35,7 +35,7 @@ For recovery and control, use the exact `harness=` in `state/<id>.meta`; never i
 Deliver lifecycle actions only through `../../../bin/fm-control.sh <task-id> interrupt|exit|relaunch`.
 Never type an interrupt key or exit command through `fm-send`, where routing-marked lifecycle text becomes chat.
 Trust handling is complete only when inspection proves the target started processing its instructions; delivery success alone is not proof.
-Muse and Gemini are verified only for crewmate and scout work, never a secondmate or primary.
+Muse, Gemini, and AGY are verified only for crewmate and scout work, never a secondmate or primary.
 
 ## Detection
 
@@ -93,7 +93,8 @@ A new tool remains undispatchable until the `verify` plan, its harness entry, ev
     "gemini": "references/harness/gemini.md",
     "muse": "references/harness/muse.md",
     "rovo": "references/harness/rovo.md",
-    "omp": "references/harness/omp.md"
+    "omp": "references/harness/omp.md",
+    "agy": "references/harness/agy.md"
   }
 }
 ```

--- a/.agents/skills/harness-adapters/references/harness/agy.md
+++ b/.agents/skills/harness-adapters/references/harness/agy.md
@@ -1,0 +1,57 @@
+# Antigravity CLI (AGY)
+
+AGY is Google's `agy` CLI, distinct from the `gemini` CLI adapter.
+Verified for ordinary ship and scout workers on tmux and Herdr only.
+Primary and secondmate supervision are unsupported and refused; zellij, Orca, and cmux placement is also refused because their AGY composer/lifecycle evidence is unverified.
+`../../../bin/fm-spawn.sh` owns launch mechanics, `../../../bin/fm-agy-lib.sh` owns catalog preflight, and `../../../docs/verification/runtime-backends.md` ("Antigravity CLI (AGY) workers") records the actual live checks.
+
+## Launch, isolation, and trust
+
+The interactive launch uses `--prompt-interactive` with one quoted, routing-marked instruction argument and `--dangerously-skip-permissions` for unattended tools.
+`--new-project` plus `--add-dir` binds AGY's tool workspace to the task's isolated copy.
+Do not omit this binding: launching AGY from a directory alone can leave its command tool in AGY's shared scratch directory even while the TUI displays the intended path.
+An added task-private customization directory carries Firstmate's hooks without replacing the project's `.agents/hooks.json` or modifying the operator's global settings.
+AGY persists its own project/conversation history; Firstmate does not delete that vendor-owned history on cleanup.
+`AGY_CLI_DISABLE_AUTO_UPDATE=true` prevents worker sessions from replacing the executable mid-task.
+
+A fresh directory can still show `Do you trust the contents of this project?` despite the permissions flag.
+The documented default is `Yes, I trust this folder`; one Enter accepts that exact folder.
+Only answer this identified folder-trust dialog, then prove instructions are processing; never type into an account-verification or login prompt.
+The launch flag auto-approves tool use, not every first-run dialog or custom hook policy.
+
+## Authentication and models
+
+Use AGY's [installation/authentication documentation](https://antigravity.google/docs/cli/install) and [CLI reference](https://antigravity.google/docs/cli/reference).
+The operator must complete AGY's own sign-in and any Google account-eligibility verification before dispatch.
+A successful `agy models` listing is not proof that the account can execute prompts; the live guard submits a trivial prompt and requires a successful result.
+Never change account/provider settings or copy secrets into launch commands to work around a refusal.
+
+Discover exact IDs with `agy models` in the active environment.
+The adapter requires an explicitly listed Gemini ID rather than relying on vendor defaults, display names, or inferred aliases.
+The live catalog included `gemini-3.8-flash-low`, `gemini-3.8-flash-medium`, and `gemini-3.8-flash-high`; availability is not a permanent promise.
+AGY also lists non-Gemini models, but they are outside this adapter's verified scope.
+`--effort` accepts `low`, `medium`, and `high` and can replace the effort suffix of a model selection.
+Firstmate refuses a conflict between an explicit suffixed model and native effort instead of silently changing the selected variant.
+Unsupported efforts follow the common record-and-omit policy; choose matching native values in dispatch profiles.
+
+Use Flash-class profiles for bounded, well-specified changes with concrete acceptance tests, not as a quota-driven downgrade for ambiguous or high-impact work.
+`../../../docs/configuration.md` ("Bounded Gemini Flash work through AGY") owns the profile example; no live dispatch configuration is changed by adding this adapter.
+
+## Identity, state, and control
+
+| Fact | Verified behavior |
+| --- | --- |
+| Detection | Exact `agy` process ancestry. Firstmate's `FM_AGY_HARNESS=agy` precedence marker requires that ancestry and is not proof by itself; the launch clears foreign markers. |
+| Busy | Native `PreInvocation` feeds `agy-hook` through the generation-bound busy writer. Repeated model invocations stay busy. |
+| Completion | Native `Stop` closes only when `fullyIdle` is boolean true and the workspace, conversation, and generation match. A subagent's Stop cannot settle the parent. |
+| Composer | Horizontal separators enclosing `>`; only live AGY identity authorizes interpreting this shell-like glyph as an agent composer. |
+| Steering | Ordinary literal text plus Enter, with a resulting tool artifact proving actual processing. External task-report writes were verified. |
+| Interrupt | One Escape, no composer repollution. AGY emits no Stop for the observed cancellation; the control plane reports delivery, not semantic cancellation proof. Busy state conservatively remains busy until another turn completes or the process exits. |
+| Exit | `/exit` plus Enter; preserves the endpoint and work. |
+| Recovery | Deterministic relaunch from the durable instructions, with a fresh generation and conversation binding. Profile preflight occurs before stopping the old agent; native `--conversation <id>` is documented but not the managed recovery path. |
+| Skills | Workspace `.agents/skills` is documented by AGY; use explicit natural-language file instructions when slash discovery has not been verified. No assumption that Gemini CLI's global skills paths apply. |
+
+`../../../bin/fm-control-lib.sh` owns executable control capabilities and `../../../bin/fm-composer-lib.sh` owns the shared composer rules.
+The rendered `esc to cancel` footer is delivery evidence only, not the task-state source.
+Custom keybindings, plan-mode policies, permission hooks, and non-default composer placeholders can require operator intervention; rerun the live guard after changing them or upgrading AGY.
+Built-in browser tooling is outside the verified contract; use the task's prescribed browser tool rather than assuming AGY's bundled browser dependencies work.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -208,7 +208,7 @@ A silent bootstrap section needs no action; for any printed actionable diagnosti
 ## 4. Harness and runtime dispatch
 
 Load `harness-adapters` before every spawn or recovery and before trust handling, skill invocation, interrupt, exit, resume, or adapter verification.
-The verified harnesses are `claude`, `codex`, `opencode`, `pi`, `pi-signed`, `grok`, `kimi`, `cursor`, and `omp`, plus `muse`, `gemini`, and `rovo` for crewmates and scouts only; never dispatch on an unverified adapter.
+The verified harnesses are `claude`, `codex`, `opencode`, `pi`, `pi-signed`, `grok`, `kimi`, `cursor`, and `omp`, plus `muse`, `gemini`, `rovo`, and `agy` for crewmates and scouts only; never dispatch on an unverified adapter.
 If static `config/crew-harness` or `config/secondmate-harness` names an unverified adapter, report it and fall back only to a verified adapter rather than launching it.
 
 `docs/configuration.md` owns dispatch-profile and runtime-backend schemas, `bin/fm-harness.sh` owns static resolution, and `bin/fm-spawn.sh` owns launch flags and fail-closed validation.

--- a/bin/backends/tmux.sh
+++ b/bin/backends/tmux.sh
@@ -156,6 +156,20 @@ fm_backend_tmux_current_command() {  # <target>
 # (fm_agent_process_classify_name) is owned by bin/fm-agent-process-lib.sh,
 # shared with the Herdr adapter so both backends mean the same thing by
 # `agent`, `shell`, and `other`.
+# AGY's exact executable name is the adapter-specific extension from the
+# replayed change; delegate every other identity decision to that shared owner.
+fm_backend_tmux_classify_process_name() {  # <path> [argv0] -> agent|shell|other
+  local path=${1:-} argv0=${2:-} candidate base
+  for candidate in "$path" "$argv0"; do
+    base=${candidate##*/}
+    base=${base#-}
+    if [ "$base" = agy ]; then
+      printf 'agent'
+      return 0
+    fi
+  done
+  fm_agent_process_classify_name "$@"
+}
 
 # fm_backend_tmux_foreground_comms: the kernel-side names of every process in
 # <target>'s pane tty foreground process group, one full value per line.
@@ -288,7 +302,7 @@ fm_backend_tmux_agent_state() {  # <target>
   while IFS= read -r name; do
     [ -n "$name" ] || continue
     fg_seen=1
-    case "$(fm_agent_process_classify_name "$name")" in
+    case "$(fm_backend_tmux_classify_process_name "$name")" in
       agent) printf 'alive'; return 0 ;;
       shell) fg_shell=1 ;;
       *) fg_other=1 ;;
@@ -300,7 +314,7 @@ EOF
   argv0s=$(fm_backend_tmux_foreground_argv0s "$target")
   while IFS= read -r name; do
     [ -n "$name" ] || continue
-    if [ "$(fm_agent_process_classify_name '' "$name")" = agent ]; then
+    if [ "$(fm_backend_tmux_classify_process_name '' "$name")" = agent ]; then
       printf 'alive'
       return 0
     fi
@@ -337,7 +351,7 @@ EOF
     printf 'unreadable'
     return 0
   }
-  if [ "$(fm_agent_process_classify_name "$comm")" = agent ]; then
+  if [ "$(fm_backend_tmux_classify_process_name "$comm")" = agent ]; then
     printf 'alive'
     return 0
   fi
@@ -356,7 +370,7 @@ EOF
   case "$comm" in
     '') printf 'unreadable'; return 0 ;;
   esac
-  case "$(fm_agent_process_classify_name "$comm")" in
+  case "$(fm_backend_tmux_classify_process_name "$comm")" in
     shell) printf 'dead' ;;
     *) printf 'ambiguous' ;;
   esac

--- a/bin/fm-agy-hook.sh
+++ b/bin/fm-agy-hook.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Translate AGY's documented PreInvocation/Stop hook payloads into the existing
+# generation-bound busy contract. No user/global configuration is changed.
+# Usage: fm-agy-hook.sh <PreInvocation|Stop> <state-dir> <id> <gen> <worktree>
+# stdin: AGY hook JSON. stdout: an empty JSON object, including on refusal.
+# Only the first PreInvocation may bind a conversation for this generation;
+# subagent/other-conversation events and mismatched workspaces are ignored.
+# Stop closes the turn only when fullyIdle is the JSON boolean true. A manual
+# Escape emits no Stop in AGY 1.2.1; it cannot be represented as a completed turn.
+# Each generation owns state/<id>.agy-hook/<gen>.conversation, so an old hook
+# cannot poison a replacement's first-conversation binding. Cleanup is owned
+# by fm-control-lib's wiring paths and fm-teardown.
+set -u
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=bin/fm-busy-lib.sh
+. "$SCRIPT_DIR/fm-busy-lib.sh"
+
+apply_hook() {
+  [ "$#" -eq 5 ] || return 1
+  local event=$1 state=$2 id=$3 gen=$4 worktree=$5 payload conversation binding current saved
+  case "$event" in PreInvocation|Stop) ;; *) return 1 ;; esac
+  fm_busy_token_valid "$id" && fm_busy_token_valid "$gen" || return 1
+  current=$(fm_busy_current_gen "$state" "$id") || return 1
+  [ "$current" = "$gen" ] || return 1
+  payload=$(jq -ce --arg wt "$worktree" '
+    select(type == "object") |
+    select(.workspacePaths | type == "array" and index($wt) != null) |
+    select(.conversationId | type == "string" and test("^[A-Za-z0-9-]+$"))
+  ') || return 1
+  conversation=$(printf '%s' "$payload" | jq -r .conversationId) || return 1
+  binding="$state/$id.agy-hook/$gen.conversation"
+  [ ! -L "$state/$id.agy-hook" ] && [ -d "$state/$id.agy-hook" ] || return 1
+  [ ! -L "$binding" ] || return 1
+  if [ "$event" = PreInvocation ] && [ ! -e "$binding" ]; then
+    # noclobber makes competing writers converge without replacing the owner.
+    (umask 077; set -C; printf '%s\t%s\n' "$gen" "$conversation" > "$binding") 2>/dev/null || true
+  fi
+  IFS= read -r saved < "$binding" || return 1
+  [ "$saved" = "$gen"$'\t'"$conversation" ] || return 1
+  if [ "$event" = PreInvocation ]; then
+    "$SCRIPT_DIR/fm-busy-event.sh" apply "$state" "$id" busy --gen "$gen" --source agy-hook --event pre-invocation
+  else
+    printf '%s' "$payload" | jq -e '.fullyIdle == true' >/dev/null || return 1
+    "$SCRIPT_DIR/fm-busy-event.sh" apply "$state" "$id" idle --gen "$gen" --source agy-hook --event stop || return 1
+    touch "$state/$id.turn-ended"
+  fi
+}
+apply_hook "$@" >/dev/null 2>&1 || true
+printf '{}\n'

--- a/bin/fm-agy-lib.sh
+++ b/bin/fm-agy-lib.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# AGY adapter preflight. Source-only; no fleet or account mutations.
+# fm_agy_backend_check <backend>: refuse placement without live control proof.
+# fm_agy_preflight <executable> <model> <effort>: require the tested CLI surface
+# and an exact Gemini catalog id before interactive launch, rather than relying
+# on vendor defaults or display-name aliases for dispatch. This performs no
+# inference: agy models establishes availability, NOT account eligibility.
+# Effort low/medium/high is native. A conflicting model suffix is refused;
+# unsupported efforts retain the common record-and-omit contract.
+fm_agy_backend_check() {
+  case "$1" in
+    tmux|herdr) return 0 ;;
+    *) echo "error: agy worker control/composer is verified only on tmux and herdr; backend '$1' is unsupported for agy" >&2; return 1 ;;
+  esac
+}
+
+fm_agy_preflight() {
+  local bin=$1 model=$2 effort=$3 help catalog flag
+  [ -x "$bin" ] || { echo 'error: agy executable is absent' >&2; return 1; }
+  help=$(AGY_CLI_DISABLE_AUTO_UPDATE=true "$bin" --help 2>&1) || return 1
+  for flag in --new-project --add-dir --prompt-interactive --model --effort --dangerously-skip-permissions; do
+    printf '%s\n' "$help" | grep -Eq -- "^[[:space:]]*$flag[[:space:]]" || {
+      echo "error: agy lacks required CLI capability $flag; adapter launch refused" >&2
+      return 1
+    }
+  done
+  case "$model" in
+    gemini-*) ;;
+    *) echo 'error: agy workers require an explicit Gemini model id from agy models' >&2; return 1 ;;
+  esac
+  catalog=$(AGY_CLI_DISABLE_AUTO_UPDATE=true "$bin" models) || {
+    echo 'error: agy model catalog unavailable; verify AGY authentication and connectivity' >&2
+    return 1
+  }
+  printf '%s\n' "$catalog" | awk -F '\t' -v model="$model" '$1 == model {found=1} END {exit !found}' || {
+    echo "error: agy model '$model' is not listed by agy models; no fallback was selected" >&2
+    return 1
+  }
+  case "$effort" in
+    low|medium|high)
+      case "$model" in
+        *-low|*-medium|*-high)
+          [ "${model##*-}" = "$effort" ] || {
+            echo "error: agy effort '$effort' would replace model variant '$model'; select matching model and effort" >&2
+            return 1
+          }
+          ;;
+      esac
+      ;;
+  esac
+}

--- a/bin/fm-agy-lib.sh
+++ b/bin/fm-agy-lib.sh
@@ -19,7 +19,7 @@ fm_agy_preflight() {
   [ -x "$bin" ] || { echo 'error: agy executable is absent' >&2; return 1; }
   help=$(AGY_CLI_DISABLE_AUTO_UPDATE=true "$bin" --help 2>&1) || return 1
   for flag in --new-project --add-dir --prompt-interactive --model --effort --dangerously-skip-permissions; do
-    printf '%s\n' "$help" | grep -Eq -- "^[[:space:]]*$flag[[:space:]]" || {
+    printf '%s\n' "$help" | grep -Eq -- "^[[:space:]]*${flag}[[:space:]]" || {
       echo "error: agy lacks required CLI capability $flag; adapter launch refused" >&2
       return 1
     }

--- a/bin/fm-bootstrap.sh
+++ b/bin/fm-bootstrap.sh
@@ -1110,7 +1110,7 @@ crew_dispatch_validate() {
     return 0
   fi
   err=$(jq -r '
-    def verified($h): ["claude","codex","opencode","pi","pi-signed","grok","kimi","cursor","muse","rovo","omp"] | index($h);
+    def verified($h): ["claude","codex","opencode","pi","pi-signed","grok","kimi","cursor","muse","rovo","omp","agy"] | index($h);
     def effort_ok($h; $m; $e):
       if $e == null then true
       elif ($e | type) != "string" then false
@@ -1121,6 +1121,7 @@ crew_dispatch_validate() {
       elif $h == "pi" or $h == "pi-signed" or $h == "omp" then (["low","medium","high","xhigh","max"] | index($e))
       elif $h == "muse" then (["low","medium","high","xhigh","max"] | index($e))
       elif $h == "rovo" then (["low","medium","high","max"] | index($e))
+      elif $h == "agy" then (["low","medium","high"] | index($e))
       elif $h == "opencode" or $h == "kimi" or $h == "cursor" then false
       else true
       end;

--- a/bin/fm-busy-lib.sh
+++ b/bin/fm-busy-lib.sh
@@ -32,6 +32,8 @@
 #   omp-ext          omp (Oh My Pi) per-task extension (agent_start/agent_end without willContinue)
 #   opencode-plugin  OpenCode per-task plugin (session.status)
 #   claude-hook      Claude lifecycle hooks (UserPromptSubmit/Stop/StopFailure/SessionEnd)
+#   agy-hook         AGY PreInvocation opens; fullyIdle Stop closes (manual
+#                    Escape has no Stop and conservatively retains busy).
 #   gemini-hook      Gemini agent hooks (BeforeAgent opens; AfterAgent and
 #                    SessionEnd close)
 #   codex-hook, codex-appserver  reserved: Codex, gated by
@@ -197,6 +199,7 @@ fm_busy_sources_for_harness() {  # <harness>
       ;;
     opencode*) adapter=opencode-plugin ;;
     gemini*) adapter=gemini-hook ;;
+    agy) adapter=agy-hook ;;
     pi|pi-signed) adapter=pi-ext ;;
     omp) adapter=omp-ext ;;
     kimi*)

--- a/bin/fm-composer-lib.sh
+++ b/bin/fm-composer-lib.sh
@@ -342,6 +342,8 @@ FM_DELIVERY_GROK_BUSY_REGEX_DEFAULT='Ctrl\+c:cancel'
 # injection. Cursor's recorded worker state comes from its transcript fold in
 # bin/fm-busy-lib.sh, never from this row.
 FM_DELIVERY_CURSOR_BUSY_REGEX_DEFAULT='ctrl\+c to stop'
+# AGY's task state comes from semantic hooks, never this delivery-only footer.
+FM_DELIVERY_AGY_BUSY_REGEX_DEFAULT='^[[:space:]]*esc to cancel[[:space:]]'
 FM_DELIVERY_KIMI_BUSY_REGEX_DEFAULT='^[[:space:]]*(🌑|🌒|🌓|🌔|🌕|🌖|🌗|🌘)[[:space:]]+·[[:space:]]+'
 
 fm_busy_lines_match() {  # [harness]
@@ -359,6 +361,7 @@ fm_busy_lines_match() {  # [harness]
       grok) regex=$FM_DELIVERY_GROK_BUSY_REGEX_DEFAULT ;;
       kimi) regex=$FM_DELIVERY_KIMI_BUSY_REGEX_DEFAULT ;;
       cursor) regex=$FM_DELIVERY_CURSOR_BUSY_REGEX_DEFAULT ;;
+      agy) regex=$FM_DELIVERY_AGY_BUSY_REGEX_DEFAULT ;;
       '') regex=$FM_DELIVERY_BUSY_REGEX_DEFAULT ;;
       *)
         # A supplied harness must never borrow another harness's signature.
@@ -1446,6 +1449,24 @@ _fm_composer_pi_verdict() {  # <screen> <styled> <has_identity> <identity>
   fi
   agent=${identity%%$'\t'*}
   agent_status=${identity#*$'\t'}
+  if [ "$agent" = agy ] && [ "$FM_COMPOSER_SCAN_PI_PAIR_VALID" = 1 ]; then
+    # AGY uses separators plus a shell-like > glyph. Only the exact live
+    # process identity authorizes stripping it; shell transcripts stay unknown.
+    local row raw content first=1
+    row=$((FM_COMPOSER_SCAN_PI_OPEN + 1))
+    while [ "$row" -lt "$FM_COMPOSER_SCAN_PI_CLOSE" ]; do
+      raw=$(_fm_composer_screen_row "$row" "$screen")
+      content=$(_fm_composer_row_content "$raw" "$styled")
+      if [ "$first" = 1 ]; then
+        case "$content" in '>'*) content=${content#>}; first=0 ;; *) printf 'unknown'; return 0 ;; esac
+      fi
+      fm_composer_normalize_trim_var content
+      [ -z "$content" ] || { printf 'pending'; return 0; }
+      row=$((row + 1))
+    done
+    case "$agent_status" in idle|done) printf 'empty' ;; *) printf 'unknown' ;; esac
+    return 0
+  fi
   if [ "$agent" != pi ] || [ "$FM_COMPOSER_SCAN_PI_PAIR_VALID" != 1 ]; then
     printf 'unknown'
     return 0

--- a/bin/fm-control-lib.sh
+++ b/bin/fm-control-lib.sh
@@ -63,7 +63,7 @@ fm_control_verb_allowed() {  # <verb>
 # than guessed at, exactly as a spawn on it would be.
 fm_control_harness_supported() {  # <harness>
   case "${1-}" in
-    claude|codex|opencode|pi|pi-signed|grok|kimi|cursor|gemini|muse|rovo|omp) return 0 ;;
+    claude|codex|opencode|pi|pi-signed|grok|kimi|cursor|gemini|muse|rovo|omp|agy) return 0 ;;
   esac
   return 1
 }
@@ -81,6 +81,7 @@ fm_control_harness_family() {  # <recorded-harness>
     pi) printf 'pi' ;;
     pi-signed) printf 'pi-signed' ;;
     omp) printf 'omp' ;;
+    agy) printf 'agy' ;;
     claude*) printf 'claude' ;;
     codex*) printf 'codex' ;;
     opencode*) printf 'opencode' ;;
@@ -105,6 +106,7 @@ fm_control_harness_supports_kind() {  # <harness> <kind>
   fm_control_harness_supported "$harness" || return 1
   case "$harness" in
     muse|gemini|rovo) [ "$kind" != secondmate ] || return 1 ;;
+    agy) case "$kind" in ship|scout) ;; *) return 1 ;; esac ;;
   esac
   return 0
 }
@@ -119,7 +121,7 @@ fm_control_harness_supports_kind() {  # <harness> <kind>
 # through Herdr).
 fm_control_interrupt_key() {  # <harness>
   case "${1-}" in
-    claude|codex|opencode|pi|pi-signed|omp|kimi|cursor|gemini|muse|rovo) printf 'Escape' ;;
+    claude|codex|opencode|pi|pi-signed|omp|kimi|cursor|gemini|muse|rovo|agy) printf 'Escape' ;;
     grok) printf 'C-c' ;;
     *) return 1 ;;
   esac
@@ -130,7 +132,7 @@ fm_control_interrupt_key() {  # <harness>
 fm_control_interrupt_repeat() {  # <harness>
   case "${1-}" in
     opencode) printf '2' ;;
-    claude|codex|pi|pi-signed|omp|grok|kimi|cursor|gemini|muse|rovo) printf '1' ;;
+    claude|codex|pi|pi-signed|omp|grok|kimi|cursor|gemini|muse|rovo|agy) printf '1' ;;
     *) return 1 ;;
   esac
 }
@@ -151,7 +153,7 @@ fm_control_interrupt_repeat() {  # <harness>
 fm_control_interrupt_clear_key() {  # <harness>
   case "${1-}" in
     muse) printf 'C-u' ;;
-    claude|codex|opencode|pi|pi-signed|omp|grok|kimi|cursor|gemini|rovo) ;;
+    claude|codex|opencode|pi|pi-signed|omp|grok|kimi|cursor|gemini|rovo|agy) ;;
     *) return 1 ;;
   esac
 }
@@ -166,7 +168,7 @@ fm_control_interrupt_ack_source() {  # <harness>
     # rovo's TUI prints "Agent cancelled" on Escape, but for parity with
     # claude/cursor this stays 'none': the ack is a rendered string, not a
     # recorded state source, and rovo has no busy wiring to confirm against.
-    claude|codex|opencode|pi|pi-signed|omp|grok|kimi|cursor|gemini|rovo) printf 'none' ;;
+    claude|codex|opencode|pi|pi-signed|omp|grok|kimi|cursor|gemini|rovo|agy) printf 'none' ;;
     *) return 1 ;;
   esac
 }
@@ -174,7 +176,7 @@ fm_control_interrupt_ack_source() {  # <harness>
 # The command that exits the agent from its own composer.
 fm_control_exit_command() {  # <harness>
   case "${1-}" in
-    claude|opencode|grok|kimi|cursor|muse|rovo) printf '/exit' ;;
+    claude|opencode|grok|kimi|cursor|muse|rovo|agy) printf '/exit' ;;
     codex|pi|pi-signed|omp|gemini) printf '/quit' ;;
     *) return 1 ;;
   esac
@@ -246,6 +248,13 @@ fm_control_harness_wiring_paths() {  # <harness> <worktree> <state-dir> <id>
     # is written into the worktree, whose own .gemini/settings.json belongs to
     # the project, and nothing global is installed.
     gemini) printf '%s\n' "$state/$id.gemini-settings.json" ;;
+    agy)
+      printf '%s\n' "$state/$id.agy-hook/.agents/hooks.json"
+      local binding
+      for binding in "$state/$id.agy-hook/"*.conversation; do
+        [ ! -e "$binding" ] && [ ! -L "$binding" ] || printf '%s\n' "$binding"
+      done
+      ;;
   esac
 }
 

--- a/bin/fm-control.sh
+++ b/bin/fm-control.sh
@@ -685,6 +685,14 @@ resolve_relaunch_profile() {
   if [ "$TARGET_EFFORT" = ultra ]; then
     "$SCRIPT_DIR/fm-harness.sh" validate-native-effort "$TARGET_HARNESS" "$TARGET_MODEL" "$TARGET_EFFORT" || return 1
   fi
+  if [ "$TARGET_HARNESS" = agy ]; then
+    # AGY requires a concrete supported profile; discover a refusal before
+    # stopping the current agent, not after relinquishing its work.
+    # shellcheck source=bin/fm-agy-lib.sh
+    . "$SCRIPT_DIR/fm-agy-lib.sh"
+    fm_agy_backend_check "$BACKEND" || return 1
+    fm_agy_preflight "$(type -P agy || true)" "$TARGET_MODEL" "$TARGET_EFFORT" || return 1
+  fi
 }
 
 # safe_checkpoint: prove, before anything is stopped, that the work a relaunch

--- a/bin/fm-harness.sh
+++ b/bin/fm-harness.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Detect the agent harness this process tree runs on.
-# Usage: fm-harness.sh                  print own harness: claude|codex|opencode|pi|pi-signed|grok|kimi|cursor|gemini|muse|rovo|omp|unknown
+# Usage: fm-harness.sh                  print own harness: claude|codex|opencode|pi|pi-signed|grok|kimi|cursor|gemini|muse|rovo|omp|agy|unknown
 #        fm-harness.sh crew             print the effective CREWMATE harness
 #                                        (config/crew-harness; "default" resolves to own)
 #        fm-harness.sh secondmate       print the harness the PRIMARY uses to launch
@@ -95,6 +95,12 @@ detect_own() {
     echo omp
     return
   fi
+  # AGY publishes no identity marker. The launch-owned marker only outranks
+  # foreign markers when an exact agy process is also in this ancestry.
+  if [ "${FM_AGY_HARNESS:-}" = agy ] && ancestry_names_agy; then
+    echo agy
+    return
+  fi
   [ "${CLAUDECODE:-}" = "1" ] && { echo claude; return; }
   if [ "${PI_CODING_AGENT:-}" = "true" ]; then
     if [ "${FM_PI_HARNESS:-}" = pi-signed ]; then echo pi-signed; else echo pi; fi
@@ -150,6 +156,7 @@ detect_own() {
       *grok*) echo grok; return ;;
       kimi) echo kimi; return ;;
       rovo) echo rovo; return ;;
+      agy) echo agy; return ;;
       # muse's installed launcher ~/.local/bin/muse execs ~/.local/bin/muse-bin-<version>
       # (verified in the published launcher, muse 0.1.0-R708.1), so the live process
       # name carries the version and CHANGES on every auto-update. Match the stable
@@ -198,6 +205,17 @@ ancestry_names_omp() {
   for _ in 1 2 3 4 5 6 7 8; do
     comm=$(ps -o comm= -p "$pid" 2>/dev/null) || return 1
     [ "$(basename -- "$comm")" = omp ] && return 0
+    pid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d ' ')
+    [ -n "$pid" ] && [ "$pid" -gt 1 ] || return 1
+  done
+  return 1
+}
+
+ancestry_names_agy() {
+  local pid=$$ comm
+  for _ in 1 2 3 4 5 6 7 8; do
+    comm=$(ps -o comm= -p "$pid" 2>/dev/null) || return 1
+    [ "$(basename -- "$comm")" = agy ] && return 0
     pid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d ' ')
     [ -n "$pid" ] && [ "$pid" -gt 1 ] || return 1
   done

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -142,6 +142,12 @@
 #   a failed or inconclusive probe omits it so older Pi versions remain launchable.
 #   A missing selected executable refuses before endpoint creation, and pi-signed
 #   never falls back to pi.
+#   AGY is worker-only on tmux and Herdr. It requires an explicit catalog Gemini model,
+#   uses --new-project and --add-dir to bind tool cwd (bare agy uses its shared
+#   scratch directory), and never updates account settings or the binary.
+#   state/<id>.agy-hook/.agents/hooks.json is an added customization workspace,
+#   not a replacement for project hooks. PreInvocation/Stop feed fm-busy-event.
+#   A fresh path may still require the documented folder-trust confirmation.
 #   For omp (Oh My Pi), fm-spawn resolves the `omp` executable from PATH once and
 #   refuses when it is absent. Every omp launch clears the foreign harness
 #   markers (omp publishes none of its own), sets the Firstmate-owned
@@ -1389,7 +1395,7 @@ if [ "$RELAUNCH" -eq 1 ]; then
   }
 elif [ "$KIND" = secondmate ]; then
   case "${POS[1]:-}" in
-    ''|claude|codex|opencode|pi|pi-signed|grok|kimi|cursor|gemini|muse|rovo|omp)
+    ''|claude|codex|opencode|pi|pi-signed|grok|kimi|cursor|gemini|muse|rovo|omp|agy)
       ARG3=${POS[1]:-}
       ;;
     *' '*)
@@ -1595,6 +1601,7 @@ launch_template() {
     # stays in task metadata only, per the record-and-omit contract.
     # Its turn-end and busy-state signals do NOT ride the launch command:
     # they are project hooks written into the worktree below.
+    agy) printf '%s' 'env -u CLAUDECODE -u PI_CODING_AGENT -u GROK_AGENT -u FM_PI_HARNESS -u GEMINI_CLI -u ATLASSIAN_AGENT_TYPE -u ROVODEV_CLI -u FM_OMP_HARNESS FM_AGY_HARNESS=agy AGY_CLI_DISABLE_AUTO_UPDATE=true __AGYBIN__ --new-project --add-dir __WORKTREE__ --add-dir __AGYHOOKDIR__ --dangerously-skip-permissions __MODELFLAG____EFFORTFLAG__--prompt-interactive "$(__OPINPUT__ encode launch-brief < __BRIEF__)"' ;;
     gemini) printf '%s' 'env -u CLAUDECODE -u PI_CODING_AGENT -u GROK_AGENT -u FM_PI_HARNESS GEMINI_CLI_TRUST_WORKSPACE=true GEMINI_CLI_SYSTEM_SETTINGS_PATH=__GEMINISETTINGS__ gemini -y __MODELFLAG__"$(__OPINPUT__ encode launch-brief < __BRIEF__)"' ;;
     # Kimi Code rejects a positional prompt, so it launches bare and receives
     # only an absolute brief pointer after the TUI readiness gate below.
@@ -1713,6 +1720,17 @@ fi
 if [ "$KIND" = secondmate ] && [ "$HARNESS" = rovo ]; then
   echo "error: rovo is a verified crewmate/scout adapter only and cannot run a secondmate; it has no primary supervision protocol. Select a harness verified for secondmates." >&2
   exit 1
+fi
+
+if [ "$HARNESS" = agy ]; then
+  case "$KIND" in ship|scout) ;; *) echo 'error: agy is worker-only; primary and secondmate supervision are unverified' >&2; exit 1 ;; esac
+  # shellcheck source=bin/fm-agy-lib.sh
+  . "$SCRIPT_DIR/fm-agy-lib.sh"
+  fm_agy_backend_check "$BACKEND" || exit 1
+  if [ "$RAW_LAUNCH" -eq 0 ]; then
+    AGY_BIN=$(resolve_pi_executable agy) || { echo 'error: agy executable not found on PATH' >&2; exit 1; }
+    fm_agy_preflight "$AGY_BIN" "$MODEL" "$EFFORT" || exit 1
+  fi
 fi
 
 case "$HARNESS" in
@@ -1902,7 +1920,7 @@ model_flag_for_harness() {
   local harness=$1 model=$2
   [ -n "$model" ] && [ "$model" != default ] || return 0
   case "$harness" in
-    claude|codex|opencode|pi|pi-signed|grok|kimi|cursor|gemini|muse|rovo|omp)
+    claude|codex|opencode|pi|pi-signed|grok|kimi|cursor|gemini|muse|rovo|omp|agy)
       printf -- '--model %s ' "$(shell_quote "$model")"
       ;;
   esac
@@ -1950,6 +1968,11 @@ effort_flag_for_harness() {
       # a superset of the shared vocabulary, so every level maps straight across.
       case "$effort" in
         low|medium|high|xhigh|max) printf -- '--thinking %s ' "$(shell_quote "$effort")" ;;
+      esac
+      ;;
+    agy)
+      case "$effort" in
+        low|medium|high) printf -- '--effort %s ' "$(shell_quote "$effort")" ;;
       esac
       ;;
     muse)
@@ -3303,7 +3326,7 @@ if [ "$KIND" != secondmate ]; then
       }
       [ "$RELAUNCH" -ne 1 ] || RELAUNCH_REPLACEMENT_BUSY_GEN=$BUSY_GEN
       ;;
-    gemini)
+    gemini|agy)
       if [ "$RAW_LAUNCH" -eq 0 ]; then
         BUSY_GEN=$("$FM_ROOT/bin/fm-busy-event.sh" arm "$STATE_REAL" "$ID") || {
           echo "error: failed to arm the busy-state contract for $ID" >&2
@@ -3324,6 +3347,21 @@ if [ "$KIND" != secondmate ]; then
       ;;
   esac
   case "$HARNESS" in
+    agy)
+      if [ "$RAW_LAUNCH" -eq 0 ]; then
+        AGY_HOOK_DIR="$STATE_REAL/$ID.agy-hook"
+        if [ -L "$AGY_HOOK_DIR" ] || [ -L "$AGY_HOOK_DIR/.agents" ] || [ -L "$AGY_HOOK_DIR/.agents/hooks.json" ]; then
+          echo 'error: agy hook workspace must not contain symlinked wiring' >&2
+          exit 1
+        fi
+        mkdir -p "$AGY_HOOK_DIR/.agents" || exit 1
+        agy_hook_prefix="$(shell_quote "$FM_ROOT/bin/fm-agy-hook.sh")"
+        agy_hook_suffix="$(shell_quote "$STATE_REAL") $(shell_quote "$ID") $(shell_quote "$BUSY_GEN") $(shell_quote "$WT")"
+        jq -n --arg pre "$agy_hook_prefix PreInvocation $agy_hook_suffix" --arg stop "$agy_hook_prefix Stop $agy_hook_suffix" \
+          '{"firstmate-worker":{"PreInvocation":[{"command":$pre,"timeout":10}],"Stop":[{"command":$stop,"timeout":10}]}}' \
+          > "$AGY_HOOK_DIR/.agents/hooks.json" || exit 1
+      fi
+      ;;
     claude*)
       # Semantic busy-state hooks (bin/fm-busy-lib.sh): UserPromptSubmit opens
       # a turn; Stop (normal completion), StopFailure (API-error turn end),
@@ -3881,12 +3919,16 @@ LAUNCH=${LAUNCH//__OPINPUT__/$sq_opinput}
 case "$HARNESS" in
   pi|pi-signed) LAUNCH=${LAUNCH//__PIBIN__/"$(shell_quote "$PI_BIN")"} ;;
   cursor) LAUNCH=${LAUNCH//__CURSORBIN__/"$(shell_quote "$CURSOR_BIN")"} ;;
+  agy)
+    LAUNCH=${LAUNCH//__AGYBIN__/"$(shell_quote "${AGY_BIN:-agy}")"}
+    LAUNCH=${LAUNCH//__AGYHOOKDIR__/"$(shell_quote "${AGY_HOOK_DIR:-}")"}
+    ;;
   gemini) LAUNCH=${LAUNCH//__GEMINISETTINGS__/"$(shell_quote "$STATE_REAL/$ID.gemini-settings.json")"} ;;
   omp) LAUNCH=${LAUNCH//__OMPBIN__/"$(shell_quote "$OMP_BIN")"} ;;
 esac
 LAUNCH=${LAUNCH//__WORKTREE__/$sq_worktree}
 case "$HARNESS" in
-  claude|codex|opencode|pi|pi-signed|grok|kimi|gemini|muse|rovo)
+  claude|codex|opencode|pi|pi-signed|grok|kimi|gemini|muse|rovo|agy)
     LAUNCH="env -u CURSOR_AGENT -u CURSOR_INVOKED_AS -u GEMINI_CLI $LAUNCH"
     ;;
 esac

--- a/bin/fm-supervision-instructions.sh
+++ b/bin/fm-supervision-instructions.sh
@@ -83,6 +83,10 @@ fi
 case "$HARNESS" in
   claude|codex|opencode|pi|grok|cursor|omp) SNIPPET="$DOC_DIR/$HARNESS.md" ;;
   pi-signed) SNIPPET="$DOC_DIR/pi.md" ;;
+  agy)
+    echo 'error: agy supports ordinary workers only; primary and secondmate supervision are not implemented' >&2
+    exit 1
+    ;;
   *) HARNESS=unknown; SNIPPET="$DOC_DIR/unknown.md" ;;
 esac
 [ -f "$SNIPPET" ] || SNIPPET="$DOC_DIR/unknown.md"

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -3038,9 +3038,11 @@ cleanup_firstmate_home_children() {
     rm -f "$sub_state/$child_id.turn-ended" "$sub_state/$child_id.progress" \
       "$sub_state/$child_id.pi-ext.ts" "$sub_state/$child_id.omp-ext.ts" \
       "$sub_state/$child_id.grok-turnend-token" "$sub_state/$child_id.kimi-turnend-token" \
+      "$sub_state/$child_id.agy-hook/.agents/hooks.json" "$sub_state/$child_id.agy-hook/"*.conversation \
       "$sub_state/$child_id.muse-session" "$sub_state/$child_id.muse-session-current" \
       "$sub_state/$child_id.cursor-session" "$sub_state/$child_id.reconcile-nudged" \
       "$sub_state/.$child_id.branch-outcome-index"
+    rmdir "$sub_state/$child_id.agy-hook/.agents" "$sub_state/$child_id.agy-hook" 2>/dev/null || true
   done
 }
 
@@ -3457,7 +3459,9 @@ rm -f "$STATE/$ID.turn-ended" "$STATE/$ID.progress" \
   "$STATE/$ID.control-relaunch" "$STATE/$ID.control-relaunch.meta-prior" \
   "$STATE/$ID.control-relaunch.brief-prior" "$STATE/$ID.control-relaunch.note" \
   "$STATE/$ID.reconcile-nudged" "$STATE/$ID.gemini-settings.json" \
+  "$STATE/$ID.agy-hook/.agents/hooks.json" "$STATE/$ID.agy-hook/"*.conversation \
   "$STATE/.$ID.branch-outcome-index"
+rmdir "$STATE/$ID.agy-hook/.agents" "$STATE/$ID.agy-hook" 2>/dev/null || true
 # The steering inbox (bin/fm-task-inbox-lib.sh) is runtime state for the
 # retired endpoint; teardown only runs after landing is confirmed, so any
 # leftover unhandled steer here is moot rather than unlanded work.

--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -278,7 +278,7 @@ family_for_basename() {
     fm-composer-ghost.test.sh|fm-composer-lib.test.sh|\
     fm-crew-state.test.sh|fm-captain-hold-lifecycle.test.sh|\
     fm-documentation-audiences.test.sh|fm-ensure-agents-md.test.sh|fm-grok-harness.test.sh|\
-    fm-kimi-harness.test.sh|fm-muse-harness.test.sh|fm-rovo-harness.test.sh|fm-omp-harness.test.sh|fm-herdr-lab.test.sh|fm-lint.test.sh|\
+    fm-kimi-harness.test.sh|fm-muse-harness.test.sh|fm-rovo-harness.test.sh|fm-omp-harness.test.sh|fm-agy-harness.test.sh|fm-herdr-lab.test.sh|fm-lint.test.sh|\
     fm-lint-workflows.test.sh|\
     fm-operational-input.test.sh|fm-pi-primary-types.test.sh|\
     fm-harness-adapter-references.test.sh|\
@@ -341,7 +341,7 @@ family_for_basename() {
     fm-cursor-primary-live-e2e.test.sh|\
     fm-grok-stop-live-e2e.test.sh|fm-harness-adapter-instructions-live-e2e.test.sh|\
     fm-harness-liveness-drift-live-e2e.test.sh|\
-    fm-muse-signals-live-e2e.test.sh|fm-rovo-signals-live-e2e.test.sh|\
+    fm-muse-signals-live-e2e.test.sh|fm-rovo-signals-live-e2e.test.sh|fm-agy-signals-live-e2e.test.sh|\
     fm-herdr-version-floor-live-e2e.test.sh|\
     fm-herdr-pi-stale-registration-live-e2e.test.sh|\
     fm-opencode-primary-live-e2e.test.sh|fm-pi-branch-live-e2e.test.sh|\

--- a/bin/fm-tmux-lib.sh
+++ b/bin/fm-tmux-lib.sh
@@ -98,9 +98,10 @@ fm_tmux_composer_caps() {
 #   - status: pi's verified busy footer via fm_pane_is_busy, mapped onto the
 #     idle/working vocabulary herdr's probe reports natively.
 # Prints "pi<TAB>idle" or "pi<TAB>working"; exits 1 when the pane is not a
-# live pi.
+# live pi. AGY uses the same process-bound separated shape, with a leading
+# > on its composer row; the shared classifier owns that content distinction.
 fm_tmux_composer_identity() {  # <target>
-  local target=$1 tty pgid tpgid comm found=0 status
+  local target=$1 tty pgid tpgid comm found=0 status agent=pi
   tty=$(tmux display-message -p -t "$target" '#{pane_tty}' 2>/dev/null) || tty=
   case "$tty" in
     /dev/*)
@@ -109,6 +110,7 @@ fm_tmux_composer_identity() {  # <target>
         [ "$pgid" = "$tpgid" ] || continue
         case "${comm##*/}" in
           pi|pi-signed|pi-launcher|Pi) found=1 ;;
+          agy) found=1; agent=agy ;;
         esac
       done <<EOF
 $(LC_ALL=C ps -t "${tty#/dev/}" -o pid=,pgid=,tpgid=,comm= 2>/dev/null)
@@ -119,13 +121,14 @@ EOF
     comm=$(tmux display-message -p -t "$target" '#{pane_current_command}' 2>/dev/null) || comm=
     case "${comm##*/}" in
       pi|pi-signed|pi-launcher) found=1 ;;
+      agy) found=1; agent=agy ;;
     esac
   fi
   [ "$found" -eq 1 ] || return 1
-  status=$(fm_pane_busy_state "$target" pi)
+  status=$(fm_pane_busy_state "$target" "$agent")
   case "$status" in
-    busy) printf 'pi\tworking' ;;
-    idle) printf 'pi\tidle' ;;
+    busy) printf '%s\tworking' "$agent" ;;
+    idle) printf '%s\tidle' "$agent" ;;
     *) return 1 ;;
   esac
 }

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -309,6 +309,8 @@ On Zellij, cmux, and Orca a typed-plane Cursor send (a harness-native invocation
 muse is verified for crewmate and scout launches ONLY, and `fm-spawn.sh` refuses it for a secondmate, because muse ships no usable hook surface for a primary session's turn-end supervision; [`docs/verification/muse.md`](verification/muse.md) owns that evidence.
 muse also needs a worker-reachable credential before spawning, and the portable fleet path is the `<config>/muse/auth.json` credential stored by `muse login`, because a caller-only `META_API_KEY` does not cross a long-lived backend daemon.
 gemini is likewise refused for secondmates because it has no primary supervision protocol; [its adapter reference](../.agents/skills/harness-adapters/references/harness/gemini.md) owns the credential precondition, canonical-launch wiring, and raw-launch limitations.
+Antigravity CLI (`agy`) supports ordinary ship/scout workers on tmux and Herdr only, not primary or secondmate sessions; [its adapter reference](../.agents/skills/harness-adapters/references/harness/agy.md) owns setup, native hook/control evidence, and limitations.
+Install and sign in through [AGY's official getting-started guide](https://antigravity.google/docs/cli/getting-started/), complete any account-eligibility verification, and verify real prompt execution before dispatch; a model catalog alone does not prove account eligibility.
 rovo is likewise verified for crewmate and scout launches ONLY, refused for a secondmate for the same reason - no turn-end hook and no primary supervision protocol; [`docs/verification/rovo.md`](verification/rovo.md) owns that evidence, including the OAuth token's silent background refresh from a stored refresh token and both tmux and herdr pane liveness (herdr placement is verified live, with a Herdr-side agent-detection gap left open for recovery classification).
 New harnesses get verified through a supervised trial task before joining the set.
 The verified adapter evidence - each harness's busy-state source, interrupt and exit behavior, skill-invocation syntax, and per-harness quirks - lives in the skill tree rooted at [`.agents/skills/harness-adapters/SKILL.md`](../.agents/skills/harness-adapters/SKILL.md).
@@ -446,6 +448,23 @@ Valid files stay silent by default; with `FM_BOOTSTRAP_VERBOSE_FACTS=1`, bootstr
 Malformed JSON, an empty or malformed rule/default array, an unverified harness, or an effort value unsupported by that harness is reported as `CREW_DISPATCH: invalid config/crew-dispatch.json - ...`; missing `jq` is reported through the normal `MISSING: jq` install-consent flow.
 While the file remains present, no crewmate or scout spawn may proceed without an explicit resolved harness; malformed configuration must be reported and corrected rather than selected around.
 Secondmate homes inherit this file from the primary, so a secondmate's own crewmates apply the same dispatch profile behavior.
+
+### Bounded Gemini Flash work through AGY
+
+This optional rule uses the existing profile mechanism, not a separate scheduler.
+Merge it into your local rules only when you want this routing; do not replace the stronger-reasoning profiles used for ambiguous investigation, design, or high-impact changes.
+
+```json
+{
+  "when": "Bounded, well-specified changes with concrete acceptance tests; no ambiguous design, security-sensitive decisions, or high-impact migration",
+  "use": { "harness": "agy", "model": "gemini-3.8-flash-low", "effort": "low" },
+  "why": "Use Gemini Flash for explicit work proportionate to its capability; retain stronger reasoning for uncertainty and broad consequences."
+}
+```
+
+Refresh the exact ID with `agy models` before using the example; the adapter requires an explicit catalog-listed Gemini model, even when `config/crew-harness` selects AGY.
+Native effort is `low`, `medium`, or `high`, and a conflicting suffix/effort pair is refused because AGY can otherwise change the chosen model variant.
+The [AGY adapter reference](../.agents/skills/harness-adapters/references/harness/agy.md) owns the capability and authentication preflight details.
 
 ## Toolchain
 

--- a/docs/documentation-audiences.json
+++ b/docs/documentation-audiences.json
@@ -177,6 +177,10 @@
       "audience": "agent-runtime"
     },
     {
+      "path": ".agents/skills/harness-adapters/references/harness/agy.md",
+      "audience": "agent-runtime"
+    },
+    {
       "path": ".agents/skills/harness-adapters/references/harness/claude.md",
       "audience": "agent-runtime"
     },

--- a/docs/verification/runtime-backends.md
+++ b/docs/verification/runtime-backends.md
@@ -6,6 +6,54 @@ This record contains reusable version-scoped evidence for active runtime guarant
 The backend guides own current setup, safety boundaries, and limitations.
 Exact task chronology, branch names, temporary homes, local paths, process ids, thread ids, and delivery transcripts remain in private reports or PR evidence.
 
+## Antigravity CLI (AGY) workers
+
+Verified on 2026-09-11 with AGY 1.2.1, tmux 3.4, and Herdr 0.9.0 (client and server, protocol 22) on Linux x86_64.
+The [AGY adapter reference](../../.agents/skills/harness-adapters/references/harness/agy.md) owns setup and limits; `bin/fm-agy-lib.sh` owns catalog preflight and `bin/fm-spawn.sh` owns canonical launch.
+No primary or secondmate support is claimed.
+
+The actual inference and interactive tool probes used `gemini-3.8-flash-low` with native `low` effort.
+The CLI catalog also returned Flash 3.8/3.7/3.6 low/medium/high variants and Gemini 3.1 Pro low/high; those catalog rows are availability evidence, not individual inference tests.
+A separate interactive probe combining the low model ID with `--effort high` reported `gemini-3.8-flash-high` in the native invocation payload, motivating the conflicting-profile refusal.
+`agy models` succeeded even before account eligibility was established, so only a successful actual prompt proves that prerequisite.
+
+Refresh commands:
+
+```sh
+FM_AGY_LIVE=1 bin/fm-test-run.sh tests/fm-agy-signals-live-e2e.test.sh
+FM_AGY_HERDR_LAB_HELPER="$HERDR_LAB_HELPER" FM_AGY_BACKEND=herdr FM_AGY_LIVE=1 bin/fm-test-run.sh tests/fm-agy-signals-live-e2e.test.sh
+```
+
+The Herdr invocation used the task's prescribed `bin/fm-herdr-lab.sh` helper; omit that override when the current tree owns the helper.
+Every Herdr operation used its named non-default lab, and teardown's unchanged-default-session tripwire passed.
+`status --json` through that same helper reported client/server version `0.9.0` and protocol `22`.
+Tmux used a private socket and a stable named window, never the fleet server.
+
+Both backend runs emitted:
+
+```text
+AGY live version=1.2.1 model=gemini-3.8-flash-low effort=low
+ok - AGY 1.2.1 actual prompt executes successfully
+ok - AGY 1.2.1 interactive prompt executes tools in the isolated workspace, detects agy and settles native hooks
+ok - AGY 1.2.1 follow-up steering performs external task reporting and completes
+ok - AGY 1.2.1 Escape interrupts, clears the composer and accepts subsequent work
+ok - AGY 1.2.1 /exit stops only the lab agent and stale shell input stays protected
+ok - AGY 1.2.1 deterministic relaunch preserves the workspace and completes with fresh hook custody
+```
+
+The complete tmux run returned `exit=0 duration_ms=64628 gate_skip=false`; the complete Herdr run returned `exit=0 duration_ms=104160 gate_skip=false`.
+The guard asserts actual tool-produced files, physical command cwd, process identity from inside the tool, backend `alive`, native busy/completion records, empty composer, cancellation followed by new work, exit, and a replacement conversation in the same preserved directory.
+It does not equate successful key delivery or an echoed prompt with processing.
+Native `PreInvocation` and `Stop` payloads supplied workspace and conversation identity; only boolean `fullyIdle: true` closed the parent turn.
+Escape emitted no Stop in the observed cancellation, so the adapter conservatively keeps semantic busy state until a subsequent turn completes or the process exits, rather than inventing a completion event.
+
+Portable coverage is in `tests/fm-agy-harness.test.sh`, with lifecycle dispatch in `tests/fm-control.test.sh` and profile preflight/retirement in `tests/fm-control-relaunch.test.sh`.
+These passed, including old-generation and other-conversation rejection, backend/kind restrictions, model/effort conflicts, and pre-stop refusal when an AGY replacement lacks a model.
+Shared composer, busy-wiring, dispatch-profile, bootstrap, and teardown regressions also passed.
+The generated launch was exercised with a fake provider for portable argv/hook checks; the credentialed guard deliberately uses equivalent raw launch arguments rather than normal fleet dispatch.
+Zellij, Orca, and cmux have no verified AGY identity/composer proof in their inspected integration surfaces and are refused for this adapter; Codex App remains outside supported spawn backends.
+Existing primary integrations and the primary-only session-lock identity table were left unchanged; AGY's supervision renderer explicitly refuses primary use.
+
 ## tmux
 
 Foreground-process behavior was verified on 2026-07-07 with tmux 3.6a on macOS.

--- a/tests/fm-agy-harness.test.sh
+++ b/tests/fm-agy-harness.test.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+# Portable AGY worker adapter behavior: exact process identity, isolated spawn,
+# model preflight, generation/workspace/conversation-bound hooks, and composer.
+set -u
+# shellcheck source=tests/fixtures.sh
+. "$(dirname "${BASH_SOURCE[0]}")/fixtures.sh"
+# shellcheck source=bin/fm-control-lib.sh
+. "$ROOT/bin/fm-control-lib.sh"
+# shellcheck source=bin/fm-busy-lib.sh
+. "$ROOT/bin/fm-busy-lib.sh"
+# shellcheck source=bin/fm-composer-lib.sh
+. "$ROOT/bin/fm-composer-lib.sh"
+# shellcheck source=bin/fm-agy-lib.sh
+. "$ROOT/bin/fm-agy-lib.sh"
+TMP_ROOT=$(fm_test_tmproot fm-agy-harness)
+
+mkdir -p "$TMP_ROOT/named"
+for name in agy agyd; do ln -s /bin/bash "$TMP_ROOT/named/$name"; done
+for name in agy agyd; do
+  # shellcheck disable=SC2016
+  out=$(env -u PI_CODING_AGENT -u FM_PI_HARNESS -u GEMINI_CLI -u GROK_AGENT \
+    -u CURSOR_AGENT -u CURSOR_INVOKED_AS -u ATLASSIAN_AGENT_TYPE -u ROVODEV_CLI \
+    CLAUDECODE=1 FM_AGY_HARNESS=agy "$TMP_ROOT/named/$name" -c '"$1"; :' _ "$ROOT/bin/fm-harness.sh")
+  if [ "$name" = agy ]; then
+    [ "$out" = agy ] || fail "real agy ancestry and marker must win: $out"
+  else
+    [ "$out" = claude ] || fail "a leaked marker cannot claim unrelated agyd: $out"
+  fi
+done
+# shellcheck disable=SC2016
+out=$(env -u PI_CODING_AGENT -u CLAUDECODE -u GEMINI_CLI -u GROK_AGENT \
+  -u CURSOR_AGENT -u CURSOR_INVOKED_AS -u ATLASSIAN_AGENT_TYPE -u ROVODEV_CLI \
+  -u FM_AGY_HARNESS "$TMP_ROOT/named/agy" -c '"$1"; :' _ "$ROOT/bin/fm-harness.sh")
+[ "$out" = agy ] || fail "agy ancestry must survive loss of its launch marker"
+pass 'AGY exact process ancestry and marker diverge safely'
+
+fm_control_harness_supports_kind agy ship || fail ship
+fm_control_harness_supports_kind agy scout || fail scout
+! fm_control_harness_supports_kind agy secondmate || fail secondmate
+! fm_control_harness_supports_kind agy primary || fail primary
+[ "$(fm_control_interrupt_key agy)" = Escape ] || fail interrupt
+[ "$(fm_control_interrupt_repeat agy)" = 1 ] || fail repeat
+[ "$(fm_control_exit_command agy)" = /exit ] || fail exit
+[ "$(fm_control_interrupt_ack_source agy)" = none ] || fail 'do not fabricate cancellation proof'
+! "$ROOT/bin/fm-supervision-instructions.sh" --harness agy >/dev/null 2>&1 || fail 'primary protocol must refuse AGY'
+fm_agy_backend_check tmux || fail tmux
+fm_agy_backend_check herdr || fail herdr
+for backend in zellij orca cmux codex-app unknown; do
+  ! fm_agy_backend_check "$backend" 2>/dev/null || fail "unverified AGY backend accepted: $backend"
+done
+pass 'AGY control supports only ordinary workers'
+
+case_dir="$TMP_ROOT/spawn"
+home="$case_dir/home"; proj="$case_dir/project"; wt="$case_dir/wt"
+fakebin=$(fm_test_make_spawn_fakebin "$case_dir/fake")
+cat > "$fakebin/agy" <<'SH'
+#!/usr/bin/env bash
+case "$1" in
+  --help) printf '%s\n' '  --new-project  Create project' '  --add-dir  Add workspace' '  --prompt-interactive  Prompt' '  --model  Model' '  --effort  Effort' '  --dangerously-skip-permissions  Approve' ;;
+  models) printf 'gemini-3.8-flash-low\tGemini 3.8 Flash (Low)\n' ;;
+  *) printf '%s\0' "$@" > "$FM_AGY_ARGV_LOG" ;;
+esac
+SH
+chmod +x "$fakebin/agy"
+fm_agy_preflight "$fakebin/agy" gemini-3.8-flash-low low || fail preflight
+! fm_agy_preflight "$fakebin/agy" gemini-unknown low 2>/dev/null || fail 'absent model accepted'
+! fm_agy_preflight "$fakebin/agy" default low 2>/dev/null || fail 'unpinned model accepted'
+! fm_agy_preflight "$fakebin/agy" gemini-3.8-flash-low high 2>/dev/null || fail 'effort silently switched model'
+fm_test_spawn_home "$home" agy
+fm_git_worktree "$proj" "$wt" agy-test
+fm_test_spawn_brief "$home" agy-test
+out=$(FM_FAKE_LAUNCH_LOG="$case_dir/launch.log" fm_test_run_spawn "$home" "$wt" "$fakebin" agy-test "$proj" --scout --harness agy --model gemini-3.8-flash-low --effort low)
+expect_code 0 "$?" "AGY spawn: $out"
+launch=$(<"$case_dir/launch.log")
+assert_contains "$launch" "--new-project --add-dir '$wt'" 'AGY tool workspace must be bound, not shared scratch'
+assert_contains "$launch" "--add-dir '$home/state/agy-test.agy-hook'" 'missing isolated hook workspace'
+assert_contains "$launch" "--model 'gemini-3.8-flash-low' --effort 'low'" 'model and effort flags'
+assert_contains "$launch" 'AGY_CLI_DISABLE_AUTO_UPDATE=true' 'AGY must not self-update workers'
+assert_contains "$launch" '--prompt-interactive "$(' 'prompt must be one quoted argument'
+assert_contains "$launch" 'encode launch-brief' 'typed envelope lost'
+FM_AGY_ARGV_LOG="$case_dir/argv" bash -c "$launch" || fail 'emitted launch command did not execute'
+python3 - "$case_dir/argv" "$wt" <<'PY'
+import pathlib, sys
+args = pathlib.Path(sys.argv[1]).read_bytes().decode().split('\0')[:-1]
+assert args[args.index('--add-dir') + 1] == sys.argv[2], args
+index = args.index('--prompt-interactive')
+assert index == len(args) - 2, 'the complete instruction envelope must be one final argument'
+assert 'FIRSTMATE_OP:' in args[index + 1], 'routing marker missing from prompt argument'
+assert 'Captain' in args[index + 1], 'brief contents missing from prompt argument'
+PY
+expect_code 0 "$?" 'AGY argv boundary must survive shell expansion'
+pass 'AGY spawn pins project, hooks, prompt boundary and model without global configuration edits'
+
+state="$home/state"
+gen=$(fm_busy_current_gen "$state" agy-test)
+hooks="$state/agy-test.agy-hook/.agents/hooks.json"
+pre=$(jq -r '."firstmate-worker".PreInvocation[0].command' "$hooks")
+stop=$(jq -r '."firstmate-worker".Stop[0].command' "$hooks")
+payload=$(jq -nc --arg wt "$wt" '{conversationId:"main-1",workspacePaths:[$wt],fullyIdle:true}')
+printf '%s' "$payload" | bash -c "$pre" >/dev/null
+[ "$(fm_busy_record_read "$state" agy-test | cut -d' ' -f1-2)" = 'busy agy-hook' ] || fail 'PreInvocation not busy'
+for value in false '"true"' null; do
+  printf '%s' "$payload" | jq --argjson value "$value" '.fullyIdle=$value' | bash -c "$stop" >/dev/null
+  [ ! -e "$state/agy-test.turn-ended" ] || fail 'only boolean true with no background work may close turn'
+done
+printf '%s' "$payload" | jq '.conversationId="child-1"' | bash -c "$stop" >/dev/null
+[ ! -e "$state/agy-test.turn-ended" ] || fail 'subagent must not close parent'
+printf '%s' "$payload" | jq '.workspacePaths=["/unrelated"]' | bash -c "$stop" >/dev/null
+[ ! -e "$state/agy-test.turn-ended" ] || fail 'other workspace must not close parent'
+printf '%s' "$payload" | bash -c "$stop" >/dev/null
+[ "$(fm_busy_record_read "$state" agy-test | cut -d' ' -f1-2)" = 'idle agy-hook' ] || fail 'Stop not idle'
+[ -f "$state/agy-test.turn-ended" ] || fail 'missing completion notification'
+new_gen=$("$ROOT/bin/fm-busy-event.sh" arm "$state" agy-test)
+[ "$new_gen" != "$gen" ] || fail 'generation did not change'
+rm "$state/agy-test.turn-ended"
+printf '%s' "$payload" | bash -c "$stop" >/dev/null
+[ ! -e "$state/agy-test.turn-ended" ] || fail 'stale Stop emitted completion'
+[ "$(fm_busy_record_read "$state" agy-test | cut -d' ' -f1-2)" = 'busy fm-spawn' ] || fail 'stale hook overwrote new turn'
+# Keep the retired binding deliberately: an in-flight old hook may finish
+# after cleanup. Its generation-specific file must not poison the replacement.
+printf '%s' "$payload" | jq '.conversationId="replacement-1"' | \
+  "$ROOT/bin/fm-agy-hook.sh" PreInvocation "$state" agy-test "$new_gen" "$wt" >/dev/null
+[ "$(fm_busy_record_read "$state" agy-test | cut -d' ' -f1-2)" = 'busy agy-hook' ] || fail 'old conversation binding poisoned replacement'
+paths=$(fm_control_harness_wiring_paths agy "$wt" "$state" agy-test)
+assert_contains "$paths" "$state/agy-test.agy-hook/$gen.conversation" 'retired binding cleanup missing'
+assert_contains "$paths" "$state/agy-test.agy-hook/$new_gen.conversation" 'current binding cleanup missing'
+pass 'AGY hook closes only the exact generation, workspace and parent conversation with fullyIdle true'
+
+screen=$(printf '──────────────\n> \n──────────────\n? for shortcuts Gemini 3.8 Flash · low\n')
+caps=$(printf 'styled=0\ncursor=1\nidentity=1\n')
+[ "$(fm_composer_classify_screen "$caps" "$screen" 1 $'agy\tidle')" = empty ] || fail 'AGY empty composer'
+[ "$(fm_composer_classify_screen "$caps" "$screen" 1 probe-absent)" = unknown ] || fail 'stale shell must not be empty'
+[ "$(fm_composer_classify_screen "$caps" "$screen" 1 $'agy\tworking')" = unknown ] || fail 'busy cannot prove safe empty composer'
+screen=$(printf '──────────────\n> pending instruction\n──────────────\n? for shortcuts\n')
+[ "$(fm_composer_classify_screen "$caps" "$screen" 1 $'agy\tidle')" = pending ] || fail 'AGY pending composer'
+pass 'AGY separator composer requires live identity; pending text and dead shells remain protected'

--- a/tests/fm-agy-harness.test.sh
+++ b/tests/fm-agy-harness.test.sh
@@ -76,6 +76,7 @@ assert_contains "$launch" "--new-project --add-dir '$wt'" 'AGY tool workspace mu
 assert_contains "$launch" "--add-dir '$home/state/agy-test.agy-hook'" 'missing isolated hook workspace'
 assert_contains "$launch" "--model 'gemini-3.8-flash-low' --effort 'low'" 'model and effort flags'
 assert_contains "$launch" 'AGY_CLI_DISABLE_AUTO_UPDATE=true' 'AGY must not self-update workers'
+# shellcheck disable=SC2016 # Assert the literal command-substitution boundary.
 assert_contains "$launch" '--prompt-interactive "$(' 'prompt must be one quoted argument'
 assert_contains "$launch" 'encode launch-brief' 'typed envelope lost'
 FM_AGY_ARGV_LOG="$case_dir/argv" bash -c "$launch" || fail 'emitted launch command did not execute'

--- a/tests/fm-agy-signals-live-e2e.test.sh
+++ b/tests/fm-agy-signals-live-e2e.test.sh
@@ -1,0 +1,238 @@
+#!/usr/bin/env bash
+# Opt-in real AGY guard. FM_AGY_BACKEND=tmux (default) uses a private socket;
+# herdr uses fm-herdr-lab.sh exclusively, with its default-fleet tripwire.
+# Both use a scratch repository, never fm-spawn or a live fleet endpoint. Submits
+# trivial prompts and verifies actual tools, native hooks, follow-up delivery,
+# process identity, composer, interruption and exit. No account/config edits.
+# FM_AGY_LIVE=1 (or FM_LIVE=1) forces the guard, including explicit missing-tool,
+# unsupported-model/capability and authentication failures. FM_AGY_MODEL pins a
+# catalog model (default gemini-3.8-flash-low); FM_AGY_EFFORT defaults to low.
+# FM_AGY_HERDR_LAB_HELPER optionally selects the task brief's helper path.
+set -eu
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+BACKEND=${FM_AGY_BACKEND:-tmux}
+case "$BACKEND" in tmux|herdr) ;; *) fail "unsupported AGY live backend: $BACKEND" ;; esac
+fm_live_gate opt-in FM_AGY_LIVE "$BACKEND" jq python3 agy
+# shellcheck source=bin/fm-agy-lib.sh
+. "$ROOT/bin/fm-agy-lib.sh"
+# shellcheck source=bin/fm-busy-lib.sh
+. "$ROOT/bin/fm-busy-lib.sh"
+# shellcheck source=bin/fm-tmux-lib.sh
+. "$ROOT/bin/fm-tmux-lib.sh"
+# shellcheck source=bin/fm-control-lib.sh
+. "$ROOT/bin/fm-control-lib.sh"
+AGY=$(command -v agy)
+VERSION=$("$AGY" --version)
+MODEL=${FM_AGY_MODEL:-gemini-3.8-flash-low}
+EFFORT=${FM_AGY_EFFORT:-low}
+printf 'AGY live version=%s model=%s effort=%s\n' "$VERSION" "$MODEL" "$EFFORT"
+fm_agy_preflight "$AGY" "$MODEL" "$EFFORT" || fail "AGY $VERSION unsupported capability/model"
+LAB=$(mktemp -d "${TMPDIR:-/tmp}/fm-agy-live.XXXXXX")
+SOCKET="$LAB/tmux.sock"
+HERDR_LAB_HELPER=${FM_AGY_HERDR_LAB_HELPER:-$ROOT/bin/fm-herdr-lab.sh}
+HERDR_LAB_SESSION=
+cleanup() {
+  local code=$?
+  if [ "$code" -ne 0 ]; then
+    capture > "$LAB/failed-screen.txt" 2>/dev/null || true
+    printf 'AGY failed lab evidence preserved at %s\n' "$LAB" >&2
+  fi
+  if [ "$BACKEND" = herdr ] && [ -n "$HERDR_LAB_SESSION" ]; then
+    "$HERDR_LAB_HELPER" teardown "$HERDR_LAB_SESSION" || exit 1
+  else
+    command tmux -S "$SOCKET" kill-server 2>/dev/null || true
+  fi
+  [ "$code" -ne 0 ] || rm -rf -- "$LAB"
+}
+trap cleanup EXIT
+mkdir -p "$LAB/project" "$LAB/state/live.agy-hook/.agents" "$LAB/external"
+git -C "$LAB/project" init -q
+WT=$(cd "$LAB/project" && pwd -P)
+STATE=$(cd "$LAB/state" && pwd -P)
+GEN=$("$ROOT/bin/fm-busy-event.sh" arm "$STATE" live)
+write_hooks() {
+python3 - "$ROOT" "$STATE" "$GEN" "$WT" <<'PY'
+import json,pathlib,shlex,sys
+root,state,gen,wt=sys.argv[1:]
+hooks={}
+for event in ['PreInvocation','Stop']:
+    cmd=shlex.join([root+'/bin/fm-agy-hook.sh',event,state,'live',gen,wt])
+    hooks[event]=[{'command':cmd,'timeout':10}]
+pathlib.Path(state+'/live.agy-hook/.agents/hooks.json').write_text(json.dumps({'firstmate-worker':hooks}))
+PY
+}
+write_hooks
+# A real model call, not version/catalog presence, proves authentication.
+if ! (cd "$WT" && AGY_CLI_DISABLE_AUTO_UPDATE=true "$AGY" --model "$MODEL" --effort "$EFFORT" \
+  --print-timeout 45s --output-format json --print 'Reply exactly AUTH_OK. Do not use tools.') > "$LAB/auth.json" 2> "$LAB/auth.stderr"; then
+  # Never print OAuth continuation URLs, account identifiers or tokens.
+  fail "AGY $VERSION actual prompt failed; verify AGY account eligibility/authentication and connectivity interactively"
+fi
+jq -e '.status == "SUCCESS" and (.response | rtrimstr("\n")) == "AUTH_OK"' "$LAB/auth.json" >/dev/null \
+  || fail "AGY $VERSION authentication probe did not produce AUTH_OK"
+pass "AGY $VERSION actual prompt executes successfully"
+
+# One shell command is constructed as a single argv vector, matching the
+# canonical interactive adapter flags without changing an operator's settings.
+python3 - "$AGY" "$WT" "$STATE" "$MODEL" "$EFFORT" "$ROOT" "$LAB" <<'PY'
+import pathlib,shlex,sys
+agy,wt,state,model,effort,root,lab=sys.argv[1:]
+prompt=('Use your run_command tool to run exactly: pwd -P > '+shlex.quote(wt+'/cwd.txt')+
+        '; '+shlex.quote(root+'/bin/fm-harness.sh')+' > '+shlex.quote(wt+'/identity.txt')+
+        '; printf AGY_FIRST_OK > '+shlex.quote(wt+'/first.txt')+
+        '. Do not inspect other files, delegate, or change anything else. Stop after the command.')
+args=['env','-u','CLAUDECODE','-u','PI_CODING_AGENT','-u','GROK_AGENT','-u','FM_PI_HARNESS',
+      '-u','GEMINI_CLI','-u','CURSOR_AGENT','-u','CURSOR_INVOKED_AS','-u','ATLASSIAN_AGENT_TYPE',
+      '-u','ROVODEV_CLI','-u','FM_OMP_HARNESS','FM_AGY_HARNESS=agy','AGY_CLI_DISABLE_AUTO_UPDATE=true',
+      agy,'--new-project','--add-dir',wt,'--add-dir',state+'/live.agy-hook',
+      '--dangerously-skip-permissions','--model',model,'--effort',effort,
+      '--prompt-interactive',prompt]
+pathlib.Path(lab+'/launch.sh').write_text('#!/bin/bash\n'+shlex.join(args)+'\nexec /bin/bash --noprofile --norc\n')
+PY
+# shellcheck source=bin/fm-backend.sh
+. "$ROOT/bin/fm-backend.sh"
+fm_backend_source "$BACKEND"
+if [ "$BACKEND" = tmux ]; then
+  command tmux -S "$SOCKET" -f /dev/null new-session -d -s agy -n proof -x 130 -y 40 -c "$WT" "bash '$LAB/launch.sh'"
+  command tmux -S "$SOCKET" set-window-option -t agy:proof automatic-rename off
+  tmux() { command tmux -S "$SOCKET" "$@"; }
+  capture() { tmux capture-pane -p -t agy; }
+  send_text() { tmux send-keys -t agy -l "$1"; }
+  send_key() { tmux send-keys -t agy "$1"; }
+  composer() { fm_tmux_composer_state agy; }
+  identity() { fm_tmux_composer_identity agy; }
+  agent_state() { fm_backend_tmux_agent_state agy:proof; }
+else
+  HERDR_LAB_SESSION=$("$HERDR_LAB_HELPER" name fm-agy-adapter)
+  "$HERDR_LAB_HELPER" provision "$HERDR_LAB_SESSION"
+  # Every Herdr call, including the backend library's capture/identity/key
+  # reads, goes through the named-lab helper with its trailing session binding.
+  fm_backend_herdr_cli() {
+    [ "$1" = "$HERDR_LAB_SESSION" ] || return 1
+    shift
+    "$HERDR_LAB_HELPER" run "$HERDR_LAB_SESSION" "$@"
+  }
+  created=$("$HERDR_LAB_HELPER" run "$HERDR_LAB_SESSION" workspace create --cwd "$WT" --label agy-proof --no-focus)
+  PANE=$(printf '%s' "$created" | jq -er '.result.root_pane.pane_id')
+  TARGET="$HERDR_LAB_SESSION:$PANE"
+  "$HERDR_LAB_HELPER" run "$HERDR_LAB_SESSION" pane run "$PANE" "bash '$LAB/launch.sh'" >/dev/null
+  capture() { fm_backend_herdr_capture "$TARGET" 40; }
+  send_text() { fm_backend_herdr_send_literal "$TARGET" "$1"; }
+  send_key() { fm_backend_herdr_send_key "$TARGET" "$1"; }
+  composer() { fm_backend_herdr_composer_state "$TARGET"; }
+  identity() { fm_backend_herdr_composer_identity "$TARGET"; }
+  agent_state() { fm_backend_herdr_agent_state "$TARGET"; }
+fi
+# Only the documented folder-trust choice is allowed. A new isolated path may
+# prompt even under --dangerously-skip-permissions; no credential field is typed.
+accept_folder_trust() {
+  local i pane
+  for i in $(seq 1 120); do
+    pane=$(capture)
+    if printf '%s' "$pane" | grep -Fq 'Do you trust the contents of this project?'; then
+      send_key Enter
+      break
+    fi
+    [ ! -f "$WT/first.txt" ] || break
+    sleep 0.5
+  done
+}
+accept_folder_trust
+wait_file() {
+  local path=$1 i
+  for i in $(seq 1 180); do
+    [ ! -s "$path" ] || return 0
+    sleep 0.5
+  done
+  fail "AGY $VERSION did not produce $(basename "$path") in the isolated lab"
+}
+wait_idle() {
+  local i
+  for i in $(seq 1 120); do
+    if [ "$(fm_busy_record_read "$STATE" live | cut -d' ' -f1-2)" = 'idle agy-hook' ] \
+       && [ "$(composer)" = empty ]; then return 0; fi
+    sleep 0.5
+  done
+  printf 'AGY diagnostics: record=%s composer=%s identity=%s\n' \
+    "$(fm_busy_record_read "$STATE" live)" "$(composer)" "$(identity || true)" >&2
+  fail "AGY $VERSION did not settle through its native Stop and live composer"
+}
+wait_file "$WT/first.txt"
+wait_idle
+[ "$(<"$WT/first.txt")" = AGY_FIRST_OK ] || fail 'first tool write differs'
+[ "$(<"$WT/cwd.txt")" = "$WT" ] || fail 'AGY tools escaped the isolated working directory'
+[ "$(<"$WT/identity.txt")" = agy ] || fail 'real AGY tool process was misidentified'
+[ -f "$STATE/live.turn-ended" ] || fail 'AGY native completion notification missing'
+[ "$(agent_state)" = alive ] || fail 'backend could not attribute the real AGY process'
+pass "AGY $VERSION interactive prompt executes tools in the isolated workspace, detects agy and settles native hooks"
+
+# The same literal text + Enter transport fm-send uses. Verify the produced
+# external report, never the return value of send-keys or echoed prompt text.
+send_text "Use run_command to run exactly: printf AGY_FOLLOW_OK > '$LAB/external/report.txt'. Do not inspect other files or delegate. Stop after the command."
+send_key Enter
+wait_file "$LAB/external/report.txt"
+wait_idle
+[ "$(<"$LAB/external/report.txt")" = AGY_FOLLOW_OK ] || fail 'external reporting failed'
+pass "AGY $VERSION follow-up steering performs external task reporting and completes"
+
+# A bounded slow tool provides a genuine active-turn cancellation window.
+send_text "Use run_command to run exactly: touch '$WT/slow-started'; sleep 20. Wait for it to finish. Do not delegate."
+send_key Enter
+for _ in $(seq 1 120); do
+  [ ! -e "$WT/slow-started" ] || break
+  sleep 0.5
+done
+[ -e "$WT/slow-started" ] || fail 'AGY did not start the slow tool'
+[ "$(fm_busy_record_read "$STATE" live | cut -d' ' -f1-2)" = 'busy agy-hook' ] || fail 'real active tool lacked native busy state'
+send_key "$(fm_control_interrupt_key agy)"
+for _ in $(seq 1 120); do
+  pane=$(capture)
+  if printf '%s' "$pane" | grep -Fq 'Interrupted' && [ "$(composer)" = empty ]; then break; fi
+  sleep 0.5
+done
+printf '%s' "$pane" | grep -Fq 'Interrupted' || fail 'AGY did not acknowledge Escape'
+[ "$(composer)" = empty ] || fail 'Escape left input behind'
+# A fresh turn proves the process survived; no cancellation claim relies only
+# on a vendor banner, spinner or process presence.
+send_text "Use run_command to run exactly: printf AGY_AFTER_CANCEL > '$WT/after.txt'. Stop after the command."
+send_key Enter
+wait_file "$WT/after.txt"
+wait_idle
+pass "AGY $VERSION Escape interrupts, clears the composer and accepts subsequent work"
+send_text "$(fm_control_exit_command agy)"
+send_key Enter
+for _ in $(seq 1 60); do
+  if ! identity 2>/dev/null | grep -q '^agy'; then break; fi
+  sleep 0.5
+done
+! identity 2>/dev/null | grep -q '^agy' || fail 'AGY remained alive after /exit'
+[ "$(composer)" = unknown ] || fail 'exited AGY still looks like an empty agent composer'
+pass "AGY $VERSION /exit stops only the lab agent and stale shell input stays protected"
+
+# Deterministic recovery starts the same durable instructions in the preserved
+# directory, with fresh hook custody. The old conversation binding is retained
+# deliberately to prove it cannot settle or poison this replacement.
+old_gen=$GEN
+GEN=$("$ROOT/bin/fm-busy-event.sh" arm "$STATE" live)
+[ "$GEN" != "$old_gen" ] || fail 'relaunch generation did not change'
+write_hooks
+mv "$WT/first.txt" "$WT/first-before-relaunch.txt"
+rm "$STATE/live.turn-ended"
+send_text "bash '$LAB/launch.sh'"
+send_key Enter
+accept_folder_trust
+wait_file "$WT/first.txt"
+wait_idle
+[ "$(<"$WT/first.txt")" = AGY_FIRST_OK ] || fail 'relaunch instructions were not processed'
+[ "$(<"$WT/cwd.txt")" = "$WT" ] || fail 'relaunch changed tool workspace'
+[ -s "$STATE/live.agy-hook/$GEN.conversation" ] || fail 'replacement conversation was not bound'
+[ -f "$STATE/live.turn-ended" ] || fail 'replacement completion notification missing'
+send_text "$(fm_control_exit_command agy)"
+send_key Enter
+for _ in $(seq 1 60); do
+  if ! identity 2>/dev/null | grep -q '^agy'; then break; fi
+  sleep 0.5
+done
+! identity 2>/dev/null | grep -q '^agy' || fail 'replacement remained alive after /exit'
+pass "AGY $VERSION deterministic relaunch preserves the workspace and completes with fresh hook custody"

--- a/tests/fm-control-relaunch.test.sh
+++ b/tests/fm-control-relaunch.test.sh
@@ -299,6 +299,37 @@ SH
 
 # --- 1. same-harness relaunch -----------------------------------------------
 
+test_agy_profile_refuses_before_stop_and_retires_wiring() {
+  local dir out rc gen
+  dir=$(new_case agy-profile rl-agy)
+  add_ship_task "$dir" rl-agy claude
+  cat > "$dir/fakebin/agy" <<'SH'
+#!/usr/bin/env bash
+case "$1" in
+  --help) printf '%s\n' '  --new-project ' '  --add-dir ' '  --prompt-interactive ' '  --model ' '  --effort ' '  --dangerously-skip-permissions ' ;;
+  models) printf 'gemini-3.8-flash-low\tGemini Flash Low\n' ;;
+esac
+SH
+  chmod +x "$dir/fakebin/agy"
+  out=$(run_control "$dir" rl-agy relaunch --harness agy --note 'continue bounded work'); rc=$?
+  expect_code 1 "$rc" 'AGY requires a model before stopping the current agent'
+  assert_contains "$out" 'require an explicit Gemini model' 'missing AGY profile diagnostic'
+  [ ! -s "$dir/fake/literal" ] && [ ! -s "$dir/fake/keys" ] || fail 'invalid AGY profile stopped the current agent'
+  printf agy > "$dir/fake/becomes"
+  out=$(run_control "$dir" rl-agy relaunch --harness agy --model gemini-3.8-flash-low --effort low --note 'continue bounded work'); rc=$?
+  expect_code 0 "$rc" "verified AGY profile should relaunch: $out"
+  gen=$(meta_field "$dir" rl-agy busy_gen)
+  [ -n "$gen" ] || fail 'AGY relaunch did not arm busy generation'
+  [ -s "$dir/home/state/rl-agy.agy-hook/.agents/hooks.json" ] || fail 'AGY relaunch lacks hook wiring'
+  printf '%s\tmain-1\n' "$gen" > "$dir/home/state/rl-agy.agy-hook/$gen.conversation"
+  printf claude > "$dir/fake/becomes"
+  out=$(run_control "$dir" rl-agy relaunch --harness claude --note 'preserve work on another adapter'); rc=$?
+  expect_code 0 "$rc" "switching away from AGY should preserve work: $out"
+  [ ! -e "$dir/home/state/rl-agy.agy-hook/$gen.conversation" ] || fail 'AGY conversation binding survived retirement'
+  [ ! -e "$dir/home/state/rl-agy.agy-hook/.agents/hooks.json" ] || fail 'AGY hooks survived retirement'
+  pass 'AGY relaunch refuses missing profiles before stop and retires old wiring on replacement'
+}
+
 test_same_harness_relaunch_keeps_identity_and_reuses_the_endpoint() {
   local dir out rc gen_before gen_after
   dir=$(new_case same rl1)
@@ -1558,6 +1589,7 @@ test_relaunch_moves_a_drifted_item_back_in_flight() {
   pass "relaunch heals an item that drifted out of In flight while the task stayed live"
 }
 
+test_agy_profile_refuses_before_stop_and_retires_wiring
 test_same_harness_relaunch_keeps_identity_and_reuses_the_endpoint
 test_relaunch_from_linked_home_preserves_recorded_worktree
 test_relaunch_preserves_durable_task_metadata

--- a/tests/fm-control.test.sh
+++ b/tests/fm-control.test.sh
@@ -35,7 +35,7 @@ mkdir -p "$TMP_ROOT"
 TMP_ROOT=$(cd "$TMP_ROOT" && pwd)
 trap 'rm -rf "$TMP_ROOT"' EXIT
 
-VERIFIED_HARNESSES="claude codex opencode pi pi-signed grok kimi cursor muse omp"
+VERIFIED_HARNESSES="claude codex opencode pi pi-signed grok kimi cursor muse omp agy"
 
 # The expectation table, written out independently of the implementation so a
 # silent change to either side shows up here. The fourth field is the composer
@@ -53,6 +53,7 @@ verified_adapter_contract() {  # <harness> -> exit command, interrupt key, repea
     kimi) printf '/exit\tEscape\t1\t\n' ;;
     cursor) printf '/exit\tEscape\t1\t\n' ;;
     muse) printf '/exit\tEscape\t1\tC-u\n' ;;
+    agy) printf '/exit\tEscape\t1\t\n' ;;
     *) return 1 ;;
   esac
 }
@@ -268,7 +269,7 @@ test_harness_family_resolution() {
   for pair in claude:claude claude-latest:claude codex:codex codex-cli:codex \
       opencode:opencode grok:grok grok-2:grok kimi:kimi cursor:cursor \
       cursor-agent:cursor muse:muse muse-bin-0.1.0:muse pi:pi \
-      pi-signed:pi-signed omp:omp; do
+      pi-signed:pi-signed omp:omp agy:agy; do
     recorded=${pair%%:*}
     want=${pair#*:}
     got=$(fm_control_harness_family "$recorded") \


### PR DESCRIPTION
Add an Antigravity CLI (agy) adapter so AGY can run as a Firstmate ship/scout worker for tasks whose difficulty matches Gemini Flash-class models.

## Intent

Use AGY as a worker for bounded, well-specified work at Flash-class capability (for example catalog IDs such as `gemini-3.8-flash-low` / `medium` / `high`). Primary and secondmate support stay out of scope.

## What changed

- Detect, launch, steer, and control AGY workers through the existing adapter owners.
- Model IDs come from AGY's own catalog; no silent alias of an undocumented `3.8 flash` string.
- Portable regressions plus an opt-in live AGY guard with explicit absent/auth/unsupported outcomes.
- Docs and dispatch-profile example for Flash-class routing; live fleet dispatch config is unchanged.

## Notes

- Branch is rebased onto current `main` (`ad14a8d`).
- Source: personal fork `thienduy2211/firstmate` branch `fm/fm-agy-adapter`.
- Please do not merge this PR from this request; merge authority stays with the maintainer.
