### PR TITLE
fix(bin): refuse workspace trust when node is on PATH but cannot execute

### DIFF
--- a/bin/fm-claude-trust.sh
+++ b/bin/fm-claude-trust.sh
@@ -246,6 +246,14 @@ fi
 # bin/fm-bootstrap.sh lists node in COMMON_TOOLS and reports it at setup, which is
 # where a missing tool belongs rather than as a stalled pane later.
 command -v node >/dev/null 2>&1 || refuse "node is required to record workspace trust and was not found on PATH"
+# Presence is not health: a node that resolves on PATH and aborts on every
+# invocation passes the check above and then fails real_file()'s node -e, so the
+# spawn dies at bin/fm-spawn.sh's trust-registration step with no mention of node.
+# Setup-time reporting does not cover this either, because bin/fm-bootstrap.sh
+# tests COMMON_TOOLS with command -v as well. Executing the interpreter is the
+# only check that distinguishes a broken one from a working one, and it is named
+# separately from the missing case because the two have different remedies.
+node -e '' >/dev/null 2>&1 || refuse "node is on PATH but failed to execute, so workspace trust cannot be recorded; check the interpreter itself with: node --version"
 
 STORE="$CONFIG_DIR_REAL/.claude.json"
 # A dotfile manager or a synced folder legitimately symlinks this store, so the

--- a/bin/fm-claude-trust.sh
+++ b/bin/fm-claude-trust.sh
@@ -253,7 +253,10 @@ command -v node >/dev/null 2>&1 || refuse "node is required to record workspace 
 # tests COMMON_TOOLS with command -v as well. Executing the interpreter is the
 # only check that distinguishes a broken one from a working one, and it is named
 # separately from the missing case because the two have different remedies.
-node -e '' >/dev/null 2>&1 || refuse "node is on PATH but failed to execute, so workspace trust cannot be recorded; check the interpreter itself with: node --version"
+# The probe runs in a subshell that exits with node's status so that when node
+# dies by signal, bash's own "Abort trap" job report lands on the subshell's
+# redirected stderr and the operator sees only the named refusal below.
+( node -e ''; exit $? ) >/dev/null 2>&1 || refuse "node is on PATH but failed to execute, so workspace trust cannot be recorded; check the interpreter itself with: node --version"
 
 STORE="$CONFIG_DIR_REAL/.claude.json"
 # A dotfile manager or a synced folder legitimately symlinks this store, so the

--- a/tests/fm-claude-trust.test.sh
+++ b/tests/fm-claude-trust.test.sh
@@ -402,8 +402,6 @@ test_missing_node_is_refused() {
   pass "fm-claude-trust.sh: a missing node is refused rather than degraded"
 }
 
-# A missing interpreter must not soften the scope boundary, which
-# git and the filesystem decide on their own.
 test_broken_node_is_refused() {
   local rec out bindir
   rec=$(make_case broken-node)
@@ -412,6 +410,12 @@ test_broken_node_is_refused() {
   out=$(PATH="$bindir" run_trust "$CONFIG" "$WT" "$PROJ")
   expect_code 1 $? "a node that cannot execute must refuse rather than let the spawn proceed: $out"
   assert_contains "$out" "failed to execute" "the refusal did not name the interpreter as the failure"
+  # The refusal is the whole report: bash's own job-signal line for the
+  # aborted probe ("Abort trap" here, "Aborted" on Linux) must not reach the
+  # operator ahead of it, or the first line they read names neither node nor
+  # the trust step.
+  [ "$(printf '%s\n' "$out" | wc -l | tr -d ' ')" = 1 ] \
+    || fail "the refusal must be the only line of output, but the probe's signal report leaked: $out"
   assert_not_trusted "$CONFIG/.claude.json" "$WT" "a worktree was trusted although the store could not be written"
   case "$out" in
     *"trusted:"*) fail "a registration was claimed although none could be written: $out" ;;
@@ -419,6 +423,8 @@ test_broken_node_is_refused() {
   pass "fm-claude-trust.sh: a node that is present but cannot execute is refused"
 }
 
+# A missing interpreter must not soften the scope boundary, which
+# git and the filesystem decide on their own.
 test_scope_refusal_stays_fail_closed_without_node() {
   local rec out bindir
   rec=$(make_case no-node-refusal)

--- a/tests/fm-claude-trust.test.sh
+++ b/tests/fm-claude-trust.test.sh
@@ -82,14 +82,16 @@ node_free_path() {  # <case-dir> -> a bin dir holding the script's own tools but
 # <case-dir> -> a bin dir whose node resolves on PATH and dies on every call.
 # This is the shape a broken toolchain actually takes - a real one on this
 # machine aborted on a missing shared library - and it is distinct from a
-# missing node, which never resolves at all.
+# missing node, which never resolves at all. The fake runs under /bin/sh,
+# which is dash on the Linux CI runner, so it uses the POSIX `kill -s` form
+# and disables core files so the abort leaves nothing behind in the case dir.
 broken_node_path() {
   local dir=$1/brokennode-bin tool
   mkdir -p "$dir"
   for tool in bash env git mkdir; do
     ln -sf "$(command -v "$tool")" "$dir/$tool"
   done
-  printf '#!/bin/sh\nkill -ABRT $$\n' > "$dir/node"
+  printf '#!/bin/sh\nulimit -c 0\nkill -s ABRT $$\n' > "$dir/node"
   chmod +x "$dir/node"
   printf '%s\n' "$dir"
 }

--- a/tests/fm-claude-trust.test.sh
+++ b/tests/fm-claude-trust.test.sh
@@ -79,6 +79,21 @@ node_free_path() {  # <case-dir> -> a bin dir holding the script's own tools but
   printf '%s\n' "$dir"
 }
 
+# <case-dir> -> a bin dir whose node resolves on PATH and dies on every call.
+# This is the shape a broken toolchain actually takes - a real one on this
+# machine aborted on a missing shared library - and it is distinct from a
+# missing node, which never resolves at all.
+broken_node_path() {
+  local dir=$1/brokennode-bin tool
+  mkdir -p "$dir"
+  for tool in bash env git mkdir; do
+    ln -sf "$(command -v "$tool")" "$dir/$tool"
+  done
+  printf '#!/bin/sh\nkill -ABRT $$\n' > "$dir/node"
+  chmod +x "$dir/node"
+  printf '%s\n' "$dir"
+}
+
 # --- secondmate homes -------------------------------------------------------
 
 # seed_secondmate_home <home> <id> [shape]: the on-disk shape bin/fm-home-seed.sh
@@ -389,6 +404,21 @@ test_missing_node_is_refused() {
 
 # A missing interpreter must not soften the scope boundary, which
 # git and the filesystem decide on their own.
+test_broken_node_is_refused() {
+  local rec out bindir
+  rec=$(make_case broken-node)
+  read_case "$rec"
+  bindir=$(broken_node_path "$CASE_DIR")
+  out=$(PATH="$bindir" run_trust "$CONFIG" "$WT" "$PROJ")
+  expect_code 1 $? "a node that cannot execute must refuse rather than let the spawn proceed: $out"
+  assert_contains "$out" "failed to execute" "the refusal did not name the interpreter as the failure"
+  assert_not_trusted "$CONFIG/.claude.json" "$WT" "a worktree was trusted although the store could not be written"
+  case "$out" in
+    *"trusted:"*) fail "a registration was claimed although none could be written: $out" ;;
+  esac
+  pass "fm-claude-trust.sh: a node that is present but cannot execute is refused"
+}
+
 test_scope_refusal_stays_fail_closed_without_node() {
   local rec out bindir
   rec=$(make_case no-node-refusal)
@@ -661,6 +691,7 @@ test_symlinked_store_to_a_foreign_owned_target_is_refused
 test_symlinked_store_to_an_owned_target_is_accepted
 test_corrupt_store_fails_closed
 test_missing_node_is_refused
+test_broken_node_is_refused
 test_scope_refusal_stays_fail_closed_without_node
 test_claude_spawn_pretrusts_its_worktree_and_reaches_the_brief
 test_refused_spawn_leaves_no_task_state


### PR DESCRIPTION
## What Changed

- `bin/fm-claude-trust.sh` now runs `node -e ''` after the existing `command -v node` check and refuses with a distinct message ("node is on PATH but failed to execute ... check the interpreter itself with: node --version") when the interpreter resolves but aborts, instead of letting the spawn die later at trust registration with no mention of node.
- `tests/fm-claude-trust.test.sh` adds a `broken_node_path` helper that installs a `node` stub which aborts on every call, and a `test_broken_node_is_refused` case asserting exit code 1, the "failed to execute" refusal text, and that no worktree is recorded as trusted.

## Risk Assessment

✅ Low: One additive fail-closed check placed after the scope tests and before any node use (real_dir is pure shell, real_file and the store write run only after it), traced with a resolvable node that aborts on every call: command -v passes, node -e '' fails, refuse names the interpreter and no store write occurs; the new test exercises the script's public exit code and stderr, and the only issue found is a misplaced comment.

## Testing

Ran the targeted claude-trust behavior suite (26/26 at target), falsified the new broken-node test against the pre-fix script (it fails with the expected missing 'failed to execute' assertion), and captured an operator-level before/after transcript showing the pre-fix run surfacing an unrelated 'could not record trust' error plus a dumped node heredoc, versus the fixed run refusing with a message that names node and points at `node --version`, exit 1, no trust store written. No UI surface involved, so no visual artifact.

<details>
<summary>Evidence: Before/after operator transcript: fm-claude-trust.sh with a node that aborts on execution</summary>

Source: [Before/after operator transcript: fm-claude-trust.sh with a node that aborts on execution](https://github.com/aviyashchin/firstmate/blob/1c321bee7abc1b144980048d1d8c0ea85fb75110/.no-mistakes/evidence/fix/claude-trust-node-health/fm-claude-trust-broken-node-transcript.txt)

<code>=== BEFORE FIX (base 76d4405) ===&#10;$ CLAUDE_CONFIG_DIR=&lt;isolated&gt; bin/fm-claude-trust.sh &lt;worktree&gt; &lt;project&gt;&#10;... bin/fm-claude-trust.sh: line 370: 30903 Abort trap: 6 node - &#34;$STORE&#34; &#34;$TARGET_REAL&#34; &lt;&lt;&#39;NODE&#39; [~70-line heredoc dumped]&#10;error: refusing to pre-register Claude trust: could not record trust for &#39;&lt;tmp&gt;/wt&#39; in &#39;&lt;tmp&gt;/claude-config/.claude.json&#39;&#10;exit=1&#10;&#10;=== AFTER FIX (target 0c07162) ===&#10;$ CLAUDE_CONFIG_DIR=&lt;isolated&gt; bin/fm-claude-trust.sh &lt;worktree&gt; &lt;project&gt;&#10;bin/fm-claude-trust.sh: line 256: 30991 Abort trap: 6 node -e &#39;&#39; &gt; /dev/null 2&gt;&amp;1&#10;error: refusing to pre-register Claude trust: node is on PATH but failed to execute, so workspace trust cannot be recorded; check the interpreter itself with: node --version&#10;exit=1&#10;&#10;$ ls &lt;config&gt;/.claude.json&#10;ls: &lt;tmp&gt;/claude-config/.claude.json: No such file or directory</code>

```text
=== BEFORE FIX (base 76d4405) ===
$ PATH=<broken-node-bin> node --version
/tmp/fm-trust-demo.sh: line 11: 30873 Abort trap: 6              PATH=$bin node --version
exit=134

$ CLAUDE_CONFIG_DIR=<isolated> bin/fm-claude-trust.sh <worktree> <project>
/Users/aviyashchin/.no-mistakes/worktrees/2dd35eef970a/01M2BGYGV80Q0SBQWJD3Q9XCHY/bin/fm-claude-trust.sh: line 370: 30903 Abort trap: 6              node - "$STORE" "$TARGET_REAL" <<'NODE'
const fs = require("node:fs");
const path = require("node:path");
const crypto = require("node:crypto");
const [store, target] = process.argv.slice(2);
const readStore = () => {
  try {
    return fs.readFileSync(store);
  } catch (err) {
    if (err.code === "ENOENT") return null;
    throw err;
  }
};
const fingerprint = (buf) =>
  buf === null ? "absent" : crypto.createHash("sha256").update(buf).digest("hex");
const attempt = () => {
  const original = readStore();
  const before = fingerprint(original);
  let root = {};
  if (original !== null) {
    const raw = original.toString("utf8");
    if (raw.trim() !== "") {
      root = JSON.parse(raw);
      if (root === null || typeof root !== "object" || Array.isArray(root)) {
        throw new Error(`${store} is not a JSON object`);
      }
    }
  }
  if (root.projects === undefined) root.projects = {};
  const projects = root.projects;
  if (projects === null || typeof projects !== "object" || Array.isArray(projects)) {
    throw new Error(`${store} has a non-object "projects" value`);
  }
  let entry = projects[target];
  if (entry === undefined || entry === null || typeof entry !== "object" || Array.isArray(entry)) {
    entry = {};
  }
  entry.hasTrustDialogAccepted = true;
  projects[target] = entry;
  // Unpredictable name plus an exclusive create: the config directory may be
  // writable by another local account, and a predictable path could be
  // pre-created there as a symlink that a plain write would follow into some
  // other file this user owns. "wx" refuses an existing path outright.
  const unique = `${process.pid}.${crypto.randomBytes(8).toString("hex")}`;
  const tmp = path.join(path.dirname(store), `.claude.json.fm-trust.${unique}`);
  // Two-space pretty-printed, because that is the format Claude Code itself
  // writes: the store on the box this was measured on begins "{\n  " and runs
  // 9646 lines. Compact would reformat the operator's whole config on every
  // spawn and the vendor's next write would expand it again, so this must not
  // be "simplified" to JSON.stringify(root) without re-measuring the vendor.
  fs.writeFileSync(tmp, `${JSON.stringify(root, null, 2)}\n`, { mode: 0o600, flag: "wx" });
  let renamed = false;
  try {
    if (fingerprint(readStore()) !== before) return "moved";
    fs.renameSync(tmp, store);
    renamed = true;
  } finally {
    if (!renamed) fs.rmSync(tmp, { force: true });
  }
  const back = JSON.parse(fs.readFileSync(store, "utf8"));
  return back.projects?.[target]?.hasTrustDialogAccepted === true ? "recorded" : "dropped";
};
try {
  for (let i = 0; i < 3; i += 1) {
    const result = attempt();
    if (result === "recorded") process.exit(0);
    if (result === "moved" && i >= 1) {
      console.error(`error: ${store} was modified while trust was being recorded; refusing to overwrite it`);
      process.exit(1);
    }
  }
} catch (err) {
  console.error(`error: ${err.message}`);
  process.exit(1);
}
console.error(`error: ${store} did not retain trust for ${target} after 3 attempts`);
process.exit(1);
NODE

error: refusing to pre-register Claude trust: could not record trust for '<tmp>/wt' in '<tmp>/claude-config/.claude.json'
exit=1

$ ls <config>/.claude.json
ls: <tmp>/claude-config/.claude.json: No such file or directory

=== AFTER FIX (target 0c07162) ===
$ PATH=<broken-node-bin> node --version
/tmp/fm-trust-demo.sh: line 11: 30961 Abort trap: 6              PATH=$bin node --version
exit=134

$ CLAUDE_CONFIG_DIR=<isolated> bin/fm-claude-trust.sh <worktree> <project>
/Users/aviyashchin/.no-mistakes/worktrees/2dd35eef970a/01M2BGYGV80Q0SBQWJD3Q9XCHY/bin/fm-claude-trust.sh: line 256: 30991 Abort trap: 6              node -e '' > /dev/null 2>&1
error: refusing to pre-register Claude trust: node is on PATH but failed to execute, so workspace trust cannot be recorded; check the interpreter itself with: node --version
exit=1

$ ls <config>/.claude.json
ls: <tmp>/claude-config/.claude.json: No such file or directory
```
</details>
<details>
<summary>Evidence: Falsification: new test against unfixed script</summary>

```text
not ok - the refusal did not name the interpreter as the failure (missing: 'failed to execute')
error: refusing to pre-register Claude trust: could not record trust for '.../broken-node/wt' in '.../broken-node/claude-config/.claude.json'
```
</details>
- Outcome: ⚠️ 1 info across 1 run (2m10s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"0c07162796c5c29f0231f58f6f2e51aa0457ce10","steps":[{"step":"intent","status":"skipped"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>⏭️ **intent** - skipped</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>⚠️ **Review** - 1 info</summary>

- ℹ️ `tests/fm-claude-trust.test.sh:407` - The comment &#34;A missing interpreter must not soften the scope boundary, which git and the filesystem decide on their own.&#34; (lines 405-406) describes test_scope_refusal_stays_fail_closed_without_node, but the new test_broken_node_is_refused was inserted between the comment and that function, so the comment now reads as the header of the wrong test. Move the new test (and its own short header) above that comment, or add a separate header for test_broken_node_is_refused and keep the existing comment attached to test_scope_refusal_stays_fail_closed_without_node.
</details>

<details>
<summary>⚠️ **Test** - 1 info</summary>

- ℹ️ `bin/fm-claude-trust.sh:256` - With the fix, bash still prints its own job-signal line (`bin/fm-claude-trust.sh: line 256: &lt;pid&gt; Abort trap: 6  node -e &#39;&#39; &gt; /dev/null 2&gt;&amp;1`) before the named refusal, since `&gt;/dev/null 2&gt;&amp;1` does not silence the parent shell&#39;s signal report. The refusal message itself is correct and names node; this is one line of noise, not a defect. Wrapping the probe in a subshell (`( node -e &#39;&#39; ) &gt;/dev/null 2&gt;&amp;1`) would drop it if wanted.
- <code>`bash tests/fm-claude-trust.test.sh` at target commit 0c07162 - 26 ok, including new `test_broken_node_is_refused`</code>
- <code>Falsification: reverted bin/fm-claude-trust.sh hunk via `git show HEAD -- bin/fm-claude-trust.sh | git apply -R`, reran suite - `not ok - the refusal did not name the interpreter as the failure (missing: &#39;failed to execute&#39;)`; restored with `git checkout -- bin/fm-claude-trust.sh`</code>
- <code>Manual operator transcript: built a PATH whose `node` is `kill -ABRT $$`, ran `bin/fm-claude-trust.sh &lt;worktree&gt; &lt;project&gt;` with isolated `CLAUDE_CONFIG_DIR` before and after the fix, captured stderr/exit code and confirmed `.claude.json` absent in both cases</code>
- <code>Verified worktree clean (`git status --porcelain` empty) and fixture temp dirs removed after evidence run</code>
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
