### PR TITLE
feat(brief): require poteto-mode in generated worker briefs by default

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ __pycache__/
 config/
 
 .tools/
+.herdr-mail/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,6 +78,7 @@ config/supervision-branch-model config/supervision-branch-effort  Pi supervision
 config/startup-memory-budget     primary-authoritative per-home startup-memory budget; LOCAL, gitignored, materialized as 7,500 estimated tokens by locked primary bootstrap and inherited into secondmate homes; see docs/configuration.md "Startup memory budget"
 config/stow-pass-horizon  optional presence flag opting this home in to /stow's default-off pass-count decay horizon; LOCAL, gitignored, and not inherited; see docs/configuration.md "Stow pass horizon"
 config/herdr-presentation-spaces  optional "off" opt-out from, or "on" opt-in to, Herdr's default-on disposable single-task visual projection, which is unconfigured-default-on only at or above a Herdr version floor; LOCAL, gitignored; inherited by secondmate homes; see docs/herdr-backend.md "Presentation spaces"
+config/poteto-mode  optional "off" opt-out from, or "on" to keep, the default-on Poteto mode section in ship and scout briefs; LOCAL, gitignored; inherited by secondmate homes; see docs/configuration.md "Poteto mode"
 config/trace-context  optional presence flag enabling default-off native W3C trace-context propagation to spawned agents; LOCAL, gitignored; inherited by secondmate homes; see docs/configuration.md "Trace context propagation" and docs/trace-context.md
 config/turnend-churn-absorb  optional presence flag opting this home into the default-off absorb of bare turn-end wakes on pane churn; LOCAL, gitignored, and not inherited; see docs/configuration.md "Turn-end pane-churn absorb"
 config/cmux-socket-password  optional cmux control-socket password; LOCAL, gitignored; read fresh on every cmux CLI call and passed through without ever overriding an operator's own ambient CMUX_SOCKET_PASSWORD when absent (docs/cmux-backend.md "Setup")
@@ -543,6 +544,7 @@ Every ship brief must retain the worktree-isolation assertion and stop if launch
 If a ship task touches firstmate's shared tracked material, explicitly require `firstmate-coding-guidelines` before editing.
 If a task will drive Herdr lifecycle behavior, scaffold with `--herdr-lab`; if that need appears after an unguarded scaffold, stop and regenerate rather than adding commands by hand.
 The generated Herdr contract must use a named non-`default` isolated lab and its guarded helper for every lifecycle action.
+Ship and scout briefs require the `poteto-mode` skill by default under `config/poteto-mode`; `bin/fm-brief.sh` owns the section text and its skill and Herdr fallbacks.
 
 Load `secondmate-provisioning` before creating or using a charter brief and preserve its idle-by-default and marked-return-channel contracts.
 Status appends are sparse supervisor-actionable events, not routine progress; `bin/fm-classify-lib.sh` owns keyed open and resolved semantics.

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -36,6 +36,12 @@
 #   after scaffolding and the caller-supplied repo string cannot reliably
 #   identify this repo. Briefs made without it carry a loud declaration so an
 #   omitted contract cannot be silent.
+# Ship and scout briefs carry a `# Poteto mode` section directly after the Herdr
+# section when enabled. Unguarded briefs authorize the skill's role-agent
+# lifecycle inside one run tab (rename own pane, splits, role and watchdog panes
+# you start); --herdr-lab briefs run the playbook in-host instead. Secondmate
+# charters never receive the section. docs/configuration.md "Poteto mode" owns
+# the config values and when the section is enabled.
 # For ship tasks, --mode is REQUIRED and shapes the definition of done. Firstmate
 # resolves it per task at intake (AGENTS.md section 7); data/projects.md holds the
 # captain's standing posture as context, and this script never reads it:
@@ -108,6 +114,7 @@ resolve_directory_input() {
 
 FM_ROOT="${FM_ROOT_OVERRIDE:-$(cd "$SCRIPT_DIR/.." && pwd)}"
 FM_HOME=$(resolve_directory_input FM_HOME "${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}") || exit 1
+CONFIG="${FM_CONFIG_OVERRIDE:-$FM_HOME/config}"
 if [ -n "${FM_DATA_OVERRIDE:-}" ]; then
   DATA=$(resolve_directory_input FM_DATA_OVERRIDE "$FM_DATA_OVERRIDE") || exit 1
 else
@@ -185,7 +192,6 @@ fi
 
 BRIEF="$DATA/$ID/brief.md"
 [ -e "$BRIEF" ] && { echo "error: $BRIEF already exists" >&2; exit 1; }
-mkdir -p "$DATA/$ID"
 
 ASK_USER_BLOCK=
 if [ "$KIND" = ship ] && [ "$MODE" = no-mistakes ]; then
@@ -215,6 +221,7 @@ EOF
 INBOX_SECTION=${INBOX_SECTION%$'\n'}
 
 if [ "$KIND" = secondmate ]; then
+mkdir -p "$DATA/$ID"
 SECONDMATE_PROJECTS=""
 idx=1
 while [ "$idx" -lt "${#POS[@]}" ]; do
@@ -311,6 +318,36 @@ fi
 exit 0
 fi
 
+# Ship and scout only: resolve config/poteto-mode before any brief side effects.
+# docs/configuration.md "Poteto mode" owns the accepted values and defaults.
+POTETO_MODE=on
+POTETO_MODE_FILE="$CONFIG/poteto-mode"
+if [ -e "$POTETO_MODE_FILE" ] || [ -L "$POTETO_MODE_FILE" ]; then
+  if [ -L "$POTETO_MODE_FILE" ] && [ ! -e "$POTETO_MODE_FILE" ]; then
+    echo "error: $POTETO_MODE_FILE: poteto-mode path is a broken symlink (need a readable regular file with \"on\" or \"off\", or absent)" >&2
+    exit 1
+  fi
+  if [ ! -f "$POTETO_MODE_FILE" ]; then
+    echo "error: $POTETO_MODE_FILE: poteto-mode path exists but is not a readable regular file (need a regular file with \"on\" or \"off\", or absent)" >&2
+    exit 1
+  fi
+  if ! POTETO_MODE_VALUE=$(cat "$POTETO_MODE_FILE"); then
+    echo "error: $POTETO_MODE_FILE: could not read poteto-mode config" >&2
+    exit 1
+  fi
+  POTETO_MODE_VALUE=$(printf '%s' "$POTETO_MODE_VALUE" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
+  case "$POTETO_MODE_VALUE" in
+    on) POTETO_MODE=on ;;
+    off) POTETO_MODE=off ;;
+    *)
+      echo "error: $POTETO_MODE_FILE: must be absent, \"on\", or \"off\" (got '$POTETO_MODE_VALUE')" >&2
+      exit 1
+      ;;
+  esac
+fi
+
+mkdir -p "$DATA/$ID"
+
 REPO=${POS[1]}
 
 if [ "$HERDR_LAB" -eq 1 ]; then
@@ -345,6 +382,36 @@ EOF
 HERDR_SECTION=${HERDR_SECTION%$'\n'}
 fi
 
+POTETO_SECTION=
+if [ "$POTETO_MODE" = on ]; then
+  if [ "$HERDR_LAB" -eq 1 ]; then
+    IFS= read -r -d '' POTETO_SECTION <<'EOF' || true
+# Poteto mode
+Run this task under the `poteto-mode` skill: invoke it (`/poteto-mode`, or your tool's skill loader) before any task work and follow the playbook it matches.
+The lab contract above governs every Herdr call, so run the skill's playbook in-host and perform each role yourself; do not start role agents.
+If your tool cannot load the skill, proceed with this brief as written.
+If the skill loads but Herdr is unavailable here (no `herdr` command or no `HERDR_PANE_ID`), follow its playbook in-host and perform each role yourself.
+Name any fallback and its reason in your `done:` line.
+This brief's safety rules, status protocol, and Definition of done win over the skill on any conflict.
+Where the skill's playbook requires a review, validation, or shipping step that this brief's Definition of done already covers, the delivery path satisfies that step; do not run an additional independent review pass for the delivery path's sake and do not open a second PR.
+EOF
+  else
+    IFS= read -r -d '' POTETO_SECTION <<'EOF' || true
+# Poteto mode
+Run this task under the `poteto-mode` skill: invoke it (`/poteto-mode`, or your tool's skill loader) before any task work and follow the playbook it matches.
+This section authorizes the skill's own role agents: you may rename your OWN agent pane to the skill's orchestrator name, create one run tab, split panes inside that run tab, and start, message, and close role agents and watchdog panes that YOU started through the skill's scripts, and that is not the Herdr lifecycle work the Herdr section above gates.
+Never stop, delete, or restart a Herdr session or server, and never touch a tab, pane, or agent belonging to another run or to the captain's fleet.
+Role agents work only inside this worktree, and the skill's run store (`.herdr-mail/`) is never committed.
+If your tool cannot load the skill, proceed with this brief as written.
+If the skill loads but Herdr is unavailable here (no `herdr` command or no `HERDR_PANE_ID`), follow its playbook in-host and perform each role yourself.
+Name any fallback and its reason in your `done:` line.
+This brief's safety rules, status protocol, and Definition of done win over the skill on any conflict.
+Where the skill's playbook requires a review, validation, or shipping step that this brief's Definition of done already covers, the delivery path satisfies that step; do not run an additional independent review pass for the delivery path's sake and do not open a second PR.
+EOF
+  fi
+  POTETO_SECTION=$'\n'"${POTETO_SECTION%$'\n'}"
+fi
+
 IFS= read -r -d '' TASK_SECTION <<'EOF' || true
 # Task
 ## Captain's intent
@@ -366,7 +433,7 @@ You are a crewmate: an autonomous worker agent managed by firstmate. Work on you
 
 $TASK_SECTION
 
-$HERDR_SECTION
+$HERDR_SECTION$POTETO_SECTION
 
 # Setup
 You are in a disposable git worktree of $REPO, at a detached HEAD on a clean default branch.
@@ -452,7 +519,7 @@ You are a crewmate: an autonomous worker agent managed by firstmate. Work on you
 
 $TASK_SECTION
 
-$HERDR_SECTION
+$HERDR_SECTION$POTETO_SECTION
 
 # Setup
 You are in a disposable git worktree of $REPO, at a detached HEAD on a clean default branch.

--- a/bin/fm-config-inherit-lib.sh
+++ b/bin/fm-config-inherit-lib.sh
@@ -12,7 +12,8 @@
 # preference - an absent primary file and an absent destination file both mean
 # the same unconfigured default, so the generic absence mirror below converges
 # a secondmate without deciding the release-dependent floor; explicit "on" and
-# "off" preferences propagate as files. Primary
+# "off" preferences propagate as files. Primary config/poteto-mode is inherited
+# (FM_INHERITABLE_CONFIG; docs/configuration.md "Poteto mode"). Primary
 # config/trace-context is copied at the launch convergence point as part of the
 # default-off W3C trace-context setup, while live convergence leaves it unchanged.
 # The primary passes its frozen home-session decision into a newly launched
@@ -66,7 +67,7 @@ FM_SHARED_CAPTAIN_MODE="444"
 # The declared inheritable set (space-separated, config-dir-relative item paths).
 # Extend here to inherit more of the primary's local config; override via the
 # environment only in tests. Items must not contain whitespace.
-FM_INHERITABLE_CONFIG="${FM_INHERITABLE_CONFIG:-crew-dispatch.json crew-harness backlog-backend backend herdr-presentation-spaces startup-memory-budget trace-context launch-env-allowlist claude-permission-mode}"
+FM_INHERITABLE_CONFIG="${FM_INHERITABLE_CONFIG:-crew-dispatch.json crew-harness backlog-backend backend herdr-presentation-spaces poteto-mode startup-memory-budget trace-context launch-env-allowlist claude-permission-mode}"
 
 # Items whose value is a home-SESSION enablement decision rather than durable
 # local configuration. They are inherited at the launch convergence point, where

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -191,6 +191,15 @@ An absent file means `auto`, i.e. default-on on macOS: the alarm exists precisel
 A missing or failing channel logs and falls through to the next, never crashing the daemon.
 See [`wedge-alarm.md`](wedge-alarm.md) for the current channel reference, [`verification/supervision.md`](verification/supervision.md#wedge-alarm-channels) for active evidence, and [`examples/wedge-alarm`](examples/wedge-alarm) for a copyable config.
 
+## Poteto mode (config/poteto-mode)
+
+The optional local, gitignored `config/poteto-mode` file controls whether ship and scout briefs include the default-on Poteto mode section; secondmate charters never read it.
+Absence enables the section.
+A readable regular file (or a symlink to one) whose value is `on` or `off` after trimming only leading and trailing whitespace enables or omits the section; internal whitespace is not normalized.
+An empty or whitespace-only file, any other value, a non-regular path (directory, FIFO, or similar), a broken symlink, or a file that cannot be read makes `bin/fm-brief.sh` refuse a ship or scout scaffold and write no brief.
+The file is inherited into secondmate homes under the primary-authoritative contract owned by [`secondmate-provisioning`](../.agents/skills/secondmate-provisioning/SKILL.md); an absent primary file mirrors as absence (still the default-on behavior for that home's ship and scout briefs).
+`bin/fm-brief.sh`'s header owns where the section sits, which kinds receive it, and the unguarded versus `--herdr-lab` variants.
+
 ## Trace context propagation (config/trace-context / FM_TRACE_CONTEXT)
 
 The optional local, gitignored `config/trace-context` presence flag enables default-off native W3C trace-context propagation.

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -901,6 +901,228 @@ test_worker_role_scope() {
   pass "fm-brief: scaffolds leave the worker role scope to the launch boundary and keep the secondmate contract"
 }
 
+assert_poteto_section_after_herdr() {
+  local brief=$1 label=$2
+  awk '
+    /^# Herdr / { herdr=1; next }
+    herdr && /^# / {
+      if ($0 != "# Poteto mode") {
+        print "expected # Poteto mode as the next top-level heading after Herdr, got: " $0
+        exit 1
+      }
+      poteto=1
+      exit 0
+    }
+    END {
+      if (!herdr) { print "missing Herdr section"; exit 1 }
+      if (!poteto) { print "missing Poteto mode section after Herdr"; exit 1 }
+    }
+  ' "$brief" >/dev/null \
+    || fail "$label: Poteto mode section must sit directly after the Herdr section"
+}
+
+test_poteto_mode_default_on_for_ship_and_scout() {
+  local home kind brief id
+  home="$TMP_ROOT/poteto-default-home"
+  mkdir -p "$home/data"
+  for kind in no-mistakes direct-PR local-only scout; do
+    id="poteto-default-$kind"
+    if [ "$kind" = scout ]; then
+      FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" sample --scout >/dev/null 2>&1 \
+        || fail "default-on scout scaffold failed"
+    else
+      FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" sample --mode "$kind" >/dev/null 2>&1 \
+        || fail "default-on $kind scaffold failed"
+    fi
+    brief="$home/data/$id/brief.md"
+    assert_grep "# Poteto mode" "$brief" "$kind brief missing default-on Poteto mode section"
+    assert_grep "Run this task under the \`poteto-mode\` skill" "$brief" \
+      "$kind brief missing poteto-mode invocation line"
+    assert_grep "rename your OWN agent pane to the skill's orchestrator name" "$brief" \
+      "$kind unguarded brief missing own-pane rename authorization"
+    assert_grep "split panes inside that run tab" "$brief" \
+      "$kind unguarded brief missing run-tab split authorization"
+    assert_grep "watchdog panes that YOU started" "$brief" \
+      "$kind unguarded brief missing watchdog authorization"
+    assert_grep "never touch a tab, pane, or agent belonging to another run or to the captain's fleet" "$brief" \
+      "$kind unguarded brief missing fleet-scoped non-interference rule"
+    assert_grep "the delivery path satisfies that step" "$brief" \
+      "$kind brief missing delivery-path satisfaction wording"
+    assert_grep "If your tool cannot load the skill, proceed with this brief as written." "$brief" \
+      "$kind brief missing skill-absent fallback"
+    assert_grep "Name any fallback and its reason in your \`done:\` line." "$brief" \
+      "$kind brief missing done-line fallback naming"
+    assert_poteto_section_after_herdr "$brief" "$kind"
+  done
+  pass "fm-brief.sh: Poteto mode is default-on for all ship modes and scout"
+}
+
+test_poteto_mode_absent_from_secondmate_charter() {
+  local home brief
+  home="$TMP_ROOT/poteto-secondmate-home"
+  mkdir -p "$home/data"
+  FM_HOME="$home" FM_SECONDMATE_CHARTER='Supervise assigned work.' \
+    "$ROOT/bin/fm-brief.sh" poteto-sm --secondmate --no-projects >/dev/null 2>&1 \
+    || fail "secondmate charter scaffold failed"
+  brief="$home/data/poteto-sm/brief.md"
+  assert_no_grep "# Poteto mode" "$brief" \
+    "secondmate charter must never receive the Poteto mode section"
+  pass "fm-brief.sh: Poteto mode is absent from secondmate charters"
+}
+
+test_poteto_mode_invalid_still_scaffolds_secondmate() {
+  local home brief status=0
+  home="$TMP_ROOT/poteto-invalid-secondmate-home"
+  mkdir -p "$home/data" "$home/config"
+  printf 'bogus\n' > "$home/config/poteto-mode"
+  FM_HOME="$home" FM_SECONDMATE_CHARTER='Supervise assigned work.' \
+    "$ROOT/bin/fm-brief.sh" poteto-sm-bad --secondmate --no-projects >/dev/null 2>&1 || status=$?
+  expect_code 0 "$status" "invalid poteto-mode must not block secondmate charter scaffolding"
+  brief="$home/data/poteto-sm-bad/brief.md"
+  assert_present "$brief" "invalid poteto-mode blocked secondmate charter write"
+  assert_no_grep "# Poteto mode" "$brief" \
+    "secondmate charter must never receive the Poteto mode section"
+  pass "fm-brief.sh: invalid poteto-mode still scaffolds a secondmate charter"
+}
+
+test_poteto_mode_off_omits_section() {
+  local home brief
+  home="$TMP_ROOT/poteto-off-home"
+  mkdir -p "$home/data" "$home/config"
+  printf 'off\n' > "$home/config/poteto-mode"
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" poteto-off sample --mode no-mistakes >/dev/null 2>&1 \
+    || fail "poteto-mode=off scaffold failed"
+  brief="$home/data/poteto-off/brief.md"
+  assert_no_grep "# Poteto mode" "$brief" "poteto-mode=off must omit the section"
+  pass "fm-brief.sh: config/poteto-mode=off omits the Poteto mode section"
+}
+
+test_poteto_mode_explicit_on_includes_section() {
+  local home brief
+  home="$TMP_ROOT/poteto-on-home"
+  mkdir -p "$home/data" "$home/config"
+  printf 'on\n' > "$home/config/poteto-mode"
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" poteto-on sample --mode no-mistakes >/dev/null 2>&1 \
+    || fail "poteto-mode=on scaffold failed"
+  brief="$home/data/poteto-on/brief.md"
+  assert_grep "# Poteto mode" "$brief" "explicit on must include the Poteto mode section"
+  pass "fm-brief.sh: config/poteto-mode=on includes the Poteto mode section"
+}
+
+test_poteto_mode_invalid_refuses_without_writing() {
+  local home err status=0
+  home="$TMP_ROOT/poteto-invalid-home"
+  mkdir -p "$home/data" "$home/config"
+  printf 'maybe\n' > "$home/config/poteto-mode"
+  err="$home/invalid.err"
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" poteto-bad sample --mode no-mistakes >/dev/null 2>"$err" || status=$?
+  expect_code 1 "$status" "invalid poteto-mode must exit 1"
+  assert_grep "$home/config/poteto-mode" "$err" "refusal must name the config file"
+  assert_grep '"on"' "$err" "refusal must name accepted values"
+  assert_grep '"off"' "$err" "refusal must name accepted values"
+  assert_absent "$home/data/poteto-bad/brief.md" "invalid poteto-mode must write no brief"
+  [ ! -d "$home/data/poteto-bad" ] || fail "invalid poteto-mode created a task data directory"
+  pass "fm-brief.sh: invalid poteto-mode exits 1 and writes no brief"
+}
+
+test_poteto_mode_parser_boundaries() {
+  local home err status brief target
+  home="$TMP_ROOT/poteto-parser-home"
+  mkdir -p "$home/data" "$home/config"
+
+  printf 'o n\n' > "$home/config/poteto-mode"
+  err="$home/internal-ws.err"; status=0
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" poteto-internal-ws sample --mode no-mistakes \
+    >/dev/null 2>"$err" || status=$?
+  expect_code 1 "$status" "internal whitespace must be refused"
+  assert_grep "got 'o n'" "$err" "internal whitespace refusal must preserve the raw value"
+  assert_absent "$home/data/poteto-internal-ws/brief.md" "internal whitespace wrote a brief"
+
+  : > "$home/config/poteto-mode"
+  err="$home/empty.err"; status=0
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" poteto-empty sample --mode no-mistakes \
+    >/dev/null 2>"$err" || status=$?
+  expect_code 1 "$status" "empty poteto-mode file must be refused"
+  assert_grep "got ''" "$err" "empty file refusal must report an empty value"
+  assert_absent "$home/data/poteto-empty/brief.md" "empty poteto-mode wrote a brief"
+
+  printf ' \t\n' > "$home/config/poteto-mode"
+  err="$home/ws-only.err"; status=0
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" poteto-ws-only sample --mode no-mistakes \
+    >/dev/null 2>"$err" || status=$?
+  expect_code 1 "$status" "whitespace-only poteto-mode must be refused"
+  assert_absent "$home/data/poteto-ws-only/brief.md" "whitespace-only poteto-mode wrote a brief"
+
+  printf 'on\r\n' > "$home/config/poteto-mode"
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" poteto-crlf sample --mode no-mistakes >/dev/null 2>&1 \
+    || fail "CRLF on must be accepted"
+  brief="$home/data/poteto-crlf/brief.md"
+  assert_grep "# Poteto mode" "$brief" "CRLF on must include the Poteto mode section"
+
+  target="$home/config/poteto-mode-target"
+  printf 'on\n' > "$target"
+  rm -f "$home/config/poteto-mode"
+  ln -s "$target" "$home/config/poteto-mode"
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" poteto-symlink sample --mode no-mistakes >/dev/null 2>&1 \
+    || fail "symlink to a valid poteto-mode file must be accepted"
+  brief="$home/data/poteto-symlink/brief.md"
+  assert_grep "# Poteto mode" "$brief" "symlink on must include the Poteto mode section"
+
+  rm -f "$home/config/poteto-mode"
+  ln -s "$home/config/missing-poteto-target" "$home/config/poteto-mode"
+  err="$home/broken-symlink.err"; status=0
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" poteto-broken-link sample --mode no-mistakes \
+    >/dev/null 2>"$err" || status=$?
+  expect_code 1 "$status" "broken poteto-mode symlink must be refused"
+  assert_grep "broken symlink" "$err" "broken symlink refusal must name the defect"
+  assert_absent "$home/data/poteto-broken-link/brief.md" "broken symlink wrote a brief"
+
+  rm -f "$home/config/poteto-mode"
+  mkdir "$home/config/poteto-mode"
+  err="$home/directory.err"; status=0
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" poteto-dir sample --mode no-mistakes \
+    >/dev/null 2>"$err" || status=$?
+  expect_code 1 "$status" "directory at poteto-mode path must be refused"
+  assert_grep "not a readable regular file" "$err" "directory refusal must name the defect"
+  assert_absent "$home/data/poteto-dir/brief.md" "directory poteto-mode wrote a brief"
+  rmdir "$home/config/poteto-mode"
+
+  printf 'on\n' > "$home/config/poteto-mode"
+  chmod a-r "$home/config/poteto-mode" || fail "could not make poteto-mode unreadable"
+  err="$home/unreadable.err"; status=0
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" poteto-unreadable sample --mode no-mistakes \
+    >/dev/null 2>"$err" || status=$?
+  chmod u+r "$home/config/poteto-mode" || true
+  if [ "$(id -u)" -eq 0 ]; then
+    pass "fm-brief.sh: poteto-mode parser boundaries (unreadable skipped as root)"
+    return 0
+  fi
+  expect_code 1 "$status" "unreadable poteto-mode must be refused"
+  assert_grep "could not read" "$err" "unreadable refusal must name the read failure"
+  assert_absent "$home/data/poteto-unreadable/brief.md" "unreadable poteto-mode wrote a brief"
+  pass "fm-brief.sh: poteto-mode parser boundaries"
+}
+
+test_poteto_mode_herdr_lab_runs_in_host() {
+  local home brief
+  home="$TMP_ROOT/poteto-lab-home"
+  mkdir -p "$home/data"
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" poteto-lab sample --mode no-mistakes --herdr-lab >/dev/null 2>&1 \
+    || fail "--herdr-lab poteto scaffold failed"
+  brief="$home/data/poteto-lab/brief.md"
+  assert_grep "# Poteto mode" "$brief" "--herdr-lab brief missing Poteto mode section"
+  assert_grep "run the skill's playbook in-host and perform each role yourself" "$brief" \
+    "--herdr-lab brief missing in-host playbook line"
+  assert_grep "do not start role agents" "$brief" \
+    "--herdr-lab brief must forbid starting role agents"
+  assert_no_grep "rename your OWN agent pane" "$brief" \
+    "--herdr-lab brief must not authorize role agents"
+  assert_grep "the delivery path satisfies that step" "$brief" \
+    "--herdr-lab brief missing delivery-path satisfaction wording"
+  assert_poteto_section_after_herdr "$brief" "herdr-lab"
+  pass "fm-brief.sh: --herdr-lab Poteto mode runs in-host without role-agent authorization"
+}
+
 test_worker_role_scope
 test_script_parses
 test_no_heredoc_in_command_substitution
@@ -925,3 +1147,11 @@ test_pause_verb_override_renders_all_brief_scaffolds
 test_scout_and_secondmate_load_decision_hold_policy
 test_scout_and_secondmate_scaffold
 test_scout_lavish_line_follows_presentation_floor
+test_poteto_mode_default_on_for_ship_and_scout
+test_poteto_mode_absent_from_secondmate_charter
+test_poteto_mode_invalid_still_scaffolds_secondmate
+test_poteto_mode_off_omits_section
+test_poteto_mode_explicit_on_includes_section
+test_poteto_mode_invalid_refuses_without_writing
+test_poteto_mode_parser_boundaries
+test_poteto_mode_herdr_lab_runs_in_host

--- a/tests/fm-secondmate-harness.test.sh
+++ b/tests/fm-secondmate-harness.test.sh
@@ -15,14 +15,17 @@
 #   B) Inheritance. The primary pushes a declared, extensible set of LOCAL
 #      (gitignored) config items - config/crew-dispatch.json, config/crew-harness,
 #      config/backlog-backend, config/backend, config/herdr-presentation-spaces,
-#      config/startup-memory-budget, and config/trace-context -
+#      config/poteto-mode, config/startup-memory-budget, and config/trace-context -
 #      down into each secondmate home's config/, so the secondmate's OWN crewmates,
 #      dispatch profiles, backlog backend, runtime-backend default, Herdr
-#      presentation choice, startup-memory budget, and trace context inherit the
+#      presentation choice, Poteto mode brief default, startup-memory budget, and
+#      trace context inherit the
 #      primary's settings. For config/herdr-presentation-spaces, an absent
 #      primary file and an absent destination file both mean the same
 #      unconfigured default, so the generic absence mirror converges that item
 #      without deciding its release-dependent floor.
+#      For config/poteto-mode, an absent primary file mirrors as absence (default
+#      on for ship and scout briefs); explicit on/off propagate.
 #      It is primary-authoritative
 #      (re-pushed at secondmate spawn, on the bootstrap secondmate sweep, and by
 #      config push).
@@ -299,6 +302,7 @@ test_propagate_lib() {
   printf 'tmux\n' > "$src/backend"
   : > "$src/herdr-presentation-spaces"
   : > "$src/trace-context"
+  printf 'on\n' > "$src/poteto-mode"
   stdout="$d/clean-copy.out"
   stderr="$d/clean-copy.err"
   propagate_inheritable_config "$src" "$dest" >"$stdout" 2>"$stderr" || fail "propagate returned non-zero"
@@ -309,6 +313,7 @@ test_propagate_lib() {
   [ "$(cat "$dest/backlog-backend")" = manual ] || fail "backlog-backend not propagated"
   [ "$(cat "$dest/backend")" = tmux ] || fail "backend not propagated"
   [ -f "$dest/herdr-presentation-spaces" ] || fail "herdr-presentation-spaces not propagated"
+  [ "$(cat "$dest/poteto-mode")" = on ] || fail "poteto-mode not propagated"
   printf 'herdr\n' > "$dest/backend"
   propagate_inheritable_config "$src" "$dest"
   [ "$(cat "$dest/backend")" = tmux ] || fail "primary backend did not overwrite a divergent destination"
@@ -349,13 +354,14 @@ test_propagate_lib() {
   # 4. removing the source mirrors absence downstream (primary-authoritative)
   printf 'herdr\n' > "$dest/backend"
   rm -f "$src/crew-dispatch.json" "$src/crew-harness" "$src/backlog-backend" \
-    "$src/backend" "$src/herdr-presentation-spaces" "$src/trace-context"
+    "$src/backend" "$src/herdr-presentation-spaces" "$src/poteto-mode" "$src/trace-context"
   propagate_inheritable_config "$src" "$dest"
   [ -e "$dest/crew-dispatch.json" ] && fail "dispatch profile absence not mirrored downstream"
   [ -e "$dest/crew-harness" ] && fail "absence not mirrored downstream"
   [ -e "$dest/backlog-backend" ] && fail "backlog-backend absence not mirrored downstream"
   [ -e "$dest/backend" ] && fail "backend absence not mirrored downstream"
   [ -e "$dest/herdr-presentation-spaces" ] && fail "herdr-presentation-spaces absence not mirrored downstream"
+  [ -e "$dest/poteto-mode" ] && fail "poteto-mode absence not mirrored downstream"
   [ -e "$dest/trace-context" ] && fail "trace-context absence not mirrored downstream"
 
   rm -f "$dest/crew-harness"
@@ -2215,11 +2221,17 @@ SH
       "$ROOT/bin/fm-config-push.sh" > "$first_out" 2>&1
   ) &
   first_pid=$!
-  for _ in $(seq 1 100); do
-    [ -e "$entered" ] && break
+  # Wait until the fake send-keys path creates $entered, or until the child
+  # exits first (reap and fail with its status and captured output). The suite
+  # runner's outer timeout covers a true hang; do not guess a local duration.
+  while [ ! -e "$entered" ]; do
+    if ! kill -0 "$first_pid" 2>/dev/null; then
+      wait "$first_pid"
+      first_status=$?
+      fail "first config push exited $first_status before pointer delivery; output: $(cat "$first_out" 2>/dev/null || true)"
+    fi
     sleep 0.02
   done
-  [ -e "$entered" ] || fail "first config push did not reach pointer delivery"
   first_instr=$(reread_instruction_path "$w/sm") \
     || fail "first concurrent push did not publish its generation"
   printf 'two\n' > "$w/home/config/crew-harness"


### PR DESCRIPTION
## Intent

Od teraz każde zadanie, jakie trafia do agentów, ma być przez nich realizowane za pomocą skilla poteto-mode. Zaimplementuj taką zmianę w Firstmate, używając już teraz tego skilla.

## What Changed

- Add a default-on Poteto mode section to ship and scout briefs, with strict `config/poteto-mode` opt-out handling and Herdr-safe fallbacks.
- Inherit the Poteto mode setting into secondmate homes and document the configuration and briefing contract.
- Ignore Poteto run state and expand brief and config-inheritance coverage for the new behavior.

## Risk Assessment

🚨 High: Three intentional, reachable exceptions let agent work proceed without the universally required poteto-mode workflow.

## Testing

Focused brief and secondmate-harness suites passed; isolated product executions produced reviewer-visible ordinary, Herdr-lab, malformed-config, and inherited-config evidence. The worktree remained clean.

- Live validation: ✅ go - 4 of 4 scenarios driven live against the product

| Scenario | Result | Live | Evidence |
| --- | --- | --- | --- |
| Ship and scout briefs require Poteto mode by default | ✅ pass | live | Default worker brief with Poteto contract; All worker modes and inherited configuration |
| Herdr-lab worker brief uses the safe in-host Poteto contract | ✅ pass | live | Herdr-lab worker brief with in-host Poteto contract |
| Malformed poteto-mode configuration fails before creating a brief | ✅ pass | live | Invalid poteto-mode configuration refusal |
| A secondmate home inherits the primary Poteto configuration | ✅ pass | live | All worker modes and inherited configuration |

<details>
<summary>Evidence: Default worker brief with Poteto contract</summary>

Source: [Default worker brief with Poteto contract](https://github.com/auss/firstmate/blob/a4e875ce85f73c02cf6efb08afd1ca4382c35bf8/.no-mistakes/evidence/fm/fm-brief-poteto-mode/fm-brief-live.Ji6NyS/default-home/data/live-default/brief.md)

```text
You are a crewmate: an autonomous worker agent managed by firstmate. Work on your own; do not wait for a human.

# Task
## Captain's intent
{TASK}

## Firstmate spec
{FIRSTMATE_SPEC}

# Herdr lifecycle declaration - NOT ENABLED
**HARD SAFETY GATE:** this scaffold cannot inspect the task text filled in above.
If the task will start, stop, delete, restart, profile, or otherwise drive Herdr lifecycle behavior, stop and regenerate the brief with `--herdr-lab` before dispatch.
Do not add Herdr lifecycle commands to this unguarded brief by hand.
# Poteto mode
Run this task under the `poteto-mode` skill: invoke it (`/poteto-mode`, or your tool's skill loader) before any task work and follow the playbook it matches.
This section authorizes the skill's own role agents: you may rename your OWN agent pane to the skill's orchestrator name, create one run tab, split panes inside that run tab, and start, message, and close role agents and watchdog panes that YOU started through the skill's scripts, and that is not the Herdr lifecycle work the Herdr section above gates.
Never stop, delete, or restart a Herdr session or server, and never touch a tab, pane, or agent belonging to another run or to the captain's fleet.
Role agents work only inside this worktree, and the skill's run store (`.herdr-mail/`) is never committed.
If your tool cannot load the skill, proceed with this brief as written.
If the skill loads but Herdr is unavailable here (no `herdr` command or no `HERDR_PANE_ID`), follow its playbook in-host and perform each role yourself.
Name any fallback and its reason in your `done:` line.
This brief's safety rules, status protocol, and Definition of done win over the skill on any conflict.
Where the skill's playbook requires a review, validation, or shipping step that this brief's Definition of done already covers, the delivery path satisfies that step; do not run an additional independent review pass for the delivery path's sake and do not open a second PR.

# Setup
You are in a disposable git worktree of firstmate, at a detached HEAD on a clean default branch.

**Verify isolation before anything else.** Run `pwd -P` and `git rev-parse --show-toplevel`; both must resolve to the disposable task worktree you were launched in, such as a treehouse pool path or an Orca-managed worktree, not the primary checkout firstmate operates from.
The path check is authoritative: `git rev-parse --git-dir` and `git rev-parse --git-common-dir` can help inspect the repo, but they do not prove you are outside the primary checkout.
If the top-level path is the primary checkout or not the worktree you were launched in, STOP - do not branch or commit here - append `blocked: launched in primary checkout, not an isolated worktree` to the status file and stop.

1. First action: create your branch: `git checkout -b fm/live-default`
2. Run `no-mistakes doctor`; if it reports the repo is not initialized here, run `no-mistakes init`.

# Rules
1. Never push to the default branch. Never merge a PR.
2. Stay inside this worktree; modify nothing outside it.
3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.
4. Report status by appending one line:
   `echo "{state}: {one short line}" >> '~/.no-mistakes/evidence/01M2AAF9B1DQKYKJJ3YSVQEFJ6/fm-brief-live.Ji6NyS/default-home/state/live-default.status'`
   States: working, needs-decision, blocked, paused, done, failed.
   Each append wakes firstmate, so report sparingly: only phase changes a supervisor
   would act on (setup done, bug reproduced, fix implemented, validation passed) and the
   needs-decision/blocked/paused/done/failed states. No step-by-step FYI progress lines;
   firstmate reads your pane for that.
   Whenever you mention a PR anywhere - a status line, your terminal, a summary - write its full
   https:// URL exactly as the forge printed it, never a bare number such as "PR 108"; firstmate
   copies that URL from your line rather than assembling one.
   A mid-task `working:` line (including setup complete) is nonterminal: do not end the
   turn after it; continue the same stage until a defined `done:` gate under Definition of done.
   Use `paused: {why}` - distinct from `blocked:` - ONLY when you are deliberately idling on a
   known external wait you expect to clear on its own (an upstream release, a rate-limit reset,
   a scheduled window): firstmate then leaves your idle pane alone and rechecks it on a long
   cadence instead of treating it as a possible wedge. Use `blocked:` when you are stuck and need help.
5. If you hit the same obstacle twice, append `blocked: {why}` and stop; firstmate will help.
6. If a decision belongs above the implementation worker (product choices, destructive actions),
   append `needs-decision: {summary of options}` and stop. Firstmate will reply with the decision.
   For a no-mistakes ask-user gate specifically, escalate all ask-user findings as one event plus one snapshot file, using that same shape even when the gate holds only a single ask-user finding: write only the ask-user findings, verbatim and unparaphrased (id, severity, file, line, description, authority), to `~/.no-mistakes/evidence/01M2AAF9B1DQKYKJJ3YSVQEFJ6/fm-brief-live.Ji6NyS/default-home/data/live-default/nm-<run>-findings.txt`, then report the gate with
   `needs-decision [key=nm-<run>-<step>]: ask-user findings=<id1>,<id2>,... file=~/.no-mistakes/evidence/01M2AAF9B1DQKYKJJ3YSVQEFJ6/fm-brief-live.Ji6NyS/default-home/data/live-default/nm-<run>-findings.txt`
   naming every ask-user finding id from that gate. The status line only points at the file; it never restates or summarizes a finding's content.
   A decision or blocker you opened stays open until a `resolved` line carrying its exact key lands; a later `done:` or `working:` line never closes it, even when the answer is what started that work.
   Firstmate's reply normally writes that closing line at answer time; when a blocker or wait clears WITHOUT a firstmate reply, append `resolved: {how it cleared}` yourself (same `[key=<slug>]` if you opened it with one) as you resume.
7. Never stop, restart, or update the shared `no-mistakes` daemon - it is one instance serving
   every lane/home, so restarting it kills other lanes' in-flight pipeline runs; only firstmate
   manages the daemon.
   Before you append `blocked:` about the pipeline, run `no-mistakes daemon status` and
   `no-mistakes axi status`. If the daemon socket refuses connections or is missing, append
   `blocked: {the daemon error}` and stop even when the local run record still says running or
   fixing, because that record can be stale after the daemon exits. A run record failed with a
   daemon error is also a real block.
   Only after ruling out socket refusal, if the run is still running or fixing, reattach and keep
   going. A drive-call error, timeout, slow read, or generic unreachability is NOT a daemon error:
   the daemon accepts `respond` immediately and runs the round in the background, so a killed or
   timed-out call was only waiting for a read while the run kept working.

# Firstmate instruction inbox
Firstmate steers you through durable message files in '~/.no-mistakes/evidence/01M2AAF9B1DQKYKJJ3YSVQEFJ6/fm-brief-live.Ji6NyS/default-home/state/live-default.inbox'.
When a terminal message says an instruction is waiting there - and at any natural checkpoint when you are unsure - list '~/.no-mistakes/evidence/01M2AAF9B1DQKYKJJ3YSVQEFJ6/fm-brief-live.Ji6NyS/default-home/state/live-default.inbox'/*.msg, read and act on each message in numeric order, then acknowledge each handled message by moving it: `mv '~/.no-mistakes/evidence/01M2AAF9B1DQKYKJJ3YSVQEFJ6/fm-brief-live.Ji6NyS/default-home/state/live-default.inbox'/NNN.msg '~/.no-mistakes/evidence/01M2AAF9B1DQKYKJJ3YSVQEFJ6/fm-brief-live.Ji6NyS/default-home/state/live-default.inbox'/handled/`.
The move IS the acknowledgement: without it firstmate rings again and eventually treats you as stuck. An empty or absent inbox needs no action.

# Project memory
If `AGENTS.md` or `CLAUDE.md` already exists, or if this task produced durable project-intrinsic knowledge, run `~/.no-mistakes/worktrees/c7b2df826ee7/01M2AAF9B1DQKYKJJ3YSVQEFJ6/bin/fm-ensure-agents-md.sh .` in the worktree.
Record only project knowledge useful to almost every future session.
For anything the codebase already shows, prefer a pointer to the authoritative file, command, or doc over copying the detail.
If you touch a project `AGENTS.md`, follow `~/.no-mistakes/worktrees/c7b2df826ee7/01M2AAF9B1DQKYKJJ3YSVQEFJ6/bin/fm-ensure-agents-md.sh`'s self-governance contract in the same pass.
Keep it proportionate: skip `AGENTS.md` edits for trivial tasks that produced no durable project knowledge.

# Definition of done
Delivery contract: mode=no-mistakes
The task is complete only when committed on your branch.
When you believe it is complete, append `done: {summary}` to the status file and stop.
Firstmate will then instruct you to run /no-mistakes to validate and ship a PR.

You drive no-mistakes by responding to its gates, not by implementing fixes.
Follow the guidance no-mistakes itself provides for the mechanics: it loads when you invoke /no-mistakes, and `no-mistakes axi run --help` plus the `help` lines in each `axi` response are authoritative and version-matched to the installed binary.
When starting no-mistakes, pass `--intent` as only this brief's `## Captain's intent` subsection plus any later words the captain actually said.
For a legacy brief with no such subsection, include only words explicitly labeled `Captain:`, `Captain's words:`, `Captain's ask:`, or `Captain's intent:`; never copy its mixed `# Task` wholesale. If it has no provenance-marked captain words, stop and ask firstmate instead of starting no-mistakes.
Do not include `## Firstmate spec`, later Firstmate build constraints, or your own decisions and tradeoffs.
The `--intent` string you pass must be self-sufficient: that string plus the codebase must let a reader reconstruct roughly the same specification, without depending on a separate report, a PR, or context that lives only in this conversation.
When the captain's intent refers to a report, decision, or PR ("do items 1, 2, 3, and 7 of the report"), write the substance of the referenced items into `--intent` in the captain's terms, not only the pointer; that substance is the captain's ask by reference, while Firstmate's build instructions and your own decisions still stay out.
This replaces the no-mistakes skill's advice to enrich `--intent` with decisions and tradeoffs; that advice does not apply to Firstmate-dispatched work.
Do not hand-edit, commit, or fix findings yourself while a run is active - the pipeline applies every fix.

One drive call blocks until the next gate or outcome, which routinely outlives what your harness lets a single command run: Claude Code kills a command at ten minutes maximum, while one fix round is capped around thirty minutes and up to three rounds chain.
So background the drive call and poll `no-mistakes axi status` from a separate call instead of sitting in one blocking hold your harness will kill.
Where a harness's own command limit is not established, assume it bounds commands and use that same background-and-poll shape.
A killed or timed-out call is never evidence the daemon died: the daemon accepts your response immediately and runs the round in the background, so the call was only ever waiting for a read while the run kept working.
Reattach and keep going rather than reporting the pipeline blocked; rule 7 owns the checks that decide when a pipeline block is real.

Two firstmate-specific rules layer on top of that guidance:
- ask-user findings are never yours to answer: escalate to firstmate using rule 6's ask-user format and stop.
  Firstmate applies `ask-user-authority` and obtains any required captain decision.
  When the decision comes back, feed it to the gate with `no-mistakes axi respond` and let the pipeline apply it - do not route the question to "the user" or implement the fix yourself.
- NEVER pass `--yes` (or `-y`) to `no-mistakes axi run` or `no-mistakes axi respond`. It is banned fleet-wide.
  It auto-resolves every gate including ask-user findings with no escalation, and answering your own ask-user finding is a hard rule violation.

After /no-mistakes reports CI green (the CI-ready return point - do not wait for it to keep monitoring in the background until merge), append `done: PR {url} checks green` and stop. You are finished.
```
</details>
<details>
<summary>Evidence: Herdr-lab worker brief with in-host Poteto contract</summary>

Source: [Herdr-lab worker brief with in-host Poteto contract](https://github.com/auss/firstmate/blob/a4e875ce85f73c02cf6efb08afd1ca4382c35bf8/.no-mistakes/evidence/fm/fm-brief-poteto-mode/fm-brief-live.Ji6NyS/lab-home/data/live-lab/brief.md)

```text
You are a crewmate: an autonomous worker agent managed by firstmate. Work on your own; do not wait for a human.

# Task
## Captain's intent
{TASK}

## Firstmate spec
{FIRSTMATE_SPEC}

# Herdr isolation - HARD SAFETY CONTRACT
This brief was explicitly scaffolded with `--herdr-lab` because the task will drive Herdr lifecycle behavior.
On Herdr 0.7.3 the API socket is not relocatable by `HERDR_CONFIG_PATH`, `XDG_CONFIG_HOME`, or `HOME`.
A named non-`default` session plus a trailing `--session <name>` on every call is the only viable local isolation.

1. Set `HERDR_LAB_HELPER='~/.no-mistakes/worktrees/c7b2df826ee7/01M2AAF9B1DQKYKJJ3YSVQEFJ6/bin/fm-herdr-lab.sh'` and generate the session name with `HERDR_LAB_SESSION=$("$HERDR_LAB_HELPER" name live-lab)`.
   Install `trap '"$HERDR_LAB_HELPER" teardown "$HERDR_LAB_SESSION"' EXIT` before provisioning, then provision only with `"$HERDR_LAB_HELPER" provision "$HERDR_LAB_SESSION"`.
2. Run every task-specific non-lifecycle Herdr command through `"$HERDR_LAB_HELPER" run "$HERDR_LAB_SESSION" <arguments...>`.
   The helper appends the required trailing `--session "$HERDR_LAB_SESSION"`; `HERDR_SESSION` alone is never accepted as isolation.
3. Teardown only through `"$HERDR_LAB_HELPER" teardown "$HERDR_LAB_SESSION"`.
   It re-checks refuse-default immediately before stop and again immediately before delete, and fails closed on ambiguity.
4. If an experiment requires a deliberate mid-run session stop, use only `"$HERDR_LAB_HELPER" stop "$HERDR_LAB_SESSION"`; it performs the same immediate refuse-default check.
5. Forbidden commands: direct `herdr server stop`, every other server-global operation such as `herdr server live-handoff` or reload/update operations, direct `herdr session stop`, direct `herdr session delete`, and any Herdr call scoped only by ambient or inline `HERDR_SESSION`.
6. The helper records the live default session before provisioning and verifies the identical fleet state after teardown.
   A missing, stopped, or changed default session is a hard tripwire failure, never a cleanup warning to ignore.

Never bypass the helper, even for a read-only lifecycle probe or cleanup after failure.
The captain fleet uses the running `default` session.
# Poteto mode
Run this task under the `poteto-mode` skill: invoke it (`/poteto-mode`, or your tool's skill loader) before any task work and follow the playbook it matches.
The lab contract above governs every Herdr call, so run the skill's playbook in-host and perform each role yourself; do not start role agents.
If your tool cannot load the skill, proceed with this brief as written.
If the skill loads but Herdr is unavailable here (no `herdr` command or no `HERDR_PANE_ID`), follow its playbook in-host and perform each role yourself.
Name any fallback and its reason in your `done:` line.
This brief's safety rules, status protocol, and Definition of done win over the skill on any conflict.
Where the skill's playbook requires a review, validation, or shipping step that this brief's Definition of done already covers, the delivery path satisfies that step; do not run an additional independent review pass for the delivery path's sake and do not open a second PR.

# Setup
You are in a disposable git worktree of firstmate, at a detached HEAD on a clean default branch.

**Verify isolation before anything else.** Run `pwd -P` and `git rev-parse --show-toplevel`; both must resolve to the disposable task worktree you were launched in, such as a treehouse pool path or an Orca-managed worktree, not the primary checkout firstmate operates from.
The path check is authoritative: `git rev-parse --git-dir` and `git rev-parse --git-common-dir` can help inspect the repo, but they do not prove you are outside the primary checkout.
If the top-level path is the primary checkout or not the worktree you were launched in, STOP - do not branch or commit here - append `blocked: launched in primary checkout, not an isolated worktree` to the status file and stop.

1. First action: create your branch: `git checkout -b fm/live-lab`
2. Run `no-mistakes doctor`; if it reports the repo is not initialized here, run `no-mistakes init`.

# Rules
1. Never push to the default branch. Never merge a PR.
2. Stay inside this worktree; modify nothing outside it.
3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.
4. Report status by appending one line:
   `echo "{state}: {one short line}" >> '~/.no-mistakes/evidence/01M2AAF9B1DQKYKJJ3YSVQEFJ6/fm-brief-live.Ji6NyS/lab-home/state/live-lab.status'`
   States: working, needs-decision, blocked, paused, done, failed.
   Each append wakes firstmate, so report sparingly: only phase changes a supervisor
   would act on (setup done, bug reproduced, fix implemented, validation passed) and the
   needs-decision/blocked/paused/done/failed states. No step-by-step FYI progress lines;
   firstmate reads your pane for that.
   Whenever you mention a PR anywhere - a status line, your terminal, a summary - write its full
   https:// URL exactly as the forge printed it, never a bare number such as "PR 108"; firstmate
   copies that URL from your line rather than assembling one.
   A mid-task `working:` line (including setup complete) is nonterminal: do not end the
   turn after it; continue the same stage until a defined `done:` gate under Definition of done.
   Use `paused: {why}` - distinct from `blocked:` - ONLY when you are deliberately idling on a
   known external wait you expect to clear on its own (an upstream release, a rate-limit reset,
   a scheduled window): firstmate then leaves your idle pane alone and rechecks it on a long
   cadence instead of treating it as a possible wedge. Use `blocked:` when you are stuck and need help.
5. If you hit the same obstacle twice, append `blocked: {why}` and stop; firstmate will help.
6. If a decision belongs above the implementation worker (product choices, destructive actions),
   append `needs-decision: {summary of options}` and stop. Firstmate will reply with the decision.
   For a no-mistakes ask-user gate specifically, escalate all ask-user findings as one event plus one snapshot file, using that same shape even when the gate holds only a single ask-user finding: write only the ask-user findings, verbatim and unparaphrased (id, severity, file, line, description, authority), to `~/.no-mistakes/evidence/01M2AAF9B1DQKYKJJ3YSVQEFJ6/fm-brief-live.Ji6NyS/lab-home/data/live-lab/nm-<run>-findings.txt`, then report the gate with
   `needs-decision [key=nm-<run>-<step>]: ask-user findings=<id1>,<id2>,... file=~/.no-mistakes/evidence/01M2AAF9B1DQKYKJJ3YSVQEFJ6/fm-brief-live.Ji6NyS/lab-home/data/live-lab/nm-<run>-findings.txt`
   naming every ask-user finding id from that gate. The status line only points at the file; it never restates or summarizes a finding's content.
   A decision or blocker you opened stays open until a `resolved` line carrying its exact key lands; a later `done:` or `working:` line never closes it, even when the answer is what started that work.
   Firstmate's reply normally writes that closing line at answer time; when a blocker or wait clears WITHOUT a firstmate reply, append `resolved: {how it cleared}` yourself (same `[key=<slug>]` if you opened it with one) as you resume.
7. Never stop, restart, or update the shared `no-mistakes` daemon - it is one instance serving
   every lane/home, so restarting it kills other lanes' in-flight pipeline runs; only firstmate
   manages the daemon.
   Before you append `blocked:` about the pipeline, run `no-mistakes daemon status` and
   `no-mistakes axi status`. If the daemon socket refuses connections or is missing, append
   `blocked: {the daemon error}` and stop even when the local run record still says running or
   fixing, because that record can be stale after the daemon exits. A run record failed with a
   daemon error is also a real block.
   Only after ruling out socket refusal, if the run is still running or fixing, reattach and keep
   going. A drive-call error, timeout, slow read, or generic unreachability is NOT a daemon error:
   the daemon accepts `respond` immediately and runs the round in the background, so a killed or
   timed-out call was only waiting for a read while the run kept working.

# Firstmate instruction inbox
Firstmate steers you through durable message files in '~/.no-mistakes/evidence/01M2AAF9B1DQKYKJJ3YSVQEFJ6/fm-brief-live.Ji6NyS/lab-home/state/live-lab.inbox'.
When a terminal message says an instruction is waiting there - and at any natural checkpoint when you are unsure - list '~/.no-mistakes/evidence/01M2AAF9B1DQKYKJJ3YSVQEFJ6/fm-brief-live.Ji6NyS/lab-home/state/live-lab.inbox'/*.msg, read and act on each message in numeric order, then acknowledge each handled message by moving it: `mv '~/.no-mistakes/evidence/01M2AAF9B1DQKYKJJ3YSVQEFJ6/fm-brief-live.Ji6NyS/lab-home/state/live-lab.inbox'/NNN.msg '~/.no-mistakes/evidence/01M2AAF9B1DQKYKJJ3YSVQEFJ6/fm-brief-live.Ji6NyS/lab-home/state/live-lab.inbox'/handled/`.
The move IS the acknowledgement: without it firstmate rings again and eventually treats you as stuck. An empty or absent inbox needs no action.

# Project memory
If `AGENTS.md` or `CLAUDE.md` already exists, or if this task produced durable project-intrinsic knowledge, run `~/.no-mistakes/worktrees/c7b2df826ee7/01M2AAF9B1DQKYKJJ3YSVQEFJ6/bin/fm-ensure-agents-md.sh .` in the worktree.
Record only project knowledge useful to almost every future session.
For anything the codebase already shows, prefer a pointer to the authoritative file, command, or doc over copying the detail.
If you touch a project `AGENTS.md`, follow `~/.no-mistakes/worktrees/c7b2df826ee7/01M2AAF9B1DQKYKJJ3YSVQEFJ6/bin/fm-ensure-agents-md.sh`'s self-governance contract in the same pass.
Keep it proportionate: skip `AGENTS.md` edits for trivial tasks that produced no durable project knowledge.

# Definition of done
Delivery contract: mode=no-mistakes
The task is complete only when committed on your branch.
When you believe it is complete, append `done: {summary}` to the status file and stop.
Firstmate will then instruct you to run /no-mistakes to validate and ship a PR.

You drive no-mistakes by responding to its gates, not by implementing fixes.
Follow the guidance no-mistakes itself provides for the mechanics: it loads when you invoke /no-mistakes, and `no-mistakes axi run --help` plus the `help` lines in each `axi` response are authoritative and version-matched to the installed binary.
When starting no-mistakes, pass `--intent` as only this brief's `## Captain's intent` subsection plus any later words the captain actually said.
For a legacy brief with no such subsection, include only words explicitly labeled `Captain:`, `Captain's words:`, `Captain's ask:`, or `Captain's intent:`; never copy its mixed `# Task` wholesale. If it has no provenance-marked captain words, stop and ask firstmate instead of starting no-mistakes.
Do not include `## Firstmate spec`, later Firstmate build constraints, or your own decisions and tradeoffs.
The `--intent` string you pass must be self-sufficient: that string plus the codebase must let a reader reconstruct roughly the same specification, without depending on a separate report, a PR, or context that lives only in this conversation.
When the captain's intent refers to a report, decision, or PR ("do items 1, 2, 3, and 7 of the report"), write the substance of the referenced items into `--intent` in the captain's terms, not only the pointer; that substance is the captain's ask by reference, while Firstmate's build instructions and your own decisions still stay out.
This replaces the no-mistakes skill's advice to enrich `--intent` with decisions and tradeoffs; that advice does not apply to Firstmate-dispatched work.
Do not hand-edit, commit, or fix findings yourself while a run is active - the pipeline applies every fix.

One drive call blocks until the next gate or outcome, which routinely outlives what your harness lets a single command run: Claude Code kills a command at ten minutes maximum, while one fix round is capped around thirty minutes and up to three rounds chain.
So background the drive call and poll `no-mistakes axi status` from a separate call instead of sitting in one blocking hold your harness will kill.
Where a harness's own command limit is not established, assume it bounds commands and use that same background-and-poll shape.
A killed or timed-out call is never evidence the daemon died: the daemon accepts your response immediately and runs the round in the background, so the call was only ever waiting for a read while the run kept working.
Reattach and keep going rather than reporting the pipeline blocked; rule 7 owns the checks that decide when a pipeline block is real.

Two firstmate-specific rules layer on top of that guidance:
- ask-user findings are never yours to answer: escalate to firstmate using rule 6's ask-user format and stop.
  Firstmate applies `ask-user-authority` and obtains any required captain decision.
  When the decision comes back, feed it to the gate with `no-mistakes axi respond` and let the pipeline apply it - do not route the question to "the user" or implement the fix yourself.
- NEVER pass `--yes` (or `-y`) to `no-mistakes axi run` or `no-mistakes axi respond`. It is banned fleet-wide.
  It auto-resolves every gate including ask-user findings with no escalation, and answering your own ask-user finding is a hard rule violation.

After /no-mistakes reports CI green (the CI-ready return point - do not wait for it to keep monitoring in the background until merge), append `done: PR {url} checks green` and stop. You are finished.
```
</details>
<details>
<summary>Evidence: Invalid poteto-mode configuration refusal</summary>

Source: [Invalid poteto-mode configuration refusal](https://github.com/auss/firstmate/blob/a4e875ce85f73c02cf6efb08afd1ca4382c35bf8/.no-mistakes/evidence/fm/fm-brief-poteto-mode/fm-brief-live.Ji6NyS/invalid-verification.txt)

`exit=1; brief=absent`

```text
exit=1; brief=absent
```
</details>
<details>
<summary>Evidence: All worker modes and inherited configuration</summary>

Source: [All worker modes and inherited configuration](https://github.com/auss/firstmate/blob/a4e875ce85f73c02cf6efb08afd1ca4382c35bf8/.no-mistakes/evidence/fm/fm-brief-poteto-mode/fm-brief-live.Ji6NyS/modes-and-inheritance-verification.txt)

<code>direct-PR=Poteto mode&#10;local-only=Poteto mode&#10;scout=Poteto mode&#10;inherited-secondmate-home=Poteto mode</code>

```text
direct-PR=Poteto mode
local-only=Poteto mode
scout=Poteto mode
inherited-secondmate-home=Poteto mode
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"1ba107dea49f0579b36eedce3d92d46a8aadb1bb","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}],"live_validation":{"verdict":"go","live":4,"total":4}} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>🔧 **Rebase** - 2 issues found → auto-fixed ✅</summary>

- ⚠️ `bin/fm-config-inherit-lib.sh` - merge conflict rebasing onto origin/main
- ⚠️ `tests/fm-brief.test.sh` - merge conflict rebasing onto origin/main

🔧 Fix applied.
✅ Re-checked - no issues remain.
</details>

<details>
<summary>⚠️ **Review** - 3 errors</summary>

- 🚨 `bin/fm-brief.sh:341` - The required criterion says every task sent to agents must use poteto-mode. A ship/scout with `config/poteto-mode=off` reaches this branch, emits no section, and proceeds; remove this unrequired opt-out (and its inheritance) unless the captain explicitly authorizes exceptions.
- 🚨 `bin/fm-brief.sh:391` - `--herdr-lab` briefs tell the worker to perform every Poteto role in-host, and ordinary briefs permit both a missing skill and missing Herdr to proceed. Those reachable paths do not execute the required poteto-mode workflow, whose playbook requires separate role agents; decide a safe Poteto-compatible Herdr-lab design or fail closed instead of continuing without the skill.
- 🚨 `bin/fm-brief.sh:321` - Secondmate charters exit before the new Poteto section. Yet the charter directs a secondmate to perform marked requests, including investigations, itself. That is a concrete agent-task path missing the required skill; either include a compatible Poteto contract for secondmates or explicitly narrow the universal requirement to crewmate ship/scout tasks.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- Live validation: ✅ go - 4 of 4 scenarios driven live against the product

| Scenario | Result | Live | Evidence |
| --- | --- | --- | --- |
| Ship and scout briefs require Poteto mode by default | ✅ pass | live | Default worker brief with Poteto contract; All worker modes and inherited configuration |
| Herdr-lab worker brief uses the safe in-host Poteto contract | ✅ pass | live | Herdr-lab worker brief with in-host Poteto contract |
| Malformed poteto-mode configuration fails before creating a brief | ✅ pass | live | Invalid poteto-mode configuration refusal |
| A secondmate home inherits the primary Poteto configuration | ✅ pass | live | All worker modes and inherited configuration |

- `bash tests/fm-brief.test.sh`
- `bash tests/fm-secondmate-harness.test.sh`
- <code>Isolated real `bin/fm-brief.sh` runs for no-mistakes, direct-PR, local-only, scout, --herdr-lab, and invalid configuration</code>
- <code>Real `propagate_inheritable_config` execution followed by `bin/fm-brief.sh` from the inherited secondmate home</code>
- `git status --short`
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
