### PR TITLE
fix: supersede stale PR CI and bound job runtimes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,10 +9,26 @@ on:
 permissions:
   contents: read
 
+# Per-PR supersession: a new push to the same PR replaces that PR's in-flight
+# CI instead of letting superseded heads keep 13 jobs of hosted-runner work.
+# The group uses the PR number for pull_request events, so every run of one PR
+# shares a group, and falls back to the unique run id for push events, so each
+# main push gets its own group and is never cancelled. Cancellation is likewise
+# limited to pull_request events. Evidence and rationale: the September 12
+# Actions starvation report, section 3 "Workflow mechanics to ship first".
+# The compliance workflow deliberately keeps its own event-specific groups; do
+# not collapse it onto this simpler shape.
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   lint:
     name: Lint
     runs-on: ubuntu-latest
+    # Hang tripwire only: lint executions measured at 14-16 minutes in the
+    # September 12 starvation report, so this leaves deliberate margin.
+    timeout-minutes: 25
     steps:
       - uses: actions/checkout@v6
       - name: Install pinned ShellCheck
@@ -37,6 +53,8 @@ jobs:
   test-coverage:
     name: Test coverage guard
     runs-on: ubuntu-latest
+    # Hang tripwire: the coverage guard is a seconds-long local computation.
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@v6
       - name: Prove complete regression partition
@@ -335,6 +353,8 @@ jobs:
   tests-timing-aggregate:
     name: Behavior timing aggregate
     runs-on: ubuntu-latest
+    # Hang tripwire: aggregation is seconds of work over lane artifacts.
+    timeout-minutes: 5
     needs:
       - tests-portable-parallel-1
       - tests-portable-parallel-2
@@ -433,6 +453,8 @@ jobs:
   invariants:
     name: Repo invariants
     runs-on: ubuntu-latest
+    # Hang tripwire: the invariant checks are seconds-long file comparisons.
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@v6
       - name: Compatibility pointers must stay intact

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -107,6 +107,7 @@ Its header and `--help` own the flags, family labels, lanes, and changed-file ma
 Portable shard balance evidence lives in `docs/fm-test-portable-shards.md`.
 Family selection is the ordinary local path; `--all` is deliberate full regression only.
 CI owns broad regression across required portable parallel shards, the portable serial lane's separate-runner shards, the Herdr lane, lint, invariants, the coverage guard, and stock macOS Bash compatibility in [`.github/workflows/ci.yml`](.github/workflows/ci.yml).
+Pushing a new head to a pull request cancels that pull request's still-running CI so only the current head is validated; pushes to `main` are never cancelled, and the workflow owns that contract and its rationale.
 Use `bin/fm-test-run.sh --list-lanes` for exact lane names and `--help` for `--jobs` rules and required gate-skip flags when reproducing a lane locally.
 Leave the `sleep 0.1` cadence in the suites' bounded condition waits alone.
 Those sleeps look like recoverable overhead - `fm-watch-triage.test.sh` alone issues about 1,900 of them, each paying a flat ~100ms scheduler wake-up penalty on macOS - but they are not overhead added to the clock; they are how a test waits for a subject that only moves on `fm-watch.sh`'s own one-second `FM_POLL` cadence.

--- a/tests/fm-ci-workflow.test.sh
+++ b/tests/fm-ci-workflow.test.sh
@@ -1,0 +1,159 @@
+#!/usr/bin/env bash
+# Contract tests for .github/workflows/ci.yml's runner-spend safeguards.
+#
+# Origin: the 2026-09-12 GitHub Actions starvation incident. firstmate CI had no
+# concurrency deduplication, so every superseded PR head kept its full job
+# fan-out, and four jobs carried no timeout at all. These tests hold both
+# safeguards: PR runs supersede within one PR while main pushes are never
+# cancelled, and every CI job carries a finite hang tripwire.
+#
+# The workflow is parsed as YAML and its concurrency expressions are resolved
+# against simulated pull_request and push contexts, so the assertions describe
+# what GitHub would do, not how the file happens to be spelled.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+CI_WORKFLOW="$ROOT/.github/workflows/ci.yml"
+
+assert_present "$CI_WORKFLOW" ".github/workflows/ci.yml is missing"
+command -v ruby >/dev/null 2>&1 \
+  || fail "ruby is required to parse .github/workflows/ci.yml as YAML"
+
+# Resolve the workflow's concurrency contract under one simulated event and
+# print "<group><TAB><cancel-in-progress>". Only the two expression constructs
+# this workflow uses are resolved: an `a || b` fallback and an `==` comparison.
+resolve_concurrency() {
+  local event=$1 pr_number=$2 run_id=$3
+  ruby -ryaml -e '
+doc = YAML.load_file(ARGV[0])
+concurrency = doc.fetch("concurrency")
+context = {
+  "github.workflow" => doc.fetch("name"),
+  "github.event_name" => ARGV[1],
+  "github.event.pull_request.number" => ARGV[2],
+  "github.run_id" => ARGV[3],
+}
+
+value = lambda do |token|
+  token = token.strip
+  next token[1..-2] if token.start_with?("\x27") && token.end_with?("\x27")
+  raise "unresolvable context reference: #{token}" unless context.key?(token)
+  context.fetch(token)
+end
+
+evaluate = lambda do |expression|
+  expression = expression.strip
+  if expression.include?("==")
+    left, right = expression.split("==", 2)
+    next value.call(left) == value.call(right) ? "true" : "false"
+  end
+  resolved = expression.split("||").map { |token| value.call(token) }.find { |v| !v.empty? }
+  resolved.to_s
+end
+
+interpolate = lambda do |raw|
+  raw.to_s.gsub(/\$\{\{(.+?)\}\}/) { evaluate.call(Regexp.last_match(1)) }
+end
+
+puts [interpolate.call(concurrency.fetch("group")),
+      interpolate.call(concurrency.fetch("cancel-in-progress"))].join("\t")
+' "$CI_WORKFLOW" "$event" "$pr_number" "$run_id"
+}
+
+job_timeout() {
+  ruby -ryaml -e '
+puts YAML.load_file(ARGV[0]).fetch("jobs").fetch(ARGV[1]).fetch("timeout-minutes", "none")
+' "$CI_WORKFLOW" "$1"
+}
+
+group_of() { printf '%s\n' "$1" | cut -f1; }
+cancel_of() { printf '%s\n' "$1" | cut -f2; }
+
+test_pr_pushes_supersede_within_one_pr() {
+  local first second
+  first=$(resolve_concurrency pull_request 108 900001) || fail "could not resolve PR concurrency"
+  second=$(resolve_concurrency pull_request 108 900002) || fail "could not resolve PR concurrency"
+  [ "$(group_of "$first")" = "$(group_of "$second")" ] \
+    || fail "two runs of one PR must share a concurrency group, got $(group_of "$first") and $(group_of "$second")"
+  [ "$(cancel_of "$first")" = true ] \
+    || fail "PR runs must cancel the in-progress run, got $(cancel_of "$first")"
+  pass "a newer push to one PR supersedes that PR's in-flight CI"
+}
+
+test_separate_prs_do_not_cancel_each_other() {
+  local one two
+  one=$(resolve_concurrency pull_request 108 900001) || fail "could not resolve PR concurrency"
+  two=$(resolve_concurrency pull_request 109 900003) || fail "could not resolve PR concurrency"
+  [ "$(group_of "$one")" != "$(group_of "$two")" ] \
+    || fail "distinct PRs must not share a concurrency group ($(group_of "$one"))"
+  pass "distinct PRs get distinct concurrency groups"
+}
+
+test_main_pushes_are_never_cancelled() {
+  local first second
+  first=$(resolve_concurrency push '' 900010) || fail "could not resolve push concurrency"
+  second=$(resolve_concurrency push '' 900011) || fail "could not resolve push concurrency"
+  [ "$(group_of "$first")" != "$(group_of "$second")" ] \
+    || fail "each main push must get its own concurrency group, got $(group_of "$first") twice"
+  [ "$(cancel_of "$first")" = false ] \
+    || fail "push runs must never cancel an in-progress run, got $(cancel_of "$first")"
+  pass "every main push keeps its own group and is never cancelled"
+}
+
+test_every_job_has_a_finite_timeout() {
+  local reported
+  reported=$(ruby -ryaml -e '
+YAML.load_file(ARGV[0]).fetch("jobs").each do |name, job|
+  timeout = job["timeout-minutes"]
+  next if timeout.is_a?(Integer) && timeout > 0
+  puts "#{name}: #{timeout.inspect}"
+end
+' "$CI_WORKFLOW") || fail "could not read job timeouts from ci.yml"
+  [ -z "$reported" ] || fail "these CI jobs have no finite hang tripwire:"$'\n'"$reported"
+  pass "every ci.yml job carries a finite timeout"
+}
+
+# The four jobs the incident found unbounded, at the report's recommended caps.
+test_previously_unbounded_jobs_keep_their_caps() {
+  local job expected actual
+  while read -r job expected; do
+    [ -n "$job" ] || continue
+    actual=$(job_timeout "$job") || fail "could not read the $job timeout"
+    [ "$actual" = "$expected" ] \
+      || fail "$job timeout must stay $expected minutes, got $actual"
+  done <<'CAPS'
+lint 25
+test-coverage 5
+tests-timing-aggregate 5
+invariants 5
+CAPS
+  pass "the incident's unbounded jobs keep their recommended caps"
+}
+
+# Cancellation makes an undersized cap costlier: a falsely tripped job now also
+# discards a run nobody replaced. These bounds were measured, not guessed.
+test_measured_lanes_keep_their_existing_bounds() {
+  local job expected actual
+  while read -r job expected; do
+    [ -n "$job" ] || continue
+    actual=$(job_timeout "$job") || fail "could not read the $job timeout"
+    [ "$actual" = "$expected" ] \
+      || fail "$job timeout must stay $expected minutes, got $actual"
+  done <<'CAPS'
+tests-portable-parallel-1 10
+tests-portable-parallel-2 10
+tests-portable-serial 30
+tests-herdr 75
+macos-stock-bash 10
+CAPS
+  pass "the already-measured lane bounds are unchanged"
+}
+
+test_pr_pushes_supersede_within_one_pr
+test_separate_prs_do_not_cancel_each_other
+test_main_pushes_are_never_cancelled
+test_every_job_has_a_finite_timeout
+test_previously_unbounded_jobs_keep_their_caps
+test_measured_lanes_keep_their_existing_bounds


### PR DESCRIPTION
## Intent

Captain authorized (2026-09-12): ship two firstmate CI safeguards in ONE no-mistakes PR, motivated by the GitHub Actions starvation incident in which firstmate CI load starved no-mistakes of hosted runners (refined cause: about 63 old runs reactivated in a burst on 2026-09-12 plus heavy CI fan-out with no per-PR supersession).

Deliver exactly these two changes, nothing more:
1. Per-PR CI supersession: firstmate .github/workflows/ci.yml currently has no concurrency deduplication, so superseded PR heads keep consuming runners. Add per-PR concurrency grouping so a newer push to the same PR cancels that PR's in-progress CI runs, WITHOUT breaking or cancelling main push CI.
2. Explicit job timeouts: several firstmate CI jobs are currently unbounded (no timeout-minutes) and can hang indefinitely. Add reasonable timeout caps as hang tripwires on the currently-unbounded jobs, aligned with the incident report's recommendations.

Out of scope - do NOT do any of these in this PR: fork approval policy changes, auto-closing PRs, a path-filter fast path, runner infrastructure, bulk historical rerun tooling, redesigning no-mistakes-required.yml, or touching any other repository. Do not lower the already-bounded shard caps (10/30/75) without evidence.

The authoritative incident analysis and recommendations are in data/fm-actions-starvation-safeguards-s1/report.md (a private firstmate-home report, not in this repository). Its substance, as the captain's ask by reference:
- The report's recommended concurrency-group pattern is exactly: group "ci-${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.run_id }}" with cancel-in-progress "${{ github.event_name == 'pull_request' }}". For PRs this keeps the newest run and keys on the PR number rather than contributor branch names; for main and other non-PR events the unique run id preserves all existing main validation instead of silently dropping pending commits.
- The report explicitly warns NOT to apply the same simple group to the compliance workflow (no-mistakes-required.yml), whose event-specific groups deliberately preserve independent evidence under fork approval.
- The report's proposed initial caps for the currently unbounded firstmate jobs are 25 minutes for lint (whose measured executions are 14-16 minutes, so the cap is a tripwire with deliberate margin) and 5 minutes each for the coverage guard, the repo invariants, and the timing aggregate. It says to keep the existing parallel (10), serial (30), Herdr (75 plus its 20-minute step) and macOS (10) bounds unchanged in this first patch.

The PR description must cite that report path and explain both the concurrency-group choice (and why it supersedes PR runs without cancelling main push) and the chosen timeout values.

## What Changed

- Add the concurrency group recommended by `data/fm-actions-starvation-safeguards-s1/report.md`, grouping pull-request runs by PR number while using unique run IDs and disabled cancellation for main pushes.
- Add timeout tripwires of 25 minutes for lint and 5 minutes each for coverage, timing aggregation, and repository invariants, while preserving existing bounded lane caps.
- Add workflow contract tests for concurrency and timeout behavior, and document PR supersession in `CONTRIBUTING.md`.

## Risk Assessment

✅ Low: The change exactly applies the authorized per-PR concurrency group and four timeout caps while preserving existing bounded jobs and main-push behavior.

## Testing

Targeted semantic tests resolved PR and push concurrency contexts, verified all timeout caps, reproduced the baseline's missing safeguards, confirmed existing 10/30/75-minute bounds remained unchanged, and found no compliance-workflow change; actual GitHub-hosted cancellation and timeout behavior could not be driven locally.

- Live validation: ⚠️ no-surface - 0 of 6 scenarios driven live against the product

| Scenario | Result | Live | Evidence |
| --- | --- | --- | --- |
| A contributor pushes a newer head to one PR and its older in-progress CI run is cancelled without affecting another PR | ⏸️ untested | no | This requires a disposable GitHub PR, Actions runner access, and permission to push successive heads while observing concurrent runs; provide those credentials and authority to drive it live. |
| Two pushes to main retain independent CI runs and neither run is cancelled | ⏸️ untested | no | Live validation requires authority to push multiple commits to main and inspect GitHub Actions; this test phase has neither that authority nor permission to push. |
| The formerly unbounded lint, coverage, aggregate, and invariants jobs terminate at their 25/5/5/5-minute tripwires | ⏸️ untested | no | Actual timeout enforcement occurs only on GitHub-hosted runners and would require authorized deliberately hanging workflow runs; provide a disposable repository or PR and Actions access. |
| Existing parallel, serial, Herdr, and macOS jobs retain their 10/30/75/10-minute bounds | ⏸️ untested | no | The parsed workflow confirms the configured values, but observing their enforcement requires GitHub-hosted Actions runs and repository write authority. |
| The compliance workflow retains its independent grouping behavior | ⏸️ untested | no | This is an unchanged declarative workflow boundary with no local runtime surface; live confirmation requires fork-approval GitHub events and Actions inspection permissions. |
| The pull request description cites `data/fm-actions-starvation-safeguards-s1/report.md` and explains the grouping and timeout rationale | ⏸️ untested | no | PR creation and description management belong to the outer pipeline phase; provide an existing PR URL and read access, or validate after the outer executor creates it. |

<details>
<summary>Evidence: CI workflow semantic contract and baseline comparison</summary>

Source: [CI workflow semantic contract and baseline comparison](https://github.com/kunchenguid/firstmate/blob/35def683f383b41abd81739e2ba0e868d278d412/.no-mistakes/evidence/fm/fm-ci-supersession-timeouts-r1/fm-ci-workflow-contract.txt)

```text
$ bash tests/fm-ci-workflow.test.sh
ok - a newer push to one PR supersedes that PR's in-flight CI
ok - distinct PRs get distinct concurrency groups
ok - every main push keeps its own group and is never cancelled
ok - every ci.yml job carries a finite timeout
ok - the incident's unbounded jobs keep their recommended caps
ok - the already-measured lane bounds are unchanged

$ semantic baseline/target comparison via Ruby YAML consumer
base.concurrency=nil
base.timeout.lint=nil
base.timeout.test-coverage=nil
base.timeout.tests-timing-aggregate=nil
base.timeout.invariants=nil
base.timeout.tests-portable-parallel-1=10
base.timeout.tests-portable-parallel-2=10
base.timeout.tests-portable-serial=30
base.timeout.tests-herdr=75
base.timeout.macos-stock-bash=10
target.concurrency={"group"=>"ci-${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.run_id }}", "cancel-in-progress"=>"${{ github.event_name == 'pull_request' }}"}
target.timeout.lint=25
target.timeout.test-coverage=5
target.timeout.tests-timing-aggregate=5
target.timeout.invariants=5
target.timeout.tests-portable-parallel-1=10
target.timeout.tests-portable-parallel-2=10
target.timeout.tests-portable-serial=30
target.timeout.tests-herdr=75
target.timeout.macos-stock-bash=10
```
</details>
- Outcome: ⚠️ 2 warnings across 1 run (1m7s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"2a8e3531a183ac17f04fe01c631ae8843dcfeb7a","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}],"live_validation":{"verdict":"no-surface","live":0,"total":6}} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>⚠️ **Test** - 2 warnings</summary>

- ⚠️ `.github/workflows/ci.yml:15` - The change is GitHub Actions configuration only, so local testing cannot demonstrate actual run cancellation or timeout enforcement. A disposable PR with permission to push replacement heads and inspect Actions runs is required for live evidence.
- ⚠️ this change has no live-validatable surface; proceed without live validation? (0 of 6 scenarios were driven live against the product); A contributor pushes a newer head to one PR and its older in-progress CI run is cancelled without affecting another PR: This requires a disposable GitHub PR, Actions runner access, and permission to push successive heads while observing concurrent runs; provide those credentials and authority to drive it live.; Two pushes to main retain independent CI runs and neither run is cancelled: Live validation requires authority to push multiple commits to main and inspect GitHub Actions; this test phase has neither that authority nor permission to push.; The formerly unbounded lint, coverage, aggregate, and invariants jobs terminate at their 25/5/5/5-minute tripwires: Actual timeout enforcement occurs only on GitHub-hosted runners and would require authorized deliberately hanging workflow runs; provide a disposable repository or PR and Actions access.; Existing parallel, serial, Herdr, and macOS jobs retain their 10/30/75/10-minute bounds: The parsed workflow confirms the configured values, but observing their enforcement requires GitHub-hosted Actions runs and repository write authority.; The compliance workflow retains its independent grouping behavior: This is an unchanged declarative workflow boundary with no local runtime surface; live confirmation requires fork-approval GitHub events and Actions inspection permissions.; The pull request description cites `data/fm-actions-starvation-safeguards-s1/report.md` and explains the grouping and timeout rationale: PR creation and description management belong to the outer pipeline phase; provide an existing PR URL and read access, or validate after the outer executor creates it.
- Live validation: ⚠️ no-surface - 0 of 6 scenarios driven live against the product

| Scenario | Result | Live | Evidence |
| --- | --- | --- | --- |
| A contributor pushes a newer head to one PR and its older in-progress CI run is cancelled without affecting another PR | ⏸️ untested | no | This requires a disposable GitHub PR, Actions runner access, and permission to push successive heads while observing concurrent runs; provide those credentials and authority to drive it live. |
| Two pushes to main retain independent CI runs and neither run is cancelled | ⏸️ untested | no | Live validation requires authority to push multiple commits to main and inspect GitHub Actions; this test phase has neither that authority nor permission to push. |
| The formerly unbounded lint, coverage, aggregate, and invariants jobs terminate at their 25/5/5/5-minute tripwires | ⏸️ untested | no | Actual timeout enforcement occurs only on GitHub-hosted runners and would require authorized deliberately hanging workflow runs; provide a disposable repository or PR and Actions access. |
| Existing parallel, serial, Herdr, and macOS jobs retain their 10/30/75/10-minute bounds | ⏸️ untested | no | The parsed workflow confirms the configured values, but observing their enforcement requires GitHub-hosted Actions runs and repository write authority. |
| The compliance workflow retains its independent grouping behavior | ⏸️ untested | no | This is an unchanged declarative workflow boundary with no local runtime surface; live confirmation requires fork-approval GitHub events and Actions inspection permissions. |
| The pull request description cites `data/fm-actions-starvation-safeguards-s1/report.md` and explains the grouping and timeout rationale | ⏸️ untested | no | PR creation and description management belong to the outer pipeline phase; provide an existing PR URL and read access, or validate after the outer executor creates it. |

- `bash tests/fm-ci-workflow.test.sh`
- <code>Ruby YAML semantic comparison of `.github/workflows/ci.yml` at base `c191eacd36a9a44db0fb1888c67fe3dbfe534919` and target</code>
- `git diff --name-only c191eacd36a9a44db0fb1888c67fe3dbfe534919..2a8e3531a183ac17f04fe01c631ae8843dcfeb7a -- .github/workflows/no-mistakes-required.yml`
- `git status --short`
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
