### PR TITLE
fix(test-run): map tests/*-fixture.sh and tests/assets/* in --changed selector

### DIFF
--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -1547,7 +1547,12 @@ families_for_changed_path() {
       families_for_test_reference git-config-helpers.sh lib.sh herdr-test-safety.sh \
         || printf '%s\n' "__unmapped__:$path"
       ;;
-    tests/lib.sh|tests/*-helpers.sh|tests/fixtures.sh)
+    # tests/remote-herdr-fixture.sh is a shared sourced helper like
+    # tests/*-helpers.sh and resolves by basename to its consuming suites.
+    # tests/herdr-client-pair-fixture.sh has its own mapping above.
+    # A test asset (tests/assets/*) resolves the same way, to whichever suite
+    # names it.
+    tests/lib.sh|tests/*-helpers.sh|tests/*-fixture.sh|tests/fixtures.sh|tests/assets/*)
       families_for_test_reference "$(basename "$path")" \
         || printf '%s\n' "__unmapped__:$path"
       ;;


### PR DESCRIPTION
## Problem

The `--changed` test selector's fallback for shared sourced test helpers only
matches `tests/lib.sh`, `tests/*-helpers.sh`, and `tests/fixtures.sh`. Two
kinds of shared reference fall outside that glob and hit `__unmapped__`,
which makes `--changed` refuse selection instead of resolving suites:

- A sourced fixture helper named `tests/*-fixture.sh`, such as
  `tests/remote-herdr-fixture.sh` (consumed by
  `tests/fm-remote-secondmate-lifecycle-e2e.test.sh`,
  `tests/fm-remote-secondmate-parent-binding.test.sh`,
  `tests/fm-remote-secondmate-trace-context.test.sh`, and
  `tests/fm-secondmate-sync.test.sh`).
- Anything under `tests/assets/`, such as
  `tests/assets/board-render-harness.mjs` (consumed by
  `tests/fm-bearings-board-render.test.sh`).

Both are exactly the kind of reference `families_for_test_reference`'s
basename scan already resolves for `tests/*-helpers.sh`; they were only
missing from the glob that routes to it.

`tests/herdr-client-pair-fixture.sh` already has its own explicit mapping
earlier in the same `case`, so widening the fallback to `tests/*-fixture.sh`
does not change its routing (case patterns are matched in order).

## Fix

Add `tests/*-fixture.sh` and `tests/assets/*` to the glob that resolves
through `families_for_test_reference`.

## Repro

```
$ echo '// touch' >> tests/assets/board-render-harness.mjs
$ echo '# touch' >> tests/remote-herdr-fixture.sh
$ bin/fm-test-run.sh --list --changed --base upstream/main
```

Before this change, both paths fall through to `__unmapped__:<path>` and the
selector refuses with "no changed-test mapping". After this change, the
command resolves 90 suites, including `tests/fm-bearings-board-render.test.sh`
and the four suites that source `tests/remote-herdr-fixture.sh`.

`bin/fm-lint.sh` passes.
