### PR TITLE
feat(bin): add opt-in read-only local status HTTP/SSE endpoint

### DIFF
--- a/bin/fm-status-pr-url.sh
+++ b/bin/fm-status-pr-url.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# fm-status-pr-url.sh - print a task's recorded PR URL, or nothing.
+#
+# Usage: fm-status-pr-url.sh <task-id>
+#
+# Reads state/<task-id>.meta through fm-pr-lib.sh's own
+# fm_pr_metadata_identity_parse, the canonical pr= reader every merge and
+# PR-status path already uses, instead of re-deriving the parse here. Prints
+# the recorded PR URL on stdout when a valid pr= line is present, otherwise
+# prints nothing and still exits 0: no recorded PR is not a failure.
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FM_ROOT="${FM_ROOT_OVERRIDE:-$(cd "$SCRIPT_DIR/.." && pwd)}"
+FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
+STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
+
+usage() {
+  sed -n '2,${/^#/!q;p;}' "$0" | sed 's/^# \{0,1\}//'
+}
+
+case "${1:-}" in
+  '') usage >&2; exit 2 ;;
+  -h|--help) usage; exit 0 ;;
+esac
+
+# shellcheck source=bin/fm-pr-lib.sh
+# shellcheck disable=SC1091
+. "$SCRIPT_DIR/fm-pr-lib.sh"
+
+if fm_pr_metadata_identity_parse "$STATE/$1.meta"; then
+  printf '%s\n' "$FM_PR_META_URL"
+fi
+exit 0

--- a/bin/fm-status-server.sh
+++ b/bin/fm-status-server.sh
@@ -13,8 +13,10 @@
 # else (404 on any other path, 405 on any non-GET method: no writes, no
 # commands):
 #   GET /status   one JSON document combining bin/fm-crew-state.sh's live
-#                 per-task verdicts, the published state/home-summary.json
-#                 fleet ledger, and quota-axi's read-only capacity report.
+#                 per-task verdicts (each with a pr_url from
+#                 bin/fm-status-pr-url.sh, null when no PR is recorded), the
+#                 published state/home-summary.json fleet ledger, and
+#                 quota-axi's read-only capacity report.
 #   GET /events   the same document as an SSE stream, re-sent every
 #                 --interval seconds (default 5) until the client disconnects.
 # Every field comes straight from those existing sources, so the endpoint

--- a/bin/fm-status-server.sh
+++ b/bin/fm-status-server.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# fm-status-server.sh - opt-in, read-only local status endpoint for this
+# FM_HOME.
+#
+# Usage: fm-status-server.sh [--port <port>] [--interval <seconds>]
+#
+# Off unless explicitly started: this script has no daemon, no session-start
+# hook, and no watcher wiring, so the endpoint exists only for the lifetime of
+# this foreground process. Ctrl-C (or killing the process) stops it.
+#
+# Binds to 127.0.0.1 only, never a routable address, and accepts no argument
+# that could change that. It serves two GET routes and refuses everything
+# else (404 on any other path, 405 on any non-GET method: no writes, no
+# commands):
+#   GET /status   one JSON document combining bin/fm-crew-state.sh's live
+#                 per-task verdicts, the published state/home-summary.json
+#                 fleet ledger, and quota-axi's read-only capacity report.
+#   GET /events   the same document as an SSE stream, re-sent every
+#                 --interval seconds (default 5) until the client disconnects.
+# Every field comes straight from those existing sources, so the endpoint
+# never re-derives fleet state and never adds anything of its own. Those
+# sources are chosen because none of them embed secrets: no tokens, no
+# credentials, no .env values, no brief text, no raw pane/scrollback content.
+# See bin/fm_status_server.py for the exact combination logic.
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FM_ROOT="${FM_ROOT_OVERRIDE:-$(cd "$SCRIPT_DIR/.." && pwd)}"
+FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
+STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
+
+usage() {
+  sed -n '2,${/^#/!q;p;}' "$0" | sed 's/^# \{0,1\}//'
+}
+
+PORT=8787
+INTERVAL=5
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --port)
+      PORT=${2:-}
+      shift 2
+      ;;
+    --interval)
+      INTERVAL=${2:-}
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+case "$PORT" in
+  ''|*[!0-9]*) echo "fm-status-server: --port must be a positive integer" >&2; exit 2 ;;
+esac
+if [ "$PORT" -lt 1 ] || [ "$PORT" -gt 65535 ]; then
+  echo "fm-status-server: --port must be between 1 and 65535" >&2
+  exit 2
+fi
+case "$INTERVAL" in
+  ''|*[!0-9.]*) echo "fm-status-server: --interval must be a positive number" >&2; exit 2 ;;
+esac
+
+PY="$(command -v python3 || true)"
+if [ -z "$PY" ]; then
+  echo "fm-status-server: python3 required" >&2
+  exit 1
+fi
+
+exec "$PY" "$SCRIPT_DIR/fm_status_server.py" \
+  --port "$PORT" \
+  --interval "$INTERVAL" \
+  --fm-root "$FM_ROOT" \
+  --fm-home "$FM_HOME" \
+  --state-dir "$STATE"

--- a/bin/fm_status_server.py
+++ b/bin/fm_status_server.py
@@ -7,8 +7,10 @@
 #     ledger) is read verbatim as the fleet snapshot.
 #   - Each active child's live one-line state comes from bin/fm-crew-state.sh
 #     <id>, called fresh per request so it never goes stale between ledger
-#     refreshes.
-#   - quota-axi --json --once --no-credential-refresh supplies capacity data,
+#     refreshes, alongside its recorded PR URL (null when absent) from
+#     bin/fm-status-pr-url.sh <id>, which defers to fm-pr-lib.sh's own pr=
+#     parser rather than re-reading state/<id>.meta by hand.
+#   - quota-axi --json --no-credential-refresh supplies capacity data,
 #     strictly read-only (no credential renewal, no keychain prompt).
 # None of those sources embed tokens, credentials, .env values, brief text,
 # or raw pane/scrollback content, and this server adds none of its own: it
@@ -27,7 +29,7 @@ from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 
 
-def _run(argv, timeout):
+def _run(argv, timeout, env=None):
     """Run argv, returning (ok, stdout_text). Never raises."""
     try:
         proc = subprocess.run(
@@ -36,6 +38,7 @@ def _run(argv, timeout):
             text=True,
             timeout=timeout,
             check=False,
+            env=env,
         )
     except (OSError, subprocess.SubprocessError) as exc:
         return False, str(exc)
@@ -56,16 +59,22 @@ def read_home_summary(state_dir):
         return None, f"home-summary.json unreadable: {exc}"
 
 
-def read_crew_state(fm_root, fm_home, task_ids, timeout):
+def build_task_rows(fm_root, fm_home, state_dir, task_ids, timeout):
     crew_state_bin = os.path.join(fm_root, "bin", "fm-crew-state.sh")
-    live = {}
+    pr_url_bin = os.path.join(fm_root, "bin", "fm-status-pr-url.sh")
     env = dict(os.environ)
     env["FM_HOME"] = fm_home
+    env["FM_STATE_OVERRIDE"] = state_dir
+    rows = []
     for task_id in task_ids:
-        ok, out = _run([crew_state_bin, task_id], timeout)
-        line = out.strip() if ok else f"state: unknown · source: none · {out.strip()}"
-        live[task_id] = line
-    return live
+        ok, out = _run([crew_state_bin, task_id], timeout, env=env)
+        state_line = (
+            out.strip() if ok else f"state: unknown · source: none · {out.strip()}"
+        )
+        pr_ok, pr_out = _run([pr_url_bin, task_id], timeout, env=env)
+        pr_url = pr_out.strip() if pr_ok and pr_out.strip() else None
+        rows.append({"id": task_id, "state": state_line, "pr_url": pr_url})
+    return rows
 
 
 def read_quota(timeout):
@@ -89,14 +98,14 @@ def build_payload(fm_root, fm_home, state_dir, timeout):
             for child in summary.get("active_children", [])
             if isinstance(child, dict) and child.get("id")
         ]
-    crew_state = read_crew_state(fm_root, fm_home, task_ids, timeout)
+    tasks = build_task_rows(fm_root, fm_home, state_dir, task_ids, timeout)
     quota, quota_error = read_quota(timeout)
     return {
         "generated": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
         "home": fm_home,
         "home_summary": summary,
         "home_summary_error": summary_error,
-        "live_crew_state": crew_state,
+        "tasks": tasks,
         "quota": quota,
         "quota_error": quota_error,
     }

--- a/bin/fm_status_server.py
+++ b/bin/fm_status_server.py
@@ -1,0 +1,205 @@
+#!/usr/bin/env python3
+# fm_status_server.py - read-only localhost HTTP/SSE status backend for
+# bin/fm-status-server.sh.
+#
+# Serves the fleet view firstmate already computes, never re-deriving state:
+#   - state/home-summary.json (bin/fm-home-summary-refresh.sh's published
+#     ledger) is read verbatim as the fleet snapshot.
+#   - Each active child's live one-line state comes from bin/fm-crew-state.sh
+#     <id>, called fresh per request so it never goes stale between ledger
+#     refreshes.
+#   - quota-axi --json --once --no-credential-refresh supplies capacity data,
+#     strictly read-only (no credential renewal, no keychain prompt).
+# None of those sources embed tokens, credentials, .env values, brief text,
+# or raw pane/scrollback content, and this server adds none of its own: it
+# passes their output through unmodified. GET /status returns one JSON
+# document; GET /events streams the same document over SSE on an interval.
+# Every other path and every non-GET method is refused. The server accepts
+# no request body, no write, and no command of any kind.
+import argparse
+import json
+import os
+import subprocess
+import sys
+import time
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+
+
+def _run(argv, timeout):
+    """Run argv, returning (ok, stdout_text). Never raises."""
+    try:
+        proc = subprocess.run(
+            argv,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError) as exc:
+        return False, str(exc)
+    if proc.returncode != 0:
+        detail = (proc.stderr or proc.stdout or "").strip()
+        return False, detail[:500] if detail else f"exit {proc.returncode}"
+    return True, proc.stdout
+
+
+def read_home_summary(state_dir):
+    path = os.path.join(state_dir, "home-summary.json")
+    try:
+        with open(path, "r", encoding="utf-8") as fh:
+            return json.load(fh), None
+    except FileNotFoundError:
+        return None, "home-summary.json not yet published for this home"
+    except (OSError, json.JSONDecodeError) as exc:
+        return None, f"home-summary.json unreadable: {exc}"
+
+
+def read_crew_state(fm_root, fm_home, task_ids, timeout):
+    crew_state_bin = os.path.join(fm_root, "bin", "fm-crew-state.sh")
+    live = {}
+    env = dict(os.environ)
+    env["FM_HOME"] = fm_home
+    for task_id in task_ids:
+        ok, out = _run([crew_state_bin, task_id], timeout)
+        line = out.strip() if ok else f"state: unknown · source: none · {out.strip()}"
+        live[task_id] = line
+    return live
+
+
+def read_quota(timeout):
+    ok, out = _run(
+        ["quota-axi", "--json", "--no-credential-refresh"], timeout
+    )
+    if not ok:
+        return None, out.strip()
+    try:
+        return json.loads(out), None
+    except json.JSONDecodeError as exc:
+        return None, f"quota-axi returned unparsable JSON: {exc}"
+
+
+def build_payload(fm_root, fm_home, state_dir, timeout):
+    summary, summary_error = read_home_summary(state_dir)
+    task_ids = []
+    if summary:
+        task_ids = [
+            child.get("id")
+            for child in summary.get("active_children", [])
+            if isinstance(child, dict) and child.get("id")
+        ]
+    crew_state = read_crew_state(fm_root, fm_home, task_ids, timeout)
+    quota, quota_error = read_quota(timeout)
+    return {
+        "generated": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+        "home": fm_home,
+        "home_summary": summary,
+        "home_summary_error": summary_error,
+        "live_crew_state": crew_state,
+        "quota": quota,
+        "quota_error": quota_error,
+    }
+
+
+class StatusHandler(BaseHTTPRequestHandler):
+    server_version = "fm-status-server/1"
+    protocol_version = "HTTP/1.1"
+
+    def log_message(self, fmt, *args):  # noqa: A003 - stdlib override
+        sys.stderr.write("fm-status-server: %s\n" % (fmt % args))
+
+    def _refuse_write(self):
+        self.send_response(405)
+        self.send_header("Content-Type", "text/plain; charset=utf-8")
+        self.send_header("Content-Length", "0")
+        self.send_header("Allow", "GET")
+        self.end_headers()
+
+    do_POST = _refuse_write
+    do_PUT = _refuse_write
+    do_DELETE = _refuse_write
+    do_PATCH = _refuse_write
+
+    def _payload(self):
+        return build_payload(
+            self.server.fm_root,
+            self.server.fm_home,
+            self.server.state_dir,
+            self.server.probe_timeout,
+        )
+
+    def do_GET(self):
+        if self.path == "/status":
+            self._serve_status()
+        elif self.path == "/events":
+            self._serve_events()
+        else:
+            self.send_response(404)
+            self.send_header("Content-Type", "text/plain; charset=utf-8")
+            self.send_header("Content-Length", "0")
+            self.end_headers()
+
+    def _serve_status(self):
+        body = json.dumps(self._payload(), indent=2).encode("utf-8")
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def _serve_events(self):
+        self.send_response(200)
+        self.send_header("Content-Type", "text/event-stream")
+        self.send_header("Cache-Control", "no-cache")
+        self.send_header("Connection", "keep-alive")
+        self.end_headers()
+        interval = self.server.sse_interval
+        try:
+            while True:
+                chunk = json.dumps(self._payload())
+                self.wfile.write(f"data: {chunk}\n\n".encode("utf-8"))
+                self.wfile.flush()
+                time.sleep(interval)
+        except (BrokenPipeError, ConnectionResetError):
+            return
+
+
+class StatusServer(ThreadingHTTPServer):
+    daemon_threads = True
+    allow_reuse_address = True
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Read-only localhost HTTP/SSE fleet status endpoint."
+    )
+    parser.add_argument("--port", type=int, required=True)
+    parser.add_argument("--fm-root", required=True)
+    parser.add_argument("--fm-home", required=True)
+    parser.add_argument("--state-dir", required=True)
+    parser.add_argument("--interval", type=float, default=5.0)
+    parser.add_argument("--probe-timeout", type=float, default=10.0)
+    args = parser.parse_args()
+
+    server = StatusServer(("127.0.0.1", args.port), StatusHandler)
+    server.fm_root = args.fm_root
+    server.fm_home = args.fm_home
+    server.state_dir = args.state_dir
+    server.sse_interval = max(args.interval, 0.5)
+    server.probe_timeout = max(args.probe_timeout, 1.0)
+    sys.stderr.write(
+        f"fm-status-server: listening on http://127.0.0.1:{args.port} "
+        f"(GET /status, GET /events)\n"
+    )
+    sys.stderr.flush()
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        pass
+    finally:
+        server.server_close()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/fm-status-server.test.sh
+++ b/tests/fm-status-server.test.sh
@@ -39,6 +39,12 @@ printf 'state: working · source: run-step · fixture task %s\n' "${1:-}"
 SH
 chmod +x "$FAKE_ROOT/bin/fm-crew-state.sh"
 
+# The real fm-status-pr-url.sh (and the fm-pr-lib.sh it sources) run for
+# real here, against fixture .meta files, rather than being stubbed: the
+# pr= parse itself is what this test needs to prove.
+ln -s "$ROOT/bin/fm-status-pr-url.sh" "$FAKE_ROOT/bin/fm-status-pr-url.sh"
+ln -s "$ROOT/bin/fm-pr-lib.sh" "$FAKE_ROOT/bin/fm-pr-lib.sh"
+
 # Stub quota-axi on PATH: the server invokes it by bare name.
 cat > "$FAKEBIN/quota-axi" <<'SH'
 #!/usr/bin/env bash
@@ -57,16 +63,23 @@ cat > "$STATE_DIR/home-summary.json" <<'JSON'
   "reason": null,
   "invalidity": {"kind": null, "ids": []},
   "state": "active_child_work",
-  "active_children": [{"id": "task1", "kind": "ship", "state": "working"}],
+  "active_children": [
+    {"id": "task1", "kind": "ship", "state": "working"},
+    {"id": "task2", "kind": "ship", "state": "working"}
+  ],
   "decisions_open": [],
   "holds": [],
   "queued": [],
   "landed": [],
   "endpoints": [],
-  "counts": {"active_children": 1, "decisions_open": 0, "holds": 0, "queued": 0, "landed": 0, "endpoints": 0},
+  "counts": {"active_children": 2, "decisions_open": 0, "holds": 0, "queued": 0, "landed": 0, "endpoints": 0},
   "omitted": []
 }
 JSON
+
+# task1 has a recorded PR; task2 has no meta file at all (no PR yet).
+printf 'window=default\npr=https://github.com/kunchenguid/firstmate/pull/9999\n' \
+  > "$STATE_DIR/task1.meta"
 
 # A decoy secret file placed next to the ledger: the endpoint must never read
 # or echo arbitrary state-dir contents, only the specific sources it names.
@@ -103,10 +116,13 @@ printf '%s' "$BODY" | python3 -c '
 import json, sys
 d = json.load(sys.stdin)
 assert d["home_summary"]["active_children"][0]["id"] == "task1", d
-assert d["live_crew_state"]["task1"].startswith("state: working"), d
+rows = {row["id"]: row for row in d["tasks"]}
+assert rows["task1"]["state"].startswith("state: working"), d
+assert rows["task1"]["pr_url"] == "https://github.com/kunchenguid/firstmate/pull/9999", d
+assert rows["task2"]["pr_url"] is None, d
 assert d["quota"]["providers"][0]["provider"] == "fixture", d
-' || fail "/status did not combine crew-state, home-summary, and quota as expected"
-pass "/status combines fm-crew-state.sh, home-summary.json, and quota-axi output"
+' || fail "/status did not combine crew-state, PR URLs, home-summary, and quota as expected"
+pass "/status combines fm-crew-state.sh, recorded PR URLs, home-summary.json, and quota-axi output"
 
 case "$BODY" in
   *do-not-leak*) fail "/status leaked the decoy .env secret" ;;

--- a/tests/fm-status-server.test.sh
+++ b/tests/fm-status-server.test.sh
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+# Behavioral coverage for the opt-in, read-only localhost status endpoint:
+# bin/fm-status-server.sh and its bin/fm_status_server.py backend.
+set -u
+
+# shellcheck source=tests/lib.sh
+# shellcheck disable=SC1091
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+command -v curl >/dev/null 2>&1 || { echo "skip: curl not found"; exit 0; }
+command -v python3 >/dev/null 2>&1 || { echo "skip: python3 not found"; exit 0; }
+
+SERVER="$ROOT/bin/fm-status-server.sh"
+TMP_ROOT=$(fm_test_tmproot fm-status-server)
+FAKE_ROOT="$TMP_ROOT/root"
+FM_HOME_DIR="$TMP_ROOT/home"
+STATE_DIR="$FM_HOME_DIR/state"
+FAKEBIN=$(fm_fakebin "$TMP_ROOT")
+SRV_PID=
+
+mkdir -p "$FAKE_ROOT/bin" "$STATE_DIR"
+
+cleanup() {
+  if [ -n "$SRV_PID" ]; then
+    kill -KILL "$SRV_PID" >/dev/null 2>&1 || true
+    wait "$SRV_PID" 2>/dev/null || true
+  fi
+  fm_test_cleanup
+}
+trap cleanup EXIT
+trap 'cleanup; exit 130' INT
+trap 'cleanup; exit 143' TERM
+
+# Stub fm-crew-state.sh under the fake FM_ROOT: the server invokes it by full
+# path (bin/fm-status-server.sh's own contract), never through PATH.
+cat > "$FAKE_ROOT/bin/fm-crew-state.sh" <<'SH'
+#!/usr/bin/env bash
+printf 'state: working · source: run-step · fixture task %s\n' "${1:-}"
+SH
+chmod +x "$FAKE_ROOT/bin/fm-crew-state.sh"
+
+# Stub quota-axi on PATH: the server invokes it by bare name.
+cat > "$FAKEBIN/quota-axi" <<'SH'
+#!/usr/bin/env bash
+printf '{"schemaVersion":5,"providers":[{"provider":"fixture","windows":[]}]}\n'
+SH
+chmod +x "$FAKEBIN/quota-axi"
+
+cat > "$STATE_DIR/home-summary.json" <<'JSON'
+{
+  "schema": "fm-secondmate-home-summary.v1",
+  "hold_classifier_schema": "fm-captain-hold-buckets.v1",
+  "generated": "2026-01-01T00:00:00Z",
+  "generated_epoch": 1,
+  "home": "/fixture/home",
+  "valid": true,
+  "reason": null,
+  "invalidity": {"kind": null, "ids": []},
+  "state": "active_child_work",
+  "active_children": [{"id": "task1", "kind": "ship", "state": "working"}],
+  "decisions_open": [],
+  "holds": [],
+  "queued": [],
+  "landed": [],
+  "endpoints": [],
+  "counts": {"active_children": 1, "decisions_open": 0, "holds": 0, "queued": 0, "landed": 0, "endpoints": 0},
+  "omitted": []
+}
+JSON
+
+# A decoy secret file placed next to the ledger: the endpoint must never read
+# or echo arbitrary state-dir contents, only the specific sources it names.
+printf 'FM_TEST_SECRET_TOKEN=do-not-leak\n' > "$STATE_DIR/.env"
+
+PORT=$(python3 -c '
+import socket
+s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+s.bind(("127.0.0.1", 0))
+print(s.getsockname()[1])
+s.close()
+')
+
+PATH="$FAKEBIN:$PATH" \
+  FM_ROOT_OVERRIDE="$FAKE_ROOT" \
+  FM_HOME="$FM_HOME_DIR" \
+  FM_STATE_OVERRIDE="$STATE_DIR" \
+  "$SERVER" --port "$PORT" --interval 1 >"$TMP_ROOT/server.log" 2>&1 &
+SRV_PID=$!
+
+ready=0
+for _ in $(seq 1 50); do
+  if curl -s -o /dev/null "http://127.0.0.1:$PORT/status"; then
+    ready=1
+    break
+  fi
+  sleep 0.1
+done
+[ "$ready" -eq 1 ] || fail "status server never came up (see $TMP_ROOT/server.log)"
+
+BODY=$(curl -s "http://127.0.0.1:$PORT/status")
+
+printf '%s' "$BODY" | python3 -c '
+import json, sys
+d = json.load(sys.stdin)
+assert d["home_summary"]["active_children"][0]["id"] == "task1", d
+assert d["live_crew_state"]["task1"].startswith("state: working"), d
+assert d["quota"]["providers"][0]["provider"] == "fixture", d
+' || fail "/status did not combine crew-state, home-summary, and quota as expected"
+pass "/status combines fm-crew-state.sh, home-summary.json, and quota-axi output"
+
+case "$BODY" in
+  *do-not-leak*) fail "/status leaked the decoy .env secret" ;;
+esac
+pass "/status never echoes arbitrary state-dir file contents"
+
+STATUS=$(curl -s -o /dev/null -w '%{http_code}' -X POST "http://127.0.0.1:$PORT/status")
+[ "$STATUS" = 405 ] || fail "POST /status expected 405, got $STATUS"
+pass "POST /status is refused (405, read-only)"
+
+STATUS=$(curl -s -o /dev/null -w '%{http_code}' "http://127.0.0.1:$PORT/nope")
+[ "$STATUS" = 404 ] || fail "GET /nope expected 404, got $STATUS"
+pass "unknown paths are refused (404)"
+
+SSE=$(curl -s --max-time 3 -N "http://127.0.0.1:$PORT/events" | head -n 1)
+case "$SSE" in
+  data:*task1*) pass "GET /events streams the same combined document over SSE" ;;
+  *) fail "GET /events did not stream the expected SSE payload (got: $SSE)" ;;
+esac
+
+if command -v lsof >/dev/null 2>&1; then
+  LISTEN_LINE=$(lsof -nP -iTCP:"$PORT" -sTCP:LISTEN 2>/dev/null | tail -n +2)
+  case "$LISTEN_LINE" in
+    *"127.0.0.1:$PORT"*) pass "status server binds 127.0.0.1 only" ;;
+    *) fail "status server is not listening on 127.0.0.1:$PORT (got: $LISTEN_LINE)" ;;
+  esac
+else
+  echo "skip: lsof not found, cannot verify bind address"
+fi


### PR DESCRIPTION
## Summary
- Implement local HTTP/SSE status endpoint in Firstmate CLI for live session metrics and agent inspection per fm-localhost-cli-telemetry-k13.
- Expose each task's recorded PR URL from the status endpoint.

## Verification
- Validated with end-to-end endpoint tests and status assertions.