### PR TITLE
docs(agents): note Codex startup sandbox permissions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -164,11 +164,8 @@ Its header is the single owner of composed commands, ordering, and digest conten
 Do not reimplement it by separately running its lock, bootstrap, initial wake-drain, or deferred-network components.
 Run-tier harness surfaces run this command for you at session open while the rest only nudge it, so confirm the digest is present in this session and run it yourself when it is not; `docs/sessionstart-nudge.md` owns adapter tiers, source routing, and compatibility.
 
-When Codex must run startup itself, run it from within the Codex session outside the sandbox through the normal approval mechanism, because session-lock identification requires `ps` access to the session's process ancestry.
-
-Keep sandboxing and on-request approvals enabled for ordinary work; `--yolo` is not required for Firstmate startup.
-
-If startup already ran, diagnose its failure rather than repeating the session-start command; blocked process inspection can produce `cannot locate harness process in ancestry` without proving that the harness is unsupported or another session holds the lock.
+When manual Codex startup needs process ancestry access, use normal approval to run it outside the sandbox; keep sandboxing enabled for ordinary work.
+If startup already ran, diagnose rather than repeat it.
 
 Read the complete digest once and trust it as this turn's startup and recovery input.
 If the harness shows only a preview and persists the full output to a file, read that file before acting.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -164,6 +164,12 @@ Its header is the single owner of composed commands, ordering, and digest conten
 Do not reimplement it by separately running its lock, bootstrap, initial wake-drain, or deferred-network components.
 Run-tier harness surfaces run this command for you at session open while the rest only nudge it, so confirm the digest is present in this session and run it yourself when it is not; `docs/sessionstart-nudge.md` owns adapter tiers, source routing, and compatibility.
 
+When Codex must run startup itself, run it from within the Codex session outside the sandbox through the normal approval mechanism, because session-lock identification requires `ps` access to the session's process ancestry.
+
+Keep sandboxing and on-request approvals enabled for ordinary work; `--yolo` is not required for Firstmate startup.
+
+If startup already ran, diagnose its failure rather than repeating the session-start command; blocked process inspection can produce `cannot locate harness process in ancestry` without proving that the harness is unsupported or another session holds the lock.
+
 Read the complete digest once and trust it as this turn's startup and recovery input.
 If the harness shows only a preview and persists the full output to a file, read that file before acting.
 Do not separately re-read the context, backlog, metadata, or bulk status inputs it just printed unless a source was reported absent or corrupt, older history is specifically needed, or a targeted workflow must inspect before writing.

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Pick whichever one matches your subscription and workflow.
 
 Oh My Pi (`omp`), a Pi fork, is verified as a primary with the same extension-owned watcher model as Pi and a stronger turn-end guard: its blocking `session_stop` hook compels a continuation instead of requesting one.
 Codex and OpenCode are also verified and supported as primary harnesses; Codex uses bounded foreground checkpoints, and OpenCode uses a TUI plugin, so both carry more harness-specific supervision tradeoffs than the three co-primaries.
-For Codex startup permissions, follow the [session-start guidance](AGENTS.md#3-session-start-run-once-at-every-session-start); ordinary work can keep sandboxing and on-request approvals enabled.
+For Codex startup permissions, see the [session-start guidance](AGENTS.md#3-session-start-run-once-at-every-session-start).
 Cursor Agent CLI is verified as a primary too, using a tracked project-scope `.cursor/hooks.json` whose `stop` hook parks on the watcher between turns, closest in shape to Claude Code's.
 Launch it with `--trust`, or none of its project hooks load; it also has no turn-end hook in headless `cursor-agent -p`, so run the primary session interactively.
 

--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ Pick whichever one matches your subscription and workflow.
 
 Oh My Pi (`omp`), a Pi fork, is verified as a primary with the same extension-owned watcher model as Pi and a stronger turn-end guard: its blocking `session_stop` hook compels a continuation instead of requesting one.
 Codex and OpenCode are also verified and supported as primary harnesses; Codex uses bounded foreground checkpoints, and OpenCode uses a TUI plugin, so both carry more harness-specific supervision tradeoffs than the three co-primaries.
+For Codex startup permissions, follow the [session-start guidance](AGENTS.md#3-session-start-run-once-at-every-session-start); ordinary work can keep sandboxing and on-request approvals enabled.
 Cursor Agent CLI is verified as a primary too, using a tracked project-scope `.cursor/hooks.json` whose `stop` hook parks on the watcher between turns, closest in shape to Claude Code's.
 Launch it with `--trust`, or none of its project hooks load; it also has no turn-end hook in headless `cursor-agent -p`, so run the primary session interactively.
 


### PR DESCRIPTION
Manual Codex startup can require process-ancestry access outside the sandbox. Add a short paragraph to `AGENTS.md` directing normal approval for that case, retaining sandboxing for ordinary work, and diagnosing startup that already ran instead of repeating it.

Add a README link to this guidance. Existing Codex support claims and supervision limitations remain unchanged.

## Validation

- Documentation/link checker and existing documentation-audience tests passed; a deliberately broken anchor was correctly rejected.
- Browser navigation reached the new guidance, and an isolated session-start instruction refresh delivered it. Real interactive Codex approval behavior was not re-tested.
- Canonical `bin/fm-lint.sh` passed with pinned ShellCheck 0.11.0 and actionlint 1.7.12 on PATH. The pipeline's default PATH lacked these tools; no source fix was needed.

## CI status

**Awaiting maintainer approval for fork workflows; CI is not green.** Neither [CI](https://github.com/kunchenguid/firstmate/actions/runs/34712702080) nor [Require no-mistakes](https://github.com/kunchenguid/firstmate/actions/runs/34712702034) executed any jobs; both reported `action_required`.

## Evidence

- Evidence: [README rendered: new Codex startup pointer highlighted in the Recommended harnesses section](https://github.com/alexg0/firstmate/blob/9858ff9cc31111a55cb8324964faa8bb38f411bb/.no-mistakes/evidence/fm/codex-startup-docs-s5/readme-codex-startup-pointer.png)
- Evidence: [AGENTS.md section 3 after following the README link: condensed startup guidance highlighted, placed right after the sessionstart-nudge paragraph](https://github.com/alexg0/firstmate/blob/9858ff9cc31111a55cb8324964faa8bb38f411bb/.no-mistakes/evidence/fm/codex-startup-docs-s5/agents-section3-landing.png)

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"4336293c184c711046b84184074cddc99777b320","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}],"live_validation":{"verdict":"go","live":5,"total":6}} -->
