### PR TITLE
test(watch): skip away-record backlog-hold triage without tasks-axi

### DIFF
--- a/tests/fm-watch-triage.test.sh
+++ b/tests/fm-watch-triage.test.sh
@@ -4665,6 +4665,8 @@ test_live_captain_held_first_sight_silenced_by_away_record() {
 
 test_backlog_hold_never_rechecked_while_away_record_exists() {
   local dir out capture wakes
+  command -v tasks-axi >/dev/null 2>&1 \
+    || { echo "skip: tasks-axi not found (away-record backlog hold)"; return 0; }
   dir=$(make_hold_home away-record-backlog-hold 'done: PR https://example.test/pr/9 checks green' hold) \
     || fail "could not build the backlog-hold fixture"
   out="$dir/watch.out"; capture="$dir/pane.txt"


### PR DESCRIPTION
## Intent

Add the missing tasks-axi skip-guard to the away-record backlog-hold watcher triage test so hosts without tasks-axi skip it like its sibling tests instead of hard-failing the fixture build

## What Changed

- Added a `command -v tasks-axi` guard to `test_backlog_hold_never_rechecked_while_away_record_exists` in `tests/fm-watch-triage.test.sh`, causing it to print a skip message and return early on hosts without `tasks-axi` instead of failing while building the fixture.
- Brings this test in line with its sibling tests in the same file that already gate on `tasks-axi` availability before constructing their fixtures.

## Risk Assessment

✅ Low: A one-line guard added to a single test, mirroring four identical existing sibling guards in the same file, correctly placed before the tasks-axi-dependent fixture build.

## Testing

Reproduced the reported failure and its fix live: on this tasks-axi-less host, a pre-fix reconstruction of the test hard-fails with `not ok - could not build the backlog-hold fixture` (exit 1), while the shipped post-fix code prints `skip: tasks-axi not found (away-record backlog hold)` and passes (exit 0) — exactly mirroring the four sibling guards already in the file. Did not run the entire fm-watch-triage.test.sh file end-to-end (140+ subprocess-driven tests, well beyond this change's scope and against the "don't run broad regression locally" guidance); the isolated reconstruction directly exercises the real bin/fm-watch.sh fixture-build path this change touches.

- Live validation: ✅ go - 3 of 3 scenarios driven live against the product

| Scenario | Result | Live | Evidence |
| --- | --- | --- | --- |
| Host without tasks-axi skips the away-record backlog-hold test | ✅ pass | live | Isolated reconstruction of test_backlog_hold_never_rechecked_while_away_record_exists (post-fix code, real bin/fm-watch.sh and real make_hold_home) run on this host (no tasks-axi in PATH): printed &#39;sk… |
| Without the guard, the same host hard-fails the fixture build (regression reproduction) | ✅ pass | live | Reconstruction with the two added guard lines removed, run on the same tasks-axi-less host: printed &#39;not ok - could not build the backlog-hold fixture&#39; and exited 1, confirming the bug this change fix… |
| New guard matches the pattern of its sibling tasks-axi guards | ✅ pass | live | grep of tests/fm-watch-triage.test.sh shows the new guard (lines 4668-4669) is structurally identical (command -v tasks-axi check, same echo/skip/return-0 form) to the four existing sibling guards at… |

<details>
<summary>Evidence: Pre-fix vs post-fix behavior on a tasks-axi-less host</summary>

```text
=== PRE-FIX (guard removed) ===
not ok - could not build the backlog-hold fixture
exit:1
=== POST-FIX (current) ===
skip: tasks-axi not found (away-record backlog hold)
ok - backlog-hold away-record (postfix)
exit:0
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"65cec10dc2198ef1f0a094f05593a93c7301630d","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}],"live_validation":{"verdict":"go","live":3,"total":3}} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- Live validation: ✅ go - 3 of 3 scenarios driven live against the product

| Scenario | Result | Live | Evidence |
| --- | --- | --- | --- |
| Host without tasks-axi skips the away-record backlog-hold test | ✅ pass | live | Isolated reconstruction of test_backlog_hold_never_rechecked_while_away_record_exists (post-fix code, real bin/fm-watch.sh and real make_hold_home) run on this host (no tasks-axi in PATH): printed &#39;sk… |
| Without the guard, the same host hard-fails the fixture build (regression reproduction) | ✅ pass | live | Reconstruction with the two added guard lines removed, run on the same tasks-axi-less host: printed &#39;not ok - could not build the backlog-hold fixture&#39; and exited 1, confirming the bug this change fix… |
| New guard matches the pattern of its sibling tasks-axi guards | ✅ pass | live | grep of tests/fm-watch-triage.test.sh shows the new guard (lines 4668-4669) is structurally identical (command -v tasks-axi check, same echo/skip/return-0 form) to the four existing sibling guards at… |

- `Isolated reconstruction of test_backlog_hold_never_rechecked_while_away_record_exists (current/post-fix code) run directly with bash against this host, which has no tasks-axi binary`
- `Same reconstruction with the two guard lines removed (pre-fix behavior) run directly with bash on the same host`
- <code>grep comparison of the new guard lines against the four existing sibling `command -v tasks-axi` guards in tests/fm-watch-triage.test.sh (lines 2517-2518, 2563-2564, 2596-2597, 2637-2638)</code>
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>⚠️ **Lint** - 1 warning</summary>

- ⚠️ linter found issues (exit code 1)

🔧 No changes applied.
1 warning still open:

- ⚠️ linter found issues (exit code 1)
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
