### PR TITLE
fix: reduce watcher token burn and stale recovery loops

### DIFF
--- a/.omp/extensions/fm-primary-omp-watch.ts
+++ b/.omp/extensions/fm-primary-omp-watch.ts
@@ -23,11 +23,14 @@
 // Session-generation ownership (stated once here):
 // omp emits session_shutdown for ordinary same-process replacements (/new,
 // /resume, /fork) as well as terminal quit. This extension binds one generation
-// per session activation. Only the active live generation may start, stop,
-// rearm, or clear the arm child. An owning replacement session_start (or fresh
-// factory bind) arms its new generation without a model turn. A replacement
-// handoff carries actionable closes that were still pending delivery; its
-// durable state lives at state/extensions/omp-primary-watch/session-replacement-actionable.json.
+// to the primary session id from ctx.sessionManager.getSessionId(). A nested
+// child or subagent may emit the same lifecycle events through the shared
+// extension runner; a different session id can neither replace nor stop the
+// primary generation. Only the active live generation may start, stop, rearm,
+// or clear the arm child. An owning replacement session_start (or fresh factory
+// bind) arms its new generation without a model turn. A replacement handoff
+// carries actionable closes that were still pending delivery; its durable state
+// lives at state/extensions/omp-primary-watch/session-replacement-actionable.json.
 // Stale callbacks from a prior generation are no-ops against the active replacement.
 //
 // Delivery versus consumption (stated once here):
@@ -253,6 +256,20 @@ function userMessageText(content: unknown): string {
     }
   }
   return parts.join("\n");
+}
+
+function contextSessionId(ctx: unknown): string {
+  if (!ctx || typeof ctx !== "object" || !("sessionManager" in ctx)) return "";
+  const manager = ctx.sessionManager;
+  if (!manager || typeof manager !== "object" || !("getSessionId" in manager)) return "";
+  const getSessionId = manager.getSessionId;
+  if (typeof getSessionId !== "function") return "";
+  try {
+    const id = getSessionId.call(manager);
+    return typeof id === "string" ? id : "";
+  } catch {
+    return "";
+  }
 }
 
 function nodeErrorCode(error: unknown): string {
@@ -485,6 +502,7 @@ process.once("exit", cleanupOnProcessExit);
 
 export default function (pi: ExtensionAPI) {
   let generation = createGeneration();
+  let owningSessionId = "";
   activateGeneration(generation);
 
   async function sendWake(
@@ -1028,14 +1046,19 @@ export default function (pi: ExtensionAPI) {
     consumeWake(generation, userMessageText(message.content));
   });
 
-  pi.on?.("session_start", async () => {
+  pi.on?.("session_start", async (_event, ctx) => {
+    const sessionId = contextSessionId(ctx);
+    if (!sessionId) return;
+    if (owningSessionId && owningSessionId !== sessionId && !generation.stopping) return;
     if (generation.stopping) generation = createGeneration();
+    owningSessionId = sessionId;
     activateGeneration(generation);
     markLoaded();
     if (lockOwnership() !== "owned") return;
     activateOwnedWatch(generation);
   });
-  pi.on?.("session_shutdown", async () => {
+  pi.on?.("session_shutdown", async (_event, ctx) => {
+    if (contextSessionId(ctx) !== owningSessionId || !owningSessionId) return;
     // omp carries no shutdown reason (verified: `reason` is undefined), so the
     // replacement handoff is always persisted when anything is pending; a
     // terminal quit then merely replays an already-drained wake next start.

--- a/bin/backends/herdr.sh
+++ b/bin/backends/herdr.sh
@@ -2223,23 +2223,20 @@ EOF
 #                 stability across a server restart"), and what a future
 #                 `resume_agents_on_restore = false` restore would produce too
 #                 (a plain shell, never an agent).
-#   stale-agent - `agent get` reports a registered agent_status (working, idle,
-#                 done, or blocked) but fm_backend_herdr_pane_process_state
-#                 proves the pane is shell-only: the registered agent's process
-#                 has exited and Herdr kept its registration (issue #4115;
-#                 Herdr does not release a Pi registration on TUI shutdown when
-#                 a nested shell sits under the pane's top shell, the crew
-#                 shape). This is the explicit agent-free reason: the pane is
-#                 recoverable, and the record it carries is not evidence of a
-#                 running agent. No registered status outranks the process
-#                 view, because a killed mid-turn agent leaves `working`
-#                 behind just as a quit one leaves `idle`.
-#   live        - `agent get` succeeds with a registered agent_status and the
-#                 process-level view is `agent` or `other`: a harness process
-#                 is running, or something that is not a bare shell is, so the
-#                 registration keeps its authority. An idle or blocked agent
-#                 is still a genuine, still-registered agent, not a restored
-#                 husk, so it is never a close-and-replace candidate.
+#   stale-agent - `agent get` reports a registered agent_status but the process
+#                 view proves the registration is terminal: either the pane is
+#                 shell-only, or status is `done` and no harness process is
+#                 live (`other`). Herdr can retain `agent=omp status=done` after
+#                 the worker exits; that terminal registration must not block
+#                 exit or relaunch. No non-terminal registered status outranks
+#                 a shell-only process view, because a killed mid-turn agent
+#                 leaves `working` behind just as a quit one leaves `idle`.
+#   live        - `agent get` succeeds with a registered non-terminal status
+#                 and the process-level view is `agent` or `other`, or a
+#                 `done` registration still has a positively identified
+#                 harness process. An idle or blocked agent is still a genuine,
+#                 still-registered agent when a non-shell process remains, not
+#                 a restored husk, so it is never a close-and-replace candidate.
 #   unknown     - anything else: an unparseable/unexpected response from
 #                 either call, a `pane get` success whose own echoed pane_id
 #                 does not round-trip (guards against misreading a herdr
@@ -2250,7 +2247,7 @@ EOF
 #                 here, never toward closing - this is the conservative
 #                 backstop the husk check depends on.
 fm_backend_herdr_pane_agent_state() {  # <session> <pane_id>
-  local session=$1 pane_id=$2 out code presence status
+  local session=$1 pane_id=$2 out code presence status process_state
   presence=$(fm_backend_herdr_pane_presence_state "$session" "$pane_id")
   if [ "$presence" != present ]; then
     case "$presence" in
@@ -2270,9 +2267,13 @@ fm_backend_herdr_pane_agent_state() {  # <session> <pane_id>
     working|idle|done|blocked) ;;
     *) printf 'unknown'; return 0 ;;
   esac
-  case "$(fm_backend_herdr_pane_process_state "$session" "$pane_id")" in
-    agent|other) printf 'live' ;;
+  process_state=$(fm_backend_herdr_pane_process_state "$session" "$pane_id")
+  case "$process_state" in
+    agent) printf 'live' ;;
     shell) printf 'stale-agent' ;;
+    other)
+      [ "$status" = "done" ] && printf 'stale-agent' || printf 'live'
+      ;;
     *) printf 'unknown' ;;
   esac
 }

--- a/bin/fm-busy-lib.sh
+++ b/bin/fm-busy-lib.sh
@@ -50,13 +50,17 @@
 # with the producing source as the second token. Precedence:
 #   1. dead endpoint (fm_busy_classify_live only) -> dead endpoint-gone
 #   2. standalone Kimi before verification       -> unknown kimi-unverified
-#   3. a valid, gen-matching, source-trusted record -> its state and source
-#   4. no record at all: herdr's native busy verdict is trusted as busy
+#   3. a valid, gen-matching, source-trusted busy record -> busy and its source
+#   4. herdr's native busy verdict overrides every non-busy stored-record result
+#      because positive live work wins over an older negative observation
+#   5. a valid, gen-matching, source-trusted non-busy record -> its state/source
+#   6. no record at all: herdr's native busy verdict is trusted as busy
 #      (generation state is sufficient for busy, not for idle), then the
 #      muse session-log and cursor transcript pull sources, then the Grok/Rovo
 #      temporary regex fallbacks classify a grok or rovo task from its
 #      rendered tail, then unknown missing
-#   5. malformed, stale, or untrusted records -> unknown, never a fallback
+#   7. malformed, stale, or untrusted records -> unknown unless Herdr reports
+#      positive native busy activity; no negative native verdict overrides them
 # Grok and Rovo are the ONLY rendered-text classifications that survive the
 # redesign, because neither's structured lifecycle was credited-live-verified
 # in the approved audit (Rovo's clean ACP stopReason lives outside the TUI
@@ -859,7 +863,7 @@ fm_busy_rovo_tail_busy() {
 # if available, else reports unknown capture-failed.
 fm_busy_classify() {  # <backend> <target> <harness> <id> <state-dir> [tail40]
   local backend=$1 target=$2 harness=$3 id=$4 state=$5 tail40=${6-}
-  local out rc r_state r_source native log
+  local out rc r_state r_source native log semantic_verdict=
   case "$harness" in
     kimi*)
       if ! fm_busy_kimi_verified; then
@@ -898,22 +902,22 @@ fm_busy_classify() {  # <backend> <target> <harness> <id> <state-dir> [tail40]
     out=${out#* }
     r_source=${out%% *}
     if fm_busy_source_trusted "$harness" "$r_source"; then
-      printf '%s %s' "$r_state" "$r_source"
+      if [ "$r_state" = busy ]; then
+        printf '%s %s' "$r_state" "$r_source"
+        return 0
+      fi
+      semantic_verdict="$r_state $r_source"
     else
-      printf 'unknown source-mismatch'
+      semantic_verdict='unknown source-mismatch'
     fi
-    return 0
+  else
+    case "$out" in
+      malformed|gen-mismatch) semantic_verdict="unknown $out" ;;
+    esac
   fi
-  case "$out" in
-    malformed|gen-mismatch)
-      printf 'unknown %s' "$out"
-      return 0
-      ;;
-  esac
-  # No record at all. A native herdr busy verdict is semantic enough to trust
-  # for BUSY (streaming means a turn is running); native idle is narrower
-  # than turn state (a long foreground tool call reads idle) and stays
-  # unknown here.
+  # Herdr's generation state is positive evidence only. A live busy verdict
+  # outranks an older idle, unknown, malformed, stale, or untrusted stored
+  # observation, while native idle can never negate another source.
   if [ "$backend" = herdr ] && command -v fm_backend_busy_state >/dev/null 2>&1; then
     native=$(fm_backend_busy_state "$backend" "$target" 2>/dev/null || true)
     if [ "$native" = busy ]; then
@@ -921,6 +925,12 @@ fm_busy_classify() {  # <backend> <target> <harness> <id> <state-dir> [tail40]
       return 0
     fi
   fi
+  if [ -n "$semantic_verdict" ]; then
+    printf '%s' "$semantic_verdict"
+    return 0
+  fi
+  # No record at all. Native idle is narrower than turn state because a long
+  # foreground tool call can read idle, so it stays unknown here.
   case "$harness" in
     muse*)
       # Semantic, on demand: fold this task's bound session log. An open run is

--- a/bin/fm-fleet-sync.sh
+++ b/bin/fm-fleet-sync.sh
@@ -7,9 +7,9 @@
 # no unique commits (it is an ancestor of origin/<default>) and whose <default>
 # branch is free to check out is re-attached and then fast-forwarded ("recovered:").
 # Every other off-default state - a non-default named branch, a detached HEAD with
-# unique commits, a dirty tree, or a diverged default - may hold real work, so it
-# is left untouched and reported as a quantified, loud "STUCK: ... N commits behind
-# ... - needs attention" warning rather than a quiet drift. Nothing is ever forced,
+# unique commits, tracked worktree changes, or a diverged default - may hold real
+# work, so it is left untouched and reported as a quantified, loud "STUCK: ... N
+# commits behind ... - needs attention" warning. Nothing is ever forced,
 # stashed, or discarded.
 # Still skips (benignly) local-only/no-origin projects, missing remotes/branches,
 # and fetch failures.
@@ -357,8 +357,11 @@ sync_project() {
   fi
 
   cur=$(git -C "$PROJ" symbolic-ref --short HEAD 2>/dev/null || echo "")
+  # Only tracked changes can carry uncommitted project work. Root-local pool
+  # metadata such as an untracked treehouse.toml is not part of a fast-forward;
+  # Git itself still refuses safely if an untracked path would be overwritten.
   dirty=no
-  [ -z "$(git -C "$PROJ" status --porcelain 2>/dev/null | head -1)" ] || dirty=yes
+  [ -z "$(git -C "$PROJ" status --porcelain --untracked-files=no 2>/dev/null | head -1)" ] || dirty=yes
   recovered=no
 
   if [ "$cur" != "$DEFAULT" ]; then
@@ -367,9 +370,9 @@ sync_project() {
     # origin/<default>) and whose <default> branch is free to check out here.
     # Re-attaching to an already-published commit strands nothing, and the
     # fast-forward path below then catches the clone up. Anything else - a
-    # non-default named branch, a detached HEAD with unique commits, a dirty tree,
-    # or <default> already checked out elsewhere - may hold real work, so it is
-    # reported loudly and left untouched.
+    # non-default named branch, a detached HEAD with unique commits, tracked
+    # worktree changes, or <default> already checked out elsewhere - may hold
+    # real work, so it is reported loudly and left untouched.
     if [ -z "$cur" ] && [ "$dirty" = no ] \
         && git -C "$PROJ" merge-base --is-ancestor HEAD "$BASE" 2>/dev/null \
         && ! default_checked_out_elsewhere \
@@ -385,7 +388,7 @@ sync_project() {
       return 0
     fi
   elif [ "$dirty" = yes ]; then
-    # On the default branch but with uncommitted changes we must not disturb.
+    # On the default branch, tracked changes may be uncommitted work.
     report_stuck "$(stuck_state)"
     return 0
   fi

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -3485,8 +3485,9 @@ EOF
       cat > "$STATE/$ID.omp-ext.ts" <<EOF
 // Firstmate semantic busy-state events + turn-end notification for omp (Oh My
 // Pi); written by fm-spawn under the contract owned by bin/fm-busy-lib.sh.
-// Semantic state: "agent_start" -> busy when a low-level agent run begins;
-// "agent_end" -> idle only when event.willContinue is not true. omp has no
+// Semantic state: "agent_start" and each inner "turn_start" -> busy;
+// "agent_end" -> idle only when event.willContinue is not true. The turn_start
+// refresh repairs an older idle edge before every inner turn. omp has no
 // agent_settled at all (verified, omp 18.1.2 and 18.1.11: zero occurrences in
 // the binary); agent_end is its loop boundary and willContinue is the reliable
 // "another loop is coming" flag, covering auto-retries, compaction retries,
@@ -3506,6 +3507,7 @@ const busyEvent = (state: string, event: string) =>
   });
 export default function (pi: any) {
   pi.on("agent_start", () => busyEvent("busy", "agent-start"));
+  pi.on("turn_start", () => busyEvent("busy", "turn-start"));
   pi.on("agent_end", (event: any) => {
     if (event && event.willContinue === true) return;
     return busyEvent("idle", "agent-end");

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -3450,6 +3450,10 @@ fm_backend_clear_transition "$BACKEND" "$STATE" "$T" || true
 remove_pr_poll_artifacts "$STATE" "$ID" || exit 1
 retire_busy_state "$STATE" "$ID" "$BUSY_GEN" || exit 1
 status_retire_presentation_task "$STATE" "$ID" || exit 1
+fm_wake_retire_task_watch_markers "$STATE" "$T" "$ID" || {
+  echo "error: could not retire watcher records for $ID" >&2
+  exit 1
+}
 rm -f "$STATE/$ID.turn-ended" "$STATE/$ID.progress" \
   "$STATE/$ID.pi-ext.ts" "$STATE/$ID.omp-ext.ts" "$STATE/$ID.grok-turnend-token" \
   "$STATE/$ID.kimi-turnend-token" "$STATE/$ID.muse-session" \

--- a/bin/fm-wake-lib.sh
+++ b/bin/fm-wake-lib.sh
@@ -2041,6 +2041,36 @@ fm_wake_actor_pending_count() {  # <actor> [<rows-file> <owner-file>]
   printf '%s\n' "$count"
 }
 
+# Normalize one runtime target into the suffix used by every watcher-owned
+# per-window record. Keep this derivation shared with teardown so one format
+# change cannot strand an old task's stale, churn, or pause state.
+fm_wake_window_marker_key() {  # <window>
+  local key=${1//:/_}
+  key=${key//\//_}
+  printf '%s' "${key//./_}"
+}
+
+# Retire every watcher record scoped to one task and its recorded runtime target.
+# All paths are exact, never globs: teardown must not touch another task whose id
+# or normalized target happens to share a prefix.
+fm_wake_retire_task_watch_markers() {  # <state> <window> <task>
+  local state=$1 key task=$3
+  key=$(fm_wake_window_marker_key "$2") || return 1
+  rm -f \
+    "$state/.hash-$key" \
+    "$state/.count-$key" \
+    "$state/.churn-since-$key" \
+    "$state/.stale-$key" \
+    "$state/.stale-since-$key" \
+    "$state/.wedge-escalations-$key" \
+    "$state/.paused-$key" \
+    "$state/.paused-rechecked-$key" \
+    "$state/.paused-resurfaced-$key" \
+    "$state/.writing-since-$key" \
+    "$state/.writing-resurfaced-$key" \
+    "$state/.turnend-surfaced-$task"
+}
+
 # --- signal announcement signatures -----------------------------------------
 #
 # The watcher's per-file signal scan (bin/fm-watch.sh scan_signals) detects a

--- a/bin/fm-watch.sh
+++ b/bin/fm-watch.sh
@@ -2,15 +2,14 @@
 # Firstmate watcher.
 # Classifies supervision wakes in bash. In normal mode it absorbs benign wakes
 # and keeps blocking; it queues and exits only for actionable wakes.
-# The no-verb signal and stale path is absorb-only-on-positive-evidence: a wake
-# is absorbed only when the crew shows it is still working through an actively
-# running no-mistakes step or a backend busy signal. A home that opts in with
-# config/turnend-churn-absorb lets a bare turn-end also use bounded pane churn
-# since the previous poll. Every other no-verb wake surfaces, so a crew
-# that finishes (or stops and waits) is never silently swallowed. A declared wait,
-# either a paused: external wait or a verified captain-held transfer, is the
-# separate idle absorb case and re-surfaces only on its long bounded cadence,
-# although its initial no-verb status signal still surfaces in normal mode.
+# A no-verb signal with no positive execution evidence surfaces immediately once,
+# then repeated bare turn-end markers for that task are absorbed for a bounded
+# cooldown. Any status append bypasses the cooldown. A home that opts in with
+# config/turnend-churn-absorb can instead absorb a bare turn-end from the start
+# while bounded pane churn proves progress. A declared wait, either a paused:
+# external wait or a verified captain-held transfer, is the separate idle absorb
+# case and re-surfaces only on its long bounded cadence, although its initial
+# no-verb status signal still surfaces in normal mode.
 # That cadence is hours long and condition-aware: a paused: line naming
 # `until <UTC ISO 8601>` is rechecked when that time passes, but a declared time
 # beyond FM_PAUSE_RESURFACE_SECS cannot extend the ordinary recheck cadence, and
@@ -222,6 +221,12 @@ SIGNAL_GRACE=${FM_SIGNAL_GRACE:-30}   # seconds to linger after a signal so trai
 TURNEND_CHURN_ABSORB_SECS=${FM_TURNEND_CHURN_ABSORB_SECS:-900}  # longest a task's
                                       # bare turn-ends may be deferred on pane-churn
                                       # evidence alone (signal_turnend_panes_churned)
+TURNEND_SURFACE_COOLDOWN_SECS=${FM_TURNEND_SURFACE_COOLDOWN_SECS:-300}  # minimum
+                                      # interval between unproven bare turn-end
+                                      # surfaces for one task; status bypasses it
+case "$TURNEND_SURFACE_COOLDOWN_SECS" in
+  ''|*[!0-9]*|0) TURNEND_SURFACE_COOLDOWN_SECS=300 ;;
+esac
 # Busy state is decided by the semantic contract in bin/fm-busy-lib.sh, which
 # is the single owner of per-harness sources, source attribution, and the one
 # remaining rendered-text fallback (Grok only).
@@ -1362,6 +1367,22 @@ age_of() {  # seconds since file mtime; "due immediately" if missing
   echo $(( now - m ))
 }
 
+# A bare turn-end with no positive work evidence still surfaces immediately once.
+# Later mechanical inner-turn markers for that task are absorbed for this bounded
+# interval, while any authored status append bypasses the cooldown.
+turnend_surface_marker() {  # <turn-ended-file>
+  local base=${1##*/}
+  printf '%s/.turnend-surfaced-%s' "$STATE" "${base%.turn-ended}"
+}
+
+turnend_surface_recent() {  # <turn-ended-file>
+  [ "$(age_of "$(turnend_surface_marker "$1")")" -lt "$TURNEND_SURFACE_COOLDOWN_SECS" ]
+}
+
+record_turnend_surface() {  # <turn-ended-file>
+  : > "$(turnend_surface_marker "$1")"
+}
+
 # Layer 2 + 3 signal scan: status files and turn-end markers.
 # Each file is compared against its persisted reported signature in .seen-* rather
 # than mtime-vs-a-startup-touch, so signals that land while no watcher is running
@@ -2074,9 +2095,20 @@ while :; do
     # path. Publication failure stays side-band.
     home_summary_refresh_detached
     files=""
+    signal_status_tasks=""
     while IFS=$(printf '\t') read -r sf sig f; do
       [ -n "$sf" ] || continue
       case " $files " in *" $f "*) ;; *) files="$files $f" ;; esac
+      case "$f" in
+        *.status)
+          task=${f##*/}
+          task=${task%.status}
+          case " $signal_status_tasks " in
+            *" $task "*) ;;
+            *) signal_status_tasks="$signal_status_tasks $task" ;;
+          esac
+          ;;
+      esac
     done <<EOF
 $pending
 EOF
@@ -2122,11 +2154,64 @@ EOF
     # shellcheck disable=SC2086  # same space-separated status-path list
     if afk_present || [ "$signal_actionable" -eq 0 ] \
       || { ! signal_crew_provably_working $files && ! signal_turnend_panes_churned $files; }; then
+      # Only the no-verb path is rate-limited. The away owner and every authored
+      # status event retain immediate delivery. A mixed batch filters per task,
+      # so one task's cooldown cannot hide another task's first turn-end.
+      if ! afk_present && [ "$signal_actionable" -ne 0 ]; then
+        surface_pending=""
+        while IFS=$(printf '\t') read -r sf sig f; do
+          [ -n "$sf" ] || continue
+          case "$f" in
+            *.turn-ended)
+              task=${f##*/}
+              task=${task%.turn-ended}
+              case " $signal_status_tasks " in
+                *" $task "*) ;;
+                *)
+                  if turnend_surface_recent "$f"; then
+                    printf '%s' "$sig" > "$sf"
+                    triage_log "absorbed repeated bare turn-end inside cooldown: $task"
+                    continue
+                  fi
+                  ;;
+              esac
+              ;;
+          esac
+          surface_pending="${surface_pending}${sf}	${sig}	${f}
+"
+        done <<EOF
+$pending
+EOF
+        if [ -n "$surface_pending" ]; then
+          pending=$surface_pending
+          files=""
+          while IFS=$(printf '\t') read -r sf sig f; do
+            [ -n "$sf" ] || continue
+            case " $files " in *" $f "*) ;; *) files="$files $f" ;; esac
+          done <<EOF
+$pending
+EOF
+          reason="signal:$files"
+        else
+          pending=""
+        fi
+      fi
+      if [ -n "$pending" ]; then
       while IFS=$(printf '\t') read -r sf sig f; do
         [ -n "$sf" ] || continue
         file_reason="$reason"
         case " $FM_SIGNAL_NEEDS_DECISION_FILES " in *" $f "*) file_reason="needs-decision:$files" ;; esac
         fm_wake_append signal "$(basename "$f")" "$file_reason" || exit 1
+        case "$f" in
+          *.turn-ended)
+            task=${f##*/}
+            task=${task%.turn-ended}
+            case " $signal_status_tasks " in
+              *" $task "*) ;;
+              *) record_turnend_surface "$f" || true ;;
+            esac
+            ;;
+        esac
       done <<EOF
 $pending
 EOF
@@ -2155,6 +2240,7 @@ EOF
 $FM_SIGNAL_SURFACE_ENDPOINTS
 EOF
       wake "$reason"
+      fi
     else
       while IFS=$(printf '\t') read -r sf sig f; do
         [ -n "$sf" ] || continue

--- a/bin/fm-watch.sh
+++ b/bin/fm-watch.sh
@@ -386,18 +386,10 @@ window_label() {
   [ -n "$task" ] && printf 'fm-%s' "$task"
 }
 
-# The ONE derivation of a window's per-window marker key: `:`, `/` and `.` become
-# `_` so a window name is usable as a filename suffix. Every per-window file the
-# watcher keeps is named by it (.hash-, .count-, .stale-, .stale-since-,
-# .wedge-escalations-, .paused-*, .writing-*), and live homes hold those markers on
-# disk under the current format, so the format lives here alone: a second copy is
-# how a future change to it silently orphans a window's markers instead of clearing
-# them. The helpers below take the derived key rather than re-deriving it, so one
-# poll of one window derives it once.
+# bin/fm-wake-lib.sh owns the marker-key derivation shared with teardown.
+# Helpers below still derive each polled window once and pass that key through.
 window_key() {  # <window>
-  local key=${1//:/_}
-  key=${key//\//_}
-  printf '%s' "${key//./_}"
+  fm_wake_window_marker_key "$1"
 }
 
 inbox_steer_escalate_unavailable() {  # <window> <task> <record>

--- a/tests/fm-backend-herdr.test.sh
+++ b/tests/fm-backend-herdr.test.sh
@@ -511,6 +511,15 @@ test_registered_agent_with_a_non_shell_foreground_process_stays_alive() {
   pass "herdr stale registration: only a shell-only pane demotes a registration"
 }
 
+test_done_registration_without_a_live_agent_process_is_agent_free() {
+  local out
+  out=$(FM_BACKEND_HERDR_IDLE_SHELL_PROOF_POLLS=1 stale_registration_case done-tool "done" \
+    '{"result":{"type":"pane_process_info","process_info":{"pane_id":"w1:p2","shell_pid":4242,"foreground_process_group_id":4250,"foreground_processes":[{"pid":4250,"name":"git","argv0":"git","argv":["git","status"],"cmdline":"git status"}]}}}')
+  [ "$out" = "stale-agent dead refused" ] \
+    || fail "a terminal registration with no live harness process must be agent-free, got '$out'"
+  pass "herdr stale registration: terminal done without a harness process is agent-free"
+}
+
 # settle_registration_case: one pane classification over a scripted sequence
 # of `pane process-info` samples, so the settle window's resampling is
 # observable in the fake CLI's call log.
@@ -5185,6 +5194,7 @@ test_stale_registration_over_a_shell_only_pane_is_agent_free
 test_stale_registration_ignores_status_and_reads_the_process
 test_registered_agent_with_a_live_foreground_process_stays_alive
 test_registered_agent_with_a_non_shell_foreground_process_stays_alive
+test_done_registration_without_a_live_agent_process_is_agent_free
 test_transient_prompt_helper_settles_into_stale_agent
 test_exhausted_settle_window_keeps_a_non_shell_foreground_live
 test_registered_agent_with_an_agent_descendant_outside_the_foreground_stays_alive

--- a/tests/fm-busy-state.test.sh
+++ b/tests/fm-busy-state.test.sh
@@ -376,25 +376,45 @@ test_dead_endpoint_overrides() {
 }
 
 test_herdr_native_busy_only() {
-  local state out
+  local state out gen
   state=$(new_state_dir herdr-native)
   # shellcheck disable=SC2329 # invoked indirectly through fm_busy_classify
-  fm_backend_busy_state() { printf '%s' "$FAKE_NATIVE"; }
+  fm_backend_busy_state() {
+    [ "$FAKE_NATIVE" != failure ] || return 1
+    printf '%s' "$FAKE_NATIVE"
+  }
   FAKE_NATIVE=busy
-  out=$(fm_busy_classify herdr s:p claude t1 "$state")
+  out=$(fm_busy_classify herdr s:p omp t1 "$state")
   [ "$out" = "busy herdr-native" ] || fail "native busy with no record must classify busy, got '$out'"
   FAKE_NATIVE=idle
-  out=$(fm_busy_classify herdr s:p claude t1 "$state")
+  out=$(fm_busy_classify herdr s:p omp t1 "$state")
   [ "$out" = "unknown missing" ] || fail "native idle must NOT classify idle, got '$out'"
-  # A valid record outranks the native verdict.
-  local gen
+
   gen=$("$EV" arm "$state" t1)
-  "$EV" apply "$state" t1 idle --gen "$gen" --source claude-hook --event stop
+  "$EV" apply "$state" t1 idle --gen "$gen" --source omp-ext --event agent-end
   FAKE_NATIVE=busy
-  out=$(fm_busy_classify herdr s:p claude t1 "$state")
-  [ "$out" = "idle claude-hook" ] || fail "the adapter record must outrank herdr's native verdict, got '$out'"
+  out=$(fm_busy_classify herdr s:p omp t1 "$state")
+  [ "$out" = "busy herdr-native" ] || fail "native busy must override an older trusted idle record, got '$out'"
+
+  "$EV" apply "$state" t1 busy --gen "$gen" --source omp-ext --event turn-start
+  FAKE_NATIVE=idle
+  out=$(fm_busy_classify herdr s:p omp t1 "$state")
+  [ "$out" = "busy omp-ext" ] || fail "native idle must not override a trusted busy record, got '$out'"
+
+  "$EV" apply "$state" t1 idle --gen "$gen" --source omp-ext --event agent-end
+  out=$(fm_busy_classify herdr s:p omp t1 "$state")
+  [ "$out" = "idle omp-ext" ] || fail "trusted idle plus native idle must remain idle, got '$out'"
+
+  printf 'superseded-gen\n' > "$state/t1.busy-gen"
+  FAKE_NATIVE=busy
+  out=$(fm_busy_classify herdr s:p omp t1 "$state")
+  [ "$out" = "busy herdr-native" ] || fail "native busy must override a generation-mismatched record, got '$out'"
+
+  FAKE_NATIVE=failure
+  out=$(fm_busy_classify herdr s:p omp t1 "$state")
+  [ "$out" = "unknown gen-mismatch" ] || fail "a failed native read must preserve the stored-record verdict, got '$out'"
   unset -f fm_backend_busy_state
-  pass "herdr's native verdict is trusted for busy only, and records outrank it"
+  pass "herdr native busy overrides non-busy records, while native idle and read failure never negate them"
 }
 
 # The record parser runs inside sourcing callers (the watcher, the daemon, the

--- a/tests/fm-fleet-sync.test.sh
+++ b/tests/fm-fleet-sync.test.sh
@@ -316,6 +316,24 @@ test_dirty_is_stuck_untouched() {
   pass "dirty working tree is reported STUCK and left untouched"
 }
 
+test_untracked_treehouse_config_does_not_block_fast_forward() {
+  local home clone out
+  home=$(new_home)
+  clone=$(build_pair "$home" gamma-untracked)
+  advance_origin "$home" gamma-untracked C1
+  printf 'pool = "local"\n' > "$clone/treehouse.toml"
+
+  out=$(run_sync "$home" "$clone")
+
+  assert_contains "$out" "gamma-untracked: synced" "untracked pool metadata blocked the fast-forward"
+  assert_not_contains "$out" "STUCK" "untracked pool metadata was reported as uncommitted work"
+  [ "$(head_sha "$clone")" = "$(git -C "$clone" rev-parse origin/main)" ] \
+    || fail "clone with untracked pool metadata was not fast-forwarded"
+  grep -Fx 'pool = "local"' "$clone/treehouse.toml" >/dev/null \
+    || fail "fast-forward removed or changed the untracked pool metadata"
+  pass "an untracked treehouse.toml survives while its real clone fast-forwards"
+}
+
 test_non_default_branch_is_stuck_untouched() {
   local home clone out
   home=$(new_home)
@@ -698,6 +716,7 @@ test_detached_clean_ancestor_recovers
 test_detached_unique_commit_is_stuck_untouched
 test_detached_clean_ancestor_with_diverged_local_default_is_stuck_untouched
 test_dirty_is_stuck_untouched
+test_untracked_treehouse_config_does_not_block_fast_forward
 test_non_default_branch_is_stuck_untouched
 test_diverged_is_stuck_untouched
 test_on_default_clean_behind_fast_forwards

--- a/tests/fm-omp-harness.test.sh
+++ b/tests/fm-omp-harness.test.sh
@@ -546,6 +546,8 @@ import { pathToFileURL } from "node:url";
 import { writeFileSync, existsSync, readFileSync } from "node:fs";
 writeFileSync(`${process.env.FM_HOME}/state/.lock`, `${process.pid}\n`);
 const handlers = new Map(); let tool = null; let command = null; const sent = [];
+const primaryCtx = { sessionManager: { getSessionId: () => "primary-session" } };
+const childCtx = { sessionManager: { getSessionId: () => "nested-child-session" } };
 const pi = {
   on(e, h) { handlers.set(e, h); },
   registerCommand(n, o) { if (n === "fm-watch-arm-omp") command = o.handler; },
@@ -562,15 +564,22 @@ const result = await tool.execute();
 if (!/^watcher: started omp extension arm child 1;/.test(result.content[0].text)) throw new Error(`unexpected arm result: ${result.content[0].text}`);
 const marker = readFileSync(`${process.env.FM_HOME}/state/.omp-watch-extension-loaded`, "utf8").split("\n");
 if (marker[1] !== String(process.pid)) throw new Error("loaded marker must record the session pid");
+await handlers.get("session_start")({ type: "session_start" }, primaryCtx);
 const again = await tool.execute();
 if (!/^watcher: unchanged - omp extension already owns an arm child/.test(again.content[0].text)) throw new Error(`redundant arm was not an ownership no-op: ${again.content[0].text}`);
+await handlers.get("session_start")({ type: "session_start" }, childCtx);
+await handlers.get("session_shutdown")({ type: "session_shutdown" }, childCtx);
+const afterChildShutdown = await tool.execute();
+if (!/^watcher: unchanged - omp extension already owns an arm child/.test(afterChildShutdown.content[0].text)) {
+  throw new Error(`nested child shutdown stopped the primary arm: ${afterChildShutdown.content[0].text}`);
+}
 await new Promise((r) => setTimeout(r, 2500));
 if (sent.length !== 1) throw new Error(`expected one follow-up wake, saw ${sent.length}: ${JSON.stringify(sent)}`);
 if (!sent[0].m.startsWith("⁣FIRSTMATE_OP: v1 watcher: FIRSTMATE WATCHER WAKE: signal: omp-e2e done")) throw new Error(`unexpected wake text: ${sent[0].m}`);
 if (sent[0].o?.deliverAs !== "followUp") throw new Error("wake must be delivered as a follow-up");
 // The wake is consumed when omp starts the next run with that exact prompt.
 await handlers.get("before_agent_start")({ type: "before_agent_start", prompt: sent[0].m }, {});
-await handlers.get("session_shutdown")({}, {});
+await handlers.get("session_shutdown")({ type: "session_shutdown" }, primaryCtx);
 if (existsSync(`${process.env.FM_HOME}/state/extensions/omp-primary-watch/session-replacement-actionable.json`)) throw new Error("a consumed wake must not ride the replacement handoff");
 process.exit(0);
 EOF
@@ -578,7 +587,7 @@ EOF
   status=$?
   expect_code 0 "$status" "omp watch extension contract: $out"
   [ -z "$out" ] || fail "omp watch extension test printed output: $out"
-  pass ".omp watch extension: fm_watch_arm_omp arms once, repeats as a no-op, and delivers an actionable close as one follow-up"
+  pass ".omp watch extension: the primary session owns its arm across nested child shutdown, then delivers one follow-up"
 }
 
 test_detection_anchored_name_and_marker_precedence

--- a/tests/fm-omp-harness.test.sh
+++ b/tests/fm-omp-harness.test.sh
@@ -23,8 +23,8 @@
 #      state/<id>.omp-ext.ts; a secondmate launch names no -e at all.
 #   4. A <provider>/<id> model is validated only when `omp models --json` lists
 #      that provider; an unlisted provider passes through with a notice.
-#   5. Busy state: agent_start is busy, agent_end with willContinue stays busy,
-#      a plain agent_end is idle, turn_end is a notification only.
+#   5. Busy state: agent_start and turn_start are busy, agent_end with
+#      willContinue stays busy, a plain agent_end is idle, turn_end is notification only.
 #   6. The turn-end guard extension compels one continuation on exit 2 and
 #      stands down when the payload already carries stop_hook_active.
 #   7. The watch extension arms through fm_watch_arm_omp and delivers an
@@ -292,6 +292,7 @@ const ctx = { isIdle: () => false };
 switch (process.env.MODE) {
   case "handlers": console.log(Object.keys(handlers).sort().join(" ")); break;
   case "agent-start": await handlers["agent_start"]({ type: "agent_start" }, ctx); break;
+  case "turn-start": await handlers["turn_start"]({ type: "turn_start", turnIndex: 0 }, ctx); break;
   case "end-continuing": await handlers["agent_end"]({ type: "agent_end", willContinue: true }, ctx); break;
   case "end-final": await handlers["agent_end"]({ type: "agent_end" }, ctx); break;
   case "turn-end": await handlers["turn_end"]({ type: "turn_end", turnIndex: 0 }, ctx); break;
@@ -316,17 +317,12 @@ test_busy_extension_lifecycle() {
   case " $out " in
     *" agent_settled "*) fail "the omp extension must not listen for agent_settled (omp has no such event)" ;;
   esac
-  for handler in agent_start agent_end turn_end; do
+  for handler in agent_start agent_end turn_start turn_end; do
     case " $out " in
       *" $handler "*) ;;
       *) fail "the omp extension must register $handler, got '$out'" ;;
     esac
   done
-
-  rm -f "$state/$id.turn-ended"
-  out=$(drive_omp_ext "$ext" turn-end) || fail "turn_end drive failed: $out"
-  [ -f "$state/$id.turn-ended" ] || fail "turn_end no longer touches the notification marker"
-  [ "$(fm_busy_classify tmux fake:w omp "$id" "$state")" = "busy fm-spawn" ] || fail "turn_end must stay a notification, not a state edge"
 
   out=$(drive_omp_ext "$ext" agent-start) || fail "agent_start drive failed: $out"
   [ "$(fm_busy_classify tmux fake:w omp "$id" "$state")" = "busy omp-ext" ] || fail "agent_start must classify 'busy omp-ext'"
@@ -334,13 +330,24 @@ test_busy_extension_lifecycle() {
   out=$(drive_omp_ext "$ext" end-continuing) || fail "continuing agent_end drive failed: $out"
   [ "$(fm_busy_classify tmux fake:w omp "$id" "$state")" = "busy omp-ext" ] || fail "agent_end with willContinue must stay busy (a session_stop continuation is coming)"
 
-  out=$(drive_omp_ext "$ext" end-final) || fail "final agent_end drive failed: $out"
+  out=$(drive_omp_ext "$ext" end-final) || fail "first final agent_end drive failed: $out"
   [ "$(fm_busy_classify tmux fake:w omp "$id" "$state")" = "idle omp-ext" ] || fail "a plain agent_end must classify 'idle omp-ext'"
+
+  out=$(drive_omp_ext "$ext" turn-start) || fail "turn_start drive failed: $out"
+  [ "$(fm_busy_classify tmux fake:w omp "$id" "$state")" = "busy omp-ext" ] || fail "turn_start must refresh an older idle record to 'busy omp-ext'"
+
+  rm -f "$state/$id.turn-ended"
+  out=$(drive_omp_ext "$ext" turn-end) || fail "turn_end drive failed: $out"
+  [ -f "$state/$id.turn-ended" ] || fail "turn_end no longer touches the notification marker"
+  [ "$(fm_busy_classify tmux fake:w omp "$id" "$state")" = "busy omp-ext" ] || fail "turn_end must stay a notification and preserve turn_start's busy state"
+
+  out=$(drive_omp_ext "$ext" end-final) || fail "terminal agent_end drive failed: $out"
+  [ "$(fm_busy_classify tmux fake:w omp "$id" "$state")" = "idle omp-ext" ] || fail "terminal agent_end must classify 'idle omp-ext'"
 
   # A record from another harness's writer is never trusted for omp.
   fm_busy_source_trusted omp pi-ext && fail "omp must not trust the Pi extension's records"
   fm_busy_source_trusted omp omp-ext || fail "omp must trust its own extension's records"
-  pass "omp extension: agent_start busy, willContinue stays busy, plain agent_end idle, turn_end a notification"
+  pass "omp extension: each turn refreshes busy, willContinue stays busy, terminal agent_end idles, turn_end only notifies"
 }
 
 # --- 4. Control, composer, supervision model -----------------------------------

--- a/tests/fm-teardown.test.sh
+++ b/tests/fm-teardown.test.sh
@@ -665,7 +665,7 @@ make_path_without_lsof() {  # <case-dir>
 }
 
 test_local_only_fork_remote_allows() {
-  local case_dir rc
+  local case_dir rc key marker
   case_dir=$(make_case fork-allow)
   write_meta "$case_dir" local-only ship
   wt_commit "$case_dir" "fix the thing"
@@ -673,6 +673,12 @@ test_local_only_fork_remote_allows() {
   # The supervision branch's bounded per-task outcome cache is a footprint of
   # the retired task, not a record anything reads after it is gone.
   printf 'fm-branch-outcome-index-v1\t5\t0\t-\n' > "$case_dir/state/.task-x1.branch-outcome-index"
+  key=firstmate_fm-task-x1
+  for marker in hash count churn-since stale stale-since wedge-escalations \
+    paused paused-rechecked paused-resurfaced writing-since writing-resurfaced; do
+    : > "$case_dir/state/.$marker-$key"
+  done
+  : > "$case_dir/state/.turnend-surfaced-task-x1"
 
   set +e
   run_teardown "$case_dir" > "$case_dir/stdout" 2> "$case_dir/stderr"
@@ -683,6 +689,13 @@ test_local_only_fork_remote_allows() {
   ! grep -q REFUSED "$case_dir/stderr" || fail "fork-allow: teardown printed a REFUSED line"
   [ ! -e "$case_dir/state/.task-x1.branch-outcome-index" ] \
     || fail "fork-allow: teardown left the task's branch outcome index behind"
+  for marker in hash count churn-since stale stale-since wedge-escalations \
+    paused paused-rechecked paused-resurfaced writing-since writing-resurfaced; do
+    assert_absent "$case_dir/state/.$marker-$key" \
+      "fork-allow: teardown left watcher marker .$marker-$key behind"
+  done
+  assert_absent "$case_dir/state/.turnend-surfaced-task-x1" \
+    "fork-allow: teardown left the task turn-end cooldown behind"
   # The supervision branch reports the teardown it just performed AFTER the
   # task's records are gone (bin/fm-branch-prompt.sh); that report must be
   # stored, must publish its ready sequence, and must not recreate the index.

--- a/tests/fm-watch-triage.test.sh
+++ b/tests/fm-watch-triage.test.sh
@@ -750,6 +750,61 @@ test_turn_ended_not_working_surfaced() {
   pass "a bare turn-end whose crew is not provably working is surfaced (the swallowed-finish fix)"
 }
 
+test_repeated_bare_turn_end_is_rate_limited_per_task() {
+  local dir state fakebin out drain_out pid marker
+  dir=$(make_case turn-ended-cooldown); state="$dir/state"; fakebin="$dir/fakebin"
+  out="$dir/watch.out"; drain_out="$dir/drain.out"
+  export FM_FAKE_CREW_STATE='state: unknown · source: none · no current-state source available'
+
+  : > "$state/first.turn-ended"
+  FM_TURNEND_SURFACE_COOLDOWN_SECS=300 watch_bg "$state" "$fakebin" "$out"
+  pid=$!
+  wait_for_exit "$pid" 100 || fail "the first bare turn-end did not surface"
+  FM_STATE_OVERRIDE="$state" "$DRAIN" > "$drain_out" 2>/dev/null || fail "drain after first turn-end failed"
+  grep "$(printf '\tsignal\t')" "$drain_out" | grep -F "$state/first.turn-ended" >/dev/null \
+    || fail "the first bare turn-end was not queued"
+  ack_stopped_cycle "$state" || fail "could not acknowledge the first bare turn-end"
+  marker="$state/.turnend-surfaced-first"
+  [ -e "$marker" ] || fail "the first bare turn-end recorded no cooldown marker"
+
+  printf x >> "$state/first.turn-ended"
+  : > "$out"
+  FM_TURNEND_SURFACE_COOLDOWN_SECS=300 watch_bg "$state" "$fakebin" "$out"
+  pid=$!
+  wait_poll_cycle "$state" "$pid" || { reap "$pid"; fail "a repeated bare turn-end inside the cooldown surfaced"; }
+  [ ! -s "$state/.wake-queue" ] || fail "a repeated bare turn-end inside the cooldown was queued"
+
+  printf 'working: authored status bypasses the mechanical cooldown\n' > "$state/first.status"
+  printf y >> "$state/first.turn-ended"
+  wait_for_exit "$pid" 100 || fail "a status append inside the turn-end cooldown did not surface"
+  FM_STATE_OVERRIDE="$state" "$DRAIN" > "$drain_out" 2>/dev/null || fail "drain after status bypass failed"
+  grep "$(printf '\tsignal\t')" "$drain_out" | grep -F "$state/first.status" >/dev/null \
+    || fail "the authored status append was not queued during the turn-end cooldown: $(cat "$drain_out")"
+  ack_stopped_cycle "$state" || fail "could not acknowledge the status bypass"
+
+  : > "$state/second.turn-ended"
+  : > "$out"
+  FM_TURNEND_SURFACE_COOLDOWN_SECS=300 watch_bg "$state" "$fakebin" "$out"
+  pid=$!
+  wait_for_exit "$pid" 100 || fail "a different task inherited the first task's turn-end cooldown"
+  FM_STATE_OVERRIDE="$state" "$DRAIN" > "$drain_out" 2>/dev/null || fail "drain after second task failed"
+  grep "$(printf '\tsignal\t')" "$drain_out" | grep -F "$state/second.turn-ended" >/dev/null \
+    || fail "a different task's first bare turn-end was not queued"
+  ack_stopped_cycle "$state" || fail "could not acknowledge the second task"
+
+  set_mtime $(( $(date +%s) - 301 )) "$marker"
+  printf z >> "$state/first.turn-ended"
+  : > "$out"
+  FM_TURNEND_SURFACE_COOLDOWN_SECS=300 watch_bg "$state" "$fakebin" "$out"
+  pid=$!
+  wait_for_exit "$pid" 100 || fail "a bare turn-end after the cooldown did not surface"
+  FM_STATE_OVERRIDE="$state" "$DRAIN" > "$drain_out" 2>/dev/null || fail "drain after expired cooldown failed"
+  grep "$(printf '\tsignal\t')" "$drain_out" | grep -F "$state/first.turn-ended" >/dev/null \
+    || fail "the bare turn-end after the cooldown was not queued"
+  unset FM_FAKE_CREW_STATE
+  pass "bare turn-end surfaces are rate-limited per task while status and cooldown expiry bypass"
+}
+
 # --- bare turn-end, unverifiable harness: pane churn is the third proof --------
 # A harness whose semantic busy state has no verified source (codex) can never
 # report working, so the two proofs above are unreachable for it and EVERY worker
@@ -4807,6 +4862,7 @@ test_secondmate_status_signal_never_absorbed_classifier
 test_provably_working_signal_absorbed
 test_turn_ended_provably_working_absorbed
 test_turn_ended_not_working_surfaced
+test_repeated_bare_turn_end_is_rate_limited_per_task
 test_turn_ended_churning_pane_absorbed
 test_turn_ended_churn_resets_prior_stale_classification
 test_turn_ended_churn_resets_wedge_state_before_stale_poll


### PR DESCRIPTION
## summary

- refresh generated OMP worker busy state at every inner turn start.
- prefer positive Herdr activity over stale non-busy semantic records.
- rate-limit repeated bare turn-end notifications per task while preserving status, failure, completion, and expiry wakes.
- retire watcher stale, churn, pause, writing, and turn-end cooldown records during task cleanup.
- treat Herdr `status=done` with no live harness process as agent-free for exit and relaunch.
- ignore untracked pool metadata during fleet fast-forward checks while tracked edits still block.
- bind OMP watcher shutdown to the owning primary session id so nested session shutdown cannot stop supervision.

## verification

- `bin/fm-test-run.sh tests/fm-omp-harness.test.sh`
- `bin/fm-test-run.sh tests/fm-busy-state.test.sh`
- `bin/fm-test-run.sh tests/fm-watch-triage.test.sh`
- `bin/fm-test-run.sh tests/fm-teardown.test.sh tests/fm-backend-herdr.test.sh`
- `bin/fm-test-run.sh tests/fm-fleet-sync.test.sh`
- `bin/fm-lint.sh`

## maintainer note

andrew cannot merge this upstream repository. a maintainer must review and merge this PR.