### PR TITLE
fix(brief): grant no-mistakes pipeline authority where the worker reads it

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -357,7 +357,7 @@ After an autonomous merge, give the captain a one-line full-URL or local-main ou
 
 ### Validate
 
-For a no-mistakes ship, trigger validation on the same worker after its implementation commit, using the harness invocation owned by `harness-adapters`.
+For a no-mistakes ship, the generated brief already authorizes the worker to run the pipeline at dispatch, so confirm the same worker started validation after its implementation commit rather than waiting to authorize it, and use the harness invocation owned by `harness-adapters` only to restart a worker that stopped short.
 The task worker that starts a no-mistakes run drives the pipeline and owns every `no-mistakes axi run` and `no-mistakes axi respond` call through the next gate or outcome.
 Firstmate never invokes `no-mistakes axi respond` for a crew-owned run.
 When the captain adds or changes an ask mid-task, append the captain's words to that brief's `## Captain's intent` and steer the worker; Firstmate build constraints stay in `## Firstmate spec` or the steer.

--- a/bin/fm-dod-lib.sh
+++ b/bin/fm-dod-lib.sh
@@ -10,6 +10,10 @@
 # mode is refused rather than silently rendered as the pipeline contract.
 # The block opens with the fixed machine-readable "Delivery contract: mode=<mode>"
 # line that bin/fm-spawn.sh checks a ship brief against.
+# The no-mistakes block states the worker's pipeline authority where the worker
+# reads it - beside the status-line instruction it acts on when the code is
+# committed - because that is the point at which seven workers in one session
+# stopped early and reported done on work the forge never received.
 # This file is the one owner of the no-mistakes `--intent` contract: only the
 # brief's `## Captain's intent` subsection plus later captain words, never
 # `## Firstmate spec` and never the worker's own tradeoffs.
@@ -218,9 +222,11 @@ EOF
       cat <<EOF
 # Definition of done
 Delivery contract: mode=no-mistakes
-The task is complete only when committed on your branch.
-When you believe it is complete, append \`done: {summary}\` to the status file and stop.
-Firstmate will then instruct you to run /no-mistakes to validate and ship a PR.
+\`mode=no-mistakes\` IS your authorization to run the pipeline, and you already have it: firstmate granted it when it dispatched you.
+Driving that pipeline to a PR is your own job and needs no further word from firstmate, so do not stop to ask for permission and do not wait to be told to start.
+Committing the implementation is the MIDDLE of this task, not the end of it.
+When the implementation is committed, append \`working: implemented, starting no-mistakes\` to the status file and invoke /no-mistakes in the same turn.
+This task has exactly one \`done:\` gate and it is the last line of this section; any \`done:\` you append before the forge holds your PR is a false claim, whatever the code is worth.
 
 You drive no-mistakes by responding to its gates, not by implementing fixes.
 Follow the guidance no-mistakes itself provides for the mechanics: it loads when you invoke /no-mistakes, and \`no-mistakes axi run --help\` plus the \`help\` lines in each \`axi\` response are authoritative and version-matched to the installed binary.
@@ -246,6 +252,10 @@ Two firstmate-specific rules layer on top of that guidance:
   It auto-resolves every gate including ask-user findings with no escalation, and answering your own ask-user finding is a hard rule violation.
 
 After /no-mistakes reports CI green (the CI-ready return point - do not wait for it to keep monitoring in the background until merge), append \`done: PR {url} checks green\` and stop. You are finished.
+Before you append that line, read the PR back from the forge with \`gh-axi\` and confirm both the full https:// URL and the PR's head SHA there; report that head SHA alongside the URL when you hand the work over.
+Read both from the forge, never from your local branch: an unpushed commit still prints a SHA locally, and that is exactly how work that never reached the forge gets reported as shipped.
+If the forge has no such PR, or its head is not the work you committed, you have nothing to claim - say what actually happened instead.
+Keep the status line itself in exactly the \`done: PR {url} checks green\` shape above, because firstmate reads the PR out of it; the head SHA goes in your handover, not into that line.
 EOF
       ;;
     *)

--- a/bin/fm-dod-lib.sh
+++ b/bin/fm-dod-lib.sh
@@ -254,7 +254,7 @@ Two firstmate-specific rules layer on top of that guidance:
 After /no-mistakes reports CI green (the CI-ready return point - do not wait for it to keep monitoring in the background until merge), append \`done: PR {url} checks green\` and stop. You are finished.
 Before you append that line, read the PR back from the forge with \`gh-axi\` and confirm both the full https:// URL and the PR's head SHA there; report that head SHA alongside the URL when you hand the work over.
 Read both from the forge, never from your local branch: an unpushed commit still prints a SHA locally, and that is exactly how work that never reached the forge gets reported as shipped.
-If the forge has no such PR for this run's validated branch, or its head is not this run's authoritative pipeline final head, which may include pipeline-authored fix commits stacked on the implementation commit, you have nothing to claim - say what actually happened instead.
+If the forge has no such PR for this run's validated branch, or its head is not this run's authoritative pipeline final head, which may include pipeline-authored fix commits stacked on the implementation commit, append \`blocked: {what the forge actually shows}\` when firstmate action is needed to get the work to the forge, or append \`failed: {what the forge actually shows}\` when delivery genuinely failed, then stop.
 Keep the status line itself in exactly the \`done: PR {url} checks green\` shape above, because firstmate reads the PR out of it; the head SHA goes in your handover, not into that line.
 EOF
       ;;

--- a/bin/fm-dod-lib.sh
+++ b/bin/fm-dod-lib.sh
@@ -251,11 +251,13 @@ Two firstmate-specific rules layer on top of that guidance:
 - NEVER pass \`--yes\` (or \`-y\`) to \`no-mistakes axi run\` or \`no-mistakes axi respond\`. It is banned fleet-wide.
   It auto-resolves every gate including ask-user findings with no escalation, and answering your own ask-user finding is a hard rule violation.
 
-After /no-mistakes reports CI green (the CI-ready return point - do not wait for it to keep monitoring in the background until merge), append \`done: PR {url} checks green\` and stop. You are finished.
-Before you append that line, read the PR back from the forge with \`gh-axi\` and confirm both the full https:// URL and the PR's head SHA there; report that head SHA alongside the URL when you hand the work over.
-Read both from the forge, never from your local branch: an unpushed commit still prints a SHA locally, and that is exactly how work that never reached the forge gets reported as shipped.
+After /no-mistakes reports CI green (the CI-ready return point - do not wait for it to keep monitoring in the background until merge), the PR URL is the deliverable and it is sufficient.
+Before appending the terminal line, confirm that you genuinely pushed the branch and opened the PR, copying the full https:// URL from what the PR step actually produced rather than composing one.
+You never attest to what the forge holds: firstmate reads the PR head from the forge itself.
+Firstmate verifies a terminal claim against the forge, so a claim that names no PR cannot be checked at all, and a commit that exists only on the local branch is not a delivery.
 If the forge has no such PR for this run's validated branch, or its head is not this run's authoritative pipeline final head, which may include pipeline-authored fix commits stacked on the implementation commit, append \`blocked: {what the forge actually shows}\` when firstmate action is needed to get the work to the forge, or append \`failed: {what the forge actually shows}\` when delivery genuinely failed, then stop.
-Keep the status line itself in exactly the \`done: PR {url} checks green\` shape above, because firstmate reads the PR out of it; the head SHA goes in your handover, not into that line.
+After that confirmation, append \`done: PR {url} checks green\` and stop. You are finished.
+Keep the status line itself in exactly the \`done: PR {url} checks green\` shape above, because firstmate reads the PR out of it.
 EOF
       ;;
     *)

--- a/bin/fm-dod-lib.sh
+++ b/bin/fm-dod-lib.sh
@@ -225,7 +225,7 @@ Delivery contract: mode=no-mistakes
 \`mode=no-mistakes\` IS your authorization to run the pipeline, and you already have it: firstmate granted it when it dispatched you.
 Driving that pipeline to a PR is your own job and needs no further word from firstmate, so do not stop to ask for permission and do not wait to be told to start.
 Committing the implementation is the MIDDLE of this task, not the end of it.
-When the implementation is committed, append \`working: implemented, starting no-mistakes\` to the status file and invoke /no-mistakes in the same turn.
+When the implementation is committed, append \`working: implemented, starting no-mistakes\` to the status file and start the pipeline in the same turn by running \`no-mistakes axi run --intent "..."\`; invoking the no-mistakes skill through this harness is equivalent convenience.
 This task has exactly one \`done:\` gate and it is the last line of this section; any \`done:\` you append before the forge holds your PR is a false claim, whatever the code is worth.
 
 You drive no-mistakes by responding to its gates, not by implementing fixes.
@@ -254,7 +254,7 @@ Two firstmate-specific rules layer on top of that guidance:
 After /no-mistakes reports CI green (the CI-ready return point - do not wait for it to keep monitoring in the background until merge), append \`done: PR {url} checks green\` and stop. You are finished.
 Before you append that line, read the PR back from the forge with \`gh-axi\` and confirm both the full https:// URL and the PR's head SHA there; report that head SHA alongside the URL when you hand the work over.
 Read both from the forge, never from your local branch: an unpushed commit still prints a SHA locally, and that is exactly how work that never reached the forge gets reported as shipped.
-If the forge has no such PR, or its head is not the work you committed, you have nothing to claim - say what actually happened instead.
+If the forge has no such PR for this run's validated branch, or its head is not this run's authoritative pipeline final head, which may include pipeline-authored fix commits stacked on the implementation commit, you have nothing to claim - say what actually happened instead.
 Keep the status line itself in exactly the \`done: PR {url} checks green\` shape above, because firstmate reads the PR out of it; the head SHA goes in your handover, not into that line.
 EOF
       ;;

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -260,7 +260,7 @@ test_ship_mode_is_explicit_not_registry() {
   brief="$home/data/brief-explicit-a5/brief.md"
   grep -qx "Delivery contract: mode=no-mistakes" "$brief" \
     || fail "registered direct-PR posture overrode the explicit --mode"
-  assert_grep "Firstmate will then instruct you to run /no-mistakes" "$brief" \
+  assert_grep "invoke /no-mistakes in the same turn" "$brief" \
     "explicit no-mistakes brief did not render the pipeline definition of done"
 
   # An unregistered project is not a blocker either, because nothing is looked up.
@@ -370,6 +370,105 @@ test_no_mistakes_dod_wording() {
   assert_no_grep "no-mistakes refuses" "$brief" \
     "no-mistakes DOD must not claim the tool itself refuses --yes"
   pass "fm-brief.sh: no-mistakes DOD keeps its apostrophe prose and bans --yes outright"
+}
+
+# Seven no-mistakes workers in one session reported done on work the forge never
+# received. Every brief had told them, at the moment the code was committed, to
+# append `done:` and stop and wait for firstmate to authorize the pipeline. The
+# authorization has to sit where the finishing worker reads it, so this pins both
+# halves: the stop-and-wait instruction is gone, and the authorization plus the
+# forge readback are rendered at the two status-line instructions they govern.
+test_no_mistakes_dod_grants_pipeline_authority_at_the_done_instruction() {
+  local home id brief auth_line commit_line done_line
+  home="$TMP_ROOT/pipeline-authority-home"
+  mkdir -p "$home/data"
+  id="brief-pipeline-authority-e1"
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" some-proj --mode no-mistakes >/dev/null 2>&1
+  brief="$home/data/$id/brief.md"
+  assert_present "$brief" "brief was not scaffolded"
+
+  # The authorization itself: granted at dispatch, needing no further word.
+  assert_grep "IS your authorization to run the pipeline, and you already have it" "$brief" \
+    "no-mistakes DOD must state that the delivery mode is itself the pipeline authorization"
+  assert_grep "needs no further word from firstmate" "$brief" \
+    "no-mistakes DOD must state that the worker needs no further permission"
+  assert_grep "Committing the implementation is the MIDDLE of this task, not the end of it." "$brief" \
+    "no-mistakes DOD must say the implementation commit is not the end of the task"
+
+  # The instruction that produced the bug must be gone, not merely contradicted.
+  assert_no_grep "Firstmate will then instruct you to run /no-mistakes" "$brief" \
+    "no-mistakes DOD still tells the worker to wait to be told to run the pipeline"
+  # shellcheck disable=SC2016  # single quotes are deliberate: the backticks and brace tokens must stay literal
+  assert_no_grep 'append `done: {summary}` to the status file and stop' "$brief" \
+    "no-mistakes DOD still offers a terminal done gate at the implementation commit"
+
+  # Placement is the whole point: a correct sentence in a distant section is what
+  # produced this, so the authorization must render beside the status-line
+  # instruction the worker acts on when the code is committed.
+  auth_line=$(grep -n -F -- "needs no further word from firstmate" "$brief" | head -1 | cut -d: -f1)
+  commit_line=$(grep -n -F -- "invoke /no-mistakes in the same turn" "$brief" | head -1 | cut -d: -f1)
+  [ -n "$auth_line" ] && [ -n "$commit_line" ] \
+    || fail "no-mistakes DOD lost the authorization or the implementation-commit instruction"
+  [ "$((commit_line - auth_line))" -ge 0 ] && [ "$((commit_line - auth_line))" -le 4 ] \
+    || fail "no-mistakes DOD separated the pipeline authorization from the instruction it governs (lines $auth_line and $commit_line)"
+
+  # The one terminal gate, and the forge readback that backs a claim made at it.
+  # shellcheck disable=SC2016  # single quotes are deliberate: the backticks and brace tokens must stay literal
+  assert_grep 'append `done: PR {url} checks green` and stop. You are finished.' "$brief" \
+    "no-mistakes DOD lost its single terminal done gate"
+  # shellcheck disable=SC2016  # single quotes are deliberate: the backticks and brace tokens must stay literal
+  done_line=$(grep -n -F -- 'append `done: PR {url} checks green` and stop.' "$brief" | head -1 | cut -d: -f1)
+  assert_grep "read the PR back from the forge with \`gh-axi\` and confirm both the full https:// URL and the PR's head SHA" "$brief" \
+    "no-mistakes DOD must require the PR URL and head SHA to be read back from the forge"
+  assert_grep "Read both from the forge, never from your local branch" "$brief" \
+    "no-mistakes DOD must forbid sourcing the terminal claim from the local branch"
+  assert_grep "an unpushed commit still prints a SHA locally" "$brief" \
+    "no-mistakes DOD must say why a local SHA is not evidence of delivery"
+  auth_line=$(grep -n -F -- "Read both from the forge, never from your local branch" "$brief" | head -1 | cut -d: -f1)
+  [ -n "$done_line" ] && [ -n "$auth_line" ] && [ "$((auth_line - done_line))" -le 4 ] \
+    || fail "no-mistakes DOD separated the forge readback from the terminal done gate"
+
+  # fm-inactive-reconcile.sh scrapes a terminal line in exactly this shape when
+  # meta pr= is absent, so the head SHA goes in the handover, not into the line.
+  assert_grep "Keep the status line itself in exactly the \`done: PR {url} checks green\` shape" "$brief" \
+    "no-mistakes DOD must preserve the machine-read terminal status-line shape"
+  pass "fm-brief.sh: the no-mistakes DOD grants pipeline authority where the finishing worker reads it"
+}
+
+# The fix is scoped to the no-mistakes pipeline brief. Every other scaffold keeps
+# its own terminal gate, and none of them inherits pipeline authority wording.
+test_pipeline_authority_is_scoped_to_no_mistakes() {
+  local home brief
+  home="$TMP_ROOT/pipeline-authority-scope-home"
+  mkdir -p "$home/data"
+
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" scope-scout some-proj --scout >/dev/null 2>&1
+  brief="$home/data/scope-scout/brief.md"
+  # shellcheck disable=SC2016  # single quotes are deliberate: the backticks and brace tokens must stay literal
+  assert_grep 'append `done: {one-line conclusion}` to the status file and stop' "$brief" \
+    "scout brief lost its own terminal done gate"
+
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" scope-local some-proj --mode local-only >/dev/null 2>&1
+  brief="$home/data/scope-local/brief.md"
+  # shellcheck disable=SC2016  # single quotes are deliberate: the backticks and brace tokens must stay literal
+  assert_grep 'append `done: ready in branch fm/scope-local` to the status file and stop' "$brief" \
+    "local-only brief lost its own terminal done gate"
+
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" scope-direct some-proj --mode direct-PR >/dev/null 2>&1
+  brief="$home/data/scope-direct/brief.md"
+  # shellcheck disable=SC2016  # single quotes are deliberate: the backticks and brace tokens must stay literal
+  assert_grep 'append `done: PR {url}` to the status file and stop' "$brief" \
+    "direct-PR brief lost its own terminal done gate"
+  assert_grep "Do NOT run /no-mistakes." "$brief" \
+    "direct-PR brief lost its no-pipeline instruction"
+
+  for brief in "$home/data/scope-scout/brief.md" "$home/data/scope-local/brief.md" "$home/data/scope-direct/brief.md"; do
+    assert_no_grep "IS your authorization to run the pipeline" "$brief" \
+      "$brief inherited the no-mistakes pipeline authorization"
+    assert_no_grep "invoke /no-mistakes in the same turn" "$brief" \
+      "$brief inherited the no-mistakes pipeline start instruction"
+  done
+  pass "fm-brief.sh: pipeline authority wording stays out of the scout, local-only, and direct-PR briefs"
 }
 
 test_ask_user_escalation_format() {
@@ -911,6 +1010,8 @@ test_ship_mode_is_explicit_not_registry
 test_delivery_flags_are_refused_where_they_do_not_apply
 test_faster_paths_use_configured_authority_without_stacked_review
 test_no_mistakes_dod_wording
+test_no_mistakes_dod_grants_pipeline_authority_at_the_done_instruction
+test_pipeline_authority_is_scoped_to_no_mistakes
 test_ask_user_escalation_format
 test_ship_project_memory_wording
 test_herdr_lab_contract_is_explicit_and_complete

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -260,7 +260,7 @@ test_ship_mode_is_explicit_not_registry() {
   brief="$home/data/brief-explicit-a5/brief.md"
   grep -qx "Delivery contract: mode=no-mistakes" "$brief" \
     || fail "registered direct-PR posture overrode the explicit --mode"
-  assert_grep "invoke /no-mistakes in the same turn" "$brief" \
+  assert_grep 'by running `no-mistakes axi run --intent "..."`' "$brief" \
     "explicit no-mistakes brief did not render the pipeline definition of done"
 
   # An unregistered project is not a blocker either, because nothing is looked up.
@@ -406,7 +406,7 @@ test_no_mistakes_dod_grants_pipeline_authority_at_the_done_instruction() {
   # produced this, so the authorization must render beside the status-line
   # instruction the worker acts on when the code is committed.
   auth_line=$(grep -n -F -- "needs no further word from firstmate" "$brief" | head -1 | cut -d: -f1)
-  commit_line=$(grep -n -F -- "invoke /no-mistakes in the same turn" "$brief" | head -1 | cut -d: -f1)
+  commit_line=$(grep -n -F -- "start the pipeline in the same turn by running" "$brief" | head -1 | cut -d: -f1)
   [ -n "$auth_line" ] && [ -n "$commit_line" ] \
     || fail "no-mistakes DOD lost the authorization or the implementation-commit instruction"
   [ "$((commit_line - auth_line))" -ge 0 ] && [ "$((commit_line - auth_line))" -le 4 ] \
@@ -424,6 +424,10 @@ test_no_mistakes_dod_grants_pipeline_authority_at_the_done_instruction() {
     "no-mistakes DOD must forbid sourcing the terminal claim from the local branch"
   assert_grep "an unpushed commit still prints a SHA locally" "$brief" \
     "no-mistakes DOD must say why a local SHA is not evidence of delivery"
+  assert_grep "pipeline-authored fix commits stacked on the implementation commit" "$brief" \
+    "no-mistakes DOD must accept pipeline-owned fix commits at the terminal head"
+  assert_no_grep "head is not the work you committed" "$brief" \
+    "no-mistakes DOD still requires personal authorship of the terminal head"
   auth_line=$(grep -n -F -- "Read both from the forge, never from your local branch" "$brief" | head -1 | cut -d: -f1)
   [ -n "$done_line" ] && [ -n "$auth_line" ] && [ "$((auth_line - done_line))" -le 4 ] \
     || fail "no-mistakes DOD separated the forge readback from the terminal done gate"

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -428,6 +428,12 @@ test_no_mistakes_dod_grants_pipeline_authority_at_the_done_instruction() {
     "no-mistakes DOD must accept pipeline-owned fix commits at the terminal head"
   assert_no_grep "head is not the work you committed" "$brief" \
     "no-mistakes DOD still requires personal authorship of the terminal head"
+  assert_no_grep "say what actually happened instead" "$brief" \
+    "no-mistakes DOD still leaves forge verification failures without a machine-readable status"
+  assert_grep 'append `blocked: {what the forge actually shows}` when firstmate action is needed to get the work to the forge' "$brief" \
+    "no-mistakes DOD must expose a blocked forge-verification status"
+  assert_grep 'append `failed: {what the forge actually shows}` when delivery genuinely failed, then stop.' "$brief" \
+    "no-mistakes DOD must expose a failed forge-verification status"
   auth_line=$(grep -n -F -- "Read both from the forge, never from your local branch" "$brief" | head -1 | cut -d: -f1)
   [ -n "$done_line" ] && [ -n "$auth_line" ] && [ "$((auth_line - done_line))" -le 4 ] \
     || fail "no-mistakes DOD separated the forge readback from the terminal done gate"

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -441,11 +441,12 @@ test_no_mistakes_dod_grants_pipeline_authority_at_the_done_instruction() {
   assert_grep 'append `failed: {what the forge actually shows}` when delivery genuinely failed, then stop.' "$brief" \
     "no-mistakes DOD must expose a failed forge-verification status"
   auth_line=$(grep -n -F -- "You never attest to what the forge holds: firstmate reads the PR head from the forge itself." "$brief" | head -1 | cut -d: -f1)
-  [ -n "$done_line" ] && [ -n "$auth_line" ] && [ "$((done_line - auth_line))" -le 5 ] \
+  [ -n "$done_line" ] && [ -n "$auth_line" ] && [ "$((done_line - auth_line))" -ge 0 ] \
+    && [ "$((done_line - auth_line))" -le 5 ] \
     || fail "no-mistakes DOD separated forge-owned verification from the terminal done gate"
 
   # fm-inactive-reconcile.sh scrapes a terminal line in exactly this shape when
-  # meta pr= is absent, so the head SHA goes in the handover, not into the line.
+  # meta pr= is absent, while firstmate verifies the PR head from the forge.
   assert_grep "Keep the status line itself in exactly the \`done: PR {url} checks green\` shape" "$brief" \
     "no-mistakes DOD must preserve the machine-read terminal status-line shape"
   pass "fm-brief.sh: the no-mistakes DOD grants pipeline authority where the finishing worker reads it"

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -418,12 +418,18 @@ test_no_mistakes_dod_grants_pipeline_authority_at_the_done_instruction() {
     "no-mistakes DOD lost its single terminal done gate"
   # shellcheck disable=SC2016  # single quotes are deliberate: the backticks and brace tokens must stay literal
   done_line=$(grep -n -F -- 'append `done: PR {url} checks green` and stop.' "$brief" | head -1 | cut -d: -f1)
-  assert_grep "read the PR back from the forge with \`gh-axi\` and confirm both the full https:// URL and the PR's head SHA" "$brief" \
-    "no-mistakes DOD must require the PR URL and head SHA to be read back from the forge"
-  assert_grep "Read both from the forge, never from your local branch" "$brief" \
-    "no-mistakes DOD must forbid sourcing the terminal claim from the local branch"
-  assert_grep "an unpushed commit still prints a SHA locally" "$brief" \
-    "no-mistakes DOD must say why a local SHA is not evidence of delivery"
+  assert_grep "the PR URL is the deliverable and it is sufficient." "$brief" \
+    "no-mistakes DOD must make the PR URL the sufficient deliverable"
+  assert_grep "You never attest to what the forge holds: firstmate reads the PR head from the forge itself." "$brief" \
+    "no-mistakes DOD must keep forge-head attestation with firstmate"
+  assert_grep "genuinely pushed the branch and opened the PR" "$brief" \
+    "no-mistakes DOD must require a genuinely pushed branch and opened PR"
+  assert_grep "copying the full https:// URL from what the PR step actually produced rather than composing one." "$brief" \
+    "no-mistakes DOD must require copying the URL from the PR step"
+  assert_grep "Firstmate verifies a terminal claim against the forge, so a claim that names no PR cannot be checked at all, and a commit that exists only on the local branch is not a delivery." "$brief" \
+    "no-mistakes DOD must explain why forge-backed URL evidence matters"
+  assert_no_grep "head SHA" "$brief" \
+    "no-mistakes DOD must not require the worker to hand over a forge head SHA"
   assert_grep "pipeline-authored fix commits stacked on the implementation commit" "$brief" \
     "no-mistakes DOD must accept pipeline-owned fix commits at the terminal head"
   assert_no_grep "head is not the work you committed" "$brief" \
@@ -434,9 +440,9 @@ test_no_mistakes_dod_grants_pipeline_authority_at_the_done_instruction() {
     "no-mistakes DOD must expose a blocked forge-verification status"
   assert_grep 'append `failed: {what the forge actually shows}` when delivery genuinely failed, then stop.' "$brief" \
     "no-mistakes DOD must expose a failed forge-verification status"
-  auth_line=$(grep -n -F -- "Read both from the forge, never from your local branch" "$brief" | head -1 | cut -d: -f1)
-  [ -n "$done_line" ] && [ -n "$auth_line" ] && [ "$((auth_line - done_line))" -le 4 ] \
-    || fail "no-mistakes DOD separated the forge readback from the terminal done gate"
+  auth_line=$(grep -n -F -- "You never attest to what the forge holds: firstmate reads the PR head from the forge itself." "$brief" | head -1 | cut -d: -f1)
+  [ -n "$done_line" ] && [ -n "$auth_line" ] && [ "$((done_line - auth_line))" -le 5 ] \
+    || fail "no-mistakes DOD separated forge-owned verification from the terminal done gate"
 
   # fm-inactive-reconcile.sh scrapes a terminal line in exactly this shape when
   # meta pr= is absent, so the head SHA goes in the handover, not into the line.

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -260,6 +260,7 @@ test_ship_mode_is_explicit_not_registry() {
   brief="$home/data/brief-explicit-a5/brief.md"
   grep -qx "Delivery contract: mode=no-mistakes" "$brief" \
     || fail "registered direct-PR posture overrode the explicit --mode"
+  # shellcheck disable=SC2016  # single quotes are deliberate: the backticks and brace tokens must stay literal
   assert_grep 'by running `no-mistakes axi run --intent "..."`' "$brief" \
     "explicit no-mistakes brief did not render the pipeline definition of done"
 
@@ -436,8 +437,10 @@ test_no_mistakes_dod_grants_pipeline_authority_at_the_done_instruction() {
     "no-mistakes DOD still requires personal authorship of the terminal head"
   assert_no_grep "say what actually happened instead" "$brief" \
     "no-mistakes DOD still leaves forge verification failures without a machine-readable status"
+  # shellcheck disable=SC2016  # single quotes are deliberate: the backticks and brace tokens must stay literal
   assert_grep 'append `blocked: {what the forge actually shows}` when firstmate action is needed to get the work to the forge' "$brief" \
     "no-mistakes DOD must expose a blocked forge-verification status"
+  # shellcheck disable=SC2016  # single quotes are deliberate: the backticks and brace tokens must stay literal
   assert_grep 'append `failed: {what the forge actually shows}` when delivery genuinely failed, then stop.' "$brief" \
     "no-mistakes DOD must expose a failed forge-verification status"
   auth_line=$(grep -n -F -- "You never attest to what the forge holds: firstmate reads the PR head from the forge itself." "$brief" | head -1 | cut -d: -f1)


### PR DESCRIPTION
## The problem

On 2026-09-13, seven no-mistakes ship workers in one session reported `done:` on work that was never pushed to the forge. Each was caught only by querying the forge by hand. All seven did good work; all seven stopped one step early, and several said so outright ("ready for /no-mistakes"). Seven for seven is not seven careless workers, it is one bad instruction.

The instruction lived in `bin/fm-dod-lib.sh`. The no-mistakes definition of done told the worker, at the exact moment the implementation was committed:

```
The task is complete only when committed on your branch.
When you believe it is complete, append `done: {summary}` to the status file and stop.
Firstmate will then instruct you to run /no-mistakes to validate and ship a PR.
```

A worker who has just finished the code reads the nearest instruction and obeys it. The rule that the task worker owns every `no-mistakes axi run` and `respond` call lived only in `AGENTS.md` section 7, which is firstmate-side knowledge a crewmate never sees, and the mode's real terminal gate sat in a later section of the same block. Nothing where the worker was actually reading said that running the pipeline was its own job.

## The change

The no-mistakes block now opens with the authorization, immediately beside the status-line instruction the worker acts on when the code is committed:

- `mode=no-mistakes` **is** the authorization, granted at dispatch; driving the pipeline to a PR needs no further word from firstmate.
- Committing the implementation is the middle of the task, not the end of it.
- The implementation commit routes to a nonterminal `working:` line and starts the pipeline in the same turn.
- There is exactly one `done:` gate, and any `done:` appended before the forge holds the PR is a false claim.

At that single terminal gate, the PR URL is the deliverable and the worker never attests to what the forge holds, because firstmate reads the PR head from the forge itself. The stated reason is part of the instruction: firstmate verifies a terminal claim against the forge, so a claim that names no PR cannot be checked at all, and a commit that exists only on the local branch is not a delivery. When the forge has no such PR, the worker appends `blocked:` or `failed:` naming what the forge actually shows rather than stopping silently.

`AGENTS.md`'s validate step no longer describes firstmate as granting that authorization, so the two records of who starts the pipeline agree.

Placement is the substance of this change, not a detail of it. A correct sentence in a distant section is what produced the original failure, so the tests assert adjacency and ordering, not just presence.

## Scope held

Scaffold wording only. The scout, local-only, and direct-PR briefs render **byte-identically** to before, verified by generating each variant from the pre-change scripts and diffing. The worktree-isolation assertion, the Herdr lifecycle gate, and the status protocol's state vocabulary are unchanged. No new handover artifact or metadata path was introduced: firstmate's existing `bin/fm-pr-check.sh` path already records `pr=` and the forge's `pr_head=`, and a second record of one fact can only disagree with the first.

An earlier draft required the worker to report a forge-read head SHA. Review found that the only durable channel, the `done: PR {url} checks green` line, cannot carry it, and that `bin/fm-inactive-reconcile.sh` forwards only that line on secondmate delivery. Routing the forge head through the worker would also have preserved the very trust problem the SHA was meant to solve, since the worker would still be the one reporting what the forge said. The obligation was removed rather than given a channel.

## Tests

Two colocated tests in `tests/fm-brief.test.sh` pin the contract through the generated brief:

- the authorization wording, its two-sided adjacency to the implementation-commit instruction, the absence of the stop-and-wait instruction, the single terminal gate, the forge-verification wording and its ordering relative to that gate, and the preserved `done: PR {url} checks green` shape that `bin/fm-inactive-reconcile.sh` scrapes;
- that the pipeline-authority wording stays out of the scout, local-only, and direct-PR briefs while each keeps its own terminal gate.

## Validation status, and how this was delivered

Read this before reading the pipeline outcome anywhere else: **the pipeline ran review, test and lint, and all three passed** at head `51c4e239`. It then failed at the push step alone, because the authenticated account on the machine this ran from has pull-only access to `kunchenguid/firstmate` (`permissions.push=false`), so the push to upstream returned 403. Custody of the pipeline's fix commits was returned through the guarded recovery path and nothing was stranded.

The branch was therefore delivered through the sanctioned route for this machine: pushed to the `ICGNU3` fork, with this PR opened against `kunchenguid/firstmate`. **This is "validated, delivered differently", not "validation failed".** A terminal status line renders those two identically and they are not remotely the same thing.

The underlying defect is real but out of scope here: the pipeline's push target is upstream, which is unwritable from this machine, so every firstmate-repo ship task fails at push and each worker rediscovers the fork route by hand. Firstmate is filing that separately; it is not fixable inside a scaffold-wording change.

## Related work

`fm-done-verified-rescue-v1` (#3683) gates the done *verdict* on an accepted run bound to the exact evaluated head: it catches a false claim after it is made, and it is the consumer of the firstmate-side metadata path this change relies on. This PR prevents the claim being made wrongly at all. The two act at different points in the chain and neither reaches into the other.

That pairing is visible in this PR's own delivery. This branch is pushed to the `ICGNU3` fork while the PR targets `kunchenguid/firstmate`, because the authenticated account on this machine has pull-only access upstream. A fork push means the branch lives in one repository while the PR targets another, so a branch name alone is not an identity - which is both why the worker must not be the carrier of forge identity here, and the legitimate case that makes repository-blind verification wrong in #3683.
