### PR TITLE
feat(bootstrap): detect hosts that cannot share a SQLite WAL database

### DIFF
--- a/.agents/skills/bootstrap-diagnostics/SKILL.md
+++ b/.agents/skills/bootstrap-diagnostics/SKILL.md
@@ -2,7 +2,7 @@
 name: bootstrap-diagnostics
 description: >-
   Agent-only handling playbook for session-start bootstrap diagnostics.
-  Use whenever the session-start digest's bootstrap or network-checks section prints an actionable diagnostic line - MISSING, MISSING_MANUAL, PRESENTATION_UNAVAILABLE, BACKEND_INVALID, NEEDS_GH_AUTH, TANGLE, STARTUP_MEMORY_BUDGET, CREW_DISPATCH invalid, FLEET_SYNC, NETWORK_CHECKS, HOME_SUMMARY, BACKLOG_RECONCILE, SECONDMATE_SYNC, SECONDMATE_LIVENESS, SECONDMATE_HANDOFF, NUDGE_SECONDMATES, or FMX - or reports that an interrupted backlog cleanup may have left an endpoint or local copy, or when a standalone bin/fm-bootstrap.sh or bin/fm-startup-network.sh run prints one of those lines.
+  Use whenever the session-start digest's bootstrap or network-checks section prints an actionable diagnostic line - MISSING, MISSING_MANUAL, PRESENTATION_UNAVAILABLE, VALIDATION_UNAVAILABLE, BACKEND_INVALID, NEEDS_GH_AUTH, TANGLE, STARTUP_MEMORY_BUDGET, CREW_DISPATCH invalid, FLEET_SYNC, NETWORK_CHECKS, HOME_SUMMARY, BACKLOG_RECONCILE, SECONDMATE_SYNC, SECONDMATE_LIVENESS, SECONDMATE_HANDOFF, NUDGE_SECONDMATES, or FMX - or reports that an interrupted backlog cleanup may have left an endpoint or local copy, or when a standalone bin/fm-bootstrap.sh or bin/fm-startup-network.sh run prints one of those lines.
   A silent bootstrap section, or any other BOOTSTRAP_INFO fact, means no skill load.
 user-invocable: false
 metadata:
@@ -25,6 +25,13 @@ When any diagnostic needs captain attention, report the plain consequence and re
 - `PRESENTATION_UNAVAILABLE: lavish-axi ...` - explain that visual presentation is unavailable and continue nonvisual work with plain-text decisions and reports; do not hold unrelated dispatch for installation consent.
   Do not use Lavish until it satisfies the floor owned by `bin/fm-bootstrap.sh`; when visual work needs it, request consent for the printed install or upgrade command, then rerun bootstrap to confirm compatibility before using it.
   Scout briefs check the same floor when scaffolded and ask for a text report instead of a Lavish loop, so scaffold a visual scout only after that rerun confirms compatibility.
+- `VALIDATION_UNAVAILABLE: no-mistakes (kernel <release> cannot share a SQLite WAL database across processes: <detail>)` - this host cannot run the no-mistakes pipeline at all, so treat the no-mistakes delivery mode as unavailable for every project here until the captain resolves it.
+  no-mistakes keeps its pipeline state in a SQLite WAL database its daemon holds open, and this host's kernel cannot hand that database to a second process; every CLI call made while the daemon is up fails with SQLITE_PROTOCOL.
+  Ship affected work `direct-PR` and say plainly in the PR that the usual validation could not run, rather than reporting work as validated.
+  Do not treat a passing call as the problem clearing: the calls succeed whenever the daemon happens to be down, so an intermittent success is the daemon's state changing, not the host's.
+  The repair is a host change and therefore the captain's call, not bootstrap's and not a worker's.
+  Two remedies are already ruled out by `tests/fm-sqlite-wal-lock-live-e2e.test.sh`, so do not spend a task on either: relocating the no-mistakes data directory does not help, because every filesystem on such a host fails the same probe, and deleting or checkpointing the state database does not help, because the fault is concurrent access rather than corruption.
+  Report it to the captain as a host-level blocker with those options closed, and re-run that guard after any host migration.
 - `MISSING_MANUAL: <tool> (instructions: <url>)` - tell the captain why the tool is required and give them the printed instructions URL, but do not pass the tool to `bin/fm-bootstrap.sh install`; wait for the captain to complete the manual installation, then rerun session start to confirm the dependency is present.
 - `BACKEND_INVALID: <name> (known: <names>)` - the resolved runtime backend has no verified dependency or lifecycle contract, so do not dispatch work until the invalid `FM_BACKEND` or `config/backend` value is corrected to one of the listed backends.
 - `NEEDS_GH_AUTH` - ask the captain to run `! gh auth login` (interactive; you cannot run it for them).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -559,7 +559,7 @@ The skill owns the guarded fleet update and restart procedure; it never touches 
 
 These skills are not captain-invocable; load them only at their precise triggers.
 
-- `bootstrap-diagnostics` - load whenever the session-start digest's bootstrap or network-checks section prints an actionable diagnostic line (`MISSING:`, `MISSING_MANUAL:`, `PRESENTATION_UNAVAILABLE:`, `BACKEND_INVALID:`, `NEEDS_GH_AUTH`, `TANGLE:`, `STARTUP_MEMORY_BUDGET:`, `CREW_DISPATCH: invalid`, `FLEET_SYNC:`, `NETWORK_CHECKS:`, `HOME_SUMMARY:`, `BACKLOG_RECONCILE:`, `SECONDMATE_SYNC:`, `SECONDMATE_LIVENESS:`, `SECONDMATE_HANDOFF:`, `NUDGE_SECONDMATES:`, or `FMX:`), or when `BOOTSTRAP_INFO:` says an interrupted backlog cleanup may have left an endpoint or local copy; silence and other `BOOTSTRAP_INFO:` facts need no load.
+- `bootstrap-diagnostics` - load whenever the session-start digest's bootstrap or network-checks section prints an actionable diagnostic line (`MISSING:`, `MISSING_MANUAL:`, `PRESENTATION_UNAVAILABLE:`, `VALIDATION_UNAVAILABLE:`, `BACKEND_INVALID:`, `NEEDS_GH_AUTH`, `TANGLE:`, `STARTUP_MEMORY_BUDGET:`, `CREW_DISPATCH: invalid`, `FLEET_SYNC:`, `NETWORK_CHECKS:`, `HOME_SUMMARY:`, `BACKLOG_RECONCILE:`, `SECONDMATE_SYNC:`, `SECONDMATE_LIVENESS:`, `SECONDMATE_HANDOFF:`, `NUDGE_SECONDMATES:`, or `FMX:`), or when `BOOTSTRAP_INFO:` says an interrupted backlog cleanup may have left an endpoint or local copy; silence and other `BOOTSTRAP_INFO:` facts need no load.
 - `diagnostic-reasoning` - load before scoping a reported bug and before acting on a diagnostic report.
 - `ask-user-authority` - load before deciding any ask-user finding.
 - `quota-array-dispatch` - load before choosing among a matched crew-dispatch profile array from current quota-axi default TOON.

--- a/bin/fm-bootstrap.sh
+++ b/bin/fm-bootstrap.sh
@@ -7,6 +7,7 @@
 #          Silent = all good.
 #          Lines: "MISSING: <tool> (install: <command>)",
 #                 "PRESENTATION_UNAVAILABLE: lavish-axi (requires >=<floor>; install: <command>) - nonvisual work may proceed with plain-text decisions and reports; install or upgrade before using Lavish",
+#                 "VALIDATION_UNAVAILABLE: no-mistakes (kernel <release> cannot share a SQLite WAL database across processes: <probe detail>) - the no-mistakes delivery mode is unavailable on this host; ship affected work direct-PR until the host is repaired",
 #                 "MISSING_MANUAL: <tool> (instructions: <url>)", "NEEDS_GH_AUTH",
 #                 "BACKEND_INVALID: <name> (known: <names>)",
 #                 "STARTUP_MEMORY_BUDGET: invalid config/startup-memory-budget - <reason>",
@@ -181,6 +182,8 @@ DATA="${FM_DATA_OVERRIDE:-$FM_HOME/data}"
 . "$SCRIPT_DIR/fm-secondmate-nudge-lib.sh"
 # shellcheck source=bin/fm-startup-memory-budget-lib.sh disable=SC1091
 . "$SCRIPT_DIR/fm-startup-memory-budget-lib.sh"
+# shellcheck source=bin/fm-sqlite-wal-lib.sh disable=SC1091
+. "$SCRIPT_DIR/fm-sqlite-wal-lib.sh"
 # shellcheck source=bin/fm-x-lib.sh disable=SC1091
 . "$SCRIPT_DIR/fm-x-lib.sh"
 # shellcheck source=bin/fm-backend.sh disable=SC1091
@@ -1414,6 +1417,25 @@ if [ "${FM_BOOTSTRAP_DETECT_ONLY:-0}" != 1 ] && local_phase; then
   fi
 fi
 
+# no-mistakes keeps its pipeline state in a SQLite WAL database its daemon holds
+# open, so a host that cannot share a WAL database across processes has no
+# working no-mistakes delivery mode at all - every CLI call made while the
+# daemon is up fails with SQLITE_PROTOCOL. The verdict comes from the real
+# two-process probe owned by bin/fm-sqlite-wal-lib.sh; the host gate there keeps
+# a normal host from paying for a check it cannot fail. Detect-only: the repair
+# is a host change, which is the captain's call and never bootstrap's.
+detect_validation_wal_locking() {
+  command -v no-mistakes >/dev/null 2>&1 || return 0
+  [ "${FM_SKIP_WAL_LOCK_PROBE:-0}" = 1 ] && return 0
+  fm_sqlite_wal_host_suspect || return 0
+  local rc=0
+  fm_sqlite_wal_probe || rc=$?
+  # 0 is a working host and 2 means the probe could not run, so nothing was
+  # observed; only an observed failure is reported.
+  [ "$rc" -eq 1 ] || return 0
+  echo "VALIDATION_UNAVAILABLE: no-mistakes (kernel $(fm_sqlite_wal_kernel) cannot share a SQLite WAL database across processes: $(fm_sqlite_wal_probe_detail)) - the no-mistakes delivery mode is unavailable on this host; ship affected work direct-PR until the host is repaired"
+}
+
 # Local detection: presence, version floors, and configuration. Nothing here
 # leaves this machine, so it stays on the session-start critical path.
 detect_local_tools() {
@@ -1437,6 +1459,7 @@ detect_local_tools() {
   if command -v no-mistakes >/dev/null 2>&1 && ! tool_version_at_least no-mistakes "$NO_MISTAKES_MIN"; then
     echo "MISSING: no-mistakes (install: $(install_cmd no-mistakes))"
   fi
+  detect_validation_wal_locking
   if command -v gh-axi >/dev/null 2>&1 && ! tool_version_at_least gh-axi "$GH_AXI_MIN"; then
     echo "MISSING: gh-axi (install: $(install_cmd gh-axi))"
   fi

--- a/bin/fm-sqlite-wal-lib.sh
+++ b/bin/fm-sqlite-wal-lib.sh
@@ -1,0 +1,98 @@
+# shellcheck shell=bash
+# Shared detection for hosts that cannot share a SQLite WAL database across processes.
+# Usage: . bin/fm-sqlite-wal-lib.sh
+#          fm_sqlite_wal_host_suspect              0 when this host is worth probing
+#          fm_sqlite_wal_probe [<dir>] [<timeout>] 0 supported, 1 unsupported, 2 unverified
+#          fm_sqlite_wal_probe_detail              the probe's one-line detail
+#          fm_sqlite_wal_kernel                    the kernel release the verdict was taken on
+#
+# ONE OWNER for "can two processes hold this host's SQLite WAL database at
+# once". no-mistakes keeps its pipeline state in a WAL database at
+# ~/.no-mistakes/state.sqlite that its daemon holds open, so on a host without
+# cross-process WAL support every CLI call that runs while the daemon is up
+# fails with SQLITE_PROTOCOL (15) - "locking protocol" - and the no-mistakes
+# delivery mode is unavailable for every project in the fleet.
+#
+# The verdict always comes from bin/fm-sqlite-wal-probe.py, which runs two real
+# processes against a real WAL database. Nothing here infers a verdict from a
+# kernel version string: the version only decides whether spending the probe is
+# worth it, because the condition is confined to WSL and a normal host must not
+# pay for a check it cannot fail.
+#
+# Why the gate is "is this WSL at all" rather than "is this WSL1": a WSL2 host
+# passes the probe in well under a second, so a generous gate costs almost
+# nothing and keeps the check from resting on the exact spelling of a release
+# string. WSL1 is the host class known to fail, and its failure is kernel-level
+# rather than filesystem-level - it reproduces on every filesystem WSL1 offers,
+# so relocating the database does not avoid it.
+
+FM_SQLITE_WAL_PROBE_TIMEOUT_DEFAULT=3
+FM_SQLITE_WAL_PROBE_DETAIL=''
+
+fm_sqlite_wal_kernel() {
+  if [ -n "${FM_FAKE_KERNEL_RELEASE:-}" ]; then
+    printf '%s\n' "$FM_FAKE_KERNEL_RELEASE"
+    return 0
+  fi
+  uname -r 2>/dev/null || printf 'unknown\n'
+}
+
+fm_sqlite_wal_root_fstype() {
+  if [ -n "${FM_FAKE_ROOT_FSTYPE:-}" ]; then
+    printf '%s\n' "$FM_FAKE_ROOT_FSTYPE"
+    return 0
+  fi
+  stat -f -c %T / 2>/dev/null || printf 'unknown\n'
+}
+
+# Cheap gate only. Three independent WSL signals, any one of which is enough to
+# spend the probe, so no single vendor spelling is load-bearing.
+fm_sqlite_wal_host_suspect() {
+  local release fstype
+  release=$(fm_sqlite_wal_kernel)
+  case "$release" in
+    *[Mm]icrosoft* | *WSL*) return 0 ;;
+  esac
+  fstype=$(fm_sqlite_wal_root_fstype)
+  case "$fstype" in
+    lxfs | wslfs) return 0 ;;
+  esac
+  [ -n "${WSL_DISTRO_NAME:-}" ] && return 0
+  [ -n "${WSL_INTEROP:-}" ] && return 0
+  return 1
+}
+
+fm_sqlite_wal_probe_detail() {
+  printf '%s\n' "$FM_SQLITE_WAL_PROBE_DETAIL"
+}
+
+# Runs the real two-process probe. <dir> defaults to the directory that actually
+# holds the no-mistakes state database, so the verdict is taken on the same
+# filesystem the pipeline uses; it falls back to TMPDIR when that directory is
+# not usable.
+fm_sqlite_wal_probe() {
+  local dir=${1:-} timeout=${2:-$FM_SQLITE_WAL_PROBE_TIMEOUT_DEFAULT}
+  local script out rc
+
+  FM_SQLITE_WAL_PROBE_DETAIL=''
+  if [ -z "$dir" ]; then
+    dir="${FM_NO_MISTAKES_HOME:-$HOME/.no-mistakes}"
+    [ -d "$dir" ] && [ -w "$dir" ] || dir=${TMPDIR:-/tmp}
+  fi
+
+  script=${FM_SQLITE_WAL_PROBE_BIN:-$(dirname "${BASH_SOURCE[0]}")/fm-sqlite-wal-probe.py}
+  if [ ! -x "$script" ]; then
+    FM_SQLITE_WAL_PROBE_DETAIL="probe helper $script is not executable"
+    return 2
+  fi
+  if ! command -v python3 >/dev/null 2>&1; then
+    FM_SQLITE_WAL_PROBE_DETAIL='python3 is not available to run the probe'
+    return 2
+  fi
+
+  out=$("$script" "$dir" --timeout "$timeout" 2>&1)
+  rc=$?
+  FM_SQLITE_WAL_PROBE_DETAIL=${out#*: }
+  [ "$out" = supported ] && FM_SQLITE_WAL_PROBE_DETAIL='supported'
+  return "$rc"
+}

--- a/bin/fm-sqlite-wal-probe.py
+++ b/bin/fm-sqlite-wal-probe.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+"""Probe whether this host can share a SQLite WAL database across processes.
+
+SQLite's WAL mode keeps its index in a shared-memory file (`<db>-shm`) that every
+connection maps and locks. A host whose kernel does not implement those shared
+mapping and POSIX advisory locking semantics lets a single process open a WAL
+database normally, and fails only when a SECOND process opens it while the first
+still holds it: SQLite retries WAL-index recovery, gives up, and returns
+SQLITE_PROTOCOL (15), surfaced by callers as "locking protocol".
+
+WSL1 is the known host in this class. The failure is kernel-level, not
+filesystem-level: it reproduces on every filesystem WSL1 offers.
+
+Usage:
+  fm-sqlite-wal-probe.py <dir> [--timeout SECONDS]
+      Run the probe in <dir>. Prints one line and exits:
+        0  "supported"
+        1  "unsupported: <detail>"
+        2  "unverified: <reason>"   (no usable sqlite3; nothing was observed)
+  fm-sqlite-wal-probe.py --read <db>
+      Internal second-process mode; not for direct use.
+
+The probe creates and removes its own scratch database and never opens a
+database it was not asked to create.
+"""
+
+import os
+import sys
+import tempfile
+
+DEFAULT_TIMEOUT = 3.0
+
+
+def _read_mode(db):
+    """Second process: open the WAL database the holder is holding."""
+    import sqlite3
+
+    try:
+        conn = sqlite3.connect(db, timeout=1)
+        conn.execute("select count(*) from probe").fetchone()
+        conn.close()
+    except Exception as exc:  # noqa: BLE001 - any failure to open is the verdict
+        sys.stdout.write("%s: %s\n" % (type(exc).__name__, exc))
+        return 1
+    sys.stdout.write("ok\n")
+    return 0
+
+
+def _probe(directory, timeout):
+    try:
+        import sqlite3  # noqa: F401
+    except Exception as exc:  # noqa: BLE001
+        sys.stdout.write("unverified: python3 has no sqlite3 module (%s)\n" % exc)
+        return 2
+
+    import sqlite3
+    import subprocess
+
+    try:
+        work = tempfile.mkdtemp(prefix="fm-walprobe-", dir=directory)
+    except OSError as exc:
+        sys.stdout.write("unverified: cannot create a scratch directory in %s (%s)\n" % (directory, exc))
+        return 2
+
+    db = os.path.join(work, "probe.db")
+    holder = None
+    try:
+        # First process: create a WAL database and keep it open, exactly as a
+        # long-running daemon holds its state database.
+        holder = sqlite3.connect(db, timeout=1, isolation_level=None)
+        mode = holder.execute("pragma journal_mode=wal").fetchone()[0]
+        if mode != "wal":
+            sys.stdout.write("unverified: this sqlite3 build refused WAL mode (journal_mode=%s)\n" % mode)
+            return 2
+        holder.execute("create table probe(x)")
+        holder.execute("insert into probe values(1)")
+        holder.execute("begin")
+        holder.execute("select count(*) from probe").fetchone()
+
+        # Second process: a genuinely separate process, which is the only thing
+        # that exercises the cross-process WAL-index contract.
+        try:
+            done = subprocess.run(
+                [sys.executable, os.path.abspath(__file__), "--read", db],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                timeout=timeout,
+            )
+        except subprocess.TimeoutExpired:
+            sys.stdout.write(
+                "unsupported: a second process could not open the WAL database within %gs\n" % timeout
+            )
+            return 1
+
+        detail = done.stdout.decode("utf-8", "replace").strip()
+        if done.returncode == 0 and detail == "ok":
+            sys.stdout.write("supported\n")
+            return 0
+        sys.stdout.write("unsupported: a second process could not open the WAL database (%s)\n" % detail)
+        return 1
+    finally:
+        if holder is not None:
+            try:
+                holder.close()
+            except Exception:  # noqa: BLE001
+                pass
+        for suffix in ("", "-wal", "-shm"):
+            try:
+                os.unlink(db + suffix)
+            except OSError:
+                pass
+        try:
+            os.rmdir(work)
+        except OSError:
+            pass
+
+
+def main(argv):
+    if len(argv) >= 3 and argv[1] == "--read":
+        return _read_mode(argv[2])
+    if len(argv) < 2 or argv[1].startswith("-"):
+        sys.stdout.write("usage: fm-sqlite-wal-probe.py <dir> [--timeout SECONDS]\n")
+        return 2
+    directory = argv[1]
+    timeout = DEFAULT_TIMEOUT
+    if len(argv) >= 4 and argv[2] == "--timeout":
+        try:
+            timeout = float(argv[3])
+        except ValueError:
+            sys.stdout.write("usage: fm-sqlite-wal-probe.py <dir> [--timeout SECONDS]\n")
+            return 2
+    return _probe(directory, timeout)
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/docs/verification/runtime-backends.md
+++ b/docs/verification/runtime-backends.md
@@ -1801,3 +1801,29 @@ A throwaway scout was spawned through `bin/fm-spawn.sh --scout --harness omp --m
 6. `bin/fm-control.sh <id> exit` stopped the agent and `bin/fm-teardown.sh` returned the worktree and closed the item.
 
 `FM_OMP_LIVE_E2E=1 tests/fm-omp-primary-live-e2e.test.sh` refreshes the primary evidence; the worker path above is refreshed by repeating the scout dispatch after any omp upgrade.
+
+## SQLite WAL cross-process locking
+
+no-mistakes keeps its pipeline state in a SQLite WAL database at `~/.no-mistakes/state.sqlite` that its daemon holds open, so a host that cannot hand a WAL database to a second process has no working no-mistakes delivery mode.
+`bin/fm-bootstrap.sh` reports that host with one `VALIDATION_UNAVAILABLE: no-mistakes ...` line, taken from the real two-process probe in `bin/fm-sqlite-wal-probe.py`.
+`FM_LIVE_SQLITE_WAL=1 tests/fm-sqlite-wal-lock-live-e2e.test.sh` refreshes every measurement below and must be re-run after any host migration.
+
+Measured on 2026-09-12 on WSL1, kernel `4.4.0-22621-Microsoft`, root filesystem `wslfs`, with SQLite 3.37.2 through python3.
+
+| Condition | Result |
+| --- | --- |
+| One process, WAL | opens normally |
+| One process, WAL, recovering an orphaned `-wal` and `-shm` left by a killed writer | opens normally and checkpoints |
+| Second process, WAL, while the first still holds the database | `SQLITE_PROTOCOL` (15), surfaced as `locking protocol`, after about ten seconds of WAL-index recovery retries |
+| Second process, `journal_mode=delete` or `truncate`, same concurrency | opens in about 0.04s |
+| Second process, WAL, on `wslfs`, `tmpfs` (`/dev/shm`) and `TMPDIR` | identical `SQLITE_PROTOCOL` on all three |
+
+Three consequences follow from that table and are what the live guard keeps true.
+
+The fault is concurrent access, not corruption: the same database opens cleanly whenever no second process holds it, so a passing call means the daemon was down at that moment rather than that the host was repaired.
+The fault is kernel-level, not filesystem-level: every filesystem the host offers returns the same verdict, so relocating the no-mistakes data directory is not a remedy, and the guard fails loudly if that ever stops being true.
+WAL is the only affected journal mode, which is why a rollback-journal database on the same host is unaffected.
+
+The failure is also self-masking on a short timescale.
+SQLite retries WAL-index recovery for about ten seconds before returning `SQLITE_PROTOCOL`, so a holder that releases inside that window lets the second process through; a probe whose holder is short-lived will report success on a host that cannot actually share a WAL database.
+The probe therefore holds its database for the whole measurement, and `bin/fm-bootstrap.sh` bounds its own call at 3s against a healthy-host open of about 0.04s.

--- a/tests/fm-sqlite-wal-lock-live-e2e.test.sh
+++ b/tests/fm-sqlite-wal-lock-live-e2e.test.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+# Default-on live guard for cross-process SQLite WAL support on THIS host.
+#
+# Whether two processes can hold one WAL database at once is a kernel fact that
+# no fixture can prove, so the portable regression
+# (tests/fm-sqlite-wal-lock.test.sh) pins only the gate, the probe machinery and
+# the verdict mapping. This guard measures the real capability with real
+# processes and a real SQLite, and fails naming the kernel release and root
+# filesystem rather than degrading quietly.
+#
+# It also pins the finding that keeps operators from chasing a remedy that does
+# not work: the failure is kernel-level, not filesystem-level, so every
+# filesystem this host offers must return the SAME verdict. A host where the
+# data directory's filesystem and tmpfs disagree would make "relocate the
+# no-mistakes data directory" a real fix, and this guard is what would catch
+# that change.
+#
+# A run spends no model tokens, so the shared live gate runs it by default
+# wherever python3 exists. Run it after any host migration (notably WSL1 to
+# WSL2) and before trusting a refreshed
+# docs/verification/runtime-backends.md "SQLite WAL cross-process locking" entry.
+set -u
+
+# shellcheck source=tests/lib.sh disable=SC1091
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+fm_live_gate default-on FM_LIVE_SQLITE_WAL python3
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TMP_ROOT=$(fm_test_tmproot fm-sqlite-wal-live)
+PROBE="$ROOT/bin/fm-sqlite-wal-probe.py"
+
+# shellcheck source=bin/fm-sqlite-wal-lib.sh disable=SC1091
+. "$ROOT/bin/fm-sqlite-wal-lib.sh"
+
+KERNEL=$(fm_sqlite_wal_kernel)
+ROOTFS=$(fm_sqlite_wal_root_fstype)
+HOST="kernel=$KERNEL rootfs=$ROOTFS"
+
+python3 -c 'import sqlite3' 2>/dev/null \
+  || fail "python3 has no sqlite3 module, so nothing could be measured ($HOST)"
+[ -x "$PROBE" ] || fail "probe helper is not executable: $PROBE ($HOST)"
+
+# A generous bound: this guard is not on the session-start path, and the real
+# SQLITE_PROTOCOL verdict only surfaces after SQLite exhausts its WAL-index
+# recovery retries, which takes about ten seconds.
+BOUND=45
+
+# --- control: the probe is sound on this host -------------------------------
+#
+# A WAL database nobody holds must open from a separate process on every host.
+# Without this, an "unsupported" verdict below could just mean a broken probe.
+control="$TMP_ROOT/control.db"
+python3 - "$control" <<'PY' || fail "could not build the uncontended WAL fixture ($HOST)"
+import sqlite3, sys
+c = sqlite3.connect(sys.argv[1])
+mode = c.execute("pragma journal_mode=wal").fetchone()[0]
+assert mode == "wal", mode
+c.execute("create table probe(x)")
+c.execute("insert into probe values(1)")
+c.commit()
+c.close()
+PY
+out=$("$PROBE" --read "$control" 2>&1) \
+  || fail "this host cannot open an UNHELD WAL database from a second process, so its SQLite is broken beyond the locking question: $out ($HOST)"
+[ "$out" = ok ] || fail "uncontended WAL read returned '$out', want 'ok' ($HOST)"
+pass "control: an unheld WAL database opens from a second process ($HOST)"
+
+# --- the measurement, on every filesystem this host offers -------------------
+
+probe_dir() { # <dir> -> "<rc> <detail>"
+  local dir=$1 out rc=0
+  out=$("$PROBE" "$dir" --timeout "$BOUND" 2>&1) || rc=$?
+  printf '%s %s\n' "$rc" "$out"
+}
+
+DATA_DIR=${FM_NO_MISTAKES_HOME:-$HOME/.no-mistakes}
+[ -d "$DATA_DIR" ] && [ -w "$DATA_DIR" ] || DATA_DIR=$TMP_ROOT
+
+declare -a NAMES=() VERDICTS=()
+for spec in "no-mistakes-data-dir:$DATA_DIR" "tmpfs:/dev/shm" "tmp:${TMPDIR:-/tmp}"; do
+  name=${spec%%:*}
+  dir=${spec#*:}
+  [ -d "$dir" ] && [ -w "$dir" ] || continue
+  result=$(probe_dir "$dir")
+  rc=${result%% *}
+  detail=${result#* }
+  case "$rc" in
+    0 | 1) ;;
+    *) fail "probe could not run in $dir ($name): $detail ($HOST)" ;;
+  esac
+  NAMES+=("$name($(stat -f -c %T "$dir" 2>/dev/null || echo '?'))")
+  VERDICTS+=("$rc")
+  printf '# %s -> %s\n' "$name" "$detail"
+done
+
+[ "${#VERDICTS[@]}" -gt 0 ] || fail "no writable directory was available to probe ($HOST)"
+
+# --- every filesystem must agree: the condition is kernel-level -------------
+first=${VERDICTS[0]}
+for i in "${!VERDICTS[@]}"; do
+  [ "${VERDICTS[$i]}" = "$first" ] && continue
+  fail "filesystems disagree on cross-process WAL support - ${NAMES[0]}=${VERDICTS[0]} ${NAMES[$i]}=${VERDICTS[$i]}; relocating the no-mistakes data directory may now be a real remedy and docs/verification/runtime-backends.md must be re-taken ($HOST)"
+done
+pass "every probed filesystem agrees (${NAMES[*]}), so the verdict is kernel-level ($HOST)"
+
+# --- the verdict must match the host class ----------------------------------
+#
+# WSL1 is the known-failing class. Asserting both directions is what makes a
+# host migration visible here instead of silently leaving a stale claim.
+case "$KERNEL" in
+  *microsoft-standard-WSL2* | *WSL2*) class=wsl2 ;;
+  *[Mm]icrosoft*) class=wsl1 ;;
+  *) class=other ;;
+esac
+[ "$class" = other ] && [ "$ROOTFS" = wslfs ] && class=wsl1
+[ "$class" = other ] && [ "$ROOTFS" = lxfs ] && class=wsl1
+
+case "$class" in
+  wsl1)
+    [ "$first" = 1 ] || fail "WSL1 host reported WORKING cross-process WAL locking; if this host was migrated, re-take docs/verification/runtime-backends.md and revisit the no-mistakes delivery mode ($HOST)"
+    pass "WSL1 host cannot share a WAL database across processes, as recorded ($HOST)"
+    ;;
+  *)
+    [ "$first" = 0 ] || fail "this host cannot share a SQLite WAL database across processes, so the no-mistakes delivery mode is unavailable here ($HOST)"
+    pass "cross-process WAL locking works on this host ($HOST)"
+    ;;
+esac

--- a/tests/fm-sqlite-wal-lock.test.sh
+++ b/tests/fm-sqlite-wal-lock.test.sh
@@ -1,0 +1,203 @@
+#!/usr/bin/env bash
+# Portable regression for the SQLite WAL cross-process locking detection.
+#
+# The host capability itself is kernel-dependent, so proving it needs the real
+# kernel and belongs to tests/fm-sqlite-wal-lock-live-e2e.test.sh. This file
+# pins everything that must hold on EVERY host: the gate that decides whether
+# the probe is worth spending, the probe's own two-process machinery, and the
+# mapping from a probe verdict to the single VALIDATION_UNAVAILABLE line
+# bin/fm-bootstrap.sh publishes.
+#
+# The verdict legs are driven through real executable stubs on the
+# FM_SQLITE_WAL_PROBE_BIN seam rather than a mocked shell function, so the
+# classifier is exercised through the same process boundary it uses in
+# production. A stub can only prove the mapping; it deliberately proves nothing
+# about the host, which is why the live guard exists.
+set -u
+
+# shellcheck source=tests/lib.sh disable=SC1091
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TMP_ROOT=$(fm_test_tmproot fm-sqlite-wal-lock)
+
+# shellcheck source=bin/fm-sqlite-wal-lib.sh disable=SC1091
+. "$ROOT/bin/fm-sqlite-wal-lib.sh"
+
+# --- host gate: three independent signals, each sufficient on its own --------
+#
+# The gate must not rest on a single vendor spelling, so each signal is driven
+# in isolation with the other two held at a plain-Linux value. The plain-Linux
+# case is asserted in the same table, so a gate that silently became
+# always-true cannot pass this block vacuously.
+
+# Each case runs in a real separate process, the way bin/fm-bootstrap.sh calls
+# the gate, rather than in a subshell whose environment edits only look isolated.
+suspect_with() { # <kernel> <fstype> <WSL_DISTRO_NAME> <WSL_INTEROP>
+  # Both WSL env signals are cleared first and then re-set only when the case
+  # wants them, so an absent signal is genuinely absent in the child.
+  local -a assigns=(FM_FAKE_KERNEL_RELEASE="$1" FM_FAKE_ROOT_FSTYPE="$2")
+  [ -n "$3" ] && assigns+=(WSL_DISTRO_NAME="$3")
+  [ -n "$4" ] && assigns+=(WSL_INTEROP="$4")
+  # shellcheck disable=SC2016 # The inner bash, not this shell, expands $1.
+  env -u WSL_DISTRO_NAME -u WSL_INTEROP "${assigns[@]}" bash -c '
+    . "$1" || exit 1
+    fm_sqlite_wal_host_suspect && echo suspect || echo clear
+  ' _ "$ROOT/bin/fm-sqlite-wal-lib.sh"
+}
+
+LINUX_KERNEL=6.1.0-generic
+LINUX_FS=ext2/ext3
+
+while read -r label kernel fstype distro interop want; do
+  [ -n "$label" ] || continue
+  case "$label" in \#*) continue ;; esac
+  [ "$kernel" = - ] && kernel=$LINUX_KERNEL
+  [ "$fstype" = - ] && fstype=$LINUX_FS
+  [ "$distro" = - ] && distro=''
+  [ "$interop" = - ] && interop=''
+  got=$(suspect_with "$kernel" "$fstype" "$distro" "$interop")
+  [ "$got" = "$want" ] || fail "host gate $label: want $want, got $got"
+done <<'TABLE'
+plain-linux            -                                  -      -        -            clear
+wsl1-kernel            4.4.0-22621-Microsoft              -      -        -            suspect
+wsl2-kernel            5.15.167.4-microsoft-standard-WSL2 -      -        -            suspect
+wslfs-rootfs-only      -                                  wslfs  -        -            suspect
+lxfs-rootfs-only       -                                  lxfs   -        -            suspect
+distro-env-only        -                                  -      Ubuntu   -            suspect
+interop-env-only       -                                  -      -        /run/x       suspect
+TABLE
+pass "host gate: each WSL signal is independently sufficient and a plain Linux host stays clear"
+
+# Losing any single signal must not lose a genuine WSL1 host.
+for drop in kernel fstype env; do
+  k=4.4.0-22621-Microsoft f=wslfs d=Ubuntu
+  case "$drop" in
+    kernel) k=$LINUX_KERNEL ;;
+    fstype) f=$LINUX_FS ;;
+    env) d='' ;;
+  esac
+  got=$(suspect_with "$k" "$f" "$d" '')
+  [ "$got" = suspect ] || fail "host gate survived losing $drop: want suspect, got $got"
+done
+pass "host gate: verdict survives losing any one signal"
+
+# --- probe machinery: real second process, real sqlite ----------------------
+#
+# This runs on every host, WSL1 included, because it deliberately has no
+# concurrent holder: a WAL database nobody else holds must open from a separate
+# process everywhere. It is what separates "this host cannot share WAL" from
+# "the probe is broken", so an unsupported verdict elsewhere cannot be vacuous.
+
+PROBE="$ROOT/bin/fm-sqlite-wal-probe.py"
+[ -x "$PROBE" ] || fail "probe helper is not executable: $PROBE"
+
+if command -v python3 >/dev/null 2>&1 && python3 -c 'import sqlite3' 2>/dev/null; then
+  uncontended="$TMP_ROOT/uncontended.db"
+  python3 - "$uncontended" <<'PY' || fail "could not build the uncontended WAL fixture"
+import sqlite3, sys
+c = sqlite3.connect(sys.argv[1])
+c.execute("pragma journal_mode=wal")
+c.execute("create table probe(x)")
+c.execute("insert into probe values(1)")
+c.commit()
+c.close()
+PY
+  out=$("$PROBE" --read "$uncontended" 2>&1) \
+    || fail "second-process read of an unheld WAL database failed: $out"
+  [ "$out" = ok ] || fail "second-process read of an unheld WAL database: want ok, got $out"
+  pass "probe: its second-process reader opens an unheld WAL database on this host"
+
+  out=$("$PROBE" --read "$TMP_ROOT/absent.db" 2>&1) && rc=0 || rc=$?
+  [ "$rc" -ne 0 ] || fail "probe reader reported success for a database with no table"
+  pass "probe: its second-process reader reports failure rather than passing blindly"
+else
+  pass "probe: skipped second-process fixtures (no python3 sqlite3 on this host)"
+fi
+
+# --- verdict mapping: probe exit status to the published line ----------------
+
+stub() { # <name> <exit> <line>
+  local path="$TMP_ROOT/$1"
+  cat > "$path" <<STUB
+#!/usr/bin/env bash
+echo '$3'
+exit $2
+STUB
+  chmod +x "$path"
+  printf '%s\n' "$path"
+}
+
+SUPPORTED=$(stub probe-supported 0 'supported')
+UNSUPPORTED=$(stub probe-unsupported 1 'unsupported: a second process could not open the WAL database (OperationalError: locking protocol)')
+UNVERIFIED=$(stub probe-unverified 2 'unverified: python3 has no sqlite3 module')
+
+for case in "supported:0:supported" "unsupported:1:a second process could not open the WAL database (OperationalError: locking protocol)" "unverified:2:python3 has no sqlite3 module"; do
+  name=${case%%:*}; rest=${case#*:}; want_rc=${rest%%:*}; want_detail=${rest#*:}
+  bin=$SUPPORTED
+  [ "$name" = unsupported ] && bin=$UNSUPPORTED
+  [ "$name" = unverified ] && bin=$UNVERIFIED
+  rc=0
+  ( FM_SQLITE_WAL_PROBE_BIN=$bin
+    # shellcheck source=bin/fm-sqlite-wal-lib.sh disable=SC1091
+    . "$ROOT/bin/fm-sqlite-wal-lib.sh"
+    fm_sqlite_wal_probe "$TMP_ROOT" 1
+    probe_rc=$?
+    printf '%s\n%s\n' "$probe_rc" "$(fm_sqlite_wal_probe_detail)"
+  ) > "$TMP_ROOT/verdict.$name" || rc=$?
+  got_rc=$(sed -n 1p "$TMP_ROOT/verdict.$name")
+  got_detail=$(sed -n 2p "$TMP_ROOT/verdict.$name")
+  [ "$got_rc" = "$want_rc" ] || fail "probe verdict $name: want exit $want_rc, got $got_rc"
+  [ "$got_detail" = "$want_detail" ] || fail "probe detail $name: want '$want_detail', got '$got_detail'"
+done
+pass "probe: each exit status maps to its verdict and one-line detail"
+
+# --- published line: only an OBSERVED failure is reported --------------------
+#
+# Driven through bin/fm-bootstrap.sh itself, so the contract pinned here is the
+# line a session start actually prints.
+
+# tests/lib.sh skips the probe suite-wide for hermeticity; this file owns the
+# behavior, so it opts each case back in explicitly.
+SKIP_PROBE=0
+bootstrap_line() { # <probe-bin>
+  local home="$TMP_ROOT/home.$$"
+  rm -rf "$home"; mkdir -p "$home"/{data,state,config,projects}
+  ( cd "$ROOT" || exit 1
+    FM_HOME="$home" \
+    FM_BOOTSTRAP_DETECT_ONLY=1 \
+    FM_SQLITE_WAL_PROBE_BIN="$1" \
+    FM_SKIP_WAL_LOCK_PROBE="$SKIP_PROBE" \
+    FM_FAKE_KERNEL_RELEASE=4.4.0-22621-Microsoft \
+    FM_FAKE_ROOT_FSTYPE=wslfs \
+    timeout 240 "$ROOT/bin/fm-bootstrap.sh" 2>/dev/null
+  ) | grep '^VALIDATION_UNAVAILABLE:' || true
+}
+
+if command -v no-mistakes >/dev/null 2>&1; then
+  line=$(bootstrap_line "$UNSUPPORTED")
+  [ -n "$line" ] || fail "bootstrap printed no VALIDATION_UNAVAILABLE line for an observed WAL locking failure"
+  case "$line" in
+    "VALIDATION_UNAVAILABLE: no-mistakes (kernel 4.4.0-22621-Microsoft cannot share a SQLite WAL database across processes: "*") - the no-mistakes delivery mode is unavailable on this host; ship affected work direct-PR until the host is repaired") ;;
+    *) fail "bootstrap VALIDATION_UNAVAILABLE line does not match its published contract: $line" ;;
+  esac
+  case "$line" in
+    *"locking protocol"*) ;;
+    *) fail "bootstrap line dropped the probe's observed detail: $line" ;;
+  esac
+  pass "bootstrap: an observed WAL locking failure prints its published VALIDATION_UNAVAILABLE line"
+
+  for quiet in "$SUPPORTED" "$UNVERIFIED"; do
+    line=$(bootstrap_line "$quiet")
+    [ -z "$line" ] || fail "bootstrap reported a WAL locking failure it did not observe ($quiet): $line"
+  done
+  pass "bootstrap: a working host and an unrunnable probe both stay silent"
+
+  SKIP_PROBE=1
+  line=$(bootstrap_line "$UNSUPPORTED")
+  SKIP_PROBE=0
+  [ -z "$line" ] || fail "FM_SKIP_WAL_LOCK_PROBE=1 did not suppress the probe: $line"
+  pass "bootstrap: FM_SKIP_WAL_LOCK_PROBE=1 suppresses the probe"
+else
+  pass "bootstrap: skipped published-line cases (no-mistakes is not installed on this host)"
+fi

--- a/tests/lib.sh
+++ b/tests/lib.sh
@@ -47,6 +47,16 @@ umask 022
 # strips this to verify real refusal.
 export FM_GATE_REFUSE_BYPASS=1
 
+# Keep the host-dependent SQLite WAL locking probe out of every other test's
+# bootstrap output. The probe reports a real property of the machine the suite
+# runs on (bin/fm-sqlite-wal-lib.sh), so on a host that cannot share a WAL
+# database across processes it would add a VALIDATION_UNAVAILABLE line to cases
+# that assert bootstrap is silent, and the suite's verdict would depend on where
+# it ran. tests/fm-sqlite-wal-lock.test.sh owns that behavior and opts each of
+# its own bootstrap cases back in, and
+# tests/fm-sqlite-wal-lock-live-e2e.test.sh runs the probe directly.
+export FM_SKIP_WAL_LOCK_PROBE=1
+
 # Clear the task-worker marker bin/fm-spawn.sh exports into ship and scout
 # panes. This suite builds git-init fixture repositories whose primary checkout
 # it runs a copied bin/fm-test-run.sh in, and that runner refuses the primary


### PR DESCRIPTION
## Why

`no-mistakes` keeps its pipeline state in a SQLite WAL database at `~/.no-mistakes/state.sqlite` that its daemon holds open.
On a host whose kernel cannot hand that database to a second process, every CLI call made while the daemon is up fails with `SQLITE_PROTOCOL` (15), surfaced as `locking protocol`.
The `no-mistakes` delivery mode is then unavailable for every project in the fleet.
Until now an operator discovered that by watching a pipeline fail.

This PR makes it a reported condition.
The underlying host repair is deliberately out of scope here: it is a host change, not a change to this repo.

## What the probe establishes

The cause was reported as suspected rather than established, so it was confirmed by measurement before anything was built.

The failure reproduces end to end through the real CLI.
`doctor` prints `database error (migrate db: locking protocol (15))` while a second process holds the database, and `database ok` when nothing holds it.

Measured on WSL1, kernel `4.4.0-22621-Microsoft`, root filesystem `wslfs`, SQLite 3.37.2.

| Condition | Result |
| --- | --- |
| One process, WAL | opens normally |
| One process, WAL, recovering an orphaned `-wal` and `-shm` left by a killed writer | opens normally and checkpoints |
| Second process, WAL, while the first still holds the database | `SQLITE_PROTOCOL` after about ten seconds of WAL-index recovery retries |
| Second process, `journal_mode=delete` or `truncate`, same concurrency | opens in about 0.04s |
| Second process, WAL, on `wslfs`, `tmpfs` (`/dev/shm`), `TMPDIR` and the Windows `drvfs` mount | identical `SQLITE_PROTOCOL` on all four |

Four findings follow.

The trigger is concurrent access rather than corruption.
The same database opens, recovers an orphaned WAL and checkpoints cleanly whenever nothing else holds it.

WAL is the only affected journal mode.
The same concurrency under a rollback journal opens in about 0.04s.

The failure is self-masking on a short timescale.
SQLite retries WAL-index recovery for about ten seconds before returning `SQLITE_PROTOCOL`, so a holder that releases inside that window lets the second process through.
A probe whose holder is short-lived therefore reports success on a host that cannot actually share a WAL database, which is how this condition can look intermittent.

## What the measurement refuted

Relocating the no-mistakes data directory is not a remedy.
`tmpfs`, the Windows `drvfs` mount, `/tmp` and the `wslfs` root all fail identically, so the fault is kernel-level rather than filesystem-level.
That closes one of the three candidate directions by measurement rather than by opinion, and `tests/fm-sqlite-wal-lock-live-e2e.test.sh` fails loudly if any two filesystems ever stop agreeing.

A 4KB main database beside a large uncheckpointed `-wal` is not a signature of broken locking.
That exact signature was reproduced on this host with locking working, and it is the ordinary signature of a long-lived holder that never checkpoints.

## What changed

`bin/fm-sqlite-wal-probe.py` runs the real two-process probe against a real WAL database and is the only source of a verdict.
Nothing infers a verdict from a kernel version string.
It creates and removes its own scratch database and never opens one it did not create.

`bin/fm-sqlite-wal-lib.sh` gates that probe on three independent WSL signals, so a normal host pays nothing and no single vendor spelling is load-bearing.

`bin/fm-bootstrap.sh` emits one `VALIDATION_UNAVAILABLE: no-mistakes (...)` line, mirroring the existing `PRESENTATION_UNAVAILABLE` precedent for an unavailable capability with degraded-mode routing.
Only an observed failure is reported, so a probe that cannot run stays silent instead of claiming a fault it did not see.
The call is bounded at 3s against a healthy-host open of about 0.04s.

The `bootstrap-diagnostics` skill owns the operator response, including that the two ruled-out remedies must not be spent on and that an intermittent success means the daemon was down rather than that the host was repaired.

`AGENTS.md` gains one trigger token in the existing section 13 list, per the inline-stub pattern and size discipline.

`docs/verification/runtime-backends.md` records the dated measurement and names the live guard that refreshes it.

## Tests

This is a kernel-dependent check, so it follows the two-test contract in `firstmate-coding-guidelines`.

`tests/fm-sqlite-wal-lock.test.sh` is the portable regression.
It pins the host gate, the probe's own two-process machinery against real SQLite, and the mapping from a probe verdict to the published line.
The verdict legs are driven through real executable stubs on a seam rather than a mocked shell function, and no implementation source bytes are asserted.

`tests/fm-sqlite-wal-lock-live-e2e.test.sh` is the default-on live guard.
It measures the real capability, refuses to pass having checked nothing, and fails naming the kernel release and root filesystem.

Both tests were mutation-checked.
Forcing the gate always-clear, forcing bootstrap to report an unverified probe, and forcing the probe to claim success were each caught by the suite.

`tests/lib.sh` skips the probe suite-wide so cases that assert bootstrap silence do not depend on the machine the suite runs on, and the two files above own that behavior themselves.

## Verification

`bin/fm-lint.sh` exits 0 with ShellCheck 0.11.0 and actionlint 1.7.12, both at their pins.
`bin/fm-doc-audience-check.sh` reports ok across 97 surfaces and 392 local links.
`tests/fm-bootstrap.test.sh` passes 28 of 28.
Both new tests pass on this host.

One unrelated failure is pre-existing and is not from this branch.
`tests/fm-fleet-sync.test.sh` fails its `stale lock: guard did not force-remove the provably-stale lock` case, which exercises `lsof`-based lock staleness.
It was confirmed to fail identically with this branch's two modified tracked files reverted, so a reviewer running that suite should not be surprised by it.
