### PR TITLE
fix(bin): give AGENTS.md/CLAUDE.md conflicts a bounded, actionable exit 3

### DIFF
--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -506,6 +506,7 @@ $INBOX_SECTION
 
 # Project memory
 If \`AGENTS.md\` or \`CLAUDE.md\` already exists, or if this task produced durable project-intrinsic knowledge, run \`$FM_ROOT/bin/fm-ensure-agents-md.sh .\` in the worktree.
+If it exits 3, the project keeps two distinct real instruction files and that is the project owner's decision, not yours: do not merge, replace, symlink, or edit either file, do not re-run it expecting a different answer, and record the exit-3 report in your status as a \`note:\` for firstmate.
 Record only project knowledge useful to almost every future session.
 For anything the codebase already shows, prefer a pointer to the authoritative file, command, or doc over copying the detail.
 If you touch a project \`AGENTS.md\`, follow \`$FM_ROOT/bin/fm-ensure-agents-md.sh\`'s self-governance contract in the same pass.

--- a/bin/fm-ensure-agents-md.sh
+++ b/bin/fm-ensure-agents-md.sh
@@ -23,9 +23,20 @@
 # filesystem (issue #389). The real-file pointer also eliminates the old
 # uppercase-literal-target dangling-symlink hazard that a CLAUDE.md -> AGENTS.md
 # link would have carried for that same mismatch.
+# Two distinct real files (a real AGENTS.md beside a real non-pointer CLAUDE.md)
+# is a project decision the helper never guesses at: it reports both files'
+# sizes, whether CLAUDE.md already imports @AGENTS.md, the two resolutions, and
+# an instruction not to edit either file from a task, then exits 3 (distinct
+# from exit 1 usage or refusal errors). A project that keeps both deliberately
+# records that with this exact first line of CLAUDE.md (LF or CRLF):
+# <!-- firstmate:separate-claude-md -->
+# after which the helper treats the pair as settled and only maintains AGENTS.md's
+# self-governance section.
 # This is a worktree utility for crewmates, not a supervision script, so it does
 # not call fm-guard.sh.
 # Usage: fm-ensure-agents-md.sh [repo-or-worktree-dir]
+# Exit: 0 settled or updated; 1 usage error or refused layout; 3 distinct real
+#       AGENTS.md and CLAUDE.md needing a project decision.
 set -eu
 
 usage() {
@@ -144,6 +155,36 @@ install_claude_pointer() {
   claude_pointer_content > "$CLAUDE"
 }
 
+# A project may keep a real CLAUDE.md deliberately separate from AGENTS.md by
+# making this exact first line of CLAUDE.md (LF or CRLF):
+# <!-- firstmate:separate-claude-md -->
+# The mark records a project decision the helper then respects; it is never
+# inferred from content.
+is_marked_separate_claude() {
+  [ -f "$CLAUDE" ] && [ ! -L "$CLAUDE" ] || return 1
+  head -n 1 "$CLAUDE" | grep -Fqx -e '<!-- firstmate:separate-claude-md -->' \
+    -e $'<!-- firstmate:separate-claude-md -->\r'
+}
+
+# Two distinct real files is a project decision, not something a task should
+# resolve by guessing which file wins. Report the exact evidence and the two
+# resolutions, tell the caller not to edit either file, and exit 3 so a caller
+# can tell "needs a project decision" from a usage error (exit 1).
+report_distinct_files_conflict() {
+  local agents_bytes claude_bytes imports
+  agents_bytes=$(wc -c < "$AGENTS" | tr -d ' ')
+  claude_bytes=$(wc -c < "$CLAUDE" | tr -d ' ')
+  imports=no
+  grep -Eq '^@AGENTS\.md[[:space:]]*$' "$CLAUDE" && imports=yes
+  {
+    echo "conflict: both AGENTS.md and CLAUDE.md are distinct real files in $DIR"
+    echo "  AGENTS.md: $agents_bytes bytes; CLAUDE.md: $claude_bytes bytes; CLAUDE.md imports @AGENTS.md: $imports"
+    echo "  This is a project decision, not a task edit: do not merge, replace, symlink, or edit either file from a crewmate task; report it to firstmate for the captain and continue."
+    echo "  Resolutions the project owner can choose: fold CLAUDE.md's unique content into AGENTS.md and replace CLAUDE.md with the canonical two-line @AGENTS.md pointer, or keep both deliberately by making this exact first line of CLAUDE.md: <!-- firstmate:separate-claude-md -->"
+  } >&2
+  exit 3
+}
+
 is_correct_claude_symlink() {
   [ -L "$CLAUDE" ] || return 1
   target=$(readlink "$CLAUDE")
@@ -227,8 +268,16 @@ if [ -e "$AGENTS" ]; then
       fi
       exit 0
     fi
-    echo "conflict: both AGENTS.md and CLAUDE.md are real files in $DIR; reconcile them manually" >&2
-    exit 1
+    if is_marked_separate_claude; then
+      ensure_maintenance_section
+      if [ "$MAINT_INJECTED" -eq 1 ]; then
+        echo "updated: added ## Maintaining this file to AGENTS.md beside the marked separate CLAUDE.md in $DIR"
+      else
+        echo "unchanged: AGENTS.md with a deliberately separate, marked CLAUDE.md in $DIR"
+      fi
+      exit 0
+    fi
+    report_distinct_files_conflict
   fi
   echo "conflict: CLAUDE.md exists in $DIR but is not a regular file or symlink" >&2
   exit 1

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -438,6 +438,10 @@ test_ship_project_memory_wording() {
     "project-memory contract lost pointer-over-copy guidance"
   assert_grep "follow \`$ROOT/bin/fm-ensure-agents-md.sh\`'s self-governance contract" "$brief" \
     "project-memory contract no longer defers to the ensure helper"
+  assert_grep "If it exits 3, the project keeps two distinct real instruction files and that is the project owner's decision, not yours" "$brief" \
+    "project-memory contract does not tell the crew that exit 3 is an owner decision"
+  assert_grep "do not re-run it expecting a different answer" "$brief" \
+    "project-memory contract does not rule out retrying the ensure helper"
   pass "fm-brief.sh: ship project-memory wording carries the AGENTS.md authoring bar"
 }
 

--- a/tests/fm-ensure-agents-md.test.sh
+++ b/tests/fm-ensure-agents-md.test.sh
@@ -342,14 +342,63 @@ test_distinct_real_files_are_refused() {
   cp "$repo/CLAUDE.md" "$repo/.claude-before"
   out=$("$ROOT/bin/fm-ensure-agents-md.sh" "$repo" 2>&1)
   rc=$?
-  [ "$rc" -ne 0 ] || fail "expected a non-zero exit for distinct real AGENTS.md and CLAUDE.md"
-  assert_contains "$out" "conflict:" "distinct real files did not report a conflict"
+  expect_code 3 "$rc" "distinct real AGENTS.md and CLAUDE.md must exit 3, distinct from a usage error"
+  assert_contains "$out" "conflict: both AGENTS.md and CLAUDE.md are distinct real files" "distinct real files did not report a conflict"
+  assert_contains "$out" "AGENTS.md: 16 bytes; CLAUDE.md: 16 bytes; CLAUDE.md imports @AGENTS.md: no" "conflict report lost its file evidence"
+  assert_contains "$out" "do not merge, replace, symlink, or edit either file from a crewmate task" "conflict report must forbid a task-level edit"
+  assert_contains "$out" "report it to firstmate for the captain" "conflict report must route the decision to the captain"
+  assert_contains "$out" "<!-- firstmate:separate-claude-md -->" "conflict report must name the deliberate-separation mark"
+  assert_not_contains "$out" "reconcile them manually" "conflict report must not instruct a manual reconciliation"
   cmp -s "$repo/.agents-before" "$repo/AGENTS.md" \
     || fail "distinct-real-files refusal modified AGENTS.md"
   cmp -s "$repo/.claude-before" "$repo/CLAUDE.md" \
     || fail "distinct-real-files refusal modified CLAUDE.md"
   [ ! -L "$repo/CLAUDE.md" ] || fail "distinct-real-files refusal turned CLAUDE.md into a symlink"
-  pass "fm-ensure-agents-md.sh: refuses distinct real AGENTS.md and CLAUDE.md"
+  pass "fm-ensure-agents-md.sh: refuses distinct real AGENTS.md and CLAUDE.md with a bounded, actionable report"
+}
+
+test_distinct_real_files_report_import_evidence() {
+  local repo out rc
+  repo="$TMP_ROOT/distinct-real-files-import-project"
+  mkdir -p "$repo"
+  printf '# Agents memory\n' > "$repo/AGENTS.md"
+  printf '# Claude memory\n\n@AGENTS.md\n\nExtra Claude-only guidance.\n' > "$repo/CLAUDE.md"
+  out=$("$ROOT/bin/fm-ensure-agents-md.sh" "$repo" 2>&1)
+  rc=$?
+  expect_code 3 "$rc" "a real CLAUDE.md that imports AGENTS.md but carries more is still a project decision"
+  assert_contains "$out" "CLAUDE.md imports @AGENTS.md: yes" "conflict report must say when CLAUDE.md already imports AGENTS.md"
+  pass "fm-ensure-agents-md.sh: the conflict report says whether CLAUDE.md already imports AGENTS.md"
+}
+
+test_marked_separate_claude_md_is_settled() {
+  local repo out
+  repo="$TMP_ROOT/marked-separate-project"
+  mkdir -p "$repo"
+  printf '# Agents memory\n\n## Maintaining this file\n\nKeep this file for knowledge useful to almost every future agent session in this project.\nDo not repeat what the codebase already shows; point to the authoritative file or command instead.\nPrefer rewriting or pruning existing entries over appending new ones.\nWhen updating this file, preserve this bar for all agents and keep entries concise.\n' > "$repo/AGENTS.md"
+  printf '<!-- firstmate:separate-claude-md -->\n# Claude memory\n\nDeliberately separate.\n' > "$repo/CLAUDE.md"
+  cp "$repo/AGENTS.md" "$repo/.agents-before"
+  cp "$repo/CLAUDE.md" "$repo/.claude-before"
+  out=$("$ROOT/bin/fm-ensure-agents-md.sh" "$repo" 2>&1) \
+    || fail "a marked separate CLAUDE.md must not be a conflict: $out"
+  assert_contains "$out" "unchanged: AGENTS.md with a deliberately separate, marked CLAUDE.md" "marked separation was not reported as settled"
+  cmp -s "$repo/.agents-before" "$repo/AGENTS.md" || fail "marked separation modified AGENTS.md"
+  cmp -s "$repo/.claude-before" "$repo/CLAUDE.md" || fail "marked separation modified CLAUDE.md"
+  pass "fm-ensure-agents-md.sh: a marked separate CLAUDE.md is a settled layout"
+}
+
+test_marked_separate_claude_md_still_maintains_agents_section() {
+  local repo out
+  repo="$TMP_ROOT/marked-separate-section-project"
+  mkdir -p "$repo"
+  printf '# Agents memory\n' > "$repo/AGENTS.md"
+  printf '<!-- firstmate:separate-claude-md -->\r\n# Claude memory\r\n' > "$repo/CLAUDE.md"
+  cp "$repo/CLAUDE.md" "$repo/.claude-before"
+  out=$("$ROOT/bin/fm-ensure-agents-md.sh" "$repo" 2>&1) \
+    || fail "a CRLF-marked separate CLAUDE.md must not be a conflict: $out"
+  assert_contains "$out" "updated: added ## Maintaining this file to AGENTS.md beside the marked separate CLAUDE.md" "marked separation did not maintain the AGENTS.md section"
+  assert_grep "## Maintaining this file" "$repo/AGENTS.md" "AGENTS.md did not gain its self-governance section"
+  cmp -s "$repo/.claude-before" "$repo/CLAUDE.md" || fail "marked separation modified CLAUDE.md"
+  pass "fm-ensure-agents-md.sh: a marked separate CLAUDE.md (CRLF) leaves CLAUDE.md alone and maintains AGENTS.md only"
 }
 
 test_agents_md_symlink_is_refused() {
@@ -429,6 +478,9 @@ test_reworded_guidance_requires_first_line_marker
 test_marked_project_guidance_stays_unchanged
 test_canonical_pointer_is_accepted_when_both_are_real_files
 test_distinct_real_files_are_refused
+test_distinct_real_files_report_import_evidence
+test_marked_separate_claude_md_is_settled
+test_marked_separate_claude_md_still_maintains_agents_section
 test_agents_md_symlink_is_refused
 test_wrong_target_symlink_is_refused
 test_non_regular_claude_md_is_refused


### PR DESCRIPTION
## Intent

Firstmate tooling repair, concern B of three (captain-approved no-mistakes run, required by CONTRIBUTING for PRs to main). Goal: bin/fm-ensure-agents-md.sh must never invite a crewmate to guess between two distinct real project instruction files. Previously a real AGENTS.md beside a real non-pointer CLAUDE.md exited 1 with 'reconcile them manually'. Now it exits 3 (deliberately distinct from usage/refused-layout exit 1) with a bounded, actionable diagnostic: both file sizes, whether CLAUDE.md already imports @AGENTS.md, an explicit instruction not to merge, replace, symlink, or edit either file from a task, and the two resolutions the project owner can choose. A deliberate separation is recorded with the exact first line '<!-- firstmate:separate-claude-md -->' in CLAUDE.md (LF or CRLF), mirroring the existing firstmate:maintained-by-project mark; the helper then treats the pair as settled and only maintains AGENTS.md's self-governance section. The ship brief scaffold in bin/fm-brief.sh now tells crews that exit 3 is the project owner's decision: leave both files alone, do not retry, record the report as a status note for firstmate. Decisions: the invariant protected (CLAUDE.md is the canonical two-line @AGENTS.md pointer, never a symlink) is unchanged; no DriveLog or other project file is touched; exit code 3 chosen so callers can distinguish 'owner decision required' from errors; tests pin the exit code, the report text, the import evidence, and both LF and CRLF mark handling; a brief test pins the new crew instruction. Scope is only this helper, its tests, the brief scaffold line, and the brief test.

## What Changed
- `bin/fm-ensure-agents-md.sh`: when a real AGENTS.md and a real non-pointer CLAUDE.md both exist, replace the old exit-1 "reconcile them manually" refusal with exit 3 and a bounded diagnostic (`report_distinct_files_conflict`) reporting both files' byte sizes, whether CLAUDE.md already imports `@AGENTS.md`, an explicit instruction not to merge/replace/symlink/edit either file from a task, and the two owner-facing resolutions.
- Adds a deliberate-separation mark: if CLAUDE.md's exact first line (LF or CRLF) is `<!-- firstmate:separate-claude-md -->` (checked by new `is_marked_separate_claude`), the pair is treated as settled — the helper exits 0 and only maintains AGENTS.md's self-governance section, leaving CLAUDE.md untouched.
- `bin/fm-brief.sh`: adds a line to the ship project-memory section telling crews that an exit 3 from the ensure helper is the project owner's decision — don't retry it, and record the report as a `note:` for firstmate.
- Updates `tests/fm-ensure-agents-md.test.sh` (pins exit code 3, report text/evidence, LF/CRLF mark handling, and that the marked-separate case leaves both files untouched except for AGENTS.md's maintained section) and `tests/fm-brief.test.sh` (pins the new crew instruction wording).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Risk Assessment

✅ Low: The change is a small, well-scoped bash script diff (helper + brief scaffold + tests only) that adds a new, cleanly gated branch (marker detection and a new exit code) without touching existing exit-1 paths, callers, or the protected pointer invariant; tests exercise real script behavior (exit codes, stdout/stderr content, file mutation) and match the stated intent exactly.

## Testing

Ran the two targeted test suites covering this change (fm-ensure-agents-md.test.sh and fm-brief.test.sh) — all 45 cases pass — and additionally reproduced the exit-3 conflict report and the marked-separate settled path manually against live fixtures in /tmp (outside the worktree, cleaned up afterward), confirming the CLI's observable exit codes and diagnostic text match the required behavior exactly; the worktree itself remains clean with no incidental changes.

<details>
<summary>Evidence: Manual CLI run: distinct real files exits 3 with bounded diagnostic</summary>

```text
conflict: both AGENTS.md and CLAUDE.md are distinct real files in /tmp/manual-fm-test
AGENTS.md: 16 bytes; CLAUDE.md: 48 bytes; CLAUDE.md imports @AGENTS.md: no
This is a project decision, not a task edit: do not merge, replace, symlink, or edit either file from a crewmate task; report it to firstmate for the captain and continue.
Resolutions the project owner can choose: fold CLAUDE.md's unique content into AGENTS.md and replace CLAUDE.md with the canonical two-line @AGENTS.md pointer, or keep both deliberately by making this exact first line of CLAUDE.md: <!-- firstmate:separate-claude-md -->
EXIT: 3
```
</details>
<details>
<summary>Evidence: Manual CLI run: marked-separate CLAUDE.md settles with exit 0</summary>

```text
updated: added ## Maintaining this file to AGENTS.md beside the marked separate CLAUDE.md in /tmp/manual-fm-test
EXIT: 0
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"37122de0834bbc72bd0a296fdc99bf88539196fd","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"skipped"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `bash tests/fm-ensure-agents-md.test.sh (21/21 pass, including the 5 new/updated cases for exit 3, conflict-report evidence, import detection, and LF/CRLF firstmate:separate-claude-md mark handling)`
- `bash tests/fm-brief.test.sh (24/24 pass, including test_ship_project_memory_wording asserting the new exit-3 crew instruction line)`
- `Manual end-to-end run of bin/fm-ensure-agents-md.sh against a real /tmp fixture with two distinct real AGENTS.md/CLAUDE.md files: confirmed exit code 3 and the exact diagnostic text (file byte sizes, import status, non-edit instruction, both resolutions, no 'reconcile them manually' wording)`
- `Manual end-to-end run after adding the LF firstmate:separate-claude-md first line to CLAUDE.md: confirmed exit 0, AGENTS.md gains '## Maintaining this file' section, CLAUDE.md left untouched`
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>⏭️ **Lint** - skipped</summary>

- ⚠️ linter found issues (exit code 1)
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
