### PR TITLE
fix(composer): ignore Pi vim footer rows

### DIFF
--- a/bin/fm-composer-lib.sh
+++ b/bin/fm-composer-lib.sh
@@ -418,8 +418,7 @@ FM_COMPOSER_OMP_STATUS_RE_DEFAULT='^[[:space:]]*(π|󰵗)[[:space:]]+·[[:space:
 # pane idle, showing exactly `─ INSERT 1:1 ─` - a single rule glyph, the mode,
 # the caret parked at the origin cell, a single rule glyph. That is the row that
 # made an idle pi read `pending` and skipped its doorbell (issue #3819). It is
-# terminal furniture, not typed text, so pi's row scan and the content extractor
-# both skip it.
+# terminal furniture, not typed text, so pi's row scan skips it.
 # The pattern accepts that shape and nothing wider, because pi's row scan treats
 # EVERY other surviving byte in the region as input (even a lone prompt glyph is
 # a draft there): a wider rule-framed match would read a draft that merely opens
@@ -1003,9 +1002,9 @@ _fm_composer_row_is_omp_status() {  # <trimmed-row>
 
 # _fm_composer_row_is_pi_status: 0 when the row is pi-vimmode's mode row
 # (FM_COMPOSER_PI_STATUS_RE_DEFAULT above) - furniture inside pi's separated
-# region. Callers pass the row's CLASSIFICATION content, never the plain row,
-# so ghost stripping has already had its say and bytes that survive styling are
-# judged as the input they are.
+# region. The caller passes the row's CLASSIFICATION content, never the plain
+# row, so ghost stripping has already had its say and bytes that survive styling
+# are judged as the input they are.
 _fm_composer_row_is_pi_status() {  # <row-content>
   fm_composer_idle_matches "$1" "${FM_COMPOSER_PI_STATUS_RE:-$FM_COMPOSER_PI_STATUS_RE_DEFAULT}" sensitive
 }
@@ -1249,12 +1248,8 @@ EOF
     # (the zellij paste proof depends on observing exactly what was typed).
     # OpenCode's left-bar hint and legacy shell-glyph boxed placeholders have no
     # such styling proof, so their structurally fixed positions remain the two
-    # idle-regex exceptions here. Pi's separated region carries a third piece of
-    # harness furniture, pi-vimmode's mode row, and the same predicate that
-    # keeps it out of pi's verdict keeps it out of the extracted content.
+    # idle-regex exceptions here.
     if [ -z "$content" ] \
-       || { [ "$FM_COMPOSER_SELECTED_KIND" = pi ] \
-            && _fm_composer_row_is_pi_status "$content"; } \
        || { { [ "$FM_COMPOSER_SELECTED_KIND" = leftbar ] \
               || { [ "$FM_COMPOSER_SELECTED_KIND" = box ] && [ "$prompt_is_shell" = 1 ]; }; } \
             && [ "$placeholder_position" = 1 ] \

--- a/bin/fm-composer-lib.sh
+++ b/bin/fm-composer-lib.sh
@@ -1383,11 +1383,22 @@ fm_composer_queued_enter_verdict() {  # <composer-state> <busy|idle|unknown>
   fi
 }
 
+# Pi's vim-mode extension can render a status/footer row inside the separated
+# region (for example `─ INSERT 1:1 ─`). It is terminal furniture, not user
+# input, and must not defeat an idle/done identity floor.
 _fm_composer_classify_pi_rows() {  # <screen> <styled>
-  local screen=$1 styled=$2 row raw content
+  local screen=$1 styled=$2 row raw content trimmed
   row=$((FM_COMPOSER_SCAN_PI_OPEN + 1))
   while [ "$row" -lt "$FM_COMPOSER_SCAN_PI_CLOSE" ]; do
     raw=$(_fm_composer_screen_row "$row" "$screen")
+    trimmed=$(printf '%s' "$raw" | fm_composer_strip_ansi)
+    fm_composer_normalize_trim_var trimmed
+    # The pi-vimmode footer is framed by the same rule glyph on both sides.
+    # Require both edges so real input that merely contains or ends with a
+    # separator glyph is not discarded as furniture.
+    case "$trimmed" in
+      '─'*'─') row=$((row + 1)); continue ;;
+    esac
     content=$(_fm_composer_row_content "$raw" "$styled")
     fm_composer_normalize_trim_var content
     if [ -n "$content" ]; then

--- a/bin/fm-composer-lib.sh
+++ b/bin/fm-composer-lib.sh
@@ -414,20 +414,26 @@ FM_COMPOSER_LEFTBAR_FOOTER_RE_DEFAULT='^(Build|Plan)[[:space:]]+·[[:space:]]+'
 FM_COMPOSER_OMP_STATUS_RE_DEFAULT='^[[:space:]]*(π|󰵗)[[:space:]]+·[[:space:]]|^[[:space:]]*'"$FM_OMP_SPINNER_FRAMES_RE"'[[:space:]]+[0-9]+[smh]([[:space:]]|$)|[[:space:]]·[[:space:]].*[0-9]+(\.[0-9]+)?%/[0-9]+K'
 
 # The `pi-vimmode` extension draws a mode row INSIDE pi's separated composer
-# region: the rule glyph, the vim mode, an optional `line:column` cursor cell,
-# then the rule glyph again. Verified live on pi 0.84.4 through Herdr as
-# `─ INSERT 1:1 ─` with the composer empty and the pane idle - the row that
-# made an idle pi read `pending` and skipped its doorbell (issue #3819).
-# It is terminal furniture, not typed text, so pi's row scan and the content
-# extractor both skip it.
-# The pattern is deliberately anchored on the full row and demands a real vim
-# mode token: pi's row scan treats EVERY other surviving byte as input (even a
-# lone prompt glyph is a draft there), so a looser rule-framed match would read
-# a draft that merely opens and closes with `─` as an empty composer and let a
-# doorbell overwrite it. FM_COMPOSER_PI_STATUS_RE overrides for an unverified
-# pi-vimmode render; matching is case-sensitive because vim's own mode labels
-# are upper-case and lower-case prose is user input.
-FM_COMPOSER_PI_STATUS_RE_DEFAULT='^─+[[:space:]]+(NORMAL|INSERT|VISUAL|VISUAL LINE|VISUAL BLOCK|REPLACE)([[:space:]]+[0-9]+:[0-9]+)?[[:space:]]+─+$'
+# region. ONE render is verified: pi 0.84.4 through Herdr, composer empty and
+# pane idle, showing exactly `─ INSERT 1:1 ─` - a single rule glyph, the mode,
+# the `line:column` cursor cell, a single rule glyph. That is the row that made
+# an idle pi read `pending` and skipped its doorbell (issue #3819). It is
+# terminal furniture, not typed text, so pi's row scan and the content extractor
+# both skip it.
+# The pattern accepts that shape and nothing wider, because pi's row scan treats
+# EVERY other surviving byte in the region as input (even a lone prompt glyph is
+# a draft there): a wider rule-framed match would read a draft that merely opens
+# and closes with `─` as an EMPTY composer and let a doorbell overwrite unsent
+# text. Unmatched furniture only defers a ring, which the watcher retries, so
+# narrow is the fail-safe direction and other mode labels, other rule widths,
+# and a missing cursor cell stay deliberately unaccepted;
+# FM_COMPOSER_PI_STATUS_RE overrides for a pane that renders differently.
+# The rule glyph is matched literally and never quantified, for the same reason
+# FM_COMPOSER_OMP_STATUS_RE_DEFAULT and FM_OMP_SPINNER_FRAMES_RE use literal
+# alternation: `grep -E` compiles a quantified multibyte glyph byte-wise under a
+# non-UTF-8 locale, which is how a verdict starts differing between a UTF-8
+# shell and a LC_ALL=C daemon (issue #1988).
+FM_COMPOSER_PI_STATUS_RE_DEFAULT='^─[[:space:]]+INSERT[[:space:]]+[0-9]+:[0-9]+[[:space:]]+─$'
 
 # The bounded row window adapters should capture for a composer read. One
 # shared policy (previously three per-backend variables that had drifted to

--- a/bin/fm-composer-lib.sh
+++ b/bin/fm-composer-lib.sh
@@ -413,6 +413,22 @@ FM_COMPOSER_LEFTBAR_FOOTER_RE_DEFAULT='^(Build|Plan)[[:space:]]+·[[:space:]]+'
 # never on the composer row itself.
 FM_COMPOSER_OMP_STATUS_RE_DEFAULT='^[[:space:]]*(π|󰵗)[[:space:]]+·[[:space:]]|^[[:space:]]*'"$FM_OMP_SPINNER_FRAMES_RE"'[[:space:]]+[0-9]+[smh]([[:space:]]|$)|[[:space:]]·[[:space:]].*[0-9]+(\.[0-9]+)?%/[0-9]+K'
 
+# The `pi-vimmode` extension draws a mode row INSIDE pi's separated composer
+# region: the rule glyph, the vim mode, an optional `line:column` cursor cell,
+# then the rule glyph again. Verified live on pi 0.84.4 through Herdr as
+# `─ INSERT 1:1 ─` with the composer empty and the pane idle - the row that
+# made an idle pi read `pending` and skipped its doorbell (issue #3819).
+# It is terminal furniture, not typed text, so pi's row scan and the content
+# extractor both skip it.
+# The pattern is deliberately anchored on the full row and demands a real vim
+# mode token: pi's row scan treats EVERY other surviving byte as input (even a
+# lone prompt glyph is a draft there), so a looser rule-framed match would read
+# a draft that merely opens and closes with `─` as an empty composer and let a
+# doorbell overwrite it. FM_COMPOSER_PI_STATUS_RE overrides for an unverified
+# pi-vimmode render; matching is case-sensitive because vim's own mode labels
+# are upper-case and lower-case prose is user input.
+FM_COMPOSER_PI_STATUS_RE_DEFAULT='^─+[[:space:]]+(NORMAL|INSERT|VISUAL|VISUAL LINE|VISUAL BLOCK|REPLACE)([[:space:]]+[0-9]+:[0-9]+)?[[:space:]]+─+$'
+
 # The bounded row window adapters should capture for a composer read. One
 # shared policy (previously three per-backend variables that had drifted to
 # 20/20/200): the composer is bottom-anchored, so a small tail window is
@@ -972,6 +988,15 @@ _fm_composer_row_is_omp_status() {  # <trimmed-row>
   fm_composer_idle_matches "$1" "${FM_COMPOSER_OMP_STATUS_RE:-$FM_COMPOSER_OMP_STATUS_RE_DEFAULT}" sensitive
 }
 
+# _fm_composer_row_is_pi_status: 0 when the row is pi-vimmode's mode row
+# (FM_COMPOSER_PI_STATUS_RE_DEFAULT above) - furniture inside pi's separated
+# region. Callers pass the row's CLASSIFICATION content, never the plain row,
+# so ghost stripping has already had its say and bytes that survive styling are
+# judged as the input they are.
+_fm_composer_row_is_pi_status() {  # <row-content>
+  fm_composer_idle_matches "$1" "${FM_COMPOSER_PI_STATUS_RE:-$FM_COMPOSER_PI_STATUS_RE_DEFAULT}" sensitive
+}
+
 # _fm_composer_wrap_region_ok: 0 when every row STRICTLY BELOW <glyph-row>
 # through <cursor-row> is non-blank and carries no structural edge - the
 # contiguity proof that those rows are the bare composer's wrapped input
@@ -1211,8 +1236,12 @@ EOF
     # (the zellij paste proof depends on observing exactly what was typed).
     # OpenCode's left-bar hint and legacy shell-glyph boxed placeholders have no
     # such styling proof, so their structurally fixed positions remain the two
-    # idle-regex exceptions here.
+    # idle-regex exceptions here. Pi's separated region carries a third piece of
+    # harness furniture, pi-vimmode's mode row, and the same predicate that
+    # keeps it out of pi's verdict keeps it out of the extracted content.
     if [ -z "$content" ] \
+       || { [ "$FM_COMPOSER_SELECTED_KIND" = pi ] \
+            && _fm_composer_row_is_pi_status "$content"; } \
        || { { [ "$FM_COMPOSER_SELECTED_KIND" = leftbar ] \
               || { [ "$FM_COMPOSER_SELECTED_KIND" = box ] && [ "$prompt_is_shell" = 1 ]; }; } \
             && [ "$placeholder_position" = 1 ] \
@@ -1383,25 +1412,20 @@ fm_composer_queued_enter_verdict() {  # <composer-state> <busy|idle|unknown>
   fi
 }
 
-# Pi's vim-mode extension can render a status/footer row inside the separated
-# region (for example `─ INSERT 1:1 ─`). It is terminal furniture, not user
-# input, and must not defeat an idle/done identity floor.
+# _fm_composer_classify_pi_rows: pi's separated-region row scan. Pi's region is
+# identity-proven rather than border-proven, so unlike the box shape EVERY
+# surviving byte there is input - including a lone prompt glyph, which is a
+# real pi draft. The one exception is pi-vimmode's own mode row, which the
+# harness draws into that region and which must not defeat an idle/done
+# identity floor (issue #3819).
 _fm_composer_classify_pi_rows() {  # <screen> <styled>
-  local screen=$1 styled=$2 row raw content trimmed
+  local screen=$1 styled=$2 row raw content
   row=$((FM_COMPOSER_SCAN_PI_OPEN + 1))
   while [ "$row" -lt "$FM_COMPOSER_SCAN_PI_CLOSE" ]; do
     raw=$(_fm_composer_screen_row "$row" "$screen")
-    trimmed=$(printf '%s' "$raw" | fm_composer_strip_ansi)
-    fm_composer_normalize_trim_var trimmed
-    # The pi-vimmode footer is framed by the same rule glyph on both sides.
-    # Require both edges so real input that merely contains or ends with a
-    # separator glyph is not discarded as furniture.
-    case "$trimmed" in
-      '─'*'─') row=$((row + 1)); continue ;;
-    esac
     content=$(_fm_composer_row_content "$raw" "$styled")
     fm_composer_normalize_trim_var content
-    if [ -n "$content" ]; then
+    if [ -n "$content" ] && ! _fm_composer_row_is_pi_status "$content"; then
       printf 'pending'
       return 0
     fi

--- a/bin/fm-composer-lib.sh
+++ b/bin/fm-composer-lib.sh
@@ -416,8 +416,8 @@ FM_COMPOSER_OMP_STATUS_RE_DEFAULT='^[[:space:]]*(π|󰵗)[[:space:]]+·[[:space:
 # The `pi-vimmode` extension draws a mode row INSIDE pi's separated composer
 # region. ONE render is verified: pi 0.84.4 through Herdr, composer empty and
 # pane idle, showing exactly `─ INSERT 1:1 ─` - a single rule glyph, the mode,
-# the `line:column` cursor cell, a single rule glyph. That is the row that made
-# an idle pi read `pending` and skipped its doorbell (issue #3819). It is
+# the caret parked at the origin cell, a single rule glyph. That is the row that
+# made an idle pi read `pending` and skipped its doorbell (issue #3819). It is
 # terminal furniture, not typed text, so pi's row scan and the content extractor
 # both skip it.
 # The pattern accepts that shape and nothing wider, because pi's row scan treats
@@ -428,12 +428,19 @@ FM_COMPOSER_OMP_STATUS_RE_DEFAULT='^[[:space:]]*(π|󰵗)[[:space:]]+·[[:space:
 # narrow is the fail-safe direction and other mode labels, other rule widths,
 # and a missing cursor cell stay deliberately unaccepted;
 # FM_COMPOSER_PI_STATUS_RE overrides for a pane that renders differently.
+# The caret cell is matched LITERALLY at `1:1` rather than as any `line:column`,
+# because a caret anywhere else is positive evidence the composer holds text.
+# The row scan needs no help reading a visible draft - the draft's own row
+# returns `pending` - so accepting a moved caret buys nothing and costs the one
+# case where it is the LAST evidence left: a de-emphasised draft that
+# fm_composer_strip_ghost removes leaves `─ INSERT 1:14 ─` as the only surviving
+# row, and reading that `empty` would type a doorbell over 13 unsent characters.
 # The rule glyph is matched literally and never quantified, for the same reason
 # FM_COMPOSER_OMP_STATUS_RE_DEFAULT and FM_OMP_SPINNER_FRAMES_RE use literal
 # alternation: `grep -E` compiles a quantified multibyte glyph byte-wise under a
 # non-UTF-8 locale, which is how a verdict starts differing between a UTF-8
 # shell and a LC_ALL=C daemon (issue #1988).
-FM_COMPOSER_PI_STATUS_RE_DEFAULT='^─[[:space:]]+INSERT[[:space:]]+[0-9]+:[0-9]+[[:space:]]+─$'
+FM_COMPOSER_PI_STATUS_RE_DEFAULT='^─[[:space:]]+INSERT[[:space:]]+1:1[[:space:]]+─$'
 
 # The bounded row window adapters should capture for a composer read. One
 # shared policy (previously three per-backend variables that had drifted to

--- a/docs/herdr-backend.md
+++ b/docs/herdr-backend.md
@@ -260,6 +260,7 @@ Herdr has no direct cursor-row primitive.
 The adapter is a thin capture: it hands a bounded ANSI tail plus Herdr's capability facts to the fleet-wide classifier in `bin/fm-composer-lib.sh`, which owns every shape - bordered boxes, bare agent-glyph rows (including muse's `⟩`, which the adapter's retired local pattern silently omitted), opencode's left bar, and the Pi separator region this adapter pioneered, admitted only when native `agent get` identity is exactly Pi and state is idle or done.
 A blocked Pi is parked on an interactive prompt, so its blank composer region is a menu's and not a free composer's; that state defers instead of proving emptiness.
 A working Pi, pending middle row, missing identity, incomplete separator pair, or over-tall candidate remains unknown or pending.
+The one middle row that is not input is `pi-vimmode`'s verified mode row (`─ INSERT 1:1 ─`), furniture the extension draws inside that region: the classifier skips exactly that shape so an idle or done Pi with an empty composer still proves `empty` instead of suppressing its steering doorbell, while a wider rule, another mode label, or a caret away from `1:1` stays input.
 Identity stays a lazy second read, consulted only when a separator pair could change the verdict.
 
 ANSI capture preserves de-emphasized placeholder style.

--- a/tests/fm-composer-lib.test.sh
+++ b/tests/fm-composer-lib.test.sh
@@ -351,6 +351,28 @@ test_matrix_omp_status_row_bounds_bare_composer() {
   pass "matrix: omp's status row bounds the bare composer's wrap region"
 }
 
+test_pi_idle_footer_does_not_become_pending() {
+  local screen typed pi_identity out
+  screen=$'transcript\n────────────────────────\n─ INSERT 1:1 ─\n────────────────────────\n vim footer'
+  pi_identity=$(printf 'pi\tidle')
+  out=$(fm_composer_classify_screen "$CAPS_STYLED" "$screen" '' "$pi_identity")
+  [ "$out" = empty ] \
+    || fail "an idle pi vim footer must not become pending composer text, got '$out'"
+  pi_identity=$(printf 'pi\tdone')
+  out=$(fm_composer_classify_screen "$CAPS_STYLED" "$screen" '' "$pi_identity")
+  [ "$out" = empty ] \
+    || fail "a done pi vim footer must not become pending composer text, got '$out'"
+  screen=$'transcript\n────────────────────────\n─ NORMAL ─\n────────────────────────'
+  out=$(fm_composer_classify_screen "$CAPS_STYLED" "$screen" '' "$(printf 'pi\tdone')")
+  [ "$out" = empty ] \
+    || fail "a done pi mode footer must not become pending composer text, got '$out'"
+  typed=$'────────────────────────\nfix the flaky test\n────────────────────────'
+  out=$(fm_composer_classify_screen "$CAPS_STYLED" "$typed" '' "$(printf 'pi\tidle')")
+  [ "$out" = pending ] \
+    || fail "real input must remain pending for an idle pi, got '$out'"
+  pass "pi idle/done identity floors terminal footer rows to empty without hiding real input"
+}
+
 test_matrix_pi_separated_needs_identity() {
   # Real idle pi: a blank row between two solid rules. The blank row alone is
   # exactly what the strict rule refuses; only structure PLUS a live
@@ -679,6 +701,7 @@ test_matrix_claude_bare_nbsp_row
 test_matrix_codex_dim_hint_row
 test_matrix_muse_truecolor_glyph_survives_signal_loss
 test_matrix_cursor_reverse_video_placeholder_remnant
+test_pi_idle_footer_does_not_become_pending
 test_matrix_herdr_halfblock_rule_bounds_bare_wrap
 test_matrix_omp_status_row_bounds_bare_composer
 test_matrix_pi_separated_needs_identity

--- a/tests/fm-composer-lib.test.sh
+++ b/tests/fm-composer-lib.test.sh
@@ -170,6 +170,18 @@ assert_screen() {
   [ "$out" = "$want" ] || fail "$label under LC_ALL=C: expected $want, got '$out'"
 }
 
+# assert_extract <label> <want> <caps> <screen>: extracted composer content,
+# asserted under the ambient locale AND LC_ALL=C. Extraction consults the same
+# furniture predicates as the verdict, so it owes the same locale invariance.
+assert_extract() {
+  local label=$1 want=$2 out
+  shift 2
+  out=$(fm_composer_extract_selected_content "$@")
+  [ "$out" = "$want" ] || fail "$label: expected '$want', got '$out'"
+  out=$(LC_ALL=C fm_composer_extract_selected_content "$@")
+  [ "$out" = "$want" ] || fail "$label under LC_ALL=C: expected '$want', got '$out'"
+}
+
 test_matrix_claude_bare_nbsp_row() {
   # Real idle claude: `❯` + U+00A0, borderless, between horizontal rules.
   # The audit's headline defect: this row read `pending` under LC_ALL=C
@@ -356,15 +368,15 @@ test_pi_vimmode_status_row_is_furniture() {
   # `─ INSERT 1:1 ─` inside its separated region. The pane was idle and the
   # composer empty, yet the row scan read `pending`, so fm-send skipped the
   # doorbell and the re-ring ladder retired the record unrung.
-  local screen typed out
+  local screen typed
   screen=$'transcript\n────────────────────────\n─ INSERT 1:1 ─\n────────────────────────\n vim footer'
   assert_screen "pi idle behind the vimmode row" empty "$CAPS_STYLED" "$screen" '' "$(printf 'pi\tidle')"
   assert_screen "pi done behind the vimmode row" empty "$CAPS_STYLED" "$screen" '' "$(printf 'pi\tdone')"
   assert_screen "pi idle behind the vimmode row on tmux" empty "$CAPS_TMUX" "$screen" 2 "$(printf 'pi\tidle')"
-  # The mode row renders without the cursor cell in other vim modes.
-  screen=$'transcript\n────────────────────────\n─ NORMAL ─\n────────────────────────'
-  assert_screen "pi done behind a bare mode row" empty "$CAPS_STYLED" "$screen" '' "$(printf 'pi\tdone')"
-  # Furniture removes the row; it does not grant a live pi an empty verdict.
+  # The cursor cell moves with the caret, and a multi-row draft raises the line.
+  screen=$'transcript\n────────────────────────\n─ INSERT 12:340 ─\n────────────────────────'
+  assert_screen "pi idle behind a moved cursor cell" empty "$CAPS_STYLED" "$screen" '' "$(printf 'pi\tidle')"
+  # Furniture removes the row; it does not grant a LIVE pi an empty verdict.
   assert_screen "working pi behind the vimmode row" unknown "$CAPS_STYLED" "$screen" '' "$(printf 'pi\tworking')"
   assert_screen "blocked pi behind the vimmode row" unknown "$CAPS_STYLED" "$screen" '' "$(printf 'pi\tblocked')"
   # Pi's region treats every other surviving byte as input. A draft that merely
@@ -376,18 +388,26 @@ test_pi_vimmode_status_row_is_furniture() {
   assert_screen "pi draft quoting a mode token" pending "$CAPS_STYLED" "$typed" '' "$(printf 'pi\tidle')"
   typed=$'────────────────────────\nfix the flaky test\n────────────────────────'
   assert_screen "plain pi draft" pending "$CAPS_STYLED" "$typed" '' "$(printf 'pi\tidle')"
+  # Only the ONE verified render is furniture. These two rows are plausible
+  # vim-status shapes that pi 0.84.4 was never observed drawing, so they stay
+  # input: a row nobody has captured is not proof of an empty composer, and
+  # deferring a ring is recoverable where overwriting a draft is not. Both
+  # assertions also pin the locale invariance - a rule glyph quantified as `─+`
+  # matches a widened rule under UTF-8 and not under LC_ALL=C (issue #1988), so
+  # the verdict would split between a UTF-8 shell and a daemon.
+  typed=$'transcript\n────────────────────────\n── INSERT 1:1 ──\n────────────────────────'
+  assert_screen "pi row with a widened rule" pending "$CAPS_STYLED" "$typed" '' "$(printf 'pi\tidle')"
+  typed=$'transcript\n────────────────────────\n─ NORMAL ─\n────────────────────────'
+  assert_screen "pi row with an unobserved mode label" pending "$CAPS_STYLED" "$typed" '' "$(printf 'pi\tidle')"
   # Extraction reads the same region, so it must agree on what is furniture:
   # the mode row's `1:1` cell moves as the user types, and a paste proof that
   # includes it can never match what was sent.
   screen=$'transcript\n────────────────────────\n─ INSERT 1:1 ─\n────────────────────────\n vim footer'
-  out=$(fm_composer_extract_selected_content "$CAPS_STYLED_NOID" "$screen")
-  [ -z "$out" ] \
-    || fail "pi extraction must exclude the vimmode mode row, got '$out'"
+  assert_extract "pi extraction drops the vimmode row" '' "$CAPS_STYLED_NOID" "$screen"
   typed=$'transcript\n────────────────────────\n─ retry the deploy ─\n────────────────────────'
-  out=$(fm_composer_extract_selected_content "$CAPS_STYLED_NOID" "$typed")
-  [ "$out" = '─ retry the deploy ─' ] \
-    || fail "pi extraction must keep a rule-framed draft, got '$out'"
-  pass "pi-vimmode's mode row is furniture in both pi readers; every other byte stays input"
+  assert_extract "pi extraction keeps a rule-framed draft" '─ retry the deploy ─' \
+    "$CAPS_STYLED_NOID" "$typed"
+  pass "pi-vimmode's verified mode row is furniture in both pi readers; every other byte stays input"
 }
 
 test_matrix_pi_separated_needs_identity() {

--- a/tests/fm-composer-lib.test.sh
+++ b/tests/fm-composer-lib.test.sh
@@ -373,12 +373,18 @@ test_pi_vimmode_status_row_is_furniture() {
   assert_screen "pi idle behind the vimmode row" empty "$CAPS_STYLED" "$screen" '' "$(printf 'pi\tidle')"
   assert_screen "pi done behind the vimmode row" empty "$CAPS_STYLED" "$screen" '' "$(printf 'pi\tdone')"
   assert_screen "pi idle behind the vimmode row on tmux" empty "$CAPS_TMUX" "$screen" 2 "$(printf 'pi\tidle')"
-  # The cursor cell moves with the caret, and a multi-row draft raises the line.
-  screen=$'transcript\n────────────────────────\n─ INSERT 12:340 ─\n────────────────────────'
-  assert_screen "pi idle behind a moved cursor cell" empty "$CAPS_STYLED" "$screen" '' "$(printf 'pi\tidle')"
   # Furniture removes the row; it does not grant a LIVE pi an empty verdict.
   assert_screen "working pi behind the vimmode row" unknown "$CAPS_STYLED" "$screen" '' "$(printf 'pi\tworking')"
   assert_screen "blocked pi behind the vimmode row" unknown "$CAPS_STYLED" "$screen" '' "$(printf 'pi\tblocked')"
+  # The caret cell is only furniture parked at the origin. Anywhere else it is
+  # positive evidence the composer holds text, and it is the LAST such evidence
+  # when the draft itself is de-emphasised: ghost stripping empties the draft
+  # row, so `1:14` is all that remains to prove 13 unsent characters. Reading
+  # that `empty` would hand consumers the one verdict they overwrite input on.
+  typed=$'transcript\n────────────────────────\n'"${ESC}[2mretry the deploy${ESC}[0m"$'\n─ INSERT 1:14 ─\n────────────────────────'
+  assert_screen "pi ghosted draft betrayed by its caret" pending "$CAPS_STYLED" "$typed" '' "$(printf 'pi\tidle')"
+  typed=$'transcript\n────────────────────────\n─ INSERT 12:340 ─\n────────────────────────'
+  assert_screen "pi row with a moved caret" pending "$CAPS_STYLED" "$typed" '' "$(printf 'pi\tidle')"
   # Pi's region treats every other surviving byte as input. A draft that merely
   # OPENS and CLOSES with the rule glyph is user text, and reading it `empty`
   # would let the doorbell overwrite an unsent steer.
@@ -400,8 +406,7 @@ test_pi_vimmode_status_row_is_furniture() {
   typed=$'transcript\n────────────────────────\n─ NORMAL ─\n────────────────────────'
   assert_screen "pi row with an unobserved mode label" pending "$CAPS_STYLED" "$typed" '' "$(printf 'pi\tidle')"
   # Extraction reads the same region, so it must agree on what is furniture:
-  # the mode row's `1:1` cell moves as the user types, and a paste proof that
-  # includes it can never match what was sent.
+  # a paste proof that includes the mode row can never match what was sent.
   screen=$'transcript\n────────────────────────\n─ INSERT 1:1 ─\n────────────────────────\n vim footer'
   assert_extract "pi extraction drops the vimmode row" '' "$CAPS_STYLED_NOID" "$screen"
   typed=$'transcript\n────────────────────────\n─ retry the deploy ─\n────────────────────────'

--- a/tests/fm-composer-lib.test.sh
+++ b/tests/fm-composer-lib.test.sh
@@ -170,18 +170,6 @@ assert_screen() {
   [ "$out" = "$want" ] || fail "$label under LC_ALL=C: expected $want, got '$out'"
 }
 
-# assert_extract <label> <want> <caps> <screen>: extracted composer content,
-# asserted under the ambient locale AND LC_ALL=C. Extraction consults the same
-# furniture predicates as the verdict, so it owes the same locale invariance.
-assert_extract() {
-  local label=$1 want=$2 out
-  shift 2
-  out=$(fm_composer_extract_selected_content "$@")
-  [ "$out" = "$want" ] || fail "$label: expected '$want', got '$out'"
-  out=$(LC_ALL=C fm_composer_extract_selected_content "$@")
-  [ "$out" = "$want" ] || fail "$label under LC_ALL=C: expected '$want', got '$out'"
-}
-
 test_matrix_claude_bare_nbsp_row() {
   # Real idle claude: `❯` + U+00A0, borderless, between horizontal rules.
   # The audit's headline defect: this row read `pending` under LC_ALL=C
@@ -405,14 +393,7 @@ test_pi_vimmode_status_row_is_furniture() {
   assert_screen "pi row with a widened rule" pending "$CAPS_STYLED" "$typed" '' "$(printf 'pi\tidle')"
   typed=$'transcript\n────────────────────────\n─ NORMAL ─\n────────────────────────'
   assert_screen "pi row with an unobserved mode label" pending "$CAPS_STYLED" "$typed" '' "$(printf 'pi\tidle')"
-  # Extraction reads the same region, so it must agree on what is furniture:
-  # a paste proof that includes the mode row can never match what was sent.
-  screen=$'transcript\n────────────────────────\n─ INSERT 1:1 ─\n────────────────────────\n vim footer'
-  assert_extract "pi extraction drops the vimmode row" '' "$CAPS_STYLED_NOID" "$screen"
-  typed=$'transcript\n────────────────────────\n─ retry the deploy ─\n────────────────────────'
-  assert_extract "pi extraction keeps a rule-framed draft" '─ retry the deploy ─' \
-    "$CAPS_STYLED_NOID" "$typed"
-  pass "pi-vimmode's verified mode row is furniture in both pi readers; every other byte stays input"
+  pass "pi-vimmode's verified mode row is furniture in pi's verdict; every other byte stays input"
 }
 
 test_matrix_pi_separated_needs_identity() {

--- a/tests/fm-composer-lib.test.sh
+++ b/tests/fm-composer-lib.test.sh
@@ -351,26 +351,43 @@ test_matrix_omp_status_row_bounds_bare_composer() {
   pass "matrix: omp's status row bounds the bare composer's wrap region"
 }
 
-test_pi_idle_footer_does_not_become_pending() {
-  local screen typed pi_identity out
+test_pi_vimmode_status_row_is_furniture() {
+  # issue #3819, reproduced: pi 0.84.4 with `pi-vimmode` loaded draws
+  # `─ INSERT 1:1 ─` inside its separated region. The pane was idle and the
+  # composer empty, yet the row scan read `pending`, so fm-send skipped the
+  # doorbell and the re-ring ladder retired the record unrung.
+  local screen typed out
   screen=$'transcript\n────────────────────────\n─ INSERT 1:1 ─\n────────────────────────\n vim footer'
-  pi_identity=$(printf 'pi\tidle')
-  out=$(fm_composer_classify_screen "$CAPS_STYLED" "$screen" '' "$pi_identity")
-  [ "$out" = empty ] \
-    || fail "an idle pi vim footer must not become pending composer text, got '$out'"
-  pi_identity=$(printf 'pi\tdone')
-  out=$(fm_composer_classify_screen "$CAPS_STYLED" "$screen" '' "$pi_identity")
-  [ "$out" = empty ] \
-    || fail "a done pi vim footer must not become pending composer text, got '$out'"
+  assert_screen "pi idle behind the vimmode row" empty "$CAPS_STYLED" "$screen" '' "$(printf 'pi\tidle')"
+  assert_screen "pi done behind the vimmode row" empty "$CAPS_STYLED" "$screen" '' "$(printf 'pi\tdone')"
+  assert_screen "pi idle behind the vimmode row on tmux" empty "$CAPS_TMUX" "$screen" 2 "$(printf 'pi\tidle')"
+  # The mode row renders without the cursor cell in other vim modes.
   screen=$'transcript\n────────────────────────\n─ NORMAL ─\n────────────────────────'
-  out=$(fm_composer_classify_screen "$CAPS_STYLED" "$screen" '' "$(printf 'pi\tdone')")
-  [ "$out" = empty ] \
-    || fail "a done pi mode footer must not become pending composer text, got '$out'"
+  assert_screen "pi done behind a bare mode row" empty "$CAPS_STYLED" "$screen" '' "$(printf 'pi\tdone')"
+  # Furniture removes the row; it does not grant a live pi an empty verdict.
+  assert_screen "working pi behind the vimmode row" unknown "$CAPS_STYLED" "$screen" '' "$(printf 'pi\tworking')"
+  assert_screen "blocked pi behind the vimmode row" unknown "$CAPS_STYLED" "$screen" '' "$(printf 'pi\tblocked')"
+  # Pi's region treats every other surviving byte as input. A draft that merely
+  # OPENS and CLOSES with the rule glyph is user text, and reading it `empty`
+  # would let the doorbell overwrite an unsent steer.
+  typed=$'transcript\n────────────────────────\n─ retry the deploy ─\n────────────────────────'
+  assert_screen "rule-framed pi draft" pending "$CAPS_STYLED" "$typed" '' "$(printf 'pi\tidle')"
+  typed=$'transcript\n────────────────────────\n─ INSERT the migration guard ─\n────────────────────────'
+  assert_screen "pi draft quoting a mode token" pending "$CAPS_STYLED" "$typed" '' "$(printf 'pi\tidle')"
   typed=$'────────────────────────\nfix the flaky test\n────────────────────────'
-  out=$(fm_composer_classify_screen "$CAPS_STYLED" "$typed" '' "$(printf 'pi\tidle')")
-  [ "$out" = pending ] \
-    || fail "real input must remain pending for an idle pi, got '$out'"
-  pass "pi idle/done identity floors terminal footer rows to empty without hiding real input"
+  assert_screen "plain pi draft" pending "$CAPS_STYLED" "$typed" '' "$(printf 'pi\tidle')"
+  # Extraction reads the same region, so it must agree on what is furniture:
+  # the mode row's `1:1` cell moves as the user types, and a paste proof that
+  # includes it can never match what was sent.
+  screen=$'transcript\n────────────────────────\n─ INSERT 1:1 ─\n────────────────────────\n vim footer'
+  out=$(fm_composer_extract_selected_content "$CAPS_STYLED_NOID" "$screen")
+  [ -z "$out" ] \
+    || fail "pi extraction must exclude the vimmode mode row, got '$out'"
+  typed=$'transcript\n────────────────────────\n─ retry the deploy ─\n────────────────────────'
+  out=$(fm_composer_extract_selected_content "$CAPS_STYLED_NOID" "$typed")
+  [ "$out" = '─ retry the deploy ─' ] \
+    || fail "pi extraction must keep a rule-framed draft, got '$out'"
+  pass "pi-vimmode's mode row is furniture in both pi readers; every other byte stays input"
 }
 
 test_matrix_pi_separated_needs_identity() {
@@ -701,7 +718,7 @@ test_matrix_claude_bare_nbsp_row
 test_matrix_codex_dim_hint_row
 test_matrix_muse_truecolor_glyph_survives_signal_loss
 test_matrix_cursor_reverse_video_placeholder_remnant
-test_pi_idle_footer_does_not_become_pending
+test_pi_vimmode_status_row_is_furniture
 test_matrix_herdr_halfblock_rule_bounds_bare_wrap
 test_matrix_omp_status_row_bounds_bare_composer
 test_matrix_pi_separated_needs_identity


### PR DESCRIPTION
## Summary
- Ignore Pi vim-mode status/footer rows inside the separated composer region.
- Preserve pending classification for real unsubmitted input.
- Add idle and done regression coverage.

## Validation
- `bin/fm-test-run.sh tests/fm-composer-lib.test.sh`
- `bin/fm-lint.sh` (ShellCheck passed; workflow lint could not run because actionlint is not installed.)