### PR TITLE
fix(brief): make the no-mistakes pipeline step unmissable

### DIFF
--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -449,10 +449,12 @@ case "$MODE" in
     # two valid forms are restated at that exact moment. Five no-mistakes tasks
     # reported `done:` on a green LOCAL suite, never having started the
     # pipeline; the Definition of done owns the forms, this is the one
-    # deliberate reinforcement at the point of the mistake.
+    # deliberate reinforcement at the point of the mistake. The literals come
+    # from their single owner in bin/fm-dod-lib.sh so this restatement cannot
+    # drift out of step with the Definition of done rendered below it.
     RULE4_DONE="
    For this task \`done:\` has exactly two valid forms, both fixed by Definition of done:
-   \`done: implementation committed, not yet validated\`, then \`done: PR {url} checks green\`.
+   \`$FM_DONE_FORM_COMMITTED\`, then \`$FM_DONE_FORM_CI_GREEN\`.
    A green local suite is neither: if the \`done:\` line you are about to write reports your own
    tests, lint, typecheck or build passing, it is the wrong line."
     ;;

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -434,15 +434,27 @@ case "$MODE" in
   direct-PR)
     SETUP2=""
     RULE1='1. Never push to the default branch (push only your `fm/'"$ID"'` branch). Never merge a PR.'
+    RULE4_DONE=""
     ;;
   local-only)
     SETUP2=""
     RULE1="1. Never push to any remote and never open a PR. Work only on your \`fm/$ID\` branch; firstmate handles the merge into local \`main\`."
+    RULE4_DONE=""
     ;;
   *)  # no-mistakes
     SETUP2="
 2. Run \`no-mistakes doctor\`; if it reports the repo is not initialized here, run \`no-mistakes init\`."
     RULE1='1. Never push to the default branch. Never merge a PR.'
+    # The status protocol is where a worker composes its `done:` line, so the
+    # two valid forms are restated at that exact moment. Five no-mistakes tasks
+    # reported `done:` on a green LOCAL suite, never having started the
+    # pipeline; the Definition of done owns the forms, this is the one
+    # deliberate reinforcement at the point of the mistake.
+    RULE4_DONE="
+   For this task \`done:\` has exactly two valid forms, both fixed by Definition of done:
+   \`done: implementation committed, not yet validated\`, then \`done: PR {url} checks green\`.
+   A green local suite is neither: if the \`done:\` line you are about to write reports your own
+   tests, lint, typecheck or build passing, it is the wrong line."
     ;;
 esac
 DOD=$(fm_dod_block "$MODE" "$ID") || exit 1
@@ -476,7 +488,7 @@ $RULE1
    firstmate reads your pane for that.
    Whenever you mention a PR anywhere - a status line, your terminal, a summary - write its full
    https:// URL exactly as the forge printed it, never a bare number such as "PR 108"; firstmate
-   copies that URL from your line rather than assembling one.
+   copies that URL from your line rather than assembling one.$RULE4_DONE
    A mid-task \`working:\` line (including setup complete) is nonterminal: do not end the
    turn after it; continue the same stage until a defined \`done:\` gate under Definition of done.
    Use \`$PAUSED_VERB: {why}\` - distinct from \`blocked:\` - ONLY when you are deliberately idling on a

--- a/bin/fm-dod-lib.sh
+++ b/bin/fm-dod-lib.sh
@@ -10,6 +10,12 @@
 # mode is refused rather than silently rendered as the pipeline contract.
 # The block opens with the fixed machine-readable "Delivery contract: mode=<mode>"
 # line that bin/fm-spawn.sh checks a ship brief against.
+# The no-mistakes block states two fixed `done:` forms rather than a free-form
+# summary, because five workers reported `done:` on a green LOCAL suite without
+# ever starting the pipeline. Only the second form is a ready signal, and
+# bin/fm-inactive-reconcile.sh parses it anchored as `done: PR <url>[ checks
+# green]`; bin/fm-brief.sh restates both forms in the status protocol, which is
+# where the worker actually composes the line.
 # This file is the one owner of the no-mistakes `--intent` contract: only the
 # brief's `## Captain's intent` subsection plus later captain words, never
 # `## Firstmate spec` and never the worker's own tradeoffs.
@@ -218,9 +224,10 @@ EOF
       cat <<EOF
 # Definition of done
 Delivery contract: mode=no-mistakes
-The task is complete only when committed on your branch.
-When you believe it is complete, append \`done: {summary}\` to the status file and stop.
-Firstmate will then instruct you to run /no-mistakes to validate and ship a PR.
+A green local suite - your own tests, lint, typecheck, build, budget - is where validation STARTS, not the finish; this task is not done until the no-mistakes pipeline has raised a PR and CI is green on it.
+So \`done:\` has exactly two valid forms here, in this order, and no others:
+1. \`done: implementation committed, not yet validated\` - that literal line, never a summary of your own results. Append it once the work is committed, then stop; firstmate replies by instructing you to run /no-mistakes.
+2. \`done: PR {url} checks green\` - the finish, reachable only through the pipeline.
 
 You drive no-mistakes by responding to its gates, not by implementing fixes.
 Follow the guidance no-mistakes itself provides for the mechanics: it loads when you invoke /no-mistakes, and \`no-mistakes axi run --help\` plus the \`help\` lines in each \`axi\` response are authoritative and version-matched to the installed binary.
@@ -245,7 +252,7 @@ Two firstmate-specific rules layer on top of that guidance:
 - NEVER pass \`--yes\` (or \`-y\`) to \`no-mistakes axi run\` or \`no-mistakes axi respond\`. It is banned fleet-wide.
   It auto-resolves every gate including ask-user findings with no escalation, and answering your own ask-user finding is a hard rule violation.
 
-After /no-mistakes reports CI green (the CI-ready return point - do not wait for it to keep monitoring in the background until merge), append \`done: PR {url} checks green\` and stop. You are finished.
+After /no-mistakes reports CI green, append form 2 above and stop. That is the CI-ready return point: do not keep monitoring in the background until merge. You are finished.
 EOF
       ;;
     *)

--- a/bin/fm-dod-lib.sh
+++ b/bin/fm-dod-lib.sh
@@ -16,6 +16,11 @@
 # bin/fm-inactive-reconcile.sh parses it anchored as `done: PR <url>[ checks
 # green]`; bin/fm-brief.sh restates both forms in the status protocol, which is
 # where the worker actually composes the line.
+# FM_DONE_FORM_COMMITTED and FM_DONE_FORM_CI_GREEN below are the single owner of
+# those two literals. Every site that spells one - the Definition of done here,
+# its closing CI-ready sentence, and the status-protocol restatement in
+# bin/fm-brief.sh - renders it from these, so no copy can drift and leave one
+# generated brief stating two different sets of valid forms.
 # This file is the one owner of the no-mistakes `--intent` contract: only the
 # brief's `## Captain's intent` subsection plus later captain words, never
 # `## Firstmate spec` and never the worker's own tradeoffs.
@@ -33,6 +38,9 @@
 # secondmate charter. Like fm_brief_intent_overlay it is a distinctly titled
 # launch section that states its own precedence for Firstmate tasks, so a brief
 # that authors its own role wording is superseded rather than duplicated.
+
+FM_DONE_FORM_COMMITTED='done: implementation committed, not yet validated'
+FM_DONE_FORM_CI_GREEN='done: PR {url} checks green'
 
 fm_brief_worker_role() {
   cat <<'EOF'
@@ -226,8 +234,8 @@ EOF
 Delivery contract: mode=no-mistakes
 A green local suite - your own tests, lint, typecheck, build, budget - is where validation STARTS, not the finish; this task is not done until the no-mistakes pipeline has raised a PR and CI is green on it.
 So \`done:\` has exactly two valid forms here, in this order, and no others:
-1. \`done: implementation committed, not yet validated\` - that literal line, never a summary of your own results. Append it once the work is committed, then stop; firstmate replies by instructing you to run /no-mistakes.
-2. \`done: PR {url} checks green\` - the finish, reachable only through the pipeline.
+1. \`$FM_DONE_FORM_COMMITTED\` - that literal line, never a summary of your own results. Append it once the work is committed, then stop; firstmate replies by instructing you to run /no-mistakes.
+2. \`$FM_DONE_FORM_CI_GREEN\` - the finish, reachable only through the pipeline.
 
 You drive no-mistakes by responding to its gates, not by implementing fixes.
 Follow the guidance no-mistakes itself provides for the mechanics: it loads when you invoke /no-mistakes, and \`no-mistakes axi run --help\` plus the \`help\` lines in each \`axi\` response are authoritative and version-matched to the installed binary.
@@ -252,7 +260,7 @@ Two firstmate-specific rules layer on top of that guidance:
 - NEVER pass \`--yes\` (or \`-y\`) to \`no-mistakes axi run\` or \`no-mistakes axi respond\`. It is banned fleet-wide.
   It auto-resolves every gate including ask-user findings with no escalation, and answering your own ask-user finding is a hard rule violation.
 
-After /no-mistakes reports CI green, append form 2 above and stop. That is the CI-ready return point: do not keep monitoring in the background until merge. You are finished.
+After /no-mistakes reports CI green, append \`$FM_DONE_FORM_CI_GREEN\` (form 2 above) and stop. That is the CI-ready return point: do not keep monitoring in the background until merge. You are finished.
 EOF
       ;;
     *)

--- a/bin/fm-dod-lib.sh
+++ b/bin/fm-dod-lib.sh
@@ -12,15 +12,19 @@
 # line that bin/fm-spawn.sh checks a ship brief against.
 # The no-mistakes block states two fixed `done:` forms rather than a free-form
 # summary, because five workers reported `done:` on a green LOCAL suite without
-# ever starting the pipeline. Only the second form is a ready signal, and
-# bin/fm-inactive-reconcile.sh parses it anchored as `done: PR <url>[ checks
-# green]`; bin/fm-brief.sh restates both forms in the status protocol, which is
-# where the worker actually composes the line.
+# ever starting the pipeline. Only the second form is a ready signal, and two
+# consumers read it: bin/fm-inactive-reconcile.sh extracts the PR only from an
+# anchored `done: PR <url>[ checks green]` line, and bin/fm-crew-state.sh reads
+# CI-ready only when the note carries both `PR` and `checks green`, so reshaping
+# that form silently loses PR extraction or the ci-ready classification.
+# bin/fm-brief.sh restates both forms in the status protocol, which is where the
+# worker actually composes the line.
 # FM_DONE_FORM_COMMITTED and FM_DONE_FORM_CI_GREEN below are the single owner of
 # those two literals. Every site that spells one - the Definition of done here,
 # its closing CI-ready sentence, and the status-protocol restatement in
 # bin/fm-brief.sh - renders it from these, so no copy can drift and leave one
-# generated brief stating two different sets of valid forms.
+# generated brief stating two different sets of valid forms;
+# tests/fm-brief.test.sh pins that agreement.
 # This file is the one owner of the no-mistakes `--intent` contract: only the
 # brief's `## Captain's intent` subsection plus later captain words, never
 # `## Firstmate spec` and never the worker's own tradeoffs.

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -260,7 +260,7 @@ test_ship_mode_is_explicit_not_registry() {
   brief="$home/data/brief-explicit-a5/brief.md"
   grep -qx "Delivery contract: mode=no-mistakes" "$brief" \
     || fail "registered direct-PR posture overrode the explicit --mode"
-  assert_grep "Firstmate will then instruct you to run /no-mistakes" "$brief" \
+  assert_grep "firstmate replies by instructing you to run /no-mistakes" "$brief" \
     "explicit no-mistakes brief did not render the pipeline definition of done"
 
   # An unregistered project is not a blocker either, because nothing is looked up.
@@ -370,6 +370,50 @@ test_no_mistakes_dod_wording() {
   assert_no_grep "no-mistakes refuses" "$brief" \
     "no-mistakes DOD must not claim the tool itself refuses --yes"
   pass "fm-brief.sh: no-mistakes DOD keeps its apostrophe prose and bans --yes outright"
+}
+
+# Five no-mistakes workers reported `done:` on a green LOCAL suite, never having
+# started the pipeline. The status protocol is where a worker composes that line,
+# so the two valid `done:` forms must be legible at that exact point, and the
+# terminal one must carry the PR URL. This is mode-conditional: direct-PR and
+# local-only own their own ready signals and must not inherit the pipeline forms.
+test_no_mistakes_done_forms_are_stated_in_the_status_protocol() {
+  local home id brief protocol mode
+  home="$TMP_ROOT/done-forms-home"
+  mkdir -p "$home/data"
+  id="brief-done-forms-b1"
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" some-proj --mode no-mistakes >/dev/null 2>&1
+  brief="$home/data/$id/brief.md"
+  assert_present "$brief" "brief was not scaffolded"
+
+  # Rule 4 only, not the whole brief: proximity to the composed line is the fix.
+  protocol=$(awk '/^4\. Report status by appending one line:/,/^5\. /' "$brief")
+  # shellcheck disable=SC2016  # single quotes are deliberate: the backticks and {url} must stay literal
+  case "$protocol" in
+    *'`done: PR {url} checks green`'*) ;;
+    *) fail "the no-mistakes status protocol does not carry the PR-URL done form" ;;
+  esac
+  # shellcheck disable=SC2016  # single quotes are deliberate: the backticks and {url} must stay literal
+  case "$protocol" in
+    *'`done: implementation committed, not yet validated`'*) ;;
+    *) fail "the no-mistakes status protocol does not carry the pre-validation done form" ;;
+  esac
+  case "$protocol" in
+    *"A green local suite is neither"*) ;;
+    *) fail "the no-mistakes status protocol does not rule out a green local suite" ;;
+  esac
+
+  for mode in direct-PR local-only; do
+    id="brief-done-forms-$mode"
+    FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" some-proj --mode "$mode" >/dev/null 2>&1
+    protocol=$(awk '/^4\. Report status by appending one line:/,/^5\. /' "$home/data/$id/brief.md")
+    # shellcheck disable=SC2016  # single quotes are deliberate: the backticks and {url} must stay literal
+    case "$protocol" in
+      *'`done: PR {url} checks green`'*)
+        fail "$mode inherited the no-mistakes done forms in its status protocol" ;;
+    esac
+  done
+  pass "fm-brief.sh: the no-mistakes status protocol states both done forms where the line is written"
 }
 
 test_ask_user_escalation_format() {
@@ -911,6 +955,7 @@ test_ship_mode_is_explicit_not_registry
 test_delivery_flags_are_refused_where_they_do_not_apply
 test_faster_paths_use_configured_authority_without_stacked_review
 test_no_mistakes_dod_wording
+test_no_mistakes_done_forms_are_stated_in_the_status_protocol
 test_ask_user_escalation_format
 test_ship_project_memory_wording
 test_herdr_lab_contract_is_explicit_and_complete

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -378,7 +378,7 @@ test_no_mistakes_dod_wording() {
 # terminal one must carry the PR URL. This is mode-conditional: direct-PR and
 # local-only own their own ready signals and must not inherit the pipeline forms.
 test_no_mistakes_done_forms_are_stated_in_the_status_protocol() {
-  local home id brief protocol mode
+  local home id brief protocol dod mode
   home="$TMP_ROOT/done-forms-home"
   mkdir -p "$home/data"
   id="brief-done-forms-b1"
@@ -403,9 +403,27 @@ test_no_mistakes_done_forms_are_stated_in_the_status_protocol() {
     *) fail "the no-mistakes status protocol does not rule out a green local suite" ;;
   esac
 
+  # The restatement is only useful while it agrees with the Definition of done
+  # that owns the forms: a one-sided edit would have one brief state two
+  # different "exactly two valid forms, and no others" sets. Both literals must
+  # also appear in the DOD section, including its closing CI-ready sentence,
+  # which is the line bin/fm-inactive-reconcile.sh parses anchored.
+  dod=$(sed -n '/^# Definition of done$/,$p' "$brief")
+  # shellcheck disable=SC2016  # single quotes are deliberate: the backticks and {url} must stay literal
+  case "$dod" in
+    *'`done: implementation committed, not yet validated`'*) ;;
+    *) fail "the Definition of done and the status protocol state different pre-validation done forms" ;;
+  esac
+  # shellcheck disable=SC2016  # single quotes are deliberate: the backticks and {url} must stay literal
+  case "$dod" in
+    *'`done: PR {url} checks green`'*'`done: PR {url} checks green`'*) ;;
+    *) fail "the Definition of done must spell the PR-URL done form both as form 2 and in its closing CI-ready sentence" ;;
+  esac
+
   for mode in direct-PR local-only; do
     id="brief-done-forms-$mode"
     FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" some-proj --mode "$mode" >/dev/null 2>&1
+    assert_present "$home/data/$id/brief.md" "$mode brief was not scaffolded"
     protocol=$(awk '/^4\. Report status by appending one line:/,/^5\. /' "$home/data/$id/brief.md")
     # shellcheck disable=SC2016  # single quotes are deliberate: the backticks and {url} must stay literal
     case "$protocol" in


### PR DESCRIPTION
## Why

Crewmates repeatedly finished their work, ran the local suite, saw it green, and appended a
`done:` status line without ever starting the no-mistakes pipeline. It happened five times in
two days on one project. Every time the work itself was fine and the correction was simply
"now run it", so this is a brief-comprehension failure rather than a competence one.

The pattern was always the same: the worker reports "all green: lint, typecheck, 378 unit and
contract tests, build, budget" and treats that as the definition of done. That is a
reasonable misreading - the worker HAS just watched a lot of things go green - which is why
the scaffold should make the mistake impossible instead of relying on careful reading.

## What changed

The generated brief now states the exact `done:` literal at the point in the status protocol
where the worker composes that line, rather than describing it earlier as background. The two
fixed `done:` forms are pinned to a single owner so they cannot drift apart, and the brief
test asserts the protocol literals.

## Worth knowing for review

The first review round caught a regression this change introduced: replacing the terminal
literal with a back-reference ("append form 2 above") would have invited approximations like
`done: PR <url> is green`, which `bin/fm-inactive-reconcile.sh` and `bin/fm-crew-state.sh`
both fail to parse - silently losing PR extraction and the CI-ready reading. That is the same
class of silent failure the change exists to close, so the literal is now spelled out exactly
where it is written. Two further findings were fixed in the same round: the duplicated
literals had no pinned owner, and the negative-mode test could pass vacuously because it never
asserted the brief existed before reading it.

Review, tests, documentation and lint all passed. The branch could not be pushed to the
upstream repository from the account that produced it, so this arrives from a fork.
