### PR TITLE
fix(bin): retain opted-in CLAUDE.md -> AGENTS.md symlink in fm-ensure-agents-md

### DIFF
--- a/bin/fm-ensure-agents-md.sh
+++ b/bin/fm-ensure-agents-md.sh
@@ -2,11 +2,13 @@
 # Ensure a project worktree follows the agent-memory file convention.
 # AGENTS.md is the real project-intrinsic knowledge file; CLAUDE.md is a
 # real regular file whose canonical content is the two-line @AGENTS.md pointer
-# that Claude Code inlines at load time. Creates a minimal AGENTS.md skeleton
+# that Claude Code inlines at load time, unless an existing correct symlink is
+# explicitly retained by the two project-owned marks documented below.
+# Creates a minimal AGENTS.md skeleton
 # when neither file exists, promotes a real CLAUDE.md file when it is the only
 # file present (unless it is already the canonical pointer), converts a correct
-# CLAUDE.md -> AGENTS.md symlink into the pointer file, and refuses to clobber
-# distinct real files or wrong symlinks.
+# CLAUDE.md -> AGENTS.md symlink into the pointer file by default, and refuses
+# to clobber distinct real files or wrong symlinks.
 # Owns the canonical "## Maintaining this file" self-governance wording for
 # project AGENTS.md files, injecting it idempotently into created skeletons,
 # promoted CLAUDE.md files, and existing AGENTS.md files lacking both the exact
@@ -15,6 +17,12 @@
 # Projects may place this mark at the start of the file and retain equivalent
 # maintenance guidance under their own heading. It declares guidance is present, not
 # permission to remove governance. No prose equivalence is inferred.
+# A project may retain an existing correct CLAUDE.md -> AGENTS.md symlink by
+# placing this exact second line immediately after that first-line mark (LF or CRLF):
+# <!-- firstmate:keep-claude-symlink -->
+# The helper never creates or retargets a symlink. A missing or misplaced
+# second-line mark keeps the default pointer conversion; a wrong target remains
+# a conflict.
 # Owns the canonical CLAUDE.md pointer content (the exact two-line @AGENTS.md
 # form). A real-file pointer cannot follow a write into AGENTS.md, which is why
 # the installer never creates a CLAUDE.md symlink.
@@ -37,6 +45,13 @@ canonical section, use this exact first line of AGENTS.md (LF or CRLF):
 <!-- firstmate:maintained-by-project -->
 The mark declares retained guidance, not permission to remove governance.
 Without the first-line mark or exact canonical heading, the helper adds the section.
+
+To retain an existing correct CLAUDE.md -> AGENTS.md symlink, place this exact
+second line immediately after the first-line project-owned mark (LF or CRLF):
+<!-- firstmate:keep-claude-symlink -->
+The helper never creates or retargets a symlink. Without both marks in those
+positions, it converts a correct symlink to the canonical @AGENTS.md pointer.
+A CLAUDE.md symlink to any other target remains a conflict.
 EOF
 }
 
@@ -162,6 +177,13 @@ PY
   return 1
 }
 
+keeps_correct_claude_symlink() {
+  sed -n '1p' "$AGENTS" | grep -Fqx -e '<!-- firstmate:maintained-by-project -->' \
+    -e $'<!-- firstmate:maintained-by-project -->\r' &&
+    sed -n '2p' "$AGENTS" | grep -Fqx -e '<!-- firstmate:keep-claude-symlink -->' \
+      -e $'<!-- firstmate:keep-claude-symlink -->\r'
+}
+
 # Refuse a case-variant real memory file (issue #389). On a case-insensitive
 # filesystem an existing lowercase agents.md satisfies every [ -e AGENTS.md ]
 # test below, so the script would emit a CLAUDE.md pointer whose @AGENTS.md
@@ -196,6 +218,10 @@ if [ -e "$AGENTS" ]; then
   if [ -L "$CLAUDE" ]; then
     if is_correct_claude_symlink; then
       ensure_maintenance_section
+      if keeps_correct_claude_symlink; then
+        echo "unchanged: AGENTS.md with project-retained CLAUDE.md -> AGENTS.md symlink in $DIR"
+        exit 0
+      fi
       install_claude_pointer
       if [ "$MAINT_INJECTED" -eq 1 ]; then
         echo "updated: added ## Maintaining this file to AGENTS.md and wrote CLAUDE.md @AGENTS.md pointer in $DIR"

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -383,9 +383,9 @@ The [Relay configuration reference](configuration.md#promised-public-replies-sta
 
 ## Project memory belongs to projects
 
-Durable project-intrinsic agent knowledge lives in each project's committed `AGENTS.md`, with `CLAUDE.md` as a real `@AGENTS.md` import pointer.
+Durable project-intrinsic agent knowledge lives in each project's committed `AGENTS.md`, with `CLAUDE.md` as a real `@AGENTS.md` import pointer by default.
 Ship briefs prompt crewmates to create or update those files through the normal delivery path; `data/projects.md` stays a thin private registry.
-Each project `AGENTS.md` carries self-governance guidance; [`bin/fm-ensure-agents-md.sh`](../bin/fm-ensure-agents-md.sh) owns the canonical wording and idempotent insertion, while its header and help document the explicit mark for equivalent project-owned guidance.
+Each project `AGENTS.md` carries self-governance guidance; [`bin/fm-ensure-agents-md.sh`](../bin/fm-ensure-agents-md.sh) owns the canonical wording and idempotent insertion, while its header and help document the explicit marks for equivalent project-owned guidance and for retaining an existing correct `CLAUDE.md` -> `AGENTS.md` symlink.
 It refuses a case-variant real memory file such as a lowercase `agents.md`, so the pointer's `@AGENTS.md` import resolves to a real `AGENTS.md` on a case-sensitive filesystem, and surfaces the mismatch for manual reconciliation.
 The full ownership rule - what is project-intrinsic versus fleet-private, and how firstmate keeps the two apart without writing into project clones - is owned by [`AGENTS.md`](../AGENTS.md) (project and knowledge management).
 

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -41,7 +41,7 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-herdr-ci-cleanup.sh` | Snapshot and tear down only job-owned `fm-lab-*` sessions in the Herdr CI lane       |
 | `fm-test-run.sh`         | Behavior-test runner: selection, portable lanes, bounded concurrency, budgets, coverage guard, timing/JSON; refuses to execute in the repository primary checkout when `FM_TASK_ID` marks a task worker |
 | `fm-test-isolation-proof.sh` | Concurrent isolation harness and portable candidate set owner |
-| `fm-ensure-agents-md.sh` | Ensure a project's real `AGENTS.md`, its `CLAUDE.md` `@AGENTS.md` pointer, and self-governance guidance (explicit project mark documented in the helper's header and help) |
+| `fm-ensure-agents-md.sh` | Ensure a project's real `AGENTS.md`, its default `CLAUDE.md` `@AGENTS.md` pointer or explicitly retained correct symlink, and self-governance guidance (exact project marks documented in the helper's header and help) |
 | `fm-guard.sh`            | Warn on primary-checkout tangles, main-session pending wakes, and unhealthy supervision |
 | `fm-primary-scope-lib.sh` | Shared marker-or-plain-checkout primary-home predicate for tracked hooks             |
 | `fm-session-lock-lib.sh` | Shared session-lock harness identity (ancestry walk and holder liveness) for fm-lock.sh and the Claude Stop auto-arm |

--- a/tests/fm-ensure-agents-md.test.sh
+++ b/tests/fm-ensure-agents-md.test.sh
@@ -7,7 +7,7 @@ set -u
 
 TMP_ROOT=$(fm_test_tmproot fm-ensure-agents-md)
 
-# Public contract: CLAUDE.md is this exact two-line pointer, never a symlink.
+# Default public contract: CLAUDE.md is this exact two-line pointer.
 assert_claude_pointer() {
   local path=$1
   [ -e "$path" ] || fail "CLAUDE.md is missing"
@@ -24,6 +24,16 @@ write_fixture_claude_pointer() {
 <!-- Points Claude at AGENTS.md via import; edit AGENTS.md, not this file. -->
 @AGENTS.md
 EOF
+}
+
+test_help_documents_symlink_opt_in() {
+  local out
+  out=$("$ROOT/bin/fm-ensure-agents-md.sh" --help 2>&1) \
+    || fail "fm-ensure-agents-md.sh --help failed"
+  assert_contains "$out" "second line immediately" "help does not require exact second-line placement"
+  assert_contains "$out" "<!-- firstmate:keep-claude-symlink -->" "help omits the symlink opt-in mark"
+  assert_contains "$out" "symlink to any other target remains a conflict" "help weakens wrong-target refusal"
+  pass "fm-ensure-agents-md.sh: help owns the symlink opt-in contract"
 }
 
 test_created_agents_md_includes_self_governance() {
@@ -151,6 +161,64 @@ test_correct_symlink_migrates_to_pointer_without_clobbering_agents() {
   cmp -s "$repo/.claude-after-first" "$repo/CLAUDE.md" \
     || fail "post-migration re-run modified CLAUDE.md"
   pass "fm-ensure-agents-md.sh: correct symlink migrates to pointer without clobbering AGENTS.md"
+}
+
+test_marked_correct_symlink_is_retained_byte_stably() {
+  local repo eol out run
+  for eol in $'\n' $'\r\n'; do
+    repo=$(mktemp -d "$TMP_ROOT/retained-symlink.XXXXXX")
+    printf '%s%s' \
+      '<!-- firstmate:maintained-by-project -->' "$eol" \
+      '<!-- firstmate:keep-claude-symlink -->' "$eol" \
+      '# Project memory' "$eol" \
+      'Keep this payload byte-identical.' "$eol" > "$repo/AGENTS.md"
+    ln -s AGENTS.md "$repo/CLAUDE.md"
+    cp "$repo/AGENTS.md" "$repo/.agents-before"
+    for run in 1 2; do
+      out=$("$ROOT/bin/fm-ensure-agents-md.sh" "$repo" 2>&1) \
+        || fail "ensure failed for retained symlink ($run)"
+      assert_contains "$out" "unchanged:" "retained symlink run $run did not report unchanged"
+      cmp -s "$repo/.agents-before" "$repo/AGENTS.md" \
+        || fail "retained symlink run $run modified AGENTS.md"
+      [ -L "$repo/CLAUDE.md" ] || fail "retained symlink run $run replaced CLAUDE.md"
+      [ "$(readlink "$repo/CLAUDE.md")" = "AGENTS.md" ] \
+        || fail "retained symlink run $run changed CLAUDE.md's target"
+    done
+  done
+  pass "fm-ensure-agents-md.sh: exact LF and CRLF opt-ins retain a correct symlink byte-stably"
+}
+
+test_missing_or_misplaced_symlink_mark_uses_pointer_default() {
+  local repo eol placement
+  for eol in $'\n' $'\r\n'; do
+    for placement in missing third first; do
+      repo=$(mktemp -d "$TMP_ROOT/non-opted-symlink-$placement.XXXXXX")
+      case "$placement" in
+        missing)
+          printf '%s%s' \
+            '<!-- firstmate:maintained-by-project -->' "$eol" \
+            '# Project memory' "$eol" > "$repo/AGENTS.md"
+          ;;
+        third)
+          printf '%s%s' \
+            '<!-- firstmate:maintained-by-project -->' "$eol" \
+            '# Project memory' "$eol" \
+            '<!-- firstmate:keep-claude-symlink -->' "$eol" > "$repo/AGENTS.md"
+          ;;
+        first)
+          printf '%s%s' \
+            '<!-- firstmate:keep-claude-symlink -->' "$eol" \
+            '<!-- firstmate:maintained-by-project -->' "$eol" \
+            '# Project memory' "$eol" > "$repo/AGENTS.md"
+          ;;
+      esac
+      ln -s AGENTS.md "$repo/CLAUDE.md"
+      "$ROOT/bin/fm-ensure-agents-md.sh" "$repo" >/dev/null 2>&1 \
+        || fail "ensure failed for $placement symlink opt-in"
+      assert_claude_pointer "$repo/CLAUDE.md"
+    done
+  done
+  pass "fm-ensure-agents-md.sh: missing and misplaced symlink opt-ins keep pointer conversion"
 }
 
 test_existing_agents_md_without_claude_gains_section_and_pointer() {
@@ -371,7 +439,10 @@ test_wrong_target_symlink_is_refused() {
   local repo out rc
   repo="$TMP_ROOT/wrong-target-project"
   mkdir -p "$repo"
-  printf '# Agents memory\n' > "$repo/AGENTS.md"
+  printf '%s\n' \
+    '<!-- firstmate:maintained-by-project -->' \
+    '<!-- firstmate:keep-claude-symlink -->' \
+    '# Agents memory' > "$repo/AGENTS.md"
   printf '# other\n' > "$repo/OTHER.md"
   ln -s OTHER.md "$repo/CLAUDE.md"
   cp "$repo/AGENTS.md" "$repo/.agents-before"
@@ -415,12 +486,15 @@ test_lowercase_agents_md_refuses_case_fragile_pointer() {
   pass "fm-ensure-agents-md.sh: refuses a case-variant lowercase agents.md (issue #389)"
 }
 
+test_help_documents_symlink_opt_in
 test_created_agents_md_includes_self_governance
 test_fresh_setup_writes_real_claude_pointer
 test_promoted_claude_md_includes_self_governance
 test_promoted_claude_md_without_trailing_newline_keeps_blank_separator
 test_existing_agents_md_with_symlink_gains_self_governance
 test_correct_symlink_migrates_to_pointer_without_clobbering_agents
+test_marked_correct_symlink_is_retained_byte_stably
+test_missing_or_misplaced_symlink_mark_uses_pointer_default
 test_existing_agents_md_without_claude_gains_section_and_pointer
 test_existing_agents_md_with_section_reports_unchanged
 test_existing_crlf_agents_md_with_section_stays_unchanged


### PR DESCRIPTION
## Intent

Allow projects whose canonical instructions live in a real AGENTS.md to retain an existing correct CLAUDE.md -> AGENTS.md symlink when they explicitly opt in with the exact project-maintenance marker on line one and exact symlink-retention marker on line two. Preserve the current real @AGENTS.md pointer conversion for unmarked, missing, or misplaced opt-ins, never create or retarget symlinks, and continue refusing wrong targets. Keep the change generic and document the helper contract. Prove LF and CRLF markers, two-run byte-stable idempotence, default fallback cases, and wrong-target refusal through the executable helper.

## What Changed

- `bin/fm-ensure-agents-md.sh` now leaves an existing correct `CLAUDE.md` -> `AGENTS.md` symlink as it is when `AGENTS.md` starts with `<!-- firstmate:maintained-by-project -->` on line one and `<!-- firstmate:keep-claude-symlink -->` on line two. Both markers can end in LF or CRLF. In that case the helper reports `unchanged` and exits. If either marker is missing or on the wrong line, the helper still converts the symlink to the real `@AGENTS.md` pointer as before. It still never creates or retargets a symlink, and a symlink to any other target is still refused as a conflict.
- The helper's header comment and `--help` output now describe the symlink opt-in. `docs/architecture.md` and `docs/scripts.md` now call the pointer the default and mention the retained-symlink option.
- `tests/fm-ensure-agents-md.test.sh` adds tests for three things: the help text, keeping the symlink with LF and CRLF markers (checked with `cmp` across runs to confirm `AGENTS.md` is unchanged byte for byte), and falling back to the pointer when the marker is missing or on the wrong line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Risk Assessment

✅ Low: The new opt-in only runs after is_correct_claude_symlink and the existing wrong-target conflict check, and a first-line mark means no section is added, so the kept path writes nothing. Default pointer conversion, the create and refuse paths, and the no-new-symlinks rule are unchanged. Tests run the real helper for LF and CRLF, two runs byte-stable, missing and misplaced marks, and wrong-target refusal.

## Testing

I ran the focused test file for fm-ensure-agents-md.sh and it passes. The new retention test fails on the pre-fix helper and passes on the new one, so it catches the regression. I also ran the real helper on temporary repos, twice per case, and saved the outputs. When both marks are present (LF, CRLF, or a ./AGENTS.md target), the helper reports "unchanged" on both runs: the symlink stays and AGENTS.md is byte-identical (same sha256). Unmarked files and missing, misplaced, swapped or inexact marks still convert to the @AGENTS.md pointer file. An opted-in symlink pointing to the wrong target exits 1 with a conflict and changes nothing. The helper never creates a symlink. The worktree was left clean.

<details>
<summary>Evidence: Helper output with the fix: opt-in, fallback and wrong-target cases, two runs each</summary>

Source: [Helper output with the fix: opt-in, fallback and wrong-target cases, two runs each](https://github.com/natalna-ai/firstmate/blob/4a2b0e91ddb83ce430046bd73b13420aaed9b239/.no-mistakes/evidence/fix/keep-claude-symlink-optin/e2e-transcript-head.txt)

```text
== opted-lf (eol=LF, CLAUDE.md -> AGENTS.md)
  AGENTS.md first lines: 0000000 < ! - - f i r s t m a t e : m 0000020 a i n t a i n e d - b y - p r o 0000040 j e c t - - > \n < ! - - f i 
  CLAUDE.md -> AGENTS.md (symlink)
  AGENTS.md sha256=27440f8eb9df0346
  $ fm-ensure-agents-md.sh <repo>  -> rc=0
    unchanged: AGENTS.md with project-retained CLAUDE.md -> AGENTS.md symlink in opted-lf
  CLAUDE.md -> AGENTS.md (symlink)
  AGENTS.md sha256=27440f8eb9df0346
  $ fm-ensure-agents-md.sh <repo>  -> rc=0
    unchanged: AGENTS.md with project-retained CLAUDE.md -> AGENTS.md symlink in opted-lf
  CLAUDE.md -> AGENTS.md (symlink)
  AGENTS.md sha256=27440f8eb9df0346

== opted-crlf (eol=CRLF, CLAUDE.md -> AGENTS.md)
  AGENTS.md first lines: 0000000 < ! - - f i r s t m a t e : m 0000020 a i n t a i n e d - b y - p r o 0000040 j e c t - - > \r \n < ! - - f 
  CLAUDE.md -> AGENTS.md (symlink)
  AGENTS.md sha256=846cf67cd887cb4d
  $ fm-ensure-agents-md.sh <repo>  -> rc=0
    unchanged: AGENTS.md with project-retained CLAUDE.md -> AGENTS.md symlink in opted-crlf
  CLAUDE.md -> AGENTS.md (symlink)
  AGENTS.md sha256=846cf67cd887cb4d
  $ fm-ensure-agents-md.sh <repo>  -> rc=0
    unchanged: AGENTS.md with project-retained CLAUDE.md -> AGENTS.md symlink in opted-crlf
  CLAUDE.md -> AGENTS.md (symlink)
  AGENTS.md sha256=846cf67cd887cb4d

== opted-dot-slash-target (eol=LF, CLAUDE.md -> ./AGENTS.md)
  AGENTS.md first lines: 0000000 < ! - - f i r s t m a t e : m 0000020 a i n t a i n e d - b y - p r o 0000040 j e c t - - > \n < ! - - f i 
  CLAUDE.md -> ./AGENTS.md (symlink)
  AGENTS.md sha256=27440f8eb9df0346
  $ fm-ensure-agents-md.sh <repo>  -> rc=0
    unchanged: AGENTS.md with project-retained CLAUDE.md -> AGENTS.md symlink in opted-dot-slash-target
  CLAUDE.md -> ./AGENTS.md (symlink)
  AGENTS.md sha256=27440f8eb9df0346
  $ fm-ensure-agents-md.sh <repo>  -> rc=0
    unchanged: AGENTS.md with project-retained CLAUDE.md -> AGENTS.md symlink in opted-dot-slash-target
  CLAUDE.md -> ./AGENTS.md (symlink)
  AGENTS.md sha256=27440f8eb9df0346

== unmarked-lf (eol=LF, CLAUDE.md -> AGENTS.md)
  AGENTS.md first lines: 0000000 # P r o j e c t m e m o r y 0000020 \n 0000021 
  CLAUDE.md -> AGENTS.md (symlink)
  AGENTS.md sha256=03c67c17d8a3f815
  $ fm-ensure-agents-md.sh <repo>  -> rc=0
    updated: added ## Maintaining this file to AGENTS.md and wrote CLAUDE.md @AGENTS.md pointer in unmarked-lf
  CLAUDE.md regular file:
    | <!-- Points Claude at AGENTS.md via import; edit AGENTS.md, not this file. -->
    | @AGENTS.md
  AGENTS.md sha256=8c0423c3be6380b5
  $ fm-ensure-agents-md.sh <repo>  -> rc=0
    unchanged: AGENTS.md with CLAUDE.md @AGENTS.md pointer in unmarked-lf
  CLAUDE.md regular file:
    | <!-- Points Claude at AGENTS.md via import; edit AGENTS.md, not this file. -->
    | @AGENTS.md
  AGENTS.md sha256=8c0423c3be6380b5

== missing-second-mark-crlf (eol=CRLF, CLAUDE.md -> AGENTS.md)
  AGENTS.md first lines: 0000000 < ! - - f i r s t m a t e : m 0000020 a i n t a i n e d - b y - p r o 0000040 j e c t - - > \r \n # P r o j 
  CLAUDE.md -> AGENTS.md (symlink)
  AGENTS.md sha256=6b2690afc4984f98
  $ fm-ensure-agents-md.sh <repo>  -> rc=0
    updated: replaced CLAUDE.md symlink with @AGENTS.md pointer in missing-second-mark-crlf
  CLAUDE.md regular file:
    | <!-- Points Claude at AGENTS.md via import; edit AGENTS.md, not this file. -->
    | @AGENTS.md
  AGENTS.md sha256=6b2690afc4984f98
  $ fm-ensure-agents-md.sh <repo>  -> rc=0
    unchanged: AGENTS.md with CLAUDE.md @AGENTS.md pointer in missing-second-mark-crlf
  CLAUDE.md regular file:
    | <!-- Points Claude at AGENTS.md via import; edit AGENTS.md, not this file. -->
    | @AGENTS.md
  AGENTS.md sha256=6b2690afc4984f98

== keep-mark-on-third-line-lf (eol=LF, CLAUDE.md -> AGENTS.md)
  AGENTS.md first lines: 0000000 < ! - - f i r s t m a t e : m 0000020 a i n t a i n e d - b y - p r o 0000040 j e c t - - > \n # P r o j e 
  CLAUDE.md -> AGENTS.md (symlink)
  AGENTS.md sha256=1f85956c9720fe01
  $ fm-ensure-agents-md.sh <repo>  -> rc=0
    updated: replaced CLAUDE.md symlink with @AGENTS.md pointer in keep-mark-on-third-line-lf
  CLAUDE.md regular file:
    | <!-- Points Claude at AGENTS.md via import; edit AGENTS.md, not this file. -->
    | @AGENTS.md
  AGENTS.md sha256=1f85956c9720fe01
  $ fm-ensure-agents-md.sh <repo>  -> rc=0
    unchanged: AGENTS.md with CLAUDE.md @AGENTS.md pointer in keep-mark-on-third-line-lf
  CLAUDE.md regular file:
    | <!-- Points Claude at AGENTS.md via import; edit AGENTS.md, not this file. -->
    | @AGENTS.md
  AGENTS.md sha256=1f85956c9720fe01

== marks-swapped-crlf (eol=CRLF, CLAUDE.md -> AGENTS.md)
  AGENTS.md first lines: 0000000 < ! - - f i r s t m a t e : k 0000020 e e p - c l a u d e - s y m l i 0000040 n k - - > \r \n < ! - - f i r 
  CLAUDE.md -> AGENTS.md (symlink)
  AGENTS.md sha256=039b41e37d0ded13
  $ fm-ensure-agents-md.sh <repo>  -> rc=0
    updated: added ## Maintaining this file to AGENTS.md and wrote CLAUDE.md @AGENTS.md pointer in marks-swapped-crlf
  CLAUDE.md regular file:
    | <!-- Points Claude at AGENTS.md via import; edit AGENTS.md, not this file. -->
    | @AGENTS.md
  AGENTS.md sha256=43d00708cecc57b0
  $ fm-ensure-agents-md.sh <repo>  -> rc=0
    unchanged: AGENTS.md with CLAUDE.md @AGENTS.md pointer in marks-swapped-crlf
  CLAUDE.md regular file:
    | <!-- Points Claude at AGENTS.md via import; edit AGENTS.md, not this file. -->
    | @AGENTS.md
  AGENTS.md sha256=43d00708cecc57b0

== keep-mark-without-first-mark-lf (eol=LF, CLAUDE.md -> AGENTS.md)
  AGENTS.md first lines: 0000000 # P r o j e c t m e m o r y 0000020 \n < ! - - f i r s t m a t e : 0000040 k e e p - c l a u d e - s y m l 
  CLAUDE.md -> AGENTS.md (symlink)
  AGENTS.md sha256=4db51a5a82b34f8c
  $ fm-ensure-agents-md.sh <repo>  -> rc=0
    updated: added ## Maintaining this file to AGENTS.md and wrote CLAUDE.md @AGENTS.md pointer in keep-mark-without-first-mark-lf
  CLAUDE.md regular file:
    | <!-- Points Claude at AGENTS.md via import; edit AGENTS.md, not this file. -->
    | @AGENTS.md
  AGENTS.md sha256=69b35bd4609b8760
  $ fm-ensure-agents-md.sh <repo>  -> rc=0
    unchanged: AGENTS.md with CLAUDE.md @AGENTS.md pointer in keep-mark-without-first-mark-lf
  CLAUDE.md regular file:
    | <!-- Points Claude at AGENTS.md via import; edit AGENTS.md, not this file. -->
    | @AGENTS.md
  AGENTS.md sha256=69b35bd4609b8760

== keep-mark-trailing-space-lf (eol=LF, CLAUDE.md -> AGENTS.md)
  AGENTS.md first lines: 0000000 < ! - - f i r s t m a t e : m 0000020 a i n t a i n e d - b y - p r o 0000040 j e c t - - > \n < ! - - f i 
  CLAUDE.md -> AGENTS.md (symlink)
  AGENTS.md sha256=1f0669ab6d4f274e
  $ fm-ensure-agents-md.sh <repo>  -> rc=0
    updated: replaced CLAUDE.md symlink with @AGENTS.md pointer in keep-mark-trailing-space-lf
  CLAUDE.md regular file:
    | <!-- Points Claude at AGENTS.md via import; edit AGENTS.md, not this file. -->
    | @AGENTS.md
  AGENTS.md sha256=1f0669ab6d4f274e
  $ fm-ensure-agents-md.sh <repo>  -> rc=0
    unchanged: AGENTS.md with CLAUDE.md @AGENTS.md pointer in keep-mark-trailing-space-lf
  CLAUDE.md regular file:
    | <!-- Points Claude at AGENTS.md via import; edit AGENTS.md, not this file. -->
    | @AGENTS.md
  AGENTS.md sha256=1f0669ab6d4f274e

== opted-wrong-target-lf (eol=LF, CLAUDE.md -> OTHER.md)
  AGENTS.md first lines: 0000000 < ! - - f i r s t m a t e : m 0000020 a i n t a i n e d - b y - p r o 0000040 j e c t - - > \n < ! - - f i 
  CLAUDE.md -> OTHER.md (symlink)
  AGENTS.md sha256=27440f8eb9df0346
  $ fm-ensure-agents-md.sh <repo>  -> rc=1
    conflict: CLAUDE.md is a symlink in opted-wrong-target-lf but does not point to AGENTS.md
  CLAUDE.md -> OTHER.md (symlink)
  AGENTS.md sha256=27440f8eb9df0346
  $ fm-ensure-agents-md.sh <repo>  -> rc=1
    conflict: CLAUDE.md is a symlink in opted-wrong-target-lf but does not point to AGENTS.md
  CLAUDE.md -> OTHER.md (symlink)
  AGENTS.md sha256=27440f8eb9df0346
```
</details>
<details>
<summary>Evidence: Same scenarios on the pre-fix helper (opted-in symlink gets converted)</summary>

Source: [Same scenarios on the pre-fix helper (opted-in symlink gets converted)](https://github.com/natalna-ai/firstmate/blob/4a2b0e91ddb83ce430046bd73b13420aaed9b239/.no-mistakes/evidence/fix/keep-claude-symlink-optin/e2e-transcript-base.txt)

```text
== opted-lf (eol=LF, CLAUDE.md -> AGENTS.md)
  AGENTS.md first lines: 0000000 < ! - - f i r s t m a t e : m 0000020 a i n t a i n e d - b y - p r o 0000040 j e c t - - > \n < ! - - f i 
  CLAUDE.md -> AGENTS.md (symlink)
  AGENTS.md sha256=27440f8eb9df0346
  $ fm-ensure-agents-md.sh <repo>  -> rc=0
    updated: replaced CLAUDE.md symlink with @AGENTS.md pointer in opted-lf
  CLAUDE.md regular file:
    | <!-- Points Claude at AGENTS.md via import; edit AGENTS.md, not this file. -->
    | @AGENTS.md
  AGENTS.md sha256=27440f8eb9df0346
  $ fm-ensure-agents-md.sh <repo>  -> rc=0
    unchanged: AGENTS.md with CLAUDE.md @AGENTS.md pointer in opted-lf
  CLAUDE.md regular file:
    | <!-- Points Claude at AGENTS.md via import; edit AGENTS.md, not this file. -->
    | @AGENTS.md
  AGENTS.md sha256=27440f8eb9df0346

== opted-crlf (eol=CRLF, CLAUDE.md -> AGENTS.md)
  AGENTS.md first lines: 0000000 < ! - - f i r s t m a t e : m 0000020 a i n t a i n e d - b y - p r o 0000040 j e c t - - > \r \n < ! - - f 
  CLAUDE.md -> AGENTS.md (symlink)
  AGENTS.md sha256=846cf67cd887cb4d
  $ fm-ensure-agents-md.sh <repo>  -> rc=0
    updated: replaced CLAUDE.md symlink with @AGENTS.md pointer in opted-crlf
  CLAUDE.md regular file:
    | <!-- Points Claude at AGENTS.md via import; edit AGENTS.md, not this file. -->
    | @AGENTS.md
  AGENTS.md sha256=846cf67cd887cb4d
  $ fm-ensure-agents-md.sh <repo>  -> rc=0
    unchanged: AGENTS.md with CLAUDE.md @AGENTS.md pointer in opted-crlf
  CLAUDE.md regular file:
    | <!-- Points Claude at AGENTS.md via import; edit AGENTS.md, not this file. -->
    | @AGENTS.md
  AGENTS.md sha256=846cf67cd887cb4d

== opted-dot-slash-target (eol=LF, CLAUDE.md -> ./AGENTS.md)
  AGENTS.md first lines: 0000000 < ! - - f i r s t m a t e : m 0000020 a i n t a i n e d - b y - p r o 0000040 j e c t - - > \n < ! - - f i 
  CLAUDE.md -> ./AGENTS.md (symlink)
  AGENTS.md sha256=27440f8eb9df0346
  $ fm-ensure-agents-md.sh <repo>  -> rc=0
    updated: replaced CLAUDE.md symlink with @AGENTS.md pointer in opted-dot-slash-target
  CLAUDE.md regular file:
    | <!-- Points Claude at AGENTS.md via import; edit AGENTS.md, not this file. -->
    | @AGENTS.md
  AGENTS.md sha256=27440f8eb9df0346
  $ fm-ensure-agents-md.sh <repo>  -> rc=0
    unchanged: AGENTS.md with CLAUDE.md @AGENTS.md pointer in opted-dot-slash-target
  CLAUDE.md regular file:
    | <!-- Points Claude at AGENTS.md via import; edit AGENTS.md, not this file. -->
    | @AGENTS.md
  AGENTS.md sha256=27440f8eb9df0346

== unmarked-lf (eol=LF, CLAUDE.md -> AGENTS.md)
  AGENTS.md first lines: 0000000 # P r o j e c t m e m o r y 0000020 \n 0000021 
  CLAUDE.md -> AGENTS.md (symlink)
  AGENTS.md sha256=03c67c17d8a3f815
  $ fm-ensure-agents-md.sh <repo>  -> rc=0
    updated: added ## Maintaining this file to AGENTS.md and wrote CLAUDE.md @AGENTS.md pointer in unmarked-lf
  CLAUDE.md regular file:
    | <!-- Points Claude at AGENTS.md via import; edit AGENTS.md, not this file. -->
    | @AGENTS.md
  AGENTS.md sha256=8c0423c3be6380b5
  $ fm-ensure-agents-md.sh <repo>  -> rc=0
    unchanged: AGENTS.md with CLAUDE.md @AGENTS.md pointer in unmarked-lf
  CLAUDE.md regular file:
    | <!-- Points Claude at AGENTS.md via import; edit AGENTS.md, not this file. -->
    | @AGENTS.md
  AGENTS.md sha256=8c0423c3be6380b5

== missing-second-mark-crlf (eol=CRLF, CLAUDE.md -> AGENTS.md)
  AGENTS.md first lines: 0000000 < ! - - f i r s t m a t e : m 0000020 a i n t a i n e d - b y - p r o 0000040 j e c t - - > \r \n # P r o j 
  CLAUDE.md -> AGENTS.md (symlink)
  AGENTS.md sha256=6b2690afc4984f98
  $ fm-ensure-agents-md.sh <repo>  -> rc=0
    updated: replaced CLAUDE.md symlink with @AGENTS.md pointer in missing-second-mark-crlf
  CLAUDE.md regular file:
    | <!-- Points Claude at AGENTS.md via import; edit AGENTS.md, not this file. -->
    | @AGENTS.md
  AGENTS.md sha256=6b2690afc4984f98
  $ fm-ensure-agents-md.sh <repo>  -> rc=0
    unchanged: AGENTS.md with CLAUDE.md @AGENTS.md pointer in missing-second-mark-crlf
  CLAUDE.md regular file:
    | <!-- Points Claude at AGENTS.md via import; edit AGENTS.md, not this file. -->
    | @AGENTS.md
  AGENTS.md sha256=6b2690afc4984f98

== keep-mark-on-third-line-lf (eol=LF, CLAUDE.md -> AGENTS.md)
  AGENTS.md first lines: 0000000 < ! - - f i r s t m a t e : m 0000020 a i n t a i n e d - b y - p r o 0000040 j e c t - - > \n # P r o j e 
  CLAUDE.md -> AGENTS.md (symlink)
  AGENTS.md sha256=1f85956c9720fe01
  $ fm-ensure-agents-md.sh <repo>  -> rc=0
    updated: replaced CLAUDE.md symlink with @AGENTS.md pointer in keep-mark-on-third-line-lf
  CLAUDE.md regular file:
    | <!-- Points Claude at AGENTS.md via import; edit AGENTS.md, not this file. -->
    | @AGENTS.md
  AGENTS.md sha256=1f85956c9720fe01
  $ fm-ensure-agents-md.sh <repo>  -> rc=0
    unchanged: AGENTS.md with CLAUDE.md @AGENTS.md pointer in keep-mark-on-third-line-lf
  CLAUDE.md regular file:
    | <!-- Points Claude at AGENTS.md via import; edit AGENTS.md, not this file. -->
    | @AGENTS.md
  AGENTS.md sha256=1f85956c9720fe01

== marks-swapped-crlf (eol=CRLF, CLAUDE.md -> AGENTS.md)
  AGENTS.md first lines: 0000000 < ! - - f i r s t m a t e : k 0000020 e e p - c l a u d e - s y m l i 0000040 n k - - > \r \n < ! - - f i r 
  CLAUDE.md -> AGENTS.md (symlink)
  AGENTS.md sha256=039b41e37d0ded13
  $ fm-ensure-agents-md.sh <repo>  -> rc=0
    updated: added ## Maintaining this file to AGENTS.md and wrote CLAUDE.md @AGENTS.md pointer in marks-swapped-crlf
  CLAUDE.md regular file:
    | <!-- Points Claude at AGENTS.md via import; edit AGENTS.md, not this file. -->
    | @AGENTS.md
  AGENTS.md sha256=43d00708cecc57b0
  $ fm-ensure-agents-md.sh <repo>  -> rc=0
    unchanged: AGENTS.md with CLAUDE.md @AGENTS.md pointer in marks-swapped-crlf
  CLAUDE.md regular file:
    | <!-- Points Claude at AGENTS.md via import; edit AGENTS.md, not this file. -->
    | @AGENTS.md
  AGENTS.md sha256=43d00708cecc57b0

== keep-mark-without-first-mark-lf (eol=LF, CLAUDE.md -> AGENTS.md)
  AGENTS.md first lines: 0000000 # P r o j e c t m e m o r y 0000020 \n < ! - - f i r s t m a t e : 0000040 k e e p - c l a u d e - s y m l 
  CLAUDE.md -> AGENTS.md (symlink)
  AGENTS.md sha256=4db51a5a82b34f8c
  $ fm-ensure-agents-md.sh <repo>  -> rc=0
    updated: added ## Maintaining this file to AGENTS.md and wrote CLAUDE.md @AGENTS.md pointer in keep-mark-without-first-mark-lf
  CLAUDE.md regular file:
    | <!-- Points Claude at AGENTS.md via import; edit AGENTS.md, not this file. -->
    | @AGENTS.md
  AGENTS.md sha256=69b35bd4609b8760
  $ fm-ensure-agents-md.sh <repo>  -> rc=0
    unchanged: AGENTS.md with CLAUDE.md @AGENTS.md pointer in keep-mark-without-first-mark-lf
  CLAUDE.md regular file:
    | <!-- Points Claude at AGENTS.md via import; edit AGENTS.md, not this file. -->
    | @AGENTS.md
  AGENTS.md sha256=69b35bd4609b8760

== keep-mark-trailing-space-lf (eol=LF, CLAUDE.md -> AGENTS.md)
  AGENTS.md first lines: 0000000 < ! - - f i r s t m a t e : m 0000020 a i n t a i n e d - b y - p r o 0000040 j e c t - - > \n < ! - - f i 
  CLAUDE.md -> AGENTS.md (symlink)
  AGENTS.md sha256=1f0669ab6d4f274e
  $ fm-ensure-agents-md.sh <repo>  -> rc=0
    updated: replaced CLAUDE.md symlink with @AGENTS.md pointer in keep-mark-trailing-space-lf
  CLAUDE.md regular file:
    | <!-- Points Claude at AGENTS.md via import; edit AGENTS.md, not this file. -->
    | @AGENTS.md
  AGENTS.md sha256=1f0669ab6d4f274e
  $ fm-ensure-agents-md.sh <repo>  -> rc=0
    unchanged: AGENTS.md with CLAUDE.md @AGENTS.md pointer in keep-mark-trailing-space-lf
  CLAUDE.md regular file:
    | <!-- Points Claude at AGENTS.md via import; edit AGENTS.md, not this file. -->
    | @AGENTS.md
  AGENTS.md sha256=1f0669ab6d4f274e

== opted-wrong-target-lf (eol=LF, CLAUDE.md -> OTHER.md)
  AGENTS.md first lines: 0000000 < ! - - f i r s t m a t e : m 0000020 a i n t a i n e d - b y - p r o 0000040 j e c t - - > \n < ! - - f i 
  CLAUDE.md -> OTHER.md (symlink)
  AGENTS.md sha256=27440f8eb9df0346
  $ fm-ensure-agents-md.sh <repo>  -> rc=1
    conflict: CLAUDE.md is a symlink in opted-wrong-target-lf but does not point to AGENTS.md
  CLAUDE.md -> OTHER.md (symlink)
  AGENTS.md sha256=27440f8eb9df0346
  $ fm-ensure-agents-md.sh <repo>  -> rc=1
    conflict: CLAUDE.md is a symlink in opted-wrong-target-lf but does not point to AGENTS.md
  CLAUDE.md -> OTHER.md (symlink)
  AGENTS.md sha256=27440f8eb9df0346
```
</details>
<details>
<summary>Evidence: Script that produces both transcripts</summary>

Source: [Script that produces both transcripts](https://github.com/natalna-ai/firstmate/blob/4a2b0e91ddb83ce430046bd73b13420aaed9b239/.no-mistakes/evidence/fix/keep-claude-symlink-optin/e2e-transcript.sh)

```text
#!/usr/bin/env bash
# End-to-end CLI transcript for fm-ensure-agents-md.sh symlink opt-in.
set -u
HELPER=${1:?helper path}
W=$(mktemp -d)
M1='<!-- firstmate:maintained-by-project -->'
M2='<!-- firstmate:keep-claude-symlink -->'
show() { # repo
  local r=$1
  if [ -L "$r/CLAUDE.md" ]; then echo "  CLAUDE.md -> $(readlink "$r/CLAUDE.md") (symlink)"
  elif [ -f "$r/CLAUDE.md" ]; then echo "  CLAUDE.md regular file:"; sed 's/^/    | /' "$r/CLAUDE.md"
  else echo "  CLAUDE.md absent"; fi
  echo "  AGENTS.md sha256=$(sha256sum < "$r/AGENTS.md" | cut -c1-16)"
}
run() { # name target
  local r=$1 out rc
  out=$("$HELPER" "$r" 2>&1); rc=$?
  echo "  \$ fm-ensure-agents-md.sh <repo>  -> rc=$rc"; echo "    $out" | sed "s#$W/##"
}
scenario() { # name eol body-builder target
  local name=$1 eol=$2 build=$3 target=${4:-AGENTS.md} r
  r="$W/$name"; mkdir -p "$r"
  $build "$eol" > "$r/AGENTS.md"
  printf '# other\n' > "$r/OTHER.md"
  ln -s "$target" "$r/CLAUDE.md"
  echo "== $name (eol=$([ "$eol" = $'\r\n' ] && echo CRLF || echo LF), CLAUDE.md -> $target)"
  echo "  AGENTS.md first lines: $(head -n 2 "$r/AGENTS.md" | od -c | head -n 3 | tr -s ' ' | tr '\n' ' ' | cut -c1-140)"
  show "$r"
  run "$r"; show "$r"
  run "$r"; show "$r"
  echo
}
opted()    { printf '%s%s' "$M1" "$1" "$M2" "$1" '# Project memory' "$1"; }
missing()  { printf '%s%s' "$M1" "$1" '# Project memory' "$1"; }
third()    { printf '%s%s' "$M1" "$1" '# Project memory' "$1" "$M2" "$1"; }
swapped()  { printf '%s%s' "$M2" "$1" "$M1" "$1" '# Project memory' "$1"; }
nofirst()  { printf '%s%s' '# Project memory' "$1" "$M2" "$1"; }
trailsp()  { printf '%s%s' "$M1" "$1" "$M2 " "$1" '# Project memory' "$1"; }
unmarked() { printf '%s%s' '# Project memory' "$1"; }
scenario opted-lf $'\n' opted
scenario opted-crlf $'\r\n' opted
scenario opted-dot-slash-target $'\n' opted ./AGENTS.md
scenario unmarked-lf $'\n' unmarked
scenario missing-second-mark-crlf $'\r\n' missing
scenario keep-mark-on-third-line-lf $'\n' third
scenario marks-swapped-crlf $'\r\n' swapped
scenario keep-mark-without-first-mark-lf $'\n' nofirst
scenario keep-mark-trailing-space-lf $'\n' trailsp
scenario opted-wrong-target-lf $'\n' opted OTHER.md
rm -rf "$W"
```
</details>
<details>
<summary>Evidence: No symlink is created when CLAUDE.md is missing or dangling</summary>

Source: [No symlink is created when CLAUDE.md is missing or dangling](https://github.com/natalna-ai/firstmate/blob/4a2b0e91ddb83ce430046bd73b13420aaed9b239/.no-mistakes/evidence/fix/keep-claude-symlink-optin/no-symlink-creation.txt)

```text
== opted AGENTS.md (LF), CLAUDE.md absent
  rc=0 wrote: CLAUDE.md @AGENTS.md pointer in no-claude-LF
  CLAUDE.md regular file:
    | <!-- Points Claude at AGENTS.md via import; edit AGENTS.md, not this file. -->
    | @AGENTS.md
== opted AGENTS.md (CRLF), CLAUDE.md absent
  rc=0 wrote: CLAUDE.md @AGENTS.md pointer in no-claude-CRLF
  CLAUDE.md regular file:
    | <!-- Points Claude at AGENTS.md via import; edit AGENTS.md, not this file. -->
    | @AGENTS.md
== AGENTS.md absent, CLAUDE.md -> AGENTS.md (dangling)
  rc=0 created: AGENTS.md and wrote CLAUDE.md @AGENTS.md pointer in dangling
  CLAUDE.md regular file (pointer)
```
</details>
<details>
<summary>Evidence: Retention test failing on the pre-fix helper</summary>

Source: [Retention test failing on the pre-fix helper](https://github.com/natalna-ai/firstmate/blob/4a2b0e91ddb83ce430046bd73b13420aaed9b239/.no-mistakes/evidence/fix/keep-claude-symlink-optin/regression-retention-test-against-base-helper.txt)

```text
not ok - retained symlink run 1 did not report unchanged (missing: 'unchanged:')
--- output ---
updated: replaced CLAUDE.md symlink with @AGENTS.md pointer in /tmp/fm-ensure-agents-md.7DJ480/retained-symlink.gnVaT1
```
</details>
<details>
<summary>Evidence: Opted-in LF case with the fix, two runs</summary>

```text
$ fm-ensure-agents-md.sh <repo> -> rc=0
unchanged: AGENTS.md with project-retained CLAUDE.md -> AGENTS.md symlink
CLAUDE.md -> AGENTS.md (symlink) AGENTS.md sha256=27440f8eb9df0346
$ fm-ensure-agents-md.sh <repo> -> rc=0
unchanged: ... CLAUDE.md -> AGENTS.md (symlink) AGENTS.md sha256=27440f8eb9df0346
Wrong target (opted-in, CLAUDE.md -> OTHER.md): rc=1 conflict: CLAUDE.md is a symlink ... but does not point to AGENTS.md
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"179bcda72886f3d02ce06373a0898af275547fc3","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 1 info</summary>

- ℹ️ `docs/architecture.md:386` - docs/architecture.md still says every project&#39;s `CLAUDE.md` is a real `@AGENTS.md` import pointer, and line 388 still names a single explicit mark. The helper now also allows a correct symlink to be kept when both first-line and second-line marks are present. Suggest wording such as &#34;by default a real `@AGENTS.md` import pointer (or an explicitly retained correct symlink)&#34; and &#34;marks&#34;, matching docs/scripts.md.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`bash tests/fm-ensure-agents-md.test.sh` (all tests, including the new help-contract, LF/CRLF retention and missing/misplaced-mark fallback tests, plus the updated wrong-target refusal test; exit 0)</code>
- <code>Regression check: ran the new retention test alone against the pre-fix helper (`git show fa65b5d:bin/fm-ensure-agents-md.sh`). It fails on the old helper (&#34;updated: replaced CLAUDE.md symlink&#34;) and passes on the new one. Restored the helper with `git checkout`</code>
- <code>Ran `e2e-transcript.sh` against the new and old helper, two runs per scenario. Scenarios: opted-in with LF, CRLF and a `./AGENTS.md` target; unmarked; retention mark missing, on line 3, swapped with the first mark, without the first mark, or with a trailing space; and opted-in with a wrong target (OTHER.md)</code>
- `Checked that no symlink is ever created: opted-in AGENTS.md with no CLAUDE.md (LF and CRLF), and AGENTS.md missing with a dangling CLAUDE.md -> AGENTS.md symlink, all produce a real pointer file`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Lint** - 1 warning</summary>

- ⚠️ linter found issues (exit code 1)

🔧 Fix: Lint passes with pinned ShellCheck and actionlint installed
1 warning still open:
- ⚠️ linter found issues (exit code 1)

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
