### PR TITLE
fix: load required Rialto context into worker prompts

### DIFF
--- a/bin/fm-config-inherit-lib.sh
+++ b/bin/fm-config-inherit-lib.sh
@@ -66,7 +66,7 @@ FM_SHARED_CAPTAIN_MODE="444"
 # The declared inheritable set (space-separated, config-dir-relative item paths).
 # Extend here to inherit more of the primary's local config; override via the
 # environment only in tests. Items must not contain whitespace.
-FM_INHERITABLE_CONFIG="${FM_INHERITABLE_CONFIG:-crew-dispatch.json crew-harness backlog-backend backend herdr-presentation-spaces startup-memory-budget trace-context launch-env-allowlist claude-permission-mode}"
+FM_INHERITABLE_CONFIG="${FM_INHERITABLE_CONFIG:-crew-dispatch.json crew-harness backlog-backend backend herdr-presentation-spaces startup-memory-budget trace-context launch-env-allowlist claude-permission-mode rialto-project-context.paths}"
 
 # Items whose value is a home-SESSION enablement decision rather than durable
 # local configuration. They are inherited at the launch convergence point, where

--- a/bin/fm-project-context.sh
+++ b/bin/fm-project-context.sh
@@ -1,15 +1,58 @@
 #!/usr/bin/env bash
 # Render required project instructions for a worker launch or context recovery.
 # Usage: fm-project-context.sh <project-dir> <worktree> <config-dir>
-# Opt in with config/project-context/<project-basename>.paths, one required file
-# per line. Relative paths resolve in the actual worker worktree; absolute paths
-# can name paired repositories. Blank lines and # comments are ignored. No shell
-# or Markdown import expansion occurs. CLAUDE.md and AGENTS.md in the worktree are
-# required automatically when the manifest exists. Output is buffered so a missing
-# source never publishes a partial prompt. Source paths and SHA-256 bind the bytes.
+# Optional projects use config/project-context/<project-basename>.paths.
+# UseRialto/rialto-backend and UseRialto/rialto-frontend always require
+# config/rialto-project-context.paths: exactly five absolute paths, ordered as
+# backend CLAUDE.md, backend AGENTS.md, frontend CLAUDE.md, frontend AGENTS.md,
+# product AGENTS.md. Repository identities are checked through Git remotes.
+# Prepare without changing a home:
+# fm-project-context.sh --prepare-rialto <backend-dir> <frontend-dir> <product-AGENTS>
+# Redirect stdout to a staging file, then review before installing configuration.
+# Rendering also requires current-worktree CLAUDE.md and AGENTS.md; optional
+# manifests resolve relative paths there. Output includes full bytes and SHA-256.
 set -euo pipefail
 if [ "${1:-}" = --help ]; then
-  sed -n '2,11p' "$0"
+  sed -n '2,14p' "$0"
+  exit 0
+fi
+repo_identity() {
+  local remote url
+  while IFS= read -r remote; do
+    url=$(git -C "$1" remote get-url "$remote") || return 1
+    url=${url%.git}
+    case "$url" in
+      https://github.com/UseRialto/rialto-backend|git@github.com:UseRialto/rialto-backend|ssh://git@github.com/UseRialto/rialto-backend)
+        printf '%s\n' backend; return 0 ;;
+      https://github.com/UseRialto/rialto-frontend|git@github.com:UseRialto/rialto-frontend|ssh://git@github.com/UseRialto/rialto-frontend)
+        printf '%s\n' frontend; return 0 ;;
+    esac
+  done < <(git -C "$1" remote 2>/dev/null)
+}
+validate_rialto() {
+  [ "$#" -eq 5 ] || { echo 'error: Rialto configuration requires exactly five source paths; use --prepare-rialto' >&2; return 1; }
+  local source
+  for source in "$@"; do
+    case "$source" in /*) ;; *) echo 'error: Rialto source paths must be absolute' >&2; return 1 ;; esac
+    [ -r "$source" ] && [ -f "$source" ] || { printf 'error: required Rialto source is unreadable: %s; prepare accessible paired sources with --prepare-rialto\n' "$source" >&2; return 1; }
+  done
+  [ "${1##*/}" = CLAUDE.md ] && [ "$2" = "${1%/*}/AGENTS.md" ] &&
+    [ "${3##*/}" = CLAUDE.md ] && [ "$4" = "${3%/*}/AGENTS.md" ] &&
+    [ "${5##*/}" = AGENTS.md ] &&
+    [ "$(repo_identity "${1%/*}")" = backend ] &&
+    [ "$(repo_identity "${3%/*}")" = frontend ] || {
+      echo 'error: Rialto sources must name verified UseRialto backend/frontend instruction pairs and product AGENTS.md; use --prepare-rialto' >&2
+      return 1
+    }
+}
+if [ "${1:-}" = --prepare-rialto ]; then
+  [ "$#" -eq 4 ] || { echo 'usage: --prepare-rialto <backend-dir> <frontend-dir> <product-AGENTS>' >&2; exit 2; }
+  backend=$(cd "$2" && pwd -P)
+  frontend=$(cd "$3" && pwd -P)
+  product_parent=$(cd "$(dirname "$4")" && pwd -P)
+  sources=("$backend/CLAUDE.md" "$backend/AGENTS.md" "$frontend/CLAUDE.md" "$frontend/AGENTS.md" "$product_parent/$(basename "$4")")
+  validate_rialto "${sources[@]}"
+  printf '%s\n' "${sources[@]}"
   exit 0
 fi
 [ "$#" -eq 3 ] || { echo 'usage: fm-project-context.sh <project-dir> <worktree> <config-dir>' >&2; exit 2; }
@@ -17,7 +60,17 @@ project=$1
 worktree=$(cd "$2" && pwd -P)
 config=$3
 manifest="$config/project-context/$(basename "$project").paths"
-[ -f "$manifest" ] || exit 0
+identity=$(repo_identity "$worktree")
+project_identity=$(repo_identity "$project")
+if [ -n "$identity" ] || [ -n "$project_identity" ]; then
+  manifest="$config/rialto-project-context.paths"
+  [ -f "$manifest" ] || { printf 'error: required Rialto configuration missing: %s; use fm-project-context.sh --prepare-rialto with verified backend, frontend and product AGENTS.md sources\n' "$manifest" >&2; exit 1; }
+  sources=()
+  while IFS= read -r source || [ -n "$source" ]; do sources+=("$source"); done < "$manifest"
+  validate_rialto "${sources[@]}"
+else
+  [ -f "$manifest" ] || exit 0
+fi
 buffer=$(mktemp)
 trap 'rm -f -- "$buffer"' EXIT
 {

--- a/bin/fm-project-context.sh
+++ b/bin/fm-project-context.sh
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
 # Render required project instructions for a worker launch or context recovery.
 # Usage: fm-project-context.sh <project-dir> <worktree> <config-dir>
-# Optional projects use config/project-context/<project-basename>.paths.
 # UseRialto/rialto-backend and UseRialto/rialto-frontend always require
 # config/rialto-project-context.paths: exactly five absolute paths, ordered as
 # backend CLAUDE.md, backend AGENTS.md, frontend CLAUDE.md, frontend AGENTS.md,
@@ -9,11 +8,11 @@
 # Prepare without changing a home:
 # fm-project-context.sh --prepare-rialto <backend-dir> <frontend-dir> <product-AGENTS>
 # Redirect stdout to a staging file, then review before installing configuration.
-# Rendering also requires current-worktree CLAUDE.md and AGENTS.md; optional
-# manifests resolve relative paths there. Output includes full bytes and SHA-256.
+# Rendering also requires current-worktree CLAUDE.md and AGENTS.md.
+# Output includes full bytes and SHA-256.
 set -euo pipefail
 if [ "${1:-}" = --help ]; then
-  sed -n '2,14p' "$0"
+  sed -n '2,12p' "$0"
   exit 0
 fi
 repo_identity() {
@@ -59,25 +58,17 @@ fi
 project=$1
 worktree=$(cd "$2" && pwd -P)
 config=$3
-manifest="$config/project-context/$(basename "$project").paths"
 identity=$(repo_identity "$worktree")
 project_identity=$(repo_identity "$project")
-if [ -n "$identity" ] || [ -n "$project_identity" ]; then
-  manifest="$config/rialto-project-context.paths"
-  [ -f "$manifest" ] || { printf 'error: required Rialto configuration missing: %s; use fm-project-context.sh --prepare-rialto with verified backend, frontend and product AGENTS.md sources\n' "$manifest" >&2; exit 1; }
-  sources=()
-  while IFS= read -r source || [ -n "$source" ]; do sources+=("$source"); done < "$manifest"
-  validate_rialto "${sources[@]}"
-else
-  [ -f "$manifest" ] || exit 0
-fi
+[ -n "$identity" ] || [ -n "$project_identity" ] || exit 0
+manifest="$config/rialto-project-context.paths"
+[ -f "$manifest" ] || { printf 'error: required Rialto configuration missing: %s; use fm-project-context.sh --prepare-rialto with verified backend, frontend and product AGENTS.md sources\n' "$manifest" >&2; exit 1; }
+sources=()
+while IFS= read -r source || [ -n "$source" ]; do sources+=("$source"); done < "$manifest"
+validate_rialto "${sources[@]}"
 buffer=$(mktemp)
 trap 'rm -f -- "$buffer"' EXIT
-{
-  printf '%s\n' 'CLAUDE.md' 'AGENTS.md'
-  cat "$manifest"
-} | while IFS= read -r source || [ -n "$source" ]; do
-  case "$source" in ''|'#'*) continue ;; /*) ;; *) source="$worktree/$source" ;; esac
+for source in "$worktree/CLAUDE.md" "$worktree/AGENTS.md" "${sources[@]}"; do
   [ -f "$source" ] && [ -r "$source" ] || { printf 'error: required project context is unreadable: %s\n' "$source" >&2; exit 1; }
   digest=$(shasum -a 256 "$source")
   digest=${digest%% *}

--- a/bin/fm-project-context.sh
+++ b/bin/fm-project-context.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Render required project instructions for a worker launch or context recovery.
+# Usage: fm-project-context.sh <project-dir> <worktree> <config-dir>
+# Opt in with config/project-context/<project-basename>.paths, one required file
+# per line. Relative paths resolve in the actual worker worktree; absolute paths
+# can name paired repositories. Blank lines and # comments are ignored. No shell
+# or Markdown import expansion occurs. CLAUDE.md and AGENTS.md in the worktree are
+# required automatically when the manifest exists. Output is buffered so a missing
+# source never publishes a partial prompt. Source paths and SHA-256 bind the bytes.
+set -euo pipefail
+if [ "${1:-}" = --help ]; then
+  sed -n '2,11p' "$0"
+  exit 0
+fi
+[ "$#" -eq 3 ] || { echo 'usage: fm-project-context.sh <project-dir> <worktree> <config-dir>' >&2; exit 2; }
+project=$1
+worktree=$(cd "$2" && pwd -P)
+config=$3
+manifest="$config/project-context/$(basename "$project").paths"
+[ -f "$manifest" ] || exit 0
+buffer=$(mktemp)
+trap 'rm -f -- "$buffer"' EXIT
+{
+  printf '%s\n' 'CLAUDE.md' 'AGENTS.md'
+  cat "$manifest"
+} | while IFS= read -r source || [ -n "$source" ]; do
+  case "$source" in ''|'#'*) continue ;; /*) ;; *) source="$worktree/$source" ;; esac
+  [ -f "$source" ] && [ -r "$source" ] || { printf 'error: required project context is unreadable: %s\n' "$source" >&2; exit 1; }
+  digest=$(shasum -a 256 "$source")
+  digest=${digest%% *}
+  printf '\n## Required instruction source: %s\nSHA-256: %s\n\n' "$source" "$digest"
+  cat "$source"
+  printf '\n'
+done > "$buffer"
+printf '\n## Project development context\nPreserve these requirements and source paths in every handoff and compaction summary.\nAfter compaction or changing checkout, reload these sources before dependent work.\n'
+cat "$buffer"

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -3857,6 +3857,19 @@ fi
 "$SCRIPT_DIR/fm-home-summary-refresh.sh" --best-effort || true
 [ "$BACKEND" = orca ] && ORCA_ABORT_CLEANUP=0
 
+# Render from the resolved worker checkout immediately before harness delivery.
+# This common launch brief is consumed by Codex, OMP and every worker adapter.
+if [ "$KIND" != secondmate ]; then
+  PROJECT_CONTEXT_TMP="$DATA/$ID/.project-context.${BASHPID:-$$}"
+  if ! "$SCRIPT_DIR/fm-project-context.sh" "$PROJ_ABS" "$WT" "$CONFIG" > "$PROJECT_CONTEXT_TMP"; then
+    rm -f -- "$PROJECT_CONTEXT_TMP"
+    echo "error: required project instructions could not be loaded" >&2
+    exit 1
+  fi
+  cat "$PROJECT_CONTEXT_TMP" >> "$BRIEF"
+  rm -f -- "$PROJECT_CONTEXT_TMP"
+fi
+
 sq_brief=$(shell_quote "$BRIEF")
 sq_turnend=$(shell_quote "$TURNEND")
 sq_piext=$(shell_quote "$STATE/$ID.pi-ext.ts")

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1132,3 +1132,9 @@ Only after those retries exhaust does it remove the lock, and only when it is pr
 A live lock, a missing `lsof`, any failed check, or any other fetch failure keeps today's behavior.
 Every wait, retry, and removal is printed to stderr, and a successful recovery also prints one `recovered:` summary line to stdout so a session-start refresh - which discards fleet-sync stderr and relays only stdout - still surfaces it.
 The shared staleness proof lives in `bin/fm-lock-lib.sh`, which both `fm-teardown.sh` and `fm-fleet-sync.sh` use.
+
+## Required project context
+
+An optional per-project context manifest supplies required development instructions to every worker runtime through the common launch text.
+See `bin/fm-project-context.sh --help` for its file format, checkout resolution, source hashes and missing-file behavior.
+The same command reloads the sources after compaction; the generated instructions require that reload before further project work.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1136,9 +1136,8 @@ The shared staleness proof lives in `bin/fm-lock-lib.sh`, which both `fm-teardow
 ## Required project context
 
 Required development instructions reach every worker runtime through the common launch text.
-Git remotes identifying `UseRialto/rialto-backend` or `UseRialto/rialto-frontend` require `config/rialto-project-context.paths` even without an optional manifest.
+Git remotes identifying `UseRialto/rialto-backend` or `UseRialto/rialto-frontend` require `config/rialto-project-context.paths`.
 This private source configuration follows the existing primary-authoritative secondmate inheritance and convergence path; inaccessible paired sources on a child host stop its worker launch.
-Other projects can opt in with a per-project manifest.
 Use `bin/fm-project-context.sh --prepare-rialto "$BACKEND_CHECKOUT" "$FRONTEND_CHECKOUT" "$PRODUCT_AGENTS" > rialto-project-context.paths` to prepare a staging artifact without modifying a running home.
 Supply the reviewed source checkouts and product instructions, review the emitted paths, and install configuration only through a separately authorized home operation.
 Private absolute paths are never shared defaults.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1135,6 +1135,12 @@ The shared staleness proof lives in `bin/fm-lock-lib.sh`, which both `fm-teardow
 
 ## Required project context
 
-An optional per-project context manifest supplies required development instructions to every worker runtime through the common launch text.
+Required development instructions reach every worker runtime through the common launch text.
+Git remotes identifying `UseRialto/rialto-backend` or `UseRialto/rialto-frontend` require `config/rialto-project-context.paths` even without an optional manifest.
+This private source configuration follows the existing primary-authoritative secondmate inheritance and convergence path; inaccessible paired sources on a child host stop its worker launch.
+Other projects can opt in with a per-project manifest.
+Use `bin/fm-project-context.sh --prepare-rialto "$BACKEND_CHECKOUT" "$FRONTEND_CHECKOUT" "$PRODUCT_AGENTS" > rialto-project-context.paths` to prepare a staging artifact without modifying a running home.
+Supply the reviewed source checkouts and product instructions, review the emitted paths, and install configuration only through a separately authorized home operation.
+Private absolute paths are never shared defaults.
 See `bin/fm-project-context.sh --help` for its file format, checkout resolution, source hashes and missing-file behavior.
 The same command reloads the sources after compaction; the generated instructions require that reload before further project work.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1135,13 +1135,13 @@ The shared staleness proof lives in `bin/fm-lock-lib.sh`, which both `fm-teardow
 
 ## Required project context
 
-Required development instructions reach every worker runtime through the common launch text.
+Required Rialto development instructions reach every worker runtime through the common launch text.
 Git remotes identifying `UseRialto/rialto-backend` or `UseRialto/rialto-frontend` require `config/rialto-project-context.paths`.
-This private source configuration follows the existing primary-authoritative secondmate inheritance and convergence path; inaccessible paired sources on a child host stop its worker launch.
-Use `bin/fm-project-context.sh --prepare-rialto "$BACKEND_CHECKOUT" "$FRONTEND_CHECKOUT" "$PRODUCT_AGENTS" > rialto-project-context.paths` to prepare a staging artifact without modifying a running home.
+This private source configuration follows the [primary-authoritative secondmate inheritance and convergence contract](../.agents/skills/secondmate-provisioning/SKILL.md); inaccessible paired sources on a child host stop its worker launch.
+Use the preparation command in [`fm-project-context.sh --help`](../bin/fm-project-context.sh) to create a staging artifact without modifying a running home.
 Supply the reviewed source checkouts and product instructions, review the emitted paths, and install configuration only through a separately authorized home operation.
 Private absolute paths are never shared defaults.
-See `bin/fm-project-context.sh --help` for its file format, checkout resolution, source hashes and missing-file behavior.
+The script header owns the source-file format and rendering interface; missing required configuration or unreadable sources stop launch before instruction delivery.
 After compaction, the generated instructions require rereading every source before further project work.
 Every configured path must therefore be readable by the worker's file tools under its unchanged workspace guard, not merely by the launch process.
 When paired checkouts are outside that boundary, prepare verified source copies inside the worker workspace, retain their original paths, Git identities and byte/hash receipts, and use `--prepare-rialto` with those accessible copies.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1142,4 +1142,7 @@ Use `bin/fm-project-context.sh --prepare-rialto "$BACKEND_CHECKOUT" "$FRONTEND_C
 Supply the reviewed source checkouts and product instructions, review the emitted paths, and install configuration only through a separately authorized home operation.
 Private absolute paths are never shared defaults.
 See `bin/fm-project-context.sh --help` for its file format, checkout resolution, source hashes and missing-file behavior.
-The same command reloads the sources after compaction; the generated instructions require that reload before further project work.
+After compaction, the generated instructions require rereading every source before further project work.
+Every configured path must therefore be readable by the worker's file tools under its unchanged workspace guard, not merely by the launch process.
+When paired checkouts are outside that boundary, prepare verified source copies inside the worker workspace, retain their original paths, Git identities and byte/hash receipts, and use `--prepare-rialto` with those accessible copies.
+Successful launch-time rendering alone does not prove post-compaction access.

--- a/tests/project-context.test.sh
+++ b/tests/project-context.test.sh
@@ -2,25 +2,11 @@
 set -euo pipefail
 root=$(cd "$(dirname "$0")/.." && pwd)
 scratch=$(mktemp -d)
+scratch=$(cd "$scratch" && pwd -P)
 trap 'rm -rf -- "$scratch"' EXIT
-mkdir -p "$scratch/config/project-context" "$scratch/worker" "$scratch/project"
-render() { "$root/bin/fm-project-context.sh" "$scratch/project" "$scratch/worker" "$scratch/config"; }
-[ -z "$(render)" ]
-printf 'paired.md\n' > "$scratch/config/project-context/project.paths"
+mkdir -p "$scratch/config" "$scratch/worker"
 printf 'actual worker Python rules\n' > "$scratch/worker/CLAUDE.md"
 printf 'owner checks\n' > "$scratch/worker/AGENTS.md"
-if render > "$scratch/output" 2>/dev/null; then echo 'missing required source accepted' >&2; exit 1; fi
-[ ! -s "$scratch/output" ]
-printf 'frontend standards\n' > "$scratch/worker/paired.md"
-render > "$scratch/output"
-grep -q 'actual worker Python rules' "$scratch/output"
-grep -q 'frontend standards' "$scratch/output"
-grep -q 'SHA-256:' "$scratch/output"
-printf 'new worker rules\n' > "$scratch/worker/CLAUDE.md"
-render > "$scratch/output"
-grep -q 'new worker rules' "$scratch/output"
-if grep -q 'actual worker Python rules' "$scratch/output"; then exit 1; fi
-printf 'PASS: absent opt-in, missing source, actual checkout, paired context, refreshed source\n'
 mkdir -p "$scratch/backend" "$scratch/frontend" "$scratch/product-rules" "$scratch/child/config"
 for repo in backend frontend; do
   git init -q "$scratch/$repo"
@@ -37,12 +23,19 @@ grep -q -- '--prepare-rialto' "$scratch/error"
 . "$root/bin/fm-config-inherit-lib.sh"
 propagate_inheritable_config "$scratch/config" "$scratch/child/config"
 render_rialto "$scratch/child/config" > "$scratch/output"
-for expected in 'backend CLAUDE rules' 'backend AGENTS rules' 'frontend CLAUDE rules' 'frontend AGENTS rules' 'shared product safety' 'new worker rules' 'owner checks'; do
+for expected in 'backend CLAUDE rules' 'backend AGENTS rules' 'frontend CLAUDE rules' 'frontend AGENTS rules' 'shared product safety' 'actual worker Python rules' 'owner checks'; do
   grep -q "$expected" "$scratch/output"
 done
 cp "$scratch/output" "$scratch/first-output"
 render_rialto > "$scratch/output"
 cmp "$scratch/output" "$scratch/first-output"
+digest=$(shasum -a 256 "$scratch/worker/CLAUDE.md")
+grep -Fq "SHA-256: ${digest%% *}" "$scratch/output"
+grep -Fq "Required instruction source: $scratch/worker/CLAUDE.md" "$scratch/output"
+printf 'new worker rules\n' > "$scratch/worker/CLAUDE.md"
+render_rialto > "$scratch/output"
+grep -q 'new worker rules' "$scratch/output"
+if grep -q 'actual worker Python rules' "$scratch/output"; then exit 1; fi
 rm "$scratch/worker/AGENTS.md"
 if render_rialto > "$scratch/output" 2>/dev/null; then echo 'Rialto accepted missing checkout instructions' >&2; exit 1; fi
 [ ! -s "$scratch/output" ]

--- a/tests/project-context.test.sh
+++ b/tests/project-context.test.sh
@@ -21,3 +21,39 @@ render > "$scratch/output"
 grep -q 'new worker rules' "$scratch/output"
 if grep -q 'actual worker Python rules' "$scratch/output"; then exit 1; fi
 printf 'PASS: absent opt-in, missing source, actual checkout, paired context, refreshed source\n'
+mkdir -p "$scratch/backend" "$scratch/frontend" "$scratch/product-rules" "$scratch/child/config"
+for repo in backend frontend; do
+  git init -q "$scratch/$repo"
+  git -C "$scratch/$repo" remote add origin "git@github.com:UseRialto/rialto-$repo.git"
+  printf '%s CLAUDE rules\n' "$repo" > "$scratch/$repo/CLAUDE.md"
+  printf '%s AGENTS rules\n' "$repo" > "$scratch/$repo/AGENTS.md"
+done
+printf 'shared product safety\n' > "$scratch/product-rules/AGENTS.md"
+render_rialto() { "$root/bin/fm-project-context.sh" "$scratch/backend" "$scratch/worker" "${1:-$scratch/config}"; }
+if render_rialto > "$scratch/output" 2> "$scratch/error"; then echo 'Rialto accepted missing manifest' >&2; exit 1; fi
+[ ! -s "$scratch/output" ]
+grep -q -- '--prepare-rialto' "$scratch/error"
+"$root/bin/fm-project-context.sh" --prepare-rialto "$scratch/backend" "$scratch/frontend" "$scratch/product-rules/AGENTS.md" > "$scratch/config/rialto-project-context.paths"
+. "$root/bin/fm-config-inherit-lib.sh"
+propagate_inheritable_config "$scratch/config" "$scratch/child/config"
+render_rialto "$scratch/child/config" > "$scratch/output"
+for expected in 'backend CLAUDE rules' 'backend AGENTS rules' 'frontend CLAUDE rules' 'frontend AGENTS rules' 'shared product safety' 'new worker rules' 'owner checks'; do
+  grep -q "$expected" "$scratch/output"
+done
+cp "$scratch/output" "$scratch/first-output"
+render_rialto > "$scratch/output"
+cmp "$scratch/output" "$scratch/first-output"
+rm "$scratch/worker/AGENTS.md"
+if render_rialto > "$scratch/output" 2>/dev/null; then echo 'Rialto accepted missing checkout instructions' >&2; exit 1; fi
+[ ! -s "$scratch/output" ]
+printf 'owner checks\n' > "$scratch/worker/AGENTS.md"
+rm "$scratch/frontend/CLAUDE.md"
+if render_rialto "$scratch/child/config" > "$scratch/output" 2>/dev/null; then echo 'child accepted missing paired context' >&2; exit 1; fi
+[ ! -s "$scratch/output" ]
+printf 'frontend CLAUDE rules\n' > "$scratch/frontend/CLAUDE.md"
+git -C "$scratch/frontend" remote set-url origin https://github.com/unrelated/rialto-frontend.git
+if "$root/bin/fm-project-context.sh" --prepare-rialto "$scratch/backend" "$scratch/frontend" "$scratch/product-rules/AGENTS.md" > "$scratch/output" 2>/dev/null; then echo 'unverified paired repository accepted' >&2; exit 1; fi
+[ ! -s "$scratch/output" ]
+git -C "$scratch/backend" remote set-url origin https://github.com/unrelated/rialto-backend.git
+[ -z "$("$root/bin/fm-project-context.sh" "$scratch/backend" "$scratch/worker" "$scratch/child/config")" ]
+printf 'PASS: required Rialto configuration, verified pairs, child inheritance, missing sources\n'

--- a/tests/project-context.test.sh
+++ b/tests/project-context.test.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+root=$(cd "$(dirname "$0")/.." && pwd)
+scratch=$(mktemp -d)
+trap 'rm -rf -- "$scratch"' EXIT
+mkdir -p "$scratch/config/project-context" "$scratch/worker" "$scratch/project"
+render() { "$root/bin/fm-project-context.sh" "$scratch/project" "$scratch/worker" "$scratch/config"; }
+[ -z "$(render)" ]
+printf 'paired.md\n' > "$scratch/config/project-context/project.paths"
+printf 'actual worker Python rules\n' > "$scratch/worker/CLAUDE.md"
+printf 'owner checks\n' > "$scratch/worker/AGENTS.md"
+if render > "$scratch/output" 2>/dev/null; then echo 'missing required source accepted' >&2; exit 1; fi
+[ ! -s "$scratch/output" ]
+printf 'frontend standards\n' > "$scratch/worker/paired.md"
+render > "$scratch/output"
+grep -q 'actual worker Python rules' "$scratch/output"
+grep -q 'frontend standards' "$scratch/output"
+grep -q 'SHA-256:' "$scratch/output"
+printf 'new worker rules\n' > "$scratch/worker/CLAUDE.md"
+render > "$scratch/output"
+grep -q 'new worker rules' "$scratch/output"
+if grep -q 'actual worker Python rules' "$scratch/output"; then exit 1; fi
+printf 'PASS: absent opt-in, missing source, actual checkout, paired context, refreshed source\n'


### PR DESCRIPTION
## Intent

Ensure Rialto product development standards are loaded into every Firstmate worker prompt, including Codex and OMP. Read the actual checkout CLAUDE.md and AGENTS.md and configured paired-repository instructions, preserve source paths and hashes, stop on missing required context, and reload after compaction. Backend standards are Python with uv, FastAPI/Uvicorn, Pydantic, async SQLAlchemy/asyncpg, Alembic, pytest and Ruff; business logic and database access belong in core with explicit owner checks and caller-owned transactions; named typed MCP tools share core logic and queued work preserves retries and evidence. Frontend standards are Vite, React, TypeScript, pnpm, Tailwind/shadcn and TanStack Query with thin API wrappers and documented CONTRACT.md shapes. Production/shared databases stay read-only; use verified isolated resources and retain them. Preserve Gauntlet and human review gates. Exact Rialto sources: ~/Desktop/rialto/product/.standards-review/backend/CLAUDE.md, ~/Desktop/rialto/product/.standards-review/backend/AGENTS.md, ~/Desktop/rialto/product/.standards-review/frontend/CLAUDE.md, ~/Desktop/rialto/product/.standards-review/frontend/AGENTS.md, ~/Desktop/rialto/product/AGENTS.md. The authorized code change here is Firstmate context loading only; product PR amendments are handled separately. Do not merge or install into running homes.

## What Changed

- Load checkout and configured paired-repository Rialto instructions into the shared worker brief, including Codex and OMP, with source paths, SHA-256 hashes, and reload instructions after compaction.
- Require verified repository pairs and readable instruction files; stop worker launch when required context is missing.
- Inherit the context configuration into secondmate homes, document preparation and workspace access requirements, and add regression coverage for rendering, inheritance, and missing or invalid sources.

## Risk Assessment

✅ Low: The change is bounded to required Rialto context loading and inheritance; source review found no substantiated correctness, scope, or privacy defects.

## Testing

Targeted regression passed. Retained live pipeline evidence covers all six scenarios; an independent audit confirmed complete OMP recovery under the preserved guard. No new harness session, broad suite, lint, or other pipeline phase ran. CLI transcripts provide evidence; no UI layout changed.

- Live validation: ✅ go - 6 of 6 scenarios driven live against the product

| Scenario | Result | Live | Evidence |
| --- | --- | --- | --- |
| Launch Codex and OMP workers with complete checkout and paired instructions, paths, and hashes | ✅ pass | live | codex-spawn.md; omp-spawn.md; launch-identities.json |
| Missing required configuration or instruction sources refuse launch without partial context | ✅ pass | live | context-cli-results.json; spawn-refusal-local.log |
| A secondmate worker receives inherited required Rialto context | ✅ pass | live | inherited-context.stdout; omp-spawn.md |
| An unrelated repository receives no Rialto context | ✅ pass | live | context-cli-results.json |
| After native Codex compaction, reread all instruction sources and detect updated content | ✅ pass | live | codex-recovery.md; codex-recovery-tools.json |
| After native OMP compaction, reread all seven accessible sources and discover an undisclosed updated marker | ✅ pass | live | omp-accessible-recovery-verification.json; final-evidence-audit.json |

<details>
<summary>Evidence: OMP live recovery verification</summary>

Source: [OMP live recovery verification](https://github.com/tomaszjezak/firstmate/blob/3908c0c29b03e71ae5bb586a566b5f8fb3e32cf0/.no-mistakes/evidence/codex/rialto-context-loading/omp-accessible-recovery-verification.json)

```text
{
  "result": "pass",
  "harness": "omp 18.1.18",
  "scenario": "Native compaction followed by full current and paired source reads",
  "compaction_id": "328a0d08",
  "compaction_timestamp": "2026-09-12T20:37:40.514Z",
  "marker_update_timestamp": "2026-09-12T20:38:19.473056+00:00",
  "source_count": 7,
  "complete_source_lines": {
    "~/.no-mistakes/worktrees/4019102881cf/01M2BJC44MJV1HEJ1P50949S5A/config/rialto-omp-recovery/pool/.treehouse/frontend-0b3a95/1/frontend/AGENTS.md": 77,
    "~/.no-mistakes/worktrees/4019102881cf/01M2BJC44MJV1HEJ1P50949S5A/config/rialto-omp-recovery/pool/.treehouse/frontend-0b3a95/1/frontend/validation-sources/rialto-frontend/AGENTS.md": 75,
    "~/.no-mistakes/worktrees/4019102881cf/01M2BJC44MJV1HEJ1P50949S5A/config/rialto-omp-recovery/pool/.treehouse/frontend-0b3a95/1/frontend/validation-sources/rialto-frontend/CLAUDE.md": 174,
    "~/.no-mistakes/worktrees/4019102881cf/01M2BJC44MJV1HEJ1P50949S5A/config/rialto-omp-recovery/pool/.treehouse/frontend-0b3a95/1/frontend/validation-sources/AGENTS.md": 76,
    "~/.no-mistakes/worktrees/4019102881cf/01M2BJC44MJV1HEJ1P50949S5A/config/rialto-omp-recovery/pool/.treehouse/frontend-0b3a95/1/frontend/validation-sources/rialto-backend/CLAUDE.md": 3686,
    "~/.no-mistakes/worktrees/4019102881cf/01M2BJC44MJV1HEJ1P50949S5A/config/rialto-omp-recovery/pool/.treehouse/frontend-0b3a95/1/frontend/validation-sources/rialto-backend/AGENTS.md": 74,
    "~/.no-mistakes/worktrees/4019102881cf/01M2BJC44MJV1HEJ1P50949S5A/config/rialto-omp-recovery/pool/.treehouse/frontend-0b3a95/1/frontend/CLAUDE.md": 174
  },
  "read_results": [
    {
      "path": "~/.no-mistakes/worktrees/4019102881cf/01M2BJC44MJV1HEJ1P50949S5A/config/rialto-omp-recovery/pool/.treehouse/frontend-0b3a95/1/frontend/AGENTS.md",
      "first": 1,
      "last": 77,
      "tool_call_id": "call_SqS552KIhtbowgcEDmicZ60r|fc_08b950258a397b5a016aa5b857a83c87d29ea6b4231e590d6e",
      "bytes_match": true
    },
    {
      "path": "~/.no-mistakes/worktrees/4019102881cf/01M2BJC44MJV1HEJ1P50949S5A/config/rialto-omp-recovery/pool/.treehouse/frontend-0b3a95/1/frontend/validation-sources/rialto-frontend/AGENTS.md",
      "first": 1,
      "last": 75,
      "tool_call_id": "call_W3T0QUNA0eVsRHM2yJH0Pitj|fc_0c545d8a470c6496016aa5b8691b3c87d284884a4d6aa0b9d1",
      "bytes_match": true
    },
    {
      "path": "~/.no-mistakes/worktrees/4019102881cf/01M2BJC44MJV1HEJ1P50949S5A/config/rialto-omp-recovery/pool/.treehouse/frontend-0b3a95/1/frontend/validation-sources/rialto-frontend/CLAUDE.md",
      "first": 1,
      "last": 150,
      "tool_call_id": "call_mYZJWptGVOEh0wLNHgDPm4Vf|fc_0c545d8a470c6496016aa5b8691b3487d2ab54c9b460e5baaf",
      "bytes_match": true
    },
    {
      "path": "~/.no-mistakes/worktrees/4019102881cf/01M2BJC44MJV1HEJ1P50949S5A/config/rialto-omp-recovery/pool/.treehouse/frontend-0b3a95/1/frontend/validation-sources/AGENTS.md",
      "first": 1,
      "last": 76,
      "tool_call_id": "call_o7Kael8dwvQGWYBRC9RFiwc4|fc_0c545d8a470c6496016aa5b8691b4487d29808d227f8c25069",
      "bytes_match": true
    },
    {
      "path": "~/.no-mistakes/worktrees/4019102881cf/01M2BJC44MJV1HEJ1P50949S5A/config/rialto-omp-recovery/pool/.treehouse/frontend-0b3a95/1/frontend/validation-sources/rialto-backend/CLAUDE.md",
      "first": 1,
      "last": 150,
      "tool_call_id": "call_FkJGZLTmUj4N16MuWByvRi3k|fc_0c545d8a470c6496016aa5b8691b1087d289f9f9ac862abbb9",
      "bytes_match": true
    },
    {
      "path": "~/.no-mistakes/worktrees/4019102881cf/01M2BJC44MJV1HEJ1P50949S5A/config/rialto-omp-recovery/pool/.treehouse/frontend-0b3a95/1/frontend/validation-sources/rialto-backend/AGENTS.md",
      "first": 1,
      "last": 74,
      "tool_call_id": "call_X56dFpIkTIm99lHTO4ydX9NU|fc_0c545d8a470c6496016aa5b8691b2887d2a8425d43f1ba7b60",
      "bytes_match": true
    },
    {
      "path": "~/.no-mistakes/worktrees/4019102881cf/01M2BJC44MJV1HEJ1P50949S5A/config/rialto-omp-recovery/pool/.treehouse/frontend-0b3a95/1/frontend/validation-sources/rialto-backend/CLAUDE.md",
      "first": 151,
      "last": 300,
      "tool_call_id": "call_u2Y0wqF0tNWBi7cOW95Vi04g|fc_02cdfd7f6d90b1da016aa5b86bd9c087d2a1df9f72ebc57955",
      "bytes_match": true
    },
    {
      "path": "~/.no-mistakes/worktrees/4019102881cf/01M2BJC44MJV1HEJ1P50949S5A/config/rialto-omp-recovery/pool/.treehouse/frontend-0b3a95/1/frontend/validation-sources/rialto-backend/CLAUDE.md",
      "first": 301,
      "last": 450,
      "tool_call_id": "call_sTIE5U55CyhPcsodOW7A8Fb8|fc_06a0d6939f61718d016aa5b871ff8487d29614e7a85ccc3697",
      "bytes_match": true
    },
    {
      "path": "~/.no-mistakes/worktrees/4019102881cf/01M2BJC44MJV1HEJ1P50949S5A/config/rialto-omp-recovery/pool/.treehouse/frontend-0b3a95/1/frontend/validation-sources/rialto-backend/CLAUDE.md",
      "first": 451,
      "last": 600,
      "tool_call_id": "call_FgdnlTPseaXimMNUHqQhcJFG|fc_0b862ab64de78ce3016aa5b876dde487d2ab8866fabfbe8d87",
      "bytes_match": true
    },
    {
      "path": "~/.no-mistakes/worktrees/4019102881cf/01M2BJC44MJV1HEJ1P50949S5A/config/rialto-omp-recovery/pool/.treehouse/frontend-0b3a95/1/frontend/validation-sources/rialto-backend/CLAUDE.md",
      "first": 601,
      "last": 750,
      "tool_call_id": "call_PGrr7ZqZL9JvK4FlZK86FkaP|fc_0d1abc2036e9c654016aa5b87c605c87d2afd662a79ea5b3a0",
      "bytes_match": true
    },
    {
      "path": "~/.no-mistakes/worktrees/4019102881cf/01M2BJC44MJV1HEJ1P50949S5A/config/rialto-omp-recovery/pool/.treehouse/frontend-0b3a95/1/frontend/validation-sources/rialto-backend/CLAUDE.md",
      "first": 751,
      "last": 900,
      "tool_call_id": "call_TdCrlqzubXBBKnnPZiIuSq8Q|fc_0aedf770f4388957016aa5b88331ac87d2b44d204dfd1db515",
      "bytes_match": true
    },
    {
      "path": "~/.no-mistakes/worktrees/4019102881cf/01M2BJC44MJV1HEJ1P50949S5A/config/rialto-omp-recovery/pool/.treehouse/frontend-0b3a95/1/frontend/validation-sources/rialto-backend/CLAUDE.md",
      "first": 901,
      "last": 1050,
      "tool_call_id": "call_M9jqPqfaM2e3pcdxmyCTLAqD|fc_04874c7680388b1b016aa5b888d91487d287e419ed9ec1c40c",
      "bytes_match": true
    },
    {
      "path": "~/.no-mistakes/worktrees/4019102881cf/01M2BJC44MJV1HEJ1P50949S5A/config/rialto-omp-recovery/pool/.treehouse/frontend-0b3a95/1/frontend/validation-sources/rialto-backend/CLAUDE.md",
      "first": 1051,
      "last": 1200,
      "tool_call_id": "call_uUjREYbqKlMvOVxdDjESsSQ8|fc_0d0ae3122d492603016aa5b88fa14887d2b4a75529f4238da1",
      "bytes_match": true
    },
    {
      "path": "~/.no-mistakes/worktrees/4019102881cf/01M2BJC44MJV1HEJ1P50949S5A/config/rialto-omp-recovery/pool/.treehouse/frontend-0b3a95/1/frontend/validation-sources/rialto-backend/CLAUDE.md",
      "first": 1201,
      "last": 1350,
      "tool_call_id": "call_Cyl0LsVesWVGmqHEcfOLYjjC|fc_071a357e07050a67016aa5b894f20487d29b9d864d013819ca",
      "bytes_match": true
    },
    {
      "path": "~/.no-mistakes/worktrees/4019102881cf/01M2BJC44MJV1HEJ1P50949S5A/config/rialto-omp-recovery/pool/.treehouse/frontend-0b3a95/1/frontend/validation-sources/rialto-backend/CLAUDE.md",
      "first": 1351,
      "last": 1500,
      "tool_call_id": "call_NYBga11SxVX1KHj0lUL7DE24|fc_0dfbb31e69716221016aa5b89a621487d28615fbb0c9de0819",
      "bytes_match": true
    },
    {
      "path": "~/.no-mistakes/worktrees/4019102881cf/01M2BJC44MJV1HEJ1P50949S5A/config/rialto-omp-recovery/pool/.treehouse/frontend-0b3a95/1/frontend/validation-sources/rialto-backend/CLAUDE.md",
      "first": 1501,
      "last": 1650,
      "tool_call_id": "call_Gsv02IEG2L9CzsMD7f159QjV|fc_017ba0f7267f9c81016aa5b89fffc887d2a638b34339a3ce2d",
      "bytes_match": true
    },
    {
      "path": "~/.no-mistakes/worktrees/4019102881cf/01M2BJC44MJV1HEJ1P50949S5A/config/rialto-omp-recovery/pool/.treehouse/frontend-0b3a95/1/frontend/validation-sources/rialto-backend/CLAUDE.md",
      "first": 1651,
      "last": 1800,
      "tool_call_id": "call_TwDQdaYgjP0x2L3bxWPRctiq|fc_0e494c10d9483018016aa5b8ad501887d28d1d690462b574f4",
      "bytes_match": true
    },
    {
      "path": "~/.no-mistakes/worktrees/4019102881cf/01M2BJC44MJV1HEJ1P50949S5A/config/rialto-omp-recovery/pool/.treehouse/frontend-0b3a95/1/frontend/validation-sources/rialto-backend/CLAUDE.md",
      "first": 1801,
      "last": 1950,
      "tool_call_id": "call_gyrpNUXl38xoJvVQINqbQnWx|fc_0e4c2897dd6e140c016aa5b8b2914087d28a1f6a5cf7c4b096",
      "bytes_match": true
    },
    {
      "path": "~/.no-mistakes/worktrees/4019102881cf/01M2BJC44MJV1HEJ1P50949S5A/config/rialto-omp-recovery/pool/.treehouse/frontend-0b3a95/1/frontend/validation-sources/rialto-backend/CLAUDE.md",
      "first": 1951,
      "last": 2100,
      "tool_call_id": "call_ezoT9uyC0qON06RaUcci0g05|fc_0675f024969340d4016aa5b8b9aad087d2bc9349819447c391",
      "bytes_match": true
    },
    {
      "path": "~/.no-mistakes/worktrees/4019102881cf/01M2BJC44MJV1HEJ1P50949S5A/config/rialto-omp-recovery/pool/.treehouse/frontend-0b3a95/1/frontend/validation-sources/rialto-backend/CLAUDE.md",
      "first": 2101,
      "last": 2250,
      "tool_call_id": "call_vNHSlL0NRWYbibqzGFzO8BC5|fc_07afea712a98b89f016aa5b8bfd9cc87d2800afcb4d24d24b5",
      "bytes_match": true
    },
    {
      "path": "~/.no-mistakes/worktrees/4019102881cf/01M2BJC44MJV1HEJ1P50949S5A/config/rialto-omp-recovery/pool/.treehouse/frontend-0b3a95/1/frontend/validation-sources/rialto-backend/CLAUDE.md",
      "first": 2251,
      "last": 2400,
      "tool_call_id": "call_WIlhkT8QG0OyGVt1zEiWSeRk|fc_0fcb352f92e66ca1016aa5b8c56ea087d29e16329de0387ab6",
      "bytes_match": true
    },
    {
      "path": "~/.no-mistakes/worktrees/4019102881cf/01M2BJC44MJV1HEJ1P50949S5A/config/rialto-omp-recovery/pool/.treehouse/frontend-0b3a95/1/frontend/validation-sources/rialto-backend/CLAUDE.md",
      "first": 2401,
      "last": 2550,
      "tool_call_id": "call_nLAucTryoftDvJHQS1k3o9jH|fc_0718486e9bbc299a016aa5b8cadb4087d292787c6b22867628",
      "bytes_match": true
    },
    {
      "path": "~/.no-mistakes/worktrees/4019102881cf/01M2BJC44MJV1HEJ1P50949S5A/config/rialto-omp-recovery/pool/.treehouse/frontend-0b3a95/1/frontend/validation-sources/rialto-backend/CLAUDE.md",
      "first": 2551,
      "last": 2700,
      "tool_call_id": "call_FcWlC45GwUIenYLz2ZC1HEtf|fc_04c9ed33c2e10590016aa5b8d3b93c87d2991594ce296805f3",
      "bytes_match": true
    },
    {
      "path": "~/.no-mistakes/worktrees/4019102881cf/01M2BJC44MJV1HEJ1P50949S5A/config/rialto-omp-recovery/pool/.treehouse/frontend-0b3a95/1/frontend/validation-sources/rialto-backend/CLAUDE.md",
      "first": 2701,
      "last": 2850,
      "tool_call_id": "call_kQyRQ7W4YdNjFFvsE7FAKamo|fc_02595de2d8dfee10016aa5b8dd212887d2bbaadde07f506a93",
      "bytes_match": true
    },
    {
      "path": "~/.no-mistakes/worktrees/4019102881cf/01M2BJC44MJV1HEJ1P50949S5A/config/rialto-omp-recovery/pool/.treehouse/frontend-0b3a95/1/frontend/validation-sources/rialto-backend/CLAUDE.md",
      "first": 2851,
      "last": 3000,
      "tool_call_id": "call_aMFeS9FDxyU3L8eRcF9YahZh|fc_05062e74236b66ca016aa5b8e2860c87d2a4009dad9a81a3a2",
      "bytes_match": true
    },
    {
      "path": "~/.no-mistakes/worktrees/4019102881cf/01M2BJC44MJV1HEJ1P50949S5A/config/rialto-omp-recovery/pool/.treehouse/frontend-0b3a95/1/frontend/validation-sources/rialto-backend/CLAUDE.md",
      "first": 3001,
      "last": 3150,
      "tool_call_id": "call_f8YDKab2D58JQ6FKYGQunoQX|fc_095ca57e21e16378016aa5b8e7eeb487d28de1dbcf18a06056",
      "bytes_match": true
    },
    {
      "path": "~/.no-mistakes/worktrees/4019102881cf/01M2BJC44MJV1HEJ1P50949S5A/config/rialto-omp-recovery/pool/.treehouse/frontend-0b3a95/1/frontend/validation-sources/rialto-backend/CLAUDE.md",
      "first": 3151,
      "last": 3300,
      "tool_call_id": "call_43cFuGbCQEZ0PJZJrYiCz615|fc_01c27a3bb8a8c47a016aa5b8ed3d7487d289ed212feed7a610",
      "bytes_match": true
    },
    {
      "path": "~/.no-mistakes/worktrees/4019102881cf/01M2BJC44MJV1HEJ1P50949S5A/config/rialto-omp-recovery/pool/.treehouse/frontend-0b3a95/1/frontend/validation-sources/rialto-backend/CLAUDE.md",
      "first": 3301,
      "last": 3450,
      "tool_call_id": "call_E5BHV5YkAWRjggq6vSjHhLo9|fc_0472de4800f2ee2a016aa5b8f3b36c87d2819a6ba40d6d0734",
      "bytes_match": true
    },
    {
      "path": "~/.no-mistakes/worktrees/4019102881cf/01M2BJC44MJV1HEJ1P50949S5A/config/rialto-omp-recovery/pool/.treehouse/frontend-0b3a95/1/frontend/validation-sources/rialto-backend/CLAUDE.md",
      "first": 3451,
      "last": 3600,
      "tool_call_id": "call_rMRnwCjvtiznf5Bkx5PMPtE4|fc_09eaf411a4b87962016aa5b8f953a087d2b37463d56e9be669",
      "bytes_match": true
    },
    {
      "path": "~/.no-mistakes/worktrees/4019102881cf/01M2BJC44MJV1HEJ1P50949S5A/config/rialto-omp-recovery/pool/.treehouse/frontend-0b3a95/1/frontend/validation-sources/rialto-frontend/CLAUDE.md",
      "first": 151,
      "last": 174,
      "tool_call_id": "call_s1uFsmr62PuqO5GRZSSZgGes|fc_04230522093b9a73016aa5b908a36087d29199270b5760bbe6",
      "bytes_match": true
    },
    {
      "path": "~/.no-mistakes/worktrees/4019102881cf/01M2BJC44MJV1HEJ1P50949S5A/config/rialto-omp-recovery/pool/.treehouse/frontend-0b3a95/1/frontend/validation-sources/rialto-backend/CLAUDE.md",
      "first": 3601,
      "last": 3686,
      "tool_call_id": "call_kpwk5XeI85UFZpHaB6w4ivhW|fc_04230522093b9a73016aa5b908a34c87d2b7a80553254d0b55",
      "bytes_match": true
    },
    {
      "path": "~/.no-mistakes/worktrees/4019102881cf/01M2BJC44MJV1HEJ1P50949S5A/config/rialto-omp-recovery/pool/.treehouse/frontend-0b3a95/1/frontend/CLAUDE.md",
      "first": 1,
      "last": 150,
      "tool_call_id": "call_V6oUgbJFp6oV9gweY3jePNNO|fc_04230522093b9a73016aa5b908a36887d28b54dd3212294325",
      "bytes_match": true
    },
    {
      "path": "~/.no-mistakes/worktrees/4019102881cf/01M2BJC44MJV1HEJ1P50949S5A/config/rialto-omp-recovery/pool/.treehouse/frontend-0b3a95/1/frontend/CLAUDE.md",
      "first": 151,
      "last": 174,
      "tool_call_id": "call_pztGVjuyDSzNdQ8Ig6LH2Gdd|fc_0562f6d2e4e0c249016aa5b90b6a5887d28ac996380ca4e4d3",
      "bytes_match": true
    }
  ],
  "fresh_hashes_match": true,
  "updated_marker_discovered_without_prompt_disclosure": true,
  "guard_preserved": true
}
```
</details>
<details>
<summary>Evidence: Independent evidence audit</summary>

Source: [Independent evidence audit](https://github.com/tomaszjezak/firstmate/blob/3908c0c29b03e71ae5bb586a566b5f8fb3e32cf0/.no-mistakes/evidence/codex/rialto-context-loading/final-evidence-audit.json)

```text
{
  "result": "pass",
  "kind": "independent audit of retained live evidence from this pipeline run",
  "candidate": "714fef668334d7a87340c9159aa1def0e4467234",
  "native_compaction_id": "328a0d08",
  "full_sources_verified": 7,
  "updated_marker_discovered": true,
  "original_receipts_match": true,
  "new_harness_session_started": false
}
```
</details>
<details>
<summary>Evidence: Pipeline validation record</summary>

Source: [Pipeline validation record](https://github.com/tomaszjezak/firstmate/blob/3908c0c29b03e71ae5bb586a566b5f8fb3e32cf0/.no-mistakes/evidence/codex/rialto-context-loading/verification-notes.md)

```text
# Rialto context verification

Target: e88e03535eea62dab49052a80b7b4bf317b55124.

`bin/fm-test-run.sh tests/project-context.test.sh` passed. All five source receipts and both published fixture commits were independently checked.

The real `fm-project-context.sh --prepare-rialto` prepared the isolated primary configuration. The real `propagate_inheritable_config` owner copied it to the child home. Rendering verified every complete source byte and SHA-256, and rejected missing configuration, current-checkout documents and paired sources with empty stdout. A non-Rialto checkout produced empty output. See context-cli-results.json.

Supervised launches used the unchanged `bin/fm-spawn.sh` through `tests/lib.sh` and `fm_live_gate opt-in FM_RIALTO_LIVE` with FM_RIALTO_LIVE=1. Task-local forwarding wrappers selected an isolated tmux socket and Treehouse pool. Codex and OMP delivery wrappers invoked the installed real binaries in ephemeral/headless mode, without replacing responses or stubbing the model. The OMP child used only inherited configuration. Full generated launch briefs contained every paired source byte. See launch-identities.json, spawn-codex.log, spawn-omp.log, codex-spawn.md and omp-spawn.md.

The first supervised spawn encountered an unauthenticated remote fetch. This was resolved by cloning the verified fixture locally, keeping a verified UseRialto source remote for identity, and letting the existing freshness gate fetch the local origin. No freshness check was disabled. The repeated missing-manifest spawn then refused before harness delivery (spawn-refusal-local.log).

Codex 0.153.4 recovery used the installed app-server stdio API, an ephemeral read-only thread, and the exact emitted launch brief. After its first turn, a test marker was added only to its task checkout AGENTS.md. The actual thread/compact/start completed, followed by a new turn that read all seven files, recomputed hashes, and found CODEX_RECOVERY_20260912. See codex-recovery.md and codex-recovery-tools.json. The first driver attempt consumed the compaction turn-completed event too early; the rerun correctly awaited the recovery turn ID. The final evidence is from that corrected run.

OMP 18.1.18 recovery ran interactively through fm-spawn and fm-control. A first /compact reported that the conversation was too small. The task-local configuration was changed to compaction.keepRecentTokens=200 and the worker was relaunched through the control plane with an explicit recovery note and a longer opening summary. Native /compact then completed (166K to 28K). After compaction it read the changed local AGENTS.md marker, but Agent Gauntlet denied the paired backend CLAUDE.md outside its allowed workspace. The initial inbox access met the same denial; direct terminal delivery through fm-send independently reproduced the source-file denial. No guard was disabled or bypassed to complete recovery. Full OMP recovery is untested pending an approved test read scope containing the worker checkout and verified paired source copies. See omp-compaction.txt and omp-recovery.txt.

The temporary source markers were restored. Original prepared fixtures are retained and their five hashes still match receipts. No product database, deployment, PR, CI, other pipeline phase, linter or broad suite was exercised. This change has no UI layout surface; evidence is CLI/model transcripts.

## Completed OMP recovery verification (2026-09-12)

The remaining scenario now passes with omp 18.1.18 and openai-codex/gpt-6-astra. The original layout was reproduced through guarded fm-spawn, native /compact (114K to 41K), and a read-tool request: Gauntlet denied the paired backend source outside the worker checkout. See omp-reproduction-compaction.txt and omp-reproduction-denial.txt.

The root cause was fixture layout, not loader code. All five original source copies were duplicated inside the isolated worker checkout. Each full byte/hash matched its original receipt; both clones matched the published commits and retained verified UseRialto remote identities. The supported --prepare-rialto command regenerated this test home's configuration. fm-control exit/relaunch preserved the workspace guard and loaded that configuration. No hooks were disabled and no additional filesystem permission was granted.

After a transient DNS failure, a retry of native /compact succeeded (115K to 41K), recorded as a real session compaction entry. Only afterward, the driver appended the same randomly generated marker to the current checkout AGENTS.md and paired backend CLAUDE.md. The marker value was never included in a user prompt. OMP read all seven paths in consecutive raw chunks, including all 3,686 backend lines with the marker. Recorded tool outputs were checked against every source byte range with complete line coverage. A read-only shasum command and the final model report both matched all seven freshly computed hashes; the report identified the updated marker in both files and recovered the required standards. See omp-accessible-recovery.jsonl, omp-accessible-recovery.md, omp-accessible-recovery-verification.json, and omp-after-compaction-marker-receipts.json. Credential-pin metadata is excluded from the exported session.

The direct guarded commands are recorded in omp-accessible-spawn.log, omp-accessible-relaunch.log, omp-accessible-preparation-command.json, and the command driver. The evidence verifier is omp-accessible-verify-recovery.py (run from the pipeline workspace before marker restoration). It checks emitted native tool results, not implementation-source strings. The first elided read attempts were followed by raw rereads; only complete raw byte matches count as full-source evidence.

The worker was stopped through fm-control, its isolated tmux session was closed, and both markers were restored. All ten original/copied source hashes were rechecked. Temporary runtime state, sessions and drivers were removed from the worktree after evidence export. The verified original fixtures and accessible source clones/configuration are retained. Earlier Codex, inheritance, refusal and unrelated-repository evidence remains unchanged; together the accepted prior results and this completed scenario cover six of six scenarios. No complete test suite, linter, static analysis, other pipeline phase, product flow, database or infrastructure mutation was run. The sole tracked change clarifies that worker-tool access under the workspace guard is required for recovery.
```
</details>
- Outcome: 🔧 2 issues found → auto-fixed → no changes applied ✅ across 3 runs (50m51s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"22ef7d7cbe8ecd0fe0692dc78d3fef7fd8564b4d","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>🔧 **Review** - 2 issues found → auto-fixed (2) ✅</summary>

- 🚨 `bin/fm-project-context.sh:20` - Intent requires “Ensure Rialto product development standards are loaded into every Firstmate worker prompt” and “stop on missing required context,” but `[ -f &#34;$manifest&#34; ] || exit 0` silently disables all loading when the manifest is absent. This change supplies neither a Rialto manifest nor a required mapping to the five specified sources. An ordinary Rialto launch therefore succeeds without this context, even with missing CLAUDE.md/AGENTS.md. Remove the optional-success path for Rialto and establish its required source configuration without installing into running homes.
- 🚨 `bin/fm-spawn.sh:3864` - Even after configuring a primary home&#39;s manifest, workers dispatched by a secondmate silently lose it: this call uses that secondmate&#39;s local CONFIG, while fm-config-inherit-lib.sh&#39;s declared inheritance set excludes project-context manifests. The loader then returns success with empty output. This contradicts “every Firstmate worker prompt.” Include the required context configuration in the existing secondmate provisioning/convergence path so delegated Rialto workers receive the same required sources.

🔧 Fix applied.
1 warning still open:

- ⚠️ `bin/fm-project-context.sh:70` - The optional non-Rialto manifest path adds a general project-context feature beyond the stated Rialto-only requirement. No intent requirement needs `config/project-context/&lt;project-basename&gt;.paths` or its relative-path handling. Remove this optional mode and its associated documentation/tests; retain the required Rialto configuration and loading path.

🔧 Fix applied.
✅ Re-checked - no issues remain.
</details>

<details>
<summary>🔧 **Test** - 2 issues found → auto-fixed → no changes applied ✅</summary>

- ⚠️ Live worker delivery and post-compaction reload remain unverified. Provide the required verified Rialto source copies within the permitted workspace and an isolated worker-launch environment to complete validation.
- ⚠️ live validation verdict: inconclusive (1 of 5 scenarios were driven live against the product); untested: Launch a Rialto worker with complete current and paired instructions, paths, and hashes, Refuse Rialto launch when required configuration or verified sources are missing, A secondmate&#39;s worker receives the required inherited Rialto context, After compaction, a worker reloads current instruction sources
- Live validation: ⚠️ inconclusive - 1 of 5 scenarios driven live against the product

| Scenario | Result | Live | Evidence |
| --- | --- | --- | --- |
| Launch a Rialto worker with complete current and paired instructions, paths, and hashes | ⏸️ untested | no | Required real Rialto source copies are outside the permitted project-read boundary. Provide verified copies inside this workspace for live Codex and OMP delivery testing. |
| Refuse Rialto launch when required configuration or verified sources are missing | ⏸️ untested | no | Guards were exercised with synthetic repositories only; a permitted real Rialto checkout is needed for live launch validation. |
| A secondmate&#39;s worker receives the required inherited Rialto context | ⏸️ untested | no | No live isolated secondmate was provisioned with verified Rialto sources; provide those sources within the allowed workspace. |
| After compaction, a worker reloads current instruction sources | ⏸️ untested | no | Renderer freshness was tested, but no live worker compaction was driven. This requires an isolated worker session with the verified sources. |
| Loading context for this non-Rialto repository adds no Rialto instructions | ✅ pass | live | bin/fm-project-context.sh &#34;$PWD&#34; &#34;$PWD&#34; &#34;$PWD/config&#34; exited successfully with empty output. |

- `TMPDIR="$PWD/.test-context-tmp" bash tests/project-context.test.sh`
- `bin/fm-project-context.sh "$PWD" "$PWD" "$PWD/config"`
- `Inspected the target diff and launch integration.`
- <code>`git status --short` confirmed no remaining test artifacts or source changes.</code>

🔧 No changes applied.
2 warnings still open:

- ⚠️ Full OMP recovery remains unverified: after real compaction, Agent Gauntlet denied reading the configured paired backend CLAUDE.md as outside the allowed workspace. Provide an approved test read scope covering the worker checkout and verified paired source copies, then rerun OMP recovery. The guard was preserved.
- ⚠️ live validation verdict: inconclusive (5 of 6 scenarios were driven live against the product); untested: Compact OMP context, then reload every current and paired instruction source
- Live validation: ⚠️ inconclusive - 5 of 6 scenarios driven live against the product

| Scenario | Result | Live | Evidence |
| --- | --- | --- | --- |
| Launch a Codex worker and receive complete development standards, actual checkout paths and source hashes | ✅ pass | live | Codex worker delivery |
| Launch an OMP worker from an inherited child-home configuration and receive all required context | ✅ pass | live | OMP child-home delivery |
| Omit required configuration or instruction files and receive an actionable refusal without partial context | ✅ pass | live | Supervised launch refusal; Context CLI results |
| Resolve context for an unrelated repository without injecting Rialto instructions | ✅ pass | live | Context CLI results: unrelated-project |
| Compact Codex context, then reread current sources and discover a changed instruction marker and hash | ✅ pass | live | Codex recovery after compaction; codex-recovery-tools.json |
| Compact OMP context, then reload every current and paired instruction source | ⏸️ untested | no | Native compaction completed and the changed checkout marker was read, but Gauntlet denied the paired source outside the worker workspace. Complete validation requires an approved test read scope inclu… |

- `bin/fm-test-run.sh tests/project-context.test.sh`
- <code>Verified all five receipts with SHA-256 and both fixture commits with `git rev-parse HEAD`.</code>
- <code>`python3 config/rialto-context-test/drive.py`: real preparation, rendering, inheritance, missing-source refusal and unrelated-repository checks.</code>
- <code>Guarded `fm-spawn.sh` launches: `deliver --scout --harness codex`, `ompchild --scout --harness omp`, and missing-manifest `refuse2`, using an isolated tmux server and Treehouse pool.</code>
- `Real ephemeral Codex and OMP headless context-delivery smoke calls.`
- <code>`python3 config/rialto-context-test/codex-compact.py`: ephemeral app-server compaction followed by current-source reads and hash verification.</code>
- <code>OMP interactive `fm-control.sh compact relaunch`, native `/compact`, and recovery requests through `fm-send.sh`.</code>
- <code>Restored instruction markers, removed temporary sessions and test worktrees, reverified retained fixture hashes, and confirmed clean `git status --short`.</code>

🔧 Fix applied.
✅ Re-checked - no issues remain.
- Live validation: ✅ go - 6 of 6 scenarios driven live against the product

| Scenario | Result | Live | Evidence |
| --- | --- | --- | --- |
| Launch Codex and OMP workers with complete checkout and paired instructions, paths, and hashes | ✅ pass | live | codex-spawn.md; omp-spawn.md; launch-identities.json |
| Missing required configuration or instruction sources refuse launch without partial context | ✅ pass | live | context-cli-results.json; spawn-refusal-local.log |
| A secondmate worker receives inherited required Rialto context | ✅ pass | live | inherited-context.stdout; omp-spawn.md |
| An unrelated repository receives no Rialto context | ✅ pass | live | context-cli-results.json |
| After native Codex compaction, reread all instruction sources and detect updated content | ✅ pass | live | codex-recovery.md; codex-recovery-tools.json |
| After native OMP compaction, reread all seven accessible sources and discover an undisclosed updated marker | ✅ pass | live | omp-accessible-recovery-verification.json; final-evidence-audit.json |

- `bin/fm-test-run.sh tests/project-context.test.sh`
- `Independently audited retained OMP native-compaction and raw read-tool outputs against all seven source receipts.`
- `Verified the updated marker followed compaction and matched the recovered report and fresh hashes.`
- `Rechecked original fixture SHA-256 receipts and retained earlier launch, refusal, inheritance, and Codex recovery evidence.`
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>⚠️ **Lint** - 1 warning</summary>

- ⚠️ linter found issues (exit code 1)

🔧 No changes applied.
1 warning still open:

- ⚠️ linter found issues (exit code 1)
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
