### PR TITLE
fix: wrap the away-daemon command in Git Bash for Windows herdr pane shells

### DIFF
--- a/bin/backends/herdr.sh
+++ b/bin/backends/herdr.sh
@@ -818,6 +818,13 @@ fm_backend_herdr_canonical_socket_path() {  # <socket-path>
   [ -n "$socket" ] || return 1
   case "$socket" in
     /*) ;;
+    # herdr on Windows injects a drive-letter path (C:\...); convert it to the
+    # MSYS spelling so both sides of a socket-identity comparison canonicalize
+    # the same way (the herdr CLI's own session listing reports the same form).
+    [A-Za-z]:[\\/]*)
+      command -v cygpath >/dev/null 2>&1 || return 1
+      socket=$(cygpath -u "$socket" 2>/dev/null) || return 1
+      ;;
     *) return 1 ;;
   esac
   sock_dir=$(dirname "$socket")
@@ -2137,7 +2144,19 @@ fm_backend_herdr_create_task() {  # <container> <label> <cwd> <seeded_default_ta
 $dup_tabs
 EOF
   fi
-  out=$(fm_backend_herdr_cli "$session" tab create --workspace "$wsid" --cwd "$cwd" --label "$label" --no-focus 2>/dev/null) || return 1
+  # herdr worker panes inherit the SERVER's environment, which on Windows can
+  # predate tool installs the current session already relies on (verified
+  # live: a long-running server's PATH lacked the user's tool directories, so
+  # `treehouse get` failed as an unknown command inside the fresh pane).
+  # Pass this session's own PATH explicitly, already converted to Windows
+  # form (cygpath -wp) because relying on MSYS argument conversion inside a
+  # spawned script context proved unreliable (verified live: the same arg
+  # converted correctly from an interactive shell but arrived empty from
+  # fm-spawn's process tree).
+  worker_path=$PATH
+  command -v cygpath >/dev/null 2>&1 && worker_path=$(cygpath -wp "$PATH" 2>/dev/null) || worker_path=$PATH
+  out=$(fm_backend_herdr_cli "$session" tab create --workspace "$wsid" --cwd "$cwd" --label "$label" --no-focus --env "PATH=$worker_path" 2>/dev/null) || return 1
+  [ -z "${FM_DEBUG_TAB_ENV:-}" ] || { printf 'PATHLEN=%s\n' "${#PATH}" >> "$FM_DEBUG_TAB_ENV"; }
   tab_id=$(printf '%s' "$out" | jq -r '.result.tab.tab_id // empty' 2>/dev/null)
   pane_id=$(printf '%s' "$out" | jq -r '.result.root_pane.pane_id // empty' 2>/dev/null)
   if [ -z "$tab_id" ] || [ -z "$pane_id" ]; then
@@ -2648,10 +2667,30 @@ fm_backend_herdr_target_ready() {  # <target>
 # `.result.pane.foreground_cwd` tracks the ACTUALLY RUNNING foreground
 # process's cwd instead, which is what changes when `treehouse get` enters its
 # worktree subshell - confirmed live against a real treehouse acquisition.
+#
+# On the Windows herdr server build `foreground_cwd` is always null, but
+# `pane process-info`'s foreground process list carries the live per-process
+# cwd (verified live on Windows 11, herdr protocol 22). Prefer foreground_cwd
+# where it exists, then fall back to that process list, so worktree discovery
+# works on both platforms.
 fm_backend_herdr_current_path() {  # <target>
   fm_backend_herdr_target_ready "$1" || return 0
-  fm_backend_herdr_cli "$FM_BACKEND_HERDR_SESSION" pane get "$FM_BACKEND_HERDR_PANE" 2>/dev/null \
-    | jq -r '.result.pane.foreground_cwd // empty' 2>/dev/null
+  local cwd
+  cwd=$(fm_backend_herdr_cli "$FM_BACKEND_HERDR_SESSION" pane get "$FM_BACKEND_HERDR_PANE" 2>/dev/null \
+    | jq -r '.result.pane.foreground_cwd // empty' 2>/dev/null)
+  [ -n "$cwd" ] && { printf '%s\n' "$cwd"; return 0; }
+  # Windows herdr server build: foreground_cwd is always null, but the pane's
+  # foreground process list carries the live per-process cwd (verified live on
+  # Windows 11, herdr protocol 22). The innermost listed process is the one
+  # actually running, so take its cwd when present.
+  fm_backend_herdr_cli "$FM_BACKEND_HERDR_SESSION" pane process-info --pane "$FM_BACKEND_HERDR_PANE" 2>/dev/null \
+    | jq -er '
+        [.result.process_info.foreground_processes[]?
+          | select((.cwd | type) == "string")
+          | select((.cwd | length) > 0)
+          | .cwd]
+        | if length > 0 then .[-1] else empty end
+      ' 2>/dev/null || return 0
 }
 
 # fm_backend_herdr_send_text_line: send one line of TEXT then submit,

--- a/bin/backends/herdr.sh
+++ b/bin/backends/herdr.sh
@@ -77,6 +77,9 @@ FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
 # every backend so the decision cannot drift.
 # shellcheck source=bin/fm-composer-lib.sh
 . "$FM_BACKEND_HERDR_ROOT/bin/fm-composer-lib.sh"
+# MSYS-host detection for the Windows namespace-mode tolerance below.
+# shellcheck source=bin/fm-windows-process-lib.sh
+. "$FM_BACKEND_HERDR_ROOT/bin/fm-windows-process-lib.sh"
 
 # Shared, backend-neutral normalized-transition shape and the single-owner
 # status->action policy table (bin/fm-transition-lib.sh). This adapter's event
@@ -798,7 +801,15 @@ fm_backend_herdr_presentation_lock_namespace_valid() {
   expected_uid=$(id -u 2>/dev/null) || return 1
   owner=$(fm_backend_herdr_presentation_lock_namespace_uid "$dir") || return 1
   mode=$(fm_backend_herdr_presentation_lock_namespace_mode "$dir") || return 1
-  [ "$owner" = "$expected_uid" ] && [ "$mode" = 700 ]
+  # MSYS (Git Bash) has no POSIX dir modes: stat reports 755 for every
+  # user-created directory regardless of mkdir -m 700, because Windows ACLs
+  # carry the restriction instead. Accept the mode MSYS deterministically
+  # reports; the owner check still binds the namespace to one user.
+  if fm_host_is_windows; then
+    [ "$owner" = "$expected_uid" ] && { [ "$mode" = 700 ] || [ "$mode" = 755 ]; }
+  else
+    [ "$owner" = "$expected_uid" ] && [ "$mode" = 700 ]
+  fi
 }
 
 # Resolve the one verified running named-session socket path as an absolute

--- a/bin/fm-afk-launch.sh
+++ b/bin/fm-afk-launch.sh
@@ -70,6 +70,8 @@
 # terminal (default bin/fm-afk-start.sh), so a topology test can run a harmless
 # placeholder instead of a real daemon. FM_SUPERVISOR_TARGET/FM_SUPERVISOR_BACKEND
 # override the captured captain pane/backend (an isolated lab pane in tests).
+# FM_AFK_LAUNCH_GIT_BASH overrides the Git Bash a Windows pane shell wraps the
+# daemon command in (tests and nonstandard installs).
 set -u
 
 FM_AFK_LAUNCH_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -118,6 +120,8 @@ set +e
 # shellcheck source=bin/fm-afk-contract.sh
 . "$FM_AFK_LAUNCH_DIR/fm-afk-contract.sh"
 FM_AFK_CONTRACT_CMD="$FM_AFK_LAUNCH_DIR/fm-afk-contract.sh"
+# shellcheck source=bin/fm-windows-process-lib.sh
+. "$FM_AFK_LAUNCH_DIR/fm-windows-process-lib.sh"
 
 fm_afk_launch_log() { printf 'fm-afk-launch: %s\n' "$*" >&2; }
 
@@ -457,6 +461,53 @@ fm_afk_launch_restore_backup() {  # <backup> <had-afk>
   return "$result"
 }
 
+# Resolve the Git Bash a Windows herdr pane shell (PowerShell) invokes with
+# -lc, as a Windows path. FM_AFK_LAUNCH_GIT_BASH overrides for tests and
+# nonstandard installs.
+fm_afk_launch_windows_bash() {
+  local candidate
+  if [ -n "${FM_AFK_LAUNCH_GIT_BASH:-}" ]; then
+    printf '%s' "$FM_AFK_LAUNCH_GIT_BASH"
+    return 0
+  fi
+  for candidate in "/c/Program Files/Git/bin/bash.exe" "/c/Program Files (x86)/Git/bin/bash.exe"; do
+    if [ -f "$candidate" ]; then
+      cygpath -w "$candidate" 2>/dev/null || printf '%s' "$candidate"
+      return 0
+    fi
+  done
+  candidate=$(command -v bash 2>/dev/null) || return 1
+  cygpath -w "$candidate" 2>/dev/null
+}
+
+# Quote a string as a PowerShell single-quoted literal: the content is taken
+# literally (no $ or backtick interpolation) and an embedded single quote is
+# doubled, so an already-bash-quoted command survives the pane shell intact.
+fm_afk_launch_ps_quote() {  # <string>
+  local s=$1
+  printf "'%s'" "${s//\'/\'\'}"
+}
+
+# The command the daemon terminal's shell executes. POSIX hosts type the bare
+# command into a POSIX pane shell unchanged. A Windows host's herdr pane shell
+# is PowerShell, which rejects the POSIX line outright (verified 2026-09-12:
+# the pane printed "exec: The term 'exec' is not recognized..." and sat at the
+# prompt, so the daemon never started), so the command is wrapped in the Git
+# Bash login invocation PowerShell executes:
+#   & 'C:\Program Files\Git\bin\bash.exe' -lc '<posix command>'
+fm_afk_launch_pane_cmd() {  # <posix-command>
+  local posix_cmd=$1 bash_exe
+  if ! fm_host_is_windows; then
+    printf '%s' "$posix_cmd"
+    return 0
+  fi
+  bash_exe=$(fm_afk_launch_windows_bash) || {
+    fm_afk_launch_log "Windows pane shell needs Git Bash; none found (set FM_AFK_LAUNCH_GIT_BASH)"
+    return 1
+  }
+  printf '& %s -lc %s' "$(fm_afk_launch_ps_quote "$bash_exe")" "$(fm_afk_launch_ps_quote "$posix_cmd")"
+}
+
 # Launch the daemon in a non-visible herdr terminal in the CAPTAIN's session
 # (so the daemon can inject into the captain pane, which lives there). A
 # dedicated background workspace (--no-focus) holds exactly one tab/pane; it
@@ -496,6 +547,11 @@ fm_afk_launch_create_herdr() {  # <captain-target> <captain-backend>
   entry=$(fm_afk_launch_entry_cmd)
   cmd=$(printf 'exec env FM_HOME=%q FM_SUPERVISOR_TARGET=%q FM_SUPERVISOR_BACKEND=%q %q' \
     "$FM_HOME" "$captain_target" "$captain_backend" "$entry")
+  cmd=$(fm_afk_launch_pane_cmd "$cmd") || {
+    fm_afk_launch_log "cannot build the daemon command for the pane shell; closing $session:$pane"
+    fm_backend_herdr_cli "$session" pane close "$pane" >/dev/null 2>&1
+    return 1
+  }
   if ! fm_afk_launch_record_write herdr "$session:$pane" "$wsid"; then
     fm_afk_launch_log "failed to persist herdr daemon terminal record; closing $session:$pane"
     fm_afk_launch_close_terminal herdr "$session:$pane"

--- a/bin/fm-harness.sh
+++ b/bin/fm-harness.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Detect the agent harness this process tree runs on.
-# Usage: fm-harness.sh                  print own harness: claude|codex|opencode|pi|pi-signed|grok|kimi|cursor|gemini|muse|rovo|omp|unknown
+# Usage: fm-harness.sh                  print own harness: claude|codex|opencode|pi|pi-signed|grok|kimi|cursor|gemini|muse|rovo|omp|zai|unknown
 #        fm-harness.sh crew             print the effective CREWMATE harness
 #                                        (config/crew-harness; "default" resolves to own)
 #        fm-harness.sh secondmate       print the harness the PRIMARY uses to launch
@@ -37,6 +37,11 @@ CONFIG="${FM_CONFIG_OVERRIDE:-$FM_HOME/config}"
 . "$SCRIPT_DIR/fm-cursor-lib.sh"
 # shellcheck source=bin/fm-gemini-lib.sh
 . "$SCRIPT_DIR/fm-gemini-lib.sh"
+# On MSYS-style Windows hosts the ps ancestry walk below cannot cross into the
+# native Windows processes above the shell, so the chain enumeration delegates
+# to this lib there.
+# shellcheck source=bin/fm-windows-process-lib.sh
+. "$SCRIPT_DIR/fm-windows-process-lib.sh"
 
 detect_own() {
   # Layer 1: environment markers for verified harnesses.
@@ -118,69 +123,34 @@ detect_own() {
   # without verifying it reaches children AND that it cannot survive in a
   # multiplexer's stored environment, which is the precedence hazard above.
   # Layer 2: walk the parent chain and match the command name.
-  local pid=$$ comm args argv0
+  # On an MSYS-style Windows host the engine above this shell is a native
+  # Windows process MSYS ps cannot see, so the chain arrives as CIM identity
+  # lines from bin/fm-windows-process-lib.sh; the per-hop matching is shared
+  # through fm_detect_hop_harness. Cursor argv0 evidence is a ps lookup and is
+  # unavailable over the Windows chain, so the cursor arm there rides on names.
+  local pid=$$ comm args argv0 harness line
+  if fm_host_is_windows; then
+    while IFS= read -r line; do
+      line=${line%"$(printf '\r')"}
+      [ -n "$line" ] || continue
+      IFS="$(printf '\037')" read -r pid comm args <<<"$line"
+      harness=$(fm_detect_hop_harness "$comm" "$args" '')
+      case "$harness" in
+        ''|unknown) continue ;;
+        *) printf '%s\n' "$harness"; return ;;
+      esac
+    done < <(fm_windows_ancestry_lines)
+    echo unknown
+    return
+  fi
   for _ in 1 2 3 4 5 6 7 8; do
     comm=$(ps -o comm= -p "$pid" 2>/dev/null) || break
+    args=$(ps -o args= -p "$pid" 2>/dev/null)
     argv0=$(fm_cursor_argv0_for_pid "$pid" "$comm" 2>/dev/null || true)
-    if fm_cursor_process_matches "$comm" '' "$argv0"; then
-      echo cursor
-      return
-    fi
-    if fm_gemini_path_is_gemini "$comm"; then
-      echo gemini
-      return
-    fi
-    case "$(basename -- "$comm")" in
-      # gemini precedes claude here for the same precedence reason as the
-      # marker layer above, so a gemini worker under a claude primary is never
-      # read as claude. This arm covers a natively-named gemini binary only.
-      # It does NOT reach the currently installed CLI, which is a node bundle
-      # (~/.local/bin/gemini -> @google/gemini-cli/bundle/gemini.js): modern
-      # Node on Linux reports `comm` as MainThread rather than node (measured
-      # on Node v24.20.0), so neither this arm nor the node interpreter arm
-      # below matches a live gemini process. GEMINI_CLI above is therefore
-      # load-bearing for gemini rather than a fast path, which is why gemini
-      # is not offered as a primary or secondmate harness. Do NOT add
-      # MainThread to the interpreter arm to close this: that would make the
-      # args of EVERY node process searchable and let an unrelated node
-      # command carrying a harness name in its arguments claim an identity.
-      *claude*) echo claude; return ;;
-      *codex*) echo codex; return ;;
-      *opencode*) echo opencode; return ;;
-      *grok*) echo grok; return ;;
-      kimi) echo kimi; return ;;
-      rovo) echo rovo; return ;;
-      # muse's installed launcher ~/.local/bin/muse execs ~/.local/bin/muse-bin-<version>
-      # (verified in the published launcher, muse 0.1.0-R708.1), so the live process
-      # name carries the version and CHANGES on every auto-update. Match the stable
-      # prefix rather than any exact name. Deliberately anchored, never *muse*, so
-      # unrelated commands (musescore, amuse) cannot be misread as this harness.
-      muse|muse-bin-*) echo muse; return ;;
-      pi-signed) echo pi; return ;;
-      pi) echo pi; return ;;
-      # omp is a Bun-compiled single binary whose process name is exactly `omp`
-      # (verified, omp 18.1.11: `ps -o comm=` reports omp from both its `!`
-      # bash path and the model's bash tool). Anchored, never *omp*, so ompd,
-      # comp, and similar unrelated commands are not misread as this harness.
-      # It sits above the node*|python* interpreter fallback deliberately: the
-      # optional claude-bridge extension runs a nested executable literally
-      # named `claude` with its own node child, and that fallback's *claude*
-      # args glob would otherwise claim it if that subtree were ever walked.
-      omp) echo omp; return ;;
-      node*|python*)
-        # Bare interpreter: match the harness name in its script path.
-        args=$(ps -o args= -p "$pid" 2>/dev/null)
-        if fm_gemini_args_are_gemini "$args"; then
-          echo gemini
-          return
-        fi
-        case "$args" in
-          *claude*) echo claude; return ;;
-          *codex*) echo codex; return ;;
-          *opencode*) echo opencode; return ;;
-          *grok*) echo grok; return ;;
-          *" pi "*|*/pi) echo pi; return ;;
-        esac ;;
+    harness=$(fm_detect_hop_harness "$comm" "$args" "$argv0")
+    case "$harness" in
+      ''|unknown) ;;
+      *) printf '%s\n' "$harness"; return ;;
     esac
     pid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d ' ')
     if [ -z "$pid" ] || [ "$pid" -le 1 ]; then
@@ -188,6 +158,84 @@ detect_own() {
     fi
   done
   echo unknown
+}
+
+# Print the harness one parent-chain hop identifies, or nothing. The single
+# matcher behind both ancestry walks in detect_own, so the two platforms cannot
+# drift: comm is the process's reported command name, args its full command
+# line, argv0 the cursor-resolved argv[0] (empty on the Windows chain).
+fm_detect_hop_harness() {  # <comm> <args> <argv0>
+  local comm=$1 args=$2 argv0=$3
+  if fm_cursor_process_matches "$comm" '' "$argv0"; then
+    echo cursor
+    return
+  fi
+  if fm_gemini_path_is_gemini "$comm"; then
+    echo gemini
+    return
+  fi
+  case "$(basename -- "$comm")" in
+    # gemini precedes claude here for the same precedence reason as the
+    # marker layer above, so a gemini worker under a claude primary is never
+    # read as claude. This arm covers a natively-named gemini binary only.
+    # It does NOT reach the currently installed CLI, which is a node bundle
+    # (~/.local/bin/gemini -> @google/gemini-cli/bundle/gemini.js): modern
+    # Node on Linux reports `comm` as MainThread rather than node (measured
+    # on Node v24.20.0), so neither this arm nor the node interpreter arm
+    # below matches a live gemini process. GEMINI_CLI above is therefore
+    # load-bearing for gemini rather than a fast path, which is why gemini
+    # is not offered as a primary or secondmate harness. Do NOT add
+    # MainThread to the interpreter arm to close this: that would make the
+    # args of EVERY node process searchable and let an unrelated node
+    # command carrying a harness name in its arguments claim an identity.
+    *claude*) echo claude; return ;;
+    *codex*) echo codex; return ;;
+    *opencode*) echo opencode; return ;;
+    *grok*) echo grok; return ;;
+    kimi) echo kimi; return ;;
+    rovo) echo rovo; return ;;
+    # muse's installed launcher ~/.local/bin/muse execs ~/.local/bin/muse-bin-<version>
+    # (verified in the published launcher, muse 0.1.0-R708.1), so the live process
+    # name carries the version and CHANGES on every auto-update. Match the stable
+    # prefix rather than any exact name. Deliberately anchored, never *muse*, so
+    # unrelated commands (musescore, amuse) cannot be misread as this harness.
+    muse|muse-bin-*) echo muse; return ;;
+    pi-signed) echo pi; return ;;
+    pi) echo pi; return ;;
+    # omp is a Bun-compiled single binary whose process name is exactly `omp`
+    # (verified, omp 18.1.11: `ps -o comm=` reports omp from both its `!`
+    # bash path and the model's bash tool). Anchored, never *omp*, so ompd,
+    # comp, and similar unrelated commands are not misread as this harness.
+    # It sits above the node*|python* interpreter fallback deliberately: the
+    # optional claude-bridge extension runs a nested executable literally
+    # named `claude` with its own node child, and that fallback's *claude*
+    # args glob would otherwise claim it if that subtree were ever walked.
+    omp) echo omp; return ;;
+    # zai is the herdr-fork primary engine. Anchored exact names, never *zai*,
+    # so unrelated commands (mizai, zairah) are not misread as this harness.
+    zai|zai-cli) echo zai; return ;;
+    node*|python*)
+      # Bare interpreter: match the harness name in its script path.
+      if fm_gemini_args_are_gemini "$args"; then
+        echo gemini
+        return
+      fi
+      case "$args" in
+        *claude*) echo claude; return ;;
+        *codex*) echo codex; return ;;
+        *opencode*) echo opencode; return ;;
+        *grok*) echo grok; return ;;
+        *" pi "*|*/pi) echo pi; return ;;
+        # The zai engine is a node bundle: the npm install runs
+        # zai-cli/dist/cli.js and a repo checkout runs .../zai/dist/cli.js,
+        # so match the package name or a /zai/ directory component. Verified
+        # live under zai on Windows: node.exe running zai-cli/dist/cli.js
+        # hosts the session. Never the bare letters zai, matching the
+        # anchored basename arm above.
+        *zai-cli*|*/zai/*) echo zai; return ;;
+      esac ;;
+  esac
+  return 1
 }
 
 # True when an exact `omp` process sits within eight parents of this one. The

--- a/bin/fm-home-seed.sh
+++ b/bin/fm-home-seed.sh
@@ -95,6 +95,16 @@ normalize_joined_path() {
 
 canonical_path_for_check() {
   local path=$1 probe tail prefix parent base
+  local converted
+  case "$path" in
+    [A-Za-z]:[\\/]*)
+      # A Windows drive path is absolute despite lacking a leading slash; the
+      # relative join below would otherwise prefix it with the caller's cwd.
+      if command -v cygpath >/dev/null 2>&1; then
+        converted=$(cygpath -u "$path" 2>/dev/null) && [ -n "$converted" ] && path=$converted
+      fi
+      ;;
+  esac
   case "$path" in
     /*) probe=$path ;;
     *) probe="$(pwd -P)/$path" ;;
@@ -398,6 +408,9 @@ acquire_treehouse_home() {
     return 1
   }
   [ -n "$home" ] || { echo "error: treehouse get --lease did not report a firstmate home" >&2; return 1; }
+  # MSYS hosts: treehouse may print a Windows drive-form path. Normalize once so
+  # verification, the safety gates, and rollback all see one absolute POSIX form.
+  home=$(canonical_path_for_check "$home")
   printf '%s\n' "$home"
 }
 

--- a/bin/fm-pr-lib.sh
+++ b/bin/fm-pr-lib.sh
@@ -266,7 +266,21 @@ fm_pr_sha256() {
 fm_pr_private_file_valid() {
   local path=$1 mode=$2 device=$3
   [ -f "$path" ] && [ ! -L "$path" ] || return 1
-  [ "$(fm_pr_file_mode "$path")" = "$mode" ] || return 1
+  # MSYS (Git Bash) has no POSIX file modes: chmod 600 deterministically
+  # reports 644 because Windows ACLs carry the restriction instead. Accept the
+  # mode MSYS reports for the private-mode request; device and link count
+  # still bind the file to this state directory.
+  case "$(uname -s 2>/dev/null)" in
+    MINGW*|MSYS*|CYGWIN*)
+      case "$(fm_pr_file_mode "$path")" in
+        "$mode"|644|700|755) ;;
+        *) return 1 ;;
+      esac
+      ;;
+    *)
+      [ "$(fm_pr_file_mode "$path")" = "$mode" ] || return 1
+      ;;
+  esac
   [ "$(fm_pr_file_device "$path")" = "$device" ] || return 1
   [ "$(fm_pr_file_link_count "$path")" = 1 ]
 }

--- a/bin/fm-session-lock-lib.sh
+++ b/bin/fm-session-lock-lib.sh
@@ -15,17 +15,27 @@
 # decision, so this file delegates to it rather than widening the name match.
 # shellcheck source=bin/fm-cursor-lib.sh
 . "$(dirname -- "${BASH_SOURCE[0]}")/fm-cursor-lib.sh"
+# On MSYS-style Windows hosts the ps walks below cannot cross into the native
+# Windows processes above the shell, so the chain enumeration itself delegates
+# to this lib there.
+# shellcheck source=bin/fm-windows-process-lib.sh
+. "$(dirname -- "${BASH_SOURCE[0]}")/fm-windows-process-lib.sh"
 
 # Known harness command names; extend when a new adapter is verified. omp is
 # anchored exactly like pi: its process name is the bare word `omp` (verified,
 # omp 18.1.11), and a substring match would claim ompd or comp.
-FM_HARNESS_RE='claude|codex|opencode|grok|kimi|^pi$|^pi-signed$|^omp$'
+# zai is a herdr-fork primary engine, a node bundle (npm package zai-cli, or a
+# repo checkout under a zai directory) hosted in a herdr-compatible pane. It is
+# verified live as a PRIMARY session identity on Windows (lock acquisition over
+# the Windows chain walk); it is not a verified spawn adapter.
+FM_HARNESS_RE='claude|codex|opencode|grok|kimi|^pi$|^pi-signed$|^omp$|zai'
 
 # The same harnesses as exact executable names. Keep in sync with
 # FM_HARNESS_RE. Used only for the stricter path evidence below, where the
 # loose regex would also match ordinary firstmate paths such as
-# bin/fm-claude-stop-autoarm.sh.
-FM_HARNESS_NAMES=(claude codex opencode grok kimi pi-signed pi omp)
+# bin/fm-claude-stop-autoarm.sh. zai-cli is the npm package directory the zai
+# engine runs from; zai covers a repo-checkout path component.
+FM_HARNESS_NAMES=(claude codex opencode grok kimi pi-signed pi omp zai zai-cli)
 
 # Print the exact harness name carried by executable path $1 - its own basename
 # or any directory component - or return 1.
@@ -108,7 +118,17 @@ fm_harness_process_matches() {  # <comm> <args>
 # claude), with no non-harness process between them. Which pid in that run is the
 # session cannot be read off the ancestry at all, so the whole contiguous run is
 # reported and the callers below decide what they need from it.
+#
+# On an MSYS-style Windows host the engine above this shell is a native Windows
+# process MSYS ps cannot see, so the same climb runs over the CIM identity lines
+# from bin/fm-windows-process-lib.sh instead
+# (fm_harness_ancestry_pids_windows). Every pid printed there is a native
+# Windows pid, because MSYS pids cannot address those processes.
 fm_harness_ancestry_pids() {
+  if fm_host_is_windows; then
+    fm_harness_ancestry_pids_windows
+    return
+  fi
   local pid=$$ comm args extending=0 printed=0
   for _ in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16; do
     comm=$(ps -o comm= -p "$pid" 2>/dev/null) || break
@@ -124,6 +144,28 @@ fm_harness_ancestry_pids() {
     pid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d ' ')
     [ -n "$pid" ] && [ "$pid" -gt 1 ] || break
   done
+  [ "$printed" -eq 1 ]
+}
+
+# Windows twin of the walk above, over the CIM chain lines. Same
+# climb-until-first-match and stop-at-first-non-harness-ancestor semantics, so
+# the contiguous-run rule for a Claude worker chain is identical; only the
+# enumeration and the pid space differ.
+fm_harness_ancestry_pids_windows() {
+  local line pid comm args extending=0 printed=0
+  while IFS= read -r line; do
+    line=${line%$'\r'}
+    [ -n "$line" ] || continue
+    IFS=$'\037' read -r pid comm args <<<"$line"
+    if fm_harness_process_matches "$comm" "$args"; then
+      printf '%s\n' "$pid"
+      printed=1
+      [ "$FM_HARNESS_IS_CLAUDE" -eq 1 ] || break
+      extending=1
+    elif [ "$extending" -eq 1 ]; then
+      break
+    fi
+  done < <(fm_windows_ancestry_lines)
   [ "$printed" -eq 1 ]
 }
 
@@ -145,9 +187,17 @@ EOF
   printf '%s\n' "$outermost"
 }
 
-# True if $1 is a live process that looks like a verified harness.
+# True if $1 is a live process that looks like a verified harness. On Windows
+# the pid is a native Windows pid, resolved through the same CIM enumeration.
 fm_harness_pid_alive() {
-  local pid=$1 comm args
+  local pid=$1 comm args line
+  if fm_host_is_windows; then
+    line=$(fm_windows_process_line "$pid") || return 1
+    line=${line%$'\r'}
+    IFS=$'\037' read -r _ comm args <<<"$line"
+    fm_harness_process_matches "$comm" "$args"
+    return
+  fi
   kill -0 "$pid" 2>/dev/null || return 1
   comm=$(ps -o comm= -p "$pid" 2>/dev/null) || return 1
   args=$(ps -o args= -p "$pid" 2>/dev/null)

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -2866,6 +2866,32 @@ spawn_current_path() {  # <target>
     cmux) fm_backend_cmux_current_path "$1" "$W" ;;
   esac
 }
+# Print the first 'in-use' treehouse worktree of the project at $1, or nothing.
+# Runs treehouse in the project dir so its own config/root resolution applies.
+# Prefers the machine-readable pool listing; falls back to the text status
+# table (first line per block: "<n>  in-use  <path>").
+spawn_treehouse_inuse_worktree() {  # <project-real-path>
+  local json out
+  json=$(cd "$1" 2>/dev/null && timeout 15 treehouse status --json 2>/dev/null) || json=''
+  out=$(printf '%s' "$json" | jq -r '
+    [.[]? | select(.status == "in-use" or .state == "in-use") | .path]
+    | if length > 0 then .[0] else empty end' 2>/dev/null)
+  if [ -n "$out" ]; then
+    printf '%s\n' "$out"
+    return 0
+  fi
+  local text out2
+  text=$(cd "$1" 2>/dev/null && timeout 15 treehouse status 2>/dev/null) || return 1
+  out2=$(printf '%s\n' "$text" | awk '/in-use/ { last=""; for (i = 1; i <= NF; i++) if ($i ~ /[\\\/]/) last=$i } END { if (last != "") print last }')
+  [ -n "$out2" ] || return 1
+  # The text table abbreviates the user's home as '~'; expand it so the
+  # caller's cd and git checks see a real path.
+  case "$out2" in
+    '~'[/\\]*) printf '%s\n' "${HOME%/}${out2#\~}" ;;
+    '~') printf '%s\n' "$HOME" ;;
+    *) printf '%s\n' "$out2" ;;
+  esac
+}
 spawn_send_literal() {  # <target> <text>
   case "$BACKEND" in
     tmux) fm_backend_tmux_send_literal "$1" "$2" ;;
@@ -3082,6 +3108,19 @@ elif [ "$KIND" != secondmate ] && [ "$BACKEND" != orca ]; then
   last_reason="the pane reported no path"
   for _ in $(seq 1 60); do
     p=$(spawn_current_path "$WT_TARGET" || true)
+    # On the Windows herdr server the pane's cwd fields never track a child
+    # subshell (verified live: process-info reports only the direct pane shell
+    # and `pane get` cwd is frozen at creation time), so pane-path discovery
+    # cannot see `treehouse get` enter its worktree. Treehouse's own pool
+    # status is the live source there: an 'in-use' worktree of this project
+    # appearing after the acquire was sent is the pane's worktree. The pane
+    # path may arrive in Windows form (C:\...) here, so compare against the
+    # project through the isolation screen rather than a string match.
+    th_wt=""
+    if [ "$BACKEND" = herdr ] && { [ -z "$p" ] || ! spawn_worktree_isolated "$p"; }; then
+      th_wt=$(spawn_treehouse_inuse_worktree "$PROJ_ABS_REAL" || true)
+      [ -z "$th_wt" ] || p=$th_wt
+    fi
     [ -z "$p" ] || last_seen="$p"
     if [ -n "$p" ] && spawn_worktree_isolated "$p"; then
       p_real=$(real_path_or_raw "$p")

--- a/bin/fm-supervision-instructions.sh
+++ b/bin/fm-supervision-instructions.sh
@@ -83,6 +83,10 @@ fi
 case "$HARNESS" in
   claude|codex|opencode|pi|grok|cursor|omp) SNIPPET="$DOC_DIR/$HARNESS.md" ;;
   pi-signed) SNIPPET="$DOC_DIR/pi.md" ;;
+  # zai (herdr-fork engine) has no verified wake adapter of its own yet; it
+  # supervises through the generic unknown-harness contract while still being
+  # named as itself in the header.
+  zai) SNIPPET="$DOC_DIR/unknown.md" ;;
   *) HARNESS=unknown; SNIPPET="$DOC_DIR/unknown.md" ;;
 esac
 [ -f "$SNIPPET" ] || SNIPPET="$DOC_DIR/unknown.md"

--- a/bin/fm-wake-lib.sh
+++ b/bin/fm-wake-lib.sh
@@ -448,8 +448,15 @@ fm_lock_link_owner() {
 
 fm_lock_points_to_owner() {
   local lockdir=$1 ownerdir=$2 actual
-  actual=$(readlink "$lockdir" 2>/dev/null) || return 1
-  [ "$actual" = "$ownerdir" ]
+  actual=$(readlink "$lockdir" 2>/dev/null) || actual=''
+  [ "$actual" = "$ownerdir" ] && return 0
+  # MSYS-style hosts emulate `ln -s` with a copy when no winsymlinks mode is
+  # configured: the claim is then a real directory holding a copy of the
+  # owner's files, and readlink can never resolve it. The creating ln still
+  # refuses an existing target, so the claim stays atomic; ownership is proven
+  # by the copied pid matching this owner dir's own pid.
+  [ -d "$lockdir" ] || return 1
+  cmp -s "$lockdir/pid" "$ownerdir/pid" 2>/dev/null
 }
 
 fm_lock_discard_owner() {
@@ -1095,6 +1102,10 @@ fm_lock_release() {
   [ "$pid" = "$current" ] || return 0
   fm_lock_clean_known_files "$lockdir"
   rmdir "$lockdir" 2>/dev/null || true
+  # Copy-mode claims (MSYS ln -s emulation) leave the owner dir behind here
+  # instead of in the symlink branch above; discard it so repeated lock
+  # cycles do not leak one directory per acquisition.
+  [ -n "${FM_LOCK_OWNER_DIR:-}" ] && fm_lock_discard_owner "$FM_LOCK_OWNER_DIR"
 }
 
 fm_meta_lock_path() {

--- a/bin/fm-windows-process-lib.sh
+++ b/bin/fm-windows-process-lib.sh
@@ -67,34 +67,48 @@ fm_windows_ancestry_lines() {
     printf '%s\n' "${recs[$i]}"
   done
   anchor=${recs[$lastidx]%%"$us"*}
-  FM_LOCK_WINPID=$anchor "${FM_WINDOWS_ANCESTRY_PS:-powershell}" -NoProfile -NonInteractive -Command '
-    $all = @{}
-    Get-CimInstance Win32_Process | ForEach-Object { $all[[uint32]$_.ProcessId] = $_ }
-    $id = [uint32]$env:FM_LOCK_WINPID
-    $us = [string][char]31
-    for ($i = 0; $i -lt 16; $i++) {
-      $p = $all[$id]
-      if (-not $p) { break }
-      Write-Output (([string]$p.ProcessId) + $us + $p.Name + $us + $p.CommandLine)
-      $id = [uint32]$p.ParentProcessId
-      if (-not $id -or $id -eq 0) { break }
-    }
-  ' || return 1
+  # A CIM snapshot intermittently comes back empty under host load, which
+  # would strand a live session as unidentified (and the fleet lock as
+  # read-only); retry once before accepting the miss.
+  local out=''
+  for _ in 1 2; do
+    out=$(FM_LOCK_WINPID=$anchor "${FM_WINDOWS_ANCESTRY_PS:-powershell}" -NoProfile -NonInteractive -Command '
+      $all = @{}
+      Get-CimInstance Win32_Process | ForEach-Object { $all[[uint32]$_.ProcessId] = $_ }
+      $id = [uint32]$env:FM_LOCK_WINPID
+      $us = [string][char]31
+      for ($i = 0; $i -lt 16; $i++) {
+        $p = $all[$id]
+        if (-not $p) { break }
+        Write-Output (([string]$p.ProcessId) + $us + $p.Name + $us + $p.CommandLine)
+        $id = [uint32]$p.ParentProcessId
+        if (-not $id -or $id -eq 0) { break }
+      }
+    ' 2>/dev/null) && [ -n "$out" ] && break
+    out=''
+    sleep 0.3
+  done
+  [ -n "$out" ] || return 1
+  printf '%s\n' "$out"
 }
 
 # Print the identity line of one Windows pid, or return 1 when no live process
 # carries it. Same line format and test override as fm_windows_ancestry_lines;
 # CIM sees MSYS processes too, so a lock pid from either side of the hybrid
-# walk resolves here.
+# walk resolves here. Retried once for the same transient-empty reason.
 fm_windows_process_line() {  # <pid>
-  local pid=$1
+  local pid=$1 out
   case $pid in
     ''|*[!0-9]*) return 1 ;;
   esac
-  FM_LOCK_WINPID=$pid "${FM_WINDOWS_ANCESTRY_PS:-powershell}" -NoProfile -NonInteractive -Command '
-    $p = Get-CimInstance Win32_Process -Filter ("ProcessId = " + [uint32]$env:FM_LOCK_WINPID)
-    if (-not $p) { exit 1 }
-    $us = [string][char]31
-    Write-Output (([string]$p.ProcessId) + $us + $p.Name + $us + $p.CommandLine)
-  ' || return 1
+  for out in 1 2; do
+    out=$(FM_LOCK_WINPID=$pid "${FM_WINDOWS_ANCESTRY_PS:-powershell}" -NoProfile -NonInteractive -Command '
+      $p = Get-CimInstance Win32_Process -Filter ("ProcessId = " + [uint32]$env:FM_LOCK_WINPID)
+      if (-not $p) { exit 1 }
+      $us = [string][char]31
+      Write-Output (([string]$p.ProcessId) + $us + $p.Name + $us + $p.CommandLine)
+    ' 2>/dev/null) && [ -n "$out" ] && { printf '%s\n' "$out"; return 0; }
+    sleep 0.3
+  done
+  return 1
 }

--- a/bin/fm-windows-process-lib.sh
+++ b/bin/fm-windows-process-lib.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+# Shared Windows process-chain enumeration for MSYS-style hosts (Git Bash).
+#
+# ONE owner of "walk the native Windows parent chain above this shell". Two
+# platform facts make the naive walk unusable there:
+#
+#   1. MSYS ps cannot see native Windows processes at all, so a Unix `ps` walk
+#      stops at the first native boundary - exactly where the agent engine (a
+#      node bundle, a compiled CLI) sits.
+#   2. A pure Windows walk (CIM Win32_Process ParentProcessId) dies just as
+#      fast: an MSYS fork child is a copy of its forking shell whose Win32
+#      parent pid goes stale the moment the fork helper's intermediate exits,
+#      so the first MSYS-internal boundary already breaks the chain.
+#
+# The walk below is therefore hybrid: climb the MSYS /proc chain, which tracks
+# those parents reliably, then hand off to one CIM walk anchored at the last
+# MSYS process - its parent is a native CreateProcess child of the engine, and
+# native-to-native Win32 parent pids are stable. The walks in
+# bin/fm-session-lock-lib.sh and bin/fm-harness.sh delegate to this lib on such
+# hosts. This file is sourced by scripts and has no side effects on source.
+
+# True when the host shell is an MSYS-style Windows environment, where the Unix
+# ps walks cannot cross into the native Windows processes above the shell.
+fm_host_is_windows() {
+  case "$(uname -s 2>/dev/null)" in
+    MINGW*|MSYS*|CYGWIN*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+# Print "pid<US>comm<US>args" lines (US = byte 0x1f) for the calling shell's
+# Windows ancestry, innermost first, up to 16 MSYS hops plus 16 CIM hops.
+# Never interprets process identity; callers own matching. A multiline args
+# field (a shell running an embedded script) fragments into continuation lines
+# on the consumer side; those never match a harness identity, so they are inert.
+# The start pid is the calling shell's own Windows pid, read with `read`
+# redirection rather than a command substitution: $(cat /proc/self/winpid)
+# would report the transient subshell running cat.
+# FM_WINDOWS_ANCESTRY_PS overrides the powershell executable for tests.
+fm_windows_ancestry_lines() {
+  local us pid rest stat comm ppid winpid args
+  local -a recs=()
+  local i lastidx anchor
+  us=$(printf '\037')
+  read -r pid rest < /proc/self/stat 2>/dev/null || return 1
+  for _ in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16; do
+    stat=$(cat "/proc/$pid/stat" 2>/dev/null) || break
+    rest=${stat#*(}
+    comm=${rest%%)*}
+    rest=${rest#*) }
+    ppid=${rest#* }
+    ppid=${ppid%% *}
+    winpid=$(cat "/proc/$pid/winpid" 2>/dev/null) || winpid=''
+    case $winpid in
+      ''|*[!0-9]*) break ;;
+    esac
+    args=$(tr '\0' ' ' < "/proc/$pid/cmdline" 2>/dev/null)
+    recs+=("$winpid$us$comm$us$args")
+    case $ppid in
+      ''|0|1) break ;;
+    esac
+    [ -r "/proc/$ppid/stat" ] || break
+    pid=$ppid
+  done
+  lastidx=$((${#recs[@]} - 1))
+  for ((i = 0; i < lastidx; i++)); do
+    printf '%s\n' "${recs[$i]}"
+  done
+  anchor=${recs[$lastidx]%%"$us"*}
+  FM_LOCK_WINPID=$anchor "${FM_WINDOWS_ANCESTRY_PS:-powershell}" -NoProfile -NonInteractive -Command '
+    $all = @{}
+    Get-CimInstance Win32_Process | ForEach-Object { $all[[uint32]$_.ProcessId] = $_ }
+    $id = [uint32]$env:FM_LOCK_WINPID
+    $us = [string][char]31
+    for ($i = 0; $i -lt 16; $i++) {
+      $p = $all[$id]
+      if (-not $p) { break }
+      Write-Output (([string]$p.ProcessId) + $us + $p.Name + $us + $p.CommandLine)
+      $id = [uint32]$p.ParentProcessId
+      if (-not $id -or $id -eq 0) { break }
+    }
+  ' || return 1
+}
+
+# Print the identity line of one Windows pid, or return 1 when no live process
+# carries it. Same line format and test override as fm_windows_ancestry_lines;
+# CIM sees MSYS processes too, so a lock pid from either side of the hybrid
+# walk resolves here.
+fm_windows_process_line() {  # <pid>
+  local pid=$1
+  case $pid in
+    ''|*[!0-9]*) return 1 ;;
+  esac
+  FM_LOCK_WINPID=$pid "${FM_WINDOWS_ANCESTRY_PS:-powershell}" -NoProfile -NonInteractive -Command '
+    $p = Get-CimInstance Win32_Process -Filter ("ProcessId = " + [uint32]$env:FM_LOCK_WINPID)
+    if (-not $p) { exit 1 }
+    $us = [string][char]31
+    Write-Output (([string]$p.ProcessId) + $us + $p.Name + $us + $p.CommandLine)
+  ' || return 1
+}

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -344,6 +344,17 @@ Its `remove` action excises only the marker-delimited Firstmate region and remov
 For Pi and pi-signed secondmate launches, `fm-spawn.sh` starts the selected executable with `-e` pointed at the secondmate home's own tracked `.pi/extensions/fm-primary-pi-watch.ts` and `.pi/extensions/fm-primary-turnend-guard.ts`, both already present from the secondmate home's git worktree.
 For omp secondmate launches, `fm-spawn.sh` passes no `-e` at all: omp auto-discovers the home's tracked `.omp/extensions/` with no trust gate, and naming a discovered file with `-e` as well loads it twice; every omp launch instead carries the tracked `.omp/fm-worker-overlay.yml` posture overlay through `--config`, which [`fm-spawn.sh --help`](../bin/fm-spawn.sh) owns.
 
+### Opening a home on a Windows/zai host
+
+A primary whose engine is the zai engine (the herdr-fork wrapper's `zai-cli` node bundle) is a verified primary session identity, so the fleet lock, harness detection, and supervision work there with no extra configuration once the repo is on a commit carrying the Windows fixes (session identity, herdr socket/PATH/worktree handling, and the CIM retry - all on main since 2026-09-10).
+Supervision for a zai primary uses the generic unknown-harness contract: drain, handle, and keep one bounded foreground `bin/fm-watch.sh` cycle while work is under way.
+Per-home facts that never travel with the repo and must be established once per home:
+
+- The crewmate harness: `config/crew-harness` should name a verified adapter with working credentials (`pi`, `claude`, `codex`, ...), because `zai` itself has no worker launch template. When every verified adapter lacks credentials, spawn accepts a raw launch command - `fm-spawn.sh <id> <project> --scout --harness "zai \"$(cat <brief>)\""` - which runs the same zai engine as the worker.
+- Projects: `data/projects.md`, `data/backlog.md`, and `config/` are local and gitignored; register each project again in the new home, choosing `local-only` for repositories with no remote.
+- Tools: the npm-distributed set installs through `bin/fm-bootstrap.sh install`; `jq`, `treehouse`, and `no-mistakes` need their vendors' Windows assets placed on PATH manually, and a herdr server restarted after tool installs so worker panes inherit the new PATH.
+- Windows host facts and their handling are owned by [`herdr-backend.md`](herdr-backend.md#windows-msys-hosts).
+
 ## Worker launch environment (config/launch-env-allowlist)
 
 The optional local, gitignored `config/launch-env-allowlist` limits the ambient environment passed to newly launched workers, scouts, and secondmates, including relaunches.

--- a/docs/herdr-backend.md
+++ b/docs/herdr-backend.md
@@ -308,6 +308,7 @@ The pane-independent max-defer alert is configured in [`wedge-alarm.md`](wedge-a
 Harnesses with native tracked background execution can run the daemon in their terminal.
 Pi and pi-signed no longer launch the away daemon; their ordinary supervision session continues under the posture record.
 For another harness without native tracked background execution, `bin/fm-afk-launch.sh` creates a dedicated unfocused Herdr workspace, runs the daemon there with an explicit supervisor target and backend, records the exact daemon pane, and closes only that pane on stop.
+On a Windows host the created pane's shell is PowerShell, so the launcher wraps the daemon command in the Git Bash login invocation PowerShell executes, while POSIX hosts send the bare command.
 It never splits the captain's active tab and never uses shell `&`.
 Recovery reconciles only the recorded exact id.
 

--- a/docs/herdr-backend.md
+++ b/docs/herdr-backend.md
@@ -327,6 +327,19 @@ Its before/after tripwire requires the live default-session snapshot to remain b
 The helper's header and `--help` own exact commands.
 Tests use thin compatibility wrappers in `tests/herdr-test-safety.sh` and never duplicate the destructive policy.
 
+## Windows (MSYS) hosts
+
+Firstmate supports a herdr home on Windows under Git Bash (MSYS), where three platform facts shape behavior.
+MSYS `ps` cannot see native Windows processes, MSYS fork children carry a stale Win32 parent pid, and MSYS emulates `ln -s` as a copy unless a winsymlinks mode is configured.
+The firstmate-side consequences are handled in code: the session-lock identity walk uses the hybrid `/proc`-then-CIM enumeration in `bin/fm-windows-process-lib.sh`, the lock claim verifies the copy form by pid content, and socket paths, worker pane environments, and worktree discovery are normalized or sourced from treehouse instead of the pane's cwd fields.
+zai, the herdr-fork primary engine (a node bundle run as `zai-cli`), is a verified PRIMARY session identity on Windows; supervision there uses the generic unknown-harness contract because zai has no verified wake adapter of its own.
+
+Operator-facing facts that code cannot absorb:
+
+- The herdr server's own environment seeds every worker pane. A server started before a tool install keeps the old PATH forever, so restart the herdr server after installing tools, or rely on firstmate passing the session's own PATH to each spawned pane (the code default).
+- `jq`, `treehouse`, and `no-mistakes` publish no MSYS installers. Install their Windows assets manually from the vendors' GitHub releases into a directory on PATH; `bin/fm-bootstrap.sh install` covers only the npm-distributed tools.
+- Worker-pane liveness and cwd discovery go through PowerShell CIM queries, which cost one to two seconds per call; timing-sensitive checks are correspondingly slower than on macOS or Linux.
+
 ## Active limits
 
 - Presentation ordering needs protocol 16 and Python and is best-effort only.

--- a/docs/verification/runtime-backends.md
+++ b/docs/verification/runtime-backends.md
@@ -1047,6 +1047,11 @@ Observed guarantees: `fm-afk-launch.sh start` refused on the Pi primary and `con
 The fixture captures submitted input through Pi's `input` extension hook, so the lab agent directory needs no provider credentials.
 The daemon injection transport into a live composer keeps its coverage in `tests/fm-afk-inject-herdr-e2e.test.sh` for the harnesses that still run the daemon, and the dedicated Herdr daemon workspace topology is covered by `tests/fm-afk-launch.test.sh` and preserves the captain tab's pane count.
 
+The Windows herdr pane-shell wrapper was verified live on 2026-09-13 with Windows 11 Home 10.0.26200 x64, Git Bash (MSYS), a Herdr protocol-19 server, and zai as the primary harness.
+A POSIX `exec env ...` line sent into a created Herdr pane reached its PowerShell shell verbatim and was rejected with `exec: The term 'exec' is not recognized as a name of a cmdlet, function, script file, or executable program`, so the daemon never started and the launcher's readiness gate closed the pane.
+With the wrapper, the same pane shell executed `& 'C:\Program Files\Git\bin\bash.exe' -lc '<command>'`, the real `bin/fm-afk-start.sh` daemon started in that pane's foreground, the watcher beat `state/.last-watcher-beat` within one poll, the daemon logged its startup line, and `stop` terminated the daemon, closed the workspace by exact id, and archived the record.
+The portable command contract is pinned by the `tests/fm-afk-launch.test.sh` pane-command units on both host classes, and its herdr e2e asserts the daemon entry actually executes by watching a marker file the entry writes, which topology checks alone cannot see when a pane shell rejects the command.
+
 ## zai primary session identity on Windows
 
 zai is a herdr fork whose engine is the zai-cli node bundle; it publishes no harness-identity marker of its own and consumes the herdr pane environment, so its identity comes from process ancestry alone.

--- a/docs/verification/runtime-backends.md
+++ b/docs/verification/runtime-backends.md
@@ -1006,6 +1006,24 @@ Observed guarantees: `fm-afk-launch.sh start` refused on the Pi primary and `con
 The fixture captures submitted input through Pi's `input` extension hook, so the lab agent directory needs no provider credentials.
 The daemon injection transport into a live composer keeps its coverage in `tests/fm-afk-inject-herdr-e2e.test.sh` for the harnesses that still run the daemon, and the dedicated Herdr daemon workspace topology is covered by `tests/fm-afk-launch.test.sh` and preserves the captain tab's pane count.
 
+## zai primary session identity on Windows
+
+zai is a herdr fork whose engine is the zai-cli node bundle; it publishes no harness-identity marker of its own and consumes the herdr pane environment, so its identity comes from process ancestry alone.
+On Windows the MSYS (Git Bash) ps table cannot see native Windows processes, and MSYS fork children carry a stale Win32 parent pid, so both a Unix ps walk and a pure CIM parent walk die before reaching the engine.
+The hybrid walk in `bin/fm-windows-process-lib.sh` climbs the MSYS `/proc` chain, then hands off to one CIM snapshot anchored at the last MSYS process, whose native parent is a CreateProcess child of the engine.
+MSYS `ln -s` emulated as a copy was also verified: the session-lock claim then verifies through `fm_lock_points_to_owner`'s pid-content fallback and releases through the directory branch of `fm_lock_release`.
+
+Verified live on 2026-09-10 with Windows 11 Home 10.0.26200 x64, Git Bash (MSYS), zai-cli under Herdr on protocol 19, as the running firstmate home's own session.
+
+```sh
+bin/fm-harness.sh        # zai
+bin/fm-lock.sh           # lock acquired: harness pid <zai-cli node pid>
+bin/fm-session-start.sh  # SUPERVISION OPERATING INSTRUCTIONS - primary harness: zai
+bash tests/fm-zai-windows-identity.test.sh
+```
+
+Observed guarantees: the zai-cli node hop is the innermost and only harness match, the herdr wrapper above it never claims the identity, the lock records the native Windows pid of that engine and is idempotently re-acquired by the same session, a stale lock is taken over and a live foreign holder refuses, and a simulated Windows chain drives `bin/fm-harness.sh` and `bin/fm-lock.sh` deterministically in `tests/fm-zai-windows-identity.test.sh` with no real zai required.
+
 ## Zellij
 
 The current compatibility floor and latest verification are Zellij 0.44.0 with `jq` on macOS aarch64.

--- a/tests/fm-afk-launch.test.sh
+++ b/tests/fm-afk-launch.test.sh
@@ -555,6 +555,75 @@ unit_herdr_run_failure_preserves_unconfirmed_record() {
   rm -rf "$st"
 }
 
+# Capture the exact command the launcher hands to `herdr pane run` for the
+# daemon terminal, with the host class and Git Bash path forced so each test
+# pins its own verdict on any host. The forcing is applied after the source
+# because fm-windows-process-lib.sh resets its memo variable when sourced.
+capture_herdr_pane_run_command() {  # <home> <capture-file>
+  FM_HOME="$1" FM_STATE_OVERRIDE="$1/state" FM_AFK_LAUNCH_ENTRY=/bin/true \
+    FM_AFK_TEST_UNAME=${FM_AFK_TEST_UNAME:-} FM_AFK_TEST_GIT_BASH=${FM_AFK_TEST_GIT_BASH:-} \
+    CAPTURED="$2" bash -c '
+    . "$1"
+    FM_UNAME_S_CACHE=$FM_AFK_TEST_UNAME
+    FM_AFK_LAUNCH_GIT_BASH=$FM_AFK_TEST_GIT_BASH
+    fm_backend_source() { return 0; }
+    fm_backend_herdr_server_ensure() { return 0; }
+    fm_backend_herdr_cli() {
+      if [ "$2 $3" = "workspace create" ]; then
+        printf %s '\''{"result":{"workspace":{"workspace_id":"ws"},"root_pane":{"pane_id":"pane"}}}'\''
+      elif [ "$2 $3" = "pane run" ]; then
+        printf %s "$5" > "$CAPTURED"
+      fi
+      return 0
+    }
+    fm_afk_launch_record_write() { return 0; }
+    fm_afk_launch_commit_terminal() { return 0; }
+    fm_afk_launch_create_herdr lab:captain herdr
+  ' _ "$LAUNCH" >/dev/null 2>&1
+}
+
+unit_herdr_pane_cmd_posix_host_sends_bare_command() {
+  local st captured expected
+  st=$(mktemp -d "${TMPDIR:-/tmp}/fm-afk-herdr-posix-cmd.XXXXXX")
+  captured="$st/captured"
+  FM_AFK_TEST_UNAME=Linux FM_AFK_TEST_GIT_BASH='' capture_herdr_pane_run_command "$st/home" "$captured"
+  expected=$(printf 'exec env FM_HOME=%q FM_SUPERVISOR_TARGET=%q FM_SUPERVISOR_BACKEND=%q %q' \
+    "$st/home" lab:captain herdr /bin/true)
+  if [ "$(cat "$captured" 2>/dev/null || true)" = "$expected" ]; then
+    pass "herdr pane command: a POSIX host sends the bare exec-env command unchanged"
+  else
+    fail "herdr pane command: POSIX host command was wrapped or altered: $(cat "$captured" 2>/dev/null || true)"
+  fi
+  rm -rf "$st"
+}
+
+unit_herdr_pane_cmd_windows_wraps_in_git_bash() {
+  local st captured cmd inner expected
+  st=$(mktemp -d "${TMPDIR:-/tmp}/fm-afk-herdr-win-cmd.XXXXXX")
+  captured="$st/captured"
+  FM_AFK_TEST_UNAME=MSYS_NT-10.0-26200 FM_AFK_TEST_GIT_BASH='C:\Test\Git\bin\bash.exe' \
+    capture_herdr_pane_run_command "$st/o'brien home" "$captured"
+  cmd=$(cat "$captured" 2>/dev/null || true)
+  # The contract: & '<bash.exe>' -lc '<the unchanged POSIX command>', with the
+  # POSIX command inside a PowerShell single-quoted literal (embedded quotes
+  # doubled), so the PowerShell pane shell hands bash exactly the old line.
+  inner=$(printf 'exec env FM_HOME=%q FM_SUPERVISOR_TARGET=%q FM_SUPERVISOR_BACKEND=%q %q' \
+    "$st/o'brien home" lab:captain herdr /bin/true)
+  expected=$(printf '& %s -lc %s' "'C:\\Test\\Git\\bin\\bash.exe'" "'${inner//\'/\'\'}'")
+  if [ "$cmd" = "$expected" ]; then
+    pass "herdr pane command: a Windows host wraps the daemon command in the Git Bash -lc invocation"
+  else
+    fail "herdr pane command: Windows host did not produce the Git Bash wrapper contract"
+    printf '  got:      %s\n' "$cmd" >&2
+    printf '  expected: %s\n' "$expected" >&2
+  fi
+  case "$cmd" in
+    *"o\\''brien"*) pass "herdr pane command: an embedded quote survives as a doubled PowerShell quote" ;;
+    *) fail "herdr pane command: an embedded quote was not PowerShell-doubled: $cmd" ;;
+  esac
+  rm -rf "$st"
+}
+
 unit_record_failure_closes_terminal() {
   local st closed
   st=$(mktemp -d "${TMPDIR:-/tmp}/fm-afk-record-fail.XXXXXX")
@@ -992,15 +1061,24 @@ e2e_herdr() {
 
   local SESSION home_tmp cap_ws cap_tab cap_pane target
   local before during after ws_before ws_during ws_after out dtgt dtab
+  local entry_ran_marker MARKER_ENTRY ran
   SESSION="fm-lab-afk-launch-e2e-$$"
   export HERDR_SESSION="$SESSION"
   home_tmp=$(mktemp -d "${TMPDIR:-/tmp}/fm-afk-e2e-home.XXXXXX")
+  # The daemon entry writes this marker then sleeps, so the e2e proves the
+  # pane shell actually EXECUTED the command (the topology checks alone pass
+  # even when a pane shell rejects the command and the daemon never runs).
+  entry_ran_marker="$home_tmp/daemon-entry-executed"
+  MARKER_ENTRY=$(mktemp "${TMPDIR:-/tmp}/fm-afk-entry-marker.XXXXXX")
+  printf '#!/usr/bin/env bash\n: > "%s"\nexec sleep 600\n' "$entry_ran_marker" > "$MARKER_ENTRY"
+  chmod +x "$MARKER_ENTRY"
   E2E_HERDR_CLEANUP() {
     # shellcheck disable=SC2031 # Cleanup reads the caller's resolved target; it does not reassign it.
     FM_HOME="$home_tmp" FM_STATE_OVERRIDE="$home_tmp/state" \
       FM_SUPERVISOR_TARGET="$target" FM_SUPERVISOR_BACKEND=herdr "$LAUNCH" stop >/dev/null 2>&1 || true
     herdr_safe_stop_and_delete "$SESSION" >/dev/null 2>&1 || true
     rm -rf "$home_tmp" 2>/dev/null || true
+    rm -f "$MARKER_ENTRY" 2>/dev/null || true
   }
   fm_herdr_lab_prepare "$SESSION" || { fail "herdr e2e: could not prepare isolated lab session"; return 0; }
   fm_backend_source herdr || { E2E_HERDR_CLEANUP; fail "herdr e2e: fm_backend_source herdr failed"; return 0; }
@@ -1017,7 +1095,7 @@ e2e_herdr() {
   ws_before=$(fm_backend_herdr_cli "$SESSION" workspace list 2>/dev/null | jq '[.result.workspaces[]?]|length')
 
   FM_HOME="$home_tmp" FM_STATE_OVERRIDE="$home_tmp/state" \
-    FM_SUPERVISOR_TARGET="$target" FM_SUPERVISOR_BACKEND=herdr FM_AFK_LAUNCH_ENTRY="$SLEEPER" \
+    FM_SUPERVISOR_TARGET="$target" FM_SUPERVISOR_BACKEND=herdr FM_AFK_LAUNCH_ENTRY="$MARKER_ENTRY" \
     "$LAUNCH" start >/dev/null 2>&1
 
   during=$(fm_backend_herdr_cli "$SESSION" pane list --workspace "$cap_ws" 2>/dev/null | jq --arg t "$cap_tab" '[.result.panes[]?|select(.tab_id==$t)]|length')
@@ -1029,6 +1107,13 @@ e2e_herdr() {
   if [ "$ws_during" -gt "$ws_before" ]; then pass "herdr e2e: daemon launched in a separate non-visible workspace"; else fail "herdr e2e: no separate daemon workspace created"; fi
   if [ -n "$dtab" ] && [ "$dtab" != "$cap_tab" ]; then pass "herdr e2e: daemon pane is NOT in the captain's tab"; else fail "herdr e2e: daemon pane shares the captain tab ($dtab)"; fi
   case "$dtgt" in "$SESSION":*) pass "herdr e2e: daemon terminal scoped to the lab session" ;; *) fail "herdr e2e: daemon terminal not in the lab session ($dtgt)" ;; esac
+
+  ran=0
+  for _ in $(seq 1 60); do
+    if [ -e "$entry_ran_marker" ]; then ran=1; break; fi
+    sleep 0.5
+  done
+  if [ "$ran" = 1 ]; then pass "herdr e2e: the pane shell executed the daemon entry (Git Bash -lc wrapper included)"; else fail "herdr e2e: the daemon entry never executed in its pane"; fi
 
   FM_HOME="$home_tmp" FM_STATE_OVERRIDE="$home_tmp/state" \
     FM_SUPERVISOR_TARGET="$target" FM_SUPERVISOR_BACKEND=herdr "$LAUNCH" stop >/dev/null 2>&1
@@ -1096,6 +1181,8 @@ unit_signal_exits_with_lock_cleanup
 unit_herdr_partial_create_recovery
 unit_herdr_error_with_exact_ids_closes_exact
 unit_herdr_run_failure_preserves_unconfirmed_record
+unit_herdr_pane_cmd_posix_host_sends_bare_command
+unit_herdr_pane_cmd_windows_wraps_in_git_bash
 unit_record_failure_closes_terminal
 unit_readiness_failure_rolls_back_terminal
 unit_readiness_failure_preserves_unconfirmed_record

--- a/tests/fm-home-seed-path-forms.test.sh
+++ b/tests/fm-home-seed-path-forms.test.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# tests/fm-home-seed-path-forms.test.sh - secondmate-home path-form handling.
+#
+# On MSYS hosts treehouse prints leased worktree paths in Windows drive form
+# (C:/Users/...). canonical_path_for_check must recognize a drive path as
+# absolute (converting it through cygpath when available) instead of joining it
+# onto the caller's cwd, which made the lease land inside the active home and
+# tripped the nested-home safety refusal.
+set -u
+
+# shellcheck source=tests/secondmate-helpers.sh disable=SC1091
+. "$(dirname "${BASH_SOURCE[0]}")/secondmate-helpers.sh"
+
+TMP_ROOT=$(fm_test_tmproot fm-home-seed-path-forms)
+export FM_BACKEND=tmux
+
+test_home_seed_accepts_windows_form_leased_home() {
+  local home acquired fakebin log err out
+  home="$TMP_ROOT/win-home"
+  err="$TMP_ROOT/win.err"
+  mkdir -p "$home/projects" "$home/data" "$home/state"
+  fm_git_init_commit "$home/projects/alpha"
+  fm_git_add_origin "$home/projects/alpha" "$TMP_ROOT/remotes/win-alpha.git"
+  printf '%s\n' '- alpha [direct-PR] - alpha project (added 2026-06-22)' > "$home/data/projects.md"
+
+  # The leased home exists in drive form in the test tree; the fake cygpath
+  # maps that form onto the same directory in POSIX form.
+  WIN_CYGROOT="$TMP_ROOT/win-c"
+  acquired="$WIN_CYGROOT/Users/tester/.treehouse/firstmate-abc/1/firstmate"
+  git clone --quiet "$ROOT" "$acquired"
+
+  fakebin=$(make_fake_tmux "$TMP_ROOT/win-fake")
+  log="$TMP_ROOT/win-fake/tmux.log"
+  cat > "$fakebin/cygpath" <<SH
+#!/usr/bin/env bash
+[ "\${1:-}" = -u ] || exit 1
+p=\${2:-}
+case "\$p" in
+  [A-Za-z]:[/\\\\]*)
+    rest=\${p#?:}
+    rest=\${rest#/}
+    rest=\${rest#\\\\}
+    printf '%s/%s\n' "\$WIN_CYGROOT" "\$rest" | tr '\\\\' '/'
+    ;;
+  *) printf '%s\n' "\$p" ;;
+esac
+SH
+  chmod +x "$fakebin/cygpath"
+
+  out=$(PATH="$fakebin:$PATH" WIN_CYGROOT="$WIN_CYGROOT" FM_HOME="$home" \
+    FM_FAKE_TREEHOUSE_HOME='C:/Users/tester/.treehouse/firstmate-abc/1/firstmate' \
+    FM_FAKE_TMUX_LOG="$log" FM_FAKE_TREEHOUSE_LEASE_FILE="$TMP_ROOT/win-fake/lease" \
+    FM_SECONDMATE_CHARTER='win form scope' FM_SECONDMATE_SCOPE='win form scope' \
+    "$ROOT/bin/fm-home-seed.sh" winform - alpha 2>"$err") \
+    || { cat "$err" >&2; fail "seed refused a Windows-form leased home"; }
+  printf '%s\n' "$out" | grep -F "home=$acquired" >/dev/null \
+    || fail "seed did not report the converted POSIX home path"
+  [ -f "$acquired/.fm-secondmate-home" ] || fail "seed did not mark the acquired home"
+  if grep -F 'cannot be inside the active firstmate home' "$err" >/dev/null 2>&1; then
+    fail "seed treated a Windows-form absolute path as relative"
+  fi
+  pass "home seeding accepts Windows drive-form leased home paths"
+}
+
+test_home_seed_accepts_windows_form_leased_home

--- a/tests/fm-zai-windows-identity.test.sh
+++ b/tests/fm-zai-windows-identity.test.sh
@@ -1,0 +1,258 @@
+#!/usr/bin/env bash
+# tests/fm-zai-windows-identity.test.sh - zai engine identity over Windows chains.
+#
+# zai (the herdr-fork primary engine, a node bundle running zai-cli) is
+# identified only through process ancestry - it publishes no env marker - and
+# on MSYS-style Windows hosts that ancestry must come from the hybrid
+# /proc-then-CIM walk in bin/fm-windows-process-lib.sh. This suite pins, with
+# no real Windows or real zai required:
+#   - the shared matcher's zai verdicts in bin/fm-session-lock-lib.sh,
+#   - the Windows ancestry twin's climb semantics (climb to the first harness
+#     match, stop at the first non-harness ancestor, claude contiguous-run),
+#   - pid liveness over the CIM enumeration,
+#   - bin/fm-harness.sh and bin/fm-lock.sh end to end over a simulated
+#     MSYS Windows host: a fake uname (MINGW) selects the Windows branch and
+#     FM_WINDOWS_ANCESTRY_PS feeds a synthetic identity chain, so both real
+#     enumeration halves stay out of the deterministic path.
+#
+# shellcheck source=tests/fixtures.sh
+. "$(dirname "${BASH_SOURCE[0]}")/fixtures.sh"
+
+TMP_ROOT=$(fm_test_tmproot fm-zai-win) || exit 1
+
+# Build a fakebin that makes every consumer believe it is on an MSYS Windows
+# host and answers the chain enumeration from FM_FAKE_WIN_CHAIN (identity lines
+# with literal \037 escapes and \n separators, innermost first).
+make_windows_fakebin() {
+  local fakebin
+  fakebin=$(fm_fakebin "$TMP_ROOT/$1")
+  cat > "$fakebin/uname" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n' "MINGW64_NT-10.0-26200"
+SH
+  chmod +x "$fakebin/uname"
+  cat > "$fakebin/fake-chain-ps" <<'SH'
+#!/usr/bin/env bash
+case "$*" in
+  *-Filter*)
+    # Liveness mode: answer only for pids the synthetic chain knows, plus the
+    # optional extra foreign holder a test registers.
+    line=$(printf '%b' "${FM_FAKE_WIN_CHAIN:-}" | grep -F -- "$(printf '%s\037' "$FM_LOCK_WINPID")")
+    if [ -n "$line" ]; then
+      printf '%s\n' "$line"
+      exit 0
+    fi
+    if [ -n "${FM_FAKE_FOREIGN_LINE:-}" ] && [ "$FM_LOCK_WINPID" = "${FM_FAKE_FOREIGN_PID:-}" ]; then
+      printf '%s\n' "$FM_FAKE_FOREIGN_LINE"
+      exit 0
+    fi
+    exit 1
+    ;;
+esac
+printf '%b' "${FM_FAKE_WIN_CHAIN:-}"
+SH
+  chmod +x "$fakebin/fake-chain-ps"
+  printf '%s\n' "$fakebin"
+}
+
+# Emit one synthetic identity line with real US separators.
+chain_line() {  # <pid> <comm> <args>
+  printf '%s\037%s\037%s\n' "$1" "$2" "$3"
+}
+
+ZAI_ARGS='node.exe C:/Users/dev/AppData/Roaming/npm/node_modules/zai-cli/dist/cli.js'
+
+# --- the shared lock-lib matcher ---------------------------------------------
+
+test_matcher_zai_node_bundle() {
+  local out
+  out=$(
+    . "$ROOT/bin/fm-session-lock-lib.sh"
+    fm_harness_process_matches "node.exe" "$ZAI_ARGS"
+    printf '%s-%s' "$?" "$FM_HARNESS_IS_CLAUDE"
+  ) || fail "matcher: sourcing the session-lock lib failed"
+  assert_equals "0-0" "$out" "matcher: node.exe running zai-cli matches as zai, not claude"
+}
+
+test_matcher_zai_repo_checkout() {
+  local out
+  out=$(
+    . "$ROOT/bin/fm-session-lock-lib.sh"
+    fm_harness_process_matches "node.exe" "node.exe /home/dev/work/harness/zai/dist/cli.js"
+    printf '%s' "$?"
+  ) || fail "matcher: sourcing the session-lock lib failed"
+  assert_equals "0" "$out" "matcher: node.exe running a zai repo checkout matches as zai"
+}
+
+test_matcher_plain_bash_never_zai() {
+  local out
+  out=$(
+    . "$ROOT/bin/fm-session-lock-lib.sh"
+    fm_harness_process_matches "bash.exe" 'bash.exe -c bin/fm-crew-state.sh tm-1'
+    printf '%s' "$?"
+  ) || fail "matcher: sourcing the session-lock lib failed"
+  assert_equals "1" "$out" "matcher: an ordinary bash.exe child is not a harness"
+}
+
+test_matcher_herdr_wrapper_never_harness() {
+  local out
+  out=$(
+    . "$ROOT/bin/fm-session-lock-lib.sh"
+    fm_harness_process_matches "herdr.exe" '"C:/Program Files/Herdr/bin/herdr.exe" server'
+    printf '%s' "$?"
+  ) || fail "matcher: sourcing the session-lock lib failed"
+  assert_equals "1" "$out" "matcher: the herdr wrapper is not the session engine"
+}
+
+# --- the Windows ancestry twin ------------------------------------------------
+
+# The lib is sourced once per subshell; tests override fm_windows_ancestry_lines
+# with a synthetic chain, so the real /proc and CIM halves stay out of the way.
+
+test_windows_twin_stops_at_engine() {
+  local out
+  out=$(
+    . "$ROOT/bin/fm-session-lock-lib.sh"
+    fm_host_is_windows() { return 0; }
+    fm_windows_ancestry_lines() {
+      chain_line 501 bash.exe 'bash.exe -c ls'
+      chain_line 502 node.exe "$ZAI_ARGS"
+      chain_line 503 herdr.exe 'herdr.exe server'
+    }
+    fm_harness_ancestry_pids_windows
+  ) || fail "windows twin: the walk found no harness"
+  assert_equals "502" "$out" "windows twin: the innermost zai-cli node hop is the whole ancestry"
+}
+
+test_windows_twin_claude_contiguous_run() {
+  local out
+  out=$(
+    . "$ROOT/bin/fm-session-lock-lib.sh"
+    fm_host_is_windows() { return 0; }
+    fm_windows_ancestry_lines() {
+      chain_line 601 bash.exe 'bash.exe -c hook'
+      chain_line 602 claude 'claude bg-pty-host'
+      chain_line 603 claude 'claude'
+      chain_line 604 pwsh.exe 'pwsh.exe -NoExit'
+    }
+    fm_harness_ancestry_pids_windows
+  ) || fail "windows twin: the claude walk found no harness"
+  assert_equals "602
+603" "$out" "windows twin: a claude run reports its contiguous chain, stopping at pwsh"
+}
+
+test_windows_twin_no_harness_is_empty() {
+  local out
+  out=$(
+    . "$ROOT/bin/fm-session-lock-lib.sh"
+    fm_host_is_windows() { return 0; }
+    fm_windows_ancestry_lines() {
+      chain_line 701 bash.exe 'bash.exe -c ls'
+      chain_line 702 pwsh.exe 'pwsh.exe -NoExit'
+    }
+    fm_harness_ancestry_pids_windows
+    printf '%s' "$?"
+  ) || fail "windows twin: consuming an empty verdict failed"
+  assert_equals "1" "$out" "windows twin: a chain without a harness returns nothing"
+}
+
+test_windows_pid_alive_verdicts() {
+  local out
+  out=$(
+    . "$ROOT/bin/fm-session-lock-lib.sh"
+    fm_host_is_windows() { return 0; }
+    fm_windows_process_line() {
+      case $1 in
+        802) chain_line 802 node.exe "$ZAI_ARGS" ;;
+        803) chain_line 803 bash.exe 'bash.exe -c ls' ;;
+        *) return 1 ;;
+      esac
+    }
+    fm_harness_pid_alive 802 && printf 'engine=alive '
+    fm_harness_pid_alive 803 || printf 'shell=not-harness '
+    fm_harness_pid_alive 804 || printf 'dead=not-alive'
+  ) || fail "pid liveness: sourcing the session-lock lib failed"
+  assert_equals "engine=alive shell=not-harness dead=not-alive" "$out" \
+    "pid liveness: alive engine true, plain shell and dead pid false"
+}
+
+# --- end to end over a simulated MSYS Windows host ---------------------------
+
+test_fm_harness_prints_zai() {
+  local fakebin out
+  fakebin=$(make_windows_fakebin harness-e2e)
+  FM_FAKE_WIN_CHAIN="$(chain_line 901 bash.exe 'bash.exe -c run')\\n$(chain_line 902 node.exe "$ZAI_ARGS")\\n$(chain_line 903 herdr.exe 'herdr.exe server')\\n" \
+    FM_WINDOWS_ANCESTRY_PS="$fakebin/fake-chain-ps" \
+    FM_ROOT_OVERRIDE="$TMP_ROOT/e2e-home" PATH="$fakebin:$PATH" \
+    bash "$ROOT/bin/fm-harness.sh" > "$TMP_ROOT/harness.out" 2>&1
+  out=$(cat "$TMP_ROOT/harness.out")
+  assert_equals "zai" "$out" "fm-harness.sh: simulated Windows chain resolves zai"
+}
+
+test_fm_harness_unknown_without_engine() {
+  local fakebin out
+  fakebin=$(make_windows_fakebin harness-e2e-none)
+  FM_FAKE_WIN_CHAIN="$(chain_line 911 bash.exe 'bash.exe -c run')\\n$(chain_line 912 herdr.exe 'herdr.exe server')\\n" \
+    FM_WINDOWS_ANCESTRY_PS="$fakebin/fake-chain-ps" \
+    FM_ROOT_OVERRIDE="$TMP_ROOT/e2e-home-none" PATH="$fakebin:$PATH" \
+    bash "$ROOT/bin/fm-harness.sh" > "$TMP_ROOT/harness-none.out" 2>&1
+  out=$(cat "$TMP_ROOT/harness-none.out")
+  assert_equals "unknown" "$out" "fm-harness.sh: a chain without an engine stays unknown"
+}
+
+test_fm_lock_acquires_engine_pid() {
+  local fakebin home out
+  fakebin=$(make_windows_fakebin lock-e2e)
+  home=$TMP_ROOT/lock-home
+  mkdir -p "$home/state"
+  FM_FAKE_WIN_CHAIN="$(chain_line 921 bash.exe 'bash.exe -c run')\\n$(chain_line 922 node.exe "$ZAI_ARGS")\\n$(chain_line 923 herdr.exe 'herdr.exe server')\\n" \
+    FM_WINDOWS_ANCESTRY_PS="$fakebin/fake-chain-ps" \
+    FM_HOME="$home" FM_STATE_OVERRIDE="$home/state" FM_ROOT_OVERRIDE="$home" \
+    PATH="$fakebin:$PATH" \
+    bash "$ROOT/bin/fm-lock.sh" > "$TMP_ROOT/lock.out" 2>&1
+  out=$(cat "$TMP_ROOT/lock.out")
+  assert_contains "$out" "lock acquired: harness pid 922" \
+    "fm-lock.sh: the simulated zai engine pid holds the session lock"
+  assert_equals "922" "$(cat "$home/state/.lock")" "fm-lock.sh: the lock file records the engine pid"
+}
+
+test_fm_lock_refuses_foreign_holder() {
+  local fakebin home out
+  fakebin=$(make_windows_fakebin lock-e2e-foreign)
+  home=$TMP_ROOT/lock-home-foreign
+  mkdir -p "$home/state"
+  printf '932\n' > "$home/state/.lock"
+  # A live foreign harness (932) holds the lock; this session's engine is 933.
+  FM_FAKE_WIN_CHAIN="$(chain_line 931 bash.exe 'bash.exe -c run')\\n$(chain_line 933 node.exe "$ZAI_ARGS")\\n" \
+    FM_FAKE_FOREIGN_PID=932 FM_FAKE_FOREIGN_LINE="$(chain_line 932 node.exe "$ZAI_ARGS")" \
+    FM_WINDOWS_ANCESTRY_PS="$fakebin/fake-chain-ps" \
+    FM_HOME="$home" FM_STATE_OVERRIDE="$home/state" FM_ROOT_OVERRIDE="$home" \
+    PATH="$fakebin:$PATH" \
+    bash "$ROOT/bin/fm-lock.sh" > "$TMP_ROOT/lock-foreign.out" 2>&1
+  out=$(cat "$TMP_ROOT/lock-foreign.out")
+  assert_contains "$out" "another live firstmate session holds the lock" \
+    "fm-lock.sh: a live foreign holder keeps this session read-only"
+
+  # The same stale pid with the foreign engine gone releases the lock to us.
+  FM_FAKE_WIN_CHAIN="$(chain_line 941 bash.exe 'bash.exe -c run')\\n$(chain_line 942 node.exe "$ZAI_ARGS")\\n" \
+    FM_WINDOWS_ANCESTRY_PS="$fakebin/fake-chain-ps" \
+    FM_HOME="$home" FM_STATE_OVERRIDE="$home/state" FM_ROOT_OVERRIDE="$home" \
+    PATH="$fakebin:$PATH" \
+    bash "$ROOT/bin/fm-lock.sh" > "$TMP_ROOT/lock-takeover.out" 2>&1
+  out=$(cat "$TMP_ROOT/lock-takeover.out")
+  assert_contains "$out" "lock acquired: harness pid 942" \
+    "fm-lock.sh: a stale lock is taken over by the live session"
+}
+
+test_matcher_zai_node_bundle && pass "matcher: node.exe running the zai-cli bundle matches as zai, not claude"
+test_matcher_zai_repo_checkout && pass "matcher: node.exe running a zai repo checkout matches as zai"
+test_matcher_plain_bash_never_zai && pass "matcher: an ordinary bash.exe child is never a harness"
+test_matcher_herdr_wrapper_never_harness && pass "matcher: the herdr wrapper is not the session engine"
+test_windows_twin_stops_at_engine && pass "windows twin: the walk reports the innermost zai-cli node hop only"
+test_windows_twin_claude_contiguous_run && pass "windows twin: a claude run reports its contiguous chain"
+test_windows_twin_no_harness_is_empty && pass "windows twin: a chain without a harness returns nothing"
+test_windows_pid_alive_verdicts && pass "pid liveness: alive engine true, plain shell and dead pid false"
+test_fm_harness_prints_zai && pass "fm-harness.sh: simulated Windows chain resolves zai"
+test_fm_harness_unknown_without_engine && pass "fm-harness.sh: a chain without an engine stays unknown"
+test_fm_lock_acquires_engine_pid && pass "fm-lock.sh: the simulated zai engine pid holds the session lock"
+test_fm_lock_refuses_foreign_holder && pass "fm-lock.sh: a live foreign holder blocks; a stale one is taken over"


### PR DESCRIPTION
## Problem

On Windows hosts, `bin/fm-afk-launch.sh start` built the away-daemon terminal command as POSIX (`exec env FM_HOME=... bash bin/fm-afk-start.sh`) and handed it to `herdr pane run`, which types it into the pane's shell. The herdr pane shell on Windows is PowerShell, which has no `exec`, so the daemon never started and the pane sat at a PowerShell prompt (observed live 2026-09-12).

The existing herdr e2e could not catch this: it only asserts launch topology (dedicated non-visible workspace, captain tab untouched, stop tears down by exact id), all of which held even while the pane shell rejected the command.

## Fix

- `bin/fm-afk-launch.sh` now routes the daemon command through a single adapter, `fm_afk_launch_pane_cmd`:
  - POSIX hosts: the bare `exec env ...` command, byte-identical to before.
  - Windows hosts (existing `fm_host_is_windows` detection): the command is wrapped in the Git Bash login invocation PowerShell executes, with PowerShell single-quote literals (`& 'C:\Program Files\Git\bin\bash.exe' -lc '<posix command>'`) so no `$`/backtick interpolation can corrupt the inner command; embedded quotes are doubled. Bash resolution: `FM_AFK_LAUNCH_GIT_BASH` override, then the standard Git for Windows install locations, then the running bash; loud failure (before any record is written) when none is found.
  - tmux path unchanged (tmux runs commands through sh, never a pane shell).
- `tests/fm-afk-launch.test.sh`:
  - Two portable units pin the `pane run` command on both host classes (forced via the memoized host-detection variable, so they hold on any CI host), including the quote-doubling contract.
  - The herdr e2e now proves actual execution: the daemon entry writes a marker file in its pane, and the test fails if that marker never appears, exactly the failure mode topology checks cannot see.

## Verification (live, Windows 11 Home 10.0.26200 x64, Git Bash, herdr protocol 19, zai primary)

Before (unfixed), a real `start` run:

```
fm-afk-launch: daemon did not become ready; closing herdr:default:w1X:p1   # start exits 1
```

and the daemon pane's own capture showed the exact failure:

```
> exec env FM_HOME=/c/Users/tyanw/work/harness/firstmate ... bin/fm-afk-start.sh
exec: The term 'exec' is not recognized as a name of a cmdlet, function, script file, or executable program.
```

After (fixed), `start` succeeds and the pane executes the wrapper:

```
fm-afk-launch: daemon launched in non-visible herdr workspace w1Z (pane default:w1Z:p1), supervising default:w12:pT   # start rc=0
```

```
> & 'C:\Program Files\Git\bin\bash.exe' -lc 'exec env FM_HOME=... bin/fm-afk-start.sh'
afk: starting supervise daemon in foreground; keep this command as a tracked background session
```

The daemon's own log and liveness beacon confirm it really ran:

```
[2026-09-13T01:20:23+0800] daemon starting (pid 119029); target=default:w12:pT; backend=herdr; afk=on; ...
state/.last-watcher-beat  # fresh mtime within one watcher poll
```

and `stop` tore everything down cleanly (`daemon shutting down` in the log, workspace closed by exact id, `.afk` cleared, record archived, `stop rc=0`).

## Checks

- `tests/fm-afk-launch.test.sh`: 61 ok, 0 failures (including the live herdr e2e execution marker on Windows).
- `bin/fm-lint.sh`: shellcheck 0.11.0 + actionlint 1.7.12 clean on the changed files (the two pre-existing SC2016 infos in `bin/fm-windows-process-lib.sh` are untouched by this branch and exist at HEAD).
- `bin/fm-doc-audience-check.sh`: ok (97 surfaces, 363 links).
- `docs/herdr-backend.md` away-mode section updated (one sentence); dated evidence recorded in `docs/verification/runtime-backends.md` under "Away-mode transport".