### PR TITLE
fix(bin): drop unverified PR merge claims from crew-state reader

### DIFF
--- a/bin/fm-crew-state.sh
+++ b/bin/fm-crew-state.sh
@@ -65,6 +65,18 @@
 #      FAILED record whose daemon an explicit probe proves down reads unknown,
 #      never failed: an instrument failure must not read as work failure
 #      (nm_daemon_probe_down).
+#      A terminal outcome maps to `done` as a statement about the PIPELINE
+#      only: this reader never queries the forge, so it can never report that
+#      a PR merged, closed, or is reviewable right now. `passed` does not even
+#      establish green checks - a step whose gate cannot return a valid verdict
+#      may be SKIPPED with authorization and the run still ends passed - and
+#      `checks-passed` records checks green at pipeline time, not now. Both
+#      details therefore report PR state as unconfirmed and send the reader to
+#      the forge before any landing-dependent action such as teardown (pinned
+#      by tests/fm-crew-state.test.sh's two terminal-outcome PR-claim cases;
+#      2026-09-10 mp-chat-grounding-fixes incident). The ci-log-tail readings
+#      above are different: their green-check and held-for-merge details rest
+#      on positive evidence read from the run's own ci log.
 #   3. Reconcile the status log: if its last line says needs-decision/blocked but
 #      the run-step shows the run moved on, the log is deterministically stale and
 #      is flagged superseded. A genuinely parked run plus a needs-decision log

--- a/bin/fm-crew-state.sh
+++ b/bin/fm-crew-state.sh
@@ -65,18 +65,6 @@
 #      FAILED record whose daemon an explicit probe proves down reads unknown,
 #      never failed: an instrument failure must not read as work failure
 #      (nm_daemon_probe_down).
-#      A terminal outcome maps to `done` as a statement about the PIPELINE
-#      only: this reader never queries the forge, so it can never report that
-#      a PR merged, closed, or is reviewable right now. `passed` does not even
-#      establish green checks - a step whose gate cannot return a valid verdict
-#      may be SKIPPED with authorization and the run still ends passed - and
-#      `checks-passed` records checks green at pipeline time, not now. Both
-#      details therefore report PR state as unconfirmed and send the reader to
-#      the forge before any landing-dependent action such as teardown (pinned
-#      by tests/fm-crew-state.test.sh's two terminal-outcome PR-claim cases;
-#      2026-09-10 mp-chat-grounding-fixes incident). The ci-log-tail readings
-#      above are different: their green-check and held-for-merge details rest
-#      on positive evidence read from the run's own ci log.
 #   3. Reconcile the status log: if its last line says needs-decision/blocked but
 #      the run-step shows the run moved on, the log is deterministically stale and
 #      is flagged superseded. A genuinely parked run plus a needs-decision log

--- a/bin/fm-crew-state.sh
+++ b/bin/fm-crew-state.sh
@@ -66,11 +66,14 @@
 #      never failed: an instrument failure must not read as work failure
 #      (nm_daemon_probe_down).
 #      A terminal outcome maps to `done` as a statement about the PIPELINE
-#      only: this reader never queries the forge, so it cannot report that a
-#      PR merged, closed, or is reviewable now. `passed` does not even
-#      establish green checks - a step whose gate cannot return a valid
-#      verdict may be SKIPPED with authorization and the run still ends
-#      passed - so both terminal details report PR state as unconfirmed.
+#      only: the `passed` and `checks-passed` details rest on no forge
+#      evidence, and `passed` carries no green-check claim either, since a
+#      step whose gate returns no valid verdict may be SKIPPED with
+#      authorization while the run still ends passed. Both report PR state
+#      as unconfirmed and send the reader to the forge before any
+#      landing-dependent action. The ci-log-tail readings above are the
+#      exception: held-for-merge and ready-for-review rest on positive
+#      evidence from the run's own ci step log (nm_ci_checks_state).
 #   3. Reconcile the status log: if its last line says needs-decision/blocked but
 #      the run-step shows the run moved on, the log is deterministically stale and
 #      is flagged superseded. A genuinely parked run plus a needs-decision log

--- a/bin/fm-crew-state.sh
+++ b/bin/fm-crew-state.sh
@@ -661,8 +661,8 @@ if [ "$HAVE_RUN" = 1 ]; then
 
     if [ -n "$outcome" ]; then
       case "$outcome" in
-        passed)        RUN_STATE="done"; RUN_DETAIL="run passed: PR merged/closed" ;;
-        checks-passed) RUN_STATE="done"; RUN_DETAIL="checks green: PR ready for review" ;;
+        passed)        RUN_STATE="done"; RUN_DETAIL="run passed: PR merge unconfirmed; check forge" ;;
+        checks-passed) RUN_STATE="done"; RUN_DETAIL="checks passed: PR state unconfirmed; check forge" ;;
         failed)
           if nm_reclassify_failed_run_as_held_green; then :; else
             RUN_STATE=failed; RUN_DETAIL="run failed"

--- a/bin/fm-crew-state.sh
+++ b/bin/fm-crew-state.sh
@@ -65,6 +65,12 @@
 #      FAILED record whose daemon an explicit probe proves down reads unknown,
 #      never failed: an instrument failure must not read as work failure
 #      (nm_daemon_probe_down).
+#      A terminal outcome maps to `done` as a statement about the PIPELINE
+#      only: this reader never queries the forge, so it cannot report that a
+#      PR merged, closed, or is reviewable now. `passed` does not even
+#      establish green checks - a step whose gate cannot return a valid
+#      verdict may be SKIPPED with authorization and the run still ends
+#      passed - so both terminal details report PR state as unconfirmed.
 #   3. Reconcile the status log: if its last line says needs-decision/blocked but
 #      the run-step shows the run moved on, the log is deterministically stale and
 #      is flagged superseded. A genuinely parked run plus a needs-decision log

--- a/tests/fm-crew-state.test.sh
+++ b/tests/fm-crew-state.test.sh
@@ -378,25 +378,6 @@ outcome: passed
 EOF
 }
 
-# A passed pipeline can include an authorized skipped CI step when its gate
-# cannot return a valid verdict, so the outcome does not establish forge state.
-run_passed_ci_skipped() {  # <branch>
-  cat <<EOF
-run:
-  id: "01RUN"
-  branch: $1
-  status: completed
-  head: "${FM_FAKE_RUN_HEAD:-abc1234}"
-  pr: "https://github.com/o/r/pull/423"
-  findings: none
-outcome: passed
-steps[3]{step,status,findings,duration_ms}:
-  test,completed,0,0
-  ci,skipped,0,0
-  push,completed,0,0
-EOF
-}
-
 run_checks_passed() {  # <branch>
   cat <<EOF
 run:
@@ -987,19 +968,19 @@ test_terminal_passed() {
   pass "terminal passed run is authoritative"
 }
 
-test_terminal_passed_with_skipped_ci_does_not_claim_pr_landed() {
+test_terminal_passed_does_not_claim_pr_landed() {
   reset_fakes
-  local d; d=$(new_case passed-ci-skipped)
-  make_repo_on_branch "$d/wt" fm/feat-passed-ci-skipped
+  local d; d=$(new_case passed-pr-claim)
+  make_repo_on_branch "$d/wt" fm/feat-passed-pr-claim
   make_fakebin "$d" >/dev/null
-  fm_write_meta "$d/state/feat-passed-ci-skipped.meta" "window=fm:fm-feat-passed-ci-skipped" "worktree=$d/wt" "kind=ship"
-  FM_FAKE_AXI_STATUS="$(run_passed_ci_skipped fm/feat-passed-ci-skipped)"
-  local out; out=$(run_crew_state "$d" feat-passed-ci-skipped)
-  assert_contains "$out" "state: done" "passed run with skipped CI remains terminal"
-  assert_contains "$out" "source: run-step" "passed run with skipped CI remains run-step sourced"
-  assert_not_contains "$out" "PR merged/closed" "passed run with skipped CI must not claim the PR landed"
+  fm_write_meta "$d/state/feat-passed-pr-claim.meta" "window=fm:fm-feat-passed-pr-claim" "worktree=$d/wt" "kind=ship"
+  FM_FAKE_AXI_STATUS="$(run_passed fm/feat-passed-pr-claim)"
+  local out; out=$(run_crew_state "$d" feat-passed-pr-claim)
+  assert_contains "$out" "state: done" "passed run remains terminal"
+  assert_contains "$out" "source: run-step" "passed run remains run-step sourced"
+  assert_not_contains "$out" "PR merged/closed" "passed run must not claim the PR landed"
   assert_contains "$out" "run passed: PR merge unconfirmed; check forge" "passed run must direct the supervisor to verify merge state"
-  pass "passed run with skipped CI does not claim the PR landed"
+  pass "passed run does not claim the PR landed"
 }
 
 test_terminal_checks_passed_does_not_claim_pr_ready() {
@@ -2569,7 +2550,7 @@ test_ci_fixing_after_green_stays_working
 test_top_level_fixing_ci_running_after_green_stays_working
 test_top_level_fixing_done_log_stays_working
 test_terminal_passed
-test_terminal_passed_with_skipped_ci_does_not_claim_pr_landed
+test_terminal_passed_does_not_claim_pr_landed
 test_terminal_checks_passed_does_not_claim_pr_ready
 test_terminal_failed
 test_terminal_failed_ci_orphan_after_green_reads_done

--- a/tests/fm-crew-state.test.sh
+++ b/tests/fm-crew-state.test.sh
@@ -378,6 +378,38 @@ outcome: passed
 EOF
 }
 
+# A passed pipeline can include an authorized skipped CI step when its gate
+# cannot return a valid verdict, so the outcome does not establish forge state.
+run_passed_ci_skipped() {  # <branch>
+  cat <<EOF
+run:
+  id: "01RUN"
+  branch: $1
+  status: completed
+  head: "${FM_FAKE_RUN_HEAD:-abc1234}"
+  pr: "https://github.com/o/r/pull/423"
+  findings: none
+outcome: passed
+steps[3]{step,status,findings,duration_ms}:
+  test,completed,0,0
+  ci,skipped,0,0
+  push,completed,0,0
+EOF
+}
+
+run_checks_passed() {  # <branch>
+  cat <<EOF
+run:
+  id: "01RUN"
+  branch: $1
+  status: completed
+  head: "${FM_FAKE_RUN_HEAD:-abc1234}"
+  pr: "https://github.com/o/r/pull/424"
+  findings: none
+outcome: checks-passed
+EOF
+}
+
 run_failed() {  # <branch>
   cat <<EOF
 run:
@@ -953,6 +985,36 @@ test_terminal_passed() {
   assert_contains "$out" "state: done" "passed run -> done"
   assert_contains "$out" "source: run-step" "passed -> run-step source"
   pass "terminal passed run is authoritative"
+}
+
+test_terminal_passed_with_skipped_ci_does_not_claim_pr_landed() {
+  reset_fakes
+  local d; d=$(new_case passed-ci-skipped)
+  make_repo_on_branch "$d/wt" fm/feat-passed-ci-skipped
+  make_fakebin "$d" >/dev/null
+  fm_write_meta "$d/state/feat-passed-ci-skipped.meta" "window=fm:fm-feat-passed-ci-skipped" "worktree=$d/wt" "kind=ship"
+  FM_FAKE_AXI_STATUS="$(run_passed_ci_skipped fm/feat-passed-ci-skipped)"
+  local out; out=$(run_crew_state "$d" feat-passed-ci-skipped)
+  assert_contains "$out" "state: done" "passed run with skipped CI remains terminal"
+  assert_contains "$out" "source: run-step" "passed run with skipped CI remains run-step sourced"
+  assert_not_contains "$out" "PR merged/closed" "passed run with skipped CI must not claim the PR landed"
+  assert_contains "$out" "run passed: PR merge unconfirmed; check forge" "passed run must direct the supervisor to verify merge state"
+  pass "passed run with skipped CI does not claim the PR landed"
+}
+
+test_terminal_checks_passed_does_not_claim_pr_ready() {
+  reset_fakes
+  local d; d=$(new_case checks-passed)
+  make_repo_on_branch "$d/wt" fm/feat-checks-passed
+  make_fakebin "$d" >/dev/null
+  fm_write_meta "$d/state/feat-checks-passed.meta" "window=fm:fm-feat-checks-passed" "worktree=$d/wt" "kind=ship"
+  FM_FAKE_AXI_STATUS="$(run_checks_passed fm/feat-checks-passed)"
+  local out; out=$(run_crew_state "$d" feat-checks-passed)
+  assert_contains "$out" "state: done" "checks-passed run remains terminal"
+  assert_contains "$out" "source: run-step" "checks-passed run remains run-step sourced"
+  assert_not_contains "$out" "PR ready for review" "checks-passed run must not claim current PR readiness"
+  assert_contains "$out" "checks passed: PR state unconfirmed; check forge" "checks-passed run must direct the supervisor to verify PR state"
+  pass "checks-passed run does not claim PR readiness"
 }
 
 test_terminal_failed() {
@@ -2507,6 +2569,8 @@ test_ci_fixing_after_green_stays_working
 test_top_level_fixing_ci_running_after_green_stays_working
 test_top_level_fixing_done_log_stays_working
 test_terminal_passed
+test_terminal_passed_with_skipped_ci_does_not_claim_pr_landed
+test_terminal_checks_passed_does_not_claim_pr_ready
 test_terminal_failed
 test_terminal_failed_ci_orphan_after_green_reads_done
 test_terminal_failed_ci_orphan_status_only_reads_done


### PR DESCRIPTION
## Intent

The captain's standing rule is that every change goes through the validation pipeline, and that
what a record claims must be what is true.
This task exists because one of firstmate's own readers claims something it cannot know.

`bin/fm-crew-state.sh` line 641 maps a no-mistakes run whose outcome is `passed` to the detail
string `run passed: PR merged/closed`.
That asserts forge truth the reader never checked.

Observed on 2026-09-10, on the market-pulse task `mp-chat-grounding-fixes`.
The reader printed `done, run passed: PR merged/closed`.
The forge reported pull request 423 as `state=OPEN`, `mergedAt=null`, `mergedBy=null`, backend
check `FAILURE`, and the default branch did not contain the work.

The path that produces it: that run's CI step was SKIPPED, which was the authorised response to a
gate that could not return a valid verdict because of a test-suite teardown hang.
The run still reached outcome `passed`, because `passed` means the pipeline finished the steps it
could run, not that the pull request landed.
A skipped step is neither a pass nor a fail.

Why this is a safety defect and not a wording nit.
Under standing merge authority, the natural next action on reading "PR merged/closed" is cleanup.
Cleanup's landed-work test reads the working copy, and that working copy was clean, so it would
not have refused.
The local copy held 28 commits for a pull request that is still open, still red, and still needed.
It was caught only because the supervision ladder escalated the same quiet pane a fourth time and
demanded deep inspection rather than allowing another routine acknowledgement.

The captain has also just made test-driven development the standing rule for every change, so
this task is expected to demonstrate it rather than merely comply with it.

## What Changed

- `bin/fm-crew-state.sh`: a `passed` run now prints `run passed: PR merge unconfirmed; check forge` (was `run passed: PR merged/closed`), and `checks-passed` prints `checks passed: PR state unconfirmed; check forge` (was `checks green: PR ready for review`). Both still report `state: done`.
- The reader's header comment now describes `done` as a statement about the pipeline only, and separates those two evidence-free details from the ci-log-tail readings (held-for-merge, ready-for-review), which do come from the run's own ci step log.
- `tests/fm-crew-state.test.sh`: adds a `run_checks_passed` fixture and two cases, one per outcome, each asserting `state: done` and `source: run-step`, the absence of the old claim string, and the presence of the new `check forge` detail.

## Risk Assessment

✅ Low: Two human-facing string edits in a reader whose detail field no consumer parses, covering two terminal outcomes (`passed` and `checks-passed`) that each asserted an unverified present-tense forge state, pinned by two tests that drive the real script and fail against the pre-fix output, with no new branches, flags, or code paths introduced.

## Testing

<code>I stood up an isolated firstmate home (real throwaway git worktree on a branch, real state/&lt;id&gt;.meta, the external `no-mistakes` and `tmux` CLIs stubbed on PATH exactly as this repo&#39;s own harness does) and ran the real reader and the real fleet snapshot against it. The 2026-09-10 incident shape — a run reaching `outcome: passed` while its PR is still open — now reads `run passed: PR merge unconfirmed; check forge` where the base commit printed `run passed: PR merged/closed` on byte-identical input; `checks-passed` likewise reads `checks passed: PR state unconfirmed; check forge`. The adversarial case for this change is the carve-out, so I drove both evidence-backed readings too: an active ci step with a green log tail still reports `checks green: PR ready for review (still monitoring for merge/close)`, and a terminal failed run whose only failure is the orphaned ci monitor still reports `checks green: PR held for merge (ci monitor ended)` with its PR URL — neither was flattened. `fm-fleet-snapshot.sh --json` over the same home still splits state and source and carries the new detail (which contains a colon and a semicolon) intact, so machine consumers are unaffected. As baseline I ran the scoped `tests/fm-crew-state.test.sh` (all pass) and, for the TDD demonstration the intent asks for, ran the change&#39;s two new tests unmodified against a base-commit tree: both fail there and pass on the change. One honest caveat on the fixture: the `ci,skipped` step row reproduces the incident shape but is inert on this path — once `outcome` is set the reader never inspects the steps table — so the reading is driven by `outcome: passed` alone and I do not claim a skipped-ci branch was exercised. Minting a genuinely terminal no-mistakes run is not available in this phase, so the run-step source is stubbed; everything else is the real product. No screenshot: the changed surface is a one-line CLI string and its JSON carrier, and the transcript plus the `--json` row are that surface. The header edit at bin/fm-crew-state.sh:68-76 is documentation with no runtime surface, so it carries no scenario. Worktree left clean and scratch dirs removed.</code>

- Live validation: ✅ go - 5 of 5 scenarios driven live against the product

| Scenario | Result | Live | Evidence |
| --- | --- | --- | --- |
| A run with outcome=passed reads merge-unconfirmed instead of claiming the PR landed | ✅ pass | live | Real bin/fm-crew-state.sh driven over an isolated home (real git worktree on fm/mp-chat-grounding-fixes, real state meta, `no-mistakes`/`tmux` stubbed on PATH as external deps) with the 2026-09-10 run… |
| A run with outcome=checks-passed reports PR state unconfirmed instead of ready for review | ✅ pass | live | Same live harness, fixture with outcome checks-passed and PR 424. Output: `state: done · source: run-step · checks passed: PR state unconfirmed; check forge`; base commit printed `checks green: PR rea… |
| Adversarial: the evidence-backed ci-log readings are not flattened by the change | ✅ pass | live | Two live drives on the same harness. Active ci step plus a ci log tail reading `all CI checks passed - still monitoring until merged or closed` -&gt; `state: done · source: run-step · checks green: PR re… |
| Downstream fleet snapshot still parses state and source and carries the new detail intact | ✅ pass | live | `bin/fm-fleet-snapshot.sh --json` run over the same isolated home returns `{&#34;state&#34;:&#34;done&#34;,&#34;source&#34;:&#34;run-step&#34;,&#34;detail&#34;:&#34;run passed: PR merge unconfirmed; check forge&#34;,&#34;raw&#34;:&#34;state: done · source: run… |
| The change&#39;s own tests fail against the pre-change reader (fail-before, pass-after) | ✅ pass | live | Base commit fa65b5d bin/ and tests/ extracted to a scratch tree, then the change&#39;s `tests/fm-crew-state.test.sh` copied in unmodified and run: `not ok - passed run must not claim the PR landed (unexpe… |

<details>
<summary>Evidence: crew-state detail: before/after live transcript + negative control</summary>

Source: [crew-state detail: before/after live transcript + negative control](https://github.com/dbeihl/firstmate/blob/fa166683abe20bf22931435128d7b435f5ffcf86/.no-mistakes/evidence/fm/fm-crew-state-merge-claim/crew-state-detail-before-after.txt)

```text
Live drive of bin/fm-crew-state.sh over an isolated firstmate home
(real git worktree + real state/<id>.meta; the external `no-mistakes` CLI
and `tmux` are stubbed on PATH, as this repo's own harness does).

Each line below is exactly what a supervisor/agent reads for that crew.
===========================================================================

\### crew-state reader from: ~/.no-mistakes/worktrees/b5ea5ab83d56/01M2AMH071HZD05GY3GXWDG09B/bin  (after)
--- S1 outcome=passed, ci SKIPPED, forge PR 423 still OPEN (2026-09-10 incident shape)
state: done · source: run-step · run passed: PR merge unconfirmed; check forge
--- S2 outcome=checks-passed
state: done · source: run-step · checks passed: PR state unconfirmed; check forge
--- S3 active ci step, ci log tail reports checks green (positive evidence)
state: done · source: run-step · checks green: PR ready for review (still monitoring for merge/close)
--- S4 terminal failed, only the ci monitor failed after checks read green
state: done · source: run-step · checks green: PR held for merge (ci monitor ended): https://github.com/o/r/pull/203

\### crew-state reader from: /private/tmp/nm-live-crewstate/base/bin  (before)
--- S1 outcome=passed, ci SKIPPED, forge PR 423 still OPEN (2026-09-10 incident shape)
state: done · source: run-step · run passed: PR merged/closed
--- S2 outcome=checks-passed
state: done · source: run-step · checks green: PR ready for review
--- S3 active ci step, ci log tail reports checks green (positive evidence)
state: done · source: run-step · checks green: PR ready for review (still monitoring for merge/close)
--- S4 terminal failed, only the ci monitor failed after checks read green
state: done · source: run-step · checks green: PR held for merge (ci monitor ended): https://github.com/o/r/pull/203

===========================================================================
Negative control: the two tests added in this change, run unmodified against
the BASE-commit reader (fa65b5d bin/ + tests/, extracted to a scratch tree).
Both fail there and pass on the change - fail-before / pass-after.
---------------------------------------------------------------------------
not ok - passed run must not claim the PR landed (unexpected: 'PR merged/closed')
--- output ---
state: done · source: run-step · run passed: PR merged/closed

not ok - checks-passed run must not claim current PR readiness (unexpected: 'PR ready for review')
--- output ---
state: done · source: run-step · checks green: PR ready for review

Note on the S1 fixture: the `ci,skipped` step row reproduces the 2026-09-10
incident shape, but it is inert on this path - once `outcome` is set the reader
never inspects the steps table, so the reading is driven by outcome=passed
alone. No skipped-ci branch exists or is claimed to be exercised here.
```
</details>
<details>
<summary>Evidence: fleet-snapshot task row carrying the new detail</summary>

Source: [fleet-snapshot task row carrying the new detail](https://github.com/dbeihl/firstmate/blob/fa166683abe20bf22931435128d7b435f5ffcf86/.no-mistakes/evidence/fm/fm-crew-state-merge-claim/fleet-snapshot-task-row.json)

```text
// bin/fm-fleet-snapshot.sh --json over the same isolated home (incident crew only).
// Proves the downstream consumer still splits state/source and carries the new detail intact.
{
  "id": "mp-chat-grounding-fixes",
  "current_state": {
    "state": "done",
    "source": "run-step",
    "detail": "run passed: PR merge unconfirmed; check forge",
    "raw": "state: done · source: run-step · run passed: PR merge unconfirmed; check forge",
    "observed_at": "2026-09-12T12:00:32Z",
    "freshness": "fresh"
  }
}
```
</details>
<details>
<summary>Evidence: Reader line for the 2026-09-10 incident shape, before vs after</summary>

```text
before (fa65b5d): state: done · source: run-step · run passed: PR merged/closed
after (10abc5c): state: done · source: run-step · run passed: PR merge unconfirmed; check forge
```
</details>
<details>
<summary>Evidence: Carve-out preserved: evidence-backed ci-log readings unchanged</summary>

```text
state: done · source: run-step · checks green: PR ready for review (still monitoring for merge/close)
state: done · source: run-step · checks green: PR held for merge (ci monitor ended): https://github.com/o/r/pull/203
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"10abc5cf053f1c489b77c543a59c43a7fe3ba99e","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}],"live_validation":{"verdict":"go","live":5,"total":5}} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>⚠️ **Review** - 2 infos</summary>

- ⚠️ `tests/fm-crew-state.test.sh:383` - Test fixture `run_passed_ci_skipped` adds a `steps[3]` table with `ci,skipped` and the test is named `test_terminal_passed_with_skipped_ci_does_not_claim_pr_landed`, but the reader never inspects steps on this path: `bin/fm-crew-state.sh:663` enters the `[ -n &#34;$outcome&#34; ]` branch, sets RUN_STATE=done at line 664, and every later block that reads the steps table is gated on `RUN_STATE = working` (the `nm_effective_ci_step_status` block at line 702 and the `log_reports_ci_ready` block at line 716) or on `RUN_STATE = parked` (the LOG_VERB reconciliation at line 752). The `ci,skipped` row and the different PR number therefore pin nothing the reader discriminates — the same assertions pass unchanged against the existing `run_passed` fixture. Narrower form: drive the test with `run_passed` and drop `with_skipped_ci` from the test name, so the test&#39;s name matches what it actually pins. Keeping the fixture is defensible purely as documentation of the 2026-09-10 incident shape, which is why this is the author&#39;s call rather than a mechanical fix. Do NOT resolve this by teaching the reader a skipped-CI branch — that would extend the change beyond its intent instead of correcting it.
- ℹ️ `bin/fm-crew-state.sh:67` - Commit 1eaedc2 (&#34;chore: keep state reader header scoped&#34;) removed the 12-line header block that commit 8cbcf5e had added at bin/fm-crew-state.sh:67, documenting that a terminal outcome maps to `done` as a statement about the PIPELINE only and that `passed` does not even establish green checks because an authorized SKIPPED step still ends the run passed. AGENTS.md:52 and AGENTS.md:68 make each script&#39;s header the owner of its contract (&#34;read each script&#39;s header before first use&#34;). The surviving header still explains the positive-evidence basis for the CI-log-tail readings (`checks green: PR held for merge` at line 455, `checks green: PR ready for review` at line 708), so the header now documents why two readings are evidence-backed while staying silent on why the two terminal-outcome readings at lines 664-665 report PR state as unconfirmed. Nothing in the code is wrong — the detail strings themselves are honest — but the invariant the incident produced is no longer written down where this repo&#39;s convention says it lives. Surfacing this because the removal is a deliberate reversal of the pipeline&#39;s own document step, not because docs are required.

🔧 Fix applied.
2 issues (1 warning, 1 info) still open:

- ⚠️ `bin/fm-crew-state.sh:671` - The change also rewrites the `checks-passed` detail (`checks green: PR ready for review` -&gt; `checks passed: PR state unconfirmed; check forge`) and adds the `run_checks_passed` fixture (tests/fm-crew-state.test.sh:381) plus `test_terminal_checks_passed_does_not_claim_pr_ready` (tests/fm-crew-state.test.sh:985) to pin it. The intent names exactly one reader claim: &#34;`bin/fm-crew-state.sh` line 641 maps a no-mistakes run whose outcome is `passed` to the detail string `run passed: PR merged/closed`&#34;, and the 2026-09-10 incident it reconstructs is the `passed` path only. No stated requirement needs the `checks-passed` string, its fixture, or its test. Narrower form satisfying the intent: change only the `passed` arm and keep only `test_terminal_passed_does_not_claim_pr_landed`; remedy is removing the `checks-passed` component, not hardening it. Counterweight the author should weigh before deciding: (a) this is the author&#39;s own commit 3fd8fdc, not a fix round; (b) it is the same shape of defect - a pipeline-time fact (checks were green when the run ended) stated as a current forge fact (&#34;PR ready for review&#34;), which the intent&#39;s opening standing rule &#34;what a record claims must be what is true&#34; also covers; (c) the original header commit 8cbcf5e called this case out explicitly (&#34;`checks-passed` records checks green at pipeline time, not now&#34;). Verified harmless either way: nothing machine-consumes the detail - bin/fm-fleet-snapshot.sh:327-334 splits on the ` · ` separator and carries detail opaquely, crew_absorb_class (bin/fm-classify-lib.sh:1803-1813) and bin/fm-inactive-reconcile.sh:498 match only the `state:`/`source:` tokens, and no test or doc outside this diff references the old strings.
- ℹ️ `bin/fm-crew-state.sh:69` - The header clause restored by fix-round commit 2208190 reads &#34;this reader never queries the forge, so it cannot report that a PR merged, closed, or is reviewable now&#34; (bin/fm-crew-state.sh:69-70). Two live detail strings in this same file do report exactly that: line 461 emits `checks green: PR held for merge (ci monitor ended)` and line 714 emits `checks green: PR ready for review (still monitoring for merge/close)`. Both are legitimate - they rest on positive evidence read from the run&#39;s own ci step log via nm_ci_checks_state (bin/fm-crew-state.sh:509-531) - and the header commit 8cbcf5e carried the carve-out that said so (&#34;The ci-log-tail readings above are different: their green-check and held-for-merge details rest on positive evidence read from the run&#39;s own ci log&#34;), which this restatement drops. AGENTS.md:52/68 and AGENTS.md:380 make each script&#39;s header the owner of its contract, so a maintainer reading the header literally could conclude lines 461 and 714 violate it. Remedy is one sentence: restore the 8cbcf5e carve-out, or rescope the clause to the `passed`/`checks-passed` details it actually governs. This is ask-user rather than auto-fix because commit 1eaedc2 (&#34;chore: keep state reader header scoped&#34;) deliberately trimmed this header, so re-expanding it challenges a stated author preference. Note this is not a revert-the-fix-round case: the restated header is narrower than the text the prior round&#39;s finding referenced, not broader.

🔧 Fix applied.
1 warning still open:

- ⚠️ `bin/fm-crew-state.sh:674` - The round-2 instruction was conditional: &#34;Verify whether checks-passed maps to the same unsupported PR merged/closed detail as passed. If it does, retain both mappings... If it does not, remove the checks-passed fixture and test and narrow the change to passed. Do not split the difference.&#34; On the face-value reading the condition is FALSE: before this change `passed` produced `run passed: PR merged/closed` (bin/fm-crew-state.sh:673) while `checks-passed` produced `checks green: PR ready for review` (line 674) - a different string, and not a merged/closed claim. The fix round took the RETAIN branch anyway, keeping the `checks passed: PR state unconfirmed; check forge` rewrite, the `run_checks_passed` fixture (tests/fm-crew-state.test.sh:381) and `test_terminal_checks_passed_does_not_claim_pr_ready` (tests/fm-crew-state.test.sh:986). That reading - &#34;same CLASS of unverifiable forge claim&#34; rather than same literal detail - is defensible: `PR ready for review` is equally a present-tense forge assertion the reader never checked, and the intent&#39;s standing rule (&#34;what a record claims must be what is true&#34;) covers it. But it is not the literal condition, so confirm it was your branch. The two affected outcomes are named here explicitly - `passed` and `checks-passed` - which discharges the retain branch&#39;s &#34;update the run intent or review record to name both affected outcomes&#34; obligation if you confirm retain. If you meant the literal reading instead, the remedy is removing the checks-passed component (detail rewrite, fixture, and test), not hardening it. No correctness risk either way: nothing machine-consumes the detail, so both spellings are behaviourally inert outside the human-facing line.

🔧 No changes applied.
2 infos still open:

- ℹ️ `bin/fm-crew-state.sh:68` - Scope record for this change (discharging the round-3 instruction to record it precisely): the fix covers TWO terminal outcomes that each asserted an unverified present-tense forge state — `passed` (was `run passed: PR merged/closed`) and `checks-passed` (was `checks green: PR ready for review`) — not one literal string. The round-3 escalation was correct: the conditional was false read literally (the two old details were different strings, and only one named merge/close) but true under its intended class terms, so flagging rather than silently picking a branch was the right call. One residual tension worth knowing about, not fixing here: the new header states `passed` rests on no forge evidence, while the unchanged nm_ci_checks_state rationale at bin/fm-crew-state.sh:510 still reads &#34;it only reaches outcome=passed once the PR is actually merged (or failed/cancelled if closed)&#34;. That older sentence is scoped to a repo where merge is left to the captain AND the ci monitor actually ran, so it is not false within its premise, and the new header supplies the reconciling counterexample (an authorized SKIPPED step) ten lines above it. Remedy if ever wanted is one qualifying clause on line 510; it does not belong in this change, which is why this is no-op.
- ℹ️ `tests/fm-crew-state.test.sh:958` - `test_terminal_passed` asserts exactly `state: done` and `source: run-step` against the `run_passed` fixture — a strict subset of the assertions the new `test_terminal_passed_does_not_claim_pr_landed` makes against the same fixture (lines 971-983), which adds the two detail assertions on top. The older test is now fully subsumed. Noting it rather than recommending deletion: it is pre-existing code the change did not introduce, it is the labelled carrier of case (d) in the test file&#39;s header index (line 957, &#34;(d) terminal run-step is authoritative&#34;), and the intent asks for TDD to be demonstrated, so a dedicated red-green regression test standing beside the original case test is defensible. No action needed.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- Live validation: ✅ go - 5 of 5 scenarios driven live against the product

| Scenario | Result | Live | Evidence |
| --- | --- | --- | --- |
| A run with outcome=passed reads merge-unconfirmed instead of claiming the PR landed | ✅ pass | live | Real bin/fm-crew-state.sh driven over an isolated home (real git worktree on fm/mp-chat-grounding-fixes, real state meta, `no-mistakes`/`tmux` stubbed on PATH as external deps) with the 2026-09-10 run… |
| A run with outcome=checks-passed reports PR state unconfirmed instead of ready for review | ✅ pass | live | Same live harness, fixture with outcome checks-passed and PR 424. Output: `state: done · source: run-step · checks passed: PR state unconfirmed; check forge`; base commit printed `checks green: PR rea… |
| Adversarial: the evidence-backed ci-log readings are not flattened by the change | ✅ pass | live | Two live drives on the same harness. Active ci step plus a ci log tail reading `all CI checks passed - still monitoring until merged or closed` -&gt; `state: done · source: run-step · checks green: PR re… |
| Downstream fleet snapshot still parses state and source and carries the new detail intact | ✅ pass | live | `bin/fm-fleet-snapshot.sh --json` run over the same isolated home returns `{&#34;state&#34;:&#34;done&#34;,&#34;source&#34;:&#34;run-step&#34;,&#34;detail&#34;:&#34;run passed: PR merge unconfirmed; check forge&#34;,&#34;raw&#34;:&#34;state: done · source: run… |
| The change&#39;s own tests fail against the pre-change reader (fail-before, pass-after) | ✅ pass | live | Base commit fa65b5d bin/ and tests/ extracted to a scratch tree, then the change&#39;s `tests/fm-crew-state.test.sh` copied in unmodified and run: `not ok - passed run must not claim the PR landed (unexpe… |

- <code>`/private/tmp/nm-live-crewstate/drive.sh &lt;bin&gt; after` — real bin/fm-crew-state.sh driven over an isolated home (real git worktree on branch, real state/&lt;id&gt;.meta, stubbed `no-mistakes`/`tmux` on PATH) across four run fixtures</code>
- <code>`/private/tmp/nm-live-crewstate/drive.sh &lt;base-bin&gt; before` — identical fixtures against bin/ extracted from base commit fa65b5d, producing the before/after transcript</code>
- <code>`bin/fm-fleet-snapshot.sh --json | jq &#39;.tasks[] | {id, current_state}&#39;` over the same isolated home (incident crew only)</code>
- <code>`bash tests/fm-crew-state.test.sh` — the scoped test file for this script, all cases pass, including `test_terminal_passed_does_not_claim_pr_landed`, `test_terminal_checks_passed_does_not_claim_pr_ready`, `test_ci_monitoring_checks_green_surfaces_done`, `test_terminal_failed_ci_orphan_after_green_reads_done`</code>
- <code>Negative control: `git archive fa65b5d bin tests` into a scratch tree, copied in the change&#39;s `tests/fm-crew-state.test.sh`, ran it against the base reader — both new tests report `not ok`</code>
- <code>`grep -rn &#39;PR merged/closed|PR ready for review&#39; bin/ tests/ skills/ docs/` — confirmed no consumer outside the changed code keys off the old detail strings</code>
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
