### PR TITLE
docs: require lavish-axi for crucial blocking changes in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -507,7 +507,7 @@ In a secondmate home, reaching the captain means appending the outcome to the pa
 Do not surface automatic fixes, retries, routine progress, or internal supervision mechanics.
 When a routine operational update's specific event requires no action but a response must be sent, reply exactly `Captain, shipshape.` without characterizing the visible session's unrelated decisions.
 Batch non-urgent updates into the next natural reply.
-Use plain chat for a yes-or-no decision and `lavish-axi` only when several options or a structured report benefit from a visual surface.
+Use plain chat for an ordinary yes-or-no decision and `lavish-axi` for crucial blocking changes (gate findings or blockers that stop work until the captain decides) and for situations where several options or a structured report benefit from a visual surface.
 Whenever a PR is mentioned, include its full `https://...` URL when the task's ready status or `pr=` metadata holds one, copied verbatim and never assembled from memory; when neither does yet, report only the identifier you actually have.
 Mention cost as a courtesy when unusually much work is running, but never block on it.
 


### PR DESCRIPTION
## Intent

Update AGENTS.md section 9 to require lavish-axi for crucial blocking changes (gate findings or blockers that stop work until the captain decides), while preserving plain-chat default for ordinary yes-or-no decisions that are not blocking. This applies the captain's new standing instruction fleet-wide across all projects. The change must be made only as a one-owner edit to the existing sentence in section 9, not as a new paragraph or duplicate elsewhere.

## What Changed
- Updated the escalation-channel sentence in AGENTS.md section 9 to require `lavish-axi` for crucial blocking changes (gate findings or blockers that stop work until the captain decides), in addition to its existing use for multi-option or structured reports.
- Preserved plain chat as the default for ordinary yes-or-no decisions that are not blocking.
- Single one-line edit to the existing sentence; no new paragraph or duplicate guidance was added.

## Risk Assessment

✅ Low: Single-sentence documentation edit in AGENTS.md section 9 that matches the required intent exactly (adds lavish-axi requirement for crucial blocking changes while preserving plain-chat default for ordinary yes-or-no decisions), with no duplication elsewhere in the file and no code/logic touched.

## Testing

This is a pure natural-language instruction/documentation change (one sentence in AGENTS.md section 9) with no executable interface or UI surface, so behavior can't be demonstrated via a screenshot or CLI transcript; per the test-quality rule, a grep-based test asserting the sentence's exact wording would be an anti-pattern and was not written. Instead I manually verified the edit against every acceptance constraint (single in-place sentence edit, no duplicate, plain-chat default preserved, lavish-axi required for blocking changes) and ran the existing targeted documentation-structure tests (fm-doc-audience-check.sh and its test suite), which exercise real link/classification validation over AGENTS.md and all passed, confirming the edit didn't break the doc's structural contract.

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"b8183631166354025573654dac6916708d6d1c0c","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>Manual diff review: `git diff 76d4405..b818363 -- AGENTS.md` confirms a single-line, one-owner edit inside section 9 (lines 468-514), not a new paragraph or a duplicate elsewhere in the file</code>
- <code>`grep -n &#34;lavish-axi\|yes-or-no\|blocking change&#34; AGENTS.md` to confirm no duplicate/second copy of the escalation sentence exists outside section 9</code>
- <code>`bash bin/fm-doc-audience-check.sh` — structural doc-audience and local-link check covering AGENTS.md, passed (surfaces=97 local_links=393)</code>
- <code>`bash tests/fm-documentation-audiences.test.sh` — full targeted suite for documentation structure/links, all 4 cases passed</code>
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>⚠️ **Lint** - 1 warning</summary>

- ⚠️ linter found issues (exit code 1)
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
