### PR TITLE
fix(dod): stop telling no-mistakes workers to halt before validating

### DIFF
--- a/bin/fm-dod-lib.sh
+++ b/bin/fm-dod-lib.sh
@@ -218,9 +218,7 @@ EOF
       cat <<EOF
 # Definition of done
 Delivery contract: mode=no-mistakes
-The task is complete only when committed on your branch.
-When you believe it is complete, append \`done: {summary}\` to the status file and stop.
-Firstmate will then instruct you to run /no-mistakes to validate and ship a PR.
+Committing your implementation is a milestone, not completion. When it is implemented and committed, append \`working: {summary}\` to the status file naming what landed, then start /no-mistakes yourself on the same branch in the same session - firstmate does not send a separate instruction to begin.
 
 You drive no-mistakes by responding to its gates, not by implementing fixes.
 Follow the guidance no-mistakes itself provides for the mechanics: it loads when you invoke /no-mistakes, and \`no-mistakes axi run --help\` plus the \`help\` lines in each \`axi\` response are authoritative and version-matched to the installed binary.

--- a/bin/fm-dod-lib.sh
+++ b/bin/fm-dod-lib.sh
@@ -246,6 +246,10 @@ Two firstmate-specific rules layer on top of that guidance:
   It auto-resolves every gate including ask-user findings with no escalation, and answering your own ask-user finding is a hard rule violation.
 
 After /no-mistakes reports CI green (the CI-ready return point - do not wait for it to keep monitoring in the background until merge), append \`done: PR {url} checks green\` and stop. You are finished.
+
+\`done:\` on this task is reserved for exactly that line, with a real PR URL in it - nothing else earns it.
+Finishing your implementation, watching your own tests pass, and committing is \`working:\`, not \`done:\`; the pipeline is your finish line, not your own test run.
+A \`done:\` line that names a commit instead of a PR URL is a contract violation, and firstmate will send the task back.
 EOF
       ;;
     *)

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -260,7 +260,7 @@ test_ship_mode_is_explicit_not_registry() {
   brief="$home/data/brief-explicit-a5/brief.md"
   grep -qx "Delivery contract: mode=no-mistakes" "$brief" \
     || fail "registered direct-PR posture overrode the explicit --mode"
-  assert_grep "Firstmate will then instruct you to run /no-mistakes" "$brief" \
+  assert_grep "start /no-mistakes yourself on the same branch in the same session" "$brief" \
     "explicit no-mistakes brief did not render the pipeline definition of done"
 
   # An unregistered project is not a blocker either, because nothing is looked up.


### PR DESCRIPTION
## The bug

The generated no-mistakes definition of done tells a worker to stop before validating:

> The task is complete only when committed on your branch.
> When you believe it is complete, append `done: {summary}` to the status file and stop.
> Firstmate will then instruct you to run /no-mistakes to validate and ship a PR.

That handshake does not happen. Firstmate does not send a separate instruction to begin validation,
so a worker that finishes implementing commits, appends `done:`, and stops — having run no validation
at all. Firstmate then has to notice that the status line carries a commit where a PR URL belongs and
send the worker back by hand.

Four crewmates did exactly this in one night, on four unrelated tasks. None was careless; all four
obeyed the contract as written.

## The change

In `bin/fm-dod-lib.sh`, the `no-mistakes` definition-of-done block:

1. The pre-pipeline paragraph now says committing is a milestone, not completion: append a
   `working:` line, then start the validation run yourself on the same branch in the same session.
   The sentence promising that firstmate will instruct the worker to run `/no-mistakes` is removed,
   because that handshake does not exist.
2. Three lines added after the closing sentence: `done:` is reserved for the CI-green PR-URL line;
   finishing implementation, tests and commit is `working:`, not `done:`; a `done:` line naming a
   commit instead of a PR URL is a contract violation.
3. A stale assertion in `tests/fm-brief.test.sh` that expected the old wording is updated.

Untouched: the `--intent` rules, the gate-driving rules, the ask-user rules, and the `direct-PR` and
`local-only` definitions of done.

Both passages now agree. A reservation at the end of the block is worthless while the front of the
block still tells the worker to stop and wait.

## Validation

Ran through the project's own no-mistakes pipeline: review, test, document and lint all passed. The
push step failed only because the authoring account has no write access to this repository, which is
why this arrives as a fork PR.
