### PR TITLE
fix: pre-register Claude trust for secondmate homes

### DIFF
--- a/.agents/skills/harness-adapters/references/common/control-and-recovery.md
+++ b/.agents/skills/harness-adapters/references/common/control-and-recovery.md
@@ -17,15 +17,11 @@ Select only its documented trust choice from the active Firstmate home, binding 
 No observed dialog proves only that launch.
 
 Each supported harness handles its folder-trust gate differently, and the tool reference owns the detail.
-Claude gates a fresh worktree and cannot be answered by key, so the spawn pre-registers the path in Claude's own store.
+For Claude, load `references/harness/claude.md`; its workspace-trust section owns the non-key-answerable gate and spawn-time pre-registration for every spawn kind.
 Cursor suppresses its dialog with launch-time `--trust`, and Muse suppresses its own with `--yolo`.
 Grok dodges its gate instead of granting trust, because its project picker appears only outside a project and the spawn starts in the isolated git root.
 Pi gates the fresh-worktree case too, but unlike Claude its dialog is answered with Enter, and `references/harness/pi.md` owns that recipe and where the decision persists.
 Codex shows a directory-trust dialog on the first run for a repository root.
-A Claude secondmate is deliberately not pre-registered, because `../../../bin/fm-spawn.sh` runs its per-harness pre-launch setup only for non-secondmate kinds, so the registration is never invoked for one.
-That kind guard is the whole exclusion, because a treehouse-leased secondmate home is itself a linked worktree that the scope test would accept, and only a plain-clone home would be refused as a primary checkout.
-The consequence is that a claude secondmate whose home Claude has never trusted meets the workspace-trust dialog itself, and firstmate cannot answer it any more than it can for a crewmate.
-This is rarely seen because a secondmate home is persistent and reused, so its trust decision is made once and survives, unlike a per-task worktree that is new every time.
 
 Use the tool's exact skill form, or natural language only when no separate command is verified or the form remains uncertain.
 A successful send or key return is not proof of submission; require the tool-specific postcondition.

--- a/.agents/skills/harness-adapters/references/harness/claude.md
+++ b/.agents/skills/harness-adapters/references/harness/claude.md
@@ -16,10 +16,10 @@ Busy hooks verified 2026-07-28 on Claude Code 2.1.220.
 
 ## Workspace trust
 
-Claude gates a folder it has never seen behind an interactive workspace-trust dialog, so every fresh task worktree would hit it.
-`--dangerously-skip-permissions` does not cover that gate: `claude --help` records that the dialog is skipped only in non-interactive mode, through `-p` or a non-TTY stdout, and a crewmate pane is interactive.
-A ship or scout spawn therefore pre-registers the worktree before launch, and the dialog does not appear.
-`../../../bin/fm-claude-trust.sh` records `hasTrustDialogAccepted` for that worktree path in `${CLAUDE_CONFIG_DIR:-$HOME}/.claude.json`, and `../../../bin/fm-spawn.sh` refuses the spawn when the write fails rather than launching a worker that would wedge.
+Claude gates a folder it has never seen behind an interactive workspace-trust dialog, so every fresh task worktree would hit it, and so would every secondmate home no operator has opened by hand.
+`--dangerously-skip-permissions` does not cover that gate: `claude --help` records that the dialog is skipped only in non-interactive mode, through `-p` or a non-TTY stdout, and a spawned pane is interactive.
+Every claude spawn therefore pre-registers the directory its pane starts in before launch, and the dialog does not appear: the task worktree for a ship or scout, and the home itself for a `--secondmate` spawn, in either seeded shape (a leased worktree or a standalone clone).
+`../../../bin/fm-claude-trust.sh` records `hasTrustDialogAccepted` for that path in `${CLAUDE_CONFIG_DIR:-$HOME}/.claude.json` and owns the structural scope test each shape must pass, and `../../../bin/fm-spawn.sh` refuses the spawn when the registration fails rather than launching an agent that would wedge.
 
 Never try to answer the trust dialog with a key.
 Firstmate's key plane carries only Enter, Escape, and C-c with no arrow navigation, so it cannot move a dialog's selection at all, and the observed rendering starts on `No, exit`, which means a sent Enter ends the session instead of accepting.

--- a/bin/fm-claude-trust.sh
+++ b/bin/fm-claude-trust.sh
@@ -1,26 +1,34 @@
 #!/usr/bin/env bash
-# Pre-register Claude Code's workspace trust for the isolated task worktree a
-# ship/scout spawn is about to launch a claude crewmate into, so the worker
-# reaches its brief instead of wedging on the trust dialog.
+# Pre-register Claude Code's workspace trust for the directory a claude spawn is
+# about to launch into - the isolated task worktree of a ship or scout crewmate,
+# or the seeded home of a secondmate - so the agent reaches its brief or charter
+# instead of wedging on the trust dialog.
 #
 # Usage: fm-claude-trust.sh <worktree> <project>
+#        fm-claude-trust.sh --secondmate-home <home> <id>
 #   <worktree>  the isolated task worktree this spawn launches into
 #   <project>   the primary checkout that worktree belongs to
+#   <home>      the seeded secondmate home this spawn launches into
+#   <id>        the secondmate id that home must already be marked for
 # Prints one line naming what it registered; refuses loudly on anything else.
 #
 # WHY THIS EXISTS. Claude Code gates a folder it has never seen behind an
 # interactive workspace-trust dialog, and --dangerously-skip-permissions does
 # NOT cover it: `claude --help` records that the dialog is skipped only in
-# non-interactive mode (-p, or a non-TTY stdout), and a crewmate pane is
-# interactive. Every fresh task worktree therefore hits it. The dialog renders
+# non-interactive mode (-p, or a non-TTY stdout), and a spawned pane is
+# interactive. Every fresh task worktree therefore hits it, and so does every
+# secondmate home the operator has not opened by hand. The dialog renders
 # with the cursor on "No, exit" and firstmate's steering plane carries only
 # Enter, Escape and C-c with no arrow navigation, so firstmate cannot answer it
-# and must not try - pressing Enter would select exit. The worker wedges before
+# and must not try - pressing Enter would select exit. The agent wedges before
 # it ever reads the brief. Registering the trust before launch is the only
 # control that reaches an interactive pane.
 #
 # THE SCOPE TEST IS THE SAFETY PROPERTY, and it is STRUCTURAL rather than a
-# path policy. <worktree> must be a LINKED git worktree - its own git dir,
+# path policy. Each mode has its own, because the two directories have entirely
+# different shapes on disk.
+#
+# WORKTREE MODE. <worktree> must be a LINKED git worktree - its own git dir,
 # sharing <project>'s common dir - whose top level is exactly the resolved
 # argument. Git is the ground truth, so the argument is never trusted on its
 # own word: a primary checkout (git dir == common dir), a worktree of an
@@ -45,12 +53,36 @@
 # opt-in guard family (FM_*_LIVE_E2E=1) and record the result in
 # docs/verification/runtime-backends.md, rather than assuming the shape here.
 #
+# SECONDMATE-HOME MODE. A secondmate home is a whole firstmate instance rather
+# than a task worktree, and bin/fm-home-seed.sh produces it in two shapes: a
+# leased treehouse worktree (linked) and a standalone clone of the firstmate
+# repo (a primary checkout). The worktree test above therefore cannot decide
+# this case at all - it refuses the standalone clone as a primary checkout,
+# which is why a claude secondmate in an explicit ~/fm-homes/<id> home met the
+# dialog with nothing registered. Git shape is not the evidence here; THE SEED
+# IS. The home must carry a .fm-secondmate-home marker that is a regular file
+# this user owns, never a symlink, naming exactly the <id> passed; it must hold
+# the firstmate instance files AGENTS.md and bin/; and each of its data, state,
+# config and projects paths must resolve inside the home. That is the set
+# bin/fm-home-seed.sh writes and bin/fm-spawn.sh's validate_firstmate_home_for_spawn
+# re-checks before launch, so this accepts exactly the homes a secondmate spawn
+# will launch into and nothing wider: a plain directory, a project checkout, an
+# ordinary firstmate checkout, a home marked for a different secondmate, and a
+# home whose operational directory escapes it are each refused. An ABSENT
+# operational directory is accepted for the same reason the spawn accepts one -
+# a test stricter than the spawn's own would move the wedge from the dialog to
+# a refusal without making any unseeded directory less trusted.
+#
+# Home-level trust is broader than worktree trust, since the pane starts in the
+# home and the secondmate works across it, so it is granted on that seed
+# evidence alone and never on a caller's word about what a path is.
+#
 # Only the launching user's own store is written: the projects entry for the
-# worktree path in ${CLAUDE_CONFIG_DIR:-$HOME}/.claude.json, which must be a
+# registered path in ${CLAUDE_CONFIG_DIR:-$HOME}/.claude.json, which must be a
 # regular file this uid owns. Every unrelated key and project entry is
 # preserved, and the replacement is atomic. fm-spawn.sh forwards CLAUDE_CONFIG_DIR
-# onto the claude launch verbatim rather than resolving it, and the worker's pane
-# starts in the task worktree, so only an absolute value names the same store on
+# onto the claude launch verbatim rather than resolving it, and the pane starts
+# in the registered directory, so only an absolute value names the same store on
 # both sides; a relative one is refused below rather than guessed at.
 set -u
 # Path resolution here must answer from the filesystem, never from the caller's
@@ -69,9 +101,36 @@ unset CDPATH \
   GIT_DISCOVERY_ACROSS_FILESYSTEM GIT_CONFIG GIT_CONFIG_GLOBAL \
   GIT_CONFIG_SYSTEM GIT_CONFIG_NOSYSTEM GIT_CONFIG_COUNT
 
-[ "$#" -eq 2 ] || { echo "usage: fm-claude-trust.sh <worktree> <project>" >&2; exit 2; }
-WT_ARG=$1
-PROJ_ARG=$2
+usage() {
+  echo "usage: fm-claude-trust.sh <worktree> <project>" >&2
+  echo "       fm-claude-trust.sh --secondmate-home <home> <id>" >&2
+  exit 2
+}
+
+# MODE selects which structural scope test decides the argument, and SCOPE_NOUN
+# names what the argument was expected to be so every shared refusal below reads
+# correctly in both modes.
+case "${1:-}" in
+  --secondmate-home)
+    [ "$#" -eq 3 ] || usage
+    MODE=secondmate-home
+    TARGET_ARG=$2
+    SUB_ID=$3
+    PROJ_ARG=
+    SCOPE_NOUN="secondmate home"
+    ;;
+  '' | -h | --help)
+    usage
+    ;;
+  *)
+    [ "$#" -eq 2 ] || usage
+    MODE=worktree
+    TARGET_ARG=$1
+    SUB_ID=
+    PROJ_ARG=$2
+    SCOPE_NOUN="task worktree"
+    ;;
+esac
 
 refuse() { echo "error: refusing to pre-register Claude trust: $1" >&2; exit 1; }
 
@@ -90,10 +149,12 @@ common_dir_of() {
   (cd -P -- "$dir" && real_dir "$common")
 }
 
-WT_REAL=$(real_dir "$WT_ARG") || true
-[ -n "$WT_REAL" ] || refuse "worktree '$WT_ARG' is not an accessible directory"
-PROJ_REAL=$(real_dir "$PROJ_ARG") || true
-[ -n "$PROJ_REAL" ] || refuse "project '$PROJ_ARG' is not an accessible directory"
+TARGET_REAL=$(real_dir "$TARGET_ARG") || true
+[ -n "$TARGET_REAL" ] || refuse "$SCOPE_NOUN '$TARGET_ARG' is not an accessible directory"
+if [ "$MODE" = worktree ]; then
+  PROJ_REAL=$(real_dir "$PROJ_ARG") || true
+  [ -n "$PROJ_REAL" ] || refuse "project '$PROJ_ARG' is not an accessible directory"
+fi
 
 CONFIG_DIR=${CLAUDE_CONFIG_DIR:-${HOME:-}}
 [ -n "$CONFIG_DIR" ] || refuse "neither CLAUDE_CONFIG_DIR nor HOME is set, so the store cannot be located"
@@ -116,30 +177,66 @@ if [ -z "$CONFIG_DIR_REAL" ]; then
 fi
 [ -n "$CONFIG_DIR_REAL" ] || refuse "Claude config directory '$CONFIG_DIR' does not exist and could not be created"
 
-# A home or config directory is never a task worktree. Checked explicitly so
-# the refusal names the real reason instead of the git verdict behind it.
-[ "$WT_REAL" != "$CONFIG_DIR_REAL" ] || refuse "'$WT_REAL' is the Claude config directory, not a task worktree"
+# The filesystem root, a home directory, and the config directory are never
+# something this registers, in either mode. Checked explicitly so the refusal
+# names the real reason instead of the scope verdict behind it.
+[ "$TARGET_REAL" != / ] || refuse "'/' is the filesystem root, not a $SCOPE_NOUN"
+[ "$TARGET_REAL" != "$CONFIG_DIR_REAL" ] || refuse "'$TARGET_REAL' is the Claude config directory, not a $SCOPE_NOUN"
 if [ -n "${HOME:-}" ]; then
   HOME_REAL=$(real_dir "$HOME") || true
-  [ "$WT_REAL" != "${HOME_REAL:-}" ] || refuse "'$WT_REAL' is the home directory, not a task worktree"
+  [ "$TARGET_REAL" != "${HOME_REAL:-}" ] || refuse "'$TARGET_REAL' is the home directory, not a $SCOPE_NOUN"
 fi
 
-WT_TOP=$(git -C "$WT_REAL" rev-parse --show-toplevel 2>/dev/null) || true
-[ -n "$WT_TOP" ] || refuse "'$WT_REAL' is not inside a git repository"
-WT_TOP_REAL=$(real_dir "$WT_TOP") || true
-[ "$WT_TOP_REAL" = "$WT_REAL" ] || refuse "'$WT_REAL' is not a worktree root (its root is '${WT_TOP_REAL:-unresolvable}')"
+if [ "$MODE" = worktree ]; then
+  WT_TOP=$(git -C "$TARGET_REAL" rev-parse --show-toplevel 2>/dev/null) || true
+  [ -n "$WT_TOP" ] || refuse "'$TARGET_REAL' is not inside a git repository"
+  WT_TOP_REAL=$(real_dir "$WT_TOP") || true
+  [ "$WT_TOP_REAL" = "$TARGET_REAL" ] || refuse "'$TARGET_REAL' is not a worktree root (its root is '${WT_TOP_REAL:-unresolvable}')"
 
-WT_GIT_DIR=$(git -C "$WT_REAL" rev-parse --absolute-git-dir 2>/dev/null) || true
-[ -n "$WT_GIT_DIR" ] || refuse "'$WT_REAL' has no resolvable git directory"
-WT_GIT_DIR=$(real_dir "$WT_GIT_DIR") || true
-[ -n "$WT_GIT_DIR" ] || refuse "'$WT_REAL' has an unresolvable git directory"
-WT_COMMON=$(common_dir_of "$WT_REAL") || true
-[ -n "$WT_COMMON" ] || refuse "'$WT_REAL' has no resolvable git common directory"
-[ "$WT_GIT_DIR" != "$WT_COMMON" ] || refuse "'$WT_REAL' is a primary checkout, not an isolated worktree"
+  WT_GIT_DIR=$(git -C "$TARGET_REAL" rev-parse --absolute-git-dir 2>/dev/null) || true
+  [ -n "$WT_GIT_DIR" ] || refuse "'$TARGET_REAL' has no resolvable git directory"
+  WT_GIT_DIR=$(real_dir "$WT_GIT_DIR") || true
+  [ -n "$WT_GIT_DIR" ] || refuse "'$TARGET_REAL' has an unresolvable git directory"
+  WT_COMMON=$(common_dir_of "$TARGET_REAL") || true
+  [ -n "$WT_COMMON" ] || refuse "'$TARGET_REAL' has no resolvable git common directory"
+  [ "$WT_GIT_DIR" != "$WT_COMMON" ] || refuse "'$TARGET_REAL' is a primary checkout, not an isolated worktree"
 
-PROJ_COMMON=$(common_dir_of "$PROJ_REAL") || true
-[ -n "$PROJ_COMMON" ] || refuse "project '$PROJ_REAL' is not inside a git repository"
-[ "$WT_COMMON" = "$PROJ_COMMON" ] || refuse "'$WT_REAL' is not a worktree of project '$PROJ_REAL'"
+  PROJ_COMMON=$(common_dir_of "$PROJ_REAL") || true
+  [ -n "$PROJ_COMMON" ] || refuse "project '$PROJ_REAL' is not inside a git repository"
+  [ "$WT_COMMON" = "$PROJ_COMMON" ] || refuse "'$TARGET_REAL' is not a worktree of project '$PROJ_REAL'"
+else
+  # The seed evidence, in the order that names the most useful reason first: the
+  # marker decides whether this is a secondmate home at all, the id decides
+  # whose, and the instance files and operational directories decide whether it
+  # is the shape bin/fm-home-seed.sh leaves behind. The marker is the token the
+  # whole boundary rests on, so it is judged as a file rather than as a value: a
+  # symlink is refused outright rather than followed, because a link is a way to
+  # make some other file's bytes stand in for the seed, and a marker this user
+  # does not own was planted by someone else.
+  [ -n "$SUB_ID" ] || refuse "no secondmate id was supplied, so '$TARGET_REAL' cannot be matched against its seed marker"
+  SUB_MARKER="$TARGET_REAL/.fm-secondmate-home"
+  [ ! -L "$SUB_MARKER" ] || refuse "'$SUB_MARKER' is a symlink; a seeded secondmate home carries the marker as a regular file"
+  [ -f "$SUB_MARKER" ] || refuse "'$TARGET_REAL' carries no .fm-secondmate-home marker, so it is not a seeded secondmate home"
+  [ -O "$SUB_MARKER" ] || refuse "'$SUB_MARKER' is not owned by this user"
+  SUB_MARKER_ID=$(cat "$SUB_MARKER" 2>/dev/null) || true
+  [ "$SUB_MARKER_ID" = "$SUB_ID" ] || refuse "'$TARGET_REAL' is marked for secondmate '${SUB_MARKER_ID:-unknown}', not '$SUB_ID'"
+  [ -f "$TARGET_REAL/AGENTS.md" ] || refuse "'$TARGET_REAL' has no AGENTS.md, so it is not a firstmate home"
+  [ -d "$TARGET_REAL/bin" ] || refuse "'$TARGET_REAL' has no bin/, so it is not a firstmate home"
+  for sub_dir_name in data state config projects; do
+    sub_dir="$TARGET_REAL/$sub_dir_name"
+    if [ -L "$sub_dir" ] && [ ! -e "$sub_dir" ]; then
+      refuse "'$sub_dir' is a broken symlink, so this home's $sub_dir_name directory cannot be shown to stay inside it"
+    fi
+    [ -e "$sub_dir" ] || continue
+    [ -d "$sub_dir" ] || refuse "'$sub_dir' is not a directory, so '$TARGET_REAL' is not a seeded secondmate home"
+    sub_dir_real=$(real_dir "$sub_dir") || true
+    [ -n "$sub_dir_real" ] || refuse "'$sub_dir' cannot be resolved"
+    case "$sub_dir_real" in
+      "$TARGET_REAL"/*) ;;
+      *) refuse "'$sub_dir' resolves to '$sub_dir_real', outside the home, so '$TARGET_REAL' is not a safe secondmate home" ;;
+    esac
+  done
+fi
 
 # The store write needs node, and a missing interpreter refuses like every other
 # failure here. Degrading instead would launch a worker straight into the dialog
@@ -190,11 +287,11 @@ fi
 # attempts, and it must fail loudly rather than report a trust it did not leave.
 # ponytail: fingerprint-and-refuse, not a lock; flock is absent on macOS and
 # cannot stop a vendor session's own rewrite anyway.
-if ! node - "$STORE" "$WT_REAL" <<'NODE'
+if ! node - "$STORE" "$TARGET_REAL" <<'NODE'
 const fs = require("node:fs");
 const path = require("node:path");
 const crypto = require("node:crypto");
-const [store, worktree] = process.argv.slice(2);
+const [store, target] = process.argv.slice(2);
 const readStore = () => {
   try {
     return fs.readFileSync(store);
@@ -223,12 +320,12 @@ const attempt = () => {
   if (projects === null || typeof projects !== "object" || Array.isArray(projects)) {
     throw new Error(`${store} has a non-object "projects" value`);
   }
-  let entry = projects[worktree];
+  let entry = projects[target];
   if (entry === undefined || entry === null || typeof entry !== "object" || Array.isArray(entry)) {
     entry = {};
   }
   entry.hasTrustDialogAccepted = true;
-  projects[worktree] = entry;
+  projects[target] = entry;
   // Unpredictable name plus an exclusive create: the config directory may be
   // writable by another local account, and a predictable path could be
   // pre-created there as a symlink that a plain write would follow into some
@@ -250,7 +347,7 @@ const attempt = () => {
     if (!renamed) fs.rmSync(tmp, { force: true });
   }
   const back = JSON.parse(fs.readFileSync(store, "utf8"));
-  return back.projects?.[worktree]?.hasTrustDialogAccepted === true ? "recorded" : "dropped";
+  return back.projects?.[target]?.hasTrustDialogAccepted === true ? "recorded" : "dropped";
 };
 try {
   for (let i = 0; i < 3; i += 1) {
@@ -265,11 +362,11 @@ try {
   console.error(`error: ${err.message}`);
   process.exit(1);
 }
-console.error(`error: ${store} did not retain trust for ${worktree} after 3 attempts`);
+console.error(`error: ${store} did not retain trust for ${target} after 3 attempts`);
 process.exit(1);
 NODE
 then
-  refuse "could not record trust for '$WT_REAL' in '$STORE'"
+  refuse "could not record trust for '$TARGET_REAL' in '$STORE'"
 fi
 
-echo "trusted: $WT_REAL"
+echo "trusted: $TARGET_REAL"

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -305,13 +305,13 @@
 # park owns that home's supervision (docs/supervision-protocols/cursor.md).
 # claude is the one harness whose pre-launch setup can REFUSE the spawn: before
 # any per-task state exists, and before its worktree .claude/settings.local.json
-# hooks are written, a non-secondmate claude launch pre-registers the worktree in
-# the launching user's own Claude trust store through bin/fm-claude-trust.sh,
-# because Claude's interactive workspace-trust dialog gates a fresh worktree and
-# firstmate cannot answer it. That helper's header owns the structural scope test
-# and every refusal; a failed registration stops this spawn rather than launching
-# a worker that would wedge on the dialog. A --secondmate launch never runs it,
-# so a claude secondmate home keeps its own one-time trust decision.
+# hooks are written, every claude launch pre-registers the directory the pane
+# starts in - the task worktree, or the secondmate home for a --secondmate spawn -
+# in the launching user's own Claude trust store through bin/fm-claude-trust.sh,
+# because Claude's interactive workspace-trust dialog gates a folder it has never
+# seen and firstmate cannot answer it. That helper's header owns the structural
+# scope test for both shapes and every refusal; a failed registration stops this
+# spawn rather than launching a worker that would wedge on the dialog.
 # Every claude launch also carries the attribution-off policy in its per-launch
 # --settings JSON, so a spawned worker never writes a Co-Authored-By trailer,
 # Claude-Session link, or generated-with line into a commit or PR body;
@@ -3217,27 +3217,35 @@ if [ "$RELAUNCH" -eq 0 ] && [ "$KIND" != secondmate ]; then
   freshen_spawn_worktree_base "$WT" || exit 1
 fi
 
-# Pre-register Claude's workspace trust for the worktree, at the first point the
-# worktree is known and before any per-task state is created below. The dialog
-# gates the pane before the brief is ever read, and it also gates loading the
-# project settings written further down, so nothing armed below takes effect
-# without it. bin/fm-claude-trust.sh owns the structural scope test and refuses
-# any path that is not this project's own isolated worktree; a refusal blocks the
-# spawn rather than launching a worker that would wedge on a dialog firstmate
-# cannot answer. Refusing here rather than beside the arm keeps this in the same
-# class as the two worktree refusals just above: no temp root, no retired
-# relaunch wiring and no busy record exists yet to strand, so the refusal names
-# the endpoint the same way they do and leaves nothing else behind.
-if [ "$KIND" != secondmate ]; then
-  case "$HARNESS" in
-    claude*)
-      if ! "$FM_ROOT/bin/fm-claude-trust.sh" "$WT" "$PROJ_ABS" >/dev/null; then
-        echo "error: could not pre-register Claude workspace trust for $WT; refusing to launch a claude worker that would wedge on the trust dialog; inspect window $T" >&2
-        exit 1
-      fi
-      ;;
-  esac
-fi
+# Pre-register Claude's workspace trust for the directory this launch starts in,
+# at the first point that directory is known and before any per-task state is
+# created below. The dialog gates the pane before the brief is ever read, and it
+# also gates loading the project settings written further down, so nothing armed
+# below takes effect without it. EVERY claude launch needs it, a secondmate's
+# included: its home is just as unseen by Claude as a fresh worktree, and
+# skipping the step for that kind left a standalone-clone secondmate home with
+# nothing registered and a pane wedged on a dialog firstmate cannot answer.
+# bin/fm-claude-trust.sh owns the structural scope test for both shapes and
+# refuses anything that is neither this project's own isolated worktree nor a
+# seeded secondmate home marked for this id; a refusal blocks the spawn rather
+# than launching a worker that would wedge. Refusing here rather than beside the
+# arm keeps this in the same class as the two worktree refusals just above: no
+# temp root, no retired relaunch wiring and no busy record exists yet to strand,
+# so the refusal names the endpoint the same way they do and leaves nothing else
+# behind.
+case "$HARNESS" in
+  claude*)
+    if [ "$KIND" = secondmate ]; then
+      spawn_trust_args=(--secondmate-home "$PROJ_ABS" "$ID")
+    else
+      spawn_trust_args=("$WT" "$PROJ_ABS")
+    fi
+    if ! "$FM_ROOT/bin/fm-claude-trust.sh" "${spawn_trust_args[@]}" >/dev/null; then
+      echo "error: could not pre-register Claude workspace trust for $WT; refusing to launch a claude worker that would wedge on the trust dialog; inspect window $T" >&2
+      exit 1
+    fi
+    ;;
+esac
 
 # Per-task temp root: /tmp/fm-<id>/ with Go's build temp nested at gotmp/. Go won't
 # create GOTMPDIR, so mkdir before it is used; fm-teardown removes the whole root.

--- a/docs/verification/runtime-backends.md
+++ b/docs/verification/runtime-backends.md
@@ -300,7 +300,48 @@ That warning rendered in the same shape as the trust dialog, with the selection 
 That gate is not a production blocker, because a normal environment has already accepted it and the treatment arm above ran against the real config and saw neither dialog.
 This change does not address that warning and does not claim to.
 
-`bin/fm-spawn.sh` therefore pre-registers the task worktree through `bin/fm-claude-trust.sh` before launch, and `tests/fm-claude-trust.test.sh` pins both halves of the scope contract: a fresh worktree is trusted, and an out-of-scope path is refused.
+### Secondmate homes
+
+Verified 2026-09-11 on Claude Code 2.1.269.
+A secondmate launches in its own firstmate home rather than a task worktree, and that home meets the same gate.
+The control arm launched a standalone-clone secondmate home that the store had no entry for, the way `bin/fm-spawn.sh --secondmate` launches one.
+
+```sh
+tmux -L <sock> new-session -d -s ctrl -x 180 -y 44 -c <home> \
+  "CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false claude --dangerously-skip-permissions"
+```
+
+```
+ Accessing workspace:
+ /private/tmp/fm-sm-trust-live-69759/fm-homes/livemate-n1
+ Quick safety check: Is this a project you created or one you trust? ...
+ ❯ No, exit
+   Yes, I trust this folder
+```
+
+The treatment arm pre-registered that same home through the secondmate-home mode and launched it identically against the operator's real config.
+
+```sh
+bin/fm-claude-trust.sh --secondmate-home <home> livemate-n1
+```
+
+```
+trusted: /private/tmp/fm-sm-trust-live-69759/fm-homes/livemate-n1
+```
+
+```
+ ▐▛███▛█   Claude Code v2.1.269
+▝▜██████▀  Opus 4.8 with high effort · Claude Max
+  ▝▝ ▝▝    /private/tmp/fm-sm-trust-live-69759/fm-homes/livemate-n1
+...
+❯
+  ⏵⏵ bypass permissions on (shift+tab to cycle) · ← for agents
+```
+
+No dialog appeared, the composer was reached, and neither did the machine-scoped bypass warning, because this ran against the real config.
+The lab home was deleted and the test entry was removed from the store and verified absent, with the same point-in-time caveat as the worktree arms above.
+
+`bin/fm-spawn.sh` therefore pre-registers the directory every claude launch starts in through `bin/fm-claude-trust.sh` before launch, and `tests/fm-claude-trust.test.sh` pins both halves of the scope contract for both shapes: a fresh worktree and a seeded secondmate home are trusted, and an out-of-scope path is refused.
 That automated spawn case runs against a fake claude, so it asserts the store entry and the launch command and nothing more; the live arms above are what establish that the entry actually suppresses the dialog.
 The composer-classification record below observes the same gate from the other side, where an untrusted worktree left Claude, Grok, and Muse unverified because the guard reads a first-launch trust dialog as an unreadable composer.
 

--- a/tests/fm-claude-trust.test.sh
+++ b/tests/fm-claude-trust.test.sh
@@ -1,9 +1,10 @@
 #!/usr/bin/env bash
 # Behavior tests for bin/fm-claude-trust.sh and the claude spawn that calls it.
 #
-# Both halves of the contract are load-bearing and both are proven here: a
-# legitimate fresh task worktree is trusted so a claude worker reaches its
-# brief with no human, and every out-of-scope path is REFUSED rather than
+# Both halves of the contract are load-bearing and both are proven here, for
+# each directory a claude launch can start in: a legitimate fresh task worktree
+# and a seeded secondmate home are trusted so the agent reaches its brief or
+# charter with no human, and every out-of-scope path is REFUSED rather than
 # warned about or quietly skipped.
 set -u
 
@@ -76,6 +77,53 @@ node_free_path() {  # <case-dir> -> a bin dir holding the script's own tools but
     ln -sf "$(command -v "$tool")" "$dir/$tool"
   done
   printf '%s\n' "$dir"
+}
+
+# --- secondmate homes -------------------------------------------------------
+
+# seed_secondmate_home <home> <id> [shape]: the on-disk shape bin/fm-home-seed.sh
+# leaves behind - the identity marker, the firstmate instance files, the four
+# operational directories, and a charter for the launch to carry. "clone" (the
+# default) is the standalone-clone home an explicit ~/fm-homes/<id> path
+# produces, a primary checkout of the firstmate repo; "worktree" is the linked
+# worktree a treehouse lease produces. Both shapes are real homes, so both must
+# be trusted.
+seed_secondmate_home() {
+  local home=$1 id=$2 shape=${3:-clone} src
+  case "$shape" in
+    worktree)
+      src="$home.src"
+      fm_git_worktree "$src" "$home" "sm-$id"
+      ;;
+    *)
+      mkdir -p "$home"
+      fm_git_init_commit "$home"
+      ;;
+  esac
+  mkdir -p "$home/bin" "$home/data" "$home/state" "$home/config" "$home/projects"
+  printf '# Firstmate\n' > "$home/AGENTS.md"
+  printf 'charter\n' > "$home/data/charter.md"
+  printf '%s\n' "$id" > "$home/.fm-secondmate-home"
+}
+
+# run_home_trust <config> <home> <id> [user-home]: invoke the secondmate-home
+# mode against an isolated store.
+run_home_trust() {
+  local config=$1 home=$2 id=$3 user_home=${4:-$1}
+  CLAUDE_CONFIG_DIR="$config" HOME="$user_home" "$TRUST" --secondmate-home "$home" "$id" 2>&1
+}
+
+# spawn_secondmate_claude <case-dir> <home> <id>: run a real --secondmate claude
+# spawn against the isolated store at <case-dir>/claude-config, logging the
+# launch to <case-dir>/launch.log. Echoes the spawn output.
+spawn_secondmate_claude() {
+  local case_dir=$1 home=$2 id=$3 primary fakebin
+  primary="$case_dir/primary"
+  mkdir -p "$case_dir/claude-config"
+  fakebin=$(make_spawn_fakebin "$case_dir/fake" claude)
+  fm_test_spawn_home "$primary" claude
+  FM_TEST_CLAUDE_CONFIG_DIR="$case_dir/claude-config" FM_FAKE_LAUNCH_LOG="$case_dir/launch.log" \
+    fm_test_run_spawn "$primary" "$home" "$fakebin" "$id" "$home" claude --secondmate
 }
 
 test_fresh_worktree_is_trusted() {
@@ -440,6 +488,162 @@ test_claude_spawn_pretrusts_its_worktree_and_reaches_the_brief() {
   pass "fm-spawn.sh: a claude spawn pre-trusts its worktree and launches with the brief"
 }
 
+# A secondmate home is the second directory a claude launch starts in, and it is
+# as unseen by Claude as a fresh worktree. The standalone-clone shape is the one
+# that wedged in production: the trust step was skipped for every secondmate, so
+# nothing was registered and the pane stopped on the dialog before it read its
+# charter.
+test_secondmate_standalone_clone_home_is_trusted() {
+  local case_dir home out
+  case_dir="$TMP_ROOT/sm-clone-spawn"
+  home="$case_dir/fm-homes/nomistakes-n1"
+  seed_secondmate_home "$home" nomistakes-n1 clone
+  out=$(spawn_secondmate_claude "$case_dir" "$home" nomistakes-n1)
+  expect_code 0 $? "a claude secondmate spawn into a standalone-clone home must succeed: $out"
+  assert_trusted "$case_dir/claude-config/.claude.json" "$home" \
+    "the claude secondmate spawn did not pre-register trust for its standalone-clone home"
+  assert_present "$case_dir/launch.log" "the claude secondmate spawn sent no launch command"
+  assert_grep 'claude --dangerously-skip-permissions' "$case_dir/launch.log" \
+    "the launch command was not the claude secondmate launch"
+  assert_grep "$home/data/charter.md" "$case_dir/launch.log" \
+    "the launch command did not carry the charter the secondmate must read"
+  # The pane must read the SAME store the registration wrote, or the trust would
+  # land somewhere it never looks and the dialog would appear anyway.
+  assert_grep "CLAUDE_CONFIG_DIR='$case_dir/claude-config'" "$case_dir/launch.log" \
+    "the launch command did not point the secondmate at the store that was trusted"
+  pass "fm-spawn.sh: a claude secondmate spawn pre-trusts a standalone-clone home"
+}
+
+# The other seeded shape, a treehouse-leased linked worktree. It must be trusted
+# through the same seed evidence rather than incidentally, so the registration
+# does not depend on which shape the home happens to have.
+test_secondmate_leased_worktree_home_is_trusted() {
+  local case_dir home out
+  case_dir="$TMP_ROOT/sm-leased-spawn"
+  home="$case_dir/leased/home"
+  mkdir -p "$case_dir/leased"
+  seed_secondmate_home "$home" leased-n1 worktree
+  out=$(spawn_secondmate_claude "$case_dir" "$home" leased-n1)
+  expect_code 0 $? "a claude secondmate spawn into a leased worktree home must succeed: $out"
+  assert_trusted "$case_dir/claude-config/.claude.json" "$home" \
+    "the claude secondmate spawn did not pre-register trust for its leased worktree home"
+  pass "fm-spawn.sh: a claude secondmate spawn pre-trusts a leased worktree home"
+}
+
+# The seed is the whole security boundary for home-level trust, so every path
+# that is not a home seeded for THIS secondmate is refused and left untrusted.
+# Each row drives one structural property apart from a genuine home.
+test_secondmate_home_trust_refuses_everything_unseeded() {
+  local case_dir config home target out
+  case_dir="$TMP_ROOT/sm-refusals"
+  config="$case_dir/claude-config"
+  mkdir -p "$config"
+
+  # A plain directory: no marker at all.
+  target="$case_dir/plain"
+  mkdir -p "$target"
+  out=$(run_home_trust "$config" "$target" plain-n1)
+  expect_code 1 $? "a plain directory must be refused: $out"
+  assert_contains "$out" "no .fm-secondmate-home marker" "the refusal did not name the missing marker"
+  assert_not_trusted "$config/.claude.json" "$target" "a plain directory was trusted"
+
+  # A firstmate checkout that was never seeded as a secondmate home: every other
+  # structural signal matches and only the marker is missing.
+  target="$case_dir/checkout"
+  seed_secondmate_home "$target" checkout-n1 clone
+  rm -f "$target/.fm-secondmate-home"
+  out=$(run_home_trust "$config" "$target" checkout-n1)
+  expect_code 1 $? "an unseeded firstmate checkout must be refused: $out"
+  assert_contains "$out" "no .fm-secondmate-home marker" "the refusal did not name the missing marker"
+  assert_not_trusted "$config/.claude.json" "$target" "an unseeded firstmate checkout was trusted"
+
+  # A home seeded for a DIFFERENT secondmate: one home's trust must not be
+  # granted while spawning another id.
+  target="$case_dir/other-mate"
+  seed_secondmate_home "$target" other-n1 clone
+  out=$(run_home_trust "$config" "$target" wanted-n1)
+  expect_code 1 $? "a home marked for another secondmate must be refused: $out"
+  assert_contains "$out" "other-n1" "the refusal did not name the id the home is marked for"
+  assert_not_trusted "$config/.claude.json" "$target" "a home marked for another secondmate was trusted"
+
+  # A marker that is a symlink: another file's bytes must not stand in for the
+  # seed, even when they read as the right id.
+  target="$case_dir/linked-marker"
+  seed_secondmate_home "$target" linked-n1 clone
+  printf 'linked-n1\n' > "$case_dir/planted-id"
+  ln -sf "$case_dir/planted-id" "$target/.fm-secondmate-home"
+  out=$(run_home_trust "$config" "$target" linked-n1)
+  expect_code 1 $? "a symlinked marker must be refused: $out"
+  assert_contains "$out" "symlink" "the refusal did not name the symlinked marker"
+  assert_not_trusted "$config/.claude.json" "$target" "a home whose marker is a symlink was trusted"
+
+  # An operational directory that escapes the home: the home's own working
+  # surface must stay inside it.
+  target="$case_dir/escaping"
+  seed_secondmate_home "$target" escaping-n1 clone
+  rm -rf "$target/projects"
+  mkdir -p "$case_dir/elsewhere"
+  ln -s "$case_dir/elsewhere" "$target/projects"
+  out=$(run_home_trust "$config" "$target" escaping-n1)
+  expect_code 1 $? "a home whose operational directory escapes it must be refused: $out"
+  assert_contains "$out" "outside the home" "the refusal did not name the escaping directory"
+  assert_not_trusted "$config/.claude.json" "$target" "a home whose projects/ escapes it was trusted"
+
+  # The user's own home directory, seeded to prove the marker alone cannot carry
+  # it: HOME is refused in this mode exactly as it is for a worktree.
+  target="$case_dir/user-home"
+  seed_secondmate_home "$target" userhome-n1 clone
+  out=$(run_home_trust "$config" "$target" userhome-n1 "$target")
+  expect_code 1 $? "the user's home directory must be refused: $out"
+  assert_contains "$out" "home directory" "the refusal did not name the home directory"
+  assert_not_trusted "$config/.claude.json" "$target" "the user's home directory was trusted"
+  # Prove the seed really would have been accepted, so the guard above is what
+  # refused rather than an unrelated failure.
+  out=$(run_home_trust "$config" "$target" userhome-n1 "$case_dir/elsewhere-home")
+  expect_code 0 $? "the same seeded home must be accepted once it is not HOME: $out"
+
+  pass "fm-claude-trust.sh: home-level trust is refused for everything but a home seeded for this secondmate"
+}
+
+# A secondmate home is not a linked worktree, so worktree mode must keep
+# refusing it rather than quietly widening to cover the new case.
+test_worktree_mode_still_refuses_a_secondmate_home() {
+  local case_dir config home out
+  case_dir="$TMP_ROOT/sm-wrong-mode"
+  config="$case_dir/claude-config"
+  home="$case_dir/home"
+  mkdir -p "$config"
+  seed_secondmate_home "$home" mode-n1 clone
+  out=$(run_trust "$config" "$home" "$home")
+  expect_code 1 $? "worktree mode must still refuse a standalone-clone home: $out"
+  assert_contains "$out" "primary checkout" "the refusal did not name the primary checkout"
+  assert_not_trusted "$config/.claude.json" "$home" "worktree mode trusted a standalone-clone home"
+  pass "fm-claude-trust.sh: worktree mode still refuses a secondmate home"
+}
+
+# The fail-closed half for secondmates: when the home's trust genuinely cannot be
+# recorded, the spawn must refuse rather than launch a pane that would wedge on
+# the dialog. This is the guard that never fired while the step was skipped.
+test_secondmate_spawn_fails_closed_when_home_trust_cannot_be_recorded() {
+  local case_dir home out
+  case_dir="$TMP_ROOT/sm-failclosed"
+  home="$case_dir/fm-homes/failclosed-n1"
+  # Root owns /etc/passwd, so a store resolving to it is refused as another
+  # user's file. Running as root would own it and make the refusal vacuous.
+  if [ "$(id -u)" = 0 ]; then
+    pass "fm-spawn.sh: a claude secondmate spawn refuses when home trust cannot be recorded (skipped as root)"
+    return 0
+  fi
+  seed_secondmate_home "$home" failclosed-n1 clone
+  mkdir -p "$case_dir/claude-config"
+  ln -s /etc/passwd "$case_dir/claude-config/.claude.json"
+  out=$(spawn_secondmate_claude "$case_dir" "$home" failclosed-n1)
+  expect_code 1 $? "a secondmate spawn whose trust registration is refused must fail: $out"
+  assert_contains "$out" "workspace trust" "the spawn did not report the trust refusal"
+  assert_absent "$case_dir/launch.log" "a secondmate was launched into a home whose trust could not be recorded"
+  pass "fm-spawn.sh: a claude secondmate spawn refuses when home trust cannot be recorded"
+}
+
 test_fresh_worktree_is_trusted
 test_registration_is_idempotent
 test_primary_checkout_is_refused
@@ -460,3 +664,8 @@ test_missing_node_is_refused
 test_scope_refusal_stays_fail_closed_without_node
 test_claude_spawn_pretrusts_its_worktree_and_reaches_the_brief
 test_refused_spawn_leaves_no_task_state
+test_secondmate_standalone_clone_home_is_trusted
+test_secondmate_leased_worktree_home_is_trusted
+test_secondmate_home_trust_refuses_everything_unseeded
+test_worktree_mode_still_refuses_a_secondmate_home
+test_secondmate_spawn_fails_closed_when_home_trust_cannot_be_recorded

--- a/tests/fm-secondmate-harness.test.sh
+++ b/tests/fm-secondmate-harness.test.sh
@@ -64,6 +64,12 @@ fm_git_identity fmtest fmtest@example.com
 TMP_ROOT=$(fm_test_tmproot fm-secondmate-harness)
 export FM_BACKEND=tmux
 
+# Every claude launch pre-registers workspace trust for the directory it starts
+# in, and for a secondmate that directory is the home (bin/fm-claude-trust.sh).
+# Several cases here resolve claude, so every spawn below pins a throwaway HOME
+# with an empty CLAUDE_CONFIG_DIR and puts node on the spawn's PATH; without the
+# first, this suite would write the developer's real ~/.claude.json.
+
 # ===========================================================================
 # A) fm-harness.sh secondmate resolution + fallback (deterministic detect_own)
 # ===========================================================================
@@ -426,6 +432,10 @@ make_noop_tmux() {
 exit 0
 SH
   chmod +x "$fakebin/tmux"
+  # BASE_PATH deliberately omits the developer's node, which the trust
+  # registration below needs, so link the real one in rather than presenting a
+  # node-less spawn host no real fleet member looks like.
+  ln -sf "$(command -v node)" "$fakebin/node"
   printf '%s\n' "$fakebin"
 }
 
@@ -455,7 +465,7 @@ spawn_secondmate() {
   [ -n "$harness" ] && spawn_args+=("$harness")
   spawn_args+=(--secondmate)
   PATH="$fakebin:$BASE_PATH" TMUX='' CLAUDECODE=1 \
-    FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$world/home" \
+    FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$world/home" HOME="$world/home/user-home" CLAUDE_CONFIG_DIR='' \
     FM_STATE_OVERRIDE="$world/home/state" FM_DATA_OVERRIDE="$world/home/data" \
     FM_PROJECTS_OVERRIDE="$world/home/projects" FM_CONFIG_OVERRIDE="$world/home/config" \
     FM_SPAWN_NO_GUARD=1 \
@@ -568,7 +578,7 @@ test_spawn_unverified_secondmate_harness_refused() {
   err="$w/spawn.err"
   rc=0
   PATH="$fakebin:$BASE_PATH" TMUX='' CLAUDECODE=1 \
-    FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$w/home" \
+    FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$w/home" HOME="$w/home/user-home" CLAUDE_CONFIG_DIR='' \
     FM_STATE_OVERRIDE="$w/home/state" FM_DATA_OVERRIDE="$w/home/data" \
     FM_PROJECTS_OVERRIDE="$w/home/projects" FM_CONFIG_OVERRIDE="$w/home/config" \
     FM_SPAWN_NO_GUARD=1 \
@@ -595,7 +605,7 @@ test_spawn_cursor_secondmate_launches_with_its_primary_contract() {
   : > "$launchlog"
   rc=0
   PATH="$fakebin:$BASE_PATH" TMUX='' CLAUDECODE=1 \
-    FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$w/home" \
+    FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$w/home" HOME="$w/home/user-home" CLAUDE_CONFIG_DIR='' \
     FM_STATE_OVERRIDE="$w/home/state" FM_DATA_OVERRIDE="$w/home/data" \
     FM_PROJECTS_OVERRIDE="$w/home/projects" FM_CONFIG_OVERRIDE="$w/home/config" \
     FM_SPAWN_NO_GUARD=1 FM_FAKE_LAUNCH_LOG="$launchlog" FM_FAKE_PANE_PATH="$sm" \
@@ -661,6 +671,10 @@ exit 0
 SH
   chmod +x "$fakebin/tmux"
   fm_fake_exit0 "$fakebin" pi
+  # BASE_PATH deliberately omits the developer's node, which the trust
+  # registration below needs, so link the real one in rather than presenting a
+  # node-less spawn host no real fleet member looks like.
+  ln -sf "$(command -v node)" "$fakebin/node"
   printf '%s\n' "$fakebin"
 }
 
@@ -674,7 +688,7 @@ spawn_secondmate_capture() {
   fakebin=$(make_launch_capturing_tmux "$world/tmux-$id")
   : > "$launchlog"
   PATH="$fakebin:$BASE_PATH" TMUX='' CLAUDECODE=1 \
-    FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$world/home" \
+    FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$world/home" HOME="$world/home/user-home" CLAUDE_CONFIG_DIR='' \
     FM_STATE_OVERRIDE="$world/home/state" FM_DATA_OVERRIDE="$world/home/data" \
     FM_PROJECTS_OVERRIDE="$world/home/projects" FM_CONFIG_OVERRIDE="$world/home/config" \
     FM_SPAWN_NO_GUARD=1 FM_FAKE_LAUNCH_LOG="$launchlog" \
@@ -2572,7 +2586,7 @@ SH
   chmod +x "$fakebin/rm"
   launchlog="$w/spawn-quarantine.launch.log"
   out=$(PATH="$fakebin:$BASE_PATH" TMUX='' CLAUDECODE=1 \
-    FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$w/home" \
+    FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$w/home" HOME="$w/home/user-home" CLAUDE_CONFIG_DIR='' \
     FM_STATE_OVERRIDE="$w/home/state" FM_DATA_OVERRIDE="$w/home/data" \
     FM_PROJECTS_OVERRIDE="$w/home/projects" FM_CONFIG_OVERRIDE="$w/home/config" \
     FM_SPAWN_NO_GUARD=1 FM_FAKE_LAUNCH_LOG="$launchlog" \

--- a/tests/fm-trace-context-spawn.test.sh
+++ b/tests/fm-trace-context-spawn.test.sh
@@ -214,8 +214,12 @@ run_two_level() {
   smlog="$base/sm-launch.log"
   smfake=$(make_spawn_fakebin "$base/sm-fake")
   : > "$smlog"
+  # A claude secondmate spawn pre-registers workspace trust for the HOME it
+  # launches into (bin/fm-claude-trust.sh), so this runs against a throwaway
+  # HOME; without it this suite would write the developer's real ~/.claude.json.
+  mkdir -p "$base/user-home"
   env FM_TRACE_CONTEXT="$penv" \
-    FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$prim" \
+    FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$prim" HOME="$base/user-home" CLAUDE_CONFIG_DIR='' \
     FM_STATE_OVERRIDE="$prim/state" FM_DATA_OVERRIDE="$prim/data" \
     FM_PROJECTS_OVERRIDE="$prim/projects" FM_CONFIG_OVERRIDE="$prim/config" \
     FM_SPAWN_NO_GUARD=1 CLAUDECODE=1 TMUX="fake,1,0" \
@@ -387,8 +391,12 @@ test_duplicate_secondmate_spawn_does_not_converge_trace_context() {
   printf 'charter\n' > "$sm/data/charter.md"
   fake=$(make_spawn_fakebin "$base/fake")
 
+  # A claude secondmate spawn pre-registers workspace trust for the HOME it
+  # launches into (bin/fm-claude-trust.sh), so this runs against a throwaway
+  # HOME; without it this suite would write the developer's real ~/.claude.json.
+  mkdir -p "$base/user-home"
   out=$(env -u FM_TRACE_CONTEXT \
-    FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$prim" \
+    FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$prim" HOME="$base/user-home" CLAUDE_CONFIG_DIR='' \
     FM_STATE_OVERRIDE="$prim/state" FM_DATA_OVERRIDE="$prim/data" \
     FM_PROJECTS_OVERRIDE="$prim/projects" FM_CONFIG_OVERRIDE="$prim/config" \
     FM_SPAWN_NO_GUARD=1 CLAUDECODE=1 TMUX="fake,1,0" \


### PR DESCRIPTION
## Intent

Routed firstmate fix, captain approved (main firstmate corr=0f149f24b15a3312; nudge corr=22bcb3cf668db4e4).
BUG: bin/fm-spawn.sh --secondmate on the claude harness does not pre-register Claude workspace trust (hasTrustDialogAccepted) for a STANDALONE-CLONE secondmate home (an explicit path like ~/fm-homes/<id>), so the launched claude secondmate wedges at the "Is this a project you trust?" dialog. Hit live today creating the nomistakes-n1 secondmate.
ROOT CAUSE: bin/fm-claude-trust.sh only registers LINKED git worktrees and by design refuses a primary checkout / standalone home / plain dir. A treehouse-leased ("-") secondmate home is a linked worktree so trust works, but an explicit standalone-clone home is skipped, so no trust is registered and the dialog appears.

## What Changed

- Pre-register Claude workspace trust before launching secondmates in standalone-clone or leased-worktree homes.
- Add a fail-closed secondmate-home trust mode that validates seed markers, identity, instance files, and operational directory boundaries.
- Expand automated coverage and documentation for secondmate trust registration, refusal cases, and launch behavior.

## Risk Assessment

✅ Low: The change is well-bounded, fail-closed, preserves existing worktree behavior, and behaviorally covers both standalone-clone and leased-worktree secondmate homes.

## Testing

The targeted trust/spawn behavior suite passed; the previous standalone-clone refusal was reproduced, the fixed helper persisted trust that real Claude consumed without showing the project-trust dialog, and adversarial homes were refused without state changes. Full live `fm-spawn --secondmate` was blocked by the gate-agent safety guard, so its wiring was exercised through the focused executable integration test with fake tmux. No screenshot was captured because this is terminal startup behavior rather than a visual-layout change; the rendered tmux pane transcript is preserved.

- Live validation: ✅ go - 2 of 4 scenarios driven live against the product

| Scenario | Result | Live | Evidence |
| --- | --- | --- | --- |
| Register a standalone-clone secondmate home and enter real Claude without the project-trust dialog | ✅ pass | live | `live-registration.log` records `hasTrustDialogAccepted: true`; `live-claude-pane-clean.txt` shows real Claude advancing to “Let&#39;s get started” and theme selection rather than “Is this a project you t… |
| Spawn a Claude secondmate into a standalone-clone home and deliver its charter using the same trusted store | ⏸️ untested | no | A real fleet spawn is intentionally refused in this environment because `NO_MISTAKES_GATE=1` and the checkout is a no-mistakes gate worktree. Re-run from a normal firstmate checkout outside an active… |
| Refuse homes marked for another secondmate or whose operational directory escapes the home | ✅ pass | live | `live-boundary-and-baseline.log` shows both executable invocations exiting 1 with specific refusal diagnostics and `trusted=false`. |
| Refuse the secondmate spawn when trust cannot be recorded instead of launching a wedged pane | ⏸️ untested | no | The no-mistakes gate-agent guard prevents a real fleet spawn here. Re-run the focused failure scenario from a normal firstmate environment with a disposable unsafe Claude store to verify the real back… |

<details>
<summary>Evidence: Targeted Claude trust and spawn behavior suite</summary>

Source: [Targeted Claude trust and spawn behavior suite](https://github.com/kunchenguid/firstmate/blob/ac223c78e29f5504a9cab843fcdfae83d3ac6206/.no-mistakes/evidence/fm/fm-secondmate-claude-trust-standalone-home-r1/fm-claude-trust-targeted.log)

```text
ok - fm-claude-trust.sh: a fresh task worktree is trusted
ok - fm-claude-trust.sh: repeat registration is idempotent
ok - fm-claude-trust.sh: refuses the primary checkout
ok - fm-claude-trust.sh: an exported CDPATH cannot defeat the scope refusal
ok - fm-claude-trust.sh: inherited git environment overrides cannot defeat the scope refusal
ok - fm-claude-trust.sh: refuses a home directory the git checks would accept
ok - fm-claude-trust.sh: refuses the Claude config directory
ok - fm-claude-trust.sh: refuses a relative CLAUDE_CONFIG_DIR
ok - fm-claude-trust.sh: refuses a directory that is not a git worktree
ok - fm-claude-trust.sh: refuses a path that does not exist
ok - fm-claude-trust.sh: refuses a worktree belonging to another project
ok - fm-claude-trust.sh: refuses a subdirectory of the worktree
ok - fm-claude-trust.sh: preserves unrelated store content
ok - fm-claude-trust.sh: refuses a store symlinked to another user's file
ok - fm-claude-trust.sh: follows a store symlink to this user's own file and leaves the link intact
ok - fm-claude-trust.sh: refuses an unparseable store and leaves it untouched
ok - fm-claude-trust.sh: a missing node is refused rather than degraded
ok - fm-claude-trust.sh: a scope refusal stays fail-closed without node
ok - fm-spawn.sh: a claude spawn pre-trusts its worktree and launches with the brief
ok - fm-spawn.sh: a trust-refused claude spawn leaves no task state behind
ok - fm-spawn.sh: a claude secondmate spawn pre-trusts a standalone-clone home
ok - fm-spawn.sh: a claude secondmate spawn pre-trusts a leased worktree home
ok - fm-claude-trust.sh: home-level trust is refused for everything but a home seeded for this secondmate
ok - fm-claude-trust.sh: worktree mode still refuses a secondmate home
ok - fm-spawn.sh: a claude secondmate spawn refuses when home trust cannot be recorded
```
</details>
<details>
<summary>Evidence: Live standalone-home trust registration and persisted vendor state</summary>

Source: [Live standalone-home trust registration and persisted vendor state](https://github.com/kunchenguid/firstmate/blob/ac223c78e29f5504a9cab843fcdfae83d3ac6206/.no-mistakes/evidence/fm/fm-secondmate-claude-trust-standalone-home-r1/live-registration.log)

```text
trusted: ~/.no-mistakes/worktrees/52b07e9083e7/01M29VP8DVACPVK3X2366BWMVM/.test-live-claude-trust/standalone-home
{
  "path": "~/.no-mistakes/worktrees/52b07e9083e7/01M29VP8DVACPVK3X2366BWMVM/.test-live-claude-trust/standalone-home",
  "hasTrustDialogAccepted": true
}
```
</details>
<details>
<summary>Evidence: Real Claude interactive pane after trust registration</summary>

Source: [Real Claude interactive pane after trust registration](https://github.com/kunchenguid/firstmate/blob/ac223c78e29f5504a9cab843fcdfae83d3ac6206/.no-mistakes/evidence/fm/fm-secondmate-claude-trust-standalone-home-r1/live-claude-pane-clean.txt)

```text
     *                                       █████▓▓░
                                 *         ███▓░     ░░
            ░░░░░░                        ███▓░
    ░░░   ░░░░░░░░░░                      ███▓░
   ░░░░░░░░░░░░░░░░░░░    *                ██▓░░      ▓
                                             ░▓▓███▓▓░
 *                                 ░░░░
                                 ░░░░░░░░
                               ░░░░░░░░░░░░░░░░
       █████████                                        *
      ██▄█████▄██                        *
       █████████      *
.......█ █   █ █..........................................

 Let's get started.

 Choose the text style that looks best with your terminal
 To change this later, run /theme

   1. Auto (match terminal)
 ❯ 2. Dark mode ✔
   3. Light mode
   4. Dark mode (colorblind-friendly)
   5. Light mode (colorblind-friendly)
   6. Dark mode (ANSI colors only)
   7. Light mode (ANSI colors only)

 ╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌
  1  function greet() {
  2 -  console.log("Hello, World!");                                                                               
  2 +  console.log("Hello, Claude!");                                                                              
  3  }
 ╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌
  Syntax theme: Monokai Extended (ctrl+t to disable)
```
</details>
<details>
<summary>Evidence: Baseline reproduction and adversarial boundary refusals</summary>

Source: [Baseline reproduction and adversarial boundary refusals](https://github.com/kunchenguid/firstmate/blob/ac223c78e29f5504a9cab843fcdfae83d3ac6206/.no-mistakes/evidence/fm/fm-secondmate-claude-trust-standalone-home-r1/live-boundary-and-baseline.log)

```text
SCENARIO: baseline reproduces standalone-home trust failure
error: refusing to pre-register Claude trust: '~/.no-mistakes/worktrees/52b07e9083e7/01M29VP8DVACPVK3X2366BWMVM/.test-live-claude-trust/standalone-home' is a primary checkout, not an isolated worktree
baseline_exit=1

SCENARIO: marker for another secondmate is refused without state change
error: refusing to pre-register Claude trust: '~/.no-mistakes/worktrees/52b07e9083e7/01M29VP8DVACPVK3X2366BWMVM/.test-live-claude-trust/standalone-home' is marked for secondmate 'other-n1', not 'nomistakes-n1'
wrong_id_exit=1
wrong_id_trusted=false (store not created)

SCENARIO: escaping projects directory is refused without state change
error: refusing to pre-register Claude trust: '~/.no-mistakes/worktrees/52b07e9083e7/01M29VP8DVACPVK3X2366BWMVM/.test-live-claude-trust/standalone-home/projects' resolves to '~/.no-mistakes/worktrees/52b07e9083e7/01M29VP8DVACPVK3X2366BWMVM/.test-live-claude-trust/outside-projects', outside the home, so '~/.no-mistakes/worktrees/52b07e9083e7/01M29VP8DVACPVK3X2366BWMVM/.test-live-claude-trust/standalone-home' is not a safe secondmate home
escaping_dir_exit=1
escaping_dir_trusted=false (store not created)
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"835ad3211bf5c2a138931b74af7a59898e01640f","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- Live validation: ✅ go - 2 of 4 scenarios driven live against the product

| Scenario | Result | Live | Evidence |
| --- | --- | --- | --- |
| Register a standalone-clone secondmate home and enter real Claude without the project-trust dialog | ✅ pass | live | `live-registration.log` records `hasTrustDialogAccepted: true`; `live-claude-pane-clean.txt` shows real Claude advancing to “Let&#39;s get started” and theme selection rather than “Is this a project you t… |
| Spawn a Claude secondmate into a standalone-clone home and deliver its charter using the same trusted store | ⏸️ untested | no | A real fleet spawn is intentionally refused in this environment because `NO_MISTAKES_GATE=1` and the checkout is a no-mistakes gate worktree. Re-run from a normal firstmate checkout outside an active… |
| Refuse homes marked for another secondmate or whose operational directory escapes the home | ✅ pass | live | `live-boundary-and-baseline.log` shows both executable invocations exiting 1 with specific refusal diagnostics and `trusted=false`. |
| Refuse the secondmate spawn when trust cannot be recorded instead of launching a wedged pane | ⏸️ untested | no | The no-mistakes gate-agent guard prevents a real fleet spawn here. Re-run the focused failure scenario from a normal firstmate environment with a disposable unsafe Claude store to verify the real back… |

- `tests/fm-claude-trust.test.sh`
- `Executed the base-commit trust helper against a standalone clone to reproduce the primary-checkout refusal.`
- <code>Executed `bin/fm-claude-trust.sh --secondmate-home &lt;standalone-home&gt; nomistakes-n1` with an isolated Claude store and inspected the persisted JSON contract.</code>
- `Launched the installed Claude Code 2.1.269 interactively in tmux using the isolated trusted store and captured its first rendered screen.`
- `Executed wrong-secondmate-ID and escaping-projects-directory adversarial registrations and verified neither created trust state.`
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
