### PR TITLE
feat(bin): add read-only PR blocker and reviewer discovery commands

### DIFF
--- a/bin/fm-pr-reviewers.sh
+++ b/bin/fm-pr-reviewers.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+# Suggest GitHub reviewers from recent authorship of a pull request's files.
+#
+# This is a read-only advisory command. It reads the pull request's exact file
+# list, then the most recent 100 commits on its base commit for each path. A
+# commit is counted once even when it touched multiple changed paths. Candidates
+# use GitHub's own commit author.login mapping; names and email addresses are
+# never converted or guessed. The pull-request author and Bot accounts are
+# excluded.
+#
+# Usage: fm-pr-reviewers.sh <pr-url-or-number>
+#   Prints candidates in descending unique-commit count as:
+#     <github-login><tab><count> recent commit[s]
+#   When no mapped author other than the pull-request author appears, prints no
+#   candidate and explains that result. Lookup or usage refusal exits non-zero.
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# shellcheck source=bin/fm-pr-lib.sh
+. "$SCRIPT_DIR/fm-pr-lib.sh"
+
+usage() {
+  sed -n '2,/^set -eu$/s/^# \{0,1\}//p' "$0"
+}
+
+die() {
+  printf 'fm-pr-reviewers: %s\n' "$*" >&2
+  exit 2
+}
+
+if [ "${1:-}" = --help ] || [ "${1:-}" = -h ]; then
+  usage
+  exit 0
+fi
+[ "$#" -eq 1 ] || die "usage: fm-pr-reviewers.sh <pr-url-or-number>"
+command -v gh >/dev/null 2>&1 || die "gh is required"
+
+INPUT=$1
+if [[ "$INPUT" =~ ^[1-9][0-9]*$ ]]; then
+  URL=$(gh pr view "$INPUT" --json url --jq .url) \
+    || die "could not read pull request $INPUT"
+else
+  URL=$INPUT
+fi
+if ! fm_pr_url_parse "$URL" || [ "$FM_PR_PROVIDER" != github ]; then
+  die "expected a GitHub pull-request URL or positive pull-request number"
+fi
+
+PATH_PART=$FM_PR_PATH
+NUMBER=$FM_PR_NUMBER
+ENDPOINT="/repos/$PATH_PART/pulls/$NUMBER"
+CORE=$(gh api "$ENDPOINT" --jq '"author=\(.user.login)", "base=\(.base.sha)"') \
+  || die "could not read $URL"
+AUTHOR=
+BASE=
+while IFS= read -r row; do
+  case "$row" in
+    author=*) AUTHOR=${row#author=} ;;
+    base=*) BASE=${row#base=} ;;
+  esac
+done <<EOF
+$CORE
+EOF
+[ -n "$AUTHOR" ] && [ -n "$BASE" ] \
+  || die "GitHub returned incomplete pull-request state for $URL"
+
+FILES=$(gh api "$ENDPOINT/files?per_page=100" --paginate --jq '.[].filename') \
+  || die "could not read changed files for $URL"
+[ -n "$FILES" ] || {
+  printf 'NO CANDIDATES: pull request changes no files\n'
+  exit 0
+}
+
+EVIDENCE=$(mktemp "${TMPDIR:-/tmp}/fm-pr-reviewers.XXXXXX") \
+  || die "could not create temporary evidence file"
+trap 'rm -f "$EVIDENCE"' EXIT INT TERM
+
+while IFS= read -r file; do
+  ROWS=$(gh api --method GET "/repos/$PATH_PART/commits" \
+    -f sha="$BASE" \
+    -f path="$file" \
+    -F per_page=100 \
+    --jq '.[] | select(.author.type != "Bot") | [.sha, (.author.login // "")] | @tsv') \
+    || die "could not read recent commits for $file"
+  [ -z "$ROWS" ] || printf '%s\n' "$ROWS" >> "$EVIDENCE"
+done <<EOF
+$FILES
+EOF
+
+CANDIDATES=$(awk -F '\t' -v author="$AUTHOR" '
+  $2 != "" && $2 != author {
+    key = $1 SUBSEP $2
+    if (!seen[key]++) count[$2]++
+  }
+  END {
+    for (login in count)
+      printf "%s\t%d recent commit%s\n", login, count[login], (count[login] == 1 ? "" : "s")
+  }
+' "$EVIDENCE" | LC_ALL=C sort -t $'\t' -k2,2nr -k1,1)
+
+if [ -z "$CANDIDATES" ]; then
+  printf 'NO CANDIDATES: no mapped author other than the PR author\n'
+else
+  printf '%s\n' "$CANDIDATES"
+fi

--- a/bin/fm-pr-reviewers.sh
+++ b/bin/fm-pr-reviewers.sh
@@ -6,9 +6,10 @@
 # commit is counted once even when it touched multiple changed paths. Candidates
 # use GitHub's own commit author.login mapping; names and email addresses are
 # never converted or guessed. The pull-request author and Bot accounts are
-# excluded.
+# excluded. One API read is issued per changed path, so a wide pull request
+# costs proportionally more reads and time.
 #
-# Usage: fm-pr-reviewers.sh <pr-url-or-number>
+# Usage: fm-pr-reviewers.sh <pr-url>
 #   Prints candidates in descending unique-commit count as:
 #     <github-login><tab><count> recent commit[s]
 #   When no mapped author other than the pull-request author appears, prints no
@@ -33,18 +34,12 @@ if [ "${1:-}" = --help ] || [ "${1:-}" = -h ]; then
   usage
   exit 0
 fi
-[ "$#" -eq 1 ] || die "usage: fm-pr-reviewers.sh <pr-url-or-number>"
+[ "$#" -eq 1 ] || die "usage: fm-pr-reviewers.sh <pr-url>"
 command -v gh >/dev/null 2>&1 || die "gh is required"
 
-INPUT=$1
-if [[ "$INPUT" =~ ^[1-9][0-9]*$ ]]; then
-  URL=$(gh pr view "$INPUT" --json url --jq .url) \
-    || die "could not read pull request $INPUT"
-else
-  URL=$INPUT
-fi
+URL=$1
 if ! fm_pr_url_parse "$URL" || [ "$FM_PR_PROVIDER" != github ]; then
-  die "expected a GitHub pull-request URL or positive pull-request number"
+  die "expected a GitHub pull-request URL"
 fi
 
 PATH_PART=$FM_PR_PATH

--- a/bin/fm-pr-state.sh
+++ b/bin/fm-pr-state.sh
@@ -15,11 +15,6 @@
 # block; review history is printed only to explain CHANGES_REQUESTED, naming
 # each reviewer whose latest verdict still requests changes and marking it
 # STALE when it was left at a superseded head.
-# The two pull-request reads are taken against one exact head, and a push that
-# lands between them invalidates the result rather than mixing two heads, so the
-# caller re-runs the command against the new head. The check and review reads
-# that follow are not re-verified against that head, so no line reports which
-# head it was read against.
 # A closed or merged pull request reports that terminal state and nothing else.
 # Unresolved review-thread state is out of this command's scope.
 #
@@ -59,12 +54,15 @@ PATH_PART=$FM_PR_PATH
 NUMBER=$FM_PR_NUMBER
 ENDPOINT="/repos/$PATH_PART/pulls/$NUMBER"
 
-CORE=$(gh api "$ENDPOINT" --jq '
-  "state=\(.state)",
-  "merged_at=\(.merged_at // "")",
-  "draft=\(.draft)",
-  "head=\(.head.sha)",
-  "author=\(.user.login)"') || die "could not read $URL"
+CORE=$(gh pr view "$URL" \
+  --json state,mergedAt,isDraft,headRefOid,author,mergeable,reviewDecision --jq '
+  "state=\(.state | ascii_downcase)",
+  "merged_at=\(.mergedAt // "")",
+  "draft=\(.isDraft)",
+  "head=\(.headRefOid)",
+  "author=\(.author.login)",
+  "mergeability=\(if .mergeable == null or .mergeable == "UNKNOWN" then "unknown" else (.mergeable | ascii_downcase) end)",
+  "review_decision=\(.reviewDecision // "")"') || die "could not read $URL"
 
 STATE=
 MERGED_AT=
@@ -72,6 +70,7 @@ DRAFT=
 MERGEABILITY=
 HEAD=
 AUTHOR=
+REVIEW_DECISION=
 while IFS= read -r row; do
   case "$row" in
     state=*) STATE=${row#state=} ;;
@@ -79,32 +78,15 @@ while IFS= read -r row; do
     draft=*) DRAFT=${row#draft=} ;;
     head=*) HEAD=${row#head=} ;;
     author=*) AUTHOR=${row#author=} ;;
+    mergeability=*) MERGEABILITY=${row#mergeability=} ;;
+    review_decision=*) REVIEW_DECISION=${row#review_decision=} ;;
   esac
 done <<EOF_CORE
 $CORE
 EOF_CORE
 [ -n "$STATE" ] && [ -n "$DRAFT" ] && [ -n "$HEAD" ] && [ -n "$AUTHOR" ] \
+  && [ -n "$MERGEABILITY" ] \
   || die "GitHub returned incomplete pull-request state for $URL"
-
-MERGE_VIEW=$(gh pr view "$URL" --json mergeable,headRefOid,reviewDecision --jq '
-  "mergeability=\(if .mergeable == null or .mergeable == "UNKNOWN" then "unknown" else (.mergeable | ascii_downcase) end)",
-  "head=\(.headRefOid)",
-  "review_decision=\(.reviewDecision // "")"') || die "could not read mergeability and review decision for $URL"
-MERGE_HEAD=
-REVIEW_DECISION=
-while IFS= read -r row; do
-  case "$row" in
-    mergeability=*) MERGEABILITY=${row#mergeability=} ;;
-    head=*) MERGE_HEAD=${row#head=} ;;
-    review_decision=*) REVIEW_DECISION=${row#review_decision=} ;;
-  esac
-done <<EOF_VIEW
-$MERGE_VIEW
-EOF_VIEW
-[ -n "$MERGEABILITY" ] && [ -n "$MERGE_HEAD" ] \
-  || die "GitHub returned incomplete mergeability for $URL"
-[ "$MERGE_HEAD" = "$HEAD" ] \
-  || die "pull-request head changed while reading $URL"
 
 if [ -n "$MERGED_AT" ]; then
   printf 'STATE: merged at %s\n' "$MERGED_AT"

--- a/bin/fm-pr-state.sh
+++ b/bin/fm-pr-state.sh
@@ -1,0 +1,164 @@
+#!/usr/bin/env bash
+# Report the live blockers that keep one GitHub pull request from being ready.
+#
+# This is a one-shot, read-only command. It reads the current pull request,
+# required checks, submitted reviews, and review decision from GitHub at
+# invocation time. It never posts, requests, approves, or merges.
+# Ready means nothing is left for the author: a pull request that only awaits
+# an approval (reviewDecision REVIEW_REQUIRED) is not reported as blocked.
+# Advisory checks do not block and are omitted. A head on which no check has
+# reported yet is unverified, not ready. GitHub's reviewDecision owns
+# whether reviews block; review history is printed only to explain
+# CHANGES_REQUESTED, naming each reviewer whose latest verdict still requests
+# changes and marking it STALE when it was left at a superseded head.
+# Every reading is taken against one exact head. A push that lands mid-read
+# invalidates the whole result rather than mixing two heads, so the caller
+# re-runs the command against the new head.
+# Unresolved review-thread state is not reported because GitHub's REST API does
+# not expose resolution and unattended commands may not use GraphQL.
+#
+# Usage: fm-pr-state.sh <pr-url-or-number>
+#   Prints one line per concrete blocker and nothing when none are found.
+#   Blockers do not change the successful exit status; lookup or usage refusal
+#   exits non-zero.
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# shellcheck source=bin/fm-pr-lib.sh
+. "$SCRIPT_DIR/fm-pr-lib.sh"
+
+usage() {
+  sed -n '2,/^set -eu$/s/^# \{0,1\}//p' "$0"
+}
+
+die() {
+  printf 'fm-pr-state: %s\n' "$*" >&2
+  exit 2
+}
+
+if [ "${1:-}" = --help ] || [ "${1:-}" = -h ]; then
+  usage
+  exit 0
+fi
+[ "$#" -eq 1 ] || die "usage: fm-pr-state.sh <pr-url-or-number>"
+command -v gh >/dev/null 2>&1 || die "gh is required"
+
+INPUT=$1
+if [[ "$INPUT" =~ ^[1-9][0-9]*$ ]]; then
+  URL=$(gh pr view "$INPUT" --json url --jq .url) \
+    || die "could not read pull request $INPUT"
+else
+  URL=$INPUT
+fi
+if ! fm_pr_url_parse "$URL" || [ "$FM_PR_PROVIDER" != github ]; then
+  die "expected a GitHub pull-request URL or positive pull-request number"
+fi
+
+PATH_PART=$FM_PR_PATH
+NUMBER=$FM_PR_NUMBER
+ENDPOINT="/repos/$PATH_PART/pulls/$NUMBER"
+
+CORE=$(gh api "$ENDPOINT" --jq '
+  "state=\(.state)",
+  "merged_at=\(.merged_at // "")",
+  "draft=\(.draft)",
+  "head=\(.head.sha)",
+  "author=\(.user.login)"') || die "could not read $URL"
+
+STATE=
+MERGED_AT=
+DRAFT=
+MERGEABILITY=
+HEAD=
+AUTHOR=
+while IFS= read -r row; do
+  case "$row" in
+    state=*) STATE=${row#state=} ;;
+    merged_at=*) MERGED_AT=${row#merged_at=} ;;
+    draft=*) DRAFT=${row#draft=} ;;
+    head=*) HEAD=${row#head=} ;;
+    author=*) AUTHOR=${row#author=} ;;
+  esac
+done <<EOF_CORE
+$CORE
+EOF_CORE
+[ -n "$STATE" ] && [ -n "$DRAFT" ] && [ -n "$HEAD" ] && [ -n "$AUTHOR" ] \
+  || die "GitHub returned incomplete pull-request state for $URL"
+
+MERGE_VIEW=$(gh pr view "$URL" --json mergeable,headRefOid,reviewDecision --jq '
+  "mergeability=\(if .mergeable == null or .mergeable == "UNKNOWN" then "unknown" else (.mergeable | ascii_downcase) end)",
+  "head=\(.headRefOid)",
+  "review_decision=\(.reviewDecision // "")"') || die "could not read mergeability and review decision for $URL"
+MERGE_HEAD=
+REVIEW_DECISION=
+while IFS= read -r row; do
+  case "$row" in
+    mergeability=*) MERGEABILITY=${row#mergeability=} ;;
+    head=*) MERGE_HEAD=${row#head=} ;;
+    review_decision=*) REVIEW_DECISION=${row#review_decision=} ;;
+  esac
+done <<EOF_VIEW
+$MERGE_VIEW
+EOF_VIEW
+[ -n "$MERGEABILITY" ] && [ -n "$MERGE_HEAD" ] \
+  || die "GitHub returned incomplete mergeability for $URL"
+[ "$MERGE_HEAD" = "$HEAD" ] \
+  || die "pull-request head changed while reading $URL"
+
+if [ -n "$MERGED_AT" ]; then
+  printf 'STATE: merged at %s\n' "$MERGED_AT"
+elif [ "$STATE" != open ]; then
+  printf 'STATE: %s\n' "$STATE"
+fi
+[ "$DRAFT" = false ] || printf 'DRAFT: pull request is not ready for review\n'
+case "$MERGEABILITY" in
+  mergeable) ;;
+  unknown) printf 'MERGEABILITY: unknown\n' ;;
+  conflicting) printf 'MERGEABILITY: conflicting\n' ;;
+  *) die "GitHub returned invalid mergeability for $URL" ;;
+esac
+
+GH_STDERR=$(mktemp "${TMPDIR:-/tmp}/fm-pr-state.XXXXXX") \
+  || die "could not create temporary file"
+trap 'rm -f "$GH_STDERR"' EXIT INT TERM
+if ! REQUIRED=$(gh pr checks "$URL" --required --json name,state,bucket,workflow --jq '
+  .[]
+  | select(.bucket != "pass" and .bucket != "skipping")
+  | "REQUIRED CHECK: \(.name) (\(.state))"' 2>"$GH_STDERR"); then
+  if grep -q "^no checks reported on the '" "$GH_STDERR"; then
+    REQUIRED="CHECKS: none reported yet on ${HEAD:0:7}"
+  elif grep -q "^no required checks reported on the '" "$GH_STDERR"; then
+    REQUIRED=
+  else
+    cat "$GH_STDERR" >&2
+    die "could not read required checks for $URL"
+  fi
+fi
+[ -z "$REQUIRED" ] || printf '%s\n' "$REQUIRED"
+
+if [ "$REVIEW_DECISION" = CHANGES_REQUESTED ]; then
+  printf 'REVIEW DECISION: CHANGES_REQUESTED\n'
+  REVIEWS=$(gh api "$ENDPOINT/reviews?per_page=100" --paginate --jq '
+    .[]
+    | select(.user.login != null and .commit_id != null and .submitted_at != null)
+    | [.user.login, .state, .commit_id, .submitted_at]
+    | @tsv') || die "could not read reviews for $URL"
+  printf '%s\n' "$REVIEWS" | awk -F '\t' -v author="$AUTHOR" -v head="$HEAD" '
+    NF == 4 && $1 != author && $2 != "COMMENTED" && (!seen[$1] || $4 >= latest[$1]) {
+      seen[$1] = 1
+      latest[$1] = $4
+      state[$1] = $2
+      commit[$1] = $3
+    }
+    END {
+      for (reviewer in state) {
+        if (state[reviewer] != "CHANGES_REQUESTED") continue
+        if (commit[reviewer] == head)
+          printf "REVIEW: %s CHANGES_REQUESTED at %s\n", reviewer, head
+        else
+          printf "STALE BLOCKING REVIEW: %s CHANGES_REQUESTED at %s; current head %s\n", \
+            reviewer, commit[reviewer], head
+      }
+    }' | LC_ALL=C sort
+fi

--- a/bin/fm-pr-state.sh
+++ b/bin/fm-pr-state.sh
@@ -110,6 +110,11 @@ if ! REQUIRED=$(gh pr checks "$URL" --required --json name,state,bucket --jq '
   .[]
   | select(.bucket != "pass" and .bucket != "skipping")
   | "REQUIRED CHECK: \(.name) (\(.state))"' 2>"$GH_STDERR"); then
+  # These two sentences are gh's own human-readable error text, verified against
+  # gh 2.100.0 on 2026-09-12. gh reports "nothing reported" as an error rather
+  # than as structured data, so matching its text is the only way to tell that
+  # apart from a real lookup failure. An unrecognised message falls through to
+  # the refusal below, so a reword degrades loudly rather than silently.
   if grep -q "^no checks reported on the '" "$GH_STDERR"; then
     REQUIRED="CHECKS: none reported yet"
   elif grep -q "^no required checks reported on the '" "$GH_STDERR"; then

--- a/bin/fm-pr-state.sh
+++ b/bin/fm-pr-state.sh
@@ -7,10 +7,13 @@
 # Ready means nothing is left for the author: a pull request that only awaits
 # an approval (reviewDecision REVIEW_REQUIRED) is not reported as blocked.
 # Advisory checks do not block and are omitted. A head on which no check has
-# reported yet is unverified, not ready. GitHub's reviewDecision owns
-# whether reviews block; review history is printed only to explain
-# CHANGES_REQUESTED, naming each reviewer whose latest verdict still requests
-# changes and marking it STALE when it was left at a superseded head.
+# reported yet is unverified, not ready. gh returns the same text whether a
+# repository configures no required check at all or configures one that has not
+# reported on this head, so that state is reported as unconfirmed rather than
+# guessed as ready. GitHub's reviewDecision owns whether reviews block; review
+# history is printed only to explain CHANGES_REQUESTED, naming each reviewer
+# whose latest verdict still requests changes and marking it STALE when it was
+# left at a superseded head.
 # Every reading is taken against one exact head. A push that lands mid-read
 # invalidates the whole result rather than mixing two heads, so the caller
 # re-runs the command against the new head.
@@ -125,7 +128,7 @@ if ! REQUIRED=$(gh pr checks "$URL" --required --json name,state,bucket,workflow
   if grep -q "^no checks reported on the '" "$GH_STDERR"; then
     REQUIRED="CHECKS: none reported yet on ${HEAD:0:7}"
   elif grep -q "^no required checks reported on the '" "$GH_STDERR"; then
-    REQUIRED=
+    REQUIRED="CHECKS: no required check has reported on ${HEAD:0:7}; readiness unconfirmed"
   else
     cat "$GH_STDERR" >&2
     die "could not read required checks for $URL"

--- a/bin/fm-pr-state.sh
+++ b/bin/fm-pr-state.sh
@@ -14,9 +14,11 @@
 # history is printed only to explain CHANGES_REQUESTED, naming each reviewer
 # whose latest verdict still requests changes and marking it STALE when it was
 # left at a superseded head.
-# Every reading is taken against one exact head. A push that lands mid-read
-# invalidates the whole result rather than mixing two heads, so the caller
-# re-runs the command against the new head.
+# The two pull-request reads are taken against one exact head, and a push that
+# lands between them invalidates the result rather than mixing two heads, so the
+# caller re-runs the command against the new head. The check and review reads
+# that follow are not re-verified against that head, so no line reports which
+# head it was read against.
 # A closed or merged pull request reports that terminal state and nothing else.
 # Unresolved review-thread state is out of this command's scope.
 #
@@ -121,14 +123,14 @@ esac
 GH_STDERR=$(mktemp "${TMPDIR:-/tmp}/fm-pr-state.XXXXXX") \
   || die "could not create temporary file"
 trap 'rm -f "$GH_STDERR"' EXIT INT TERM
-if ! REQUIRED=$(gh pr checks "$URL" --required --json name,state,bucket,workflow --jq '
+if ! REQUIRED=$(gh pr checks "$URL" --required --json name,state,bucket --jq '
   .[]
   | select(.bucket != "pass" and .bucket != "skipping")
   | "REQUIRED CHECK: \(.name) (\(.state))"' 2>"$GH_STDERR"); then
   if grep -q "^no checks reported on the '" "$GH_STDERR"; then
-    REQUIRED="CHECKS: none reported yet on ${HEAD:0:7}"
+    REQUIRED="CHECKS: none reported yet"
   elif grep -q "^no required checks reported on the '" "$GH_STDERR"; then
-    REQUIRED="CHECKS: no required check has reported on ${HEAD:0:7}; readiness unconfirmed"
+    REQUIRED="CHECKS: no required check has reported; readiness unconfirmed"
   else
     cat "$GH_STDERR" >&2
     die "could not read required checks for $URL"
@@ -154,10 +156,10 @@ if [ "$REVIEW_DECISION" = CHANGES_REQUESTED ]; then
       for (reviewer in state) {
         if (state[reviewer] != "CHANGES_REQUESTED") continue
         if (commit[reviewer] == head)
-          printf "REVIEW: %s CHANGES_REQUESTED at %s\n", reviewer, head
+          printf "REVIEW: %s CHANGES_REQUESTED\n", reviewer
         else
-          printf "STALE BLOCKING REVIEW: %s CHANGES_REQUESTED at %s; current head %s\n", \
-            reviewer, commit[reviewer], head
+          printf "STALE BLOCKING REVIEW: %s CHANGES_REQUESTED at %s\n", \
+            reviewer, commit[reviewer]
       }
     }' | LC_ALL=C sort
 fi

--- a/bin/fm-pr-state.sh
+++ b/bin/fm-pr-state.sh
@@ -14,10 +14,10 @@
 # Every reading is taken against one exact head. A push that lands mid-read
 # invalidates the whole result rather than mixing two heads, so the caller
 # re-runs the command against the new head.
-# Unresolved review-thread state is not reported because GitHub's REST API does
-# not expose resolution and unattended commands may not use GraphQL.
+# A closed or merged pull request reports that terminal state and nothing else.
+# Unresolved review-thread state is out of this command's scope.
 #
-# Usage: fm-pr-state.sh <pr-url-or-number>
+# Usage: fm-pr-state.sh <pr-url>
 #   Prints one line per concrete blocker and nothing when none are found.
 #   Blockers do not change the successful exit status; lookup or usage refusal
 #   exits non-zero.
@@ -41,18 +41,12 @@ if [ "${1:-}" = --help ] || [ "${1:-}" = -h ]; then
   usage
   exit 0
 fi
-[ "$#" -eq 1 ] || die "usage: fm-pr-state.sh <pr-url-or-number>"
+[ "$#" -eq 1 ] || die "usage: fm-pr-state.sh <pr-url>"
 command -v gh >/dev/null 2>&1 || die "gh is required"
 
-INPUT=$1
-if [[ "$INPUT" =~ ^[1-9][0-9]*$ ]]; then
-  URL=$(gh pr view "$INPUT" --json url --jq .url) \
-    || die "could not read pull request $INPUT"
-else
-  URL=$INPUT
-fi
+URL=$1
 if ! fm_pr_url_parse "$URL" || [ "$FM_PR_PROVIDER" != github ]; then
-  die "expected a GitHub pull-request URL or positive pull-request number"
+  die "expected a GitHub pull-request URL"
 fi
 
 PATH_PART=$FM_PR_PATH
@@ -108,8 +102,10 @@ EOF_VIEW
 
 if [ -n "$MERGED_AT" ]; then
   printf 'STATE: merged at %s\n' "$MERGED_AT"
+  exit 0
 elif [ "$STATE" != open ]; then
   printf 'STATE: %s\n' "$STATE"
+  exit 0
 fi
 [ "$DRAFT" = false ] || printf 'DRAFT: pull request is not ready for review\n'
 case "$MERGEABILITY" in

--- a/bin/fm-pr-state.sh
+++ b/bin/fm-pr-state.sh
@@ -1,19 +1,20 @@
 #!/usr/bin/env bash
-# Report the live blockers that keep one GitHub pull request from being ready.
+# Report the blockers this command can see on one GitHub pull request.
 #
 # This is a one-shot, read-only command. It reads the current pull request,
-# required checks, submitted reviews, and review decision from GitHub at
+# reported checks, submitted reviews, and review decision from GitHub at
 # invocation time. It never posts, requests, approves, or merges.
-# Ready means nothing is left for the author: a pull request that only awaits
-# an approval (reviewDecision REVIEW_REQUIRED) is not reported as blocked.
-# Advisory checks do not block and are omitted. A head on which no check has
-# reported yet is unverified, not ready. gh returns the same text whether a
-# repository configures no required check at all or configures one that has not
-# reported on this head, so that state is reported as unconfirmed rather than
-# guessed as ready. GitHub's reviewDecision owns whether reviews block; review
-# history is printed only to explain CHANGES_REQUESTED, naming each reviewer
-# whose latest verdict still requests changes and marking it STALE when it was
-# left at a superseded head.
+# It reports on checks that have reported. A required context that has never
+# reported on this head is absent from what this command reads and cannot be
+# enumerated here. Empty output therefore means that no reported required check
+# is failing or pending; it does not mean the pull request is ready to merge.
+# When nothing has reported, or nothing required has, that is printed rather
+# than read as ready. Advisory checks do not block and are omitted.
+# A pull request that only awaits an approval (reviewDecision REVIEW_REQUIRED)
+# is not reported as blocked. GitHub's reviewDecision owns whether reviews
+# block; review history is printed only to explain CHANGES_REQUESTED, naming
+# each reviewer whose latest verdict still requests changes and marking it
+# STALE when it was left at a superseded head.
 # The two pull-request reads are taken against one exact head, and a push that
 # lands between them invalidates the result rather than mixing two heads, so the
 # caller re-runs the command against the new head. The check and review reads
@@ -23,7 +24,7 @@
 # Unresolved review-thread state is out of this command's scope.
 #
 # Usage: fm-pr-state.sh <pr-url>
-#   Prints one line per concrete blocker and nothing when none are found.
+#   Prints one line per blocker it can see and nothing when it sees none.
 #   Blockers do not change the successful exit status; lookup or usage refusal
 #   exits non-zero.
 set -eu

--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -347,6 +347,7 @@ family_for_basename() {
     fm-opencode-primary-live-e2e.test.sh|fm-pi-branch-live-e2e.test.sh|\
     fm-pi-branch-responsiveness-live-e2e.test.sh|\
     fm-pi-primary-live-e2e.test.sh|fm-pi-codex-native.test.sh|fm-omp-primary-live-e2e.test.sh|\
+    fm-pr-state-live-e2e.test.sh|\
     fm-sessionstart-hook-live-e2e.test.sh|fm-sessionstart-instruction-refresh-live-e2e.test.sh|\
     fm-quota-array-dispatch-live-e2e.test.sh|fm-send-secondmate-marker-herdr-e2e.test.sh|\
     fm-send-inbox-doorbell-live-e2e.test.sh|\
@@ -364,6 +365,7 @@ family_for_basename() {
       printf '%s\n' backend-dispatch
       ;;
     fm-check-unregister.test.sh|fm-pr-check-security.test.sh|fm-pr-merge.test.sh|\
+    fm-pr-reviewers.test.sh|fm-pr-state.test.sh|\
     fm-review-diff.test.sh|fm-teardown.test.sh|fm-x-mode.test.sh)
       printf '%s\n' pr-forge
       ;;

--- a/docs/fm-test-isolation-proof.md
+++ b/docs/fm-test-isolation-proof.md
@@ -80,6 +80,7 @@ This record owns concurrent isolation evidence for the portable parallel candida
 
 `bin/fm-test-isolation-proof.sh --pool <family>` runs the same concurrent proof over a whole `bin/fm-test-run.sh` family, for a stateful family that stays serial on CI but can earn bounded local concurrency.
 A family is admitted to `list_concurrent_safe_families` in `bin/fm-test-run.sh` only by a passing proof recorded here.
+Admission is by family rather than by script, so a script that joins an admitted family afterwards runs concurrently on that family's recorded result without appearing in it.
 
 ### watcher-wake-lock: admitted
 
@@ -143,7 +144,7 @@ The production runner measured the same family at `--family pr-forge --jobs 1` i
 That is close to the family's ceiling rather than a scheduling loss: its longest script runs 198.5s, so no partition of these six can finish faster than about 2.1x.
 The family's clock is two long scripts that do not contend: `fm-pr-check-security` (198.5s) and `fm-teardown` (194.1s) each own a worker for nearly the whole run, and `fm-pr-merge` (118.5s) plus `fm-x-mode` (79.4s) fill the other two.
 `bin/fm-test-isolation-proof.sh`'s own `--list-exclusions` keeps `fm-pr-check-security` and `fm-teardown` out of the mixed PORTABLE pool, where they would share a machine with unrelated lock and forge stress.
-Admitting them inside their own family is a different question and this proof answers it: the family's six scripts are safe with each other at four workers.
+Admitting them inside their own family is a different question and this proof answers it: the six members present on that date are safe with each other at four workers.
 
 ### secondmate: admitted
 

--- a/docs/fm-test-isolation-proof.md
+++ b/docs/fm-test-isolation-proof.md
@@ -146,6 +146,10 @@ The family's clock is two long scripts that do not contend: `fm-pr-check-securit
 `bin/fm-test-isolation-proof.sh`'s own `--list-exclusions` keeps `fm-pr-check-security` and `fm-teardown` out of the mixed PORTABLE pool, where they would share a machine with unrelated lock and forge stress.
 Admitting them inside their own family is a different question and this proof answers it: the six members present on that date are safe with each other at four workers.
 
+`tests/fm-pr-state.test.sh` and `tests/fm-pr-reviewers.test.sh` joined this family after that date and are not covered by the result above.
+`script_allows_concurrency` in `bin/fm-test-run.sh` still grants them four workers by family membership alone, so they run concurrently on evidence measured without them.
+`bin/fm-test-isolation-proof.sh --pool pr-forge --jobs 4` closes that gap, and its refreshed measurement lands on this branch before the pull request leaves draft.
+
 ### secondmate: admitted
 
 - Date: 2026-09-03

--- a/docs/fm-test-isolation-proof.md
+++ b/docs/fm-test-isolation-proof.md
@@ -146,9 +146,24 @@ The family's clock is two long scripts that do not contend: `fm-pr-check-securit
 `bin/fm-test-isolation-proof.sh`'s own `--list-exclusions` keeps `fm-pr-check-security` and `fm-teardown` out of the mixed PORTABLE pool, where they would share a machine with unrelated lock and forge stress.
 Admitting them inside their own family is a different question and this proof answers it: the six members present on that date are safe with each other at four workers.
 
-`tests/fm-pr-state.test.sh` and `tests/fm-pr-reviewers.test.sh` joined this family after that date and are not covered by the result above.
-`script_allows_concurrency` in `bin/fm-test-run.sh` still grants them four workers by family membership alone, so they run concurrently on evidence measured without them.
-`bin/fm-test-isolation-proof.sh --pool pr-forge --jobs 4` closes that gap, and its refreshed measurement lands on this branch before the pull request leaves draft.
+`tests/fm-pr-state.test.sh` and `tests/fm-pr-reviewers.test.sh` joined this family after the date above, so that result does not cover them.
+`script_allows_concurrency` in `bin/fm-test-run.sh` grants concurrency by family membership alone, so the family was re-proved at its full eight-member membership.
+
+- Date: 2026-09-12
+- Command: `bin/fm-test-isolation-proof.sh --pool pr-forge --jobs 4`
+- Result: two consecutive runs, 8 candidates, 0 failures.
+
+| Run | Summary |
+|---|---|
+| 1 | `FM_ISOLATION_SUMMARY total=8 failed=0 concurrency=4 duration_ms=367947` |
+| 2 | `FM_ISOLATION_SUMMARY total=8 failed=0 concurrency=4 duration_ms=352910` |
+
+Both recorded runs began with the machine's one-minute load average below 6.0, at 5.55 and 5.76, so they measure isolation rather than contention.
+A third run taken between them also reported `total=8 failed=0 concurrency=4 duration_ms=357804`, but it started at a load average of 9.20 while the previous run's workers were still decaying, so it is disclosed here rather than recorded as a measurement.
+That its duration landed within 3% of the two clean runs is evidence the elevated figure was a lagging load average rather than real competition for the machine.
+
+These durations are not comparable with the six-member run above: that measurement was taken on a different machine state, and the gap is far larger than two short scripts can account for, so it is not evidence about the two new members.
+For the same reason the 1.72x four-worker figure recorded above is left as a statement about that measurement rather than restated as current.
 
 ### secondmate: admitted
 

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -131,6 +131,8 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-pr-poll.sh`          | Provide the byte-static watcher program for validated PR/MR-poll sidecars           |
 | `fm-pr-check.sh`         | Record validated `pr=` and `pr_head=` values, then atomically arm a static merge poll |
 | `fm-pr-merge.sh`         | Record PR metadata, merge a task's canonical full GitHub or GitLab URL, then refuse an outcome it cannot prove landed or queued |
+| `fm-pr-state.sh`         | Read-only: print one line per live GitHub pull-request blocker and nothing when nothing is left for the author |
+| `fm-pr-reviewers.sh`     | Read-only: suggest reviewers from GitHub's own author mapping of recent commits on a pull request's changed files, never requesting one |
 | `fm-merge-outcome-lib.sh` | Publish a confirmed merge's durable, role-routed supervision outcome                 |
 | `fm-merge-authority-lib.sh` | Resolve merge authority at the gate, persist it against the accepted canonical PR, and identity-check its later poll consumption |
 | `fm-parent-channel-lib.sh` | Resolve a secondmate home's parent channel and append a captain-facing outcome line to it at most once |

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -131,7 +131,7 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-pr-poll.sh`          | Provide the byte-static watcher program for validated PR/MR-poll sidecars           |
 | `fm-pr-check.sh`         | Record validated `pr=` and `pr_head=` values, then atomically arm a static merge poll |
 | `fm-pr-merge.sh`         | Record PR metadata, merge a task's canonical full GitHub or GitLab URL, then refuse an outcome it cannot prove landed or queued |
-| `fm-pr-state.sh`         | Read-only: print one line per GitHub pull-request blocker it can see, reporting on checks that have reported rather than verdicting mergeability |
+| `fm-pr-state.sh`         | Read-only: print one line per GitHub pull-request blocker it can see, reporting on checks that have reported rather than verdicting merge-readiness |
 | `fm-pr-reviewers.sh`     | Read-only: suggest reviewers from GitHub's own author mapping of recent commits on a pull request's changed files, never requesting one |
 | `fm-merge-outcome-lib.sh` | Publish a confirmed merge's durable, role-routed supervision outcome                 |
 | `fm-merge-authority-lib.sh` | Resolve merge authority at the gate, persist it against the accepted canonical PR, and identity-check its later poll consumption |

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -131,7 +131,7 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-pr-poll.sh`          | Provide the byte-static watcher program for validated PR/MR-poll sidecars           |
 | `fm-pr-check.sh`         | Record validated `pr=` and `pr_head=` values, then atomically arm a static merge poll |
 | `fm-pr-merge.sh`         | Record PR metadata, merge a task's canonical full GitHub or GitLab URL, then refuse an outcome it cannot prove landed or queued |
-| `fm-pr-state.sh`         | Read-only: print one line per live GitHub pull-request blocker and nothing when nothing is left for the author |
+| `fm-pr-state.sh`         | Read-only: print one line per GitHub pull-request blocker it can see, reporting on checks that have reported rather than verdicting mergeability |
 | `fm-pr-reviewers.sh`     | Read-only: suggest reviewers from GitHub's own author mapping of recent commits on a pull request's changed files, never requesting one |
 | `fm-merge-outcome-lib.sh` | Publish a confirmed merge's durable, role-routed supervision outcome                 |
 | `fm-merge-authority-lib.sh` | Resolve merge authority at the gate, persist it against the accepted canonical PR, and identity-check its later poll consumption |

--- a/tests/fm-pr-reviewers.test.sh
+++ b/tests/fm-pr-reviewers.test.sh
@@ -19,9 +19,6 @@ cat > "$FAKEBIN/gh" <<'SH'
 set -o pipefail
 serve() {
   case "$*" in
-    "pr view "*" --json url --jq .url")
-      printf '%s\n' '{"url":"https://github.com/o/r/pull/7"}'
-      ;;
     "api /repos/o/r/pulls/7 --jq "*)
       printf '%s\n' '{"user":{"login":"prauthor"},"base":{"sha":"base123"}}'
       ;;
@@ -70,7 +67,7 @@ SH
 chmod +x "$FAKEBIN/gh"
 
 run_reviewers() {
-  PATH="$FAKEBIN:$PATH" "$SCRIPT" 7
+  PATH="$FAKEBIN:$PATH" "$SCRIPT" https://github.com/o/r/pull/7
 }
 
 test_candidates_use_api_logins_and_unique_commit_counts() {
@@ -103,6 +100,11 @@ test_refusals_exit_nonzero() {
   status=0
   PATH="$FAKEBIN:$PATH" "$SCRIPT" not-a-pr >/dev/null 2>&1 || status=$?
   [ "$status" -ne 0 ] || fail "lookup refusal exited zero"
+
+  status=0
+  PATH="$FAKEBIN:$PATH" "$SCRIPT" 7 >/dev/null 2>&1 || status=$?
+  [ "$status" -ne 0 ] \
+    || fail "a bare number resolves against the ambient repository and is not an address"
   pass "argument and lookup refusals exit nonzero"
 }
 

--- a/tests/fm-pr-reviewers.test.sh
+++ b/tests/fm-pr-reviewers.test.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+# Behavioral tests for bin/fm-pr-reviewers.sh.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+SCRIPT="$ROOT/bin/fm-pr-reviewers.sh"
+TMP_ROOT=$(fm_test_tmproot fm-pr-reviewers-tests)
+FAKEBIN=$(fm_fakebin "$TMP_ROOT")
+command -v jq >/dev/null 2>&1 \
+  || fail "these tests run the script's own jq programs over API-shaped JSON with the real jq, which was not found"
+
+# The fake gh answers every query with the JSON shape GitHub returns and runs
+# the --jq program it received with the real jq, so field selection is what is
+# under test.
+cat > "$FAKEBIN/gh" <<'SH'
+#!/usr/bin/env bash
+set -o pipefail
+serve() {
+  case "$*" in
+    "pr view "*" --json url --jq .url")
+      printf '%s\n' '{"url":"https://github.com/o/r/pull/7"}'
+      ;;
+    "api /repos/o/r/pulls/7 --jq "*)
+      printf '%s\n' '{"user":{"login":"prauthor"},"base":{"sha":"base123"}}'
+      ;;
+    "api /repos/o/r/pulls/7/files?per_page=100 --paginate --jq .[].filename")
+      printf '%s\n' '[{"filename":"a.ts"},{"filename":"dir/b.ts"}]'
+      ;;
+    "api --method GET /repos/o/r/commits -f sha=base123 -f path=a.ts -F per_page=100 --jq "*)
+      if [ "${FM_TEST_ONLY_AUTHOR:-0}" = 1 ]; then
+        printf '%s\n' '[
+          {"sha":"own1","author":{"login":"prauthor","type":"User"}},
+          {"sha":"unmapped1","author":null}]'
+      else
+        printf '%s\n' '[
+          {"sha":"carol1","author":{"login":"carol","type":"User"}},
+          {"sha":"alice1","author":{"login":"alice","type":"User"}},
+          {"sha":"own1","author":{"login":"prauthor","type":"User"}},
+          {"sha":"bot1","author":{"login":"renovate[bot]","type":"Bot"}},
+          {"sha":"bot2","author":{"login":"renovate[bot]","type":"Bot"}},
+          {"sha":"bot3","author":{"login":"renovate[bot]","type":"Bot"}},
+          {"sha":"unmapped1","author":null}]'
+      fi
+      ;;
+    "api --method GET /repos/o/r/commits -f sha=base123 -f path=dir/b.ts -F per_page=100 --jq "*)
+      if [ "${FM_TEST_ONLY_AUTHOR:-0}" = 1 ]; then
+        printf '%s\n' '[{"sha":"own2","author":{"login":"prauthor","type":"User"}}]'
+      else
+        printf '%s\n' '[
+          {"sha":"carol1","author":{"login":"carol","type":"User"}},
+          {"sha":"carol2","author":{"login":"carol","type":"User"}}]'
+      fi
+      ;;
+    *)
+      printf 'unexpected gh call: %s\n' "$*" >&2
+      exit 91
+      ;;
+  esac
+}
+prog=
+prev=
+for arg in "$@"; do
+  [ "$prev" != --jq ] || prog=$arg
+  prev=$arg
+done
+serve "$@" | jq -r "$prog"
+SH
+chmod +x "$FAKEBIN/gh"
+
+run_reviewers() {
+  PATH="$FAKEBIN:$PATH" "$SCRIPT" 7
+}
+
+test_candidates_use_api_logins_and_unique_commit_counts() {
+  local out
+  out=$(run_reviewers) || fail "reviewer fixture was refused"
+  assert_contains "$out" $'carol\t2 recent commits' \
+    "the top candidate's API-resolved login or deduplicated count is wrong"
+  assert_contains "$out" $'alice\t1 recent commit' \
+    "the single-commit candidate's mapped authorship evidence is missing"
+  assert_not_contains "$out" 'prauthor' \
+    "the PR author must not be a reviewer candidate"
+  assert_not_contains "$out" 'renovate[bot]' \
+    "a Bot account cannot review and must not be a candidate"
+  pass "reviewer candidates use API-resolved logins and unique commits"
+}
+
+test_only_author_evidence_says_no_candidates() {
+  local out
+  out=$(FM_TEST_ONLY_AUTHOR=1 run_reviewers) || fail "author-only fixture was refused"
+  [ "$out" = 'NO CANDIDATES: no mapped author other than the PR author' ] \
+    || fail "author-only evidence was not explained plainly: $out"
+  pass "author-only evidence produces no candidate and says why"
+}
+
+test_refusals_exit_nonzero() {
+  local status=0
+  PATH="$FAKEBIN:$PATH" "$SCRIPT" >/dev/null 2>&1 || status=$?
+  [ "$status" -ne 0 ] || fail "missing argument refusal exited zero"
+
+  status=0
+  PATH="$FAKEBIN:$PATH" "$SCRIPT" not-a-pr >/dev/null 2>&1 || status=$?
+  [ "$status" -ne 0 ] || fail "lookup refusal exited zero"
+  pass "argument and lookup refusals exit nonzero"
+}
+
+test_candidates_use_api_logins_and_unique_commit_counts
+test_only_author_evidence_says_no_candidates
+test_refusals_exit_nonzero

--- a/tests/fm-pr-reviewers.test.sh
+++ b/tests/fm-pr-reviewers.test.sh
@@ -101,10 +101,13 @@ test_refusals_exit_nonzero() {
   PATH="$FAKEBIN:$PATH" "$SCRIPT" not-a-pr >/dev/null 2>&1 || status=$?
   [ "$status" -ne 0 ] || fail "lookup refusal exited zero"
 
+  local out
   status=0
-  PATH="$FAKEBIN:$PATH" "$SCRIPT" 7 >/dev/null 2>&1 || status=$?
+  out=$(PATH="$FAKEBIN:$PATH" "$SCRIPT" 7 2>&1) || status=$?
   [ "$status" -ne 0 ] \
     || fail "a bare number resolves against the ambient repository and is not an address"
+  assert_contains "$out" 'expected a GitHub pull-request URL' \
+    "a bare number must be refused as an address, not attempted as a lookup"
   pass "argument and lookup refusals exit nonzero"
 }
 

--- a/tests/fm-pr-state-live-e2e.test.sh
+++ b/tests/fm-pr-state-live-e2e.test.sh
@@ -6,8 +6,8 @@
 # they compile and produce the shape the script parses where they are actually
 # executed. cli/cli#1 is a merged 2019 pull request, so its verdict is stable.
 # That stability costs reach: a terminal pull request reports its state and
-# stops, so this guard covers the two pull-request reads taken before that
-# verdict. The required-check and review-history programs stay hermetic-only,
+# stops, so this guard covers the pull-request read taken before that verdict.
+# The required-check and review-history programs stay hermetic-only,
 # the latter because it runs only behind a CHANGES_REQUESTED decision, which no
 # public pull request holds stably.
 set -u
@@ -32,7 +32,7 @@ test_pull_request_read_jq_programs_run_under_gh_engine() {
   [ "$status" -eq 0 ] \
     || fail "fm-pr-state.sh refused a readable public pull request (exit $status): $out"
   assert_contains "$out" 'STATE: merged at 2019-10-04T16:01:04Z' \
-    "the merged verdict must come from the live REST object"
+    "the merged verdict must come from the live pull-request read"
   pass "fm-pr-state.sh's pull-request read programs are accepted by gh's jq engine"
 }
 

--- a/tests/fm-pr-state-live-e2e.test.sh
+++ b/tests/fm-pr-state-live-e2e.test.sh
@@ -5,8 +5,11 @@
 # script's jq programs through the local jq, so only a real gh invocation proves
 # they compile and produce the shape the script parses where they are actually
 # executed. cli/cli#1 is a merged 2019 pull request, so its verdict is stable.
-# The review-history program stays hermetic-only: it runs only behind a
-# CHANGES_REQUESTED decision, which no public pull request holds stably.
+# That stability costs reach: a terminal pull request reports its state and
+# stops, so this guard covers the two pull-request reads taken before that
+# verdict. The required-check and review-history programs stay hermetic-only,
+# the latter because it runs only behind a CHANGES_REQUESTED decision, which no
+# public pull request holds stably.
 set -u
 
 # shellcheck source=tests/lib.sh
@@ -23,14 +26,14 @@ PR=https://github.com/cli/cli/pull/1
 
 gh auth status >/dev/null 2>&1 || fail "gh is not authenticated"
 
-test_every_jq_program_runs_under_gh_engine() {
+test_pull_request_read_jq_programs_run_under_gh_engine() {
   local out status=0
   out=$("$SCRIPT" "$PR" 2>&1) || status=$?
   [ "$status" -eq 0 ] \
     || fail "fm-pr-state.sh refused a readable public pull request (exit $status): $out"
   assert_contains "$out" 'STATE: merged at 2019-10-04T16:01:04Z' \
     "the merged verdict must come from the live REST object"
-  pass "fm-pr-state.sh's jq programs are accepted by gh's own jq engine"
+  pass "fm-pr-state.sh's pull-request read programs are accepted by gh's jq engine"
 }
 
-test_every_jq_program_runs_under_gh_engine
+test_pull_request_read_jq_programs_run_under_gh_engine

--- a/tests/fm-pr-state-live-e2e.test.sh
+++ b/tests/fm-pr-state-live-e2e.test.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Credentialed regression for bin/fm-pr-state.sh against gh's own jq engine.
+#
+# gh evaluates --jq with gojq, not the jq binary. The hermetic suite runs the
+# script's jq programs through the local jq, so only a real gh invocation proves
+# they compile and produce the shape the script parses where they are actually
+# executed. cli/cli#1 is a merged 2019 pull request, so its verdict is stable.
+# The review-history program stays hermetic-only: it runs only behind a
+# CHANGES_REQUESTED decision, which no public pull request holds stably.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+# The shared gate is the live-harness family's one on/off contract: it is what
+# lets FM_LIVE=0 turn every live guard off together, and tests/fm-live-gate.test.sh
+# sweeps the whole family for it. The trailing tool list replaces a hand-rolled
+# gh presence check; authentication is not a tool check and stays below.
+fm_live_gate opt-in FM_PR_STATE_LIVE_E2E gh
+
+SCRIPT="$ROOT/bin/fm-pr-state.sh"
+PR=https://github.com/cli/cli/pull/1
+
+gh auth status >/dev/null 2>&1 || fail "gh is not authenticated"
+
+test_every_jq_program_runs_under_gh_engine() {
+  local out status=0
+  out=$("$SCRIPT" "$PR" 2>&1) || status=$?
+  [ "$status" -eq 0 ] \
+    || fail "fm-pr-state.sh refused a readable public pull request (exit $status): $out"
+  assert_contains "$out" 'STATE: merged at 2019-10-04T16:01:04Z' \
+    "the merged verdict must come from the live REST object"
+  pass "fm-pr-state.sh's jq programs are accepted by gh's own jq engine"
+}
+
+test_every_jq_program_runs_under_gh_engine

--- a/tests/fm-pr-state.test.sh
+++ b/tests/fm-pr-state.test.sh
@@ -1,0 +1,297 @@
+#!/usr/bin/env bash
+# Behavioral tests for bin/fm-pr-state.sh.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+SCRIPT="$ROOT/bin/fm-pr-state.sh"
+TMP_ROOT=$(fm_test_tmproot fm-pr-state-tests)
+FAKEBIN=$(fm_fakebin "$TMP_ROOT")
+command -v jq >/dev/null 2>&1 \
+  || fail "these tests run the script's own jq programs over API-shaped JSON with the real jq, which was not found"
+
+HEAD=c2eac54c17a1ddc2633ad51b83e21e5fe888142e
+OLD_HEAD_1=2710bc5efc936efb70e95b86ca3582e9da7e60f4
+OLD_HEAD_2=4dc2291e6969de1bf204fbdb53c9e57a8353d4e2
+
+# The fake gh answers every query with the JSON shape GitHub returns and runs
+# the --jq program it received with the real jq, so field selection is what is
+# under test. The REST pull-request object always carries the stale
+# `mergeable: null` GitHub reports right after a push.
+# It evaluates with the local jq, while gh itself embeds gojq; the live guard in
+# tests/fm-pr-state-live-e2e.test.sh runs the real engine.
+cat > "$FAKEBIN/gh" <<'SH'
+#!/usr/bin/env bash
+set -o pipefail
+head=c2eac54c17a1ddc2633ad51b83e21e5fe888142e
+serve() {
+  case "$*" in
+    "pr view "*" --json url --jq .url")
+      printf '%s\n' '{"url":"https://github.com/o/r/pull/7"}'
+      ;;
+    "pr view "*" --json mergeable,headRefOid,reviewDecision --jq "*)
+      jq -n --arg mergeable "${FM_TEST_VIEW_MERGEABLE-MERGEABLE}" \
+        --arg head "${FM_TEST_VIEW_HEAD-$head}" \
+        --arg decision "${FM_TEST_VIEW_REVIEW_DECISION-APPROVED}" \
+        '{mergeable: (if $mergeable == "null" then null else $mergeable end),
+          headRefOid: $head, reviewDecision: $decision}'
+      ;;
+    "api /repos/o/r/pulls/7 --jq "*)
+      jq -n --arg head "$head" --arg state "${FM_TEST_STATE-open}" \
+        --arg merged "${FM_TEST_MERGED_AT-}" --arg draft "${FM_TEST_DRAFT-false}" \
+        '{state: $state, merged_at: (if $merged == "" then null else $merged end),
+          draft: ($draft == "true"), mergeable: null,
+          head: {sha: $head, ref: "fm/fixture"}, base: {ref: "dev"},
+          title: "fix: fixture", body: "", user: {login: "prauthor"}}'
+      ;;
+    "api /repos/o/r/pulls/7/reviews?per_page=100 --paginate --jq "*)
+      printf '%s\n' "${FM_TEST_REVIEWS:-[]}"
+      ;;
+    "pr checks "*" --required --json name,state,bucket,workflow --jq "*)
+      if [ -n "${FM_TEST_CHECKS_ERROR-}" ]; then
+        printf '%s\n' "$FM_TEST_CHECKS_ERROR" >&2
+        exit 1
+      fi
+      checks='[{"name":"lint","state":"SUCCESS","bucket":"pass","workflow":"ci"},{"name":"optional","state":"SKIPPED","bucket":"skipping","workflow":"ci"}]'
+      printf '%s\n' "${FM_TEST_REQUIRED_CHECKS:-$checks}"
+      ;;
+    "pr checks "*)
+      printf '%s\n' '[{"name":"browser shard","state":"FAILURE","bucket":"fail","workflow":"ci"}]'
+      ;;
+    *)
+      printf 'unexpected gh call: %s\n' "$*" >&2
+      exit 91
+      ;;
+  esac
+}
+prog=
+prev=
+for arg in "$@"; do
+  [ "$prev" != --jq ] || prog=$arg
+  prev=$arg
+done
+serve "$@" | jq -r "$prog"
+SH
+chmod +x "$FAKEBIN/gh"
+
+run_state() {
+  PATH="$FAKEBIN:$PATH" "$SCRIPT" 7
+}
+
+# reviews "<login> <state> <commit> <submitted_at>"... prints the JSON array
+# GitHub's reviews endpoint returns for those submissions.
+reviews() {
+  printf '%s\n' "$@" | jq -Rsc 'split("\n") | map(select(. != "") | split(" +"; "")
+    | {user: {login: .[0], type: .[1]}, state: .[2], commit_id: .[3], submitted_at: .[4]})'
+}
+
+test_clean_pr_is_silent_and_ignores_advisory_failures() {
+  local out
+  out=$(run_state) || fail "clean fixture was refused"
+  [ -z "$out" ] || fail "clean fixture should be silent, got: $out"
+  pass "clean PR is silent and advisory failures do not block"
+}
+
+test_closed_and_merged_state_are_reported() {
+  local out
+  out=$(FM_TEST_STATE=closed run_state) || fail "closed fixture was refused"
+  assert_contains "$out" 'STATE: closed' "a closed pull request must report its state"
+
+  out=$(FM_TEST_STATE=closed FM_TEST_MERGED_AT=2019-10-04T16:01:04Z run_state) \
+    || fail "merged fixture was refused"
+  assert_contains "$out" 'STATE: merged at 2019-10-04T16:01:04Z' \
+    "a merged pull request must say so rather than reading as merely closed"
+  assert_not_contains "$out" 'STATE: closed' \
+    "merged is the more specific verdict and must not be doubled with closed"
+  pass "closed and merged pull requests report their terminal state"
+}
+
+test_draft_is_a_blocker() {
+  local out
+  out=$(FM_TEST_DRAFT=true run_state) || fail "draft fixture was refused"
+  assert_contains "$out" 'DRAFT: pull request is not ready for review' \
+    "a draft pull request leaves the author something to do"
+  pass "draft state blocks readiness"
+}
+
+test_head_moving_mid_read_invalidates_the_result() {
+  local status=0 out
+  out=$(FM_TEST_VIEW_HEAD=$OLD_HEAD_1 run_state 2>&1) || status=$?
+  [ "$status" -ne 0 ] \
+    || fail "a head that moved between readings must invalidate the result, got: $out"
+  assert_contains "$out" 'head changed' \
+    "the refusal must name the moved head so the caller knows to re-run"
+  pass "a head that moves mid-read invalidates rather than mixes two snapshots"
+}
+
+test_stale_blocking_reviews_explain_a_blocking_decision() {
+  local out history
+  history=$(reviews \
+    "coderabbitai[bot] Bot CHANGES_REQUESTED $OLD_HEAD_1 2026-09-01T00:15:44Z" \
+    "coderabbitai[bot] Bot CHANGES_REQUESTED $OLD_HEAD_2 2026-09-01T23:02:13Z" \
+    "commenter User COMMENTED $OLD_HEAD_2 2026-09-01T23:10:00Z" \
+    "alice User APPROVED $OLD_HEAD_2 2026-09-01T23:11:00Z")
+  out=$(FM_TEST_VIEW_REVIEW_DECISION=CHANGES_REQUESTED FM_TEST_REVIEWS=$history run_state) \
+    || fail "voided-review fixture was refused"
+  assert_contains "$out" 'REVIEW DECISION: CHANGES_REQUESTED' \
+    "GitHub's blocking decision must be printed"
+  assert_contains "$out" "STALE BLOCKING REVIEW: coderabbitai[bot] CHANGES_REQUESTED at $OLD_HEAD_2; current head $HEAD" \
+    "the reviewer's latest stale changes-requested verdict was not shown with both SHAs"
+  assert_not_contains "$out" "$OLD_HEAD_1" \
+    "a verdict the same reviewer later superseded is history, not a blocker"
+  assert_not_contains "$out" 'commenter' \
+    "a stale COMMENTED review is informational noise"
+  assert_not_contains "$out" 'alice' \
+    "a stale approval is not a concrete blocker"
+  pass "stale changes-requested verdicts explain a blocking review decision"
+}
+
+test_approved_pr_with_only_stale_changes_requested_is_silent() {
+  local out history
+  history=$(reviews \
+    "coderabbitai[bot] Bot CHANGES_REQUESTED $OLD_HEAD_1 2026-09-01T00:15:44Z" \
+    "coderabbitai[bot] Bot CHANGES_REQUESTED $HEAD 2026-09-02T13:53:41Z" \
+    "coderabbitai[bot] Bot APPROVED $HEAD 2026-09-02T14:05:42Z")
+  out=$(FM_TEST_VIEW_REVIEW_DECISION=APPROVED FM_TEST_REVIEWS=$history run_state) \
+    || fail "approved stale-review fixture was refused"
+  [ -z "$out" ] || fail "an approved PR with only stale review history should be silent, got: $out"
+  pass "approved PR ignores stale changes-requested history"
+}
+
+test_current_changes_requested_review_is_a_blocker() {
+  local out history
+  history=$(reviews "coderabbitai[bot] Bot CHANGES_REQUESTED $HEAD 2026-09-02T13:53:41Z")
+  out=$(FM_TEST_VIEW_REVIEW_DECISION=CHANGES_REQUESTED FM_TEST_REVIEWS=$history run_state) \
+    || fail "current-review fixture was refused"
+  assert_contains "$out" "REVIEW: coderabbitai[bot] CHANGES_REQUESTED at $HEAD" \
+    "a current changes-requested review must block readiness"
+  pass "current changes-requested review blocks readiness"
+}
+
+test_changes_requested_decision_is_never_silent() {
+  local out history
+  history=$(reviews \
+    "bob User CHANGES_REQUESTED $HEAD 2026-09-02T13:53:41Z" \
+    "bob User COMMENTED $HEAD 2026-09-02T14:05:42Z")
+  out=$(FM_TEST_VIEW_REVIEW_DECISION=CHANGES_REQUESTED FM_TEST_REVIEWS=$history run_state) \
+    || fail "comment-after-changes fixture was refused"
+  assert_contains "$out" "REVIEW: bob CHANGES_REQUESTED at $HEAD" \
+    "a later COMMENTED review does not clear the reviewer's change request"
+
+  out=$(FM_TEST_VIEW_REVIEW_DECISION=CHANGES_REQUESTED run_state) \
+    || fail "decision-only fixture was refused"
+  [ "$out" = 'REVIEW DECISION: CHANGES_REQUESTED' ] \
+    || fail "GitHub's blocking decision must be printed even without an explaining review, got: $out"
+  pass "a CHANGES_REQUESTED decision is always reported"
+}
+
+test_authors_own_changes_requested_review_is_not_a_blocker() {
+  local out history
+  history=$(reviews "prauthor User CHANGES_REQUESTED $HEAD 2026-09-02T13:53:41Z")
+  out=$(FM_TEST_VIEW_REVIEW_DECISION=CHANGES_REQUESTED FM_TEST_REVIEWS=$history run_state) \
+    || fail "self-review fixture was refused"
+  assert_not_contains "$out" 'REVIEW: prauthor' \
+    "the author's own verdict is not a reviewer blocking them"
+  pass "the author's own review is never listed as a blocker"
+}
+
+test_pending_approval_is_not_a_blocker() {
+  local out
+  out=$(FM_TEST_VIEW_REVIEW_DECISION=REVIEW_REQUIRED run_state) \
+    || fail "review-required fixture was refused"
+  [ -z "$out" ] || fail "awaiting approval leaves nothing for the author, got: $out"
+  pass "a pending approval is not reported as a blocker"
+}
+
+test_required_failure_is_a_blocker() {
+  local out
+  out=$(FM_TEST_REQUIRED_CHECKS='[{"name":"CI Status","state":"FAILURE","bucket":"fail","workflow":"ci"},{"name":"lint","state":"SUCCESS","bucket":"pass","workflow":"ci"}]' run_state) \
+    || fail "blocked fixture was refused"
+  assert_contains "$out" 'REQUIRED CHECK: CI Status (FAILURE)' \
+    "required failure was not reported"
+  assert_not_contains "$out" 'lint' \
+    "a passing required check is not a blocker"
+  pass "required failure blocks readiness"
+}
+
+test_no_required_checks_is_silent() {
+  local out status
+  out=$(FM_TEST_CHECKS_ERROR="no required checks reported on the 'fm/fixture' branch" run_state) \
+    || fail "a base without required checks was refused"
+  [ -z "$out" ] || fail "a base without required checks has no check blocker, got: $out"
+
+  status=0
+  FM_TEST_CHECKS_ERROR='HTTP 502: Bad Gateway' run_state >/dev/null 2>&1 || status=$?
+  [ "$status" -ne 0 ] || fail "a real check lookup failure must still refuse"
+  pass "a base without required checks is silent, other check lookup failures refuse"
+}
+
+test_no_reported_checks_is_unverified() {
+  local out
+  out=$(FM_TEST_CHECKS_ERROR="no checks reported on the 'fm/fixture' branch" run_state) \
+    || fail "a head without reported checks was refused"
+  [ "$out" = "CHECKS: none reported yet on ${HEAD:0:7}" ] \
+    || fail "a head with no reported checks must read as unverified, not ready, got: $out"
+  pass "a head with no reported checks is unverified rather than ready"
+}
+
+test_help_discloses_unavailable_thread_resolution() {
+  local out
+  out=$("$SCRIPT" --help) || fail "help was refused"
+  assert_contains "$out" 'Unresolved review-thread state is not reported' \
+    "help must disclose the REST-only thread-resolution limit"
+  pass "help discloses the unavailable REST thread-resolution signal"
+}
+
+test_unknown_mergeability_is_a_blocker() {
+  local out
+  out=$(FM_TEST_VIEW_MERGEABLE=null run_state) \
+    || fail "unknown-mergeability fixture was refused"
+  assert_contains "$out" 'MERGEABILITY: unknown' \
+    "null mergeability must not be treated as clean"
+
+  out=$(FM_TEST_VIEW_MERGEABLE=CONFLICTING run_state) \
+    || fail "conflicting fixture was refused"
+  assert_contains "$out" 'MERGEABILITY: conflicting' \
+    "a conflicting merge state must be reported"
+  pass "unknown and conflicting mergeability block readiness"
+}
+
+test_mergeability_uses_current_pr_view_value_without_retry() {
+  local out
+  out=$(FM_TEST_VIEW_MERGEABLE=MERGEABLE run_state) \
+    || fail "current-mergeability fixture was refused"
+  assert_not_contains "$out" 'MERGEABILITY: unknown' \
+    "a current MERGEABLE view must win over the REST object's stale null"
+  pass "mergeability uses the current pull-request view value"
+}
+
+test_refusals_exit_nonzero() {
+  local status=0
+  PATH="$FAKEBIN:$PATH" "$SCRIPT" >/dev/null 2>&1 || status=$?
+  [ "$status" -ne 0 ] || fail "missing argument refusal exited zero"
+
+  status=0
+  PATH="$FAKEBIN:$PATH" "$SCRIPT" not-a-pr >/dev/null 2>&1 || status=$?
+  [ "$status" -ne 0 ] || fail "lookup refusal exited zero"
+  pass "argument and lookup refusals exit nonzero"
+}
+
+test_clean_pr_is_silent_and_ignores_advisory_failures
+test_closed_and_merged_state_are_reported
+test_draft_is_a_blocker
+test_head_moving_mid_read_invalidates_the_result
+test_stale_blocking_reviews_explain_a_blocking_decision
+test_approved_pr_with_only_stale_changes_requested_is_silent
+test_current_changes_requested_review_is_a_blocker
+test_changes_requested_decision_is_never_silent
+test_authors_own_changes_requested_review_is_not_a_blocker
+test_pending_approval_is_not_a_blocker
+test_required_failure_is_a_blocker
+test_no_required_checks_is_silent
+test_no_reported_checks_is_unverified
+test_help_discloses_unavailable_thread_resolution
+test_unknown_mergeability_is_a_blocker
+test_mergeability_uses_current_pr_view_value_without_retry
+test_refusals_exit_nonzero

--- a/tests/fm-pr-state.test.sh
+++ b/tests/fm-pr-state.test.sh
@@ -53,9 +53,6 @@ serve() {
       checks='[{"name":"lint","state":"SUCCESS","bucket":"pass","workflow":"ci"},{"name":"optional","state":"SKIPPED","bucket":"skipping","workflow":"ci"}]'
       printf '%s\n' "${FM_TEST_REQUIRED_CHECKS:-$checks}"
       ;;
-    "pr checks "*)
-      printf '%s\n' '[{"name":"browser shard","state":"FAILURE","bucket":"fail","workflow":"ci"}]'
-      ;;
     *)
       printf 'unexpected gh call: %s\n' "$*" >&2
       exit 91
@@ -83,11 +80,11 @@ reviews() {
     | {user: {login: .[0], type: .[1]}, state: .[2], commit_id: .[3], submitted_at: .[4]})'
 }
 
-test_clean_pr_is_silent_and_ignores_advisory_failures() {
+test_clean_pr_is_silent_and_ignores_skipped_checks() {
   local out
   out=$(run_state) || fail "clean fixture was refused"
   [ -z "$out" ] || fail "clean fixture should be silent, got: $out"
-  pass "clean PR is silent and advisory failures do not block"
+  pass "a passing required check and a skipped one leave nothing to report"
 }
 
 test_terminal_state_is_the_whole_report() {
@@ -213,16 +210,17 @@ test_required_failure_is_a_blocker() {
   pass "required failure blocks readiness"
 }
 
-test_no_required_checks_is_silent() {
+test_unreported_required_checks_are_unconfirmed() {
   local out status
   out=$(FM_TEST_CHECKS_ERROR="no required checks reported on the 'fm/fixture' branch" run_state) \
-    || fail "a base without required checks was refused"
-  [ -z "$out" ] || fail "a base without required checks has no check blocker, got: $out"
+    || fail "a head without reported required checks was refused"
+  [ "$out" = "CHECKS: no required check has reported on ${HEAD:0:7}; readiness unconfirmed" ] \
+    || fail "gh cannot tell an unconfigured required check from an unreported one, so neither may read as ready, got: $out"
 
   status=0
   FM_TEST_CHECKS_ERROR='HTTP 502: Bad Gateway' run_state >/dev/null 2>&1 || status=$?
   [ "$status" -ne 0 ] || fail "a real check lookup failure must still refuse"
-  pass "a base without required checks is silent, other check lookup failures refuse"
+  pass "an unreported required check is unconfirmed, other check lookup failures refuse"
 }
 
 test_no_reported_checks_is_unverified() {
@@ -274,14 +272,17 @@ test_refusals_exit_nonzero() {
   PATH="$FAKEBIN:$PATH" "$SCRIPT" not-a-pr >/dev/null 2>&1 || status=$?
   [ "$status" -ne 0 ] || fail "lookup refusal exited zero"
 
+  local out
   status=0
-  PATH="$FAKEBIN:$PATH" "$SCRIPT" 7 >/dev/null 2>&1 || status=$?
+  out=$(PATH="$FAKEBIN:$PATH" "$SCRIPT" 7 2>&1) || status=$?
   [ "$status" -ne 0 ] \
     || fail "a bare number resolves against the ambient repository and is not an address"
+  assert_contains "$out" 'expected a GitHub pull-request URL' \
+    "a bare number must be refused as an address, not attempted as a lookup"
   pass "argument and lookup refusals exit nonzero"
 }
 
-test_clean_pr_is_silent_and_ignores_advisory_failures
+test_clean_pr_is_silent_and_ignores_skipped_checks
 test_terminal_state_is_the_whole_report
 test_draft_is_a_blocker
 test_head_moving_mid_read_invalidates_the_result
@@ -292,7 +293,7 @@ test_changes_requested_decision_is_never_silent
 test_authors_own_changes_requested_review_is_not_a_blocker
 test_pending_approval_is_not_a_blocker
 test_required_failure_is_a_blocker
-test_no_required_checks_is_silent
+test_unreported_required_checks_are_unconfirmed
 test_no_reported_checks_is_unverified
 test_help_states_thread_resolution_is_out_of_scope
 test_unknown_mergeability_is_a_blocker

--- a/tests/fm-pr-state.test.sh
+++ b/tests/fm-pr-state.test.sh
@@ -27,9 +27,6 @@ set -o pipefail
 head=c2eac54c17a1ddc2633ad51b83e21e5fe888142e
 serve() {
   case "$*" in
-    "pr view "*" --json url --jq .url")
-      printf '%s\n' '{"url":"https://github.com/o/r/pull/7"}'
-      ;;
     "pr view "*" --json mergeable,headRefOid,reviewDecision --jq "*)
       jq -n --arg mergeable "${FM_TEST_VIEW_MERGEABLE-MERGEABLE}" \
         --arg head "${FM_TEST_VIEW_HEAD-$head}" \
@@ -76,7 +73,7 @@ SH
 chmod +x "$FAKEBIN/gh"
 
 run_state() {
-  PATH="$FAKEBIN:$PATH" "$SCRIPT" 7
+  PATH="$FAKEBIN:$PATH" "$SCRIPT" https://github.com/o/r/pull/7
 }
 
 # reviews "<login> <state> <commit> <submitted_at>"... prints the JSON array
@@ -93,18 +90,19 @@ test_clean_pr_is_silent_and_ignores_advisory_failures() {
   pass "clean PR is silent and advisory failures do not block"
 }
 
-test_closed_and_merged_state_are_reported() {
+test_terminal_state_is_the_whole_report() {
   local out
-  out=$(FM_TEST_STATE=closed run_state) || fail "closed fixture was refused"
-  assert_contains "$out" 'STATE: closed' "a closed pull request must report its state"
+  out=$(FM_TEST_STATE=closed FM_TEST_VIEW_MERGEABLE=null run_state) \
+    || fail "closed fixture was refused"
+  [ "$out" = 'STATE: closed' ] \
+    || fail "a closed pull request leaves the author nothing else to read, got: $out"
 
-  out=$(FM_TEST_STATE=closed FM_TEST_MERGED_AT=2019-10-04T16:01:04Z run_state) \
+  out=$(FM_TEST_STATE=closed FM_TEST_MERGED_AT=2019-10-04T16:01:04Z \
+    FM_TEST_VIEW_MERGEABLE=null FM_TEST_VIEW_REVIEW_DECISION=CHANGES_REQUESTED run_state) \
     || fail "merged fixture was refused"
-  assert_contains "$out" 'STATE: merged at 2019-10-04T16:01:04Z' \
-    "a merged pull request must say so rather than reading as merely closed"
-  assert_not_contains "$out" 'STATE: closed' \
-    "merged is the more specific verdict and must not be doubled with closed"
-  pass "closed and merged pull requests report their terminal state"
+  [ "$out" = 'STATE: merged at 2019-10-04T16:01:04Z' ] \
+    || fail "a merged pull request says so and reports no blocker after it, got: $out"
+  pass "a terminal pull request reports that state and nothing else"
 }
 
 test_draft_is_a_blocker() {
@@ -236,12 +234,12 @@ test_no_reported_checks_is_unverified() {
   pass "a head with no reported checks is unverified rather than ready"
 }
 
-test_help_discloses_unavailable_thread_resolution() {
+test_help_states_thread_resolution_is_out_of_scope() {
   local out
   out=$("$SCRIPT" --help) || fail "help was refused"
-  assert_contains "$out" 'Unresolved review-thread state is not reported' \
-    "help must disclose the REST-only thread-resolution limit"
-  pass "help discloses the unavailable REST thread-resolution signal"
+  assert_contains "$out" "Unresolved review-thread state is out of this command's scope" \
+    "help must state the thread-resolution boundary without inventing a reason for it"
+  pass "help states the thread-resolution boundary as scope"
 }
 
 test_unknown_mergeability_is_a_blocker() {
@@ -275,11 +273,16 @@ test_refusals_exit_nonzero() {
   status=0
   PATH="$FAKEBIN:$PATH" "$SCRIPT" not-a-pr >/dev/null 2>&1 || status=$?
   [ "$status" -ne 0 ] || fail "lookup refusal exited zero"
+
+  status=0
+  PATH="$FAKEBIN:$PATH" "$SCRIPT" 7 >/dev/null 2>&1 || status=$?
+  [ "$status" -ne 0 ] \
+    || fail "a bare number resolves against the ambient repository and is not an address"
   pass "argument and lookup refusals exit nonzero"
 }
 
 test_clean_pr_is_silent_and_ignores_advisory_failures
-test_closed_and_merged_state_are_reported
+test_terminal_state_is_the_whole_report
 test_draft_is_a_blocker
 test_head_moving_mid_read_invalidates_the_result
 test_stale_blocking_reviews_explain_a_blocking_decision
@@ -291,7 +294,7 @@ test_pending_approval_is_not_a_blocker
 test_required_failure_is_a_blocker
 test_no_required_checks_is_silent
 test_no_reported_checks_is_unverified
-test_help_discloses_unavailable_thread_resolution
+test_help_states_thread_resolution_is_out_of_scope
 test_unknown_mergeability_is_a_blocker
 test_mergeability_uses_current_pr_view_value_without_retry
 test_refusals_exit_nonzero

--- a/tests/fm-pr-state.test.sh
+++ b/tests/fm-pr-state.test.sh
@@ -45,7 +45,7 @@ serve() {
     "api /repos/o/r/pulls/7/reviews?per_page=100 --paginate --jq "*)
       printf '%s\n' "${FM_TEST_REVIEWS:-[]}"
       ;;
-    "pr checks "*" --required --json name,state,bucket,workflow --jq "*)
+    "pr checks "*" --required --json name,state,bucket --jq "*)
       if [ -n "${FM_TEST_CHECKS_ERROR-}" ]; then
         printf '%s\n' "$FM_TEST_CHECKS_ERROR" >&2
         exit 1
@@ -121,7 +121,7 @@ test_head_moving_mid_read_invalidates_the_result() {
 }
 
 test_stale_blocking_reviews_explain_a_blocking_decision() {
-  local out history
+  local out history expected
   history=$(reviews \
     "coderabbitai[bot] Bot CHANGES_REQUESTED $OLD_HEAD_1 2026-09-01T00:15:44Z" \
     "coderabbitai[bot] Bot CHANGES_REQUESTED $OLD_HEAD_2 2026-09-01T23:02:13Z" \
@@ -129,10 +129,9 @@ test_stale_blocking_reviews_explain_a_blocking_decision() {
     "alice User APPROVED $OLD_HEAD_2 2026-09-01T23:11:00Z")
   out=$(FM_TEST_VIEW_REVIEW_DECISION=CHANGES_REQUESTED FM_TEST_REVIEWS=$history run_state) \
     || fail "voided-review fixture was refused"
-  assert_contains "$out" 'REVIEW DECISION: CHANGES_REQUESTED' \
-    "GitHub's blocking decision must be printed"
-  assert_contains "$out" "STALE BLOCKING REVIEW: coderabbitai[bot] CHANGES_REQUESTED at $OLD_HEAD_2; current head $HEAD" \
-    "the reviewer's latest stale changes-requested verdict was not shown with both SHAs"
+  expected=$(printf 'REVIEW DECISION: CHANGES_REQUESTED\nSTALE BLOCKING REVIEW: coderabbitai[bot] CHANGES_REQUESTED at %s' "$OLD_HEAD_2")
+  [ "$out" = "$expected" ] \
+    || fail "a stale verdict names the commit it was left at and no head this reading was not verified against, got: $out"
   assert_not_contains "$out" "$OLD_HEAD_1" \
     "a verdict the same reviewer later superseded is history, not a blocker"
   assert_not_contains "$out" 'commenter' \
@@ -159,8 +158,8 @@ test_current_changes_requested_review_is_a_blocker() {
   history=$(reviews "coderabbitai[bot] Bot CHANGES_REQUESTED $HEAD 2026-09-02T13:53:41Z")
   out=$(FM_TEST_VIEW_REVIEW_DECISION=CHANGES_REQUESTED FM_TEST_REVIEWS=$history run_state) \
     || fail "current-review fixture was refused"
-  assert_contains "$out" "REVIEW: coderabbitai[bot] CHANGES_REQUESTED at $HEAD" \
-    "a current changes-requested review must block readiness"
+  [ "$out" = $'REVIEW DECISION: CHANGES_REQUESTED\nREVIEW: coderabbitai[bot] CHANGES_REQUESTED' ] \
+    || fail "a verdict left at the head under review blocks readiness and names no head, got: $out"
   pass "current changes-requested review blocks readiness"
 }
 
@@ -171,8 +170,8 @@ test_changes_requested_decision_is_never_silent() {
     "bob User COMMENTED $HEAD 2026-09-02T14:05:42Z")
   out=$(FM_TEST_VIEW_REVIEW_DECISION=CHANGES_REQUESTED FM_TEST_REVIEWS=$history run_state) \
     || fail "comment-after-changes fixture was refused"
-  assert_contains "$out" "REVIEW: bob CHANGES_REQUESTED at $HEAD" \
-    "a later COMMENTED review does not clear the reviewer's change request"
+  [ "$out" = $'REVIEW DECISION: CHANGES_REQUESTED\nREVIEW: bob CHANGES_REQUESTED' ] \
+    || fail "a later COMMENTED review does not clear the reviewer's change request, got: $out"
 
   out=$(FM_TEST_VIEW_REVIEW_DECISION=CHANGES_REQUESTED run_state) \
     || fail "decision-only fixture was refused"
@@ -214,7 +213,7 @@ test_unreported_required_checks_are_unconfirmed() {
   local out status
   out=$(FM_TEST_CHECKS_ERROR="no required checks reported on the 'fm/fixture' branch" run_state) \
     || fail "a head without reported required checks was refused"
-  [ "$out" = "CHECKS: no required check has reported on ${HEAD:0:7}; readiness unconfirmed" ] \
+  [ "$out" = 'CHECKS: no required check has reported; readiness unconfirmed' ] \
     || fail "gh cannot tell an unconfigured required check from an unreported one, so neither may read as ready, got: $out"
 
   status=0
@@ -227,7 +226,7 @@ test_no_reported_checks_is_unverified() {
   local out
   out=$(FM_TEST_CHECKS_ERROR="no checks reported on the 'fm/fixture' branch" run_state) \
     || fail "a head without reported checks was refused"
-  [ "$out" = "CHECKS: none reported yet on ${HEAD:0:7}" ] \
+  [ "$out" = 'CHECKS: none reported yet' ] \
     || fail "a head with no reported checks must read as unverified, not ready, got: $out"
   pass "a head with no reported checks is unverified rather than ready"
 }

--- a/tests/fm-pr-state.test.sh
+++ b/tests/fm-pr-state.test.sh
@@ -17,8 +17,9 @@ OLD_HEAD_2=4dc2291e6969de1bf204fbdb53c9e57a8353d4e2
 
 # The fake gh answers every query with the JSON shape GitHub returns and runs
 # the --jq program it received with the real jq, so field selection is what is
-# under test. The REST pull-request object always carries the stale
-# `mergeable: null` GitHub reports right after a push.
+# under test. The pull-request object speaks GitHub's own vocabulary: an
+# uppercase state with MERGED as its own value, and a null mergeable while
+# GitHub is still computing one.
 # It evaluates with the local jq, while gh itself embeds gojq; the live guard in
 # tests/fm-pr-state-live-e2e.test.sh runs the real engine.
 cat > "$FAKEBIN/gh" <<'SH'
@@ -27,20 +28,16 @@ set -o pipefail
 head=c2eac54c17a1ddc2633ad51b83e21e5fe888142e
 serve() {
   case "$*" in
-    "pr view "*" --json mergeable,headRefOid,reviewDecision --jq "*)
-      jq -n --arg mergeable "${FM_TEST_VIEW_MERGEABLE-MERGEABLE}" \
-        --arg head "${FM_TEST_VIEW_HEAD-$head}" \
-        --arg decision "${FM_TEST_VIEW_REVIEW_DECISION-APPROVED}" \
-        '{mergeable: (if $mergeable == "null" then null else $mergeable end),
-          headRefOid: $head, reviewDecision: $decision}'
-      ;;
-    "api /repos/o/r/pulls/7 --jq "*)
-      jq -n --arg head "$head" --arg state "${FM_TEST_STATE-open}" \
+    "pr view "*" --json state,mergedAt,isDraft,headRefOid,author,mergeable,reviewDecision --jq "*)
+      jq -n --arg head "$head" --arg state "${FM_TEST_STATE-OPEN}" \
         --arg merged "${FM_TEST_MERGED_AT-}" --arg draft "${FM_TEST_DRAFT-false}" \
-        '{state: $state, merged_at: (if $merged == "" then null else $merged end),
-          draft: ($draft == "true"), mergeable: null,
-          head: {sha: $head, ref: "fm/fixture"}, base: {ref: "dev"},
-          title: "fix: fixture", body: "", user: {login: "prauthor"}}'
+        --arg mergeable "${FM_TEST_VIEW_MERGEABLE-MERGEABLE}" \
+        --arg decision "${FM_TEST_VIEW_REVIEW_DECISION-APPROVED}" \
+        '{state: $state, mergedAt: (if $merged == "" then null else $merged end),
+          isDraft: ($draft == "true"), headRefOid: $head,
+          author: {login: "prauthor", is_bot: false},
+          mergeable: (if $mergeable == "null" then null else $mergeable end),
+          reviewDecision: $decision}'
       ;;
     "api /repos/o/r/pulls/7/reviews?per_page=100 --paginate --jq "*)
       printf '%s\n' "${FM_TEST_REVIEWS:-[]}"
@@ -89,12 +86,12 @@ test_clean_pr_is_silent_and_ignores_skipped_checks() {
 
 test_terminal_state_is_the_whole_report() {
   local out
-  out=$(FM_TEST_STATE=closed FM_TEST_VIEW_MERGEABLE=null run_state) \
+  out=$(FM_TEST_STATE=CLOSED FM_TEST_VIEW_MERGEABLE=null run_state) \
     || fail "closed fixture was refused"
   [ "$out" = 'STATE: closed' ] \
     || fail "a closed pull request leaves the author nothing else to read, got: $out"
 
-  out=$(FM_TEST_STATE=closed FM_TEST_MERGED_AT=2019-10-04T16:01:04Z \
+  out=$(FM_TEST_STATE=MERGED FM_TEST_MERGED_AT=2019-10-04T16:01:04Z \
     FM_TEST_VIEW_MERGEABLE=null FM_TEST_VIEW_REVIEW_DECISION=CHANGES_REQUESTED run_state) \
     || fail "merged fixture was refused"
   [ "$out" = 'STATE: merged at 2019-10-04T16:01:04Z' ] \
@@ -108,16 +105,6 @@ test_draft_is_a_blocker() {
   assert_contains "$out" 'DRAFT: pull request is not ready for review' \
     "a draft pull request leaves the author something to do"
   pass "draft state blocks readiness"
-}
-
-test_head_moving_mid_read_invalidates_the_result() {
-  local status=0 out
-  out=$(FM_TEST_VIEW_HEAD=$OLD_HEAD_1 run_state 2>&1) || status=$?
-  [ "$status" -ne 0 ] \
-    || fail "a head that moved between readings must invalidate the result, got: $out"
-  assert_contains "$out" 'head changed' \
-    "the refusal must name the moved head so the caller knows to re-run"
-  pass "a head that moves mid-read invalidates rather than mixes two snapshots"
 }
 
 test_stale_blocking_reviews_explain_a_blocking_decision() {
@@ -257,15 +244,6 @@ test_unknown_mergeability_is_a_blocker() {
   pass "unknown and conflicting mergeability block readiness"
 }
 
-test_mergeability_uses_current_pr_view_value_without_retry() {
-  local out
-  out=$(FM_TEST_VIEW_MERGEABLE=MERGEABLE run_state) \
-    || fail "current-mergeability fixture was refused"
-  assert_not_contains "$out" 'MERGEABILITY: unknown' \
-    "a current MERGEABLE view must win over the REST object's stale null"
-  pass "mergeability uses the current pull-request view value"
-}
-
 test_refusals_exit_nonzero() {
   local status=0
   PATH="$FAKEBIN:$PATH" "$SCRIPT" >/dev/null 2>&1 || status=$?
@@ -288,7 +266,6 @@ test_refusals_exit_nonzero() {
 test_clean_pr_is_silent_and_ignores_skipped_checks
 test_terminal_state_is_the_whole_report
 test_draft_is_a_blocker
-test_head_moving_mid_read_invalidates_the_result
 test_stale_blocking_reviews_explain_a_blocking_decision
 test_approved_pr_with_only_stale_changes_requested_is_silent
 test_current_changes_requested_review_is_a_blocker
@@ -300,5 +277,4 @@ test_unreported_required_checks_are_unconfirmed
 test_no_reported_checks_is_unverified
 test_help_states_what_silence_means_and_what_is_out_of_scope
 test_unknown_mergeability_is_a_blocker
-test_mergeability_uses_current_pr_view_value_without_retry
 test_refusals_exit_nonzero

--- a/tests/fm-pr-state.test.sh
+++ b/tests/fm-pr-state.test.sh
@@ -194,7 +194,7 @@ test_pending_approval_is_not_a_blocker() {
   local out
   out=$(FM_TEST_VIEW_REVIEW_DECISION=REVIEW_REQUIRED run_state) \
     || fail "review-required fixture was refused"
-  [ -z "$out" ] || fail "awaiting approval leaves nothing for the author, got: $out"
+  [ -z "$out" ] || fail "awaiting approval is not a blocker this command reports, got: $out"
   pass "a pending approval is not reported as a blocker"
 }
 
@@ -214,7 +214,7 @@ test_unreported_required_checks_are_unconfirmed() {
   out=$(FM_TEST_CHECKS_ERROR="no required checks reported on the 'fm/fixture' branch" run_state) \
     || fail "a head without reported required checks was refused"
   [ "$out" = 'CHECKS: no required check has reported; readiness unconfirmed' ] \
-    || fail "gh cannot tell an unconfigured required check from an unreported one, so neither may read as ready, got: $out"
+    || fail "a head where nothing required has reported must not pass silently as ready, got: $out"
 
   status=0
   FM_TEST_CHECKS_ERROR='HTTP 502: Bad Gateway' run_state >/dev/null 2>&1 || status=$?
@@ -231,12 +231,16 @@ test_no_reported_checks_is_unverified() {
   pass "a head with no reported checks is unverified rather than ready"
 }
 
-test_help_states_thread_resolution_is_out_of_scope() {
+test_help_states_what_silence_means_and_what_is_out_of_scope() {
   local out
   out=$("$SCRIPT" --help) || fail "help was refused"
+  assert_contains "$out" 'it does not mean the pull request is ready to merge' \
+    "help must not let empty output read as a verdict that the pull request can merge"
+  assert_contains "$out" 'is absent from what this command reads' \
+    "help must name the limit: a required context that never reported is absent from what is read"
   assert_contains "$out" "Unresolved review-thread state is out of this command's scope" \
     "help must state the thread-resolution boundary without inventing a reason for it"
-  pass "help states the thread-resolution boundary as scope"
+  pass "help states what empty output means and what is out of scope"
 }
 
 test_unknown_mergeability_is_a_blocker() {
@@ -294,7 +298,7 @@ test_pending_approval_is_not_a_blocker
 test_required_failure_is_a_blocker
 test_unreported_required_checks_are_unconfirmed
 test_no_reported_checks_is_unverified
-test_help_states_thread_resolution_is_out_of_scope
+test_help_states_what_silence_means_and_what_is_out_of_scope
 test_unknown_mergeability_is_a_blocker
 test_mergeability_uses_current_pr_view_value_without_retry
 test_refusals_exit_nonzero

--- a/tests/fm-pr-state.test.sh
+++ b/tests/fm-pr-state.test.sh
@@ -196,17 +196,22 @@ test_required_failure_is_a_blocker() {
   pass "required failure blocks readiness"
 }
 
+# The next two cases supply gh's own "nothing reported" sentences through
+# FM_TEST_CHECKS_ERROR, so they prove the behaviour GIVEN those strings and
+# nothing about the strings themselves. A gh reword is invisible to this
+# hermetic suite; only a run against a real gh would catch one.
 test_unreported_required_checks_are_unconfirmed() {
   local out status
   out=$(FM_TEST_CHECKS_ERROR="no required checks reported on the 'fm/fixture' branch" run_state) \
     || fail "a head without reported required checks was refused"
   [ "$out" = 'CHECKS: no required check has reported; readiness unconfirmed' ] \
     || fail "a head where nothing required has reported must not pass silently as ready, got: $out"
+  # This asserts the branch taken for that sentence, not that gh still says it.
 
   status=0
   FM_TEST_CHECKS_ERROR='HTTP 502: Bad Gateway' run_state >/dev/null 2>&1 || status=$?
   [ "$status" -ne 0 ] || fail "a real check lookup failure must still refuse"
-  pass "an unreported required check is unconfirmed, other check lookup failures refuse"
+  pass "given gh's sentence, an unreported required check is unconfirmed, other check lookup failures refuse"
 }
 
 test_no_reported_checks_is_unverified() {
@@ -215,7 +220,8 @@ test_no_reported_checks_is_unverified() {
     || fail "a head without reported checks was refused"
   [ "$out" = 'CHECKS: none reported yet' ] \
     || fail "a head with no reported checks must read as unverified, not ready, got: $out"
-  pass "a head with no reported checks is unverified rather than ready"
+  # This asserts the branch taken for that sentence, not that gh still says it.
+  pass "given gh's sentence, a head with no reported checks is unverified rather than ready"
 }
 
 test_help_states_what_silence_means_and_what_is_out_of_scope() {


### PR DESCRIPTION
## What this adds

Two read-only commands, both off until invoked, neither of which writes to GitHub. Closes #3731.

- `bin/fm-pr-state.sh <pr-url>` prints one line per blocker it can see on a pull request: terminal (merged or closed) state as the whole report, draft state, unknown or conflicting mergeability, required checks that have reported as failing or pending, and — only behind a `CHANGES_REQUESTED` review decision — each reviewer whose latest verdict still requests changes, marked `STALE` when it was left at a superseded head. Blockers keep exit 0; only usage or lookup refusal exits non-zero.
- `bin/fm-pr-reviewers.sh <pr-url>` reads the pull request's changed files and the recent commits touching each path at its base commit, then ranks candidates by unique commit count using GitHub's own `author.login` mapping, excluding the pull-request author and Bot accounts. It never requests a review.

Both reuse `fm_pr_url_parse` from `fm-pr-lib.sh` and refuse anything that is not a GitHub pull-request URL. They are two focused scripts rather than an extension of `fm-pr-check.sh`, because that script records task metadata and arms merge polls; composing a read-only advisory command into it would put that machinery on a path that must not write.

## What it deliberately does not do

**Silence is not a merge-ready verdict.** `gh pr checks --required` can only see required contexts that have actually reported on the head, because it filters status-check rollup nodes carrying a per-node required flag; a required context that has never reported is simply absent from the data. So empty output means no *reported* required check is failing or pending, and the `--help` text says exactly that rather than implying readiness. Enumerating configured-but-unreported required contexts would need a branch-protection read that requires admin scope on many repositories, which seemed too costly for an opt-in read-only command — so the command reports the limitation instead of guessing. Say if you want that read and it can be added.

**The reviewer command issues one API read per changed path, with no cap**, so a wide pull request costs proportionally. Capping would invent a number this issue never asked for, so the cost is stated plainly and left as your call.

**One pull-request read, not two plus a guard.** All seven fields come from a single `gh pr view --json` call. An earlier shape read the pull request twice and reconciled the two reads, which could refuse outright with no blocker report at all when an author pushed and immediately asked what was still blocking — the normal moment to use the tool was the moment it failed, for a reason the command itself introduced. Removing the second read removes that failure mode rather than hardening against it. The reviews read stays on the REST endpoint because `gh pr view --json reviews` does not expose `commit_id`, which the `STALE` comparison needs.

**Unresolved review-thread state is out of scope** for this command.

**The portable-serial lane counts in `docs/fm-test-portable-shards.md` are left alone.** This change adds three scripts to that lane, and its recorded counts were already stale before it, so they are left to that document's own hint-refresh procedure rather than rewritten here on unmeasured hints. Happy to file an issue if you want that drift tracked.

## Two deliberate deferrals

Both of these were open questions in an earlier revision of this description. Settling them here rather than leaving them open, so this is not waiting on an answer.

1. **No branch-protection read.** Naming configured-but-unreported required contexts needs admin scope on many repositories, which is more authority than an opt-in read-only advisory command should ask for. The limitation is reported in `--help` and in the command's own output instead, so a caller is never told that silence means ready. Straightforward to add later if you want it.
2. **No cap on the reviewer command's per-path reads.** Issue #3731 does not ask for one, and any number chosen here would be invented rather than measured. The cost is stated plainly in `--help`, so a caller on a wide pull request knows what it will do. A cap is a clean follow-up if you would rather have one.

## Testing

Both hermetic suites and the live guard pass. Beyond that, both commands were driven as an end user would against real GitHub pull requests chosen to reach every branch they distinguish, each case beside an independent read of the same pull request as ground truth.

| Scenario | Result | Live | Evidence |
| --- | --- | --- | --- |
| A merged pull request reports its terminal state and nothing else | ✅ pass | live | `bin/fm-pr-state.sh https://github.com/cli/cli/pull/1` printed `STATE: merged at 2019-10-04T16:01:04Z` and exited 0; also `FM_PR_STATE_LIVE_E2E=1 bin/fm-test-run.sh tests/fm-pr-… |
| A closed, unmerged pull request reports that state and stops | ✅ pass | live | cli/cli#14423 (observed CLOSED, MERGEABLE, REVIEW_REQUIRED) printed exactly `STATE: closed`, no check or review lines |
| A draft pull request with merge conflicts reports both blockers | ✅ pass | live | cli/cli#14285 (observed OPEN draft=true mergeable=CONFLICTING) printed `DRAFT: pull request is not ready for review` and `MERGEABILITY: conflicting` |
| A failing required check is reported while passing and skipped checks are omitted | ✅ pass | live | pnpm/pnpm#14852, whose live required checks are Rust CI/Success FAILURE, TS CI/Success SUCCESS and TS CI/Compile & Lint SKIPPED, printed only `REQUIRED CHECK: Rust CI / Success… |
| Required checks still running are reported as blockers | ✅ pass | live | sebin-gg/sebin-gg-portfolio#30 printed six `REQUIRED CHECK: ... (IN_PROGRESS)` lines matching its live pending checks |
| A head where no required check has reported prints readiness unconfirmed rather than passing silently | ✅ pass | live | cli/cli#14398, where real gh answers `no required checks reported on the 'issue-12195' branch`, printed `CHECKS: no required check has reported; readiness unconfirmed` |
| A head with no check reported at all prints CHECKS: none reported yet | ✅ pass | live | CREFLEINC/omf-mes-client#1127, where real gh answers `no checks reported on the 'feat/1113-web-vietnamese-shell' branch`, printed `CHECKS: none reported yet`; this exercises the… |
| A current changes-requested review names the reviewer and no commit | ✅ pass | live | coderabbitai[bot]'s latest verdict sits at head 92bb0416ccf6 and printed as `REVIEW: coderabbitai[bot] CHANGES_REQUESTED`; its own superseded earlier verdict at 7b46c4fc8b78 did… |
| A blocking review left at a superseded commit is marked STALE and names that commit | ✅ pass | live | hermesbaby#76 printed `STALE BLOCKING REVIEW: basejumpa CHANGES_REQUESTED at 552621fbbf85...` against head 92644f7ff9ef, and sebin-gg#30 printed the same shape for codera… |
| A clean open pull request awaiting approval prints nothing and exits 0 | ✅ pass | live | (retry): circlefin/arc-node#387 (OPEN, not draft, MERGEABLE, REVIEW_REQUIRED, required check StepSecurity SUCCESS) produced no output at exit 0; a pending approval is deliberatel… |
| Adversarial: any address that is not one GitHub pull-request URL is refused without contacting GitHub | ✅ pass | live | no argument, `7`, `not-a-pr`, an issues URL, `pull/1/files`, `pull/0`, an http URL, a GitLab merge-request URL and two arguments each exited 2 with a one-line refusal, and the r… |
| Adversarial: neither command ever writes to GitHub | ✅ pass | live | all 44 recorded gh invocations from the live run are `pr view`, `pr checks` or GET api reads; no POST/PATCH/PUT/DELETE method and no merge, review, comment, edit, close or create… |
| One invocation of the state command issues exactly one pull-request read | ✅ pass | live | a single run against pnpm/pnpm#14852 logged one `gh pr view --json state,mergedAt,isDraft,headRefOid,author,mergeable,reviewDecision`, one `gh pr checks --required` and o… |
| Reviewer candidates come from GitHub's own author mapping, ranked by unique commit count | ✅ pass | live | ; for cli/cli#14398 an independent recount of the same path history produced mislav 19, samcoe 15, andyfeller 5, BagToad 3, Jackenmen 3 — identical to the command's output… |
| Adversarial: a commit touching two changed paths is counted once, not twice | ✅ pass | live | bolorundurovj/setout#52 read 19 raw path-rows over 15 distinct commits; the naive count is 19, the deduped count is 15, and the command printed `bolorundurovj 15 recent commits` |
| Adversarial: Bot accounts never become reviewer candidates | ✅ pass | live | renovatebot/renovate#45855 read 200 rows of which 190 are renovate[bot]; the output lists only jamietanna, secustor and zharinov, with no bot login |
| Adversarial: the pull request's own author is never suggested as their own reviewer | ✅ pass | live | on cli/cli#14351 the author williammartin holds 25 of the 72 rows read and would have ranked first at 25 unique commits; the command's 15 candidates start at jtmcg and williamma… |
| A file history holding no author but the submitter yields no candidate and says why | ✅ pass | live | TauCetiProject/TauCeti#6402 printed `NO CANDIDATES: no mapped author other than the PR author` at exit 0 |
| --help states what empty output does and does not mean | ✅ pass | live | `bin/fm-pr-state.sh --help` prints the read-only contract, that a never-reported required context is absent from what it reads, and that empty output does not mean the pull requ… |
| The live guard honours the shared live gate (opt-in on, own variable off, FM_LIVE off, FM_LIVE on) | ✅ pass | live | `FM_PR_STATE_LIVE_E2E=1` ran the guard green; the default run skipped with `live: opt-in; set FM_PR_STATE_LIVE_E2E=1 to run`; `FM_LIVE=0` alone and `FM_PR_STATE_LIVE_E2E=0` each skipped with their own… |
| Adversarial: a mergeability GitHub has not computed is reported as unknown, never read as clean | ⏸️ untested | no | Reaching an uncomputed mergeability needs write authority this read-only validation does not have: a pull request in a repository this run controls, pushed to and then read within GitHub's computation… |

Two scenarios are marked untested because reaching them needs state GitHub itself will not hold stably: a required context configured by branch protection that has never reported (needs admin on a repository), and a mergeability GitHub has not yet computed.

The check paths above match gh's own human-readable error text, because gh returns an error rather than structured data at that point and text is the only way to tell "nothing reported" from a real lookup failure. Those two sentences were verified against gh 2.100.0, an unrecognised message falls through to the refusal path so a reword fails loudly rather than silently, and the limitation is noted at the matching site and in the test that exercises it. A live guard covering it can be added if you want one.

`tests/fm-pr-state.test.sh` and `tests/fm-pr-reviewers.test.sh` join the `pr-forge` test family, which grants four-worker concurrency by membership alone, so that family was re-proved at its full eight-member size: two consecutive runs, 0 failures, each started with the machine's one-minute load average below 6.0.

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"a080c2308503fd0eff714b1419426a659658bc95","steps":[{"step":"intent","status":"skipped"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}],"live_validation":{"verdict":"go","live":20,"total":21}} -->
