### PR TITLE
fix: bound lock acquisition, make spawn transactional, and gate Claude dispatch on its attended prerequisite

### DIFF
--- a/.agents/skills/harness-adapters/references/harness/claude.md
+++ b/.agents/skills/harness-adapters/references/harness/claude.md
@@ -28,6 +28,8 @@ A visible trust dialog means pre-registration did not take effect, so inspect th
 The once-per-machine bypass-permissions confirmation is a separate dialog, scoped to the machine rather than the path, and pre-registration does not address it.
 Never send Enter to that one either: it was observed rendering in the same shape as the trust dialog, with the selection on `No, exit` and the footer `Enter to confirm . Esc to cancel`, so Enter ends the session rather than accepting.
 Firstmate cannot move a selection with Enter, Escape, and C-c alone, so it cannot accept this dialog at all, and an operator accepts it once per machine instead.
+Because that prerequisite is attended, `../../../bin/fm-claude-ready.sh` establishes it before dispatch rather than after: a bypass-mode spawn refuses with the operator's exact setup command when the machine has not accepted the confirmation, so no endpoint is allocated for a worker that would stop there.
+That check reads Claude's own `skipDangerousModePermissionPrompt` setting, which is what accepting the dialog records; the script's header owns its evidence and its declared-readiness override.
 Inspect the pane to identify which dialog is on screen, and report it rather than answering it.
 A launch under `config/claude-permission-mode=auto` never meets the bypass confirmation, because it does not request bypass mode: on 2.1.269 `claude --permission-mode auto` reached the composer directly with the footer `⏵⏵ auto mode on (shift+tab to cycle)`, so a captain who refuses the bypass dialog selects `auto` there instead of accepting it.
 The workspace-trust dialog is unaffected by the permission mode and still needs the pre-registration above.

--- a/bin/fm-claude-ready.sh
+++ b/bin/fm-claude-ready.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# Report whether this machine has accepted Claude Code's bypass-permissions
+# confirmation, so a spawn can refuse before allocating a worker that would
+# stop on a dialog firstmate cannot answer.
+#
+# Usage: fm-claude-ready.sh check [<project>]
+#   <project>  optional project root whose .claude settings also count
+# Prints one line naming the evidence it found; refuses loudly otherwise.
+#
+# WHY THIS EXISTS. Launching with --dangerously-skip-permissions does not by
+# itself get a worker to its brief. Claude Code shows a separate once-per-
+# machine confirmation before it will run in bypass mode. That dialog renders
+# with the selection on "No, exit", and firstmate's key plane carries only
+# Enter, Escape and C-c with no arrow navigation, so firstmate cannot accept
+# it - a sent Enter ends the session instead. A worker that meets it sits
+# there until the watcher reports it wedged and an operator relaunches the
+# task on another runtime. That prerequisite is attended, so the only useful
+# thing firstmate can do about it is establish it BEFORE dispatch.
+#
+# This is separate from workspace trust, which is per-path and is
+# pre-registered by bin/fm-claude-trust.sh. Both gates must be clear.
+#
+# THE SIGNAL. Claude Code skips that confirmation for a session started in
+# bypass mode when `skipDangerousModePermissionPrompt` is set in the settings
+# chain it reads, and accepting the dialog is what records it. The check reads
+# the same files Claude does - managed settings, this user's settings, and the
+# project's own settings - and treats a `true` anywhere in that chain as the
+# acceptance. Nothing is ever written here; provisioning stays attended.
+#
+# If a future Claude release records the acceptance somewhere else, this
+# refuses a machine that is in fact ready rather than passing one that is not.
+# That refusal names the installed Claude version so the change is visible
+# rather than silent, and FM_CLAUDE_BYPASS_READY=1 declares readiness for one
+# invocation while the check is brought back in line with the release.
+set -u
+
+unset CDPATH
+
+SCRIPT_NAME=$(basename "${BASH_SOURCE[0]}")
+refuse() { printf '%s: %s\n' "$SCRIPT_NAME" "$1" >&2; exit 1; }
+
+[ "${1:-}" = check ] || { printf 'usage: %s check [<project>]\n' "$SCRIPT_NAME" >&2; exit 2; }
+PROJECT=${2:-}
+
+if [ "${FM_CLAUDE_BYPASS_READY:-}" = 1 ]; then
+  echo "ready: declared by FM_CLAUDE_BYPASS_READY"
+  exit 0
+fi
+
+CLAUDE_VERSION=$(claude --version 2>/dev/null | head -n 1 || true)
+[ -n "$CLAUDE_VERSION" ] || CLAUDE_VERSION="unknown version"
+
+case ${CLAUDE_CONFIG_DIR:-} in
+  '') USER_SETTINGS_DIR="${HOME:-}/.claude" ;;
+  /*) USER_SETTINGS_DIR="$CLAUDE_CONFIG_DIR" ;;
+  *) refuse "CLAUDE_CONFIG_DIR '$CLAUDE_CONFIG_DIR' is a relative path, so the settings the worker reads cannot be located; set it to an absolute path" ;;
+esac
+
+# Claude's own precedence puts managed settings above the user's, but this only
+# asks whether ANY of them records the acceptance, so order does not matter.
+SETTINGS_FILES=(
+  "/Library/Application Support/ClaudeCode/managed-settings.json"
+  "/etc/claude-code/managed-settings.json"
+  "$USER_SETTINGS_DIR/settings.json"
+)
+if [ -n "$PROJECT" ]; then
+  SETTINGS_FILES+=("$PROJECT/.claude/settings.json" "$PROJECT/.claude/settings.local.json")
+fi
+
+# node reads the settings, matching bin/fm-claude-trust.sh's own store access:
+# a hand-rolled JSON scan would accept the key inside a comment or a string.
+command -v node >/dev/null 2>&1 \
+  || refuse "node is required to read Claude's settings and was not found on PATH"
+
+for settings in "${SETTINGS_FILES[@]}"; do
+  [ -f "$settings" ] && [ -r "$settings" ] || continue
+  if node - "$settings" <<'NODE'
+const fs = require("node:fs");
+let parsed;
+try {
+  parsed = JSON.parse(fs.readFileSync(process.argv[2], "utf8"));
+} catch {
+  process.exit(1);
+}
+process.exit(parsed && parsed.skipDangerousModePermissionPrompt === true ? 0 : 1);
+NODE
+  then
+    echo "ready: bypass-permissions confirmation accepted ($settings)"
+    exit 0
+  fi
+done
+
+refuse "this machine has not accepted Claude Code's bypass-permissions confirmation ($CLAUDE_VERSION), which firstmate cannot answer for a worker; run 'claude --dangerously-skip-permissions' once in a terminal and accept it, then re-run the spawn"

--- a/bin/fm-mail.sh
+++ b/bin/fm-mail.sh
@@ -433,7 +433,7 @@ mail_heal() {
   # Both are generation-scoped: only evidence matching the CURRENT mailbox
   # generation is healed, so a legacy key or a stale prior-generation wake can
   # never mark a reused numeric uid as surfaced in the new mailbox.
-  local generation=$1 jgen juid jtag keyrest keygen keyuid heal_ok=0
+  local generation=$1 jgen juid jtag keyrest keygen keyuid heal_ok=0 queued_keys
   if [ -s "$WOKEN" ]; then
     while IFS=$'\t' read -r jgen juid jtag; do
       [ -n "$juid" ] || continue
@@ -461,7 +461,10 @@ mail_heal() {
   # unfinished for the next poll. Treating the second as the first would record
   # nothing and report success, and the uids it failed to heal would surface
   # again as duplicate mail wakes.
-  if queued_keys=$(fm_wake_queued_keys check 2>&1); then
+  # Capture stdout only. Folding stderr in would parse a diagnostic as queue
+  # content; letting it pass through keeps it reaching the operator, and adds
+  # no state file to the inventory docs/configuration.md owns.
+  if queued_keys=$(fm_wake_queued_keys check); then
     while IFS= read -r k; do
       keyrest="${k#mail:}"
       [ "$keyrest" = "$k" ] && continue
@@ -484,7 +487,7 @@ mail_heal() {
 $queued_keys
 EOF
   else
-    echo "fm-mail: could not read the wake queue to finish recovery; retried on next poll: $queued_keys" >&2
+    echo "fm-mail: could not read the wake queue to finish recovery; retried on next poll" >&2
     heal_ok=1
   fi
   return "$heal_ok"

--- a/bin/fm-mail.sh
+++ b/bin/fm-mail.sh
@@ -454,25 +454,39 @@ mail_heal() {
       mail_prune_journal || true
     fi
   fi
-  while IFS= read -r k; do
-    keyrest="${k#mail:}"
-    [ "$keyrest" = "$k" ] && continue
-    keygen=""
-    keyuid=""
-    case "$keyrest" in
-      */*) keygen="${keyrest%%/*}"; keyuid="${keyrest#*/}" ;;
-      *) keyuid="$keyrest" ;;
-    esac
-    [ -z "$keyuid" ] && continue
-    [ "$keygen" != "$generation" ] && continue
-    if ! mail_seen "$keyuid"; then
-      if printf '%s\n' "$keyuid" >> "$CURSOR"; then
-        :
-      else
-        heal_ok=1
+  # Read the queue into a variable rather than straight into the loop, so an
+  # unreadable queue is distinguishable from an empty one. They demand opposite
+  # conclusions here: empty means every published wake is already recorded and
+  # phase 2 is complete, while unreadable proves nothing and must leave phase 2
+  # unfinished for the next poll. Treating the second as the first would record
+  # nothing and report success, and the uids it failed to heal would surface
+  # again as duplicate mail wakes.
+  if queued_keys=$(fm_wake_queued_keys check 2>&1); then
+    while IFS= read -r k; do
+      keyrest="${k#mail:}"
+      [ "$keyrest" = "$k" ] && continue
+      keygen=""
+      keyuid=""
+      case "$keyrest" in
+        */*) keygen="${keyrest%%/*}"; keyuid="${keyrest#*/}" ;;
+        *) keyuid="$keyrest" ;;
+      esac
+      [ -z "$keyuid" ] && continue
+      [ "$keygen" != "$generation" ] && continue
+      if ! mail_seen "$keyuid"; then
+        if printf '%s\n' "$keyuid" >> "$CURSOR"; then
+          :
+        else
+          heal_ok=1
+        fi
       fi
-    fi
-  done < <(fm_wake_queued_keys check 2>/dev/null || true)
+    done <<EOF
+$queued_keys
+EOF
+  else
+    echo "fm-mail: could not read the wake queue to finish recovery; retried on next poll: $queued_keys" >&2
+    heal_ok=1
+  fi
   return "$heal_ok"
 }
 

--- a/bin/fm-procevent-lib.sh
+++ b/bin/fm-procevent-lib.sh
@@ -335,13 +335,42 @@ fm_procevent_source_lock_path() {
   printf '%s/%s.lock\n' "$(fm_procevent_claim_root)" "$1"
 }
 
+# How long a source-lock acquisition waits for a live holder before refusing.
+# A source lock guards one short ownership transition, so a wait this long
+# already means the holder is wedged rather than working.
+FM_PROCEVENT_SOURCE_LOCK_WAIT="${FM_PROCEVENT_SOURCE_LOCK_WAIT:-30}"
+
+# fm_procevent_source_lock_acquire <source-id>
+#
+# Bounded acquisition of the machine-wide source lock. On failure it leaves an
+# operator-actionable sentence in FM_PROCEVENT_LOCK_ERROR, because the two ways
+# this fails need opposite responses: an unwritable claim root is a permission
+# problem to fix (a sandbox that denies the machine-wide state directory is the
+# usual cause, and FM_PROCEVENT_CLAIM_ROOT redirects it), while a live holder
+# is a process to inspect.
 fm_procevent_source_lock_acquire() {
-  local id=$1 root
+  local id=$1 root rc
+  FM_PROCEVENT_LOCK_ERROR=
   fm_procevent_source_id_valid "$id" || return 1
   root=$(fm_procevent_claim_root)
-  (umask 077; mkdir -p "$root") || return 1
-  [ -d "$root" ] && [ ! -L "$root" ] || return 1
-  fm_lock_acquire_wait "$(fm_procevent_source_lock_path "$id")"
+  (umask 077; mkdir -p "$root") 2>/dev/null
+  if [ ! -d "$root" ] || [ -L "$root" ]; then
+    FM_PROCEVENT_LOCK_ERROR="claims root is not a directory: $root"
+    return 1
+  fi
+  if ! fm_lock_dir_writable "$root"; then
+    FM_PROCEVENT_LOCK_ERROR="claims root not writable: $root"
+    return 1
+  fi
+  fm_lock_acquire_wait_bounded "$(fm_procevent_source_lock_path "$id")" \
+    "$FM_PROCEVENT_SOURCE_LOCK_WAIT" && return 0
+  rc=$?
+  if [ "$rc" -eq 124 ] && [ -n "${FM_LOCK_HELD_PID:-}" ]; then
+    FM_PROCEVENT_LOCK_ERROR="lock held by live PID $FM_LOCK_HELD_PID"
+  else
+    FM_PROCEVENT_LOCK_ERROR="could not acquire source lock: $id"
+  fi
+  return 1
 }
 
 # fm_procevent_source_lock_try_acquire <source-id>
@@ -349,11 +378,25 @@ fm_procevent_source_lock_acquire() {
 # that caller owns the exit-cleanup lock-order invariant.
 fm_procevent_source_lock_try_acquire() {
   local id=$1 root
+  FM_PROCEVENT_LOCK_ERROR=
   fm_procevent_source_id_valid "$id" || return 1
   root=$(fm_procevent_claim_root)
-  (umask 077; mkdir -p "$root") || return 1
-  [ -d "$root" ] && [ ! -L "$root" ] || return 1
-  fm_lock_try_acquire "$(fm_procevent_source_lock_path "$id")"
+  (umask 077; mkdir -p "$root") 2>/dev/null
+  if [ ! -d "$root" ] || [ -L "$root" ]; then
+    FM_PROCEVENT_LOCK_ERROR="claims root is not a directory: $root"
+    return 1
+  fi
+  if ! fm_lock_dir_writable "$root"; then
+    FM_PROCEVENT_LOCK_ERROR="claims root not writable: $root"
+    return 1
+  fi
+  fm_lock_try_acquire "$(fm_procevent_source_lock_path "$id")" && return 0
+  if [ "${FM_LOCK_FAILURE:-}" = held ] && [ -n "${FM_LOCK_HELD_PID:-}" ]; then
+    FM_PROCEVENT_LOCK_ERROR="lock held by live PID $FM_LOCK_HELD_PID"
+  else
+    FM_PROCEVENT_LOCK_ERROR="could not acquire source lock: $id"
+  fi
+  return 1
 }
 
 fm_procevent_source_lock_release() {

--- a/bin/fm-procevent-when.sh
+++ b/bin/fm-procevent-when.sh
@@ -171,7 +171,8 @@ cmd_arm() {
   done
 
   [ -d "$STATE" ] && [ ! -L "$STATE" ] || die "state directory is unavailable"
-  fm_procevent_source_lock_acquire "$sid" || die "cannot lock the watch source"
+  fm_procevent_source_lock_acquire "$sid" \
+    || die "cannot lock the watch source: ${FM_PROCEVENT_LOCK_ERROR:-unknown lock failure}"
   trap 'fm_procevent_source_lock_release "$sid"' EXIT
   local leftover
   for leftover in "$(spec_file "$sid")" "$(trust_file "$sid")" "$(fired_file "$sid")" \

--- a/bin/fm-procevent.sh
+++ b/bin/fm-procevent.sh
@@ -217,6 +217,10 @@ STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
 . "$SCRIPT_DIR/fm-procevent-lib.sh"
 
 die() { printf 'error: %s\n' "$1" >&2; exit 1; }
+# Refusing to lock a source has two operator responses, so never collapse them
+# into one generic message: fm_procevent_source_lock_acquire distinguishes an
+# unwritable claim root from a live holder.
+die_lock() { die "cannot lock source $1: ${FM_PROCEVENT_LOCK_ERROR:-unknown lock failure}"; }
 usage() { sed -n '2,/^set -u$/p' "${BASH_SOURCE[0]}" | sed '$d; s/^# \{0,1\}//'; exit 2; }
 
 case "${1-}" in ''|-h|--help|help) usage ;; esac
@@ -474,7 +478,7 @@ cmd_register() {
   done
   [ -f "$(adapter_script "$adapter")" ] || die "no installed adapter for: $adapter"
   state_root_bind create || die "cannot safely prepare the process-event state root"
-  fm_procevent_source_lock_acquire "$id" || die "cannot lock the source"
+  fm_procevent_source_lock_acquire "$id" || die_lock "$id"
   if ! extension_registration_replacement_safe_locked "$id"; then
     fm_procevent_source_lock_release "$id"
     die "cannot replace extension registration while its prior runner remains active: $id"
@@ -558,7 +562,7 @@ cmd_register_extension() {
   fi
   if ! fm_procevent_source_lock_acquire "$id"; then
     extension_lifecycle_lock_release
-    die "cannot lock the source"
+    die_lock "$id"
   fi
   if ! extension_registration_replacement_safe_locked "$id"; then
     fm_procevent_source_lock_release "$id"
@@ -725,7 +729,7 @@ cmd_start() {
   local extension_owner=0 extension_load_state extension_sequence='' extension_request_id=''
   fm_procevent_source_id_valid "$id" || die "source id must be path-safe: $id"
   require_runner_group
-  fm_procevent_source_lock_acquire "$id" || die "cannot lock source: $id"
+  fm_procevent_source_lock_acquire "$id" || die_lock "$id"
   if [ ! -f "$(source_file "$id")" ] || [ -L "$(source_file "$id")" ]; then
     fm_procevent_source_lock_release "$id"
     die "source is not registered: $id"
@@ -1630,7 +1634,7 @@ cmd_handled() {
   fm_procevent_source_id_valid "$id" || die "source id must be path-safe: $id"
   case "$seq" in ''|*[!0-9]*) die "sequence must be a nonnegative integer: $seq" ;; esac
   owner_lease_refresh
-  fm_procevent_source_lock_acquire "$id" || die "cannot lock source: $id"
+  fm_procevent_source_lock_acquire "$id" || die_lock "$id"
   fm_procevent_mark_handled "$STATE" "$id" "$seq"
   status=$?
   fm_procevent_source_lock_release "$id"
@@ -1664,7 +1668,7 @@ cmd_retire() {
       ;;
     *) usage ;;
   esac
-  fm_procevent_source_lock_acquire "$id" || die "cannot lock source: $id"
+  fm_procevent_source_lock_acquire "$id" || die_lock "$id"
   if [ -e "$(source_file "$id")" ] || [ -L "$(source_file "$id")" ]; then
     if [ -z "$condition" ]; then
       fm_procevent_extension_registration_load_locked "$STATE" "$id"

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -921,6 +921,17 @@ SPAWN_TASK_SET_LOCK_HELD=0
 SPAWN_TREEHOUSE_PROJECT_LOCK=
 SPAWN_TREEHOUSE_PROJECT_LOCK_HELD=0
 SPAWN_SLOT_CLAIMED=0
+# A freshly created endpoint has no other owner until this spawn's task record
+# is durably published: teardown and the watcher only ever learn about an
+# endpoint a record names. Every exit between creation and that publication
+# therefore has to close the endpoint itself, or it is orphaned - a live window
+# nothing will ever clean up, which is what an unborn repository produced. Set
+# only for a fresh allocation, never for a relaunch, so an adopted pre-existing
+# endpoint can never be killed by this obligation.
+SPAWN_ENDPOINT_CLEANUP=0
+SPAWN_ENDPOINT_BACKEND=
+SPAWN_ENDPOINT_TARGET=
+SPAWN_ENDPOINT_TAB=
 RELAUNCH_REPLACEMENT_PENDING=0
 RELAUNCH_REPLACEMENT_BUSY_GEN=
 RELAUNCH_REPLACEMENT_HARNESS=
@@ -999,6 +1010,16 @@ spawn_abort_cleanup() {
   if [ "$HERDR_PRESENTATION_ORDER_LOCK_HELD" = 1 ]; then
     HERDR_PRESENTATION_ORDER_LOCK_HELD=0
     fm_lock_release "$HERDR_PRESENTATION_ORDER_LOCK" || true
+  fi
+  # Orca owns its endpoint and worktree together through ORCA_ABORT_CLEANUP
+  # below, so the generic obligation never covers it.
+  if [ "$SPAWN_ENDPOINT_CLEANUP" = 1 ]; then
+    SPAWN_ENDPOINT_CLEANUP=0
+    if [ ! -e "$STATE/$ID.meta" ] && [ ! -L "$STATE/$ID.meta" ]; then
+      fm_backend_kill "$SPAWN_ENDPOINT_BACKEND" "$SPAWN_ENDPOINT_TARGET" \
+        "$SPAWN_ENDPOINT_TAB" "fm-$ID" 2>/dev/null \
+        || echo "warning: could not close task $ID's endpoint $SPAWN_ENDPOINT_TARGET after an aborted spawn; close it by hand" >&2
+    fi
   fi
   if [ "$ORCA_ABORT_CLEANUP" = 1 ]; then
     ORCA_ABORT_CLEANUP=0
@@ -2627,6 +2648,19 @@ herdr_projection_existing_meta_allows_flat() {  # <meta>
   esac
 }
 
+# Repository preflight. An isolated local copy is made by detaching from the
+# project's default branch, so a repository with no commit on it cannot produce
+# one - a clone of a brand-new empty remote has no ref to resolve at all.
+# Proving that here, before any endpoint exists, is what keeps a guaranteed
+# failure from being spent as the full worktree-detection window and then
+# leaving a live endpoint nothing owns.
+if [ "$RELAUNCH" -eq 0 ] && [ "$KIND" != secondmate ] \
+   && git -C "$PROJ_ABS" rev-parse --git-dir >/dev/null 2>&1 \
+   && ! git -C "$PROJ_ABS" rev-parse --verify --quiet 'HEAD^{commit}' >/dev/null 2>&1; then
+  echo "error: project $PROJ_ABS has no commit on its default branch, so no isolated local copy can be made from it; push an initial commit to that repository and re-run the spawn" >&2
+  exit 1
+fi
+
 # Backlog preflight (bin/fm-backlog-transition-lib.sh). This spawn is about to
 # become the sole owner of the row's In-flight transition, so prove the row is
 # transitionable BEFORE any endpoint, worktree, or record exists: a refusal here
@@ -2910,6 +2944,14 @@ EOF
     T="$ORCA_TERMINAL"
     ;;
 esac
+# The endpoint now exists and no record names it yet. Own it until publication.
+if [ "$BACKEND" != orca ]; then
+  SPAWN_ENDPOINT_CLEANUP=1
+  SPAWN_ENDPOINT_BACKEND=$BACKEND
+  SPAWN_ENDPOINT_TARGET=$T
+  SPAWN_ENDPOINT_TAB=
+  [ "$BACKEND" != zellij ] || SPAWN_ENDPOINT_TAB=$ZELLIJ_TAB_ID
+fi
 fi
 if [ "$KIND" = secondmate ]; then
   FM_INHERITABLE_CONFIG=trace-context \
@@ -3769,6 +3811,10 @@ if [ "$RELAUNCH" -eq 0 ]; then
     exit 1
   fi
   SPAWN_META_TMP=
+  # The record names the endpoint, so teardown owns it from here. A later
+  # failure unwinds through the backlog rollback, which reports the endpoint
+  # and local copy to close by hand rather than closing them silently.
+  SPAWN_ENDPOINT_CLEANUP=0
 fi
 
 # Fuse the backlog In-flight transition into the publication that just created

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -2661,6 +2661,27 @@ if [ "$RELAUNCH" -eq 0 ] && [ "$KIND" != secondmate ] \
   exit 1
 fi
 
+# Claude bypass-permissions readiness. This is the second dialog firstmate
+# cannot answer, and unlike workspace trust it is attended and per-machine, so
+# it cannot be provisioned during a spawn at all: a worker launched without it
+# stops on the confirmation until the watcher reports it wedged and the task is
+# relaunched on another runtime. Refusing here, beside the repository check and
+# before any endpoint exists, is what turns fifteen minutes of escalation into
+# one setup instruction. bin/fm-claude-ready.sh owns the check and that
+# instruction. Only a bypass-mode launch meets the dialog:
+# config/claude-permission-mode=auto does not request bypass mode.
+if [ "$CLAUDE_PERMISSION_MODE" = bypass ]; then
+  case "$HARNESS" in
+    claude*)
+      if ! CLAUDE_READY_REPORT=$("$FM_ROOT/bin/fm-claude-ready.sh" check "$PROJ_ABS" 2>&1); then
+        echo "error: $CLAUDE_READY_REPORT" >&2
+        echo "error: refusing to dispatch $ID on claude, because it would stop on a dialog firstmate cannot answer" >&2
+        exit 1
+      fi
+      ;;
+  esac
+fi
+
 # Backlog preflight (bin/fm-backlog-transition-lib.sh). This spawn is about to
 # become the sole owner of the row's In-flight transition, so prove the row is
 # transitionable BEFORE any endpoint, worktree, or record exists: a refusal here
@@ -3280,6 +3301,7 @@ if [ "$KIND" != secondmate ]; then
       ;;
   esac
 fi
+
 
 # Per-task temp root: /tmp/fm-<id>/ with Go's build temp nested at gotmp/. Go won't
 # create GOTMPDIR, so mkdir before it is used; fm-teardown removes the whole root.

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -3302,7 +3302,6 @@ if [ "$KIND" != secondmate ]; then
   esac
 fi
 
-
 # Per-task temp root: /tmp/fm-<id>/ with Go's build temp nested at gotmp/. Go won't
 # create GOTMPDIR, so mkdir before it is used; fm-teardown removes the whole root.
 # Nested (not a bare /tmp/fm-<id>/gotmp) so other per-task temp can live alongside

--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -360,6 +360,7 @@ family_for_basename() {
     fm-send-inbox.test.sh|fm-spawn-batch.test.sh|\
     fm-spawn-dispatch-profile.test.sh|fm-claude-trust.test.sh|\
     fm-trace-context-spawn.test.sh|fm-spawn-worktree-settle.test.sh|\
+    fm-spawn-transaction.test.sh|\
     fm-teardown-endpoint-safety.test.sh)
       printf '%s\n' backend-dispatch
       ;;
@@ -764,6 +765,7 @@ tests/fm-sessionstart-nudge.test.sh 66194
 tests/fm-shared-captain-inheritance.test.sh 6108
 tests/fm-spawn-dispatch-profile.test.sh 63996
 tests/fm-spawn-pool-base-freshen.test.sh 34920
+tests/fm-spawn-transaction.test.sh 5687
 tests/fm-spawn-worktree-settle.test.sh 5687
 tests/fm-startup-memory-budget.test.sh 6964
 tests/fm-startup-network.test.sh 62274

--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -359,6 +359,7 @@ family_for_basename() {
     fm-herdr-session-cleanup.test.sh|fm-send-resolve-key.test.sh|fm-send-strict.test.sh|\
     fm-send-inbox.test.sh|fm-spawn-batch.test.sh|\
     fm-spawn-dispatch-profile.test.sh|fm-claude-trust.test.sh|\
+    fm-claude-ready.test.sh|\
     fm-trace-context-spawn.test.sh|fm-spawn-worktree-settle.test.sh|\
     fm-spawn-transaction.test.sh|\
     fm-teardown-endpoint-safety.test.sh)
@@ -677,6 +678,7 @@ tests/fm-calm-pi-extension.test.sh 256
 tests/fm-check-unregister.test.sh 481
 tests/fm-classify-corr-token.test.sh 38742
 tests/fm-classify-decision-key.test.sh 1167
+tests/fm-claude-ready.test.sh 1023
 tests/fm-claude-stop-autoarm-live-e2e.test.sh 21
 tests/fm-claude-stop-autoarm.test.sh 60709
 tests/fm-cmux-claude-composer-live-e2e.test.sh 23
@@ -765,7 +767,7 @@ tests/fm-sessionstart-nudge.test.sh 66194
 tests/fm-shared-captain-inheritance.test.sh 6108
 tests/fm-spawn-dispatch-profile.test.sh 63996
 tests/fm-spawn-pool-base-freshen.test.sh 34920
-tests/fm-spawn-transaction.test.sh 5687
+tests/fm-spawn-transaction.test.sh 2993
 tests/fm-spawn-worktree-settle.test.sh 5687
 tests/fm-startup-memory-budget.test.sh 6964
 tests/fm-startup-network.test.sh 62274

--- a/bin/fm-wake-lib.sh
+++ b/bin/fm-wake-lib.sh
@@ -562,6 +562,37 @@ fm_lock_dir_writable() {
   return 0
 }
 
+# The recursive stale-lock path this file used to take built `<lock>.steal`,
+# then `.steal.steal`, without a depth bound, so the machines an upgrade reaches
+# are exactly the ones with such chains on disk. Nothing else in bin/ removes
+# one, and depth-1 arbitration cannot claim `<lock>.steal` while a leftover
+# `<lock>.steal.steal` blocks it through fm_lock_claim_blocked_by_steal, so a
+# leftover chain would wedge the primary lock forever - trading the old crash
+# for a silent hang. Clear it instead, deepest level first so no orphan is left
+# to block a later claim, and stop at the first level still owned.
+FM_LOCK_STEAL_CHAIN_MAX="${FM_LOCK_STEAL_CHAIN_MAX:-512}"
+
+fm_lock_clear_stale_steal_chain() {
+  local lockdir=$1 next pid i
+  local levels=()
+  next="$lockdir.steal"
+  while [ "${#levels[@]}" -lt "$FM_LOCK_STEAL_CHAIN_MAX" ]; do
+    { [ -e "$next" ] || [ -L "$next" ]; } || break
+    pid=$(cat "$next/pid" 2>/dev/null || true)
+    if fm_pid_alive "$pid" || fm_lock_mid_acquire_is_fresh "$next" "$pid"; then
+      return 1
+    fi
+    levels[${#levels[@]}]=$next
+    next="$next.steal"
+  done
+  i=${#levels[@]}
+  while [ "$i" -gt 0 ]; do
+    i=$((i - 1))
+    fm_lock_remove_path "${levels[$i]}" || return 1
+  done
+  return 0
+}
+
 fm_lock_mid_acquire_is_fresh() {
   local lockdir=$1 pid=$2 mid_acquire_stale
   case "$pid" in
@@ -935,14 +966,18 @@ _fm_lock_try_acquire() {
     return 0
   fi
 
+  # Classify an uncreatable lock before anything else, and independently of
+  # what is already on disk: a leftover lock or steal chain in an unwritable
+  # directory is still a permission problem, and waiting cannot clear it. A
+  # live holder is reported below only when a lock could in principle be taken.
+  if ! fm_lock_dir_writable "$(dirname "$lockdir")"; then
+    FM_LOCK_FAILURE=unwritable
+    # shellcheck disable=SC2034 # Read by callers after acquisition fails.
+    FM_LOCK_FAILURE_PATH=$(dirname "$lockdir")
+    return 1
+  fi
   if [ ! -e "$lockdir" ] && [ ! -L "$lockdir" ]; then
     # Creation failed with no lock present, so this was never contention.
-    if ! fm_lock_dir_writable "$(dirname "$lockdir")"; then
-      FM_LOCK_FAILURE=unwritable
-      # shellcheck disable=SC2034 # Read by callers after acquisition fails.
-      FM_LOCK_FAILURE_PATH=$(dirname "$lockdir")
-      return 1
-    fi
     return 1
   fi
 
@@ -982,6 +1017,10 @@ _fm_lock_try_acquire() {
     # atomic arbiter: two reclaimers can both remove the stale link, but only
     # one can recreate it, and the loser's primary claim is then refused by
     # fm_lock_claim_blocked_by_steal.
+    if ! fm_lock_clear_stale_steal_chain "$lockdir"; then
+      FM_LOCK_HELD_PID=$(cat "$lockdir.steal/pid" 2>/dev/null || true)
+      return 1
+    fi
     fm_lock_remove_path "$lockdir" || true
     if fm_lock_try_create "$lockdir"; then
       return 0

--- a/bin/fm-wake-lib.sh
+++ b/bin/fm-wake-lib.sh
@@ -550,6 +550,18 @@ fm_lock_remove_path() {
   rmdir "$lockdir" 2>/dev/null
 }
 
+# fm_lock_dir_writable <dir>
+# Probe rather than test -w: -w reports true for root on a mode-0500 directory
+# and false for an ACL that does permit writing, and a lock is only ever as
+# real as the file the caller can actually create there.
+fm_lock_dir_writable() {
+  local dir=$1 probe
+  [ -d "$dir" ] || return 1
+  probe=$(mktemp "$dir/.lock-write.XXXXXX" 2>/dev/null) || return 1
+  rm -f "$probe" 2>/dev/null || return 1
+  return 0
+}
+
 fm_lock_mid_acquire_is_fresh() {
   local lockdir=$1 pid=$2 mid_acquire_stale
   case "$pid" in
@@ -890,14 +902,48 @@ fm_recovery_marker_reopen_announced() {
   fm_recovery_transition "$1" reopen-announced
 }
 
+# fm_lock_try_acquire <lockdir>
+#
+# Non-blocking acquisition. On failure it classifies why in FM_LOCK_FAILURE so
+# a caller can tell a wait that will clear from one that never can:
+#
+#   held        another live process owns the lock; FM_LOCK_HELD_PID names it
+#   unwritable  no lock can be created here; FM_LOCK_FAILURE_PATH names the
+#               directory that refused it
+#   contended   a transient loss; retrying is the right response
+#
+# The classification is only meaningful on failure.
+#
+# Stale-lock recovery arbitrates through one `<lockdir>.steal` lock and stops
+# there. It used to recurse into `.steal.steal...` without a depth bound, so a
+# directory that could hold no lock at all - a sandboxed claim root, a
+# read-only state directory - grew the lock name until the path overflowed and
+# bash died with a segfault rather than reporting the permission problem.
 fm_lock_try_acquire() {
-  local lockdir=$1 pid steal cur rc steal_owner primary_owner current
+  _fm_lock_try_acquire "$1" 0
+}
+
+_fm_lock_try_acquire() {
+  local lockdir=$1 depth=$2 pid steal cur rc steal_owner steal_failure primary_owner current
   FM_LOCK_HELD_PID=
   FM_LOCK_OWNER_DIR=
   FM_LOCK_RECOVERED_PID=
+  FM_LOCK_FAILURE=contended
+  FM_LOCK_FAILURE_PATH=
 
   if fm_lock_try_create "$lockdir"; then
     return 0
+  fi
+
+  if [ ! -e "$lockdir" ] && [ ! -L "$lockdir" ]; then
+    # Creation failed with no lock present, so this was never contention.
+    if ! fm_lock_dir_writable "$(dirname "$lockdir")"; then
+      FM_LOCK_FAILURE=unwritable
+      # shellcheck disable=SC2034 # Read by callers after acquisition fails.
+      FM_LOCK_FAILURE_PATH=$(dirname "$lockdir")
+      return 1
+    fi
+    return 1
   fi
 
   fm_current_pid current || return 1
@@ -920,17 +966,38 @@ fm_lock_try_acquire() {
   fi
   if fm_pid_alive "$pid"; then
     FM_LOCK_HELD_PID=$pid
+    FM_LOCK_FAILURE=held
     return 1
   fi
   if fm_lock_mid_acquire_is_fresh "$lockdir" "$pid"; then
     FM_LOCK_HELD_PID=$pid
+    FM_LOCK_FAILURE=held
+    return 1
+  fi
+
+  if [ "$depth" -ge 1 ]; then
+    # Depth 1 IS the arbitration lock, so there is no further level to
+    # arbitrate with. Reaching here means its own recorded owner is dead and
+    # past the mid-acquire window, so reclaim it directly. `ln -s` stays the
+    # atomic arbiter: two reclaimers can both remove the stale link, but only
+    # one can recreate it, and the loser's primary claim is then refused by
+    # fm_lock_claim_blocked_by_steal.
+    fm_lock_remove_path "$lockdir" || true
+    if fm_lock_try_create "$lockdir"; then
+      return 0
+    fi
+    FM_LOCK_HELD_PID=$(cat "$lockdir/pid" 2>/dev/null || true)
     return 1
   fi
 
   steal="$lockdir.steal"
-  if ! fm_lock_try_acquire "$steal"; then
+  if ! _fm_lock_try_acquire "$steal" $((depth + 1)); then
+    # The nested call has already reset FM_LOCK_FAILURE; carry its class out
+    # unchanged, because an unwritable directory refuses both locks alike.
+    steal_failure=${FM_LOCK_FAILURE:-contended}
     FM_LOCK_HELD_PID=$(cat "$lockdir/pid" 2>/dev/null || true)
     FM_LOCK_OWNER_DIR=
+    FM_LOCK_FAILURE=$steal_failure
     return 1
   fi
   steal_owner=${FM_LOCK_OWNER_DIR:-}
@@ -940,12 +1007,14 @@ fm_lock_try_acquire() {
     fm_lock_release "$steal"
     FM_LOCK_HELD_PID=$cur
     FM_LOCK_OWNER_DIR=
+    FM_LOCK_FAILURE=held
     return 1
   fi
   if fm_lock_mid_acquire_is_fresh "$lockdir" "$cur"; then
     fm_lock_release "$steal"
     FM_LOCK_HELD_PID=$cur
     FM_LOCK_OWNER_DIR=
+    FM_LOCK_FAILURE=held
     return 1
   fi
   if ! fm_lock_points_to_owner "$steal" "$steal_owner"; then
@@ -990,9 +1059,25 @@ fm_lock_try_acquire() {
   return "$rc"
 }
 
+# fm_lock_acquire_wait <lockdir>
+#
+# Waits out contention, including a lock a live process legitimately holds:
+# that always clears, so blocking is safe and callers may rely on this
+# returning only once the lock is held.
+#
+# A lock that can never be created is not contention, and no amount of waiting
+# makes an unwritable directory writable. That case fails closed here - a named
+# diagnostic and a nonzero exit - rather than returning, because most callers
+# do not check the return value and none can safely continue without the lock
+# they asked for.
 fm_lock_acquire_wait() {
   local lockdir=$1
   while ! fm_lock_try_acquire "$lockdir"; do
+    if [ "${FM_LOCK_FAILURE:-}" = unwritable ]; then
+      printf 'error: cannot create lock %s: directory not writable: %s\n' \
+        "$lockdir" "${FM_LOCK_FAILURE_PATH:-$(dirname "$lockdir")}" >&2
+      exit 1
+    fi
     sleep 0.1
   done
 }

--- a/bin/fm-wake-lib.sh
+++ b/bin/fm-wake-lib.sh
@@ -1915,12 +1915,28 @@ fm_wake_append_locked() {
 # durable queue stays the authority: a key appears here exactly while a record
 # for it is queued and unacknowledged, and disappears only after post-handling
 # acknowledgement consumes it.
+# fm_wake_queued_keys <kind>
+#
+# Unlike every other lock-taking helper here, this one is read from inside
+# command and process substitutions (bin/fm-mail.sh, bin/fm-watch.sh,
+# bin/fm-inactive-reconcile.sh). An `exit` in that context kills only the
+# subshell, so fm_lock_acquire_wait's fail-closed refusal would reach the
+# caller as an empty result with a successful-looking read - indistinguishable
+# from "nothing is queued", which is the answer that suppresses a duplicate
+# wake. Report an unreadable queue as status 3 instead, so a caller can tell
+# "nothing queued" from "could not look".
 fm_wake_queued_keys() {
-  local kind=$1
+  local kind=$1 lock_dir
   case "$kind" in
     signal|stale|check|heartbeat) ;;
     *) printf 'fm_wake_queued_keys: invalid wake kind: %s\n' "$kind" >&2; return 2 ;;
   esac
+  lock_dir=$(dirname "$FM_WAKE_QUEUE_LOCK")
+  if ! fm_lock_dir_writable "$lock_dir"; then
+    printf 'fm_wake_queued_keys: cannot read the wake queue: directory not writable: %s\n' \
+      "$lock_dir" >&2
+    return 3
+  fi
   fm_lock_acquire_wait "$FM_WAKE_QUEUE_LOCK"
   fm_wake_queued_keys_locked "$kind"
   fm_lock_release "$FM_WAKE_QUEUE_LOCK"

--- a/tests/fixtures.sh
+++ b/tests/fixtures.sh
@@ -292,10 +292,24 @@ fm_test_run_spawn() {
   # stands in for a provisioned machine so every spawn case here exercises what
   # it is actually about; the refusal itself is covered in
   # tests/fm-claude-ready.test.sh.
+  # Provision only inside a fixture tree. fm-spawn-dispatch-profile
+  # deliberately points FM_TEST_CLAUDE_CONFIG_DIR at the bare absolute path
+  # /opt/test/claude-work for a codex spawn the readiness gate never consults,
+  # so creating it would either error or litter outside the test tree; an
+  # in-tree store that does not exist yet still needs provisioning, because the
+  # spawn is what creates it. The test applies fm_test_in_fixture_tree rather
+  # than a TMPDIR prefix, because fm_test_tmproot resolves its root with
+  # `pwd -P` and on macOS that makes the root /private/var/... while TMPDIR
+  # still reads /var/..., so a prefix comparison silently never matches.
   if [ "${FM_TEST_CLAUDE_BYPASS_UNREADY:-0}" != 1 ]; then
-    mkdir -p "${FM_TEST_CLAUDE_CONFIG_DIR:-$spawn_home/.claude}"
-    printf '{"skipDangerousModePermissionPrompt":true}\n' \
-      > "${FM_TEST_CLAUDE_CONFIG_DIR:-$spawn_home/.claude}/settings.json"
+    local ready_dir=$spawn_home/.claude
+    if [ -n "${FM_TEST_CLAUDE_CONFIG_DIR:-}" ]; then
+      ready_dir=$FM_TEST_CLAUDE_CONFIG_DIR
+    fi
+    if fm_test_in_fixture_tree "$ready_dir"; then
+      mkdir -p "$ready_dir"
+      printf '{"skipDangerousModePermissionPrompt":true}\n' > "$ready_dir/settings.json"
+    fi
   fi
   FM_ROOT_OVERRIDE='' FM_HOME="$home" HOME="$spawn_home" \
     CLAUDE_CONFIG_DIR="${FM_TEST_CLAUDE_CONFIG_DIR:-}" \

--- a/tests/fixtures.sh
+++ b/tests/fixtures.sh
@@ -287,6 +287,16 @@ fm_test_run_spawn() {
   # A test that needs the set case opts in through FM_TEST_CLAUDE_CONFIG_DIR.
   local spawn_home=$home/user-home
   mkdir -p "$spawn_home"
+  # A claude spawn also refuses when the machine has not accepted Claude's
+  # bypass-permissions confirmation (bin/fm-claude-ready.sh). The throwaway HOME
+  # stands in for a provisioned machine so every spawn case here exercises what
+  # it is actually about; the refusal itself is covered in
+  # tests/fm-claude-ready.test.sh.
+  if [ "${FM_TEST_CLAUDE_BYPASS_UNREADY:-0}" != 1 ]; then
+    mkdir -p "${FM_TEST_CLAUDE_CONFIG_DIR:-$spawn_home/.claude}"
+    printf '{"skipDangerousModePermissionPrompt":true}\n' \
+      > "${FM_TEST_CLAUDE_CONFIG_DIR:-$spawn_home/.claude}/settings.json"
+  fi
   FM_ROOT_OVERRIDE='' FM_HOME="$home" HOME="$spawn_home" \
     CLAUDE_CONFIG_DIR="${FM_TEST_CLAUDE_CONFIG_DIR:-}" \
     FM_STATE_OVERRIDE="$home/state" FM_DATA_OVERRIDE="$home/data" \

--- a/tests/fm-claude-ready.test.sh
+++ b/tests/fm-claude-ready.test.sh
@@ -36,6 +36,10 @@ managed_settings_already_ready() {
 
 test_unaccepted_machine_is_refused_with_the_setup_command() {
   local config out status
+  if managed_settings_already_ready; then
+    pass "fm-claude-ready.sh: unaccepted-machine refusal (skipped: this machine records the acceptance machine-wide)"
+    return 0
+  fi
   config="$TMP_ROOT/unaccepted/claude-config"
   mkdir -p "$config"
 
@@ -64,6 +68,10 @@ test_accepted_machine_is_ready() {
 
 test_unparseable_settings_do_not_read_as_accepted() {
   local config out status
+  if managed_settings_already_ready; then
+    pass "fm-claude-ready.sh: unparseable-settings refusal (skipped: this machine records the acceptance machine-wide)"
+    return 0
+  fi
   config="$TMP_ROOT/corrupt/claude-config"
   mkdir -p "$config"
   printf 'skipDangerousModePermissionPrompt: true\n' > "$config/settings.json"

--- a/tests/fm-claude-ready.test.sh
+++ b/tests/fm-claude-ready.test.sh
@@ -22,7 +22,7 @@ READY="$ROOT/bin/fm-claude-ready.sh"
 # run_ready <config-dir> [project]: check against an isolated Claude config.
 run_ready() {
   local config=$1 project=${2:-}
-  CLAUDE_CONFIG_DIR="$config" FM_CLAUDE_BYPASS_READY= "$READY" check "$project" 2>&1
+  CLAUDE_CONFIG_DIR="$config" FM_CLAUDE_BYPASS_READY='' "$READY" check "$project" 2>&1
 }
 
 # Machine-wide managed settings could record the acceptance for every case
@@ -35,12 +35,13 @@ managed_settings_already_ready() {
 }
 
 test_unaccepted_machine_is_refused_with_the_setup_command() {
-  local config out
+  local config out status
   config="$TMP_ROOT/unaccepted/claude-config"
   mkdir -p "$config"
 
   out=$(run_ready "$config")
-  [ "$?" -ne 0 ] || fail "an unprovisioned machine reported ready: $out"
+  status=$?
+  [ "$status" -ne 0 ] || fail "an unprovisioned machine reported ready: $out"
   assert_contains "$out" "has not accepted Claude Code's bypass-permissions confirmation" \
     "the refusal did not say what is missing"
   assert_contains "$out" "claude --dangerously-skip-permissions" \
@@ -49,25 +50,27 @@ test_unaccepted_machine_is_refused_with_the_setup_command() {
 }
 
 test_accepted_machine_is_ready() {
-  local config out
+  local config out status
   config="$TMP_ROOT/accepted/claude-config"
   mkdir -p "$config"
   printf '{"skipDangerousModePermissionPrompt":true}\n' > "$config/settings.json"
 
   out=$(run_ready "$config")
-  expect_code 0 "$?" "an accepted machine was refused: $out"
+  status=$?
+  expect_code 0 "$status" "an accepted machine was refused: $out"
   assert_contains "$out" "ready:" "the accepted machine did not report readiness"
   pass "fm-claude-ready.sh: a machine that accepted the confirmation reads as ready"
 }
 
 test_unparseable_settings_do_not_read_as_accepted() {
-  local config out
+  local config out status
   config="$TMP_ROOT/corrupt/claude-config"
   mkdir -p "$config"
   printf 'skipDangerousModePermissionPrompt: true\n' > "$config/settings.json"
 
   out=$(run_ready "$config")
-  [ "$?" -ne 0 ] || fail "settings that are not JSON were read as acceptance: $out"
+  status=$?
+  [ "$status" -ne 0 ] || fail "settings that are not JSON were read as acceptance: $out"
   pass "fm-claude-ready.sh: settings that are not JSON never read as acceptance"
 }
 
@@ -103,7 +106,7 @@ SH
 # before allocating an endpoint, instead of launching a worker that stops on
 # the dialog and is escalated as wedged.
 test_claude_spawn_refuses_before_allocating_an_endpoint() {
-  local case_dir home proj wt config fakebin log id out
+  local case_dir home proj wt config fakebin log id out status
   case_dir="$TMP_ROOT/spawn-refusal"
   home="$case_dir/home"
   proj="$case_dir/project"
@@ -128,7 +131,8 @@ test_claude_spawn_refuses_before_allocating_an_endpoint() {
     FM_FAKE_WINDOW_LOG="$log" \
     fm_test_run_spawn "$home" "$wt" "$fakebin" "$id" "$proj" claude \
     --mode no-mistakes --yolo off)
-  [ "$?" -ne 0 ] || fail "a claude spawn on an unprovisioned machine reported success: $out"
+  status=$?
+  [ "$status" -ne 0 ] || fail "a claude spawn on an unprovisioned machine reported success: $out"
   assert_contains "$out" "claude --dangerously-skip-permissions" \
     "the refused spawn did not carry the setup command"
   assert_absent "$home/state/$id.meta" "a refused spawn published a task record"

--- a/tests/fm-claude-ready.test.sh
+++ b/tests/fm-claude-ready.test.sh
@@ -1,0 +1,148 @@
+#!/usr/bin/env bash
+# Behavior tests for bin/fm-claude-ready.sh and the claude spawn that calls it.
+#
+# Claude Code shows a once-per-machine bypass-permissions confirmation that
+# firstmate cannot answer: the dialog's selection starts on "No, exit" and
+# firstmate's key plane carries only Enter, Escape and C-c, so a sent Enter
+# ends the session. A worker launched on a machine that has never accepted it
+# sits on that dialog until the watcher reports it wedged. The gate exists so
+# the operator gets one setup instruction instead of repeated escalations, and
+# so no endpoint is allocated for a worker that cannot reach its brief.
+#
+# Workspace trust is the separate per-path gate and lives in
+# tests/fm-claude-trust.test.sh.
+set -u
+
+# shellcheck source=tests/fixtures.sh
+. "$(dirname "${BASH_SOURCE[0]}")/fixtures.sh"
+
+TMP_ROOT=$(fm_test_tmproot fm-claude-ready)
+READY="$ROOT/bin/fm-claude-ready.sh"
+
+# run_ready <config-dir> [project]: check against an isolated Claude config.
+run_ready() {
+  local config=$1 project=${2:-}
+  CLAUDE_CONFIG_DIR="$config" FM_CLAUDE_BYPASS_READY= "$READY" check "$project" 2>&1
+}
+
+# Machine-wide managed settings could record the acceptance for every case
+# here, which would make the refusals vacuous. Ask the check itself once and
+# report rather than pass silently.
+managed_settings_already_ready() {
+  local probe="$TMP_ROOT/managed-probe"
+  mkdir -p "$probe"
+  run_ready "$probe" >/dev/null 2>&1
+}
+
+test_unaccepted_machine_is_refused_with_the_setup_command() {
+  local config out
+  config="$TMP_ROOT/unaccepted/claude-config"
+  mkdir -p "$config"
+
+  out=$(run_ready "$config")
+  [ "$?" -ne 0 ] || fail "an unprovisioned machine reported ready: $out"
+  assert_contains "$out" "has not accepted Claude Code's bypass-permissions confirmation" \
+    "the refusal did not say what is missing"
+  assert_contains "$out" "claude --dangerously-skip-permissions" \
+    "the refusal did not name the command that provisions the machine"
+  pass "fm-claude-ready.sh: an unaccepted machine is refused with its setup command"
+}
+
+test_accepted_machine_is_ready() {
+  local config out
+  config="$TMP_ROOT/accepted/claude-config"
+  mkdir -p "$config"
+  printf '{"skipDangerousModePermissionPrompt":true}\n' > "$config/settings.json"
+
+  out=$(run_ready "$config")
+  expect_code 0 "$?" "an accepted machine was refused: $out"
+  assert_contains "$out" "ready:" "the accepted machine did not report readiness"
+  pass "fm-claude-ready.sh: a machine that accepted the confirmation reads as ready"
+}
+
+test_unparseable_settings_do_not_read_as_accepted() {
+  local config out
+  config="$TMP_ROOT/corrupt/claude-config"
+  mkdir -p "$config"
+  printf 'skipDangerousModePermissionPrompt: true\n' > "$config/settings.json"
+
+  out=$(run_ready "$config")
+  [ "$?" -ne 0 ] || fail "settings that are not JSON were read as acceptance: $out"
+  pass "fm-claude-ready.sh: settings that are not JSON never read as acceptance"
+}
+
+# A tmux stub that records the windows it creates, so the refusal can be shown
+# to arrive before any endpoint exists rather than after one is allocated.
+make_ready_fakebin() {
+  local dir=$1 fakebin
+  fakebin=$(fm_fakebin "$dir")
+  cat > "$fakebin/tmux" <<'SH'
+#!/usr/bin/env bash
+set -u
+case "$*" in
+  *"#{pane_current_path}"*) printf '%s\n' "${FM_FAKE_PANE_PATH:-}"; exit 0 ;;
+esac
+case "${1:-}" in
+  display-message) printf 'firstmate\n'; exit 0 ;;
+  list-windows) exit 0 ;;
+  new-window)
+    printf '%s\n' "new-window $*" >> "${FM_FAKE_WINDOW_LOG:?FM_FAKE_WINDOW_LOG unset}"
+    exit 0
+    ;;
+  has-session|new-session|set-window-option|send-keys|kill-window) exit 0 ;;
+esac
+exit 0
+SH
+  chmod +x "$fakebin/tmux"
+  fm_fake_exit0 "$fakebin" treehouse claude
+  fm_test_fake_sleep_noop "$fakebin"
+  printf '%s\n' "$fakebin"
+}
+
+# The dispatch half: a claude spawn on an unprovisioned machine must refuse
+# before allocating an endpoint, instead of launching a worker that stops on
+# the dialog and is escalated as wedged.
+test_claude_spawn_refuses_before_allocating_an_endpoint() {
+  local case_dir home proj wt config fakebin log id out
+  case_dir="$TMP_ROOT/spawn-refusal"
+  home="$case_dir/home"
+  proj="$case_dir/project"
+  wt="$case_dir/wt"
+  config="$case_dir/claude-config"
+  log="$case_dir/window-log"
+  id="claudeready$$"
+
+  if managed_settings_already_ready; then
+    pass "fm-spawn.sh: claude bypass-readiness refusal (skipped: this machine records the acceptance machine-wide)"
+    return 0
+  fi
+
+  mkdir -p "$config"
+  : > "$log"
+  fakebin=$(make_ready_fakebin "$case_dir/fake")
+  fm_test_spawn_home "$home" claude
+  fm_git_worktree "$proj" "$wt" wt-ready
+  fm_test_spawn_brief "$home" "$id"
+
+  out=$(FM_TEST_CLAUDE_BYPASS_UNREADY=1 FM_TEST_CLAUDE_CONFIG_DIR="$config" \
+    FM_FAKE_WINDOW_LOG="$log" \
+    fm_test_run_spawn "$home" "$wt" "$fakebin" "$id" "$proj" claude \
+    --mode no-mistakes --yolo off)
+  [ "$?" -ne 0 ] || fail "a claude spawn on an unprovisioned machine reported success: $out"
+  assert_contains "$out" "claude --dangerously-skip-permissions" \
+    "the refused spawn did not carry the setup command"
+  assert_absent "$home/state/$id.meta" "a refused spawn published a task record"
+  if grep -q 'new-window' "$log" 2>/dev/null; then
+    fail "a refused spawn allocated an endpoint before checking bypass readiness"
+  fi
+  [ ! -e "/tmp/fm-$id" ] \
+    || { rm -rf "/tmp/fm-$id"; fail "a refused spawn stranded a temp root no teardown can find"; }
+  pass "fm-spawn.sh: a claude spawn refuses before allocating an endpoint when the machine is unprovisioned"
+}
+
+test_unaccepted_machine_is_refused_with_the_setup_command
+test_accepted_machine_is_ready
+test_unparseable_settings_do_not_read_as_accepted
+test_claude_spawn_refuses_before_allocating_an_endpoint
+
+printf '\nall claude readiness tests passed\n'

--- a/tests/fm-procevent.test.sh
+++ b/tests/fm-procevent.test.sh
@@ -3566,4 +3566,42 @@ kill -0 -"$CRASH_PID" 2>/dev/null \
 pass "a group whose leader died to something else is still refused, not signalled"
 kill -KILL -"$CRASH_PID" 2>/dev/null || true
 
+# --- the claim root's two refusals stay distinct -----------------------------
+#
+# Regression. A claim root the runner cannot write used to be mistaken for a
+# stale lock and retried as `<lock>.steal`, then `.steal.steal`, until the path
+# overflowed and bash crashed - which is what a sandbox that denies the
+# machine-wide state directory produced. It must instead name the directory,
+# and must stay distinguishable from the opposite problem, a live holder, since
+# the two need opposite responses.
+
+HLOCK="$TMP_ROOT/lock-refusals"; new_home "$HLOCK"
+
+DENIED_ROOT="$TMP_ROOT/denied-claims"
+mkdir -p "$DENIED_ROOT"
+chmod 500 "$DENIED_ROOT"
+out=$(FM_PROCEVENT_CLAIM_ROOT="$DENIED_ROOT" pe "$HLOCK" handled denied-src 1 2>&1) \
+  && { chmod 700 "$DENIED_ROOT"; fail "an unwritable claim root reported success"; }
+chmod 700 "$DENIED_ROOT"
+assert_contains "$out" "claims root not writable: $DENIED_ROOT" \
+  "an unwritable claim root names the directory that refused the lock"
+case "$out" in
+  *.steal.steal*) fail "an unwritable claim root still built a steal-of-steal lock name: $out" ;;
+esac
+find "$DENIED_ROOT" -name '*.steal*' 2>/dev/null | head -n 1 | grep -q . \
+  && fail "an unwritable claim root left steal locks behind"
+
+sleep 60 &
+LOCK_HOLDER=$!
+mkdir -p "$FM_PROCEVENT_CLAIM_ROOT/held-src.lock"
+printf '%s\n' "$LOCK_HOLDER" > "$FM_PROCEVENT_CLAIM_ROOT/held-src.lock/pid"
+out=$(FM_PROCEVENT_SOURCE_LOCK_WAIT=2 pe "$HLOCK" handled held-src 1 2>&1) \
+  && fail "a source lock held by a live process reported success"
+kill "$LOCK_HOLDER" 2>/dev/null || true
+wait "$LOCK_HOLDER" 2>/dev/null || true
+rm -rf "$FM_PROCEVENT_CLAIM_ROOT/held-src.lock"
+assert_contains "$out" "lock held by live PID $LOCK_HOLDER" \
+  "a live source-lock holder is named rather than waited on forever"
+pass "an unwritable claim root and a live lock holder stay distinct refusals"
+
 printf '\nall procevent tests passed\n'

--- a/tests/fm-spawn-transaction.test.sh
+++ b/tests/fm-spawn-transaction.test.sh
@@ -1,0 +1,141 @@
+#!/usr/bin/env bash
+# Regression tests for fm-spawn.sh's spawn transaction: the repository
+# preflight that runs before any endpoint exists, and the cleanup obligation
+# that owns a freshly created endpoint until the task record names it.
+#
+# Both come from the same live failure. Spawning against a brand-new empty
+# GitHub repository could not produce an isolated local copy, because there is
+# no commit to detach from. The spawn nevertheless created its endpoint first,
+# spent the whole worktree-detection window waiting for something that could
+# not happen, and then exited leaving a live window that no record named - so
+# nothing else would ever close it.
+#
+# The worktree-detection loop itself is covered by
+# tests/fm-spawn-worktree-settle.test.sh; these cases are about what the spawn
+# owns before and after that loop.
+set -u
+
+# shellcheck source=tests/fixtures.sh
+. "$(dirname "${BASH_SOURCE[0]}")/fixtures.sh"
+
+SPAWN="$ROOT/bin/fm-spawn.sh"
+TMP_ROOT=$(fm_test_tmproot fm-spawn-transaction)
+
+# A tmux stub that records every window it creates and every window it kills,
+# so a test can assert that an aborted spawn closed exactly the endpoint it
+# opened. The pane never leaves FM_FAKE_PANE_PATH, which is how a spawn whose
+# local copy never materializes is simulated.
+make_transaction_fakebin() {
+  local dir=$1 fakebin
+  fakebin=$(fm_fakebin "$dir")
+  cat > "$fakebin/tmux" <<'SH'
+#!/usr/bin/env bash
+set -u
+case "$*" in
+  *"#{pane_current_path}"*) printf '%s\n' "${FM_FAKE_PANE_PATH:-}"; exit 0 ;;
+esac
+case "${1:-}" in
+  display-message) printf 'firstmate\n'; exit 0 ;;
+  list-windows) exit 0 ;;
+  new-window)
+    printf '%s\n' "new-window $*" >> "${FM_FAKE_WINDOW_LOG:?FM_FAKE_WINDOW_LOG unset}"
+    exit 0
+    ;;
+  kill-window|kill-pane)
+    printf '%s\n' "kill $*" >> "${FM_FAKE_WINDOW_LOG:?FM_FAKE_WINDOW_LOG unset}"
+    exit 0
+    ;;
+  has-session|new-session|set-window-option|send-keys) exit 0 ;;
+esac
+exit 0
+SH
+  chmod +x "$fakebin/tmux"
+  fm_fake_exit0 "$fakebin" treehouse
+  fm_test_fake_sleep_noop "$fakebin"
+  printf '%s\n' "$fakebin"
+}
+
+# make_case <name> <id> echoes "<home>|<fakebin>|<window-log>" for a home whose
+# project is created by the caller.
+make_case() {
+  local name=$1 id=$2 case_dir home fakebin log
+  case_dir="$TMP_ROOT/$name"
+  home="$case_dir/home"
+  log="$case_dir/window-log"
+  fakebin=$(make_transaction_fakebin "$case_dir/fake")
+  fm_test_spawn_home "$home" codex
+  fm_test_spawn_brief "$home" "$id" "Exercise the spawn transaction for $id."
+  : > "$log"
+  printf '%s\n' "$home|$fakebin|$log"
+}
+
+run_spawn() {  # <home> <fakebin> <window-log> <id> <project> <pane-path>
+  FM_ROOT_OVERRIDE='' FM_HOME="$1" \
+    FM_STATE_OVERRIDE="$1/state" FM_DATA_OVERRIDE="$1/data" \
+    FM_PROJECTS_OVERRIDE="$1/projects" FM_CONFIG_OVERRIDE="$1/config" \
+    FM_SPAWN_NO_GUARD=1 TMUX="fake,1,0" \
+    FM_FAKE_PANE_PATH="$6" FM_FAKE_WINDOW_LOG="$3" \
+    PATH="$2:$PATH" \
+    "$SPAWN" "$4" "$5" --mode no-mistakes --yolo off 2>&1
+}
+
+# The reported case: a clone of a remote with no commits. The refusal has to
+# arrive before any endpoint exists, so the operator gets an explanation rather
+# than a minute of waiting followed by a window to close.
+test_unborn_repository_is_refused_before_any_endpoint() {
+  local rec home fakebin log id proj out status
+  id=txn-unborn-z1
+  rec=$(make_case unborn "$id")
+  IFS='|' read -r home fakebin log <<EOF
+$rec
+EOF
+  proj="$TMP_ROOT/unborn/project"
+  git init -q --bare "$TMP_ROOT/unborn/remote.git"
+  git clone --quiet "$TMP_ROOT/unborn/remote.git" "$proj" 2>/dev/null
+
+  out=$(run_spawn "$home" "$fakebin" "$log" "$id" "$proj" "$proj")
+  status=$?
+  [ "$status" -ne 0 ] || fail "spawning against an unborn repository reported success: $out"
+  assert_contains "$out" "$proj" "the refusal did not name the repository"
+  assert_contains "$out" "has no commit on its default branch" \
+    "the refusal did not explain that the repository has no commit"
+  assert_contains "$out" "push an initial commit" \
+    "the refusal did not tell the operator how to fix it"
+  assert_absent "$home/state/$id.meta" \
+    "a refused spawn published a task record"
+  if grep -q 'new-window' "$log" 2>/dev/null; then
+    fail "a refused spawn created an endpoint before the repository was checked"
+  fi
+  pass "an unborn repository is refused before any endpoint is created"
+}
+
+# Any failure before the task record is published has to close the endpoint the
+# spawn created, because no record names it yet and so nothing else will. A
+# pane that never leaves the project stands in for every such mid-spawn
+# failure; the isolation check refuses it after the endpoint already exists.
+test_mid_spawn_failure_closes_the_endpoint_it_created() {
+  local rec home fakebin log id proj out status
+  id=txn-cleanup-z2
+  rec=$(make_case cleanup "$id")
+  IFS='|' read -r home fakebin log <<EOF
+$rec
+EOF
+  proj="$TMP_ROOT/cleanup/project"
+  fm_git_init_commit "$proj"
+
+  out=$(run_spawn "$home" "$fakebin" "$log" "$id" "$proj" "$proj")
+  status=$?
+  [ "$status" -ne 0 ] || fail "a spawn whose local copy never appeared reported success: $out"
+  assert_absent "$home/state/$id.meta" \
+    "a failed spawn published a task record"
+  grep -q 'new-window' "$log" \
+    || fail "the fixture never created an endpoint, so nothing was under test"
+  grep -q '^kill ' "$log" \
+    || fail "a spawn that failed before publishing its record left its endpoint open: $(cat "$log")"
+  pass "a spawn that fails before publishing its record closes the endpoint it created"
+}
+
+test_unborn_repository_is_refused_before_any_endpoint
+test_mid_spawn_failure_closes_the_endpoint_it_created
+
+printf '\nall spawn transaction tests passed\n'

--- a/tests/fm-watcher-lock.test.sh
+++ b/tests/fm-watcher-lock.test.sh
@@ -454,6 +454,69 @@ test_queued_keys_reports_an_unreadable_queue_from_a_substitution() {
   pass "an unreadable wake queue reports a failed read rather than an empty one"
 }
 
+# Regression: the recursive stale-lock path this replaced is what created
+# `<lock>.steal.steal` chains, so the machines an upgrade reaches are exactly
+# the ones carrying them, and nothing else in bin/ removes one. Depth-1
+# arbitration cannot claim `<lock>.steal` while a leftover blocks it, so a
+# chain left behind would wedge the primary lock forever - trading the old
+# crash for a silent hang.
+test_lock_clears_a_legacy_nested_steal_chain() {
+  local dir state lockdir out level i
+  dir=$(make_case lock-legacy-chain)
+  state="$dir/state"
+  lockdir="$state/.legacy.lock"
+  level=$lockdir
+  i=0
+  while [ "$i" -lt 3 ]; do
+    mkdir -p "$level"
+    printf '%s\n' 999999 > "$level/pid"
+    level="$level.steal"
+    i=$((i + 1))
+  done
+  out=$(FM_LOCK_STALE_AFTER=0 FM_STATE_OVERRIDE="$state" bash -c '
+    . "$1"
+    if fm_lock_try_acquire "$2"; then rc=0; else rc=1; fi
+    printf "rc=%s class=%s\n" "$rc" "${FM_LOCK_FAILURE:-}"
+  ' _ "$LIB" "$lockdir")
+  case "$out" in
+    *"rc=0"*) ;;
+    *) fail "a leftover nested steal chain blocked acquisition instead of being cleared: $out" ;;
+  esac
+  [ ! -e "$lockdir.steal" ] && [ ! -L "$lockdir.steal" ] \
+    || fail "the leftover steal chain was not removed"
+  [ ! -e "$lockdir.steal.steal" ] && [ ! -L "$lockdir.steal.steal" ] \
+    || fail "a deeper leftover level survived and would block a later claim"
+  pass "a legacy nested steal chain is cleared rather than wedging the lock"
+}
+
+# Regression: the required unwritable refusal must not depend on what is
+# already on disk. A leftover steal in an unwritable directory used to be
+# classified as ordinary contention, so the named permission refusal - the
+# whole point of classifying at all - was unreachable in the compound case.
+test_lock_unwritable_is_classified_despite_a_leftover_steal() {
+  local dir state locks lockdir out
+  dir=$(make_case lock-unwritable-leftover)
+  state="$dir/state"
+  locks="$dir/unwritable"
+  mkdir -p "$locks"
+  lockdir="$locks/x.lock"
+  mkdir -p "$lockdir" "$lockdir.steal"
+  printf '%s\n' 999999 > "$lockdir/pid"
+  printf '%s\n' 999999 > "$lockdir.steal/pid"
+  chmod 500 "$locks"
+  out=$(FM_LOCK_STALE_AFTER=0 FM_STATE_OVERRIDE="$state" bash -c '
+    . "$1"
+    if fm_lock_try_acquire "$2"; then rc=0; else rc=1; fi
+    printf "rc=%s class=%s path=%s\n" "$rc" "${FM_LOCK_FAILURE:-}" "${FM_LOCK_FAILURE_PATH:-}"
+  ' _ "$LIB" "$lockdir" 2>&1)
+  chmod 700 "$locks"
+  case "$out" in
+    *"class=unwritable"*"path=$locks"*) ;;
+    *) fail "an unwritable directory holding a leftover steal was not classified as unwritable: $out" ;;
+  esac
+  pass "an unwritable directory is classified even when a leftover steal is present"
+}
+
 test_lock_empty_pid_uses_minimum_grace() {
   local dir state lockdir out
   dir=$(make_case lock-empty-grace)
@@ -1236,6 +1299,8 @@ test_lock_unwritable_dir_is_classified_not_recursed
 test_lock_acquire_wait_fails_closed_on_unwritable_dir
 test_lock_live_holder_is_reported_without_steal_chain
 test_queued_keys_reports_an_unreadable_queue_from_a_substitution
+test_lock_clears_a_legacy_nested_steal_chain
+test_lock_unwritable_is_classified_despite_a_leftover_steal
 test_lock_empty_pid_uses_minimum_grace
 test_lock_late_claim_loses_after_recreate
 test_lock_paused_mid_acquire_claim_fails_during_steal

--- a/tests/fm-watcher-lock.test.sh
+++ b/tests/fm-watcher-lock.test.sh
@@ -423,6 +423,37 @@ test_lock_live_holder_is_reported_without_steal_chain() {
   pass "live-held lock reports its holder without a steal chain"
 }
 
+# Regression: fm_wake_queued_keys is read inside command and process
+# substitutions, where an exit kills only the subshell. A refusal reaching the
+# caller as an empty-but-successful read is indistinguishable from "nothing is
+# queued" - the answer that suppresses a duplicate wake - so an unreadable
+# queue has to carry its own nonzero status out of the substitution.
+test_queued_keys_reports_an_unreadable_queue_from_a_substitution() {
+  local dir state out status err
+  dir=$(make_case queued-keys-unreadable)
+  state="$dir/state"
+  err="$dir/read.err"
+  chmod 500 "$state"
+  out=$(FM_STATE_OVERRIDE="$state" bash -c '
+    . "$1"
+    queued=$(fm_wake_queued_keys check)
+    printf "rc=%s keys=[%s]\n" "$?" "$queued"
+  ' _ "$LIB" 2> "$err")
+  status=$?
+  chmod 700 "$state"
+  [ "$status" -eq 0 ] || fail "the reading fixture itself died instead of reporting: $out $(cat "$err")"
+  case "$out" in
+    *"rc=0"*) fail "an unreadable wake queue read as an empty queue: $out" ;;
+  esac
+  case "$out" in
+    *"keys=[]"*) ;;
+    *) fail "an unreadable wake queue returned keys: $out" ;;
+  esac
+  grep -q "cannot read the wake queue" "$err" \
+    || fail "an unreadable wake queue named no cause: $(cat "$err")"
+  pass "an unreadable wake queue reports a failed read rather than an empty one"
+}
+
 test_lock_empty_pid_uses_minimum_grace() {
   local dir state lockdir out
   dir=$(make_case lock-empty-grace)
@@ -1204,6 +1235,7 @@ test_lock_does_not_steal_live_lock
 test_lock_unwritable_dir_is_classified_not_recursed
 test_lock_acquire_wait_fails_closed_on_unwritable_dir
 test_lock_live_holder_is_reported_without_steal_chain
+test_queued_keys_reports_an_unreadable_queue_from_a_substitution
 test_lock_empty_pid_uses_minimum_grace
 test_lock_late_claim_loses_after_recreate
 test_lock_paused_mid_acquire_claim_fails_during_steal

--- a/tests/fm-watcher-lock.test.sh
+++ b/tests/fm-watcher-lock.test.sh
@@ -337,6 +337,92 @@ test_lock_does_not_steal_live_lock() {
   pass "live-held lock is not stolen"
 }
 
+# Regression: an unwritable lock directory used to be mistaken for a stale lock
+# and retried as `<lock>.steal`, then `.steal.steal`, without a depth bound,
+# until the path overflowed and bash died. Both the classification and the
+# bounded name are asserted, because either one alone could go quietly vacuous.
+test_lock_unwritable_dir_is_classified_not_recursed() {
+  local dir state locks lockdir out longest
+  dir=$(make_case lock-unwritable)
+  state="$dir/state"
+  locks="$dir/unwritable"
+  mkdir -p "$locks"
+  lockdir="$locks/x.lock"
+  chmod 500 "$locks"
+  out=$(FM_STATE_OVERRIDE="$state" bash -c '
+    . "$1"
+    if fm_lock_try_acquire "$2"; then rc=0; else rc=1; fi
+    printf "rc=%s class=%s path=%s\n" "$rc" "${FM_LOCK_FAILURE:-}" "${FM_LOCK_FAILURE_PATH:-}"
+  ' _ "$LIB" "$lockdir" 2>&1)
+  chmod 700 "$locks"
+  case "$out" in
+    *"rc=1"*) ;;
+    *) fail "unwritable lock directory did not refuse acquisition: $out" ;;
+  esac
+  case "$out" in
+    *"class=unwritable"*) ;;
+    *) fail "unwritable lock directory was not classified as unwritable: $out" ;;
+  esac
+  case "$out" in
+    *"path=$locks"*) ;;
+    *) fail "refusal did not name the directory that refused the lock: $out" ;;
+  esac
+  longest=$(find "$locks" -name '*.steal*' 2>/dev/null | head -n 1)
+  [ -z "$longest" ] || fail "steal-of-steal lock names were created: $longest"
+  pass "unwritable lock directory is classified, not recursed"
+}
+
+# Regression: a worker that asked for a lock in a directory it cannot write
+# used to spin or crash instead of saying why. Waiting cannot make a directory
+# writable, so the wait fails closed with the refusing path named.
+test_lock_acquire_wait_fails_closed_on_unwritable_dir() {
+  local dir state locks rc err
+  dir=$(make_case lock-unwritable-wait)
+  state="$dir/state"
+  locks="$dir/unwritable"
+  mkdir -p "$locks"
+  chmod 500 "$locks"
+  err="$dir/wait.err"
+  rc=0
+  FM_STATE_OVERRIDE="$state" bash -c '
+    . "$1"
+    fm_lock_acquire_wait "$2"
+    printf "returned\n"
+  ' _ "$LIB" "$locks/x.lock" >/dev/null 2> "$err" || rc=$?
+  chmod 700 "$locks"
+  [ "$rc" -ne 0 ] || fail "waiting for an uncreatable lock returned as if it had been acquired"
+  grep -q "not writable: $locks" "$err" \
+    || fail "wait refusal did not name the unwritable directory: $(cat "$err")"
+  pass "waiting for an uncreatable lock fails closed and names the directory"
+}
+
+# Regression: acquisition against a live holder must report that holder rather
+# than build an arbitration chain behind it.
+test_lock_live_holder_is_reported_without_steal_chain() {
+  local dir state lockdir live out stray
+  dir=$(make_case lock-live-classified)
+  state="$dir/state"
+  lockdir="$state/.contend.lock"
+  sleep 300 &
+  live=$!
+  mkdir "$lockdir"
+  printf '%s\n' "$live" > "$lockdir/pid"
+  out=$(FM_STATE_OVERRIDE="$state" bash -c '
+    . "$1"
+    if fm_lock_try_acquire "$2"; then rc=0; else rc=1; fi
+    printf "rc=%s class=%s held=%s\n" "$rc" "${FM_LOCK_FAILURE:-}" "${FM_LOCK_HELD_PID:-}"
+  ' _ "$LIB" "$lockdir")
+  kill "$live" 2>/dev/null || true
+  wait "$live" 2>/dev/null || true
+  case "$out" in
+    *"rc=1"*"class=held"*"held=$live"*) ;;
+    *) fail "live-held lock was not reported as held by that pid: $out" ;;
+  esac
+  stray=$(find "$state" -name '.contend.lock.steal*' 2>/dev/null | head -n 1)
+  [ -z "$stray" ] || fail "a live-held lock built an arbitration chain: $stray"
+  pass "live-held lock reports its holder without a steal chain"
+}
+
 test_lock_empty_pid_uses_minimum_grace() {
   local dir state lockdir out
   dir=$(make_case lock-empty-grace)
@@ -1115,6 +1201,9 @@ test_lock_steals_dead_pid_lock
 test_lock_stale_steal_single_winner_under_concurrency
 test_lock_live_steal_mutex_is_not_reclaimed
 test_lock_does_not_steal_live_lock
+test_lock_unwritable_dir_is_classified_not_recursed
+test_lock_acquire_wait_fails_closed_on_unwritable_dir
+test_lock_live_holder_is_reported_without_steal_chain
 test_lock_empty_pid_uses_minimum_grace
 test_lock_late_claim_loses_after_recreate
 test_lock_paused_mid_acquire_claim_fails_during_steal

--- a/tests/lib.sh
+++ b/tests/lib.sh
@@ -189,6 +189,30 @@ fm_test_tmproot() {
   printf '%s\n' "$root"
 }
 
+# fm_test_in_fixture_tree <path>: true when <path> lies inside a root
+# fm_test_tmproot allocated, proved by the .fm-test-fixture marker that
+# function writes rather than by a path prefix. A prefix test cannot be
+# trusted here: fm_test_tmproot resolves its root with `pwd -P`, so on macOS
+# the root reads /private/var/... while TMPDIR still reads /var/..., and the
+# comparison silently never matches. The path need not exist yet.
+fm_test_in_fixture_tree() {
+  local path=$1 dir depth=0
+  case "$path" in
+    /*) ;;
+    *) return 1 ;;
+  esac
+  dir=$path
+  while [ "$depth" -lt 64 ]; do
+    [ -f "$dir/.fm-test-fixture" ] && return 0
+    case "$dir" in
+      /|'') return 1 ;;
+    esac
+    dir=$(dirname "$dir")
+    depth=$((depth + 1))
+  done
+  return 1
+}
+
 trap fm_test_cleanup EXIT
 trap 'fm_test_cleanup; exit 130' INT
 trap 'fm_test_cleanup; exit 143' TERM


### PR DESCRIPTION
Three bugs that cost fleet time in real use on 2026-09-11, fixed as three commits with regression tests, plus two follow-up commits described at the end.

## 1. Lock acquisition recursed until the process died

**Symptom.** Under a command sandbox that denied writes below `~/.local/state/firstmate`, `fm-procevent.sh handled` built lock names `.lock.steal.steal.steal...` until `File name too long`, then crashed with exit 139. Almost every fleet command needed the sandbox disabled to work at all. The same root cause hit again later the same day when a worker asked for a lock in a state directory it could not write and hung instead of reporting why.

**Cause.** `fm_lock_try_acquire` treated a lock it could not *create* as a *stale* lock. A directory that can hold no lock at all therefore fell straight into the stale-lock steal path, which recursed into `<lock>.steal` with no depth bound.

**Fix.** Stale-lock recovery now arbitrates through one `.steal` lock and reclaims a dead stealer's lock directly at that depth, so the name can no longer grow. `ln -s` stays the atomic arbiter, so two reclaimers still resolve to one winner. Failed acquisition is classified as a live holder, a directory that refuses lock creation, or ordinary contention, and waiting fails closed on the second - no wait makes a directory writable, and most callers do not check the return value. The machine-wide process-event claim root reports the two apart, because they need opposite responses: `claims root not writable: <path>` is a permission problem to fix, `lock held by live PID <n>` is a process to inspect.

**Tests.** `tests/fm-watcher-lock.test.sh` gains three cases: an unwritable lock directory is classified rather than recursed (and leaves no `.steal` names behind), waiting on an uncreatable lock fails closed naming the directory, and a live holder is reported without building an arbitration chain. `tests/fm-procevent.test.sh` pins the two refusals as distinct through the real `handled` command. All three fail on the unfixed tree.

Fixes #4106.

## 2. Spawn was not transactional against an unborn repository

**Symptom.** A spawn against a brand-new empty GitHub repository failed, because `git worktree add ... refs/remotes/origin/main` has no ref to resolve. The spawn had already created the shell endpoint, waited the full sixty seconds of its worktree-detection window, then exited and left a window that no task record named - so nothing else would ever close it, and it had to be closed by hand.

**Fix.** The repository is proved to have a commit on its default branch before any endpoint exists, and the refusal names the repository and says to push an initial commit. Separately, a freshly created endpoint now carries a cleanup obligation from the moment it exists until the task record is durably published, so every earlier failure closes it instead of orphaning it. The obligation is armed only for a fresh allocation, never for the endpoint a relaunch adopts, and Orca keeps owning its endpoint and worktree together through its existing path.

**Tests.** New `tests/fm-spawn-transaction.test.sh`: an unborn repository is refused before any endpoint is created, and a spawn that fails before publishing its record closes the endpoint it created. On the unfixed tree the first case reproduces the exact incident - a sixty-second wait ending in "inspect window ..." - and the second leaves the window open.

## 3. Claude's bypass-permissions confirmation was an unmodelled prerequisite

**Symptom.** A worker launched with `--dangerously-skip-permissions` stopped on Claude Code's once-per-machine bypass confirmation. Firstmate cannot answer it: the dialog's selection starts on "No, exit" and firstmate's key plane carries only Enter, Escape and C-c with no arrow navigation, so a sent Enter would end the session. The watcher escalated it as wedged three times over about fifteen minutes before the task was relaunched on another runtime.

**Fix.** That prerequisite is attended, so it is established before dispatch rather than discovered after. New `bin/fm-claude-ready.sh` reads Claude's own `skipDangerousModePermissionPrompt` setting - what accepting the dialog records - across the settings chain Claude itself reads, and a bypass-mode spawn refuses before allocating any endpoint, printing the operator's exact setup command. A launch under `config/claude-permission-mode=auto` never requests bypass mode and is not gated. The per-worktree workspace-trust pre-registration is unchanged; it is the separate per-path gate, and both must be clear.

A future Claude release that records the acceptance elsewhere makes this refuse a ready machine rather than pass an unready one. The refusal names the installed Claude version so that change is visible, and `FM_CLAUDE_BYPASS_READY=1` declares readiness for one invocation meanwhile.

**Tests.** New `tests/fm-claude-ready.test.sh`: the refusal carries its setup command, an accepted machine reads as ready, settings that are not JSON never read as acceptance, and a claude spawn on an unprovisioned machine refuses before allocating an endpoint. The spawn case reports itself skipped rather than passing silently on a machine whose managed settings would make the refusal vacuous.

## Follow-up commits

`ed30800` fixes four ShellCheck findings that `bin/fm-lint.sh` reports in the readiness test added by the third commit (SC2181, SC1007), and removes a stray blank line left in `fm-spawn.sh` by moving the readiness gate ahead of endpoint allocation. Behavior unchanged. It is a separate commit rather than an amendment because force-pushing this branch was not available to the author.

`acd8b84` closes a gap found by reviewing the first commit. `fm_wake_queued_keys` is the one lock-taking helper read from inside command and process substitutions (`bin/fm-mail.sh`, `bin/fm-watch.sh`, `bin/fm-inactive-reconcile.sh`), where an `exit` kills only the subshell. The fail-closed refusal therefore reached its callers as an empty result with a successful-looking read, which is indistinguishable from "nothing is queued" - the answer that suppresses a duplicate wake.

Two of the three call sites append immediately afterwards and so still failed closed, because the append takes the same lock in the caller's own process; that was verified rather than assumed. The mail plane's recovery did not: its queue heal treats an empty read as proof that every published wake is already recorded, so an unreadable queue would finish recovery having healed nothing and report success, and the uids it missed would surface again as duplicate mail wakes once the directory became writable.

`fm_wake_queued_keys` now reports an unreadable queue as its own nonzero status instead of relying on an exit a substitution swallows, and the mail queue heal leaves phase two unfinished for the next poll. `tests/fm-watcher-lock.test.sh` gains a case pinning that distinction from inside a substitution; it fails on the pre-fix tree.

`6fe990a` fixes two regressions that a review of the first commit found, each reproduced against the base tree before being fixed.

The depth cap bounded lock-name growth but could not clear a chain that already existed on disk. The recursive version this replaced is precisely what created `<lock>.steal.steal` chains, and nothing else in `bin/` removes one, so the machines an upgrade reaches are exactly the population at risk: depth-1 arbitration cannot claim `<lock>.steal` while a leftover blocks it through `fm_lock_claim_blocked_by_steal`, so acquisition returned `contended` forever and the waiting caller spun silently. That traded the original crash for a hang, which is worse. A bounded sweep now clears a stale chain deepest level first, so no orphan is left to block a later claim, and stops at the first level still owned.

The required unwritable refusal also depended on what was already on disk: a leftover steal skipped the writability branch, so an unwritable directory was reported as ordinary contention and the named permission refusal - the point of classifying at all - was unreachable in the compound case. An uncreatable lock is now classified before anything else and independently of any leftover.

The same commit carries three test-hygiene fixes from that review. The spawn fixture no longer provisions Claude readiness outside a fixture tree, proved by the `.fm-test-fixture` marker `fm_test_tmproot` writes rather than a `TMPDIR` prefix, which cannot match once the root is resolved with `pwd -P` on macOS. The two readiness refusal cases capability-skip like their sibling on a machine whose managed settings record the acceptance. The mail queue heal captures stdout only, so a diagnostic reaches the operator instead of being parsed as queue content.

One review finding was deliberately left as classified no-op: the preflight resolves a local `HEAD^{commit}` while the refusal speaks of the default branch. That signal was chosen to avoid coupling Firstmate to Treehouse internals, and the endpoint cleanup obligation removes the durable harm in the residual case, so no orphaned window remains.

`tests/fm-watcher-lock.test.sh` gains two cases for the compound situations, both failing on the pre-fix tree: a dead-owner primary lock behind a leftover nested chain, and an unwritable directory that already contains a leftover steal.

## Validation

- `bin/fm-lint.sh` exits 0 (ShellCheck 0.11.0, actionlint 1.7.12).
- `bin/fm-test-run.sh --check-coverage` ok; both new suites are registered in the backend-dispatch family with measured weight hints.
- Passing locally: `fm-watcher-lock` (35), `fm-procevent` (107), `fm-procevent-when` (13), `fm-mail` (57), `fm-inactive-reconcile` (29), `fm-wake-drain-outcome-backstop` (18), `fm-claude-trust` (20), `fm-claude-ready` (4), `fm-spawn-transaction` (2), `fm-spawn-worktree-settle` (4), `fm-spawn-dispatch-profile` (54), `fm-spawn-batch` (5), `fm-spawn-pool-base-freshen` (23), `fm-captain-hold-lifecycle` (50), `fm-send-inbox` (12).
- Two suites fail identically on this branch and on the unmodified base commit, so they are environment-dependent here rather than regressions: `fm-teardown.test.sh` (`herdr-preflight-missing-adapter`, no Herdr adapter installed) and `fm-wake-queue.test.sh` (timing-sensitive under load; the failing case moves between runs on both trees).
- No no-mistakes pipeline attestation: this task was dispatched `direct-PR` with an explicit instruction not to run the pipeline, so the author cannot supply one. Raising that with the dispatching side.
